### PR TITLE
update ecf-govspeak version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end
 
-gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "1b56c44"
+gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "114c888"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end
 
-gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "5258996"
+gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "1b56c44"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/ecf-govspeak.git
-  revision: 525899621ee1f11e6fa7c5a28299757f6cbd91c7
-  ref: 5258996
+  revision: 1b56c4401ee67d968567a7ca92975b9afefd0c3e
+  ref: 1b56c44
   specs:
     govspeak (6.5.10)
       actionview (>= 5.0, < 7)
@@ -317,7 +317,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
-    sanitize (5.2.2)
+    sanitize (5.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/ecf-govspeak.git
-  revision: 1b56c4401ee67d968567a7ca92975b9afefd0c3e
-  ref: 1b56c44
+  revision: 114c88830b6641a24687d78fa52cd020def2c69a
+  ref: 114c888
   specs:
     govspeak (6.5.10)
       actionview (>= 5.0, < 7)


### PR DESCRIPTION
### Context
Figures have been added to the latest ECF-govspeak.

### Changes proposed in this pull request
Bumping the ECF-govspeak version so that images will now be rendered in the app.

### Guidance to review

the below should output as shown in the picture
```
$Figure
$Alt Example of the part-whole model using the number 28. The number 20 has already been added to the lower left field, the lower right field is blank ready to be filled in. 
$EndAlt 
$URL https://www.early-career-framework.education.gov.uk/teachfirst/wp-content/uploads/sites/4/2020/08/Part-whole-model.jpg 
$EndURL 
$Caption Figure 1: Part-whole model. 
$EndCaption
$EndFigure
```

<img width="956" alt="Screenshot 2021-01-14 at 11 39 03" src="https://user-images.githubusercontent.com/69353998/104586301-35d48700-565d-11eb-9318-f85b216dbb6c.png">



