### PR TITLE
Adds first component tests

### DIFF
--- a/app/components/school_information/details/main_info_component.html.erb
+++ b/app/components/school_information/details/main_info_component.html.erb
@@ -24,7 +24,6 @@
           <% else %>
             No local authority assigned
           <% end %>
-
         </dd>
       </div>
 

--- a/app/components/school_information/details/main_info_component.html.erb
+++ b/app/components/school_information/details/main_info_component.html.erb
@@ -32,7 +32,7 @@
           School contact
         </dt>
         <dd class="govuk-summary-list__value">
-<!--          TODO: This will need to be updated after talks with Ethan and Michal-->
+<!--         TODO: This will need to be updated after talks with Ethan and Michal-->
           <%= mail_to 'induction_coordinator@school.com' %>
         </dd>
       </div>

--- a/app/components/school_information/details/main_info_component.html.erb
+++ b/app/components/school_information/details/main_info_component.html.erb
@@ -19,7 +19,12 @@
           Local authority
         </dt>
         <dd class="govuk-summary-list__value">
-          Essex
+          <% if @school.local_authority %>
+            <%= @school.local_authority.name %>
+          <% else %>
+            No local authority assigned
+          <% end %>
+
         </dd>
       </div>
 

--- a/spec/components/school_information/details/breadcrumb_component_spec.rb
+++ b/spec/components/school_information/details/breadcrumb_component_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::SchoolInformation::Details::BreadcrumbComponent, type: :component do
+  let(:selected_cohort){ create(:cohort, start_year: 2021) }
+  let(:component){ described_class.new(selected_cohort: selected_cohort) }
+  let(:render_component){ render_inline(component) }
+  let(:before_content_output){ component.content_for(:before_content) }
+
+  before(:each) do
+    render_component
+  end
+
+  it 'includes Schools breadcrumb' do
+    expect(before_content_output).to include 'Schools'
+    expect(before_content_output).to include lead_providers_your_schools_path
+  end
+
+  it 'includes Cohort breadcrumb' do
+    expect(before_content_output).to include '2021 cohort'
+    expect(before_content_output).to include lead_providers_your_schools_path(selected_cohort_id: selected_cohort.id )
+  end
+end

--- a/spec/components/school_information/details/breadcrumb_component_spec.rb
+++ b/spec/components/school_information/details/breadcrumb_component_spec.rb
@@ -3,22 +3,22 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::Details::BreadcrumbComponent, type: :component do
-  let(:selected_cohort){ create(:cohort, start_year: 2021) }
-  let(:component){ described_class.new(selected_cohort: selected_cohort) }
-  let(:render_component){ render_inline(component) }
-  let(:before_content_output){ component.content_for(:before_content) }
+  let(:selected_cohort) { create(:cohort, start_year: 2021) }
+  let(:component) { described_class.new(selected_cohort: selected_cohort) }
+  let(:render_component) { render_inline(component) }
+  let(:before_content_output) { component.content_for(:before_content) }
 
   before(:each) do
     render_component
   end
 
-  it 'includes Schools breadcrumb' do
-    expect(before_content_output).to include 'Schools'
+  it "includes Schools breadcrumb" do
+    expect(before_content_output).to include "Schools"
     expect(before_content_output).to include lead_providers_your_schools_path
   end
 
-  it 'includes Cohort breadcrumb' do
-    expect(before_content_output).to include '2021 cohort'
-    expect(before_content_output).to include lead_providers_your_schools_path(selected_cohort_id: selected_cohort.id )
+  it "includes Cohort breadcrumb" do
+    expect(before_content_output).to include "2021 cohort"
+    expect(before_content_output).to include lead_providers_your_schools_path(selected_cohort_id: selected_cohort.id)
   end
 end

--- a/spec/components/school_information/details/head_component_spec.rb
+++ b/spec/components/school_information/details/head_component_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::Details::HeadComponent, type: :component do
-  let(:school){ create(:school) }
-  let(:selected_cohort){ create(:cohort, start_year: 2021) }
-  let(:rendered_component){ render_inline(described_class.new(school: school, selected_cohort: selected_cohort)).to_html }
+  let(:school) { create(:school) }
+  let(:selected_cohort) { create(:cohort, start_year: 2021) }
+  let(:rendered_component) { render_inline(described_class.new(school: school, selected_cohort: selected_cohort)).to_html }
 
-  it 'contains the name of the school' do
+  it "contains the name of the school" do
     expect(rendered_component).to include school.name
   end
 
-  it 'contains correct cohort recruitment text' do
+  it "contains correct cohort recruitment text" do
     expect(rendered_component).to include "#{selected_cohort.start_year} recruitment"
   end
 end

--- a/spec/components/school_information/details/head_component_spec.rb
+++ b/spec/components/school_information/details/head_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::SchoolInformation::Details::HeadComponent, type: :component do
+  let(:school){ create(:school) }
+  let(:selected_cohort){ create(:cohort, start_year: 2021) }
+  let(:rendered_component){ render_inline(described_class.new(school: school, selected_cohort: selected_cohort)).to_html }
+
+  it 'contains the name of the school' do
+    expect(rendered_component).to include school.name
+  end
+
+  it 'contains correct cohort recruitment text' do
+    expect(rendered_component).to include "#{selected_cohort.start_year} recruitment"
+  end
+end

--- a/spec/components/school_information/details/main_info_component_spec.rb
+++ b/spec/components/school_information/details/main_info_component_spec.rb
@@ -3,36 +3,36 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::Details::MainInfoComponent, type: :component do
-  let(:local_authority) { create(:local_authority, name: 'York') }
+  let(:local_authority) { create(:local_authority, name: "York") }
   let(:school) { create(:school) }
   let(:rendered_component) { render_inline(described_class.new(school: school)).to_html }
 
-  context 'with local authority assigned' do
+  context "with local authority assigned" do
     before(:each) do
       create(:school_local_authority, school: school, local_authority: local_authority, start_year: 2021)
     end
 
-    it 'Contains School Information text' do
+    it "Contains School Information text" do
       expect(rendered_component).to include "School information"
     end
 
-    it 'Contains URN' do
+    it "Contains URN" do
       expect(rendered_component).to include "URN"
-      expect(rendered_component).to include "#{school.urn}"
+      expect(rendered_component).to include school.urn.to_s
     end
 
-    it 'Contains Local Authority' do
+    it "Contains Local Authority" do
       expect(rendered_component).to include "Local authority"
-      expect(rendered_component).to include "#{school.local_authority.name}"
+      expect(rendered_component).to include school.local_authority.name.to_s
     end
 
-    it 'Contains School contact' do
+    it "Contains School contact" do
       expect(rendered_component).to include "School contact"
     end
   end
 
-  context 'without local authority assigned' do
-    it 'Contains Local Authority' do
+  context "without local authority assigned" do
+    it "Contains Local Authority" do
       expect(rendered_component).to include "Local authority"
       expect(rendered_component).to include "No local authority assigned"
     end

--- a/spec/components/school_information/details/main_info_component_spec.rb
+++ b/spec/components/school_information/details/main_info_component_spec.rb
@@ -3,23 +3,38 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::Details::MainInfoComponent, type: :component do
-  let(:school){ create(:school) }
-  let(:rendered_component){ render_inline(described_class.new(school: school)).to_html }
+  let(:local_authority) { create(:local_authority, name: 'York') }
+  let(:school) { create(:school) }
+  let(:rendered_component) { render_inline(described_class.new(school: school)).to_html }
 
-  it 'Contains School Information text' do
-    expect(rendered_component).to include "School information"
+  context 'with local authority assigned' do
+    before(:each) do
+      create(:school_local_authority, school: school, local_authority: local_authority, start_year: 2021)
+    end
+
+    it 'Contains School Information text' do
+      expect(rendered_component).to include "School information"
+    end
+
+    it 'Contains URN' do
+      expect(rendered_component).to include "URN"
+      expect(rendered_component).to include "#{school.urn}"
+    end
+
+    it 'Contains Local Authority' do
+      expect(rendered_component).to include "Local authority"
+      expect(rendered_component).to include "#{school.local_authority.name}"
+    end
+
+    it 'Contains School contact' do
+      expect(rendered_component).to include "School contact"
+    end
   end
 
-  it 'Contains URN' do
-    expect(rendered_component).to include "URN"
-    expect(rendered_component).to include "#{school.urn}"
-  end
-
-  it 'Contains Local Authority' do
-    expect(rendered_component).to include "Local authority"
-  end
-
-  it 'Contains School contact' do
-    expect(rendered_component).to include "School contact"
+  context 'without local authority assigned' do
+    it 'Contains Local Authority' do
+      expect(rendered_component).to include "Local authority"
+      expect(rendered_component).to include "No local authority assigned"
+    end
   end
 end

--- a/spec/components/school_information/details/main_info_component_spec.rb
+++ b/spec/components/school_information/details/main_info_component_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::SchoolInformation::Details::MainInfoComponent, type: :component do
+  let(:school){ create(:school) }
+  let(:rendered_component){ render_inline(described_class.new(school: school)).to_html }
+
+  it 'Contains School Information text' do
+    expect(rendered_component).to include "School information"
+  end
+
+  it 'Contains URN' do
+    expect(rendered_component).to include "URN"
+    expect(rendered_component).to include "#{school.urn}"
+  end
+
+  it 'Contains Local Authority' do
+    expect(rendered_component).to include "Local authority"
+  end
+
+  it 'Contains School contact' do
+    expect(rendered_component).to include "School contact"
+  end
+end

--- a/spec/components/school_information/your_schools/heading_component_spec.rb
+++ b/spec/components/school_information/your_schools/heading_component_spec.rb
@@ -3,14 +3,14 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::YourSchools::HeadingComponent, type: :component do
-  let(:component){ described_class.new }
-  let(:rendered_component){ render_inline(component).to_html }
+  let(:component) { described_class.new }
+  let(:rendered_component) { render_inline(component).to_html }
 
-  it 'includes Your schools text' do
-    expect(rendered_component).to include 'Your schools'
+  it "includes Your schools text" do
+    expect(rendered_component).to include "Your schools"
   end
 
-  it 'includes Find and add schools text' do
-    expect(rendered_component).to include 'Find and add schools'
+  it "includes Find and add schools text" do
+    expect(rendered_component).to include "Find and add schools"
   end
 end

--- a/spec/components/school_information/your_schools/heading_component_spec.rb
+++ b/spec/components/school_information/your_schools/heading_component_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::SchoolInformation::YourSchools::HeadingComponent, type: :component do
+  let(:component){ described_class.new }
+  let(:rendered_component){ render_inline(component).to_html }
+
+  it 'includes Your schools text' do
+    expect(rendered_component).to include 'Your schools'
+  end
+
+  it 'includes Find and add schools text' do
+    expect(rendered_component).to include 'Find and add schools'
+  end
+end

--- a/spec/components/school_information/your_schools/participants_component_spec.rb
+++ b/spec/components/school_information/your_schools/participants_component_spec.rb
@@ -3,14 +3,14 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::YourSchools::ParticipantsComponent, type: :component do
-  let(:component){ described_class.new }
-  let(:rendered_component){ render_inline(component).to_html }
+  let(:component) { described_class.new }
+  let(:rendered_component) { render_inline(component).to_html }
 
-  it 'includes participant target text' do
-    expect(rendered_component).to include 'participant target'
+  it "includes participant target text" do
+    expect(rendered_component).to include "participant target"
   end
 
-  it 'includes participants added by schools text' do
-    expect(rendered_component).to include 'participants added by schools'
+  it "includes participants added by schools text" do
+    expect(rendered_component).to include "participants added by schools"
   end
 end

--- a/spec/components/school_information/your_schools/participants_component_spec.rb
+++ b/spec/components/school_information/your_schools/participants_component_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::SchoolInformation::YourSchools::ParticipantsComponent, type: :component do
+  let(:component){ described_class.new }
+  let(:rendered_component){ render_inline(component).to_html }
+
+  it 'includes participant target text' do
+    expect(rendered_component).to include 'participant target'
+  end
+
+  it 'includes participants added by schools text' do
+    expect(rendered_component).to include 'participants added by schools'
+  end
+end

--- a/spec/components/school_information/your_schools/participants_school_search_component_spec.rb
+++ b/spec/components/school_information/your_schools/participants_school_search_component_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::SchoolInformation::YourSchools::ParticipantsSchoolSearchComponent, type: :component do
+  let(:cohort_1){ create(:cohort, start_year: 2021) }
+  let(:cohort_2){ create(:cohort, start_year: 2022) }
+  let(:school_1){ create(:school) }
+  let(:school_2){ create(:school) }
+  let(:lead_provider){ create(:lead_provider, cohorts: [cohort_1, cohort_2]) }
+  let(:schools){ school_search_form.find_schools(nil) }
+  let(:selected_cohort){ cohort_1 }
+  let(:component){ described_class.new(schools: schools, selected_cohort: cohort_1, school_search_form: school_search_form) }
+  let(:rendered_component){ render_inline(component).to_html }
+  let(:partnership_1){ create(:partnership, cohort: cohort_1, school: school_1, lead_provider: lead_provider) }
+  let(:partnership_2){ create(:partnership, cohort: cohort_1, school: school_2, lead_provider: lead_provider) }
+
+  let(:school_search_form) do
+    search_form = SchoolSearchForm.new
+    search_form.cohort_year = cohort_1.start_year
+    search_form.lead_provider_id = lead_provider.id
+    search_form.with_school_partnerships = true
+    search_form
+  end
+
+  it 'contains Search your schools text' do
+    expect(rendered_component).to include 'Search your schools<'
+  end
+
+  it 'contains hidden input field for cohort year in the form' do
+    expect(rendered_component).to include ['<input value="',cohort_1.start_year,'" type="hidden" name="school_search_form[cohort_year]" id="school_search_form_cohort_year">'].join
+  end
+
+  it 'contains hidden input field for selected_cohort_id' do
+    expect(rendered_component).to include ['<input value="', cohort_1.id, '" type="hidden" name="school_search_form[selected_cohort_id]" id="school_search_form_selected_cohort_id">'].join
+  end
+
+  context 'with partnerships' do
+    before(:each) do
+      partnership_1
+      partnership_2
+    end
+
+    it 'includes both school names in the table' do
+      expect(rendered_component).to include "#{school_1.name}"
+      expect(rendered_component).to include "#{school_2.name}"
+    end
+
+    it 'contains correct links for both schools' do
+      expect(rendered_component).to include lead_providers_school_detail_path(school_1.id, selected_cohort_id: selected_cohort.id)
+      expect(rendered_component).to include lead_providers_school_detail_path(school_2.id, selected_cohort_id: selected_cohort.id)
+    end
+  end
+
+  context 'without partnerships' do
+    it 'contains There are currently no partnered schools text' do
+      expect(rendered_component).to include 'There are currently no partnered schools'
+    end
+  end
+end

--- a/spec/components/school_information/your_schools/participants_school_search_component_spec.rb
+++ b/spec/components/school_information/your_schools/participants_school_search_component_spec.rb
@@ -3,17 +3,17 @@
 require "rails_helper"
 
 RSpec.describe ::SchoolInformation::YourSchools::ParticipantsSchoolSearchComponent, type: :component do
-  let(:cohort_1){ create(:cohort, start_year: 2021) }
-  let(:cohort_2){ create(:cohort, start_year: 2022) }
-  let(:school_1){ create(:school) }
-  let(:school_2){ create(:school) }
-  let(:lead_provider){ create(:lead_provider, cohorts: [cohort_1, cohort_2]) }
-  let(:schools){ school_search_form.find_schools(nil) }
-  let(:selected_cohort){ cohort_1 }
-  let(:component){ described_class.new(schools: schools, selected_cohort: cohort_1, school_search_form: school_search_form) }
-  let(:rendered_component){ render_inline(component).to_html }
-  let(:partnership_1){ create(:partnership, cohort: cohort_1, school: school_1, lead_provider: lead_provider) }
-  let(:partnership_2){ create(:partnership, cohort: cohort_1, school: school_2, lead_provider: lead_provider) }
+  let(:cohort_1) { create(:cohort, start_year: 2021) }
+  let(:cohort_2) { create(:cohort, start_year: 2022) }
+  let(:school_1) { create(:school) }
+  let(:school_2) { create(:school) }
+  let(:lead_provider) { create(:lead_provider, cohorts: [cohort_1, cohort_2]) }
+  let(:schools) { school_search_form.find_schools(nil) }
+  let(:selected_cohort) { cohort_1 }
+  let(:component) { described_class.new(schools: schools, selected_cohort: cohort_1, school_search_form: school_search_form) }
+  let(:rendered_component) { render_inline(component).to_html }
+  let(:partnership_1) { create(:partnership, cohort: cohort_1, school: school_1, lead_provider: lead_provider) }
+  let(:partnership_2) { create(:partnership, cohort: cohort_1, school: school_2, lead_provider: lead_provider) }
 
   let(:school_search_form) do
     search_form = SchoolSearchForm.new
@@ -23,38 +23,38 @@ RSpec.describe ::SchoolInformation::YourSchools::ParticipantsSchoolSearchCompone
     search_form
   end
 
-  it 'contains Search your schools text' do
-    expect(rendered_component).to include 'Search your schools<'
+  it "contains Search your schools text" do
+    expect(rendered_component).to include "Search your schools<"
   end
 
-  it 'contains hidden input field for cohort year in the form' do
-    expect(rendered_component).to include ['<input value="',cohort_1.start_year,'" type="hidden" name="school_search_form[cohort_year]" id="school_search_form_cohort_year">'].join
+  it "contains hidden input field for cohort year in the form" do
+    expect(rendered_component).to include ['<input value="', cohort_1.start_year, '" type="hidden" name="school_search_form[cohort_year]" id="school_search_form_cohort_year">'].join
   end
 
-  it 'contains hidden input field for selected_cohort_id' do
+  it "contains hidden input field for selected_cohort_id" do
     expect(rendered_component).to include ['<input value="', cohort_1.id, '" type="hidden" name="school_search_form[selected_cohort_id]" id="school_search_form_selected_cohort_id">'].join
   end
 
-  context 'with partnerships' do
+  context "with partnerships" do
     before(:each) do
       partnership_1
       partnership_2
     end
 
-    it 'includes both school names in the table' do
-      expect(rendered_component).to include "#{school_1.name}"
-      expect(rendered_component).to include "#{school_2.name}"
+    it "includes both school names in the table" do
+      expect(rendered_component).to include school_1.name.to_s
+      expect(rendered_component).to include school_2.name.to_s
     end
 
-    it 'contains correct links for both schools' do
+    it "contains correct links for both schools" do
       expect(rendered_component).to include lead_providers_school_detail_path(school_1.id, selected_cohort_id: selected_cohort.id)
       expect(rendered_component).to include lead_providers_school_detail_path(school_2.id, selected_cohort_id: selected_cohort.id)
     end
   end
 
-  context 'without partnerships' do
-    it 'contains There are currently no partnered schools text' do
-      expect(rendered_component).to include 'There are currently no partnered schools'
+  context "without partnerships" do
+    it "contains There are currently no partnered schools text" do
+      expect(rendered_component).to include "There are currently no partnered schools"
     end
   end
 end

--- a/spec/factories/partnership.rb
+++ b/spec/factories/partnership.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :partnership do
   end

--- a/spec/factories/partnership.rb
+++ b/spec/factories/partnership.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :partnership do
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,6 +82,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include ViewComponent::TestHelpers, type: :component
+  config.include Rails.application.routes.url_helpers
 
   config.before :each do
     clear_enqueued_jobs


### PR DESCRIPTION
This pull request adds a test suite for components.

Some of the surprises and difficulties observed on content_for components as they don't render the normal way - solved but required digging deeper into the code for view components.

Overall - I think components are great - self-contained lego blocks that are very easy to test and as long as we keep views as flat as possible and not nest components - we should see plenty of benefits.

The one major benefit is the speed and simplicity of the tests - as long as we put the right variables in - we would always get predictable results.

There is much more to components and their configurability - for example using builder pattern (for example .with_header, .with_footer)
