### PR TITLE
Add cip views

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,23 +11,3 @@
 @import "./govspeak/highlights";
 @import "./govspeak/quote";
 @import "./govspeak/tables";
-
-.app-task-list {
-  list-style: none;
-}
-
-.app-task-list__items {
-  padding-left: 30px;
-  margin-bottom: 60px;
-  list-style: none;
-}
-
-.app-task-list__tag {
-  float: right;
-}
-.app-task-list__item {
-  border-bottom: 1px solid #b1b4b6;
-  margin-bottom: 0;
-  padding-top: 10px;
-  padding-bottom: 10px;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,23 @@
 @import "./govspeak/highlights";
 @import "./govspeak/quote";
 @import "./govspeak/tables";
+
+.app-task-list {
+  list-style: none;
+}
+
+.app-task-list__items {
+  padding-left: 30px;
+  margin-bottom: 60px;
+  list-style: none;
+}
+
+.app-task-list__tag {
+  float: right;
+}
+.app-task-list__item {
+  border-bottom: 1px solid #b1b4b6;
+  margin-bottom: 0;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}

--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -2,7 +2,6 @@
 
 class CoreInductionProgramme::LessonsController < ApplicationController
   def show
-    single_lesson = CourseLesson.find(params[:id])
-    @lesson = Govspeak::Document.new(single_lesson.content, options: { allow_extra_quotes: true }).to_html
+    @lesson = CourseLesson.find(params[:lesson_id])
   end
 end

--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CoreInductionProgramme::LessonsController < ApplicationController
+  def show
+    single_lesson = CourseLesson.find(params[:id])
+    @lesson = Govspeak::Document.new(single_lesson.content, options: { allow_extra_quotes: true }).to_html
+  end
+end

--- a/app/controllers/core_induction_programme/lessons_controller.rb
+++ b/app/controllers/core_induction_programme/lessons_controller.rb
@@ -2,6 +2,6 @@
 
 class CoreInductionProgramme::LessonsController < ApplicationController
   def show
-    @lesson = CourseLesson.find(params[:lesson_id])
+    @course_lesson = CourseLesson.find(params[:lesson_id])
   end
 end

--- a/app/controllers/core_induction_programme/modules_controller.rb
+++ b/app/controllers/core_induction_programme/modules_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CoreInductionProgramme::ModulesController < ApplicationController
+  def show
+    @modules = CourseModule.where(course_year: params[:id])
+    @lessons = CourseLesson.all
+  end
+end

--- a/app/controllers/core_induction_programme/modules_controller.rb
+++ b/app/controllers/core_induction_programme/modules_controller.rb
@@ -2,7 +2,6 @@
 
 class CoreInductionProgramme::ModulesController < ApplicationController
   def show
-    @modules = CourseModule.where(course_year: params[:id])
-    @lessons = CourseLesson.all
+    @modules = CourseModule.where(course_year: params[:id]).includes(:course_lessons)
   end
 end

--- a/app/controllers/core_induction_programme/modules_controller.rb
+++ b/app/controllers/core_induction_programme/modules_controller.rb
@@ -2,6 +2,6 @@
 
 class CoreInductionProgramme::ModulesController < ApplicationController
   def show
-    @module = CourseModule.includes(:course_lessons).find(params[:module_id])
+    @course_module = CourseModule.includes(:course_lessons).find(params[:module_id])
   end
 end

--- a/app/controllers/core_induction_programme/modules_controller.rb
+++ b/app/controllers/core_induction_programme/modules_controller.rb
@@ -2,6 +2,6 @@
 
 class CoreInductionProgramme::ModulesController < ApplicationController
   def show
-    @modules = CourseModule.where(course_year: params[:id]).includes(:course_lessons)
+    @module = CourseModule.includes(:course_lessons).find(params[:module_id])
   end
 end

--- a/app/controllers/core_induction_programme/years_controller.rb
+++ b/app/controllers/core_induction_programme/years_controller.rb
@@ -2,6 +2,6 @@
 
 class CoreInductionProgramme::YearsController < ApplicationController
   def show
-    @course_years = CourseYear.where(lead_provider: params[:id])
+    @course_year = CourseYear.includes(:course_modules).find(params[:year_id])
   end
 end

--- a/app/controllers/core_induction_programme/years_controller.rb
+++ b/app/controllers/core_induction_programme/years_controller.rb
@@ -3,6 +3,5 @@
 class CoreInductionProgramme::YearsController < ApplicationController
   def show
     @course_years = CourseYear.where(lead_provider: params[:id])
-    @gov_speak_content = Govspeak::Document.new(@course_years[1].content, options: { allow_extra_quotes: true }).to_html
   end
 end

--- a/app/controllers/core_induction_programme/years_controller.rb
+++ b/app/controllers/core_induction_programme/years_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CoreInductionProgramme::YearsController < ApplicationController
+  def show
+    @course_years = CourseYear.where(lead_provider: params[:id])
+    @gov_speak_content = Govspeak::Document.new(@course_years[1].content, options: { allow_extra_quotes: true }).to_html
+  end
+end

--- a/app/controllers/core_induction_programme_controller.rb
+++ b/app/controllers/core_induction_programme_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CoreInductionProgrammeController < ApplicationController
+  def show
+    @lead_providers = LeadProvider.all
+  end
+end

--- a/app/controllers/core_induction_programme_controller.rb
+++ b/app/controllers/core_induction_programme_controller.rb
@@ -2,6 +2,6 @@
 
 class CoreInductionProgrammeController < ApplicationController
   def show
-    @lead_providers = LeadProvider.all
+    @course_years = CourseYear.all
   end
 end

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -7,4 +7,8 @@ class CourseLesson < ApplicationRecord
 
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }
+
+  def content_in_html
+    Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
+  end
 end

--- a/app/models/course_lesson.rb
+++ b/app/models/course_lesson.rb
@@ -8,7 +8,7 @@ class CourseLesson < ApplicationRecord
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }
 
-  def content_in_html
+  def content_to_html
     Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
   end
 end

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -9,7 +9,7 @@ class CourseModule < ApplicationRecord
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }
 
-  def content_in_html
+  def content_to_html
     Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
   end
 end

--- a/app/models/course_module.rb
+++ b/app/models/course_module.rb
@@ -8,4 +8,8 @@ class CourseModule < ApplicationRecord
 
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }
+
+  def content_in_html
+    Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
+  end
 end

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -7,7 +7,7 @@ class CourseYear < ApplicationRecord
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }
 
-  def content_in_html
+  def content_to_html
     Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
   end
 end

--- a/app/models/course_year.rb
+++ b/app/models/course_year.rb
@@ -6,4 +6,8 @@ class CourseYear < ApplicationRecord
 
   validates :title, presence: { message: "Enter a title" }
   validates :content, presence: { message: "Enter content" }
+
+  def content_in_html
+    Govspeak::Document.new(content, options: { allow_extra_quotes: true }).to_html
+  end
 end

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Govspeak lesson converted</h1>
+    <div class="gem-c-govspeak govuk-govspeak ">
+      <%= @lesson.html_safe %>
+    </div>
+  </div>
+</div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -1,6 +1,5 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Govspeak lesson converted</h1>
     <div class="gem-c-govspeak govuk-govspeak ">
       <%= @lesson.html_safe %>
     </div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -1,7 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"> <%= @lesson.title %></h1>
+
     <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @lesson.html_safe %>
+      <%= @lesson.content_in_html.html_safe %>
     </div>
+
   </div>
 </div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-l"> <%= @course_lesson.title %></h1>
 
     <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_lesson.content_in_html.html_safe %>
+      <%= @course_lesson.content_to_html.html_safe %>
     </div>
 
   </div>

--- a/app/views/core_induction_programme/lessons/show.html.erb
+++ b/app/views/core_induction_programme/lessons/show.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l"> <%= @lesson.title %></h1>
+    <h1 class="govuk-heading-l"> <%= @course_lesson.title %></h1>
 
     <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @lesson.content_in_html.html_safe %>
+      <%= @course_lesson.content_in_html.html_safe %>
     </div>
 
   </div>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -1,25 +1,25 @@
-<main class="govuk-main-wrapper dfe-main-wrapper" id="main-content" role="main">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <article>
-        <% @modules.each do |mod| %>
-          <ol class="app-task-list">
-            <h3 class="govuk-heading-m"> <%= mod.title %></h3>
-            <li>
-              <p><strong>Topic materials</strong></p>
-              <ul class="app-task-list__items">
-                <% mod.course_lessons.each do |lesson| %>
-                  <li class="app-task-list__item">
-                    <span><a class="govuk-link">
-                        <%= link_to lesson.title, cip_years_modules_lessons_url(lesson) %>
-                      </a></span>
-                    <strong class="govuk-tag app-task-list__tag"><%= ["complete", "in progress", "not_started"].sample%></strong>
-                  </li>
-                <%end%>
-              </ul>
-            </li>
-          </ol>
-        <% end %>
-      </article>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"> <%= @module.title %></h1>
+
+    <div class="gem-c-govspeak govuk-govspeak ">
+      <%= @module.content_in_html.html_safe %>
     </div>
+
+    <ol class="app-task-list">
+      <li>
+        <p><strong>Topic materials</strong></p>
+        <ul class="app-task-list__items">
+          <% @module.course_lessons.each do |lesson| %>
+            <li class="app-task-list__item">
+              <span>
+                  <%= govuk_link_to lesson.title, cip_years_modules_lessons_url(@module.course_year, @module, lesson) %>
+              </span>
+              <strong class="govuk-tag app-task-list__tag">complete</strong>
+            </li>
+          <%end%>
+        </ul>
+      </li>
+    </ol>
   </div>
+</div>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -10,13 +10,17 @@
       <li>
         <p><strong>Topic materials</strong></p>
         <ul class="app-task-list__items">
-          <% @course_module.course_lessons.each do |lesson| %>
-            <li class="app-task-list__item">
-              <span>
-                  <%= govuk_link_to lesson.title, cip_years_modules_lessons_url(@course_module.course_year, @course_module, lesson) %>
-              </span>
-              <strong class="govuk-tag app-task-list__tag">complete</strong>
-            </li>
+          <% if @course_module.course_lessons.any? %>
+            <% @course_module.course_lessons.each do |lesson| %>
+              <li class="app-task-list__item">
+                <span>
+                    <%= govuk_link_to lesson.title, cip_years_modules_lessons_url(@course_module.course_year, @course_module, lesson) %>
+                </span>
+                <strong class="govuk-tag app-task-list__tag">complete</strong>
+              </li>
+            <% end %>
+          <% else %>
+            <p>No course lessons were found!</p>
           <% end %>
         </ul>
       </li>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -1,23 +1,23 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"> <%= @module.title %></h1>
+    <h1 class="govuk-heading-l"> <%= @course_module.title %></h1>
 
     <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @module.content_in_html.html_safe %>
+      <%= @course_module.content_in_html.html_safe %>
     </div>
 
     <ol class="app-task-list">
       <li>
         <p><strong>Topic materials</strong></p>
         <ul class="app-task-list__items">
-          <% @module.course_lessons.each do |lesson| %>
+          <% @course_module.course_lessons.each do |lesson| %>
             <li class="app-task-list__item">
               <span>
-                  <%= govuk_link_to lesson.title, cip_years_modules_lessons_url(@module.course_year, @module, lesson) %>
+                  <%= govuk_link_to lesson.title, cip_years_modules_lessons_url(@course_module.course_year, @course_module, lesson) %>
               </span>
               <strong class="govuk-tag app-task-list__tag">complete</strong>
             </li>
-          <%end%>
+          <% end %>
         </ul>
       </li>
     </ol>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -1,0 +1,19 @@
+<h1>module page</h1>
+<div class="govuk-grid-column-two-thirds">
+  <div id="course-results">
+    <% @modules.each do |mod| %>
+      <div class="card">
+        <div class="govuk-grid-row">
+          <h1> <%= mod.title %>
+            <div class="govuk-grid-column-two-third">
+              <% @lessons.each do |lesson| %>
+                <% if lesson.course_module.title == mod.title %>
+                  <%= link_to lesson.title, cip_years_modules_lessons_url(lesson) %>
+                <%end %>
+              <%end%>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -1,19 +1,25 @@
-<h1>module page</h1>
-<div class="govuk-grid-column-two-thirds">
-  <div id="course-results">
-    <% @modules.each do |mod| %>
-      <div class="card">
-        <div class="govuk-grid-row">
-          <h1> <%= mod.title %>
-            <div class="govuk-grid-column-two-third">
-              <% @lessons.each do |lesson| %>
-                <% if lesson.course_module.title == mod.title %>
-                  <%= link_to lesson.title, cip_years_modules_lessons_url(lesson) %>
-                <%end %>
-              <%end%>
-            </div>
-          </div>
-        </div>
-      <% end %>
+<main class="govuk-main-wrapper dfe-main-wrapper" id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <article>
+        <% @modules.each do |mod| %>
+          <ol class="app-task-list">
+            <h3 class="govuk-heading-m"> <%= mod.title %></h3>
+            <li>
+              <p><strong>Topic materials</strong></p>
+              <ul class="app-task-list__items">
+                <% mod.course_lessons.each do |lesson| %>
+                  <li class="app-task-list__item">
+                    <span><a class="govuk-link">
+                        <%= link_to lesson.title, cip_years_modules_lessons_url(lesson) %>
+                      </a></span>
+                    <strong class="govuk-tag app-task-list__tag"><%= ["complete", "in progress", "not_started"].sample%></strong>
+                  </li>
+                <%end%>
+              </ul>
+            </li>
+          </ol>
+        <% end %>
+      </article>
     </div>
   </div>

--- a/app/views/core_induction_programme/modules/show.html.erb
+++ b/app/views/core_induction_programme/modules/show.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-l"> <%= @course_module.title %></h1>
 
     <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_module.content_in_html.html_safe %>
+      <%= @course_module.content_to_html.html_safe %>
     </div>
 
     <ol class="app-task-list">

--- a/app/views/core_induction_programme/show.html.erb
+++ b/app/views/core_induction_programme/show.html.erb
@@ -1,35 +1,33 @@
-<div class="govuk-width-container">
-  <h2>What is the early career framework?</h2>
-  <p>The early career framework (ECF) was designed to make sure early career teachers focus on learning the things that make the most difference in the classroom and their professional practice.</p>
-  <p>The core induction programmes include high-quality development materials, underpinned by the ECF, which will support early career teachers to develop the essential knowledge and skills to set them up for a successful and fulfilling career in teaching.</p>
-  <p>Schools have an opportunity to take advantage of the benefits of the ECF early by using the core induction programmes published here, in whichever way that best suits them and their early career teachers.</p>
-  <h2>ECF core induction programme suppliers</h2>
-  <p>The Department for Education has selected four expert teacher training providers who have each developed their own core induction programme based on the ECF:</p>
-  <ul>
-    <li>Ambition Institute</li>
-    <li>Education Development Trust</li>
-    <li>Teach First</li>
-    <li>UCL Early Career Teacher Consortium</li>
-  </ul>
-  <p>Each set of materials cover the five core areas of the ECF:</p>
-  <ul>
-    <li>behaviour management</li>
-    <li>pedagogy</li>
-    <li>curriculum</li>
-    <li>assessment</li>
-    <li>professional behaviours</li>
-  </ul>
-  <p>Although structured differently, each programme contains approximately the same amount of self-study material in terms of hours covered.</p>
-  <p>Schools can use or draw upon any of four core induction programmes published here in whichever way is most beneficial to them and their early career teachers.</p>
-  <p>You can read more about these suppliers on their own websites or in the course descriptions below.</p>
-</div>
-<div class="home-tier home-tier--suppliers">
-  <div class="govuk-width-container">
-    <h2>Suppliers</h2>
-    <% @lead_providers.each do |lp| %>
-      <div class="card">
-        <p><%= link_to lp.name, cip_years_url(lp) %></p>
-      </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">What is the early career framework?</h1>
+    <p>The early career framework (ECF) was designed to make sure early career teachers focus on learning the things that make the most difference in the classroom and their professional practice.</p>
+    <p>The core induction programmes include high-quality development materials, underpinned by the ECF, which will support early career teachers to develop the essential knowledge and skills to set them up for a successful and fulfilling career in teaching.</p>
+    <p>Schools have an opportunity to take advantage of the benefits of the ECF early by using the core induction programmes published here, in whichever way that best suits them and their early career teachers.</p>
+
+    <h2 class="govuk-heading-l">ECF core induction programme suppliers</h2>
+    <p>The Department for Education has selected four expert teacher training providers who have each developed their own core induction programme based on the ECF:</p>
+    <ul>
+      <li>Ambition Institute</li>
+      <li>Education Development Trust</li>
+      <li>Teach First</li>
+      <li>UCL Early Career Teacher Consortium</li>
+    </ul>
+    <p>Each set of materials cover the five core areas of the ECF:</p>
+    <ul>
+      <li>behaviour management</li>
+      <li>pedagogy</li>
+      <li>curriculum</li>
+      <li>assessment</li>
+      <li>professional behaviours</li>
+    </ul>
+    <p>Although structured differently, each programme contains approximately the same amount of self-study material in terms of hours covered.</p>
+    <p>Schools can use or draw upon any of four core induction programmes published here in whichever way is most beneficial to them and their early career teachers.</p>
+    <p>You can read more about these suppliers on their own websites or in the course descriptions below.</p>
+
+    <h2 class="govuk-heading-l">Years</h2>
+    <% @course_years.each do |course_year| %>
+        <p><%= govuk_link_to course_year.title, cip_years_url(course_year) %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/core_induction_programme/show.html.erb
+++ b/app/views/core_induction_programme/show.html.erb
@@ -1,13 +1,34 @@
-<h1> this is the CIP page</h1>
-<div class="govuk-grid-column-two-thirds">
-  <div id="course-results">
+<div class="govuk-width-container">
+  <h2>What is the early career framework?</h2>
+  <p>The early career framework (ECF) was designed to make sure early career teachers focus on learning the things that make the most difference in the classroom and their professional practice.</p>
+  <p>The core induction programmes include high-quality development materials, underpinned by the ECF, which will support early career teachers to develop the essential knowledge and skills to set them up for a successful and fulfilling career in teaching.</p>
+  <p>Schools have an opportunity to take advantage of the benefits of the ECF early by using the core induction programmes published here, in whichever way that best suits them and their early career teachers.</p>
+  <h2>ECF core induction programme suppliers</h2>
+  <p>The Department for Education has selected four expert teacher training providers who have each developed their own core induction programme based on the ECF:</p>
+  <ul>
+    <li>Ambition Institute</li>
+    <li>Education Development Trust</li>
+    <li>Teach First</li>
+    <li>UCL Early Career Teacher Consortium</li>
+  </ul>
+  <p>Each set of materials cover the five core areas of the ECF:</p>
+  <ul>
+    <li>behaviour management</li>
+    <li>pedagogy</li>
+    <li>curriculum</li>
+    <li>assessment</li>
+    <li>professional behaviours</li>
+  </ul>
+  <p>Although structured differently, each programme contains approximately the same amount of self-study material in terms of hours covered.</p>
+  <p>Schools can use or draw upon any of four core induction programmes published here in whichever way is most beneficial to them and their early career teachers.</p>
+  <p>You can read more about these suppliers on their own websites or in the course descriptions below.</p>
+</div>
+<div class="home-tier home-tier--suppliers">
+  <div class="govuk-width-container">
+    <h2>Suppliers</h2>
     <% @lead_providers.each do |lp| %>
       <div class="card">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-third">
-            <p><%= link_to lp.name, cip_years_url(lp) %></p>
-          </div>
-        </div>
+        <p><%= link_to lp.name, cip_years_url(lp) %></p>
       </div>
     <% end %>
   </div>

--- a/app/views/core_induction_programme/show.html.erb
+++ b/app/views/core_induction_programme/show.html.erb
@@ -26,8 +26,12 @@
     <p>You can read more about these suppliers on their own websites or in the course descriptions below.</p>
 
     <h2 class="govuk-heading-l">Years</h2>
-    <% @course_years.each do |course_year| %>
+    <% if @course_years.any? %>
+      <% @course_years.each do |course_year| %>
         <p><%= govuk_link_to course_year.title, cip_years_url(course_year) %></p>
+      <% end %>
+    <% else %>
+      <p>No course years were found!</p>
     <% end %>
   </div>
 </div>

--- a/app/views/core_induction_programme/show.html.erb
+++ b/app/views/core_induction_programme/show.html.erb
@@ -1,0 +1,14 @@
+<h1> this is the CIP page</h1>
+<div class="govuk-grid-column-two-thirds">
+  <div id="course-results">
+    <% @lead_providers.each do |lp| %>
+      <div class="card">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-third">
+            <p><%= link_to lp.name, cip_years_url(lp) %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,15 +1,14 @@
-<h1>years page</h1>
-<div class="govuk-grid-column-two-thirds">
-  <div id="course-results">
-    <% @course_years.each do |course| %>
-      <%= course.title %>
-      <div class="card">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-half">
+<main class="govuk-main-wrapper dfe-main-wrapper" id="main-content" role="main">
+  <article>
+    <div id="course-results">
+      <% @course_years.each do |course| %>
+        <h1 class="entry-title"><%= course.title %></h1>
+        <div class="card">
+          <div class="govuk-grid-row">
             <p><%= link_to "Go to self-directed study materials", cip_years_modules_url(course) %></p>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+</article>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,0 +1,15 @@
+<h1>years page</h1>
+<div class="govuk-grid-column-two-thirds">
+  <div id="course-results">
+    <% @course_years.each do |course| %>
+      <%= course.title %>
+      <div class="card">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <p><%= link_to "Go to self-directed study materials", cip_years_modules_url(course) %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,14 +1,16 @@
-<main class="govuk-main-wrapper dfe-main-wrapper" id="main-content" role="main">
-  <article>
-    <div id="course-results">
-      <% @course_years.each do |course| %>
-        <h1 class="entry-title"><%= course.title %></h1>
-        <div class="card">
-          <div class="govuk-grid-row">
-            <p><%= link_to "Go to self-directed study materials", cip_years_modules_url(course) %></p>
-          </div>
-        </div>
-      <% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= @course_year.title %></h1>
+
+    <h2 class="govuk-heading-l">Modules</h2>
+    <% @course_year.course_modules.each do |course_module| %>
+      <p>
+        <%= govuk_link_to course_module.title, cip_years_modules_url(@course_year, course_module) %>
+      </p>
+    <% end %>
+
+    <div class="gem-c-govspeak govuk-govspeak ">
+      <%= @course_year.content_in_html.html_safe %>
     </div>
   </div>
-</article>
+</div>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <div class="gem-c-govspeak govuk-govspeak ">
-      <%= @course_year.content_in_html.html_safe %>
+      <%= @course_year.content_to_html.html_safe %>
     </div>
   </div>
 </div>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -3,10 +3,14 @@
     <h1 class="govuk-heading-l"><%= @course_year.title %></h1>
 
     <h2 class="govuk-heading-l">Modules</h2>
-    <% @course_year.course_modules.each do |course_module| %>
-      <p>
-        <%= govuk_link_to course_module.title, cip_years_modules_url(@course_year, course_module) %>
-      </p>
+    <% if @course_year.course_modules.any? %>
+      <% @course_year.course_modules.each do |course_year| %>
+        <p>
+          <%= govuk_link_to course_module.title, cip_years_modules_url(@course_year, course_module) %>
+        </p>
+      <% end %>
+    <% else %>
+      <p>No course modules were found!</p>
     <% end %>
 
     <div class="gem-c-govspeak govuk-govspeak ">

--- a/app/webpacker/styles/app_task_list.scss
+++ b/app/webpacker/styles/app_task_list.scss
@@ -1,0 +1,19 @@
+.app-task-list {
+  list-style: none;
+}
+
+.app-task-list__items {
+  padding-left: 30px;
+  margin-bottom: 60px;
+  list-style: none;
+}
+
+.app-task-list__tag {
+  float: right;
+}
+.app-task-list__item {
+  border-bottom: 1px solid #b1b4b6;
+  margin-bottom: 0;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -11,3 +11,4 @@ $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
 @import "school_search";
+@import "app_task_list";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,10 +43,10 @@ Rails.application.routes.draw do
 
   resource :school_search, only: %i[show create], path: "school-search", controller: :school_search
 
-  resource :core_induction_programme, controller: :core_induction_programme, only: :show, as: "cip", path: "/cip" do
-    resource :years, controller: "core_induction_programme/years", only: :show, path: "/:id" do
-      resource :modules, controller: "core_induction_programme/modules", only: :show, path: "/:id" do
-        resource :lessons, controller: "core_induction_programme/lessons", only: :show, path: "/:id"
+  resource :core_induction_programme, controller: :core_induction_programme, only: :show, as: "cip", path: "/core_induction_programme" do
+    resource :years, controller: "core_induction_programme/years", only: :show, path: "/:year_id" do
+      resource :modules, controller: "core_induction_programme/modules", only: :show, path: "/:module_id" do
+        resource :lessons, controller: "core_induction_programme/lessons", only: :show, path: "/:lesson_id"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,5 +43,13 @@ Rails.application.routes.draw do
 
   resource :school_search, only: %i[show create], path: "school-search", controller: :school_search
 
+  resource :core_induction_programme, controller: :core_induction_programme, only: :show, as: "cip", path: "/cip" do
+    resource :years, controller: "core_induction_programme/years", only: :show, path: "/:id" do
+      resource :modules, controller: "core_induction_programme/modules", only: :show, path: "/:id" do
+        resource :lessons, controller: "core_induction_programme/lessons", only: :show, path: "/:id"
+      end
+    end
+  end
+
   root to: "pages#home"
 end

--- a/spec/requests/core_induction_programme/core_induction_programme_spec.rb
+++ b/spec/requests/core_induction_programme/core_induction_programme_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Core Induction Programme", type: :request do
+  it "renders the core_induction_programme page" do
+    get "/core_induction_programme"
+    expect(response).to render_template(:show)
+  end
+end

--- a/spec/requests/core_induction_programme/course_lesson_spec.rb
+++ b/spec/requests/core_induction_programme/course_lesson_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Core Induction Programme Lesson", type: :request do
+  it "renders the cip lesson page" do
+    course_lesson = FactoryBot.create(:course_lesson)
+    get "/core_induction_programme/#{course_lesson.course_module.course_year.id}/#{course_lesson.course_module.id}/#{course_lesson.id}"
+    expect(response).to render_template(:show)
+  end
+end

--- a/spec/requests/core_induction_programme/course_module_spec.rb
+++ b/spec/requests/core_induction_programme/course_module_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Core Induction Programme Module", type: :request do
+  it "renders the cip module page" do
+    course_module = FactoryBot.create(:course_module)
+    get "/core_induction_programme/#{course_module.course_year.id}/#{course_module.id}"
+    expect(response).to render_template(:show)
+  end
+end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Core Induction Programme Year", type: :request do
+  it "renders the cip year page" do
+    course_year = FactoryBot.create(:course_year)
+    get "/core_induction_programme/#{course_year.id}"
+    expect(response).to render_template(:show)
+  end
+end


### PR DESCRIPTION
### Context
We want to display core induction programme content

### Changes proposed in this pull request
Add a cip page, showing some introduction and all years.

Add a year page showing year page content and its modules.

Add a module page showing module page contents and its lessons.

Add a lesson page.

### Guidance to review
Go to `/core_induction_programme` on web app, we should have some dummy data.

Majority of content is to follow in a later massive seeding PR. 