### PR TITLE
School search page

### DIFF
--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "govspeak"
-
 class SchoolSearchController < ApplicationController
   def show
     @search_schools_form = SchoolSearchForm.new(*form_params_show)

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "govspeak"
+
+class SchoolSearchController < ApplicationController
+  def show
+    @search_schools_form = SearchSchoolsForm.new(*form_params_show)
+    @schools = @search_schools_form.find_schools
+  end
+
+  def create
+    redirect_to school_search_path(*form_params_post)
+  end
+
+private
+
+  def form_params_show
+    params.permit(*search_schools_params)
+  end
+
+  def form_params_post
+    params.require(:search_schools_form).permit(*search_schools_params)
+  end
+
+  def search_schools_params
+    [
+      :school_name,
+      :location,
+      :search_distance,
+      :search_distance_unit,
+      characteristics: [],
+      partnership: [],
+    ]
+  end
+end

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -2,8 +2,8 @@
 
 class SchoolSearchController < ApplicationController
   def show
-    @search_schools_form = SchoolSearchForm.new(*form_params_show)
-    @schools = @search_schools_form.find_schools
+    @school_search_form = SchoolSearchForm.new(*form_params_show)
+    @schools = @school_search_form.find_schools
   end
 
   def create
@@ -13,14 +13,14 @@ class SchoolSearchController < ApplicationController
 private
 
   def form_params_show
-    params.permit(*search_schools_params)
+    params.permit(*school_search_params)
   end
 
   def form_params_post
-    params.require(:search_schools_form).permit(*search_schools_params)
+    params.require(:school_search_form).permit(*school_search_params)
   end
 
-  def search_schools_params
+  def school_search_params
     [
       :school_name,
       :location,

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -4,7 +4,7 @@ require "govspeak"
 
 class SchoolSearchController < ApplicationController
   def show
-    @search_schools_form = SearchSchoolsForm.new(*form_params_show)
+    @search_schools_form = SchoolSearchForm.new(*form_params_show)
     @schools = @search_schools_form.find_schools
   end
 

--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class SearchSchoolsForm
+class SchoolSearchForm
   include ActiveModel::Model
 
   attr_accessor :school_name, :location, :search_distance, :search_distance_unit, :characteristics, :partnership
 
   def find_schools
-    School.where("lower(name) like ?", "%#{school_name.downcase}%").includes(:network)
+    School.where("lower(name) like ?", "%#{(school_name || '').downcase}%").includes(:network)
   end
 end

--- a/app/forms/search_schools_form.rb
+++ b/app/forms/search_schools_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SearchSchoolsForm
+  include ActiveModel::Model
+
+  attr_accessor :school_name, :location, :search_distance, :search_distance_unit, :characteristics, :partnership
+
+  def find_schools
+    School.where("lower(name) like ?", "%#{school_name.downcase}%").includes(:network)
+  end
+end

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -1,0 +1,91 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-xl">Find schools</h1>
+    <p>Use our search and filters to find schools you want to recruit.</p>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <div style="width: 100%; height: 100%; background-color: #dee0e2; padding: 8px;">
+      <%= form_with model: @search_schools_form, url: school_search_path, method: :post do |f| %>
+        <h2 class="govuk-heading-m">Filter Schools</h2>
+
+        <%= f.govuk_submit "Apply filters", classes: "govuk-button govuk-!-margin-bottom-0" %>
+        <p><a href="?" id="clear-filters">Clear filters</a></p>
+
+        <%= f.govuk_text_field(
+              :school_name,
+              value: @search_schools_form.school_name,
+              label: {text: "School name or group", class: "govuk-label govuk-label--s"}) %>
+
+        <%= f.govuk_text_field(
+              :location,
+              label: {text: "Location", class: "govuk-label govuk-label--s"},
+              hint: {text: "Enter a postcode, town or region"}) %>
+
+        <%= f.govuk_fieldset legend: {text: 'Search distance', class: "govuk-hint"} do %>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <%= f.govuk_collection_select(
+                    :search_distance,
+                    [OpenStruct.new(value: 50), OpenStruct.new(value: 20)],
+                    :value,
+                    :value,
+                    label: {text: "Number of units", hidden: true},
+                    html_options: {style: "width: 100%;"}) %>
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <%= f.govuk_collection_select(
+                    :search_distance_unit,
+                    [OpenStruct.new(id: 1, name: 'miles')],
+                    :id,
+                    :name,
+                    label: {text: "Type of units", hidden: true},
+                    html_options: {style: "width: 100%;"}) %>
+            </div>
+          </div>
+        <% end %>
+
+        <%= f.govuk_collection_check_boxes(
+              :characteristics,
+              [OpenStruct.new(id: :pupil_premium_above_40, name: 'Pupil premium above 40%'),
+               OpenStruct.new(id: :top_20_remote_areas, name: 'Located in top 20% most remote areas')],
+              :id,
+              :name,
+              legend: {text: "Characteristic", class: "govuk-fieldset__legend govuk-fieldset__legend--s"}) %>
+
+        <%= f.govuk_collection_check_boxes(
+              :partnership,
+              [OpenStruct.new(
+                id: :partnered_with_another_provider, name: 'Show schools partnered with another provider')],
+              :id,
+              :name,
+              legend: {text: "Partnership Status", class: "govuk-fieldset__legend govuk-fieldset__legend--s"}) %>
+      <% end %>
+    </div>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <div id="school-results">
+      <% @schools.each do |school| %>
+        <div class="card">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-half">
+              <h3 class="govuk-heading-m"><%= school.name %></h3>
+            </div>
+            <div class="govuk-grid-column-one-half">
+              <!-- TODO: if school is linked to other provider than current one, show a tag here -->
+            </div>
+          </div>
+          <p><%= school.full_address %></p>
+          <p>URN: <%= school.urn %></p>
+          <% if school.network %>
+            <p>School group: <%= school.network.name %></p>
+          <% end %>
+          <p>Phase/Type: <%= school.school_type %></p>
+          <!-- TODO: Add school url -->
+          <hr>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :before_content, govuk_back_link(text: 'Back to dashboard', href: supplier_dashboard_path) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl">Find schools</h1>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -8,15 +8,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <div style="width: 100%; height: 100%; background-color: #dee0e2; padding: 8px;">
-      <%= form_with model: @search_schools_form, url: school_search_path, method: :post do |f| %>
+      <%= form_with model: @school_search_form, url: school_search_path, method: :post do |f| %>
         <h2 class="govuk-heading-m">Filter Schools</h2>
 
         <%= f.govuk_submit "Apply filters", classes: "govuk-button govuk-!-margin-bottom-0" %>
-        <p><a href="?" id="clear-filters">Clear filters</a></p>
+        <p>
+          <%= govuk_link_to "Clear filters", "?" %>
+        </p>
 
         <%= f.govuk_text_field(
               :school_name,
-              value: @search_schools_form.school_name,
+              value: @school_search_form.school_name,
               label: {text: "School name or group", class: "govuk-label govuk-label--s"}) %>
 
         <%= f.govuk_text_field(

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -10,3 +10,4 @@ $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
+@import "school_search";

--- a/app/webpacker/styles/school_search.scss
+++ b/app/webpacker/styles/school_search.scss
@@ -1,0 +1,23 @@
+.govuk-checkboxes__label:before {
+  background: white;
+}
+
+.govuk-phase-banner__content__tag {
+  background-color: #6f777b;
+}
+
+.card {
+  margin-top: 8px;
+}
+
+.card p {
+  margin: 0;
+}
+
+.card h3 {
+  margin-bottom: 4px;
+}
+
+.tag-right {
+  float: right;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,5 +40,7 @@ Rails.application.routes.draw do
     post "/govspeak_test", to: "govspeak_test#preview"
   end
 
+  resource :school_search, only: %i[show create], path: "school-search", controller: :school_search
+
   root to: "pages#home"
 end

--- a/spec/forms/school_search_form_spec.rb
+++ b/spec/forms/school_search_form_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
+  describe "find_schools" do
+    let!(:schools) do
+      [create(:school, name: "Test school one"),
+       create(:school, name: "Amazing school"),
+       create(:school, name: "Academy")]
+    end
+
+    it "finds schools that include lowercase part of name" do
+      form = SchoolSearchForm.new(school_name: "test")
+      schools = form.find_schools
+      expect(schools.count).to eq(1)
+      expect(schools.first.name).to eq("Test school one")
+    end
+
+    it "finds all schools with empty query" do
+      form = SchoolSearchForm.new(school_name: "")
+      schools = form.find_schools
+      expect(schools.count).to eq(3)
+    end
+  end
+end

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Search schools", type: :request do
   end
 
   it "redirects to the school search page with appropriate query params when given a post request" do
-    post "/school-search", params: { search_schools_form: { school_name: "" } }
+    post "/school-search", params: { school_search_form: { school_name: "" } }
     expect(response).to redirect_to(school_search_path(school_name: ""))
   end
 end

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Search schools", type: :request do
+  it "renders the school search page" do
+    get "/school-search"
+    expect(response).to render_template(:show)
+  end
+
+  it "redirects to the school search page with appropriate query params when given a post request" do
+    post "/school-search", params: { search_schools_form: { school_name: "" } }
+    expect(response).to redirect_to(school_search_path(school_name: ""))
+  end
+end


### PR DESCRIPTION
### Context
We would like to have a page on which suppliers can search for schools with a bunch of filters.

### Changes proposed in this pull request
Mostly frontend, vast majority of the things we want to search by are in GIAS, so coming up with architecture around the search is probably best done when we have some dummy data from them.

I went for 'show searches for schools based on query params of the url' and 'post redirects to show with correct parameters' - that seemed to result in nicest url that can be copy-pasted or bookmarked. `get` form was a close second in that. 

### Guidance to review
Review app is probably a good place to play around with the search form. 

I used https://ecf-beta-prototype.herokuapp.com/school-search as inspiration. 
