### PR TITLE
Add ect profile

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Cohort < ApplicationRecord
+  has_many :early_career_teacher_profiles
+  has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
+
   def display_name
     "#{start_year} to #{start_year + 2}"
   end

--- a/app/models/core_induction_programme.rb
+++ b/app/models/core_induction_programme.rb
@@ -2,4 +2,6 @@
 
 class CoreInductionProgramme < ApplicationRecord
   has_many :course_years, dependent: :delete_all
+  has_many :early_career_teacher_profiles
+  has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
 end

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EarlyCareerTeacherProfile < ApplicationRecord
+  belongs_to :user
+  belongs_to :school
+  has_one :core_induction_programme
+  belongs_to :cohort, optional: true
+end

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -3,6 +3,6 @@
 class EarlyCareerTeacherProfile < ApplicationRecord
   belongs_to :user
   belongs_to :school
-  has_one :core_induction_programme
+  belongs_to :core_induction_programme, optional: true
   belongs_to :cohort, optional: true
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -12,6 +12,9 @@ class School < ApplicationRecord
   has_one :lead_provider, through: :partnership
   has_and_belongs_to_many :induction_coordinator_profiles
 
+  has_many :early_career_teacher_profiles
+  has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
+
   def full_address
     address = <<~ADDRESS
       #{address_line1}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_one :lead_provider_profile
   has_one :delivery_partner_profile
   has_one :admin_profile
+  has_one :early_career_teacher_profile
   has_one :lead_provider, through: :lead_provider_profile
   has_one :delivery_partner, through: :delivery_partner_profile
 
@@ -23,6 +24,10 @@ class User < ApplicationRecord
 
   def induction_coordinator?
     induction_coordinator_profile.present?
+  end
+
+  def early_career_teacher?
+    early_career_teacher_profile.present?
   end
 
   def password_required?

--- a/db/migrate/20210202093613_create_early_career_teacher_profiles.rb
+++ b/db/migrate/20210202093613_create_early_career_teacher_profiles.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateEarlyCareerTeacherProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :early_career_teacher_profiles do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.references :core_induction_programme, null: true, foreign_key: true, type: :uuid, index: { name: :index_ect_profiles_on_core_induction_programme_id }
+      t.references :cohort, null: true, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_29_133823) do
+ActiveRecord::Schema.define(version: 2021_02_02_093613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -112,6 +112,19 @@ ActiveRecord::Schema.define(version: 2021_01_29_133823) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
+  end
+
+  create_table "early_career_teacher_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "school_id", null: false
+    t.uuid "core_induction_programme_id"
+    t.uuid "cohort_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cohort_id"], name: "index_early_career_teacher_profiles_on_cohort_id"
+    t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
+    t.index ["school_id"], name: "index_early_career_teacher_profiles_on_school_id"
+    t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
   end
 
   create_table "induction_coordinator_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -276,6 +289,10 @@ ActiveRecord::Schema.define(version: 2021_01_29_133823) do
   add_foreign_key "course_years", "core_induction_programmes"
   add_foreign_key "delivery_partner_profiles", "delivery_partners"
   add_foreign_key "delivery_partner_profiles", "users"
+  add_foreign_key "early_career_teacher_profiles", "cohorts"
+  add_foreign_key "early_career_teacher_profiles", "core_induction_programmes"
+  add_foreign_key "early_career_teacher_profiles", "schools"
+  add_foreign_key "early_career_teacher_profiles", "users"
   add_foreign_key "induction_coordinator_profiles", "users"
   add_foreign_key "lead_provider_cips", "cohorts"
   add_foreign_key "lead_provider_cips", "core_induction_programmes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,10 @@
 
 # store all seeds inside the folder db/seeds
 
-Dir[Rails.root.join("db/seeds/dummy_structures.rb")].each { |seed| load seed }
-
 CourseLesson.delete_all
 CourseModule.delete_all
 CourseYear.delete_all
 
 Dir[Rails.root.join("db/seeds/cip_seed.rb")].each { |seed| load seed }
+
+Dir[Rails.root.join("db/seeds/dummy_structures.rb")].each { |seed| load seed }

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -31,3 +31,11 @@ unless Cohort.first
   Cohort.create!(start_year: 2021)
   Cohort.create!(start_year: 2022)
 end
+
+unless EarlyCareerTeacherProfile.first
+  user = User.find_or_create_by!(email: "early-career-teacher@example.com") do |u|
+    u.full_name = "Joe Bloggs"
+    u.confirmed_at = Time.zone.now.utc
+  end
+  EarlyCareerTeacherProfile.create!(user: user, school: School.first, cohort: Cohort.first, core_induction_programme: CoreInductionProgramme.first)
+end

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :early_career_teacher_profile do
+    user
+    school
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :delivery_partner do
       delivery_partner_profile
     end
+
+    trait :early_career_teacher do
+      early_career_teacher_profile
+    end
   end
 end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe Cohort, type: :model do
       expect(Cohort.new(start_year: 2021).display_name).to eq "2021 to 2023"
     end
   end
+
+  describe "associations" do
+    it { is_expected.to have_many(:early_career_teacher_profiles) }
+    it { is_expected.to have_many(:early_career_teachers).through(:early_career_teacher_profiles) }
+  end
 end

--- a/spec/models/core_induction_programme.rb
+++ b/spec/models/core_induction_programme.rb
@@ -5,5 +5,7 @@ require "rails_helper"
 RSpec.describe CoreInductionProgramme, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:course_years) }
+    it { is_expected.to have_many(:early_career_teacher_profiles) }
+    it { is_expected.to have_many(:early_career_teachers).through(:early_career_teacher_profiles) }
   end
 end

--- a/spec/models/early_career_teacher_profile.rb
+++ b/spec/models/early_career_teacher_profile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EarlyCareerTeacherProfile, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:core_induction_programme).optional }
+    it { is_expected.to belong_to(:cohort).optional }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_one(:partnership) }
     it { is_expected.to have_one(:lead_provider).through(:partnership) }
     it { is_expected.to have_and_belong_to_many(:induction_coordinator_profiles) }
+    it { is_expected.to have_many(:early_career_teacher_profiles) }
+    it { is_expected.to have_many(:early_career_teachers).through(:early_career_teacher_profiles) }
   end
 
   describe "#not_registered?" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_one(:delivery_partner_profile) }
     it { is_expected.to have_one(:lead_provider).through(:lead_provider_profile) }
     it { is_expected.to have_one(:delivery_partner).through(:delivery_partner_profile) }
+    it { is_expected.to have_one(:early_career_teacher_profile) }
   end
 
   describe "validations" do
@@ -82,6 +83,20 @@ RSpec.describe User, type: :model do
       user = create(:user)
 
       expect(user.induction_coordinator?).to be false
+    end
+  end
+
+  describe "#early_career_teacher?" do
+    it "is expected to be true when the user has an early career teacher profile" do
+      user = create(:user, :early_career_teacher)
+
+      expect(user.early_career_teacher?).to be true
+    end
+
+    it "is expected to be false when the user does not have an early career teacher profile" do
+      user = create(:user)
+
+      expect(user.early_career_teacher?).to be false
     end
   end
 end


### PR DESCRIPTION
### Context
One of sprint goals on engage and learn this (next?) sprint is adding an ECT dashboard and tracking ECT progress through CIP. Before we can do any of that, we need to add something representing an ECT.

### Changes proposed in this pull request
Add a new profile, `EarlyCareerTeacherProfile`. 

Make it link to reasonable things - like user, school, cohort and cip. One day we might rethink whether the connection to cip lives on the profile, on the school, or on the cohort (or somewhere else entirely) - but for time being I opted for the simplest solution for the upcoming work.

### Guidance to review
I moved the order of seed files loaded, because I want core induction programmes to exist by the time I generate my dummy ECT.
