### PR TITLE
Fix lead provider profile ID

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "pundit"
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"
 
+# Use UUIDs as db primary key by default
+gem "ar-uuid", "~> 0.2.1"
+
 # Use Puma as the app server
 gem "puma", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ar-uuid (0.2.1)
+      activerecord
     ast (2.4.1)
     bcrypt (3.1.16)
     bindex (0.8.1)
@@ -405,6 +407,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ar-uuid (~> 0.2.1)
   bootsnap (>= 1.1.0)
   byebug
   canonical-rails (>= 0.2.10)

--- a/db/migrate/20210113155153_change_lead_provider_profiles_id_to_uuid.rb
+++ b/db/migrate/20210113155153_change_lead_provider_profiles_id_to_uuid.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# rubocop:disable all
+class ChangeLeadProviderProfilesIdToUuid < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :lead_provider_profiles, :id
+    add_column :lead_provider_profiles, :id, :uuid, null: false, default: -> { "gen_random_uuid()" }
+    execute "ALTER TABLE lead_provider_profiles ADD PRIMARY KEY (id);"
+  end
+end
+# rubocop:enable all

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_094059) do
+ActiveRecord::Schema.define(version: 2021_01_13_155153) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2021_01_07_094059) do
     t.index ["school_id"], name: "index_icp_schools_on_schools"
   end
 
-  create_table "lead_provider_profiles", force: :cascade do |t|
+  create_table "lead_provider_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.uuid "lead_provider_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
I left the primary key for this table as an integer by mistake. This is a migration to fix that.

I have also added [a gem](https://rubygems.org/gems/ar-uuid/versions/0.2.1) which changes the PK to be UUID by default, so this doesn't happen again