### PR TITLE
[ECF-1-364] Email newly created admin

### DIFF
--- a/app/controllers/admin/administrators/administrators_controller.rb
+++ b/app/controllers/admin/administrators/administrators_controller.rb
@@ -47,6 +47,9 @@ module Admin
         ActiveRecord::Base.transaction do
           user.save!
           AdminProfile.create!(user: user)
+          AdminMailer.account_created_email(
+            user, helpers.new_user_session_url
+          ).deliver_now
         end
         session.delete(:administrator_user)
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AdminMailer < ApplicationMailer
+  ADMIN_ACCOUNT_CREATED_TEMPLATE = "3620d073-d2cc-4d65-9a51-e12770cf25d9"
+
+  def account_created_email(admin, url)
+    template_mail(
+      ADMIN_ACCOUNT_CREATED_TEMPLATE,
+      to: admin.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        full_name: admin.full_name,
+        sign_in_link: url,
+      },
+    )
+  end
+end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdminMailer, type: :mailer do
+  let(:user) { create(:user, :admin) }
+  let(:sign_in_link) { "http://www.example.com/users/sign_in" }
+
+  describe "#account_created_email" do
+    let(:account_created_email) do
+      AdminMailer.account_created_email(user, sign_in_link)
+    end
+
+    it "renders the right headers" do
+      expect(account_created_email.to).to eq([user.email])
+      expect(account_created_email.from).to eq(["mail@example.com"])
+    end
+  end
+end

--- a/spec/requests/admin/administrators/administrators_spec.rb
+++ b/spec/requests/admin/administrators/administrators_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe "Admin::Administrators::Administrators", type: :request do
         }),
       )
     end
+
+    it "sends new admin an account created email" do
+      url = "http://www.example.com/users/sign_in"
+      allow(AdminMailer).to receive(:account_created_email).and_call_original
+
+      given_a_user_is_created
+
+      expect(AdminMailer).to have_received(:account_created_email).with(new_user, url)
+    end
   end
 
   let(:admin_profile) { create(:admin_profile) }


### PR DESCRIPTION
### Context

We need to send a welcome email to admins who have had their accounts created by other admins.

### Changes proposed in this pull request

Added a new admin mailers and some tests. 
