### PR TITLE
Improve styling for quotes and accordions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end
 
-gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "e7637cd"
+gem "govspeak", git: "https://github.com/DFE-Digital/ecf-govspeak.git", ref: "b1922aa"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DFE-Digital/ecf-govspeak.git
-  revision: e7637cd2f6d0f1338b4e92e868bf7d9fe8cbf796
-  ref: e7637cd
+  revision: b1922aa10ebc001121c9a296daa01a663726bf22
+  ref: b1922aa
   specs:
     govspeak (6.6.0)
       actionview (>= 5.0, < 7)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,8 @@
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/textarea";
 
-@import "./govspeak/highlights";
+@import "./govspeak/accordion";
 @import "./govspeak/call-to-action";
+@import "./govspeak/highlights";
+@import "./govspeak/quote";
 @import "./govspeak/tables";

--- a/app/assets/stylesheets/govspeak/_accordion.scss
+++ b/app/assets/stylesheets/govspeak/_accordion.scss
@@ -1,0 +1,7 @@
+.gem-c-govspeak {
+  div.govuk-accordion__section-content {
+    a {
+      display: block;
+    }
+  }
+}

--- a/app/assets/stylesheets/govspeak/_quote.scss
+++ b/app/assets/stylesheets/govspeak/_quote.scss
@@ -1,0 +1,16 @@
+.gem-c-govspeak blockquote {
+  p:before {
+    margin-left: 0;
+  }
+  p:after {
+    content: "";
+  }
+  p:last-child:after {
+    content: "";
+  }
+  p {
+    border-left: 10px solid #b1b4b6;
+    padding: 15px;
+    clear: both;
+  }
+}

--- a/app/controllers/govspeak_test_controller.rb
+++ b/app/controllers/govspeak_test_controller.rb
@@ -10,7 +10,7 @@ class GovspeakTestController < ApplicationController
 
   def preview
     @preview_string = params[:preview_string]
-    @content = Govspeak::Document.new(@preview_string).to_html
+    @content = Govspeak::Document.new(@preview_string, options: { allow_extra_quotes: true }).to_html
     render :show
   end
 end


### PR DESCRIPTION
### Context
Quotes didn't look great, and to make it worse, they were eating up some quotes from the beginning of the in-quote statement. So I decided to fix it. 

### Changes proposed in this pull request
Old:
![image](https://user-images.githubusercontent.com/42969249/104896870-9a4e5980-596f-11eb-9d21-327bcac260fa.png)

New:
![image](https://user-images.githubusercontent.com/42969249/104896809-8571c600-596f-11eb-8876-0b1b29568c50.png)

Also, links in accordions were inline, decided to change it.
Old:
![image](https://user-images.githubusercontent.com/42969249/104897344-2c566200-5970-11eb-921b-5c23c25c1178.png)

New:
![image](https://user-images.githubusercontent.com/42969249/104897395-3aa47e00-5970-11eb-8a32-25edf57c1770.png)

### Guidance to review
I used the following for the links:

```
$Accordion
$Heading
Behaviour
$EndHeading
$Summary

$EndSummary
$Content

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/1-strand-fundamentals-and-contracting/">
  B1. Strand fundamentals and contracting
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/2-routines/">
  B2. Routines
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/3-instructions/">
  B3. Instructions
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/4-directing-attention/">
  B4. Directing attention
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/5-low-level-disruption/">
  B5. Low-level disruption
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/6-consistency/">
  B6. Consistency
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/7-positive-learning-environment/">
  B7. Positive learning environment
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/8-structured-support-of-learning/">
  B8. Structured support of learning
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/9-challenge/">
  B9. Challenge
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/10-independent-practice/">
  B10. Independent practice
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/11-pairs-and-groups/">
  B11. Pairs and groups
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/12-upholding-high-expectations/">
  B12. Upholding high expectations
</a>
$EndContent $Heading Instruction $EndHeading $Summary

$EndSummary
$Content

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/1-strand-fundamentals-and-re-contracting/">
  I1. Strand fundamentals and re-contracting
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/2-identifying-learning-content/">
  I2. Identifying learning content
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/3-instruction-for-memory/">
  I3. Instruction for memory
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/4-prior-knowledge/">
  I4. Prior knowledge
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/5-teacher-exposition/">
  I5. Teacher exposition
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/6-adapting-teaching/">
  I6. Adapting teaching
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/7-practice-challenge-and-success/">
  I7. Practice, challenge and success
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/8-explicit-learning/">
  I8. Explicit learning
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/9-scaffolding/">
  I9. Scaffolding
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/10-questioning/">
  I10. Questioning
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/2-instruction/11-classroom-talk/">
  I11. Classroom talk
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/12-instruction/feedback/">
  I12. Feedback
</a>
$EndContent $Heading Subject $EndHeading $Summary

$EndSummary
$Content

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/1-strand-fundamentals-and-re-contracting/">
  S1. Strand fundamentals and re-contracting
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/2-planning-backwards-from-learning-goals/">
  S2. Planning backwards from learning goals
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/3-types-of-knowledge/">
  S3. Types of knowledge
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/4-gaps-and-misconceptions/">
  S4. Gaps and misconceptions
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/5-acquisition-before-application/">
  S5. Acquisition before application
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/6-promoting-deep-learning/">
  S6. Promoting deep learning
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/7-developing-pupils-literacy/">
  S7. Developing pupils’ literacy
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/8-sharing-academic-expectations/">
  S8. Sharing academic expectations
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/9-assessing-for-formative-purposes/">
  S9. Assessing for formative purposes
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/10-examining-pupils-responses/">
  S10. Examining pupils’ responses
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3-subject/11-adapting-lessons-to-meet-pupils-needs/">
  S11. Adapting lessons to meet pupils needs
</a>

<a href="http://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/3.subject/feedback/">
  S12. Feedback
</a>
$EndContent $EndAccordion
```