### PR TITLE
Removes default value for cohorts in partnership

### DIFF
--- a/db/migrate/20210308161408_remove_default_cohort.rb
+++ b/db/migrate/20210308161408_remove_default_cohort.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveDefaultCohort < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default(:partnerships, :cohort_id, from: Cohort.find_or_create_by!(start_year: 2021).id, to: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_144821) do
+ActiveRecord::Schema.define(version: 2021_03_08_161408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_144821) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "school_id", null: false
     t.uuid "lead_provider_id", null: false
-    t.uuid "cohort_id", default: "cfc2f3d1-c585-4949-bbc2-5cb164d84727", null: false
+    t.uuid "cohort_id", null: false
     t.index ["cohort_id"], name: "index_partnerships_on_cohort_id"
     t.index ["lead_provider_id"], name: "index_partnerships_on_lead_provider_id"
     t.index ["school_id"], name: "index_partnerships_on_school_id"


### PR DESCRIPTION
### Context

Removes default value for cohorts in partnership

### Changes proposed in this pull request

Removes default cohort id in partnerships table that tends to change

### Guidance to review

Be or not to be a nil Cohort - that is the question

### Testing

Tests pass
