### PR TITLE
Add view_component and create tabs component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem "govuk-components", ">= 1.0.0"
 gem "govuk_design_system_formbuilder", "~> 2.1", ">= 2.1.5"
 gem "httpclient"
 gem "seed_dump"
+gem "view_component", require: "view_component/engine"
 
 # Database based asynchronous priority queue system
 gem "delayed_cron_job"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,6 +451,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
+  view_component
   wdm (>= 0.1.0)
   web-console (>= 4.1.0)
   webdrivers (~> 4.4, >= 4.4.1)
@@ -461,4 +462,4 @@ RUBY VERSION
    ruby 2.7.1p83
 
 BUNDLED WITH
-   2.1.4
+   2.2.8

--- a/app/components/tabs_component.html.erb
+++ b/app/components/tabs_component.html.erb
@@ -1,0 +1,6 @@
+<div class="page-tab-container">
+  <% tabs.each do |tab| %>
+    <%= tab %>
+  <% end %>
+</div>
+<hr class="govuk-!-margin-top-0"/>

--- a/app/components/tabs_component.rb
+++ b/app/components/tabs_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TabsComponent < ViewComponent::Base
+  include ViewComponent::SlotableV2
+
+  renders_many :tabs, "TabComponent"
+
+  class TabComponent < ViewComponent::Base
+    attr_reader :path
+
+    def initialize(path:)
+      @path = path
+    end
+  end
+end

--- a/app/components/tabs_component/tab_component.html.erb
+++ b/app/components/tabs_component/tab_component.html.erb
@@ -1,0 +1,5 @@
+<div class="page-tab govuk-!-margin-right-8 <%= "page-tab__selected" if current_page?(path) %>">
+  <%= govuk_link_to path do %>
+    <%= content %> <%= "<span class='govuk-visually-hidden'>Current page</span>".html_safe if current_page?(path) %>
+  <% end %>
+</div>

--- a/app/controllers/admin/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers_controller.rb
@@ -8,7 +8,7 @@ class Admin::SuppliersController < Admin::BaseController
     lead_providers = policy_scope(LeadProvider)
     delivery_partners = policy_scope(DeliveryPartner)
     sorted_suppliers = (lead_providers + delivery_partners).sort_by(&:name)
-    @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(20)
+    @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(1)
     @page = @suppliers.current_page
     @total_pages = @suppliers.total_pages
   end

--- a/app/controllers/admin/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers_controller.rb
@@ -8,7 +8,7 @@ class Admin::SuppliersController < Admin::BaseController
     lead_providers = policy_scope(LeadProvider)
     delivery_partners = policy_scope(DeliveryPartner)
     sorted_suppliers = (lead_providers + delivery_partners).sort_by(&:name)
-    @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(1)
+    @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(20)
     @page = @suppliers.current_page
     @total_pages = @suppliers.total_pages
   end

--- a/app/views/admin/suppliers/_layout.html.erb
+++ b/app/views/admin/suppliers/_layout.html.erb
@@ -1,14 +1,10 @@
 <h1 class="govuk-heading-l">Suppliers</h1>
-<div class="page-tab-container">
-  <div class="page-tab govuk-!-margin-right-8 <%= "page-tab__selected" if page == "suppliers" %>">
-    <%= govuk_link_to admin_suppliers_path do %>
-      All suppliers <%= "<span class='govuk-visually-hidden'>Current page</span>".html_safe if page == "suppliers" %>
-    <% end %>
-  </div>
-  <div class="page-tab govuk-!-margin-right-8 <%= "page-tab__selected" if page == "users" %>">
-    <%= govuk_link_to admin_supplier_users_path do %>
-      All users <%= "<span class='govuk-visually-hidden'>Current page</span>".html_safe if page == "users" %>
-    <% end %>
-  </div>
-</div>
-<hr class="govuk-!-margin-top-0"/>
+
+<%= render TabsComponent.new do |c| %>
+  <%= c.tab(path: admin_suppliers_path) do %>
+    All suppliers
+  <% end %>
+  <%= c.tab(path: admin_supplier_users_path) do %>
+    All users
+  <% end %>
+<% end %>


### PR DESCRIPTION
### Context

I've moved the existing tabs HTML into a view_component component - mostly to test view_component and give an example of how it works.

### Changes proposed in this pull request

There is a slight behaviour change - instead of the supplier and supplier user page passing a local variable in, it's using `current_page?` to check the current path against the specified one. This will break if child pages use the same layout, but nothing does that at the moment and would require other changes if desired in the future.

### Guidance to review

To test pagination without manually adding hundreds of providers, set `.per(20)` to `.per(2)` or something like that in the suppliers controller (or revert 35a22e9 where I left it in by mistake).

