### PR TITLE
[ECF-1-138] Replace first name and last name with fullname

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
 protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[email first_name last_name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[email full_name])
   end
 
   def set_current_user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        full_name: user.full_name.titleize,
+        full_name: user.full_name,
         sign_in_url: url,
       },
     )
@@ -29,7 +29,7 @@ class UserMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        full_name: user.full_name.capitalize,
+        full_name: user.full_name,
         confirmation_url: confirmation_url,
       },
     )

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        first_name: user.first_name.capitalize,
+        full_name: user.full_name.titleize,
         sign_in_url: url,
       },
     )
@@ -29,7 +29,7 @@ class UserMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        first_name: user.first_name.capitalize,
+        full_name: user.full_name.capitalize,
         confirmation_url: confirmation_url,
       },
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,7 @@ class User < ApplicationRecord
   has_one :admin_profile
   has_one :lead_provider, through: :lead_provider_profile
 
-  validates :first_name, presence: { message: "Enter a first name" }
-  validates :last_name, presence: { message: "Enter a last name" }
+  validates :full_name, presence: { message: "Enter your full name" }
   validates :email, presence: true
 
   def admin?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -11,7 +11,7 @@ class UserPolicy < ApplicationPolicy
 
   def permitted_attributes
     if user.admin?
-      %i[first_name last_name email]
+      %i[full_name email]
     end
   end
 

--- a/app/views/admin/lead_provider_users/_form_fields.html.erb
+++ b/app/views/admin/lead_provider_users/_form_fields.html.erb
@@ -1,12 +1,9 @@
 <%= f.govuk_text_field(
-      :first_name,
-      label: { text: 'First name' })
+      :full_name,
+      label: { text: "Full name" })
 %>
-<%= f.govuk_text_field(
-      :last_name,
-      label: { text: 'Last name' })
-%>
+
 <%= f.govuk_email_field(
       :email,
-      label: { text: 'Email' })
+      label: { text: "Email" })
 %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -11,9 +11,7 @@
 
       <%= f.hidden_field :school_id, value: @school.id %>
 
-      <%= f.govuk_text_field :first_name, label: { text: "First name" } %>
-
-      <%= f.govuk_text_field :last_name, label: { text: "Last name" } %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
 
       <%= f.govuk_submit "Sign up" %>
     <% end %>

--- a/db/migrate/20210115122323_add_eligible_to_schools.rb
+++ b/db/migrate/20210115122323_add_eligible_to_schools.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEligibleToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :eligible, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20210119070223_rename_first_name_to_full_name.rb
+++ b/db/migrate/20210119070223_rename_first_name_to_full_name.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameFirstNameToFullName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :first_name, :full_name
+  end
+end

--- a/db/migrate/20210119093554_remove_last_name_from_users.rb
+++ b/db/migrate/20210119093554_remove_last_name_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveFirstNameFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :last_name, if_exists: true
+  end
+end

--- a/db/migrate/20210119093554_remove_last_name_from_users.rb
+++ b/db/migrate/20210119093554_remove_last_name_from_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveFirstNameFromUsers < ActiveRecord::Migration[6.1]
+class RemoveLastNameFromUsers < ActiveRecord::Migration[6.1]
   def change
     remove_column :users, :last_name, if_exists: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_102533) do
+ActiveRecord::Schema.define(version: 2021_01_19_093554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_102533) do
     t.string "postcode", null: false
     t.uuid "network_id"
     t.string "domains", default: [], null: false, array: true
+    t.boolean "eligible", default: true, null: false
     t.index ["high_pupil_premium"], name: "index_schools_on_high_pupil_premium", where: "high_pupil_premium"
     t.index ["is_rural"], name: "index_schools_on_is_rural", where: "is_rural"
     t.index ["name"], name: "index_schools_on_name"
@@ -131,8 +132,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_102533) do
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "first_name", null: false
-    t.string "last_name", null: false
+    t.string "full_name", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "login_token"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,16 +16,7 @@ end
 
 unless AdminProfile.first || Rails.env.production?
   user = User.find_or_create_by!(email: "ecf@mailinator.com") do |u|
-    u.first_name = "Admin"
-    u.last_name = "User"
+    u.full_name = "Admin User"
   end
   AdminProfile.create!(user: user)
-end
-
-unless CourseYear.first || Rails.env.production?
-  course_year = CourseYear.create!(
-    lead_provider: LeadProvider.first, is_year_one: true, title: "Test title", content: "Test **content**",
-  )
-  course_module = CourseModule.create!(course_year: course_year, title: "Test title", content: "Test **content**")
-  CourseLesson.create!(course_module: course_module, title: "Test title", content: "Test **content**")
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,10 +21,10 @@ unless AdminProfile.first || Rails.env.production?
   AdminProfile.create!(user: user)
 end
 
-unless CourseYear.first || Rails.env.production?	
-  course_year = CourseYear.create!(	
-    lead_provider: LeadProvider.first, is_year_one: true, title: "Test title", content: "Test **content**",	
-  )	
-  course_module = CourseModule.create!(course_year: course_year, title: "Test title", content: "Test **content**")	
-  CourseLesson.create!(course_module: course_module, title: "Test title", content: "Test **content**")	
+unless CourseYear.first || Rails.env.production?
+  course_year = CourseYear.create!(
+    lead_provider: LeadProvider.first, is_year_one: true, title: "Test title", content: "Test **content**",
+  )
+  course_module = CourseModule.create!(course_year: course_year, title: "Test title", content: "Test **content**")
+  CourseLesson.create!(course_module: course_module, title: "Test title", content: "Test **content**")
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,3 +20,11 @@ unless AdminProfile.first || Rails.env.production?
   end
   AdminProfile.create!(user: user)
 end
+
+unless CourseYear.first || Rails.env.production?	
+  course_year = CourseYear.create!(	
+    lead_provider: LeadProvider.first, is_year_one: true, title: "Test title", content: "Test **content**",	
+  )	
+  course_module = CourseModule.create!(course_year: course_year, title: "Test title", content: "Test **content**")	
+  CourseLesson.create!(course_module: course_module, title: "Test title", content: "Test **content**")	
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,8 +3,7 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    full_name { Faker::Name.name }
     login_token { Faker::Alphanumeric.alpha(number: 10) }
     confirmed_at { 1.hour.ago }
     login_token_valid_until { 1.hour.from_now }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe User, type: :model do
 
   describe "validations" do
     subject { FactoryBot.create(:user) }
-    it { is_expected.to validate_presence_of(:first_name).with_message("Enter a first name") }
-    it { is_expected.to validate_presence_of(:last_name).with_message("Enter a last name") }
+    it { is_expected.to validate_presence_of(:full_name).with_message("Enter your full name") }
     it { is_expected.to validate_presence_of(:email).with_message("Enter an email") }
     it {
       is_expected.to validate_uniqueness_of(:email)

--- a/spec/requests/admin/lead_provider_users_spec.rb
+++ b/spec/requests/admin/lead_provider_users_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 RSpec.describe "Admin::LeadProviderUsers", type: :request do
   let(:lead_provider) { FactoryBot.create(:lead_provider) }
   let(:user) { FactoryBot.create(:user, lead_provider: lead_provider) }
-  let(:first_name) { Faker::Name.first_name }
-  let(:last_name) { Faker::Name.last_name }
+  let(:full_name) { Faker::Name.name }
   let(:email) { Faker::Internet.email }
 
   before do
@@ -28,8 +27,7 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
     it "redirects to the list of users on success" do
       # When
       post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-        first_name: "First",
-        last_name: "Last",
+        full_name: "First Last",
         email: "first.last@email.com",
       } }
 
@@ -40,8 +38,7 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
     it "creates a new user" do
       expect {
         post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-          first_name: first_name,
-          last_name: last_name,
+          full_name: full_name,
           email: email,
         } }
       }.to change { User.count }.by(1)
@@ -50,33 +47,20 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
     it "creates a user with the correct details" do
       # When
       post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-        first_name: first_name,
-        last_name: last_name,
+        full_name: full_name,
         email: email,
       } }
 
       # Then
       new_user = User.find_by_email(email)
       expect(new_user).not_to be_nil
-      expect(new_user.first_name).to eq(first_name)
-      expect(new_user.last_name).to eq(last_name)
+      expect(new_user.full_name).to eq(full_name)
     end
 
-    it "does not create a user when the first name is empty" do
+    it "does not create a user when the full name is empty" do
       expect {
         post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-          first_name: "",
-          last_name: last_name,
-          email: email,
-        } }
-      }.not_to(change { User.count })
-    end
-
-    it "does not create a user when the last name is empty" do
-      expect {
-        post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-          first_name: first_name,
-          last_name: "",
+          full_name: "",
           email: email,
         } }
       }.not_to(change { User.count })
@@ -85,23 +69,21 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
     it "does not create a user when the email is empty" do
       expect {
         post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-          first_name: first_name,
-          last_name: last_name,
+          full_name: full_name,
           email: "",
         } }
       }.not_to(change { User.count })
     end
 
-    it "shows an error message when the first name is empty" do
+    it "shows an error message when the full name is empty" do
       # When
       post "/admin/lead_providers/#{lead_provider.id}/users", params: { user: {
-        first_name: "",
-        last_name: last_name,
+        full_name: "",
         email: email,
       } }
 
       # Then
-      expect(response.body).to include("Enter a first name")
+      expect(response.body).to include("Enter your full name")
     end
   end
 
@@ -129,7 +111,7 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
       get "/admin/lead_providers/#{lead_provider.id}/users/#{user.id}/edit"
 
       # Then
-      expect(response.body).to include(CGI.escapeHTML(user.first_name))
+      expect(response.body).to include(CGI.escapeHTML(user.full_name))
     end
   end
 
@@ -137,8 +119,7 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
     it "redirects to the list of lead providers" do
       # When
       put "/admin/lead_providers/#{lead_provider.id}/users/#{user.id}", params: { user: {
-        first_name: first_name,
-        last_name: user.last_name,
+        full_name: user.full_name,
         email: user.email,
       } }
 
@@ -149,40 +130,37 @@ RSpec.describe "Admin::LeadProviderUsers", type: :request do
     it "updates the name of an existing user" do
       # When
       put "/admin/lead_providers/#{lead_provider.id}/users/#{user.id}", params: { user: {
-        first_name: first_name,
-        last_name: user.last_name,
+        full_name: full_name,
         email: user.email,
       } }
 
       # Then
-      expect(User.find(user.id).first_name).to eq(first_name)
+      expect(user.reload.full_name).to eq(full_name)
     end
 
     it "does not update the name of the user when the new first name is blank" do
       # Given
-      previous_name = user.first_name
+      previous_name = user.full_name
 
       # When
       put "/admin/lead_providers/#{lead_provider.id}/users/#{user.id}", params: { user: {
-        first_name: "",
-        last_name: user.last_name,
+        full_name: "",
         email: user.email,
       } }
 
       # Then
-      expect(User.find(user.id).first_name).to eq(previous_name)
+      expect(User.find(user.id).full_name).to eq(previous_name)
     end
 
     it "displays an error message when the name is blank" do
       # When
       put "/admin/lead_providers/#{lead_provider.id}/users/#{user.id}", params: { user: {
-        first_name: "",
-        last_name: user.last_name,
+        full_name: "",
         email: user.email,
       } }
 
       # Then
-      expect(response.body).to include("Enter a first name")
+      expect(response.body).to include("Enter your full name")
     end
   end
 end

--- a/spec/requests/users/registrations/register_spec.rb
+++ b/spec/requests/users/registrations/register_spec.rb
@@ -4,8 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Users::Registrations /register", type: :request do
   let(:school) { FactoryBot.create(:school) }
-  let(:first_name) { Faker::Name.first_name }
-  let(:last_name) { Faker::Name.last_name }
+  let(:full_name) { Faker::Name.name }
   let(:email) { Faker::Internet.email(domain: school.domains.first) }
 
   describe "GET /users/register" do
@@ -21,8 +20,7 @@ RSpec.describe "Users::Registrations /register", type: :request do
     it "redirects to homepage on successful user creation" do
       # When
       post "/users/register", params: { user: {
-        first_name: first_name,
-        last_name: last_name,
+        full_name: full_name,
         email: email,
         school_id: school.id,
       } }
@@ -35,8 +33,7 @@ RSpec.describe "Users::Registrations /register", type: :request do
     it "creates a user with the correct details" do
       # When
       post "/users/register", params: { user: {
-        first_name: first_name,
-        last_name: last_name,
+        full_name: full_name,
         email: email,
         school_id: school.id,
       } }
@@ -45,15 +42,13 @@ RSpec.describe "Users::Registrations /register", type: :request do
       created_user = User.find_by_email(email)
 
       expect(created_user).not_to be_nil
-      expect(created_user.first_name).to eq(first_name)
-      expect(created_user.last_name).to eq(last_name)
+      expect(created_user.full_name).to eq(full_name)
     end
 
     it "creates an induction coordinator profile for the user" do
       # When
       post "/users/register", params: { user: {
-        first_name: first_name,
-        last_name: last_name,
+        full_name: full_name,
         email: email,
         school_id: school.id,
       } }
@@ -67,8 +62,7 @@ RSpec.describe "Users::Registrations /register", type: :request do
     it "makes the user the induction coordinator for the school" do
       # When
       post "/users/register", params: { user: {
-        first_name: first_name,
-        last_name: last_name,
+        full_name: full_name,
         email: email,
         school_id: school.id,
       } }
@@ -82,8 +76,7 @@ RSpec.describe "Users::Registrations /register", type: :request do
     it "returns bad request when the email does not match the school" do
       expect {
         post "/users/register", params: { user: {
-          first_name: first_name,
-          last_name: last_name,
+          full_name: full_name,
           email: "email@differentdomain.com",
           school_id: school.id,
         } }
@@ -93,8 +86,7 @@ RSpec.describe "Users::Registrations /register", type: :request do
     it "returns bad request when the email is missing" do
       expect {
         post "/users/register", params: { user: {
-          first_name: first_name,
-          last_name: last_name,
+          full_name: full_name,
           school_id: school.id,
         } }
       }.to raise_error(ActionController::BadRequest)
@@ -103,8 +95,7 @@ RSpec.describe "Users::Registrations /register", type: :request do
     it "returns bad request when the school_id is missing" do
       expect {
         post "/users/register", params: { user: {
-          first_name: first_name,
-          last_name: last_name,
+          full_name: full_name,
           email: email,
         } }
       }.to raise_error(ActionController::BadRequest)


### PR DESCRIPTION
### Context

The design wireframes use full name when capturing user information. And following some discussions with the team it was decided that we should use full name rather than first name and last name. 
https://miro.com/app/board/o9J_lZ2k8oc=/

### Changes proposed in this pull request

The main change in this pr is the migration to rename first name to full name and drop the last name column. Unfortunately this has far reaching repercussions when it comes to the tests. The tests have been updated accordingly.


