### PR TITLE
ECF-RP-322: Add success flash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem "tzinfo-data"
 # serialization gem that offers more features than active model serializer
 gem "blueprinter"
 
-gem "govuk-components", ">= 1.0.2"
+gem "govuk-components", ">= 1.1.3"
 gem "govuk_design_system_formbuilder", "~> 2.1", ">= 2.1.5"
 gem "view_component", require: "view_component/engine"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,9 +122,9 @@ GEM
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-components (1.1.0)
+    govuk-components (1.1.3)
       rails (>= 6.0)
-      view_component (>= 2.22.1, < 2.25.0)
+      view_component (>= 2.22.1, < 2.27.0)
     govuk_design_system_formbuilder (2.1.6)
       actionview (~> 6.1.0, >= 6.1)
       activemodel (~> 6.1.0, >= 6.1)
@@ -387,7 +387,7 @@ DEPENDENCIES
   factory_bot_rails (>= 6.1.0)
   faker
   foreman
-  govuk-components (>= 1.0.2)
+  govuk-components (>= 1.1.3)
   govuk_design_system_formbuilder (~> 2.1, >= 2.1.5)
   httpclient (~> 2.8, >= 2.8.3)
   kaminari (>= 1.2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,10 @@ class ApplicationController < ActionController::Base
     stored_location_for(user) || helpers.profile_dashboard_url(user)
   end
 
+  def set_success_message(title: "Success", heading: "", content: "")
+    flash[:success] = { title: title, heading: heading, content: content }
+  end
+
 protected
 
   def configure_permitted_parameters

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,21 +80,26 @@
 
       <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
         <% flash.each do |type, msg| %>
-        <% if type == "alert" %>
-          <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-            <h2 class="govuk-error-summary__title" id="error-summary-title">
-              <%= msg %>
-            </h2>
-          </div>
-        <% else%>
-          <div class="govuk-success-summary" aria-labelledby="success-message" tabindex="-1" role="alert">
-            <div class="govuk-success-summary__title">
-              <h2 class="govuk-heading-m" id="success-message">
+          <% if type == "alert" %>
+            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+              <h2 class="govuk-error-summary__title" id="error-summary-title">
                 <%= msg %>
               </h2>
             </div>
-          </div>
-          <%end%>
+          <% elsif type == "success" %>
+            <%= govuk_notification_banner title: msg["title"], success: true do |banner| %>
+              <% banner.add_heading(text: msg["heading"]) %>
+              <% msg["content"] %>
+            <% end %>
+          <% else %>
+            <div class="govuk-success-summary" aria-labelledby="success-message" tabindex="-1" role="alert">
+              <div class="govuk-success-summary__title">
+                <h2 class="govuk-heading-m" id="success-message">
+                  <%= msg %>
+                </h2>
+              </div>
+            </div>
+          <% end %>
         <% end %>
         <%= yield %>
       </main>


### PR DESCRIPTION
### Context
Set up for flash success notifications. Eventually I want to go through all of our `flash` and use either a green or blue notification banner, but Al doesn't have time for this right now.

I've not used this anywhere in this PR, just set up work for the ones to follow.

[Here](https://design-system.service.gov.uk/components/notification-banner/#reacting-to-something-the-user-has-done:~:text=Use%20the%20green%20version%20of%20the,they%E2%80%99re%20expecting%20to%20happen%20has%20happened.) is the design system component.
![image](https://user-images.githubusercontent.com/40488007/110835570-e09ca680-8296-11eb-9db7-b881d3683667.png)
