### PR TITLE
[ECF-1-131] Allow registrations if school is not confirmed within 24 hours

### DIFF
--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -70,12 +70,23 @@ RSpec.describe School, type: :model do
       expect(school.partially_registered?).to be false
     end
 
-    context "when school has an unconfirmed induction coordinator" do
-      let(:user) { create(:user, confirmed_at: nil) }
+    context "when school has an unconfirmed induction coordinator in the last 24 hours" do
+      let(:user) { create(:user, confirmed_at: nil, confirmation_sent_at: 2.hours.ago) }
       let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
 
       it "returns true" do
         expect(school.partially_registered?).to be true
+      end
+    end
+
+    context "when unconfirmed induction coordinator was emailed more than 24 hours ago" do
+      let(:user) { create(:user, confirmed_at: nil) }
+      let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
+
+      before { user.update(confirmation_sent_at: 2.days.ago) }
+
+      it "returns false" do
+        expect(school.partially_registered?).to be false
       end
     end
 

--- a/spec/requests/users/registrations/check_details_spec.rb
+++ b/spec/requests/users/registrations/check_details_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Users::Registrations /check-details", type: :request do
   let(:school) { FactoryBot.create(:school) }
   let(:email) { Faker::Internet.email(domain: school.domains.first) }
 
-  describe "POST /users/check_email" do
+  describe "POST /users/check-details" do
     it "renders :start_registration when no schools are found" do
       # When
       post "/users/check-details", params: { induction_coordinator_profile: {

--- a/spec/requests/users/registrations/register_spec.rb
+++ b/spec/requests/users/registrations/register_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Users::Registrations /register", type: :request do
   let(:school) { FactoryBot.create(:school) }
   let(:full_name) { Faker::Name.name }
+  let(:created_user) { User.find_by_email(email) }
   let(:email) { Faker::Internet.email(domain: school.domains.first) }
 
   describe "POST /users/register" do
@@ -29,8 +30,6 @@ RSpec.describe "Users::Registrations /register", type: :request do
       } }
 
       # Then
-      created_user = User.find_by_email(email)
-
       expect(created_user).not_to be_nil
       expect(created_user.full_name).to eq(full_name)
     end
@@ -44,8 +43,6 @@ RSpec.describe "Users::Registrations /register", type: :request do
       } }
 
       # Then
-      created_user = User.find_by_email(email)
-
       expect(created_user.induction_coordinator_profile).not_to be_nil
     end
 
@@ -58,8 +55,6 @@ RSpec.describe "Users::Registrations /register", type: :request do
       } }
 
       # Then
-      created_user = User.find_by_email(email)
-
       expect(created_user.induction_coordinator_profile.schools).to include(school)
     end
 
@@ -94,7 +89,6 @@ RSpec.describe "Users::Registrations /register", type: :request do
     context "when school has old unconfirmed registrations" do
       let(:user) { create(:user, confirmed_at: nil) }
       let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
-      let(:created_user) { User.find_by_email(email) }
 
       before { user.update(confirmation_sent_at: 2.days.ago) }
 


### PR DESCRIPTION
### Context
When an induction coordinator registers a school they get a confirmation email with a confirmation link. They are given 24hrs to confirm otherwise we'll allow other users to register the school.

What should happen to the user who didn't confirm registration? That is up for discussion but my view would be to remove the induction coordinator profile as well as user profile.

