### PR TITLE
Bump govspeak version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end
 
-gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "114c888"
+gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "e7637cd"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/ecf-govspeak.git
-  revision: 114c88830b6641a24687d78fa52cd020def2c69a
-  ref: 114c888
+  revision: e7637cd2f6d0f1338b4e92e868bf7d9fe8cbf796
+  ref: e7637cd
   specs:
-    govspeak (6.5.10)
+    govspeak (6.6.0)
       actionview (>= 5.0, < 7)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (>= 23)


### PR DESCRIPTION
I rebased our govspeak master on top of alphagov govspeak master - they added some useful things. And that got rid of commit we were pointing at in our Rails app. So any new PR will fail horribly when trying to bundle install it. oops.

Might make a new branch next time that happens, or a tag, to prevent that happening again.

