### PR TITLE
ECF-29: Remove Turbolinks and Rails-UJS

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application', defer: true %>
   </head>
 
   <body class="govuk-template__body ">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,10 +1,6 @@
 require.context('govuk-frontend/govuk/assets');
 
 import '../styles/application.scss';
-import Rails from 'rails-ujs';
-import Turbolinks from 'turbolinks';
 import { initAll } from 'govuk-frontend';
 
-Rails.start();
-Turbolinks.start();
 initAll();

--- a/package.json
+++ b/package.json
@@ -5,10 +5,8 @@
   "dependencies": {
     "@rails/webpacker": "^5.2.1",
     "govuk-frontend": "^3.9.1",
-    "rails-ujs": "^5.2.4",
     "serialize-javascript": "^5.0.1",
-    "set-value": "^3.0.2",
-    "turbolinks": "^5.2.0"
+    "set-value": "^3.0.2"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6217,11 +6217,6 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
-rails-ujs@^5.2.4:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/rails-ujs/-/rails-ujs-5.2.4.tgz#31056ccd62d868f7d044395f31d77a4440550ceb"
-  integrity sha512-Mzu6bnTBKn4IuJvP7BDJRy4lzvR1zMWVDeTdPwDubXBfxpFEKqwOi5Nb6tfE2SYtTd+bb3PRETf40I94jgKw3w==
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -7422,11 +7417,6 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
-
-turbolinks@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
-  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
### Context
General consensus is that we don't want the turbolinks or rails-ujs libraries in this project. They don't fit very well with our aim of progressive enhancement, and the requirement to make everything work without JS.

### Changes proposed in this pull request
Remove turbolinks and rails-ujs, and everything that mentions them

### Guidance to review
Let me know if you think anything else needs stripping out

