### PR TITLE
ECF-RP-333: Remove success page, copy changes

### DIFF
--- a/app/controllers/admin/suppliers/supplier_users_controller.rb
+++ b/app/controllers/admin/suppliers/supplier_users_controller.rb
@@ -7,7 +7,7 @@ module Admin
       skip_after_action :verify_policy_scoped
 
       before_action :set_suppliers, only: %i[new receive_supplier]
-      before_action :form_from_session, only: %i[user_details review create success]
+      before_action :form_from_session, only: %i[user_details review create]
 
       def index
         sorted_users = User.for_lead_provider.sort_by(&:full_name)
@@ -64,16 +64,11 @@ module Admin
         authorize User
         authorize LeadProviderProfile
 
-        user = @supplier_user_form.save!
-        redirect_to admin_new_supplier_user_success_path(user_id: user.id)
-      end
-
-      def success
-        @user = User.find(params[:user_id])
-        authorize @user, :show?
-        @supplier_name = @supplier_user_form.chosen_supplier.name
-
+        @supplier_user_form.save!
         session.delete(:supplier_user_form)
+
+        set_success_message(heading: "User added", content: "They have been sent an email to sign in")
+        redirect_to admin_supplier_users_path
       end
 
     private

--- a/app/views/admin/suppliers/supplier_users/index.html.erb
+++ b/app/views/admin/suppliers/supplier_users/index.html.erb
@@ -5,7 +5,7 @@
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Name</th>
       <th scope="col" class="govuk-table__header">Email address</th>
-      <th scope="col" class="govuk-table__header">Organisation</th>
+      <th scope="col" class="govuk-table__header">Supplier</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/app/views/admin/suppliers/supplier_users/review.html.erb
+++ b/app/views/admin/suppliers/supplier_users/review.html.erb
@@ -34,14 +34,14 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Organisation
+      Supplier
     </dt>
     <dd class="govuk-summary-list__value">
       <%= @supplier_user_form.chosen_supplier.name %>
     </dd>
     <dd class="govuk-summary-list__actions">
       <%= govuk_link_to new_admin_supplier_user_path(continue: true), class: "govuk-link--no-visited-state" do %>
-        Change<span class="govuk-visually-hidden"> organisation</span>
+        Change<span class="govuk-visually-hidden"> supplier</span>
       <% end %>
     </dd>
   </div>

--- a/app/views/admin/suppliers/supplier_users/success.html.erb
+++ b/app/views/admin/suppliers/supplier_users/success.html.erb
@@ -1,4 +1,0 @@
-<%= govuk_panel title: "User added", body: nil %>
-<p><%= @user.full_name %> has been added to <%= @supplier_name %>. They have been sent an email.</p>
-<p>Back to <%= govuk_link_to "manage suppliers", admin_suppliers_path %></p>
-<%= govuk_link_to "Add another user", new_admin_supplier_user_path, button: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,6 @@ Rails.application.routes.draw do
         get "user-details", controller: :supplier_users, action: :user_details, as: :new_supplier_user_details
         post "user-details", controller: :supplier_users, action: :receive_user_details
         get "review", controller: :supplier_users, action: :review, as: :new_supplier_user_review
-        get "success", controller: :supplier_users, action: :success, as: :new_supplier_user_success
       end
 
       resources :delivery_partners, only: %i[show edit update destroy], path: "delivery-partners" do

--- a/spec/cypress/integration/admin/suppliers/create-lead-provider-user.js
+++ b/spec/cypress/integration/admin/suppliers/create-lead-provider-user.js
@@ -35,19 +35,12 @@ describe("Admin user creating lead provider user", () => {
     cy.get("main").should("contain", userEmail);
     cy.confirmCreateSupplierUser();
 
-    cy.location("pathname").should(
-      "contain",
-      "/admin/suppliers/users/new/success"
-    );
-
-    cy.get("a").contains("manage suppliers").click();
-    cy.location("pathname").should("equal", "/admin/suppliers");
-
-    cy.get("a").contains("All users").click();
     cy.location("pathname").should("equal", "/admin/suppliers/users");
     cy.get("main").should("contain", userName);
     cy.get("main").should("contain", userEmail);
     cy.get("main").should("contain", leadProviderName);
+    cy.get("main").should("contain", "User added");
+    cy.get("main").should("contain", "They have been sent an email to sign in");
   });
 
   it("remembers previous choices", () => {
@@ -77,14 +70,12 @@ describe("Admin user creating lead provider user", () => {
 
     cy.confirmCreateSupplierUser();
 
-    cy.get("a").contains("manage suppliers").click();
-    cy.location("pathname").should("equal", "/admin/suppliers");
-
-    cy.get("a").contains("All users").click();
     cy.location("pathname").should("equal", "/admin/suppliers/users");
     cy.get("main").should("contain", userName);
     cy.get("main").should("contain", userEmail);
     cy.get("main").should("contain", leadProviderName);
+    cy.get("main").should("contain", "User added");
+    cy.get("main").should("contain", "They have been sent an email to sign in");
   });
 
   it("allows changing name choice", () => {
@@ -106,13 +97,11 @@ describe("Admin user creating lead provider user", () => {
 
     cy.confirmCreateSupplierUser();
 
-    cy.get("a").contains("manage suppliers").click();
-    cy.location("pathname").should("equal", "/admin/suppliers");
-
-    cy.get("a").contains("All users").click();
     cy.location("pathname").should("equal", "/admin/suppliers/users");
     cy.get("main").should("contain", userName);
     cy.get("main").should("contain", userEmail);
     cy.get("main").should("contain", leadProviderName);
+    cy.get("main").should("contain", "User added");
+    cy.get("main").should("contain", "They have been sent an email to sign in");
   });
 });

--- a/spec/requests/admin/suppliers/supplier_users_spec.rb
+++ b/spec/requests/admin/suppliers/supplier_users_spec.rb
@@ -124,12 +124,11 @@ RSpec.describe "Admin::SupplierUsers", type: :request do
       given_i_have_entered_user_details(full_name, email)
     end
 
-    it "redirects to the confirmation page" do
+    it "redirects to the supplier users page" do
       when_i_confirm_my_choices
 
       # Then
-      new_user = User.order(:created_at).last
-      expect(response).to redirect_to "/admin/suppliers/users/new/success?user_id=#{new_user.id}"
+      expect(response).to redirect_to "/admin/suppliers/users"
     end
 
     it "creates a new user" do


### PR DESCRIPTION
### Changes proposed in this pull request
- Remove success page for creating LP user, replace with success banner
- "organisation" -> "supplier" everywhere

### Testing
Just updated existing
