### PR TITLE
[ECF-145] Login user after confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -7,6 +7,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     if resource.errors.empty?
       notify_school_primary_contact
+      sign_in(resource)
       render :confirmed
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }

--- a/app/views/users/confirmations/confirmed.html.erb
+++ b/app/views/users/confirmations/confirmed.html.erb
@@ -3,6 +3,6 @@
   <div class="govuk-grid-column-two-thirds">
     <p>You can now use your email address to sign in. No password required.</p>
     <p>Sign in to your registered account for more guidance and next steps.</p>
-    <%= govuk_link_to "Continue", user_session_path, button: true %>
+    <%= govuk_link_to "Continue", dashboard_path, button: true %>
   </div>
 </div>

--- a/app/views/users/confirmations/confirmed.html.erb
+++ b/app/views/users/confirmations/confirmed.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m confirmed-banner">Your school is registered</h2>
   <div class="govuk-grid-column-two-thirds">
     <p>You can now use your email address to sign in. No password required.</p>
-    <p>Sign in to your registered account for more guidance and next steps.</p>
+    <p>Continue to your registered account for more guidance and next steps.</p>
     <%= govuk_link_to "Continue", dashboard_path, button: true %>
   </div>
 </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -134,7 +134,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 24.hours
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Users::Confirmations", type: :request do
       get "/users/confirmation?confirmation_token=#{confirmation_token}"
       expect(user.reload.confirmed?).to be true
       expect(response).to render_template(:confirmed)
+      expect(user.sign_in_count).to eq 1
     end
 
     it "notifies the school primary contact" do


### PR DESCRIPTION
### Context

Currently users are taken to the sign in page after confirming their registration email. However, ideally we want to automatically login the user as they have already confirmed their email. Users should be taken directly to the dashboard instead.

https://trello.com/c/Xm6zj6gY/145-automatically-login-users-after-registration-email-confirmation

https://miro.com/app/board/o9J_lZ2k8oc=/
