### PR TITLE
[ECF-144] Email school primary contact when school is confirmed

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -17,6 +17,9 @@ private
 
   def notify_school_primary_contact
     school = resource.induction_coordinator_profile.schools.first
-    UserMailer.primary_contact_notification(resource, school)
+
+    if school.primary_contact_email != resource.email
+      UserMailer.primary_contact_notification(resource, school)
+    end
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -6,9 +6,17 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
 
     if resource.errors.empty?
+      notify_school_primary_contact
       render :confirmed
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
     end
+  end
+
+private
+
+  def notify_school_primary_contact
+    school = resource.induction_coordinator_profile.schools.first
+    UserMailer.primary_contact_notification(resource, school)
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -16,6 +16,8 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 private
 
   def notify_school_primary_contact
+    return unless resource.induction_coordinator?
+
     school = resource.induction_coordinator_profile.schools.first
 
     if school.primary_contact_email != resource.email

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,6 +3,7 @@
 class UserMailer < ApplicationMailer
   SIGN_IN_EMAIL_TEMPLATE = "7ab8db5b-9842-4bc3-8dbb-f590a3198d9e"
   EMAIL_CONFIRMATION_TEMPLATE = "50059d26-c65d-4e88-831a-8bfb9f4116cd"
+  PRIMARY_CONTACT_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
 
   def sign_in_email(user, url)
     template_mail(
@@ -31,6 +32,19 @@ class UserMailer < ApplicationMailer
       personalisation: {
         full_name: user.full_name,
         confirmation_url: confirmation_url,
+      },
+    )
+  end
+
+  def primary_contact_notification(coordinator, school)
+    template_mail(
+      PRIMARY_CONTACT_TEMPLATE,
+      to: school.primary_contact_email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        coordinator_full_name: coordinator.full_name,
+        coordinator_email_address: coordinator.email,
       },
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,10 @@ class User < ApplicationRecord
     admin_profile.present?
   end
 
+  def induction_coordinator?
+    induction_coordinator_profile.present?
+  end
+
   def password_required?
     false
   end

--- a/db/migrate/20210128143531_add_primary_contact_email_to_school.rb
+++ b/db/migrate/20210128143531_add_primary_contact_email_to_school.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrimaryContactEmailToSchool < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :primary_contact_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_103901) do
+ActiveRecord::Schema.define(version: 2021_01_28_143531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_103901) do
     t.uuid "network_id"
     t.string "domains", default: [], null: false, array: true
     t.boolean "eligible", default: true, null: false
+    t.string "primary_contact_email"
     t.index ["high_pupil_premium"], name: "index_schools_on_high_pupil_premium", where: "high_pupil_premium"
     t.index ["is_rural"], name: "index_schools_on_is_rural", where: "is_rural"
     t.index ["name"], name: "index_schools_on_name"

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     address_line1 { Faker::Address.street_address }
     domains { [Faker::Internet.domain_name] }
+    primary_contact_email { Faker::Internet.email(domain: domains[0]) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
       admin_profile
     end
 
+    trait :induction_coordinator do
+      induction_coordinator_profile
+    end
+
     trait :lead_provider do
       lead_provider_profile { lead_provider }
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -36,4 +36,18 @@ RSpec.describe UserMailer, type: :mailer do
       expect(confirmation_email.from).to eq(["mail@example.com"])
     end
   end
+
+  describe "#primary_contact_notification" do
+    let(:school) { create(:school) }
+    let(:coordinator) { create(:user) }
+
+    let(:notification_email) do
+      UserMailer.primary_contact_notification(coordinator, school)
+    end
+
+    it "renders the right headers" do
+      expect(notification_email.from).to eq(["mail@example.com"])
+      expect(notification_email.to).to eq([school.primary_contact_email])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,4 +51,18 @@ RSpec.describe User, type: :model do
       expect(user.admin?).to be false
     end
   end
+
+  describe "#induction_coordinator?" do
+    it "is expected to be true when the user has an induction coordinator profile" do
+      user = create(:user, :induction_coordinator)
+
+      expect(user.induction_coordinator?).to be true
+    end
+
+    it "is expected to be false when the user does not have an induction coordinator profile" do
+      user = create(:user)
+
+      expect(user.induction_coordinator?).to be false
+    end
+  end
 end

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Users::Confirmations", type: :request do
   let(:school) { create(:school) }
   let(:induction_coordinator) { user.induction_coordinator_profile }
 
-  let!(:user) do
+  let(:user) do
     create(:user, :induction_coordinator, confirmed_at: nil, confirmation_token: confirmation_token)
   end
 
@@ -30,6 +30,20 @@ RSpec.describe "Users::Confirmations", type: :request do
 
     context "when school primary contact email equals induction coordinator email" do
       before { user.update(email: school.primary_contact_email) }
+
+      it "does not notify the school primary contact" do
+        expect(UserMailer).not_to receive(:primary_contact_notification).with(user, school)
+
+        get "/users/confirmation?confirmation_token=#{confirmation_token}"
+      end
+    end
+  end
+
+  describe "GET /users/confirmation" do
+    context "when user is not an induction coordinator" do
+      let!(:user) do
+        create(:user, confirmed_at: nil, confirmation_token: confirmation_token)
+      end
 
       it "does not notify the school primary contact" do
         expect(UserMailer).not_to receive(:primary_contact_notification).with(user, school)

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -4,16 +4,28 @@ require "rails_helper"
 
 RSpec.describe "Users::Confirmations", type: :request do
   let(:confirmation_token) { "soC7rF8i_BgYdUxafFcP" }
+  let(:school) { create(:school) }
+  let(:induction_coordinator) { user.induction_coordinator_profile }
 
   let!(:user) do
-    create(:user, confirmed_at: nil, confirmation_token: confirmation_token)
+    create(:user, :induction_coordinator, confirmed_at: nil, confirmation_token: confirmation_token)
   end
 
   describe "GET /users/confirmation" do
+    before do
+      school.induction_coordinator_profiles << induction_coordinator
+    end
+
     it "confirms the account" do
       get "/users/confirmation?confirmation_token=#{confirmation_token}"
       expect(user.reload.confirmed?).to be true
       expect(response).to render_template(:confirmed)
+    end
+
+    it "notifies the school primary contact" do
+      expect(UserMailer).to receive(:primary_contact_notification).with(user, school)
+
+      get "/users/confirmation?confirmation_token=#{confirmation_token}"
     end
   end
 end

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -27,5 +27,15 @@ RSpec.describe "Users::Confirmations", type: :request do
 
       get "/users/confirmation?confirmation_token=#{confirmation_token}"
     end
+
+    context "when school primary contact email equals induction coordinator email" do
+      before { user.update(email: school.primary_contact_email) }
+
+      it "does not notify the school primary contact" do
+        expect(UserMailer).not_to receive(:primary_contact_notification).with(user, school)
+
+        get "/users/confirmation?confirmation_token=#{confirmation_token}"
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Send email to school primary contact once an induction coordinator has registered a school  and confirmed the account.

Only send an email to the primary contact if the email they registered with is different from that of the school primary contact.