### PR TITLE
ECF-EL-73 add CIP structure

### DIFF
--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CourseLesson < ApplicationRecord
+  belongs_to :course_module
+  has_one :next_lesson, class_name: "CourseLesson"
+  has_one :previous_lesson, class_name: "CourseLesson"
+
+  validates :title, presence: { message: "Enter a title" }
+  validates :content, presence: { message: "Enter content" }
+end

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -2,8 +2,8 @@
 
 class CourseLesson < ApplicationRecord
   belongs_to :course_module
-  has_one :next_lesson, class_name: "CourseLesson"
-  has_one :previous_lesson, class_name: "CourseLesson"
+  has_one :next_lesson, class_name: "CourseLesson", foreign_key: :next_lesson_id
+  belongs_to :previous_lesson, class_name: "CourseLesson", inverse_of: :next_lesson, optional: true
 
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CourseModule < ApplicationRecord
+  belongs_to :course_year
+  has_one :next_module, class_name: "CourseModule"
+  has_one :previous_module, class_name: "CourseModule"
+  has_many :course_lessons
+
+  validates :title, presence: { message: "Enter a title" }
+  validates :content, presence: { message: "Enter content" }
+end

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -2,8 +2,8 @@
 
 class CourseModule < ApplicationRecord
   belongs_to :course_year
-  has_one :next_module, class_name: "CourseModule"
-  has_one :previous_module, class_name: "CourseModule"
+  has_one :next_module, class_name: "CourseModule", foreign_key: :next_module_id
+  belongs_to :previous_module, class_name: "CourseModule", inverse_of: :next_module, optional: true
   has_many :course_lessons
 
   validates :title, presence: { message: "Enter a title" }

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CourseYear < ApplicationRecord
+  belongs_to :lead_provider
+  has_many :course_modules
+
+  validates :title, presence: { message: "Enter a title" }
+  validates :content, presence: { message: "Enter content" }
+end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -5,6 +5,7 @@ class LeadProvider < ApplicationRecord
   has_many :schools, through: :partnerships
   has_many :lead_provider_profiles
   has_many :users, through: :lead_provider_profiles
+  has_many :course_years
 
   validates :name, presence: { message: "Enter a name" }
 end

--- a/db/migrate/20210118102533_add_cip_content.rb
+++ b/db/migrate/20210118102533_add_cip_content.rb
@@ -6,7 +6,7 @@ class AddCipContent < ActiveRecord::Migration[6.1]
       t.timestamps
       t.column :is_year_one, :boolean, null: false
       t.column :title, :string, null: false
-      t.column :content, :string, null: false
+      t.column :content, :text, null: false, limit: 200_000
 
       t.references :lead_provider, null: false, foreign_key: true, type: :uuid
     end
@@ -14,9 +14,9 @@ class AddCipContent < ActiveRecord::Migration[6.1]
     create_table :course_modules, id: :uuid do |t|
       t.timestamps
       t.column :title, :string, null: false
-      t.column :content, :string, null: false
+      t.column :content, :text, null: false, limit: 200_000
 
-      t.references :course_modules, null: true, foreign_key: { to_table: :course_modules }, type: :uuid
+      t.references :next_module, null: true, foreign_key: { to_table: :course_modules }, type: :uuid
       t.references :previous_module, null: true, foreign_key: { to_table: :course_modules }, type: :uuid
       t.references :course_year, null: false, foreign_key: true, type: :uuid
     end
@@ -24,7 +24,7 @@ class AddCipContent < ActiveRecord::Migration[6.1]
     create_table :course_lessons, id: :uuid do |t|
       t.timestamps
       t.column :title, :string, null: false
-      t.column :content, :string, null: false
+      t.column :content, :text, null: false, limit: 200_000
 
       t.references :next_lesson, null: true, foreign_key: { to_table: :course_lessons }, type: :uuid
       t.references :previous_lesson, null: true, foreign_key: { to_table: :course_lessons }, type: :uuid

--- a/db/migrate/20210118102533_add_cip_content.rb
+++ b/db/migrate/20210118102533_add_cip_content.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AddCipContent < ActiveRecord::Migration[6.1]
+  def change
+    create_table :course_years, id: :uuid do |t|
+      t.timestamps
+      t.column :is_year_one, :boolean, null: false
+      t.column :title, :string, null: false
+      t.column :content, :string, null: false
+
+      t.references :lead_provider, null: false, foreign_key: true, type: :uuid
+    end
+
+    create_table :course_modules, id: :uuid do |t|
+      t.timestamps
+      t.column :title, :string, null: false
+      t.column :content, :string, null: false
+
+      t.references :course_modules, null: true, foreign_key: { to_table: :course_modules }, type: :uuid
+      t.references :previous_module, null: true, foreign_key: { to_table: :course_modules }, type: :uuid
+      t.references :course_year, null: false, foreign_key: true, type: :uuid
+    end
+
+    create_table :course_lessons, id: :uuid do |t|
+      t.timestamps
+      t.column :title, :string, null: false
+      t.column :content, :string, null: false
+
+      t.references :next_lesson, null: true, foreign_key: { to_table: :course_lessons }, type: :uuid
+      t.references :previous_lesson, null: true, foreign_key: { to_table: :course_lessons }, type: :uuid
+      t.references :course_module, null: false, foreign_key: true, type: :uuid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_155153) do
+ActiveRecord::Schema.define(version: 2021_01_18_102533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -21,6 +21,42 @@ ActiveRecord::Schema.define(version: 2021_01_13_155153) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_admin_profiles_on_user_id"
+  end
+
+  create_table "course_lessons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "title", null: false
+    t.string "content", null: false
+    t.uuid "next_lesson_id"
+    t.uuid "previous_lesson_id"
+    t.uuid "course_module_id", null: false
+    t.index ["course_module_id"], name: "index_course_lessons_on_course_module_id"
+    t.index ["next_lesson_id"], name: "index_course_lessons_on_next_lesson_id"
+    t.index ["previous_lesson_id"], name: "index_course_lessons_on_previous_lesson_id"
+  end
+
+  create_table "course_modules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "title", null: false
+    t.string "content", null: false
+    t.uuid "course_modules_id"
+    t.uuid "previous_module_id"
+    t.uuid "course_year_id", null: false
+    t.index ["course_modules_id"], name: "index_course_modules_on_course_modules_id"
+    t.index ["course_year_id"], name: "index_course_modules_on_course_year_id"
+    t.index ["previous_module_id"], name: "index_course_modules_on_previous_module_id"
+  end
+
+  create_table "course_years", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_year_one", null: false
+    t.string "title", null: false
+    t.string "content", null: false
+    t.uuid "lead_provider_id", null: false
+    t.index ["lead_provider_id"], name: "index_course_years_on_lead_provider_id"
   end
 
   create_table "induction_coordinator_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -117,6 +153,13 @@ ActiveRecord::Schema.define(version: 2021_01_13_155153) do
   end
 
   add_foreign_key "admin_profiles", "users"
+  add_foreign_key "course_lessons", "course_lessons", column: "next_lesson_id"
+  add_foreign_key "course_lessons", "course_lessons", column: "previous_lesson_id"
+  add_foreign_key "course_lessons", "course_modules"
+  add_foreign_key "course_modules", "course_modules", column: "course_modules_id"
+  add_foreign_key "course_modules", "course_modules", column: "previous_module_id"
+  add_foreign_key "course_modules", "course_years"
+  add_foreign_key "course_years", "lead_providers"
   add_foreign_key "induction_coordinator_profiles", "users"
   add_foreign_key "lead_provider_profiles", "lead_providers"
   add_foreign_key "lead_provider_profiles", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_102533) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "title", null: false
-    t.string "content", null: false
+    t.text "content", null: false
     t.uuid "next_lesson_id"
     t.uuid "previous_lesson_id"
     t.uuid "course_module_id", null: false
@@ -40,12 +40,12 @@ ActiveRecord::Schema.define(version: 2021_01_18_102533) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "title", null: false
-    t.string "content", null: false
-    t.uuid "course_modules_id"
+    t.text "content", null: false
+    t.uuid "next_module_id"
     t.uuid "previous_module_id"
     t.uuid "course_year_id", null: false
-    t.index ["course_modules_id"], name: "index_course_modules_on_course_modules_id"
     t.index ["course_year_id"], name: "index_course_modules_on_course_year_id"
+    t.index ["next_module_id"], name: "index_course_modules_on_next_module_id"
     t.index ["previous_module_id"], name: "index_course_modules_on_previous_module_id"
   end
 
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_102533) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "is_year_one", null: false
     t.string "title", null: false
-    t.string "content", null: false
+    t.text "content", null: false
     t.uuid "lead_provider_id", null: false
     t.index ["lead_provider_id"], name: "index_course_years_on_lead_provider_id"
   end
@@ -156,7 +156,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_102533) do
   add_foreign_key "course_lessons", "course_lessons", column: "next_lesson_id"
   add_foreign_key "course_lessons", "course_lessons", column: "previous_lesson_id"
   add_foreign_key "course_lessons", "course_modules"
-  add_foreign_key "course_modules", "course_modules", column: "course_modules_id"
+  add_foreign_key "course_modules", "course_modules", column: "next_module_id"
   add_foreign_key "course_modules", "course_modules", column: "previous_module_id"
   add_foreign_key "course_modules", "course_years"
   add_foreign_key "course_years", "lead_providers"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,3 +21,11 @@ unless AdminProfile.first || Rails.env.production?
   end
   AdminProfile.create!(user: user)
 end
+
+unless CourseYear.first || Rails.env.production?
+  course_year = CourseYear.create!(
+    lead_provider: LeadProvider.first, is_year_one: true, title: "Test title", content: "Test **content**",
+  )
+  course_module = CourseModule.create!(course_year: course_year, title: "Test title", content: "Test **content**")
+  CourseLesson.create!(course_module: course_module, title: "Test title", content: "Test **content**")
+end

--- a/spec/factories/course_lesson.rb
+++ b/spec/factories/course_lesson.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course_lesson do
+    title { "Test Course lesson" }
+    content { "No content" }
+    course_module { FactoryBot.create(:course_module) }
+  end
+end

--- a/spec/factories/course_module.rb
+++ b/spec/factories/course_module.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course_module do
+    title { "Test Course module" }
+    content { "No content" }
+    course_year { FactoryBot.create(:course_year) }
+  end
+end

--- a/spec/factories/course_year.rb
+++ b/spec/factories/course_year.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :course_year do
+    title { "Test Course year" }
+    content { "No content" }
+    is_year_one { true }
+    lead_provider { FactoryBot.create(:lead_provider) }
+  end
+end

--- a/spec/models/course_lesson_spec.rb
+++ b/spec/models/course_lesson_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe CourseLesson, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:course_module) }
+    it { is_expected.to have_one(:next_lesson) }
+    it { is_expected.to belong_to(:previous_lesson).optional }
   end
 
   describe "validations" do

--- a/spec/models/course_lesson_spec.rb
+++ b/spec/models/course_lesson_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseLesson, type: :model do
+  it "can be created" do
+    expect {
+      CourseLesson.create(
+        title: "Test Course lesson",
+        content: "No content",
+        course_module: FactoryBot.create(:course_module),
+      )
+    }.to change { CourseLesson.count }.by(1)
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:course_module) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:course_lesson) }
+    it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
+    it { is_expected.to validate_presence_of(:content).with_message("Enter content") }
+  end
+end

--- a/spec/models/course_module_spec.rb
+++ b/spec/models/course_module_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe CourseModule, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:course_year) }
+    it { is_expected.to have_one(:next_module) }
+    it { is_expected.to belong_to(:previous_module).optional }
     it { is_expected.to have_many(:course_lessons) }
   end
 

--- a/spec/models/course_module_spec.rb
+++ b/spec/models/course_module_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseModule, type: :model do
+  it "can be created" do
+    expect {
+      CourseModule.create(
+        title: "Test Course module",
+        content: "No content",
+        course_year: FactoryBot.create(:course_year),
+      )
+    }.to change { CourseModule.count }.by(1)
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:course_year) }
+    it { is_expected.to have_many(:course_lessons) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:course_module) }
+    it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
+    it { is_expected.to validate_presence_of(:content).with_message("Enter content") }
+  end
+end

--- a/spec/models/course_year_spec.rb
+++ b/spec/models/course_year_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseYear, type: :model do
+  it "can be created" do
+    expect {
+      CourseYear.create(
+        title: "Test Course year",
+        content: "No content",
+        is_year_one: false,
+        lead_provider: FactoryBot.create(:lead_provider),
+      )
+    }.to change { CourseYear.count }.by(1)
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to have_many(:course_modules) }
+  end
+
+  describe "validations" do
+    subject { FactoryBot.create(:course_year) }
+    it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
+    it { is_expected.to validate_presence_of(:content).with_message("Enter content") }
+  end
+end


### PR DESCRIPTION
### Context
We want to start the work of migrating CIP content into our Rails app. Since it will be stored in our db, the first step is to write some migrations and models. There are no routes or views, and it's by design - so more work is unblocked faster. 

### Changes proposed in this pull request
Add `course_year`, `course_module` and `course_lesson` to our db, add models describing their relations, write tests for them. 

### Guidance to review
https://miro.com/app/board/o9J_kj-a9uA=/?moveToWidget=3074457353294903980&cot=14 is dev corner part describing the structure I think CIP will eventually take - and this PR is just taking care of year-module-lesson part.
