### PR TITLE
Remove success screen at end of admin creation journey

### DIFF
--- a/app/controllers/admin/administrators/administrators_controller.rb
+++ b/app/controllers/admin/administrators/administrators_controller.rb
@@ -49,6 +49,9 @@ module Admin
           AdminProfile.create!(user: user)
         end
         session.delete(:administrator_user)
+
+        set_success_message(heading: "User added", content: "They have been sent an email to sign in")
+        redirect_to admin_administrators_path
       end
 
       def edit; end

--- a/app/views/admin/administrators/administrators/create.html.erb
+++ b/app/views/admin/administrators/administrators/create.html.erb
@@ -1,8 +1,0 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel title: "Administrator created", body: nil %>
-
-    <%= govuk_link_to "Add another administrator", new_admin_administrator_path, button: true %>
-    <%= govuk_link_to "View all administrators", admin_administrators_path, button: true, class: "govuk-button--secondary" %>
-  </div>
-</div>

--- a/app/views/admin/administrators/administrators/index.html.erb
+++ b/app/views/admin/administrators/administrators/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l">Administrators</h1>
-<%= govuk_link_to "Create a new administrator", new_admin_administrator_path, button: true %>
+<%= govuk_link_to "Create a new administrator", new_admin_administrator_path, button: true, "data-test" => "create-admin-button" %>
 <table class="govuk-table">
   <thead>
     <tr class="govuk-table__row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,7 +84,11 @@
               </h2>
             </div>
           <% elsif type == "success" %>
-            <%= govuk_notification_banner title: msg["title"], success: true do |banner| %>
+            <%= govuk_notification_banner(
+                  title: msg["title"],
+                  success: true,
+                  html_attributes: { data: { test: "notification-banner" } }
+                ) do |banner| %>
               <% banner.add_heading(text: msg["heading"]) %>
               <% msg["content"] %>
             <% end %>

--- a/spec/cypress/integration/admin/administrators/create-administrator.js
+++ b/spec/cypress/integration/admin/administrators/create-administrator.js
@@ -13,7 +13,7 @@ describe("Admin user creating another admin user", () => {
     const email = "j.smith@example.com";
 
     cy.visit("/admin/administrators");
-    cy.get(".govuk-button").contains("Create a new administrator").click();
+    cy.get("[data-test=create-admin-button").click();
 
     cy.location("pathname").should("equal", "/admin/administrators/new");
     cy.get("input[name='user[full_name]']").type(fullName);
@@ -29,14 +29,13 @@ describe("Admin user creating another admin user", () => {
     cy.get("input.govuk-button").contains("Create administrator user").click();
 
     cy.location("pathname").should("equal", "/admin/administrators");
-    cy.get(".govuk-button").contains("View all administrators").click();
-
-    cy.location("pathname").should("equal", "/admin/administrators");
     cy.get("main").should("contain", fullName);
     cy.get("main").should("contain", email);
-
-    cy.appEval(`User.find_by(email: "${email}").admin?`).then((result) =>
-      expect(result).to.equal(true)
+    cy.get("[data-test=notification-banner]").should("contain", "Success");
+    cy.get("[data-test=notification-banner]").should("contain", "User added");
+    cy.get("[data-test=notification-banner]").should(
+      "contain",
+      "They have been sent an email to sign in"
     );
   });
 });

--- a/spec/cypress/integration/admin/suppliers/create-lead-provider-user.js
+++ b/spec/cypress/integration/admin/suppliers/create-lead-provider-user.js
@@ -39,8 +39,12 @@ describe("Admin user creating lead provider user", () => {
     cy.get("main").should("contain", userName);
     cy.get("main").should("contain", userEmail);
     cy.get("main").should("contain", leadProviderName);
-    cy.get("main").should("contain", "User added");
-    cy.get("main").should("contain", "They have been sent an email to sign in");
+    cy.get("[data-test=notification-banner]").should("contain", "Success");
+    cy.get("[data-test=notification-banner]").should("contain", "User added");
+    cy.get("[data-test=notification-banner]").should(
+      "contain",
+      "They have been sent an email to sign in"
+    );
   });
 
   it("remembers previous choices", () => {
@@ -74,8 +78,12 @@ describe("Admin user creating lead provider user", () => {
     cy.get("main").should("contain", userName);
     cy.get("main").should("contain", userEmail);
     cy.get("main").should("contain", leadProviderName);
-    cy.get("main").should("contain", "User added");
-    cy.get("main").should("contain", "They have been sent an email to sign in");
+    cy.get("[data-test=notification-banner]").should("contain", "Success");
+    cy.get("[data-test=notification-banner]").should("contain", "User added");
+    cy.get("[data-test=notification-banner]").should(
+      "contain",
+      "They have been sent an email to sign in"
+    );
   });
 
   it("allows changing name choice", () => {
@@ -102,6 +110,11 @@ describe("Admin user creating lead provider user", () => {
     cy.get("main").should("contain", userEmail);
     cy.get("main").should("contain", leadProviderName);
     cy.get("main").should("contain", "User added");
-    cy.get("main").should("contain", "They have been sent an email to sign in");
+    cy.get("[data-test=notification-banner]").should("contain", "Success");
+    cy.get("[data-test=notification-banner]").should("contain", "User added");
+    cy.get("[data-test=notification-banner]").should(
+      "contain",
+      "They have been sent an email to sign in"
+    );
   });
 });

--- a/spec/requests/admin/administrators/administrators_spec.rb
+++ b/spec/requests/admin/administrators/administrators_spec.rb
@@ -88,7 +88,14 @@ RSpec.describe "Admin::Administrators::Administrators", type: :request do
     it "renders a success message" do
       given_a_user_is_created
 
-      expect(response).to render_template("admin/administrators/administrators/create")
+      expect(response).to redirect_to("/admin/administrators")
+      expect(flash[:success]).to(
+        eql({
+          title: "Success",
+          heading: "User added",
+          content: "They have been sent an email to sign in",
+        }),
+      )
     end
   end
 

--- a/spec/requests/admin/suppliers/supplier_users_spec.rb
+++ b/spec/requests/admin/suppliers/supplier_users_spec.rb
@@ -129,6 +129,13 @@ RSpec.describe "Admin::SupplierUsers", type: :request do
 
       # Then
       expect(response).to redirect_to "/admin/suppliers/users"
+      expect(flash[:success]).to(
+        eql({
+          title: "Success",
+          heading: "User added",
+          content: "They have been sent an email to sign in",
+        }),
+      )
     end
 
     it "creates a new user" do


### PR DESCRIPTION
### Context
We're replacing most of the success pages with notification banners. This is that for the admin creation journey

### Changes proposed in this pull request
- Replace success panel with notification banner
- Make use of data-test attributes in a couple of places

### Testing
Updated existing