### PR TITLE
Env var cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,6 @@ RUN apk -U upgrade && \
 # published as dfedigital/early-careers-framework-gems-node-modules
 FROM ${BASE_RUBY_IMAGE} AS early-careers-framework-gems-node-modules
 
-ENV RAILS_ENV=production \
-    AUTHORISED_HOSTS=127.0.0.1 \
-    SECRET_KEY_BASE=TestKey \
-    IGNORE_SECRETS_FOR_BUILD=1
-
 RUN apk -U upgrade && \
     apk add --update --no-cache nodejs yarn tzdata libpq libxml2 libxslt graphviz && \
     echo "Europe/London" > /etc/timezone && \
@@ -51,7 +46,11 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 FROM ${BASE_RUBY_IMAGE_WITH_GEMS_AND_NODE_MODULES} AS assets-precompile
 
 ENV GOVUK_APP_DOMAIN="http://localhost:3000" \
-    GOVUK_WEBSITE_ROOT="http://localhost:3000"
+    GOVUK_WEBSITE_ROOT="http://localhost:3000" \
+    RAILS_ENV=production \
+    AUTHORISED_HOSTS=127.0.0.1 \
+    SECRET_KEY_BASE=TestKey \
+    IGNORE_SECRETS_FOR_BUILD=1
 
 WORKDIR /app
 COPY . .
@@ -69,11 +68,7 @@ RUN yarn jest --passWithNoTests && \
 FROM ${BASE_RUBY_IMAGE} AS production
 
 ARG VERSION
-ENV RAILS_ENV=production \
-    GOVUK_NOTIFY_API_KEY=TestKey \
-    AUTHORISED_HOSTS=127.0.0.1 \
-    SECRET_KEY_BASE=TestKey \
-    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey \
+ENV AUTHORISED_HOSTS=127.0.0.1 \
     SHA=${VERSION}
 
 RUN apk -U upgrade && \

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ platform :mswin, :mingw, :x64_mingw do
 end
 
 gem "govspeak", git: "https://github.com/alphagov/govspeak.git"
-gem "govuk_publishing_components"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,6 @@ DEPENDENCIES
   foreman
   govspeak!
   govuk_design_system_formbuilder (~> 2.1)
-  govuk_publishing_components
   listen (>= 3.0.5, < 3.4)
   mail-notify
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
### Context
We were setting env vars in the production container that we shouldn't be. This meant the secret key base on the deployed app was "TestKey". I have verified this is no longer the case on the review app

### Changes proposed in this pull request
- clean up env vars
- clean up gemfile

### Guidance to review
Commit by commit here, details in commit messages
