### PR TITLE
ECF-RP-370: Create github action create PR to release to staging

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -16,6 +16,13 @@ jobs:
           INPUTS='${{ format('{{"environment": "staging", "ref": "{0}"}}', github.sha) }}'
           echo "INPUTS=${INPUTS}" >> $GITHUB_ENV
 
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Tag release
+        run: |
+           TAGNAME=$(git log -1 --pretty=%B | sed -n 's/Release version \(.*\) to staging/\1/p')
+           ([[ ! -z "$TAGNAME" ]] && git tag -f $TAGNAME && git push origin $TAGNAME -f) || echo "No version found" && exit 1
+
       - name: trigger-deploy
         uses: benc-uk/workflow-dispatch@v1.1
         with:

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Tag release
         run: |
-           TAGNAME=$(git log -1 --pretty=%B | sed -n 's/Release version \(.*\) to staging/\1/p')
+           TAGNAME=$(git log -1 --pretty=%B | sed -n 's/.*Release version \(.*\) to staging.*/\1/p')
            ([[ ! -z "$TAGNAME" ]] && git tag -f $TAGNAME && git push origin $TAGNAME -f) || echo "No version found" && exit 1
 
       - name: trigger-deploy

--- a/.github/workflows/trigger_staging_deploy.yml
+++ b/.github/workflows/trigger_staging_deploy.yml
@@ -1,0 +1,38 @@
+name: Trigger release to staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version are you creating?
+        required: true
+      ref:
+        description: Git ref to deploy
+        required: true
+        default: develop
+jobs:
+  create-pr:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Code
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Update master
+        run: |
+          git fetch
+          git branch tmp-branch
+          git switch master
+          git reset --hard tmp-branch --
+          git branch -D tmp-branch
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          branch: staging-release
+          title: Release version ${{ github.event.inputs.version }} to staging
+          team-reviewers: DFE-Digital/ecf
+          base: master
+


### PR DESCRIPTION
### Context
Process for releasing to staging:
 - Manually trigger the new workflow, specify a git ref to deploy and a version number
 - PR is opened automatically
 - PR is approved and merged
 - Tag is created from commit message
 - Deploy to staging happens

### Changes proposed in this pull request
- Create workflow to create pull request of correct format
- Tag release before deploying to staging (deploy fails if no tag)