### PR TITLE
Sign in defects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(user)
-    helpers.profile_dashboard_url(user)
+    stored_location_for(user) || helpers.profile_dashboard_url(user)
   end
 
 protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,10 @@ class ApplicationController < ActionController::Base
     render json: { status: "OK", version: ENV["SHA"], environment: Rails.env }, status: :ok
   end
 
+  def after_sign_in_path_for(user)
+    helpers.profile_dashboard_url(user)
+  end
+
 protected
 
   def configure_permitted_parameters

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -34,13 +34,13 @@ private
   def ensure_login_token_valid
     @user = User.find_by(login_token: params[:login_token])
 
-    if @user.blank? || login_token_expired
+    if @user.blank? || login_token_expired?
       flash[:alert] = "There was an error while logging you in. Please enter your email again."
       redirect_to new_user_session_path
     end
   end
 
-  def login_token_expired
+  def login_token_expired?
     Time.zone.now > @user.login_token_valid_until
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -33,9 +33,14 @@ private
 
   def ensure_login_token_valid
     @user = User.find_by(login_token: params[:login_token])
-    unless @user.present? && Time.zone.now < @user.login_token_valid_until
+
+    if @user.blank? || login_token_expired
       flash[:alert] = "There was an error while logging you in. Please enter your email again."
       redirect_to new_user_session_path
     end
+  end
+
+  def login_token_expired
+    Time.zone.now > @user.login_token_valid_until
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,9 @@ class Users::SessionsController < Devise::SessionsController
   class EmailNotFoundError < StandardError; end
   class LoginIncompleteError < StandardError; end
 
+  before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]
+  before_action :ensure_login_token_valid, only: %i[sign_in_with_token redirect_from_magic_link]
+
   def create
     super
   rescue LoginIncompleteError
@@ -13,19 +16,26 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def sign_in_with_token
-    user = User.find_by(login_token: params[:login_token])
-
-    if user.present? && Time.zone.now < user.login_token_valid_until
-      user.update!(login_token: nil, login_token_valid_until: 1.year.ago)
-      sign_in(user, scope: :user)
-      redirect_to helpers.profile_dashboard_url(user)
-    else
-      flash[:alert] = "There was an error while logging you in. Please enter your email again."
-      redirect_to new_user_session_path
-    end
+    @user.update!(login_token: nil, login_token_valid_until: 1.year.ago)
+    sign_in(@user, scope: :user)
+    redirect_to_dashboard
   end
 
   def redirect_from_magic_link
     @login_token = params[:login_token] if params[:login_token].present?
+  end
+
+private
+
+  def redirect_to_dashboard
+    redirect_to helpers.profile_dashboard_url(current_user) if current_user.present?
+  end
+
+  def ensure_login_token_valid
+    @user = User.find_by(login_token: params[:login_token])
+    unless @user.present? && Time.zone.now < @user.login_token_valid_until
+      flash[:alert] = "There was an error while logging you in. Please enter your email again."
+      redirect_to new_user_session_path
+    end
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,7 +7,7 @@ en:
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
+      already_authenticated: ""
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys}."
       locked: "Your account is locked."

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -51,22 +51,24 @@ RSpec.describe "Users::Sessions", type: :request do
       get "/users/confirm_sign_in?login_token=aaaaaaaaaa"
 
       expect(response).to redirect_to "/users/sign_in"
+      expect(flash[:alert]).to eq "There was an error while logging you in. Please enter your email again."
     end
 
     context "when the token has expired" do
       before { user.update!(login_token_valid_until: 1.hour.ago) }
 
-      it "redirects to sign in when the token has expired" do
+      it "redirects to sign in" do
         get "/users/confirm_sign_in?login_token=#{user.login_token}"
 
         expect(response).to redirect_to "/users/sign_in"
+        expect(flash[:alert]).to eq "There was an error while logging you in. Please enter your email again."
       end
     end
 
     context "when already signed in" do
       before { sign_in user }
 
-      it "redirects to the dashboard when already signed in" do
+      it "redirects to the dashboard" do
         get "/users/confirm_sign_in?login_token=aaaaaaaaaa"
 
         expect(response).to redirect_to "/dashboard"

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -5,6 +5,24 @@ require "rails_helper"
 RSpec.describe "Users::Sessions", type: :request do
   let(:user) { create(:user) }
 
+  describe "GET /users/sign_in" do
+    it "renders the sign in page" do
+      get "/users/sign_in"
+
+      expect(response).to render_template(:new)
+    end
+
+    context "when already signed in" do
+      before { sign_in user }
+
+      it "redirects to the dashboard" do
+        get "/users/sign_in"
+
+        expect(response).to redirect_to "/dashboard"
+      end
+    end
+  end
+
   describe "POST /users/sign_in" do
     context "when sign in email has been sent" do
       it "renders the login_email_sent template" do
@@ -27,6 +45,32 @@ RSpec.describe "Users::Sessions", type: :request do
       get "/users/confirm_sign_in?login_token=#{user.login_token}"
       expect(assigns(:login_token)).to eq(user.login_token)
       expect(response).to render_template(:redirect_from_magic_link)
+    end
+
+    it "redirects to sign in when the token doesn't match" do
+      get "/users/confirm_sign_in?login_token=aaaaaaaaaa"
+
+      expect(response).to redirect_to "/users/sign_in"
+    end
+
+    context "when the token has expired" do
+      before { user.update!(login_token_valid_until: 1.hour.ago) }
+
+      it "redirects to sign in when the token has expired" do
+        get "/users/confirm_sign_in?login_token=#{user.login_token}"
+
+        expect(response).to redirect_to "/users/sign_in"
+      end
+    end
+
+    context "when already signed in" do
+      before { sign_in user }
+
+      it "redirects to the dashboard when already signed in" do
+        get "/users/confirm_sign_in?login_token=aaaaaaaaaa"
+
+        expect(response).to redirect_to "/dashboard"
+      end
     end
   end
 


### PR DESCRIPTION
### Context

> Defect1:User able to land on sign in
> successful page with expire token
> Given I am on sign in page.
> When I entered emailId on sign in page
> And I click on Expired notification link in mail inbox.
> Then I am landing on “Sign in successful page”
> But I should land on sign in page.

### Changes proposed in this pull request
 - Ensure no success message is displayed when clicking an invalid link
 - Ensure logged in users are redirected to the dashboard when clicking a sign-in link
 - Ensure logged in users are redirected to the dashboard when clicking Start now

### Guidance to review
Now added tests

