### PR TITLE
Improve deletion flow consistency

### DIFF
--- a/app/controllers/admin/suppliers/delivery_partners_controller.rb
+++ b/app/controllers/admin/suppliers/delivery_partners_controller.rb
@@ -98,6 +98,7 @@ module Admin
         authorize @delivery_partner
 
         @delivery_partner.discard!
+        set_success_message(content: "Delivery partner deleted", title: "Success")
         redirect_to admin_suppliers_path
       end
 

--- a/app/views/admin/administrators/administrators/delete.html.erb
+++ b/app/views/admin/administrators/administrators/delete.html.erb
@@ -1,6 +1,8 @@
 <h1>Do you want to delete this user?</h1>
 <p class="govuk-!-font-weight-bold">Admin user: <span class="govuk-!-font-weight-regular"><%= @administrator.full_name %></span></p>
 <%= form_for :confirmation, url: admin_administrator_path(@administrator), method: :delete do |f| %>
-  <%= f.govuk_submit "Delete", classes: "govuk-button--warning data-test-delete-submit-button" %>
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Delete", classes: "govuk-button--warning data-test-delete-submit-button" %>
+    <%= govuk_link_to "Back", edit_admin_administrator_path(@administrator), button: true, class: "govuk-button--secondary" %>
+  </div>
 <% end %>
-<%= govuk_link_to "Back", edit_admin_administrator_path(@administrator), button: true, class: "govuk-button--secondary" %>

--- a/app/views/admin/administrators/administrators/edit.html.erb
+++ b/app/views/admin/administrators/administrators/edit.html.erb
@@ -13,10 +13,12 @@
             :email,
             label: { text: "Email" })
       %>
-      <%= f.govuk_submit "Save" %>
-      <% if current_user.id != @administrator.id %>
-        <%= govuk_link_to "Delete", delete_admin_administrator_path(@administrator), button: true, class: "govuk-button--warning", "data-test" => "delete-button" %>
-      <% end %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Save" %>
+        <% if current_user.id != @administrator.id %>
+          <%= govuk_link_to "Delete", delete_admin_administrator_path(@administrator), button: true, class: "govuk-button--warning", "data-test" => "delete-button" %>
+        <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/suppliers/delivery_partners/delete.html.erb
+++ b/app/views/admin/suppliers/delivery_partners/delete.html.erb
@@ -1,6 +1,8 @@
 <h1>Confirm deletion of <%= @delivery_partner.name %></h1>
 <%= form_for :confirmation, url: admin_delivery_partner_path(@delivery_partner), method: :delete do |f| %>
   <%= f.hidden_field :answers_checked, value: true %>
-  <%= f.govuk_submit "Delete", classes: "govuk-button--warning" %>
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Delete", classes: "govuk-button--warning" %>
+    <%= govuk_link_to "Back", edit_admin_delivery_partner_path(@delivery_partner), button: true, class: "govuk-button--secondary" %>
+  </div>
 <% end %>
-<%= govuk_link_to "Back", edit_admin_delivery_partner_path(@delivery_partner), button: true, class: "govuk-button--secondary" %>

--- a/app/views/admin/suppliers/delivery_partners/edit.html.erb
+++ b/app/views/admin/suppliers/delivery_partners/edit.html.erb
@@ -8,8 +8,10 @@
 
       <%= f.govuk_text_field :name, label: { size: "m" } %>
       <%= render "lead_providers_cohorts", locals = { f: f, legend_options: { size: "m" } } %>
-      <%= f.govuk_submit "Save" %>
-    <%= govuk_link_to "Delete", delete_admin_delivery_partner_path(@delivery_partner), button: true, class: "govuk-button--warning" %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Save" %>
+        <%= govuk_link_to "Delete", delete_admin_delivery_partner_path(@delivery_partner), button: true, class: "govuk-button--warning" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/suppliers/lead_provider_users/delete.html.erb
+++ b/app/views/admin/suppliers/lead_provider_users/delete.html.erb
@@ -1,6 +1,8 @@
 <h1>Do you want to delete this user?</h1>
 <p class="govuk-!-font-weight-bold">Supplier user: <span class="govuk-!-font-weight-regular"><%= @lead_provider_user.full_name %></span></p>
 <%= form_for :confirmation, url: admin_lead_provider_user_path(@lead_provider_user), method: :delete do |f| %>
-  <%= f.govuk_submit "Delete", classes: "govuk-button--warning data-test-delete-submit-button" %>
+  <div class="govuk-button-group">
+    <%= f.govuk_submit "Delete", classes: "govuk-button--warning data-test-delete-submit-button" %>
+    <%= govuk_link_to "Back", edit_admin_lead_provider_user_path(@lead_provider_user), button: true, class: "govuk-button--secondary" %>
+  </div>
 <% end %>
-<%= govuk_link_to "Back", edit_admin_lead_provider_user_path(@lead_provider_user), button: true, class: "govuk-button--secondary" %>

--- a/app/views/admin/suppliers/lead_provider_users/edit.html.erb
+++ b/app/views/admin/suppliers/lead_provider_users/edit.html.erb
@@ -13,8 +13,10 @@
             :email,
             label: { text: "Email" })
       %>
-      <%= f.govuk_submit "Save" %>
-      <%= govuk_link_to "Delete", delete_admin_lead_provider_user_path(@lead_provider_user), button: true, class: "govuk-button--warning", "data-test"=> "delete-button" %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Save" %>
+        <%= govuk_link_to "Delete", delete_admin_lead_provider_user_path(@lead_provider_user), button: true, class: "govuk-button--warning", "data-test"=> "delete-button" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/spec/cypress/integration/admin/suppliers/delete-delivery-partner.js
+++ b/spec/cypress/integration/admin/suppliers/delete-delivery-partner.js
@@ -26,6 +26,7 @@ describe("Admin user deleting delivery partner", () => {
 
     cy.location("pathname").should("equal", "/admin/suppliers");
     cy.get("main").should("not.contain", deliveryPartnerName);
+    cy.get("main").should("contain", "Delivery partner deleted");
   });
 
   it("has a back button to the edit page", () => {


### PR DESCRIPTION
### Context

There were a couple different designs for the deletion pages before, this makes them all looks the same and (hopefully) makes them look a bit nicer

### Changes proposed in this pull request

Button groups

Also, there was no flash message after deleting a delivery provider - I fixed that

### Guidance to review

Percy would help here :D

### Testing

yes