### PR TITLE
School search pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby File.read(".ruby-version").chomp
 gem "rails", "~> 6.1.0"
 
 gem "devise", ">= 4.7.3"
+gem "kaminari", ">= 1.2.0"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"
@@ -41,7 +42,6 @@ gem "tzinfo-data"
 
 gem "govuk-components", ">= 1.0.0"
 gem "govuk_design_system_formbuilder", "~> 2.1", ">= 2.1.5"
-
 gem "govuk_publishing_components", ">= 23.11.0"
 gem "sass-rails", ">= 6.0.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,18 @@ GEM
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     jwt (2.2.2)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kgio (2.11.3)
     kramdown (2.3.0)
       rexml
@@ -402,6 +414,7 @@ DEPENDENCIES
   govuk-components (>= 1.0.0)
   govuk_design_system_formbuilder (~> 2.1, >= 2.1.5)
   govuk_publishing_components (>= 23.11.0)
+  kaminari (>= 1.2.0)
   listen (>= 3.0.5, < 3.4)
   mail-notify (>= 1.0.3)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_current_user
 
   def check
     render json: { status: "OK", version: ENV["SHA"], environment: Rails.env }, status: :ok
@@ -13,5 +14,9 @@ protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[email first_name last_name])
+  end
+
+  def set_current_user
+    @current_user = current_user
   end
 end

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SchoolSearchController < ApplicationController
+  before_action :authenticate_user!, :set_lead_provider
+
   def show
     @school_search_form = SchoolSearchForm.new(*form_params_show)
     @schools = @school_search_form.find_schools(params[:page])
@@ -29,5 +31,9 @@ private
       characteristics: [],
       partnership: [],
     ]
+  end
+
+  def set_lead_provider
+    @lead_provider = @current_user&.lead_provider
   end
 end

--- a/app/controllers/school_search_controller.rb
+++ b/app/controllers/school_search_controller.rb
@@ -3,7 +3,7 @@
 class SchoolSearchController < ApplicationController
   def show
     @school_search_form = SchoolSearchForm.new(*form_params_show)
-    @schools = @school_search_form.find_schools
+    @schools = @school_search_form.find_schools(params[:page])
   end
 
   def create

--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -5,7 +5,7 @@ class SchoolSearchForm
 
   attr_accessor :school_name, :location, :search_distance, :search_distance_unit, :characteristics, :partnership
 
-  def find_schools
-    School.where("lower(name) like ?", "%#{(school_name || '').downcase}%").includes(:network)
+  def find_schools(page)
+    School.where("lower(name) like ?", "%#{(school_name || '').downcase}%").includes(:network).page(page)
   end
 end

--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -6,6 +6,10 @@ class SchoolSearchForm
   attr_accessor :school_name, :location, :search_distance, :search_distance_unit, :characteristics, :partnership
 
   def find_schools(page)
-    School.where("lower(name) like ?", "%#{(school_name || '').downcase}%").includes(:network).page(page)
+    School.where(
+      "lower(name) like ?", "%#{(school_name || '').downcase}%"
+    ).includes(
+      :network, :lead_provider
+    ).page(page)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class School < ApplicationRecord
+  paginates_per 2
   belongs_to :network, optional: true
   has_one :partnership
   has_one :lead_provider, through: :partnership

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class School < ApplicationRecord
-  paginates_per 2
+  paginates_per 3
   belongs_to :network, optional: true
   has_one :partnership
   has_one :lead_provider, through: :partnership

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -2,5 +2,8 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">User dashboard</h1>
     <p class="govuk-body"> You are logged in</p>
+    <% if @current_user.lead_provider_profile %>
+      <%= govuk_link_to "Go to school search", school_search_path %>
+    <% end %>
   </div>
 </div>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -69,6 +69,9 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div id="school-results">
+      <% if @schools.count == 0 %>
+        <h2 class="govuk-heading-m">No schools matching filters found!</h2>
+      <% end %>
       <% @schools.each do |school| %>
         <div class="card">
           <div class="govuk-grid-row">

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -92,6 +92,7 @@
           <hr>
         </div>
       <% end %>
+      <%= paginate @schools %>
     </div>
   </div>
 </div>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -79,7 +79,11 @@
               <h3 class="govuk-heading-m"><%= school.name %></h3>
             </div>
             <div class="govuk-grid-column-one-half">
-              <!-- TODO: if school is linked to other provider than current one, show a tag here -->
+              <% if @lead_provider && school.lead_provider && (school.lead_provider != @lead_provider) %>
+                <strong class="govuk-tag tag-right">
+                  Other provider
+                </strong>
+              <% end %>
             </div>
           </div>
           <p><%= school.full_address %></p>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -69,9 +69,7 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div id="school-results">
-      <% if @schools.count == 0 %>
-        <h2 class="govuk-heading-m">No schools matching filters found!</h2>
-      <% end %>
+      <h2 class="govuk-heading-m"><%= @schools.count %> results found</h2>
       <% @schools.each do |school| %>
         <div class="card">
           <div class="govuk-grid-row">

--- a/app/webpacker/styles/school_search.scss
+++ b/app/webpacker/styles/school_search.scss
@@ -1,9 +1,5 @@
 .govuk-checkboxes__label:before {
-  background: white;
-}
-
-.govuk-phase-banner__content__tag {
-  background-color: #6f777b;
+  background: govuk-colour("white");
 }
 
 .card {

--- a/spec/forms/school_search_form_spec.rb
+++ b/spec/forms/school_search_form_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
 
     it "finds schools that include lowercase part of name" do
       form = SchoolSearchForm.new(school_name: "test")
-      schools = form.find_schools
+      schools = form.find_schools(1)
       expect(schools.count).to eq(1)
       expect(schools.first.name).to eq("Test school one")
     end
 
     it "finds all schools with empty query" do
       form = SchoolSearchForm.new(school_name: "")
-      schools = form.find_schools
+      schools = form.find_schools(1)
       expect(schools.count).to eq(3)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,3 +73,7 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+end

--- a/spec/requests/school_search_spec.rb
+++ b/spec/requests/school_search_spec.rb
@@ -3,13 +3,23 @@
 require "rails_helper"
 
 RSpec.describe "Search schools", type: :request do
+  let(:lead_provider) { FactoryBot.create(:lead_provider) }
+  let(:lead_provider_user) { FactoryBot.create(:lead_provider_profile, lead_provider: lead_provider).user }
+
   it "renders the school search page" do
+    sign_in lead_provider_user
     get "/school-search"
     expect(response).to render_template(:show)
   end
 
   it "redirects to the school search page with appropriate query params when given a post request" do
+    sign_in lead_provider_user
     post "/school-search", params: { school_search_form: { school_name: "" } }
     expect(response).to redirect_to(school_search_path(school_name: ""))
+  end
+
+  it "redirects to log in when user is not logged in" do
+    get "/school-search"
+    expect(response).to redirect_to(new_user_session_path)
   end
 end


### PR DESCRIPTION
### Context
We expect thousands of schools in our system, and on some queries we will display a lot of them. Paginating seems a must.

### Changes proposed in this pull request
Add [kaminari](https://github.com/kaminari/kaminari) - a gem that does pagination for us.

Add pagination to school search.

Add empty school search state, link to school search from dashboard if user is a lead provider admin, show the blue tag if the school is already partnered with someone else. Do we need a green tag for when it is partnered with us?

### Guidance to review
I added `paginates_per` attribute to show off pagination in test app with 4 schools, happy to get rid of it (and maybe add a bunch more schools to the seed file if we want it). 

Tests to follow. 
