### PR TITLE
Make seeding idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,9 @@ Review apps are automatically created when a PR is opened. A link to the app wil
 Check the file `manifest.yml` for customisation of name (you may need to change it as there could be a conflict on that name), buildpacks and eventual services (PostgreSQL needs to be [set up](https://docs.cloud.service.gov.uk/deploying_services/postgresql/)).
 
 The app should be available at https://govuk-rails-boilerplate.london.cloudapps.digital
+
+### Seeding cip content / anything else
+
+1. Make sure you are ok with the content in seed files to be created in your db.
+2. Run `cf login -a api.london.cloud.service.gov.uk -u USERNAME`, `USERNAME` is your personal GOV.UK PaaS account email address
+3. Run `cf run-task ecf-dev "cd .. && cd app && ../usr/local/bundle/bin/bundle exec rails db:seed"` to start the task.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,7 @@
 
 Dir[Rails.root.join("db/seeds/dummy_structures.rb")].each { |seed| load seed }
 
-CURRENT_CIP_VERSION = 2
+CURRENT_CIP_VERSION = 3
 CourseLesson.where("version < ?", CURRENT_CIP_VERSION).delete_all
 CourseModule.where("version < ?", CURRENT_CIP_VERSION).delete_all
 CourseYear.where("version < ?", CURRENT_CIP_VERSION).delete_all

--- a/db/seeds/cip_ambition.rb
+++ b/db/seeds/cip_ambition.rb
@@ -1,4 +1,4 @@
-ambition = CourseYear.create!(
+ambition = CourseYear.find_or_create_by!(
     version: CURRENT_CIP_VERSION, lead_provider: LeadProvider.first, is_year_one: true, title: "Ambition Institute",
     content: <<~MultilineString
 Welcome to Ambition Institute’s Early Career Teachers programme. This programme has been designed to help teachers early in their career to keep getting better in the most accessible way possible.
@@ -275,7 +275,7 @@ MultilineString
 # ==================================================
 # UNPROCESSABLE:
 # ==================================================
-one_behaviour = CourseModule.create!(
+one_behaviour = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: ambition, title: "1. Behaviour", previous_module: nil,
     content: <<~MultilineString
 Welcome to the Behaviour strand of the programme. This strand is composed of 12 modules and has been designed to last roughly a term. It is best completed during your first term as an NQT – typically the autumn term.
@@ -292,7 +292,7 @@ MultilineString
 )
 
 # ==================================================
-two_instruction = CourseModule.create!(
+two_instruction = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: ambition, title: "2. Instruction", previous_module: one_behaviour,
     content: <<~MultilineString
 Welcome to the Instruction strand of the programme. This strand is composed of 12 modules and has been designed to last roughly a term. It is best completed during your second term as an NQT – typically the spring term.
@@ -310,7 +310,7 @@ MultilineString
 )
 
 # ==================================================
-three_subject = CourseModule.create!(
+three_subject = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: ambition, title: "3. Subject", previous_module: two_instruction,
     content: <<~MultilineString
 Welcome to the Subject strand of the programme. This strand invites you to consider their planning and assessment through the lens of the subject or phase that you work in. It explores evidence and practice in curriculum and assessment in ways that will be of benefit now but will also be useful as you progress through your career.
@@ -328,7 +328,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourone_strand_fundamentals_and_contracting = CourseLesson.create!(
+one_behaviourone_strand_fundamentals_and_contracting = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "1. Strand overview and contracting", previous_lesson: nil,
     content: <<~MultilineString
 $YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo
@@ -658,7 +658,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourtwo_routines = CourseLesson.create!(
+one_behaviourtwo_routines = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "2. Routines", previous_lesson: one_behaviourone_strand_fundamentals_and_contracting,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/lWdabi1Km2U?list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R)$EndYoutubeVideo
@@ -932,7 +932,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourthree_instructions = CourseLesson.create!(
+one_behaviourthree_instructions = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "3. Instructions", previous_lesson: one_behaviourtwo_routines,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/6SM-4WmXhSc?list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R)$EndYoutubeVideo
@@ -1178,7 +1178,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourfour_directing_attention = CourseLesson.create!(
+one_behaviourfour_directing_attention = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "4. Directing attention", previous_lesson: one_behaviourthree_instructions,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -1436,7 +1436,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourfive_low_level_disruption = CourseLesson.create!(
+one_behaviourfive_low_level_disruption = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "5. Low-level disruption", previous_lesson: one_behaviourfour_directing_attention,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/gebOYHdS8ZI?list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R)$EndYoutubeVideo
@@ -1713,7 +1713,7 @@ MultilineString
 )
 
 # ==================================================
-one_behavioursix_consistency = CourseLesson.create!(
+one_behavioursix_consistency = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "6. Consistency", previous_lesson: one_behaviourfive_low_level_disruption,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/VXmlZYepobM?list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R)$EndYoutubeVideo
@@ -2013,7 +2013,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourseven_positive_learning_environment = CourseLesson.create!(
+one_behaviourseven_positive_learning_environment = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "7. Positive learning environment", previous_lesson: one_behavioursix_consistency,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/clQadkPPyy0)$EndYoutubeVideo
@@ -2376,7 +2376,7 @@ MultilineString
 )
 
 # ==================================================
-one_behavioureight_structured_support_of_learning = CourseLesson.create!(
+one_behavioureight_structured_support_of_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "8. Structured support of learning", previous_lesson: one_behaviourseven_positive_learning_environment,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/wwwLmWUSmz8)$EndYoutubeVideo
@@ -2689,7 +2689,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviournine_challenge = CourseLesson.create!(
+one_behaviournine_challenge = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "9. Challenge", previous_lesson: one_behavioureight_structured_support_of_learning,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/dIATol2i5yY)$EndYoutubeVideo
@@ -3043,7 +3043,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourone_zero_independent_practice = CourseLesson.create!(
+one_behaviourone_zero_independent_practice = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "10. Independent practice", previous_lesson: one_behaviournine_challenge,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/akOyC9epHEY)$EndYoutubeVideo
@@ -3458,7 +3458,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourone_one_pairs_and_groups = CourseLesson.create!(
+one_behaviourone_one_pairs_and_groups = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "11. Pairs and groups", previous_lesson: one_behaviourone_zero_independent_practice,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/n94O-Si3ljU)$EndYoutubeVideo
@@ -3946,7 +3946,7 @@ MultilineString
 )
 
 # ==================================================
-one_behaviourone_two_upholding_high_expectations = CourseLesson.create!(
+one_behaviourone_two_upholding_high_expectations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: one_behaviour, title: "12. Upholding high expectations", previous_lesson: one_behaviourone_one_pairs_and_groups,
     content: <<~MultilineString
 $YoutubeVideo(https://youtu.be/jYQvRpkKEeY)$EndYoutubeVideo
@@ -4271,7 +4271,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionone_strand_fundamentals_and_re_contracting = CourseLesson.create!(
+two_instructionone_strand_fundamentals_and_re_contracting = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "1. Strand fundamentals and (re)contracting", previous_lesson: one_behaviourone_two_upholding_high_expectations,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -4637,7 +4637,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructiontwo_identifying_learning_content = CourseLesson.create!(
+two_instructiontwo_identifying_learning_content = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "2. Identifying learning content", previous_lesson: two_instructionone_strand_fundamentals_and_re_contracting,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -4976,7 +4976,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionthree_instruction_for_memory = CourseLesson.create!(
+two_instructionthree_instruction_for_memory = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "3. Instruction for memory", previous_lesson: two_instructiontwo_identifying_learning_content,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -5307,7 +5307,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionfour_prior_knowledge = CourseLesson.create!(
+two_instructionfour_prior_knowledge = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "4. Prior knowledge", previous_lesson: two_instructionthree_instruction_for_memory,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -5575,7 +5575,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionfive_teacher_exposition = CourseLesson.create!(
+two_instructionfive_teacher_exposition = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "5. Teacher exposition", previous_lesson: two_instructionfour_prior_knowledge,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -5902,7 +5902,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionsix_adapting_teaching = CourseLesson.create!(
+two_instructionsix_adapting_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "6. Adapting teaching", previous_lesson: two_instructionfive_teacher_exposition,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -6276,7 +6276,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionseven_practice_challenge_and_success = CourseLesson.create!(
+two_instructionseven_practice_challenge_and_success = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "7. Practice, challenge and success", previous_lesson: two_instructionsix_adapting_teaching,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -6578,7 +6578,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructioneight_explicit_learning = CourseLesson.create!(
+two_instructioneight_explicit_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "8. Explicit learning", previous_lesson: two_instructionseven_practice_challenge_and_success,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -6915,7 +6915,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionnine_scaffolding = CourseLesson.create!(
+two_instructionnine_scaffolding = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "9. Scaffolding", previous_lesson: two_instructioneight_explicit_learning,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -7235,7 +7235,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionone_zero_questioning = CourseLesson.create!(
+two_instructionone_zero_questioning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "10. Questioning", previous_lesson: two_instructionnine_scaffolding,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -7560,7 +7560,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionone_one_classroom_talk = CourseLesson.create!(
+two_instructionone_one_classroom_talk = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "11. Classroom talk", previous_lesson: two_instructionone_zero_questioning,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -7874,7 +7874,7 @@ MultilineString
 )
 
 # ==================================================
-two_instructionfeedback = CourseLesson.create!(
+two_instructionfeedback = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: two_instruction, title: "12. Feedback", previous_lesson: two_instructionone_one_classroom_talk,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -8167,7 +8167,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectone_strand_fundamentals_and_re_contracting = CourseLesson.create!(
+three_subjectone_strand_fundamentals_and_re_contracting = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "1. Strand fundamentals and re-contracting", previous_lesson: two_instructionfeedback,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -8431,7 +8431,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjecttwo_planning_backwards_from_learning_goals = CourseLesson.create!(
+three_subjecttwo_planning_backwards_from_learning_goals = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "2. Planning backwards from learning goals", previous_lesson: three_subjectone_strand_fundamentals_and_re_contracting,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -8853,7 +8853,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectthree_types_of_knowledge = CourseLesson.create!(
+three_subjectthree_types_of_knowledge = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "3. Types of knowledge", previous_lesson: three_subjecttwo_planning_backwards_from_learning_goals,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -9256,7 +9256,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectfour_gaps_and_misconceptions = CourseLesson.create!(
+three_subjectfour_gaps_and_misconceptions = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "4. Gaps and misconceptions", previous_lesson: three_subjectthree_types_of_knowledge,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -9499,7 +9499,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectfive_acquisition_before_application = CourseLesson.create!(
+three_subjectfive_acquisition_before_application = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "5. Acquisition before application", previous_lesson: three_subjectfour_gaps_and_misconceptions,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -9828,7 +9828,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectsix_promoting_deep_learning = CourseLesson.create!(
+three_subjectsix_promoting_deep_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "6. Promoting deep learning", previous_lesson: three_subjectfive_acquisition_before_application,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -10084,7 +10084,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectseven_developing_pupils_literacy = CourseLesson.create!(
+three_subjectseven_developing_pupils_literacy = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "7. Developing pupils' literacy", previous_lesson: three_subjectsix_promoting_deep_learning,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -10358,7 +10358,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjecteight_sharing_academic_expectations = CourseLesson.create!(
+three_subjecteight_sharing_academic_expectations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "8. Sharing academic expectations", previous_lesson: three_subjectseven_developing_pupils_literacy,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -10591,7 +10591,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectnine_assessing_for_formative_purposes = CourseLesson.create!(
+three_subjectnine_assessing_for_formative_purposes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "9. Assessing for formative purposes", previous_lesson: three_subjecteight_sharing_academic_expectations,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -10876,7 +10876,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectone_zero_examining_pupils_responses = CourseLesson.create!(
+three_subjectone_zero_examining_pupils_responses = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "10. Examining pupils' responses", previous_lesson: three_subjectnine_assessing_for_formative_purposes,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -11109,7 +11109,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectone_one_adapting_lessons_to_meet_pupils_needs = CourseLesson.create!(
+three_subjectone_one_adapting_lessons_to_meet_pupils_needs = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "11. Adapting lessons to meet pupils needs", previous_lesson: three_subjectone_zero_examining_pupils_responses,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -11406,7 +11406,7 @@ MultilineString
 )
 
 # ==================================================
-three_subjectfeedback = CourseLesson.create!(
+three_subjectfeedback = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: three_subject, title: "12. Feedback", previous_lesson: three_subjectone_one_adapting_lessons_to_meet_pupils_needs,
     content: <<~MultilineString
 The final version of this video will be available from spring 2021, as the publication of this programme was fast-tracked in response to disruptions to this year’s initial teacher training.
@@ -11678,7 +11678,7 @@ MultilineString
 )
 
 # ==================================================
-ambitionambition_instituteintroduction = CourseModule.create!(
+ambitionambition_instituteintroduction = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: ambition, title: "Introduction to the Early Career Teacher self-directed study materials", previous_module: nil,
     content: <<~MultilineString
 This page describes the structure of the programme and explains how you can make the most of your study.

--- a/db/seeds/cip_edt.rb
+++ b/db/seeds/cip_edt.rb
@@ -1,6 +1,6 @@
 # UNPROCESSABLE: edt
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materials = CourseYear.create!(
+edtedt_early_career_frameworkself_directed_study_materials = CourseYear.find_or_create_by!(
     version: CURRENT_CIP_VERSION, lead_provider: LeadProvider.first, is_year_one: true, title: "Self-directed study materials",
     content: <<~MultilineString
 ## Welcome
@@ -352,7 +352,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "1: Establishing a positive climate for learning", previous_module: nil,
     content: <<~MultilineString
 ## Time commitment
@@ -385,7 +385,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "2: How pupils learn ‒ memory and cognition", previous_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning,
     content: <<~MultilineString
 ## Time commitment
@@ -416,7 +416,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.1: What you will learn, and video introduction to the Block", previous_lesson: nil,
     content: <<~MultilineString
 ## 1.1a: What you will learn
@@ -576,7 +576,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_two_understanding_the_evidence_the_importance_of_expectations_routines_and_relationships = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_two_understanding_the_evidence_the_importance_of_expectations_routines_and_relationships = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.2: Understanding the evidence: The importance of expectations, routines and relationships", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## 1.2a
@@ -1190,7 +1190,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_three_learning_about_classroom_routines = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_three_learning_about_classroom_routines = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.3: Learning about… classroom routines", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_two_understanding_the_evidence_the_importance_of_expectations_routines_and_relationships,
     content: <<~MultilineString
 ## Time allocation
@@ -1627,7 +1627,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_four_learning_about_maintaining_consistently_high_behavioural_expectations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_four_learning_about_maintaining_consistently_high_behavioural_expectations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.4: Learning about… Maintaining consistently high behavioural expectations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_three_learning_about_classroom_routines,
     content: <<~MultilineString
 ## Time allocation
@@ -1934,7 +1934,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_five_developing_your_teaching_your_role_in_establishing_positive_behaviour = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_five_developing_your_teaching_your_role_in_establishing_positive_behaviour = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.5: Developing your teaching – your role in establishing positive behaviour", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_four_learning_about_maintaining_consistently_high_behavioural_expectations,
     content: <<~MultilineString
 ## Time allocation
@@ -2212,7 +2212,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_six_observations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_six_observations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.6: Observations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_five_developing_your_teaching_your_role_in_establishing_positive_behaviour,
     content: <<~MultilineString
 ## Time allocation
@@ -2311,7 +2311,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_seven_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_seven_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learning, title: "1.7: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_six_observations,
     content: <<~MultilineString
 ## Time allocation
@@ -2336,7 +2336,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "3: Developing effective classroom practice ‒ teaching and adapting", previous_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition,
     content: <<~MultilineString
 ## Time commitment
@@ -2367,7 +2367,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "4: The importance of subject and curriculum knowledge", previous_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting,
     content: <<~MultilineString
 ## Time commitment
@@ -2410,7 +2410,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "5: Assessment, feedback and questioning", previous_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge,
     content: <<~MultilineString
 ## Time commitment
@@ -2443,7 +2443,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "6: A people profession", previous_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning,
     content: <<~MultilineString
 ## Time commitment
@@ -2482,7 +2482,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "7: Embedding a positive climate for learning", previous_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession,
     content: <<~MultilineString
 ## Time commitment
@@ -2519,7 +2519,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "8: How pupils learn – making it stick", previous_module: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning,
     content: <<~MultilineString
 ## Time commitment
@@ -2550,7 +2550,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "9: Enhancing classroom practice ‒ grouping and tailoring", previous_module: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick,
     content: <<~MultilineString
 ## Time commitment
@@ -2579,7 +2579,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "10: Revisiting the importance of subject and curriculum knowledge", previous_module: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring,
     content: <<~MultilineString
 ## Time commitment
@@ -2621,7 +2621,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning = CourseModule.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "11: Deepening assessment, feedback and questioning", previous_module: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge,
     content: <<~MultilineString
 ## Time commitment
@@ -2650,7 +2650,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition, title: "2.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsestablishing_a_positive_climate_for_learningone_seven_reflecting_on_learning,
     content: <<~MultilineString
 ## 2.1a: What you will learn
@@ -2892,7 +2892,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_two_understanding_the_evidence = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_two_understanding_the_evidence = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition, title: "2.2: Understanding the evidence", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## Time allocation
@@ -3384,7 +3384,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_three_learning_about_prior_knowledge_misconceptions_and_worked_examples = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_three_learning_about_prior_knowledge_misconceptions_and_worked_examples = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition, title: "2.3: Learning about... prior knowledge, misconceptions and worked examples", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_two_understanding_the_evidence,
     content: <<~MultilineString
 ## Time allocation
@@ -3571,7 +3571,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_four_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_four_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition, title: "2.4: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_three_learning_about_prior_knowledge_misconceptions_and_worked_examples,
     content: <<~MultilineString
 ## Time allocation
@@ -3714,7 +3714,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_five_improving_your_teaching_lesson_observations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_five_improving_your_teaching_lesson_observations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition, title: "2.5: Improving your teaching – lesson observations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_four_developing_your_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -3820,7 +3820,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_six_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_six_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognition, title: "2.6: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_five_improving_your_teaching_lesson_observations,
     content: <<~MultilineString
 ## Time allocation
@@ -3845,7 +3845,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialshow_pupils_learn_etwo_eight_zero_nine_two_memory_and_cognitiontwo_six_reflecting_on_learning,
     content: <<~MultilineString
 ## 3.1a: What you will learn
@@ -3971,7 +3971,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_two_understanding_the_evidence_one_effective_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_two_understanding_the_evidence_one_effective_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.2: Understanding the evidence 1: effective teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## Time allocation
@@ -4694,7 +4694,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_three_understanding_the_evidence_two_metacognition_and_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_three_understanding_the_evidence_two_metacognition_and_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.3: Understanding the evidence 2: metacognition and teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_two_understanding_the_evidence_one_effective_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -4828,7 +4828,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_four_learning_about_adaptive_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_four_learning_about_adaptive_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.4: Learning about adaptive teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_three_understanding_the_evidence_two_metacognition_and_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -5025,7 +5025,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_five_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_five_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.5: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_four_learning_about_adaptive_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -5371,7 +5371,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_six_improving_your_teaching_lesson_observations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_six_improving_your_teaching_lesson_observations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.6: Improving your teaching: lesson observations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_five_developing_your_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -5480,7 +5480,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_seven_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_seven_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adapting, title: "3.7: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_six_improving_your_teaching_lesson_observations,
     content: <<~MultilineString
 ## **Time allocation**
@@ -5505,7 +5505,7 @@ MultilineString
 
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_one_what_you_will_learn_and_video_introduction_to_the_block_two_ = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_one_what_you_will_learn_and_video_introduction_to_the_block_two_ = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge, title: "4.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsthree_developing_effective_classroom_practice_etwo_eight_zero_nine_two_teaching_and_adaptingthree_seven_reflecting_on_learning,
     content: <<~MultilineString
 ## 4.1a: What you will learn
@@ -5620,7 +5620,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_two_understanding_the_evidence = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_two_understanding_the_evidence = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge, title: "4.2: Understanding the evidence", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_one_what_you_will_learn_and_video_introduction_to_the_block_two_,
     content: <<~MultilineString
 ## Time allocation
@@ -5943,7 +5943,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_three_learning_about_literacy = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_three_learning_about_literacy = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge, title: "4.3: Learning about literacy", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_two_understanding_the_evidence,
     content: <<~MultilineString
 ## Time allocation
@@ -6482,7 +6482,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_four_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_four_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge, title: "4.4: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_three_learning_about_literacy,
     content: <<~MultilineString
 ## Time allocation
@@ -6814,7 +6814,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_five_improving_your_teaching_lesson_observations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_five_improving_your_teaching_lesson_observations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge, title: "4.5: Improving your teaching – lesson observations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_four_developing_your_teaching,
     content: <<~MultilineString
 ## **Time allocation**
@@ -6906,7 +6906,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_six_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_six_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledge, title: "4.6: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_five_improving_your_teaching_lesson_observations,
     content: <<~MultilineString
 ## Time allocation
@@ -6936,7 +6936,7 @@ MultilineString
 
 
 
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_one_what_you_will_learn_and_video_introduction_to_the_block_two_two_ = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_one_what_you_will_learn_and_video_introduction_to_the_block_two_two_ = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning, title: "5.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfour_the_importance_of_subject_and_curriculum_knowledgefour_six_reflecting_on_learning,
     content: <<~MultilineString
 ## 5.1a: What you will learn
@@ -7030,7 +7030,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_two_understanding_the_evidence = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_two_understanding_the_evidence = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning, title: "5.2: Understanding the evidence", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_one_what_you_will_learn_and_video_introduction_to_the_block_two_two_,
     content: <<~MultilineString
 ## Time allocation
@@ -7731,7 +7731,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_three_learning_about_questioning_and_high_quality_classroom_talk = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_three_learning_about_questioning_and_high_quality_classroom_talk = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning, title: "5.3: Learning about questioning and high-quality classroom talk", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_two_understanding_the_evidence,
     content: <<~MultilineString
 ## Time allocation
@@ -8201,7 +8201,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_four_developing_your_teaching_assessment_and_questioning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_four_developing_your_teaching_assessment_and_questioning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning, title: "5.4: Developing your teaching - Assessment and questioning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_three_learning_about_questioning_and_high_quality_classroom_talk,
     content: <<~MultilineString
 ## Time allocation
@@ -8476,7 +8476,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_five_improving_your_teaching_lesson_observations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_five_improving_your_teaching_lesson_observations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning, title: "5.5: Improving your teaching: lesson observations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_four_developing_your_teaching_assessment_and_questioning,
     content: <<~MultilineString
 ## Time allocation
@@ -8593,7 +8593,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_six_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_six_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioning, title: "5.6: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_five_improving_your_teaching_lesson_observations,
     content: <<~MultilineString
 ## Time allocation
@@ -8622,7 +8622,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_one_what_you_will_learn_and_video_introduction_to_the_block_two_ = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_one_what_you_will_learn_and_video_introduction_to_the_block_two_ = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsfive_assessment_feedback_and_questioningfive_six_reflecting_on_learning,
     content: <<~MultilineString
 ## 6.1a: What you will learn
@@ -8715,7 +8715,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_two_understanding_the_evidence_a_people_profession = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_two_understanding_the_evidence_a_people_profession = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.2: Understanding the evidence: A people profession", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_one_what_you_will_learn_and_video_introduction_to_the_block_two_,
     content: <<~MultilineString
 ## **Time allocation**
@@ -9256,7 +9256,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_three_effective_professional_relationships = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_three_effective_professional_relationships = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.3: Effective professional relationships", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_two_understanding_the_evidence_a_people_profession,
     content: <<~MultilineString
 ## Time allocation
@@ -9381,7 +9381,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_four_working_with_the_senco = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_four_working_with_the_senco = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.4: Working with the SENCO", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_three_effective_professional_relationships,
     content: <<~MultilineString
 ## Time allocation
@@ -9655,7 +9655,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_five_working_effectively_with_teaching_assistants = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_five_working_effectively_with_teaching_assistants = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.5: Working effectively with teaching assistants", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_four_working_with_the_senco,
     content: <<~MultilineString
 ## Time allocation
@@ -9707,7 +9707,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_six_observations = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_six_observations = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.6: Observations", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_five_working_effectively_with_teaching_assistants,
     content: <<~MultilineString
 ## Time allocation
@@ -9772,7 +9772,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_seven_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_seven_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_profession, title: "6.7: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_six_observations,
     content: <<~MultilineString
 ## Time allocation
@@ -9801,7 +9801,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning, title: "7.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialssix_a_people_professionsix_seven_reflecting_on_learning,
     content: <<~MultilineString
 ## 7.1a: What you will learn
@@ -9898,7 +9898,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_two_understanding_the_evidence_pupil_motivation = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_two_understanding_the_evidence_pupil_motivation = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning, title: "7.3: Developing your teaching – supporting pupils to achieve with challenging content", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## Time allocation
@@ -10012,7 +10012,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_three_developing_your_teaching_supporting_pupils_to_achieve_with_challenging_content = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_three_developing_your_teaching_supporting_pupils_to_achieve_with_challenging_content = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning, title: "7.2: Understanding the evidence: Pupil motivation", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_two_understanding_the_evidence_pupil_motivation,
     content: <<~MultilineString
 ## Time allocation
@@ -10343,7 +10343,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_four_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_four_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learning, title: "7.4: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_three_developing_your_teaching_supporting_pupils_to_achieve_with_challenging_content,
     content: <<~MultilineString
 ## Time allocation
@@ -10372,7 +10372,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick, title: "8.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsseven_embedding_a_positive_climate_for_learningseven_four_reflecting_on_learning,
     content: <<~MultilineString
 ## 8.1a: What you will learn
@@ -10563,7 +10563,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_two_understanding_the_evidence = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_two_understanding_the_evidence = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick, title: "8.2: Understanding the evidence", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## Time allocation
@@ -11067,7 +11067,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_three_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_three_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick, title: "8.3: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_two_understanding_the_evidence,
     content: <<~MultilineString
 ## Time allocation
@@ -11153,7 +11153,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_four_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_four_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stick, title: "8.4: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_three_developing_your_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -11182,7 +11182,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring, title: "9.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialseight_how_pupils_learn_making_it_stickeight_four_reflecting_on_learning,
     content: <<~MultilineString
 ## 9.1a: What you will learn
@@ -11328,7 +11328,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_two_understanding_the_evidence = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_two_understanding_the_evidence = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring, title: "9.2: Understanding the evidence", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## **Time allocation**
@@ -11771,7 +11771,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_three_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_three_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring, title: "9.3: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_two_understanding_the_evidence,
     content: <<~MultilineString
 ## Time allocation
@@ -11863,7 +11863,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_four_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_four_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoring, title: "9.4: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_three_developing_your_teaching,
     content: <<~MultilineString
 ## Time allocation
@@ -11892,7 +11892,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge, title: "10.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsnine_enhancing_classroom_practice_etwo_eight_zero_nine_two_grouping_and_tailoringnine_four_reflecting_on_learning,
     content: <<~MultilineString
 ## 10.1a: What you will learn
@@ -11988,7 +11988,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_two_curriculum_design_around_the_big_ideas = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_two_curriculum_design_around_the_big_ideas = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge, title: "10.2: Curriculum design around the big ideas", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## **Time allocation**
@@ -12282,7 +12282,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_three_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_three_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge, title: "10.3: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_two_curriculum_design_around_the_big_ideas,
     content: <<~MultilineString
 ## Time allocation
@@ -12330,7 +12330,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_four_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_four_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledge, title: "10.4: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_three_developing_your_teaching,
     content: <<~MultilineString
 ## **Time allocation**
@@ -12359,7 +12359,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_one_what_you_will_learn_and_video_introduction_to_the_block = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning, title: "11.1: What you will learn, and video introduction to the Block", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_zero_revisiting_the_importance_of_subject_and_curriculum_knowledgeone_zero_four_reflecting_on_learning,
     content: <<~MultilineString
 ## 11.1a: What you will learn
@@ -12476,7 +12476,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_two_understanding_the_evidence = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_two_understanding_the_evidence = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning, title: "11.2: Understanding the evidence", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_one_what_you_will_learn_and_video_introduction_to_the_block,
     content: <<~MultilineString
 ## **Time allocation**
@@ -12666,7 +12666,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_three_learning_about_developing_efficient_and_effective_approaches_to_assessment = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_three_learning_about_developing_efficient_and_effective_approaches_to_assessment = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning, title: "11.3: Learning about developing efficient and effective approaches to assessment", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_two_understanding_the_evidence,
     content: <<~MultilineString
 ## Time allocation
@@ -12798,7 +12798,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_four_developing_your_teaching = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_four_developing_your_teaching = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning, title: "11.4: Developing your teaching", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_three_learning_about_developing_efficient_and_effective_approaches_to_assessment,
     content: <<~MultilineString
 ## **Time allocation**
@@ -12940,7 +12940,7 @@ MultilineString
 )
 
 # ==================================================
-edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_five_reflecting_on_learning = CourseLesson.create!(
+edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_five_reflecting_on_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioning, title: "11.5: Reflecting on learning", previous_lesson: edtedt_early_career_frameworkself_directed_study_materialsone_one_deepening_assessment_feedback_and_questioningone_one_four_developing_your_teaching,
     content: <<~MultilineString
 ## **Time allocation**
@@ -12987,7 +12987,7 @@ MultilineString
 # ==================================================
 # UNPROCESSABLE: edttraining_trashedjulia_trashed
 # ==================================================
-edtedt_early_career_frameworkmentor_materials = CourseModule.create!(
+edtedt_early_career_frameworkmentor_materials = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: edtedt_early_career_frameworkself_directed_study_materials, title: "Mentor materials", previous_module: nil,
     content: <<~MultilineString
 Use the links below to download PDFs for mentor content and mentor handouts.

--- a/db/seeds/cip_teachfirst.rb
+++ b/db/seeds/cip_teachfirst.rb
@@ -1,6 +1,6 @@
 # UNPROCESSABLE: teachfirst
 # ==================================================
-teachfirstteach_firstself_directed_study_material = CourseYear.create!(
+teachfirstteach_firstself_directed_study_material = CourseYear.find_or_create_by!(
     version: CURRENT_CIP_VERSION, lead_provider: LeadProvider.first, is_year_one: true, title: "Self-directed study material",
     content: <<~MultilineString
 The online study materials consist of six modules. You will complete one module per half-term in your first year of the programme. Each module has been broken down into weekly sessions to provide you with research informed, bitesize information on best practice.
@@ -188,7 +188,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment = CourseModule.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: teachfirstteach_firstself_directed_study_material, title: "1: How can you create an effective learning environment?", previous_module: nil,
     content: <<~MultilineString
 ## Module Overview
@@ -284,7 +284,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn = CourseModule.create!(
+teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: teachfirstteach_firstself_directed_study_material, title: "2: How do pupils learn?", previous_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment,
     content: <<~MultilineString
 ## Module Overview
@@ -313,7 +313,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective = CourseModule.create!(
+teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: teachfirstteach_firstself_directed_study_material, title: "3: What makes classroom practice effective?", previous_module: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn,
     content: <<~MultilineString
 ## Introduction
@@ -415,7 +415,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect = CourseModule.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: teachfirstteach_firstself_directed_study_material, title: "4: How can you use assessment and feedback to greatest effect?", previous_module: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective,
     content: <<~MultilineString
 ## Session 1: Introduction
@@ -445,7 +445,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed = CourseModule.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: teachfirstteach_firstself_directed_study_material, title: "5: How can you support all pupils to succeed?", previous_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect,
     content: <<~MultilineString
 ## Introduction
@@ -516,7 +516,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum = CourseModule.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: teachfirstteach_firstself_directed_study_material, title: "6: How to design a coherent curriculum", previous_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed,
     content: <<~MultilineString
 ## Module overview
@@ -554,7 +554,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentone_establishing_effective_routines_five_one_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentone_establishing_effective_routines_five_one_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment, title: "1. Establishing effective routines", previous_lesson: nil,
     content: <<~MultilineString
 This session will take **approximately 51 minutes** to complete.
@@ -1270,7 +1270,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmenttwo_creating_a_positive_and_respectful_classroom_environment_three_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmenttwo_creating_a_positive_and_respectful_classroom_environment_three_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment, title: "2. Creating a positive and respectful classroom environment", previous_lesson: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentone_establishing_effective_routines_five_one_minutes,
     content: <<~MultilineString
 This session will take **approximately 30 minutes** to complete.
@@ -1611,7 +1611,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentthree_addressing_low_level_behaviour_four_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentthree_addressing_low_level_behaviour_four_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment, title: "3. Addressing low-level behaviour", previous_lesson: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmenttwo_creating_a_positive_and_respectful_classroom_environment_three_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 40 minutes** to complete.
@@ -1961,7 +1961,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentfour_addressing_persistent_and_challenging_behaviour_five_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentfour_addressing_persistent_and_challenging_behaviour_five_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment, title: "4. Addressing persistent and challenging behaviour", previous_lesson: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentthree_addressing_low_level_behaviour_four_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 50 minutes** to complete.
@@ -2471,7 +2471,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentfive_developing_pupils_intrinsic_motivation_four_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentfive_developing_pupils_intrinsic_motivation_four_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment, title: "5. Developing pupils’ intrinsic motivation", previous_lesson: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentfour_addressing_persistent_and_challenging_behaviour_five_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 40 minutes** to complete.
@@ -2821,7 +2821,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentsix_holding_high_expectations_and_maintaining_engagement_five_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentsix_holding_high_expectations_and_maintaining_engagement_five_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environment, title: "6. Holding high expectations and maintaining engagement", previous_lesson: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentfive_developing_pupils_intrinsic_motivation_four_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 50 minutes** to complete.
@@ -3248,7 +3248,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnone_the_working_and_long_term_memory_five_five_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnone_the_working_and_long_term_memory_five_five_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn, title: "1. The working and long-term memory", previous_lesson: teachfirstteach_firstself_directed_study_materialone_how_can_you_create_an_effective_learning_environmentsix_holding_high_expectations_and_maintaining_engagement_five_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 55 minutes** to complete.
@@ -3490,7 +3490,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learntwo_considering_how_to_introduce_new_knowledge_to_pupils_six_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learntwo_considering_how_to_introduce_new_knowledge_to_pupils_six_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn, title: "2. Considering how to introduce new knowledge to pupils", previous_lesson: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnone_the_working_and_long_term_memory_five_five_minutes,
     content: <<~MultilineString
 This session will take **approximately** **60 minutes** to complete.
@@ -3673,7 +3673,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnthree_using_worked_and_partially_completed_examples_four_five_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnthree_using_worked_and_partially_completed_examples_four_five_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn, title: "3. Using worked and partially completed examples", previous_lesson: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learntwo_considering_how_to_introduce_new_knowledge_to_pupils_six_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 45 minutes** to complete.
@@ -3932,7 +3932,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnfour_helping_pupils_remember_eight_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnfour_helping_pupils_remember_eight_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn, title: "4. Helping pupils remember", previous_lesson: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnthree_using_worked_and_partially_completed_examples_four_five_minutes,
     content: <<~MultilineString
 This session will take **approximately 80 minutes** to complete.
@@ -4164,7 +4164,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnfive_introduction_to_metacognition_one_five_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnfive_introduction_to_metacognition_one_five_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learn, title: "5. Introduction to Metacognition", previous_lesson: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnfour_helping_pupils_remember_eight_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 15 minutes** to complete.
@@ -4347,7 +4347,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectiveone_review_of_previous_learning_one_five_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectiveone_review_of_previous_learning_one_five_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective, title: "1. Review of previous learning", previous_lesson: teachfirstteach_firstself_directed_study_materialtwo_how_do_pupils_learnfive_introduction_to_metacognition_one_five_minutes,
     content: <<~MultilineString
 This session will take **approximately 15 minutes** to complete.
@@ -4466,7 +4466,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivetwo_explanations_and_modelling_six_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivetwo_explanations_and_modelling_six_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective, title: "2. Explanations and Modelling", previous_lesson: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectiveone_review_of_previous_learning_one_five_minutes,
     content: <<~MultilineString
 This session will take **approximately 65 minutes** to complete.
@@ -4972,7 +4972,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivethree_guided_practice_six_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivethree_guided_practice_six_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective, title: "3. Guided Practice", previous_lesson: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivetwo_explanations_and_modelling_six_five_mins,
     content: <<~MultilineString
 This session will take **approximately 60 minutes** to complete.
@@ -5279,7 +5279,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivefour_independent_practice_six_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivefour_independent_practice_six_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective, title: "4. Independent Practice", previous_lesson: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivethree_guided_practice_six_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 60 minutes** to complete.
@@ -5898,7 +5898,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivefive_questioning_six_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivefive_questioning_six_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effective, title: "5. Questioning", previous_lesson: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivefour_independent_practice_six_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 60 minutes** to complete.
@@ -6558,7 +6558,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectone_what_makes_assessment_effective_five_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectone_what_makes_assessment_effective_five_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect, title: "1. What Makes Assessment Effective?", previous_lesson: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivefive_questioning_six_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 50 minutes** to complete.
@@ -6801,7 +6801,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effecttwo_planning_for_effective_assessment_five_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effecttwo_planning_for_effective_assessment_five_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect, title: "2. Planning for Effective Assessment", previous_lesson: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectone_what_makes_assessment_effective_five_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 50 minutes** to complete.
@@ -7149,7 +7149,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectthree_monitoring_misconceptions_four_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectthree_monitoring_misconceptions_four_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect, title: "3. Monitoring Misconceptions", previous_lesson: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effecttwo_planning_for_effective_assessment_five_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 45 minutes** to complete.
@@ -7351,7 +7351,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectfour_making_feedback_purposeful_and_manageable_part_one_five_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectfour_making_feedback_purposeful_and_manageable_part_one_five_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect, title: "4. Making Feedback Purposeful and Manageable, Part 1: What does effective feedback look like?", previous_lesson: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectthree_monitoring_misconceptions_four_five_mins,
     content: <<~MultilineString
 This session will take **approximately 55 minutes** to complete.
@@ -7777,7 +7777,7 @@ MultilineString
 # ==================================================
 # UNPROCESSABLE: teachfirstsample_page_trashedcharlotte_trashed
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectfive_making_feedback_purposeful_and_manageable_part_two_three_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectfive_making_feedback_purposeful_and_manageable_part_two_three_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect, title: "5. Making Feedback Purposeful and Manageable, Part 2: Effective peer and self-assessment", previous_lesson: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectfour_making_feedback_purposeful_and_manageable_part_one_five_five_mins,
     content: <<~MultilineString
 This session will take **approximately 35 minutes** to complete.
@@ -8065,7 +8065,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectsix_summative_assessment_three_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectsix_summative_assessment_three_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effect, title: "6. Summative Assessment", previous_lesson: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectfive_making_feedback_purposeful_and_manageable_part_two_three_five_mins,
     content: <<~MultilineString
 This session will take **approximately 30 minutes** to complete.
@@ -8260,7 +8260,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedone_supporting_all_pupils_to_access_the_curriculum_developing_high_quality_oral_language_four_two_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedone_supporting_all_pupils_to_access_the_curriculum_developing_high_quality_oral_language_four_two_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "1. Supporting all pupils to access the curriculum - developing high-quality oral language", previous_lesson: teachfirstteach_firstself_directed_study_materialfour_how_can_you_use_assessment_and_feedback_to_greatest_effectsix_summative_assessment_three_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 42 minutes** to complete.
@@ -8719,7 +8719,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedtwo_supporting_all_pupils_to_access_the_curriculum_developing_reading_and_writing_four_five_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedtwo_supporting_all_pupils_to_access_the_curriculum_developing_reading_and_writing_four_five_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "2. Supporting all pupils to access the curriculum - developing reading and writing", previous_lesson: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedone_supporting_all_pupils_to_access_the_curriculum_developing_high_quality_oral_language_four_two_minutes,
     content: <<~MultilineString
 This session will take **approximately 45 minutes** to complete.
@@ -9121,7 +9121,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedthree_further_developing_prior_knowledge_three_five_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedthree_further_developing_prior_knowledge_three_five_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "3. Further developing prior knowledge", previous_lesson: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedtwo_supporting_all_pupils_to_access_the_curriculum_developing_reading_and_writing_four_five_minutes,
     content: <<~MultilineString
 This session will take **approximately 35 minutes** to complete.
@@ -9380,7 +9380,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfour_providing_additional_scaffolds_six_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfour_providing_additional_scaffolds_six_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "4. Providing additional scaffolds", previous_lesson: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedthree_further_developing_prior_knowledge_three_five_minutes,
     content: <<~MultilineString
 This session will take **approximately 60 minutes** to complete.
@@ -10086,7 +10086,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfive_the_send_code_of_practice_three_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfive_the_send_code_of_practice_three_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "5. The SEND code of practice", previous_lesson: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfour_providing_additional_scaffolds_six_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 30 minutes** to complete.
@@ -10421,7 +10421,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedsix_teaching_pupils_who_require_a_greater_level_of_support_five_zero_minutes = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedsix_teaching_pupils_who_require_a_greater_level_of_support_five_zero_minutes = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "6. Teaching pupils who require a greater level of support", previous_lesson: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfive_the_send_code_of_practice_three_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 50 minutes** to complete.
@@ -11533,7 +11533,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumone_what_is_the_purpose_of_a_curriculum_two_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumone_what_is_the_purpose_of_a_curriculum_two_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum, title: "1. What is the purpose of a curriculum?", previous_lesson: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedsix_teaching_pupils_who_require_a_greater_level_of_support_five_zero_minutes,
     content: <<~MultilineString
 This session will take **approximately 25 minutes** to complete.
@@ -11761,7 +11761,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumtwo_identifying_concepts_knowledge_and_skills_five_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumtwo_identifying_concepts_knowledge_and_skills_five_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum, title: "2. Identifying concepts, knowledge and skills", previous_lesson: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumone_what_is_the_purpose_of_a_curriculum_two_five_mins,
     content: <<~MultilineString
 This session will take **approximately 50 minutes** to complete.
@@ -12142,7 +12142,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumthree_sequencing_teaching_and_learning_five_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumthree_sequencing_teaching_and_learning_five_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum, title: "3. Sequencing teaching and learning", previous_lesson: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumtwo_identifying_concepts_knowledge_and_skills_five_zero_mins,
     content: <<~MultilineString
 This session will take **approximately 55 minutes** to complete.
@@ -12387,7 +12387,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumfour_helping_pupils_master_important_concepts_knowledge_and_skills_part_one_four_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumfour_helping_pupils_master_important_concepts_knowledge_and_skills_part_one_four_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum, title: "4. Helping pupils master important concepts, knowledge and skills – Part 1", previous_lesson: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumthree_sequencing_teaching_and_learning_five_five_mins,
     content: <<~MultilineString
 This session will take **approximately 45 minutes** to complete.
@@ -12591,7 +12591,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumfive_helping_pupils_master_important_concepts_knowledge_and_skills_part_two_three_five_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumfive_helping_pupils_master_important_concepts_knowledge_and_skills_part_two_three_five_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum, title: "5. Helping pupils master important concepts, knowledge and skills – Part 2", previous_lesson: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumfour_helping_pupils_master_important_concepts_knowledge_and_skills_part_one_four_five_mins,
     content: <<~MultilineString
 This session will take **approximately 35 minutes** to complete.
@@ -12766,7 +12766,7 @@ MultilineString
 )
 
 # ==================================================
-teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumsix_supporting_pupils_to_build_increasingly_complex_mental_models_six_zero_mins = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumsix_supporting_pupils_to_build_increasingly_complex_mental_models_six_zero_mins = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculum, title: "6. Supporting pupils to build increasingly complex mental models", previous_lesson: teachfirstteach_firstself_directed_study_materialsix_how_to_design_a_coherent_curriculumfive_helping_pupils_master_important_concepts_knowledge_and_skills_part_two_three_five_mins,
     content: <<~MultilineString
 This session will take **approximately 60 minutes** to complete.
@@ -13095,7 +13095,7 @@ MultilineString
 # ==================================================
 # UNPROCESSABLE: teachfirstteach_firstself_directed_study_materialthree_what_makes_classroom_practice_effectivetwo_explanations_and_modelling_six_five_minsmodule_three_session_two_quiz
 # ==================================================
-teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfive_the_send_code_of_practice_three_zero_minutesmodule_five_session_three_further_developing_prior_knowledge = CourseLesson.create!(
+teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeedfive_the_send_code_of_practice_three_zero_minutesmodule_five_session_three_further_developing_prior_knowledge = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: teachfirstteach_firstself_directed_study_materialfive_how_can_you_support_all_pupils_to_succeed, title: "Module 5 Session 3 Further developing prior knowledge", previous_lesson: nil,
     content: <<~MultilineString
 <!-- wp:gravityforms/form {"formId":"4","title":false,"description":false} /-->

--- a/db/seeds/cip_ucl.rb
+++ b/db/seeds/cip_ucl.rb
@@ -1,6 +1,6 @@
 # UNPROCESSABLE: ucl
 # ==================================================
-uclucltwo_understanding_teachers_as_role_models = CourseYear.create!(
+uclucltwo_understanding_teachers_as_role_models = CourseYear.find_or_create_by!(
     version: CURRENT_CIP_VERSION, lead_provider: LeadProvider.first, is_year_one: true, title: "Self-directed study materials",
     content: <<~MultilineString
 Any topics not listed below are for mentors or part of the Full Induction Programme only.
@@ -156,7 +156,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "1: Enabling pupil learning", previous_module: nil,
     content: <<~MultilineString
 Module 1 of the ECF addresses Teachers’ Standard 1: Set high expectations and Teachers’ Standard 7: Manage behaviour effectively.
@@ -173,7 +173,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsunderstanding_teachers_as_role_models = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsunderstanding_teachers_as_role_models = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models, title: "2: Understanding teachers as role models", previous_lesson: nil,
     content: <<~MultilineString
 ## Session Elements
@@ -375,7 +375,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsthree_establishing_the_learning_environment = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsthree_establishing_the_learning_environment = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models, title: "3: Establishing the learning environment", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsunderstanding_teachers_as_role_models,
     content: <<~MultilineString
 ## Session Elements
@@ -638,7 +638,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsfive_understanding_pupils_as_learners = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsfive_understanding_pupils_as_learners = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models, title: "5: Understanding pupils as learners", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsthree_establishing_the_learning_environment,
     content: <<~MultilineString
 ## Session Elements
@@ -807,7 +807,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelssix_managing_behaviour = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelssix_managing_behaviour = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models, title: "6: Managing behaviour", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelsfive_understanding_pupils_as_learners,
     content: <<~MultilineString
 ## Session Elements
@@ -1003,7 +1003,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "2: Engaging pupils in learning", previous_module: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_models,
     content: <<~MultilineString
 Module 2 of the ECF addresses Teachers’ Standards 2 and 3: Promote good
@@ -1022,7 +1022,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "3: Developing quality pedagogy", previous_module: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning,
     content: <<~MultilineString
 Module 3 of the ECF addresses Teachers’ Standard 4: Plan and teach well structured lessons and Standard 5: Adapt teaching.
@@ -1039,7 +1039,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "4: Making productive use of assessment", previous_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy,
     content: <<~MultilineString
 Module 4 of the ECF addresses Teachers’ Standard 6: Make accurate and productive use of assessment.
@@ -1057,7 +1057,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilities = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilities = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "5: Fulfilling professional responsibilities", previous_module: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment,
     content: <<~MultilineString
 Module 5 of the ECF addresses Teachers’ Standard 8: Fulfil wider professional responsibilities.
@@ -1074,7 +1074,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learning = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "6: Enabling pupil learning", previous_module: uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilities,
     content: <<~MultilineString
 Module 6 of the ECF addresses Teachers’ Standards 1 (Set high expectations) & 7 (Manage behaviour effectively). It is a continuation of Module 1 from the first year of this programme.
@@ -1092,7 +1092,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learning = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learning = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "7: Engaging pupils in learning", previous_module: uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learning,
     content: <<~MultilineString
 Module 7 of the ECF is designed around an inquiry into Engaging Pupils in Learning, and addresses Teachers’ Standards 2 (Promote good progress) & 3 (Demonstrate good subject and curriculum knowledge). It is a continuation of Module 2 from the first year of this programme.
@@ -1109,7 +1109,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessment = CourseModule.create!(
+uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessment = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "8: Developing quality pedagogy and making productive use of assessment", previous_module: uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learning,
     content: <<~MultilineString
 Module 8 of the ECF is designed around an inquiry into Developing quality pedagogy (Standard 4 and Standard 5) and making productive use of assessment (Standard 6). It is a continuation of Modules 3 and 4 from the first year of this programme.
@@ -1127,7 +1127,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningtwo_prior_knowledge_memory_and_misconceptions = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningtwo_prior_knowledge_memory_and_misconceptions = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning, title: "2: Prior knowledge, memory and misconceptions", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_understanding_teachers_as_role_modelssix_managing_behaviour,
     content: <<~MultilineString
 ## Session Elements
@@ -1288,7 +1288,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningthree_literacy_and_learning = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningthree_literacy_and_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning, title: "3: Literacy and learning", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningtwo_prior_knowledge_memory_and_misconceptions,
     content: <<~MultilineString
 ## Session Elements
@@ -1448,7 +1448,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningfour_consolidation_of_learning = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningfour_consolidation_of_learning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning, title: "4: Consolidation of learning", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningthree_literacy_and_learning,
     content: <<~MultilineString
 ## Session Elements
@@ -1562,7 +1562,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningfive_curriculum_and_subject_knowledge = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningfive_curriculum_and_subject_knowledge = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learning, title: "5: Curriculum and subject knowledge", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningfour_consolidation_of_learning,
     content: <<~MultilineString
 ## Session Elements
@@ -1797,7 +1797,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogytwo_implementing_effective_modelling = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogytwo_implementing_effective_modelling = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "2: Implementing effective modelling", previous_lesson: uclucltwo_understanding_teachers_as_role_modelstwo_engaging_pupils_in_learningfive_curriculum_and_subject_knowledge,
     content: <<~MultilineString
 ## Session Elements
@@ -1983,7 +1983,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogythree_introducing_new_material_in_steps_using_exposition_and_questioning = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogythree_introducing_new_material_in_steps_using_exposition_and_questioning = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "3: Introducing new material in steps using exposition and questioning", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogytwo_implementing_effective_modelling,
     content: <<~MultilineString
 ## Session Elements
@@ -2214,7 +2214,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyfour_modelling_metacognitive_strategies = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyfour_modelling_metacognitive_strategies = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "4: Modelling metacognitive strategies", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogythree_introducing_new_material_in_steps_using_exposition_and_questioning,
     content: <<~MultilineString
 ## Session Elements
@@ -2390,7 +2390,7 @@ MultilineString
 
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyfive_developing_high_quality_classroom_talk = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyfive_developing_high_quality_classroom_talk = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "5: Developing high-quality classroom talk", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyfour_modelling_metacognitive_strategies,
     content: <<~MultilineString
 ## Session Elements
@@ -2602,7 +2602,7 @@ MultilineString
 
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyeight_using_groupings_to_support_specific_needs = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyeight_using_groupings_to_support_specific_needs = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "8: Using groupings to support specific needs", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyfive_developing_high_quality_classroom_talk,
     content: <<~MultilineString
 ## Session Elements
@@ -2771,7 +2771,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogynine_building_on_pupils_prior_knowledge_through_formative_assessment = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogynine_building_on_pupils_prior_knowledge_through_formative_assessment = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "9: Building on pupils' prior knowledge through formative assessment", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyeight_using_groupings_to_support_specific_needs,
     content: <<~MultilineString
 ## Session Elements
@@ -2963,7 +2963,7 @@ MultilineString
 
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyone_zero_making_new_concepts_accessible_through_targeted_support = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyone_zero_making_new_concepts_accessible_through_targeted_support = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "10: Making new concepts accessible through targeted support", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogynine_building_on_pupils_prior_knowledge_through_formative_assessment,
     content: <<~MultilineString
 ## Session Elements
@@ -3108,7 +3108,7 @@ MultilineString
 
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyone_one_meeting_individual_needs_and_balancing_workload = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyone_one_meeting_individual_needs_and_balancing_workload = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogy, title: "11: Meeting individual needs and balancing workload", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyone_zero_making_new_concepts_accessible_through_targeted_support,
     content: <<~MultilineString
 ## Session Elements
@@ -3259,7 +3259,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentone_fundamental_principles_of_effective_assessment_one_ = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentone_fundamental_principles_of_effective_assessment_one_ = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment, title: "1: Fundamental principles of effective assessment (1)", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsthree_developing_quality_pedagogyone_one_meeting_individual_needs_and_balancing_workload,
     content: <<~MultilineString
 ## Session Elements
@@ -3447,7 +3447,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentthree_applying_good_assessment_practice_in_the_classroom = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentthree_applying_good_assessment_practice_in_the_classroom = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment, title: "3: Applying good assessment practice in the classroom", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentone_fundamental_principles_of_effective_assessment_one_,
     content: <<~MultilineString
 ## Session Elements
@@ -3692,7 +3692,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentfour_giving_high_quality_feedback = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentfour_giving_high_quality_feedback = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment, title: "4: Giving high-quality feedback", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentthree_applying_good_assessment_practice_in_the_classroom,
     content: <<~MultilineString
 ## Session Elements
@@ -3961,7 +3961,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentfive_planning_effective_and_manageable_marking_and_feedback = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentfive_planning_effective_and_manageable_marking_and_feedback = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessment, title: "5: Planning effective and manageable marking and feedback", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentfour_giving_high_quality_feedback,
     content: <<~MultilineString
 ## Session Elements
@@ -4146,7 +4146,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilitiessix_revisiting_professional_development = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilitiessix_revisiting_professional_development = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilities, title: "6: Revisiting professional development", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsfour_making_productive_use_of_assessmentfive_planning_effective_and_manageable_marking_and_feedback,
     content: <<~MultilineString
 ## Session Elements
@@ -4286,7 +4286,7 @@ MultilineString
 # ==================================================
 # UNPROCESSABLE: uclsample_page_trashed
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learningthree_what_is_evidence_telling_us_about_the_effects_upon_their_pupils_of_how_the_ect_sets_high_expectations_and_manages_behaviour_effectively = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learningthree_what_is_evidence_telling_us_about_the_effects_upon_their_pupils_of_how_the_ect_sets_high_expectations_and_manages_behaviour_effectively = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learning, title: "3: What is evidence telling us about the effects upon their pupils of how the ECT sets high expectations and manages behaviour effectively?", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsfive_fulfilling_professional_responsibilitiessix_revisiting_professional_development,
     content: <<~MultilineString
 ## Session Elements
@@ -4564,7 +4564,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learningthree_in_their_focus_area_what_impact_is_the_ect_having_on_their_pupils = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learningthree_in_their_focus_area_what_impact_is_the_ect_having_on_their_pupils = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learning, title: "3: In their focus area, what impact is the ECT having on their pupils?", previous_lesson: uclucltwo_understanding_teachers_as_role_modelssix_enabling_pupil_learningthree_what_is_evidence_telling_us_about_the_effects_upon_their_pupils_of_how_the_ect_sets_high_expectations_and_manages_behaviour_effectively,
     content: <<~MultilineString
 ## Session Elements
@@ -4831,7 +4831,7 @@ In that meeting, you will discuss with your mentor any alteration to your practi
 MultilineString
 )
 
-uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmenteight_developing_quality_pedagogy_and_making_productive_use_of_assessment_two_ = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmenteight_developing_quality_pedagogy_and_making_productive_use_of_assessment_two_ = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessment, title: "2: What is evidence telling us about the effects upon their pupils of the ECT’s practice in relation to Standards 4, 5 and 6?", previous_lesson: uclucltwo_understanding_teachers_as_role_modelsseven_engaging_pupils_in_learningthree_in_their_focus_area_what_impact_is_the_ect_having_on_their_pupils,
     content: <<~MultilineString
 ## Session Elements
@@ -5297,7 +5297,7 @@ MultilineString
 
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmenteight_what_is_evidence_telling_us_about_the_effects_upon_their_pupils_of_the_ects_practice_in_relation_to_standards_four_five_and_six_ = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmenteight_what_is_evidence_telling_us_about_the_effects_upon_their_pupils_of_the_ects_practice_in_relation_to_standards_four_five_and_six_ = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessment, title: "8: What is evidence telling us about the effects upon their pupils of the ECT’s practice in relation to Standards 4, 5 and 6?", previous_lesson: uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmenteight_developing_quality_pedagogy_and_making_productive_use_of_assessment_two_,
     content: <<~MultilineString
 ## Session Elements
@@ -5760,7 +5760,7 @@ MultilineString
 )
 
 # ==================================================
-uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmentone_three_the_impacts_upon_the_ect_of_their_inquiry = CourseLesson.create!(
+uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmentone_three_the_impacts_upon_the_ect_of_their_inquiry = CourseLesson.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_module: uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessment, title: "13: The impacts upon the ECT of their inquiry", previous_lesson: uclucltwo_understanding_teachers_as_role_modelseight_developing_quality_pedagogy_and_making_productive_use_of_assessmenteight_what_is_evidence_telling_us_about_the_effects_upon_their_pupils_of_the_ects_practice_in_relation_to_standards_four_five_and_six_,
     content: <<~MultilineString
 ## Session Elements
@@ -6274,7 +6274,7 @@ MultilineString
 # ==================================================
 
 # ==================================================
-ucluclmentor_materials = CourseModule.create!(
+ucluclmentor_materials = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "Mentor materials", previous_module: nil,
     content: <<~MultilineString
 Use the links below to download PDFs for mentor content. Where topics are not listed below see the Module Summaries listed under ECF Leads on the [UCL Early Career Teacher Consortium homepage](http://www.early-career-framework.education.gov.uk/ucl/).
@@ -6285,7 +6285,7 @@ MultilineString
 # ==================================================
 # UNPROCESSABLE: ucluclmentor_materials_two_trashed
 # ==================================================
-uclucltraining_materials = CourseModule.create!(
+uclucltraining_materials = CourseModule.find_or_create_by!(
     version: CURRENT_CIP_VERSION, course_year: uclucltwo_understanding_teachers_as_role_models, title: "Training materials", previous_module: nil,
     content: <<~MultilineString
 Use the links below to download PDFs for training content.


### PR DESCRIPTION
### Context
This makes it so that running the seeding twice doesn't make a copy of everything, like I might have on dev environment.

### Changes proposed in this pull request
Use `find_or_create` for creating cip content instead of just `create`.

Also bump the cip content version, so I can get rid of duplicates on dev, oops.

Also include the command to start a task in Readme so next person will have an easier time.

### Guidance to review
Eh, not much really :) 
