### PR TITLE
Update school search

### DIFF
--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -6,12 +6,20 @@ class SchoolSearchForm
   attr_accessor :school_name, :location, :search_distance, :search_distance_unit, :characteristics, :partnership
 
   def find_schools(page)
-    if partnership&.include? "partnered_with_another_provider"
-      School.where(id: Partnership.select(:school_id).map(&:school_id)).page(page)
-    else
-      School.where("lower(name) LIKE ? OR lower(urn) LIKE ?", "%#{(school_name || '').downcase}%", "%#{(school_name || '').downcase}%").includes(
-        :network, :lead_provider
-      ).page(page)
-    end
+    schools = School.where("lower(name) LIKE ? OR
+                            lower(urn) LIKE ?",
+                           "%#{(school_name || '').downcase}%",
+                           "%#{(school_name || '').downcase}%")
+    .includes(:network, :lead_provider)
+
+    schools = schools.where(id: Partnership.pluck(:school_id)) if filter_by_partnership_status
+
+    schools.page(page)
+  end
+
+private
+
+  def filter_by_partnership_status
+    partnership&.include? "partnered_with_another_provider"
   end
 end

--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -20,6 +20,6 @@ class SchoolSearchForm
 private
 
   def filter_by_partnership_status
-    partnership&.include? "partnered_with_another_provider"
+    partnership&.include? "in_a_partnership"
   end
 end

--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -6,10 +6,12 @@ class SchoolSearchForm
   attr_accessor :school_name, :location, :search_distance, :search_distance_unit, :characteristics, :partnership
 
   def find_schools(page)
-    School.where(
-      "lower(name) like ?", "%#{(school_name || '').downcase}%"
-    ).includes(
-      :network, :lead_provider
-    ).page(page)
+    if partnership&.include? "partnered_with_another_provider"
+      School.where(id: Partnership.select(:school_id).map(&:school_id)).page(page)
+    else
+      School.where("lower(name) LIKE ? OR lower(urn) LIKE ?", "%#{(school_name || '').downcase}%", "%#{(school_name || '').downcase}%").includes(
+        :network, :lead_provider
+      ).page(page)
+    end
   end
 end

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -10,22 +10,18 @@
     <div style="width: 100%; height: 100%; background-color: #dee0e2; padding: 8px;">
       <%= form_with model: @school_search_form, url: school_search_path, method: :post do |f| %>
         <h2 class="govuk-heading-m">Filter Schools</h2>
-
         <%= f.govuk_submit "Apply filters", classes: "govuk-button govuk-!-margin-bottom-0" %>
         <p>
           <%= govuk_link_to "Clear filters", "?" %>
         </p>
-
         <%= f.govuk_text_field(
               :school_name,
               value: @school_search_form.school_name,
               label: {text: "School name or group", class: "govuk-label govuk-label--s"}) %>
-
         <%= f.govuk_text_field(
               :location,
               label: {text: "Location", class: "govuk-label govuk-label--s"},
               hint: {text: "Enter a postcode, town or region"}) %>
-
         <%= f.govuk_fieldset legend: {text: 'Search distance', class: "govuk-hint"} do %>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-half">
@@ -48,7 +44,6 @@
             </div>
           </div>
         <% end %>
-
         <%= f.govuk_collection_check_boxes(
               :characteristics,
               [OpenStruct.new(id: :pupil_premium_above_40, name: 'Pupil premium above 40%'),
@@ -56,14 +51,15 @@
               :id,
               :name,
               legend: {text: "Characteristic", class: "govuk-fieldset__legend govuk-fieldset__legend--s"}) %>
-
-        <%= f.govuk_collection_check_boxes(
+        <% if @lead_provider%>
+          <%= f.govuk_collection_check_boxes(
               :partnership,
               [OpenStruct.new(
                 id: :partnered_with_another_provider, name: 'Show schools partnered with another provider')],
               :id,
               :name,
               legend: {text: "Partnership Status", class: "govuk-fieldset__legend govuk-fieldset__legend--s"}) %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -55,7 +55,7 @@
           <%= f.govuk_collection_check_boxes(
               :partnership,
               [OpenStruct.new(
-                id: :partnered_with_another_provider, name: 'Show schools partnered with another provider')],
+                id: :in_a_partnership, name: 'Schools in a partnership')],
               :id,
               :name,
               legend: {text: "Partnership Status", class: "govuk-fieldset__legend govuk-fieldset__legend--s"}) %>

--- a/app/views/school_search/show.html.erb
+++ b/app/views/school_search/show.html.erb
@@ -55,7 +55,7 @@
           <%= f.govuk_collection_check_boxes(
               :partnership,
               [OpenStruct.new(
-                id: :in_a_partnership, name: 'Schools in a partnership')],
+                id: :in_a_partnership, name: "Show schools in a partnership")],
               :id,
               :name,
               legend: {text: "Partnership Status", class: "govuk-fieldset__legend govuk-fieldset__legend--s"}) %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ unless LeadProvider.first
 end
 
 # TODO: Remove this when we have a way of adding partnerships
-unless Partnership.first
+unless Partnership.first || Rails.env.production?
   Partnership.create!(school: School.first, lead_provider: LeadProvider.first)
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,11 @@ unless LeadProvider.first
   LeadProvider.create!(name: "Test Lead Provider")
 end
 
+# TODO: Remove this when we have a way of adding partnerships
+unless Partnership.first
+  Partnership.create!(school: School.first, lead_provider: LeadProvider.first)
+end
+
 unless AdminProfile.first || Rails.env.production?
   user = User.find_or_create_by!(email: "ecf@mailinator.com") do |u|
     u.first_name = "Admin"

--- a/spec/factories/partnership.rb
+++ b/spec/factories/partnership.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :partnership do
-  end
-end

--- a/spec/factories/partnership.rb
+++ b/spec/factories/partnership.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :partnership do
+  end
+end

--- a/spec/forms/school_search_form_spec.rb
+++ b/spec/forms/school_search_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
       lead_provider = FactoryBot.create(:lead_provider)
       Partnership.create!(school: school, lead_provider: lead_provider)
 
-      form = SchoolSearchForm.new(partnership: ["", "partnered_with_another_provider"])
+      form = SchoolSearchForm.new(partnership: ["", "in_a_partnership"])
       search_result = form.find_schools(1)
 
       expect(search_result.first.name).to eql(school.name)
@@ -53,7 +53,7 @@ RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
       lead_provider = FactoryBot.create(:lead_provider)
       Partnership.create!(school: school, lead_provider: lead_provider)
 
-      form = SchoolSearchForm.new(school_name: "Test school one", partnership: ["", "partnered_with_another_provider"])
+      form = SchoolSearchForm.new(school_name: "Test school one", partnership: ["", "in_a_partnership"])
       search_result = form.find_schools(1)
 
       expect(search_result.count).to eq(0)

--- a/spec/forms/school_search_form_spec.rb
+++ b/spec/forms/school_search_form_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
   describe "find_schools" do
     let!(:schools) do
-      [create(:school, name: "Test school one"),
-       create(:school, name: "Amazing school"),
-       create(:school, name: "Academy")]
+      [create(:school, name: "Test school one", urn: "1234567"),
+       create(:school, name: "Amazing school", urn: "2345678"),
+       create(:school, name: "Academy", urn: "3456789")]
     end
 
     it "finds schools that include lowercase part of name" do
@@ -21,6 +21,31 @@ RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
       form = SchoolSearchForm.new(school_name: "")
       schools = form.find_schools(1)
       expect(schools.count).to eq(3)
+    end
+
+    it "finds school with matching Unique Reference Number (URN)" do
+      form = SchoolSearchForm.new(school_name: "2345678")
+      schools = form.find_schools(1)
+      expect(schools.count).to eq(1)
+      expect(schools.first.name).to eql("Amazing school")
+    end
+
+    it "finds all schools with an empty query" do
+      form = SchoolSearchForm.new(school_name: "")
+      schools = form.find_schools(1)
+      expect(schools.count).to eq(3)
+    end
+
+    it "finds schools that have a partnership" do
+      school = schools[2]
+      lead_provider = FactoryBot.create(:lead_provider)
+      partnership = FactoryBot.create(:partnership, school: school, lead_provider: lead_provider)
+
+      form = SchoolSearchForm.new(partnership: ["", "partnered_with_another_provider"])
+      search_result = form.find_schools(1)
+
+      expect(search_result.first.name).to eql(school.name)
+      expect(search_result.count).to eq(1)
     end
   end
 end

--- a/spec/forms/school_search_form_spec.rb
+++ b/spec/forms/school_search_form_spec.rb
@@ -39,13 +39,24 @@ RSpec.describe SchoolSearchForm, type: :model, with_audited: true do
     it "finds schools that have a partnership" do
       school = schools[2]
       lead_provider = FactoryBot.create(:lead_provider)
-      partnership = FactoryBot.create(:partnership, school: school, lead_provider: lead_provider)
+      Partnership.create!(school: school, lead_provider: lead_provider)
 
       form = SchoolSearchForm.new(partnership: ["", "partnered_with_another_provider"])
       search_result = form.find_schools(1)
 
       expect(search_result.first.name).to eql(school.name)
       expect(search_result.count).to eq(1)
+    end
+
+    it "filters schools by name and partnership status" do
+      school = schools[2]
+      lead_provider = FactoryBot.create(:lead_provider)
+      Partnership.create!(school: school, lead_provider: lead_provider)
+
+      form = SchoolSearchForm.new(school_name: "Test school one", partnership: ["", "partnered_with_another_provider"])
+      search_result = form.find_schools(1)
+
+      expect(search_result.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
### Context
The school search form can currently only search for school group. Additional functionality is needed.  

### Changes proposed in this pull request

- Adding a partnership when seeding the database.
- The 'Show schools partnered with another provider' check box is only seen if a lead provider is logged in.
- You can now search by URN
- The partnership checkbox now filters to only 'Show schools partnered with another provider'. 

### Guidance to review
To check the Partnerships filters on localhost you'll need to run the seed file again to create the partnership in the db. 
Unless you're logged in as an LP you'll need to comment out the if statement on the school_search/show.html.erb view.

The linter has failed because of line 42 on the school_search_form_spec (unused variable), unless we want to use it for any testing, i'll remove it.  I spotted this afterwards.
