### PR TITLE
Update school data imports to act on unscoped schools

### DIFF
--- a/app/services/pupil_premium_importer.rb
+++ b/app/services/pupil_premium_importer.rb
@@ -27,7 +27,7 @@ private
 
   def update_school_premium(row)
     urn = row.fetch("URN")
-    school = School.find_by(urn: urn)
+    school = School.unscoped.find_by(urn: urn)
     logger.info "Could not find school with URN #{urn}" and return unless school
 
     total_pupils = row.fetch("Number of pupils on roll (7)").delete(",").to_i

--- a/app/services/school_data_importer.rb
+++ b/app/services/school_data_importer.rb
@@ -34,7 +34,7 @@ private
   end
 
   def row_to_school(row)
-    school = School.find_or_initialize_by(urn: row.fetch("URN"))
+    school = School.unscoped.find_or_initialize_by(urn: row.fetch("URN"))
     school.name = row.fetch("EstablishmentName")
     school.school_type_code = row.fetch("TypeOfEstablishment (code)").to_i
     school.school_type_name = row.fetch("TypeOfEstablishment (name)")

--- a/spec/services/pupil_premium_importer_spec.rb
+++ b/spec/services/pupil_premium_importer_spec.rb
@@ -62,5 +62,15 @@ RSpec.describe PupilPremiumImporter do
 
       expect(School.first.pupil_premiums.count).to be 2
     end
+
+    context "when the school is not eligible" do
+      before do
+        School.find_by(urn: 100_000).update(school_status_code: 2)
+      end
+
+      it "updates the school" do
+        expect(School.unscoped.find_by(urn: 100_000).pupil_premiums.first).to be_present
+      end
+    end
   end
 end

--- a/spec/services/school_data_importer_spec.rb
+++ b/spec/services/school_data_importer_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe SchoolDataImporter do
           expect(existing_school.school_local_authority_districts.where(end_year: 2021).count).to be 1
         end
       end
+
+      context "when the school exists and is not eligible" do
+        let!(:existing_school) { create(:school, urn: 20_001, name: "NOT The Starship Children's Centre", school_status_code: 2) }
+
+        it "updates the school" do
+          school_data_importer.run
+          existing_school.reload
+
+          expect(existing_school.name).to eql("The Starship Children's Centre")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We should be able to update schools which are not eligible, so are excluded from the default scope

