### PR TITLE
[ECF-1-264] ECT mentor estimates

### DIFF
--- a/app/controllers/induction_programme/base_controller.rb
+++ b/app/controllers/induction_programme/base_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class InductionProgramme::BaseController < ApplicationController
+  before_action :authenticate_user!
+  before_action :ensure_induction_coordinator
+
+private
+
+  def ensure_induction_coordinator
+    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.induction_coordinator?
+  end
+end

--- a/app/controllers/induction_programme/choices_controller.rb
+++ b/app/controllers/induction_programme/choices_controller.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-class InductionProgramme::ChoicesController < ApplicationController
-  before_action :authenticate_user!
-  before_action :ensure_induction_coordinator
-
+class InductionProgramme::ChoicesController < InductionProgramme::BaseController
   def show
     @programme_choices = [
-      OpenStruct.new(id: "funded_training_provider", name: "Use a training provider funded by the Department for Education"),
-      OpenStruct.new(id: "free_development_materials", name: "Use the free development materials"),
+      OpenStruct.new(id: "full_induction_programme", name: "Use a training provider funded by the Department for Education"),
+      OpenStruct.new(id: "core_induction_programme", name: "Use the free development materials"),
       OpenStruct.new(id: "design_our_own", name: "Design your own induction based on the Early Career Framework"),
       OpenStruct.new(id: "not_yet_known", name: "I don't know yet"),
     ]
@@ -25,14 +22,10 @@ class InductionProgramme::ChoicesController < ApplicationController
 
     if @school_cohort.not_yet_known?
       redirect_to :registrations_learn_options
+    elsif @school_cohort.full_induction_programme?
+      redirect_to estimates_path
     else
       redirect_to choices_path, notice: "Succesfully saved"
     end
-  end
-
-private
-
-  def ensure_induction_coordinator
-    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.induction_coordinator?
   end
 end

--- a/app/controllers/induction_programme/choices_controller.rb
+++ b/app/controllers/induction_programme/choices_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class InductionProgrammeChoicesController < ApplicationController
+class InductionProgramme::ChoicesController < ApplicationController
   before_action :authenticate_user!
   before_action :ensure_induction_coordinator
 
@@ -26,7 +26,7 @@ class InductionProgrammeChoicesController < ApplicationController
     if @school_cohort.not_yet_known?
       redirect_to :registrations_learn_options
     else
-      redirect_to induction_programme_choices_path, notice: "Succesfully saved"
+      redirect_to choices_path, notice: "Succesfully saved"
     end
   end
 

--- a/app/controllers/induction_programme/estimates_controller.rb
+++ b/app/controllers/induction_programme/estimates_controller.rb
@@ -1,5 +1,37 @@
 # frozen_string_literal: true
 
-class InductionProgramme::EstimatesController < ApplicationController
-  def create; end
+class InductionProgramme::EstimatesController < InductionProgramme::BaseController
+  def show
+    @school_cohort_form = SchoolCohortForm.new
+  end
+
+  def create
+    @school_cohort_form = SchoolCohortForm.new(cohort_estimates)
+
+    if @school_cohort_form.valid?
+      school_cohort.update!(cohort_estimates)
+      redirect_to helpers.profile_dashboard_url(current_user)
+    else
+      render :show
+    end
+  end
+
+private
+
+  def school_cohort
+    @school_cohort ||= begin
+      # TODO: Register and Partner 262: Figure out how to update current year
+      @cohort = Cohort.find_by(start_year: 2021)
+      @school = current_user.induction_coordinator_profile.schools.first
+      SchoolCohort.find_or_create_by!(cohort: @cohort, school: @school)
+    end
+  end
+
+  def cohort_estimates
+    params.require(:school_cohort_form)
+          .permit(
+            :estimated_teacher_count,
+            :estimated_mentor_count,
+          )
+  end
 end

--- a/app/controllers/induction_programme/estimates_controller.rb
+++ b/app/controllers/induction_programme/estimates_controller.rb
@@ -21,17 +21,18 @@ private
   def school_cohort
     @school_cohort ||= begin
       # TODO: Register and Partner 262: Figure out how to update current year
-      @cohort = Cohort.find_by(start_year: 2021)
-      @school = current_user.induction_coordinator_profile.schools.first
-      SchoolCohort.find_or_create_by!(cohort: @cohort, school: @school)
+      cohort = Cohort.find_by(start_year: 2021)
+      school = current_user.induction_coordinator_profile.schools.first
+      SchoolCohort.find_or_create_by!(cohort: cohort, school: school)
     end
   end
 
   def cohort_estimates
-    params.require(:school_cohort_form)
-          .permit(
-            :estimated_teacher_count,
-            :estimated_mentor_count,
-          )
+    params
+      .require(:school_cohort_form)
+      .permit(
+        :estimated_teacher_count,
+        :estimated_mentor_count,
+      )
   end
 end

--- a/app/controllers/induction_programme/estimates_controller.rb
+++ b/app/controllers/induction_programme/estimates_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class InductionProgramme::EstimatesController < ApplicationController
+  def create; end
+end

--- a/app/forms/school_cohort_form.rb
+++ b/app/forms/school_cohort_form.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SchoolCohortForm
+  include ActiveModel::Model
+
+  attr_accessor :estimated_mentor_count, :estimated_teacher_count
+
+  validates :estimated_mentor_count, presence: { message: "Enter your expected number of mentors" }
+  validates :estimated_teacher_count, presence: { message: "Enter your expected number of ECTs" }
+end

--- a/app/forms/school_cohort_form.rb
+++ b/app/forms/school_cohort_form.rb
@@ -7,4 +7,6 @@ class SchoolCohortForm
 
   validates :estimated_mentor_count, presence: { message: "Enter your expected number of mentors" }
   validates :estimated_teacher_count, presence: { message: "Enter your expected number of ECTs" }
+  validates :estimated_mentor_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :estimated_teacher_count, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/views/induction_programme/choices/show.html.erb
+++ b/app/views/induction_programme/choices/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-xl">Welcome to your account</h1>
   <p class="govuk-!-margin-bottom-7">To confirm your induction programme, we will ask you a few quick questions.</p>
-  <%= form_with url: induction_programme_choices_path, method: :post do |f| %>
+  <%= form_with url: choices_path, method: :post do |f| %>
     <%= f.govuk_collection_radio_buttons(
           :choice, @programme_choices, :id, :name,
           legend: -> { tag.h1("How do you want to run your induction in the 2021/22 academic year?" , class: "govuk-heading-m") }

--- a/app/views/induction_programme/estimates/show.html.erb
+++ b/app/views/induction_programme/estimates/show.html.erb
@@ -1,0 +1,2 @@
+<h1>InductionProgrammeEstimates#p</h1>
+<p>Find me in app/views/induction_programme_estimates/p.html.erb</p>

--- a/app/views/induction_programme/estimates/show.html.erb
+++ b/app/views/induction_programme/estimates/show.html.erb
@@ -24,7 +24,6 @@
           }
       ) %>
 
-        
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/induction_programme/estimates/show.html.erb
+++ b/app/views/induction_programme/estimates/show.html.erb
@@ -1,2 +1,31 @@
-<h1>InductionProgrammeEstimates#p</h1>
-<p>Find me in app/views/induction_programme_estimates/p.html.erb</p>
+<% content_for :before_content, govuk_back_link(text: "Back", href: choices_path) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Estimated numbers of participants starting in 2021</h2>
+    <%= form_with(model: @school_cohort_form, url: estimates_path) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field(
+          :estimated_teacher_count,
+          width: 20,
+          link_errors: true,
+          label: {
+            text: "Number of ECTs",
+            class: "govuk-label govuk-label--m"
+          }
+      ) %>
+
+      <%= f.govuk_text_field(
+          :estimated_mentor_count,
+          width: 20,
+          link_errors: true,
+          label: {
+            text: "Number of mentors",
+            class: "govuk-label govuk-label--m"
+          }
+      ) %>
+
+        
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registrations/learn_options/show.html.erb
+++ b/app/views/registrations/learn_options/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_back_link(text: "Back", href: induction_programme_choices_path) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: choices_path) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Learn more about your options</h1>

--- a/app/views/users/confirmations/confirmed.html.erb
+++ b/app/views/users/confirmations/confirmed.html.erb
@@ -3,6 +3,6 @@
   <div class="govuk-grid-column-two-thirds">
     <p>You can now use your email address to sign in. No password required.</p>
     <p>Continue to your registered account for more guidance and next steps.</p>
-    <%= govuk_link_to "Continue", induction_programme_choices_path, button: true %>
+    <%= govuk_link_to "Continue", choices_path, button: true %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,10 @@ Rails.application.routes.draw do
     resources :school_search, only: %i[index]
   end
 
-  resource :induction_programme_choices, only: %i[show create], path: "/induction-programme-choices"
+  scope path: "induction-programme", module: :induction_programme do
+    resource :estimates, only: %i[show create]
+    resource :choices, only: %i[show create]
+  end
 
   namespace :demo do
     resources :school_search, only: %i[index]

--- a/db/migrate/20210225081103_add_estimates_to_school_cohorts.rb
+++ b/db/migrate/20210225081103_add_estimates_to_school_cohorts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddEstimatesToSchoolCohorts < ActiveRecord::Migration[6.1]
+  def change
+    change_table :school_cohorts, bulk: true do |t|
+      t.integer :estimated_teacher_count
+      t.integer :estimated_mentor_count
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_18_175518) do
+ActiveRecord::Schema.define(version: 2021_02_25_081103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -203,6 +203,8 @@ ActiveRecord::Schema.define(version: 2021_02_18_175518) do
     t.uuid "cohort_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "estimated_teacher_count"
+    t.integer "estimated_mentor_count"
     t.index ["cohort_id"], name: "index_school_cohorts_on_cohort_id"
     t.index ["school_id"], name: "index_school_cohorts_on_school_id"
   end

--- a/spec/forms/school_cohort_form_spec.rb
+++ b/spec/forms/school_cohort_form_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolCohortForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:estimated_mentor_count).with_message("Enter your expected number of mentors") }
+    it { is_expected.to validate_presence_of(:estimated_teacher_count).with_message("Enter your expected number of ECTs") }
+  end
+end

--- a/spec/forms/school_cohort_form_spec.rb
+++ b/spec/forms/school_cohort_form_spec.rb
@@ -6,13 +6,7 @@ RSpec.describe SchoolCohortForm, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:estimated_mentor_count).with_message("Enter your expected number of mentors") }
     it { is_expected.to validate_presence_of(:estimated_teacher_count).with_message("Enter your expected number of ECTs") }
-
-    it do
-      should validate_numericality_of(:estimated_mentor_count).is_greater_than_or_equal_to(0)
-    end
-
-    it do
-      should validate_numericality_of(:estimated_teacher_count).is_greater_than_or_equal_to(0)
-    end
+    it { is_expected.to validate_numericality_of(:estimated_mentor_count).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_numericality_of(:estimated_teacher_count).is_greater_than_or_equal_to(0) }
   end
 end

--- a/spec/forms/school_cohort_form_spec.rb
+++ b/spec/forms/school_cohort_form_spec.rb
@@ -6,5 +6,13 @@ RSpec.describe SchoolCohortForm, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:estimated_mentor_count).with_message("Enter your expected number of mentors") }
     it { is_expected.to validate_presence_of(:estimated_teacher_count).with_message("Enter your expected number of ECTs") }
+
+    it do
+      should validate_numericality_of(:estimated_mentor_count).is_greater_than_or_equal_to(0)
+    end
+
+    it do
+      should validate_numericality_of(:estimated_teacher_count).is_greater_than_or_equal_to(0)
+    end
   end
 end

--- a/spec/requests/induction_programme/choices_spec.rb
+++ b/spec/requests/induction_programme/choices_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "InductionProgrammeChoices", type: :request do
+RSpec.describe "InductionProgramme::Choices", type: :request do
   let(:school) { create(:school) }
   let(:induction_coordinator) { user.induction_coordinator_profile }
   let(:user) { create(:user, :induction_coordinator, confirmed_at: 2.hours.ago) }
@@ -12,25 +12,25 @@ RSpec.describe "InductionProgrammeChoices", type: :request do
     induction_coordinator.schools << school
   end
 
-  describe "GET /induction-programme-choices" do
+  describe "GET /induction-programme/choices" do
     it "renders the show template" do
-      get "/induction-programme-choices"
+      get "/induction-programme/choices"
       expect(response.body).to include("Welcome to your account")
-      expect(response).to render_template("induction_programme_choices/show")
+      expect(response).to render_template("induction_programme/choices/show")
     end
   end
 
-  describe "POST /induction-programme-choices" do
+  describe "POST /induction-programme/choices" do
     let(:school_cohort) { school.school_cohorts.last }
 
     it "saves the choice of induction programme" do
-      post "/induction-programme-choices", params: { choice: "design_our_own" }
+      post "/induction-programme/choices", params: { choice: "design_our_own" }
 
       expect(school_cohort.induction_programme_choice).to eq("design_our_own")
     end
 
     it "redirects to /registrations/learn-options if the choice is not_yet_known" do
-      post "/induction-programme-choices", params: { choice: "not_yet_known" }
+      post "/induction-programme/choices", params: { choice: "not_yet_known" }
       expect(response).to redirect_to(:registrations_learn_options)
     end
   end

--- a/spec/requests/induction_programme/choices_spec.rb
+++ b/spec/requests/induction_programme/choices_spec.rb
@@ -33,5 +33,10 @@ RSpec.describe "InductionProgramme::Choices", type: :request do
       post "/induction-programme/choices", params: { choice: "not_yet_known" }
       expect(response).to redirect_to(:registrations_learn_options)
     end
+
+    it "redirects to /induction-programme/choices if the choice is full_induction_programme" do
+      post "/induction-programme/choices", params: { choice: "full_induction_programme" }
+      expect(response).to redirect_to(:estimates)
+    end
   end
 end

--- a/spec/requests/induction_programme/estimates_spec.rb
+++ b/spec/requests/induction_programme/estimates_spec.rb
@@ -3,10 +3,42 @@
 require "rails_helper"
 
 RSpec.describe "InductionProgramme::Estimates", type: :request do
+  let(:school) { create(:school) }
+  let(:cohort) { create(:cohort, start_year: 2021) }
+  let(:induction_coordinator) { user.induction_coordinator_profile }
+  let(:user) { create(:user, :induction_coordinator, confirmed_at: 2.hours.ago) }
+  let!(:school_cohort) { SchoolCohort.create(cohort: cohort, school: school) }
+
+  before do
+    sign_in user
+    induction_coordinator.schools << school
+  end
+
   describe "GET /induction-programme/estimates" do
-    it "returns http success" do
+    it "renders the show template" do
       get "/induction-programme/estimates"
-      expect(response).to have_http_status(:success)
+      expect(response).to render_template("induction_programme/estimates/show")
+    end
+  end
+
+  describe "POST /induction-programme/estimates" do
+    it "saves teacher and mentor estimates for the school cohort" do
+      post "/induction-programme/estimates", params: { school_cohort_form: {
+        estimated_teacher_count: 5, estimated_mentor_count: 2
+      } }
+
+      expect(school_cohort.reload.estimated_teacher_count).to be 5
+      expect(school_cohort.reload.estimated_mentor_count).to be 2
+      expect(response).to redirect_to :dashboard
+    end
+
+    it "renders errors when the form is invalid" do
+      post "/induction-programme/estimates", params: { school_cohort_form: {
+        estimated_teacher_count: nil, estimated_mentor_count: nil
+      } }
+
+      expect(response.body).to include("Enter your expected number of ECTs")
+      expect(response).to render_template("induction_programme/estimates/show")
     end
   end
 end

--- a/spec/requests/induction_programme/estimates_spec.rb
+++ b/spec/requests/induction_programme/estimates_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "InductionProgramme::Estimates", type: :request do
+  describe "GET /induction-programme/estimates" do
+    it "returns http success" do
+      get "/induction-programme/estimates"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
### Context
As a newly registered induction coordinator
Given that I have selected the full induction programme for my school
I should be able to enter estimates for the number of mentors and early career teachers in the next cohort

### Changes proposed in this pull request
Refactoring choices controller. I have added an induction_programme namespace and refactored accordingly.
Added estimates controller 
