### PR TITLE
Email testing - add unit tests

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -22,7 +22,7 @@ private
     school = resource.induction_coordinator_profile.schools.first
 
     if school.primary_contact_email != resource.email
-      UserMailer.primary_contact_notification(resource, school)
+      UserMailer.primary_contact_notification(resource, school).deliver_now
     end
   end
 end

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,10 +1,10 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: registrations_root_path)
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% content_for :before_content, govuk_back_link(
-      text: "Back",
-      href: registrations_root_path)
-    %>
-
     <h1 class="govuk-heading-l">Sign in</h1>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="govuk-form-group">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-  <% content_for :before_content, govuk_back_link(
-    text: "Back",
-    href: registrations_root_path)
-  %>
+    <% content_for :before_content, govuk_back_link(
+      text: "Back",
+      href: registrations_root_path)
+    %>
 
     <h1 class="govuk-heading-l">Sign in</h1>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
@@ -15,6 +15,6 @@
     <% end %>
     <%= govuk_link_to "Register your school", registrations_question_one_path %>
     <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-15"><strong>Problems signing in</strong></p>
-    <p class="govuk-!-margin-top-1">Contact us: <%= mail_to "ecf-support@digital.education.gov.uk" %> </p>
+    <p class="govuk-!-margin-top-1">Contact us: <%= mail_to "ecf-support@digital.education.gov.uk" %></p>
   </div>
 </div>

--- a/spec/requests/registrations/user_profile_spec.rb
+++ b/spec/requests/registrations/user_profile_spec.rb
@@ -23,38 +23,103 @@ RSpec.describe "Registrations::UserProfile", type: :request do
   end
 
   describe "POST /registrations/user-profile" do
-    it "creates an induction coordinator profile" do
-      post "/registrations/user-profile", params: { user: {
-        full_name: full_name,
-        email: email,
-      } }
+    before do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
+      allow(UserMailer).to receive(:confirmation_instructions).and_return(mail)
+    end
 
-      expect(created_user.full_name).to eq(full_name)
-      expect(response).to redirect_to(:registrations_verification_sent)
-      expect(created_user.induction_coordinator_profile.schools).to include(school)
+    context "when request is valid" do
+      let(:send_request) do
+        post "/registrations/user-profile", params: { user: {
+          full_name: full_name,
+          email: email,
+        } }
+      end
+
+      it "creates an induction coordinator profile" do
+        send_request
+        expect(created_user.full_name).to eq(full_name)
+        expect(created_user.induction_coordinator_profile.schools).to include(school)
+      end
+
+      it "redirects to verification sent page" do
+        send_request
+        expect(response).to redirect_to(:registrations_verification_sent)
+      end
+
+      it "sends a confirmation email" do
+        send_request
+        expect(UserMailer).to have_received(:confirmation_instructions).with(created_user, /.*/, {})
+      end
+
+      context "when school has old unconfirmed registrations" do
+        let(:user) { create(:user, confirmed_at: nil) }
+        let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
+
+        before do
+          user.update!(confirmation_sent_at: 2.days.ago)
+        end
+
+        it "registers new induction coordinator" do
+          send_request
+          expect(school.reload.induction_coordinator_profiles).to include created_user.induction_coordinator_profile
+        end
+
+        it "removes the old coordinator profiles" do
+          send_request
+          expect(school.induction_coordinator_profiles).not_to include user.reload.induction_coordinator_profile
+        end
+
+        it "sends a confirmation email to the new induction coordinator" do
+          send_request
+          expect(UserMailer).to have_received(:confirmation_instructions).with(created_user, /.*/, {})
+        end
+      end
     end
 
     context "when email is missing" do
+      let(:send_request) do
+        post "/registrations/user-profile", params: { user: {
+          full_name: full_name,
+        } }
+      end
+
       it "does not create the user" do
-        expect {
-          post "/registrations/user-profile", params: { user: {
-            full_name: full_name,
-          } }
-        }.not_to(change { User.count })
+        expect { send_request }.not_to(change { User.count })
+      end
+
+      it "shows validation error" do
+        send_request
         expect(response.body).to include("Enter an email")
         expect(response).to render_template("registrations/user_profile/new")
+      end
+
+      it "does not send a confirmation email" do
+        send_request
+        expect(UserMailer).not_to have_received(:confirmation_instructions)
       end
     end
 
     context "when full name is missing" do
+      let(:send_request) do
+        post "/registrations/user-profile", params: { user: {
+          email: email,
+        } }
+      end
+
       it "does not create the user" do
-        expect {
-          post "/registrations/user-profile", params: { user: {
-            email: email,
-          } }
-        }.not_to(change { User.count })
+        expect { send_request }.not_to(change { User.count })
+      end
+
+      it "shows validation error" do
+        send_request
         expect(response.body).to include("Enter a full name")
         expect(response).to render_template("registrations/user_profile/new")
+      end
+
+      it "does not send a confirmation email" do
+        send_request
+        expect(UserMailer).not_to have_received(:confirmation_instructions)
       end
     end
 
@@ -72,23 +137,7 @@ RSpec.describe "Registrations::UserProfile", type: :request do
             email: email,
           } }
         }.to raise_error(ActionController::BadRequest)
-      end
-    end
-
-    context "when school has old unconfirmed registrations" do
-      let(:user) { create(:user, confirmed_at: nil) }
-      let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
-
-      before { user.update(confirmation_sent_at: 2.days.ago) }
-
-      it "registers new induction coordinator and removes the old coordinator profiles" do
-        post "/registrations/user-profile", params: { user: {
-          full_name: full_name,
-          email: email,
-        } }
-
-        expect(school.reload.induction_coordinator_profiles).to include created_user.induction_coordinator_profile
-        expect(school.induction_coordinator_profiles).not_to include user.reload.induction_coordinator_profile
+        expect(UserMailer).not_to have_received(:confirmation_instructions)
       end
     end
   end

--- a/spec/requests/registrations/user_profile_spec.rb
+++ b/spec/requests/registrations/user_profile_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe "Registrations::UserProfile", type: :request do
 
   describe "POST /registrations/user-profile" do
     before do
-      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
-      allow(UserMailer).to receive(:confirmation_instructions).and_return(mail)
+      allow(UserMailer).to receive(:confirmation_instructions).and_call_original
     end
 
     context "when request is valid" do

--- a/spec/requests/registrations/user_profile_spec.rb
+++ b/spec/requests/registrations/user_profile_spec.rb
@@ -29,96 +29,78 @@ RSpec.describe "Registrations::UserProfile", type: :request do
     end
 
     context "when request is valid" do
-      let(:send_request) do
-        post "/registrations/user-profile", params: { user: {
-          full_name: full_name,
-          email: email,
-        } }
+      before do
+        send_valid_create_request
       end
 
       it "creates an induction coordinator profile" do
-        send_request
         expect(created_user.full_name).to eq(full_name)
         expect(created_user.induction_coordinator_profile.schools).to include(school)
       end
 
       it "redirects to verification sent page" do
-        send_request
         expect(response).to redirect_to(:registrations_verification_sent)
       end
 
       it "sends a confirmation email" do
-        send_request
-        expect(UserMailer).to have_received(:confirmation_instructions).with(created_user, /.*/, {})
+        token_regex = /.*/
+        empty_options = {}
+        expect(UserMailer).to have_received(:confirmation_instructions).with(created_user, token_regex, empty_options)
+      end
+    end
+
+    context "when request is valid and school has old unconfirmed registrations" do
+      let(:user) { create(:user, confirmed_at: nil) }
+      let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
+
+      before do
+        user.update!(confirmation_sent_at: 2.days.ago)
+        send_valid_create_request
       end
 
-      context "when school has old unconfirmed registrations" do
-        let(:user) { create(:user, confirmed_at: nil) }
-        let!(:coordinator) { create(:induction_coordinator_profile, user: user, schools: [school]) }
+      it "registers new induction coordinator" do
+        expect(school.reload.induction_coordinator_profiles).to include created_user.induction_coordinator_profile
+      end
 
-        before do
-          user.update!(confirmation_sent_at: 2.days.ago)
-        end
+      it "removes the old coordinator profiles" do
+        expect(school.induction_coordinator_profiles).not_to include user.reload.induction_coordinator_profile
+      end
 
-        it "registers new induction coordinator" do
-          send_request
-          expect(school.reload.induction_coordinator_profiles).to include created_user.induction_coordinator_profile
-        end
-
-        it "removes the old coordinator profiles" do
-          send_request
-          expect(school.induction_coordinator_profiles).not_to include user.reload.induction_coordinator_profile
-        end
-
-        it "sends a confirmation email to the new induction coordinator" do
-          send_request
-          expect(UserMailer).to have_received(:confirmation_instructions).with(created_user, /.*/, {})
-        end
+      it "sends a confirmation email to the new induction coordinator" do
+        expect(UserMailer).to have_received(:confirmation_instructions).with(created_user, /.*/, {})
       end
     end
 
     context "when email is missing" do
-      let(:send_request) do
-        post "/registrations/user-profile", params: { user: {
-          full_name: full_name,
-        } }
-      end
-
       it "does not create the user" do
-        expect { send_request }.not_to(change { User.count })
+        expect { send_create_request_no_email }.not_to(change { User.count })
       end
 
       it "shows validation error" do
-        send_request
+        send_create_request_no_email
         expect(response.body).to include("Enter an email")
         expect(response).to render_template("registrations/user_profile/new")
       end
 
       it "does not send a confirmation email" do
-        send_request
+        send_create_request_no_email
         expect(UserMailer).not_to have_received(:confirmation_instructions)
       end
     end
 
     context "when full name is missing" do
-      let(:send_request) do
-        post "/registrations/user-profile", params: { user: {
-          email: email,
-        } }
-      end
-
       it "does not create the user" do
-        expect { send_request }.not_to(change { User.count })
+        expect { send_create_request_no_name }.not_to(change { User.count })
       end
 
       it "shows validation error" do
-        send_request
+        send_create_request_no_name
         expect(response.body).to include("Enter a full name")
         expect(response).to render_template("registrations/user_profile/new")
       end
 
       it "does not send a confirmation email" do
-        send_request
+        send_create_request_no_name
         expect(UserMailer).not_to have_received(:confirmation_instructions)
       end
     end
@@ -140,5 +122,26 @@ RSpec.describe "Registrations::UserProfile", type: :request do
         expect(UserMailer).not_to have_received(:confirmation_instructions)
       end
     end
+  end
+
+private
+
+  def send_valid_create_request
+    post "/registrations/user-profile", params: { user: {
+      full_name: full_name,
+      email: email,
+    } }
+  end
+
+  def send_create_request_no_name
+    post "/registrations/user-profile", params: { user: {
+      email: email,
+    } }
+  end
+
+  def send_create_request_no_email
+    post "/registrations/user-profile", params: { user: {
+      full_name: full_name,
+    } }
   end
 end

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Users::Confirmations", type: :request do
 
   describe "GET /users/confirmation" do
     before do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
+      allow(UserMailer).to receive(:primary_contact_notification).and_return(mail)
       school.induction_coordinator_profiles << induction_coordinator
     end
 

--- a/spec/requests/users/confirmations_spec.rb
+++ b/spec/requests/users/confirmations_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe "Users::Confirmations", type: :request do
 
   describe "GET /users/confirmation" do
     before do
-      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
-      allow(UserMailer).to receive(:primary_contact_notification).and_return(mail)
+      allow(UserMailer).to receive(:primary_contact_notification).and_call_original
       school.induction_coordinator_profiles << induction_coordinator
     end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe "Users::Sessions", type: :request do
     let(:login_url_regex) { /http:\/\/localhost:3000\/users\/confirm_sign_in\?login_token=.*/ }
 
     before do
-      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
-      allow(UserMailer).to receive(:sign_in_email).and_return(mail)
+      allow(UserMailer).to receive(:sign_in_email).and_call_original
     end
 
     context "when email matches a user" do


### PR DESCRIPTION
### Context
We want more testing around emails. This PR deals with adding them to RSpec - I went through the places I expected to be sending emails and added unit tests to them. That said, devise likes sending some emails implicitly - I guess if the user is confirmed when we create them it won't send a confirmation email? I wonder if I want to test that in all the places that deal with making new users. 

### Changes proposed in this pull request
1. A bunch of unit tests - checking what calls `UserMailer` received
2. A primary email notification was created, but never sent. I am not sure that's a good idea - if we don't want emails to be sent to the real world emails, well, that's what the non-live notify keys are for, right?

### Guidance to review
Keen to hear opinions about primary email notifications.
There will be another PR coming at some point, when I figure out how best test emails in cypress.

### Testing
To quote Ethan, "this is testing".