### PR TITLE
Govuk styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,21 +7,5 @@
 @import "govuk_publishing_components/components/textarea";
 
 @import "./govspeak/highlights";
-
-// Proof of concept that our styling takes priority
-.gem-c-govspeak {
-  table {
-    td,
-    th {
-      padding: 10px 20px;
-    }
-    td:last-child {
-      padding-right: 0;
-    }
-  }
-  .call-to-action {
-    background-color: #fff;
-    border-style: dashed;
-    border-radius: 9px;
-  }
-}
+@import "./govspeak/call-to-action";
+@import "./govspeak/tables";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,8 @@
 @import 'govuk_publishing_components/components/govspeak';
 @import 'govuk_publishing_components/components/textarea';
 
+@import './govspeak/highlights';
+
 // Proof of concept that our styling takes priority
 .gem-c-govspeak {
   table {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,12 +1,12 @@
-@import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
-@import 'govuk_publishing_components/components/button';
-@import 'govuk_publishing_components/components/file-upload';
-@import 'govuk_publishing_components/components/layout-header';
-@import 'govuk_publishing_components/components/govspeak';
-@import 'govuk_publishing_components/components/textarea';
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/file-upload";
+@import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/textarea";
 
-@import './govspeak/highlights';
+@import "./govspeak/highlights";
 
 // Proof of concept that our styling takes priority
 .gem-c-govspeak {
@@ -18,5 +18,10 @@
     td:last-child {
       padding-right: 0;
     }
+  }
+  .call-to-action {
+    background-color: #fff;
+    border-style: dashed;
+    border-radius: 9px;
   }
 }

--- a/app/assets/stylesheets/govspeak/_call-to-action.scss
+++ b/app/assets/stylesheets/govspeak/_call-to-action.scss
@@ -1,0 +1,6 @@
+.gem-c-govspeak {
+  .call-to-action {
+    border-style: dashed;
+    border-radius: 9px;
+  }
+}

--- a/app/assets/stylesheets/govspeak/_highlights.scss
+++ b/app/assets/stylesheets/govspeak/_highlights.scss
@@ -1,0 +1,7 @@
+.information,
+.call-to-action {
+  border-radius: 9px;
+  background-color: #dbdce1;
+  padding: 40px;
+  margin: 50px;
+}

--- a/app/assets/stylesheets/govspeak/_highlights.scss
+++ b/app/assets/stylesheets/govspeak/_highlights.scss
@@ -1,7 +1,6 @@
-.information,
-.call-to-action {
+.information {
+  border-style: solid;
   border-radius: 9px;
-  background-color: #dbdce1;
   padding: 40px;
   margin: 50px;
 }

--- a/app/assets/stylesheets/govspeak/_highlights.scss
+++ b/app/assets/stylesheets/govspeak/_highlights.scss
@@ -1,6 +1,8 @@
-.information {
-  border-style: solid;
-  border-radius: 9px;
-  padding: 40px;
-  margin: 50px;
+.gem-c-govspeak {
+  .information {
+    border-style: solid;
+    border-radius: 9px;
+    padding: 40px;
+    margin: 50px;
+  }
 }

--- a/app/assets/stylesheets/govspeak/_tables.scss
+++ b/app/assets/stylesheets/govspeak/_tables.scss
@@ -1,0 +1,11 @@
+.gem-c-govspeak {
+  table {
+    td,
+    th {
+      padding: 10px 20px;
+    }
+    td:last-child {
+      padding-right: 0;
+    }
+  }
+}


### PR DESCRIPTION
### Context
Highlights in the govspeak need some additional styling. Speaking with Mark A he said that highlight sections should be kept black and white for govifying. 

### Changes proposed in this pull request
Styling of .call-to-action and information classes so that they resemble what is published on govuk. 

### Guidance to review
Having the .call-to-action change in the _highlights file didn't work and the govuk_publishing_components seemed to overwrite changes in there. I Moved them to the application.scss and it worked. 

