### PR TITLE
Add youtube in govspeak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end
 
-gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "352199a2493818dd60c804d5201f0c69d15f6f92"
+gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "eaf8ce3"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/ecf-govspeak.git
-  revision: 352199a2493818dd60c804d5201f0c69d15f6f92
-  ref: 352199a2493818dd60c804d5201f0c69d15f6f92
+  revision: eaf8ce3a81e737a6393ee083c8d5b8ffad1f3f9e
+  ref: eaf8ce3
   specs:
     govspeak (6.5.10)
       actionview (>= 5.0, < 7)

--- a/app/controllers/govspeak_test_controller.rb
+++ b/app/controllers/govspeak_test_controller.rb
@@ -5,11 +5,12 @@ require "govspeak"
 class GovspeakTestController < ApplicationController
   def show
     @content = Govspeak::Document.new("").to_html
+    @preview_string = ""
   end
 
   def preview
-    preview_string = params[:preview_string]
-    @content = Govspeak::Document.new(preview_string).to_html
+    @preview_string = params[:preview_string]
+    @content = Govspeak::Document.new(@preview_string).to_html
     render :show
   end
 end

--- a/app/views/govspeak_test/show.html.erb
+++ b/app/views/govspeak_test/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Govspeak dev test</h1>
     <%= form_with url: '/govspeak_test', method: :post do |f| %>
-      <%= f.govuk_text_area :preview_string, label: { text: "Markdown string to preview" } %>
+      <%= f.govuk_text_area :preview_string, label: { text: "Markdown string to preview" }, rows: 10, value: @preview_string %>
       <%= f.govuk_submit "See preview" %>
     <% end %>
     <%= @content.html_safe %>


### PR DESCRIPTION
### Context
One more component added to our version of govspeak, one more version bump.

### Changes proposed in this pull request
Bump the govspeak version. If you are interested what it's doing you can check out https://github.com/DFE-Digital/ecf-govspeak (last commit). 

Also add some much needed changes - more rows on the text area and remembering entered value on govspeak test page.

### Guidance to review
```
$YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo
```
should produce an embedded video on the govspeak test page of our review app. 

