### PR TITLE
Fix bug where school search JS ran on every page, throwing an error

### DIFF
--- a/app/webpacker/packs/school_search.js
+++ b/app/webpacker/packs/school_search.js
@@ -17,15 +17,17 @@ function suggest(query, populateResults) {
     .then((data) => populateResults(data));
 }
 
-accessibleAutocomplete({
-  element,
-  id,
-  source: suggest,
-  showNoOptionsFound: false,
-  minLength: 1,
-  name: "school_search_form[school_name]",
-  templates: {
-    inputValue: inputValueTemplate,
-    suggestion: suggestionTemplate,
-  },
-});
+if (element) {
+  accessibleAutocomplete({
+    element,
+    id,
+    source: suggest,
+    showNoOptionsFound: false,
+    minLength: 1,
+    name: "school_search_form[school_name]",
+    templates: {
+      inputValue: inputValueTemplate,
+      suggestion: suggestionTemplate,
+    },
+  });
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/472830/108073340-d6a0d280-705f-11eb-85f2-0001d5ef818b.png)

This was being thrown on every page but the school search page - wrapping it in a conditional fixes it.