### PR TITLE
add functionality to edit year content

### DIFF
--- a/app/controllers/core_induction_programme/years_controller.rb
+++ b/app/controllers/core_induction_programme/years_controller.rb
@@ -1,7 +1,36 @@
 # frozen_string_literal: true
 
 class CoreInductionProgramme::YearsController < ApplicationController
-  def show
-    @course_year = CourseYear.includes(:course_modules).find(params[:id])
+  include Pundit
+  include GovspeakHelper
+
+  after_action :verify_authorized, except: :show
+  before_action :authenticate_user!, except: :show
+  before_action :load_and_authorize_course_year
+
+  def show; end
+
+  def edit
+    @year_preview = params[:year_preview] || @course_year.content
+    @html_content = content_to_html(@year_preview)
+  end
+
+  def update
+    if params[:commit] == "Save changes"
+      @course_year.update!(content: params[:year_preview])
+      flash[:success] = "Your changes have been saved"
+      redirect_to cip_year_url
+    else
+      @year_preview = params[:year_preview]
+      @html_content = content_to_html(@year_preview)
+      render action: "edit"
+    end
+  end
+
+private
+
+  def load_and_authorize_course_year
+    @course_year = CourseYear.find(params[:id])
+    authorize @course_year
   end
 end

--- a/app/policies/course_year_policy.rb
+++ b/app/policies/course_year_policy.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CourseYearPolicy < ApplicationPolicy
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin_only
+  end
+
+  def update?
+    admin_only
+  end
+end

--- a/app/views/core_induction_programme/years/edit.html.erb
+++ b/app/views/core_induction_programme/years/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Content change preview</h1>
+    <%= form_with url: cip_year_path, method: :put do |f| %>
+      <%= f.govuk_text_area :year_preview, label: { text: "Markdown string for course year content" }, rows: 10, value: @year_preview %>
+      <%= f.govuk_submit "See preview" %>
+      <%= f.govuk_submit "Save changes" %>
+    <% end %>
+    <div class="gem-c-govspeak govuk-govspeak ">
+      <%= @html_content.html_safe %>
+    </div>
+  </div>
+</div>

--- a/app/views/core_induction_programme/years/show.html.erb
+++ b/app/views/core_induction_programme/years/show.html.erb
@@ -1,5 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <% if policy(@course_year).edit? %>
+      <%= link_to "Edit year content", edit_cip_year_url(@course_year), class: "govuk-button" %>
+    <% end %>
     <h1 class="govuk-heading-l"><%= @course_year.title %></h1>
     <h2 class="govuk-heading-l">Modules</h2>
     <% if @course_year.course_modules.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
   resource :core_induction_programme, controller: :core_induction_programme, only: :show, as: "cip", path: "/core-induction-programme" do
     get "download-export", to: "core_induction_programme#download_export", as: "download_export"
 
-    resources :years, controller: "core_induction_programme/years", only: :show do
+    resources :years, controller: "core_induction_programme/years", only: %i[show edit update] do
       resources :modules, controller: "core_induction_programme/modules", only: %i[show edit update] do
         resources :lessons, controller: "core_induction_programme/lessons", only: %i[show edit update]
       end

--- a/spec/policies/course_year_policy_spec.rb
+++ b/spec/policies/course_year_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseYearPolicy, type: :policy do
+  subject { described_class.new(user, course_year) }
+  let(:course_year) { create(:course_year) }
+
+  context "editing as admin" do
+    let(:user) { create(:user, :admin) }
+
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_edit_and_update_actions }
+  end
+  context "trying to edit as user" do
+    let(:user) { create(:user) }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_edit_and_update_actions }
+  end
+  context "being a visitor" do
+    let(:user) { nil }
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_edit_and_update_actions }
+  end
+end

--- a/spec/requests/core_induction_programme/course_year_spec.rb
+++ b/spec/requests/core_induction_programme/course_year_spec.rb
@@ -3,9 +3,79 @@
 require "rails_helper"
 
 RSpec.describe "Core Induction Programme Year", type: :request do
-  it "renders the cip year page" do
-    course_year = FactoryBot.create(:course_year)
-    get "/core-induction-programme/years/#{course_year.id}"
-    expect(response).to render_template(:show)
+  let(:course_year) { FactoryBot.create(:course_year) }
+  let(:course_year_url) { "/core-induction-programme/years/#{course_year.id}" }
+
+  describe "when an admin user is logged in" do
+    before do
+      admin_user = create(:user, :admin)
+      sign_in admin_user
+    end
+    describe "GET /core-induction-programe/years/years_id" do
+      it "renders the cip year page" do
+        get course_year_url
+        expect(response).to render_template(:show)
+      end
+    end
+    describe "GET /core-induction-programme/years/years_id/edit" do
+      it "render the cip years edit page" do
+        get "#{course_year_url}/edit"
+        expect(response).to render_template(:edit)
+      end
+    end
+    describe "PUT /core-induction-programme/years/years_id" do
+      it "renders a preview of changes to a year" do
+        put course_year_url, params: { commit: "See preview", year_preview: "Extra content" }
+        expect(response).to render_template(:edit)
+        expect(response.body).to include("Extra content")
+      end
+    end
+    describe "PUT /core-induction-programme/years/years_id" do
+      it "redirects to the year page and updates content when saving changes" do
+        put course_year_url, params: { commit: "Save changes", year_preview: "Adding new content" }
+        expect(response).to redirect_to(course_year_url)
+        get course_year_url
+        expect(response.body).to include("Adding new content")
+      end
+    end
+  end
+
+  describe "when a non-admin user is logged in" do
+    before do
+      user = create(:user)
+      sign_in user
+    end
+    describe "GET /core-induction-programme/years/years_id" do
+      it "renders the cip year page" do
+        get course_year_url
+        expect(response).to render_template(:show)
+      end
+    end
+    describe "GET /core-induction-programme/years/years_id/edit" do
+      it "raises an error when trying to access edit page" do
+        expect { get "#{course_year_url}/edit" }.to raise_error Pundit::NotAuthorizedError
+      end
+    end
+  end
+
+  describe "when a non-user is accessing the year page" do
+    describe "GET /core-induction-programme/years/years_id" do
+      it "renders the cip year page" do
+        get course_year_url
+        expect(response).to render_template(:show)
+      end
+    end
+    describe "GET /core-induction-programme/years/years_id/edit" do
+      it "redirects to the sign in page" do
+        get "#{course_year_url}/edit"
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+    describe "PUT /core-induction-programme/years/years_id" do
+      it "redirects to the sign in page" do
+        put course_year_url, params: { commit: "Save changes", year_preview: course_year.content }
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
We need to be able to edit course year content. 

### Changes proposed in this pull request
- Edit view to preview and save changes to year content
- Include CourseYear policy to restrict access to editing to dfe admin
- Update routes for core-induction-programme/years
- CourseYearPolicy tests
- CourseYear request tests

### Guidance to review
The changes follow the same pattern as course module editing and course lesson editing. 

