### PR TITLE
[ECF-1-248] Persist logit setup in terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,7 @@ jobs:
           export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY_BASE }}${{ env.DOCKERHUB_ENV }}:${{ env.TAG }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/dev.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}' -var='secret_paas_app_env_values={"SYSLOG_DRAIN_URL":"${{secrets.SYSLOG_DRAIN_URL}}"}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/dev.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'
 
       - name: Deploy review app to dev
         if: ${{ startsWith(github.event.inputs.environment, 'review') }}
@@ -132,7 +132,7 @@ jobs:
           export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY_BASE }}${{ env.DOCKERHUB_ENV }}:${{ env.TAG }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=${{ github.event.inputs.environment }}/terraform.tfstate"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}' -var='secret_paas_app_env_values={"SYSLOG_DRAIN_URL":"${{secrets.SYSLOG_DRAIN_URL}}"}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'
 
 
       - name: Deploy to staging
@@ -146,5 +146,5 @@ jobs:
           export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY_BASE }}${{ env.DOCKERHUB_ENV }}:${{ env.TAG }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-e2123d0b-d394-4594-8056-315300e7d8a8"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/staging.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_STAGING}}"}' -var='environment=${{github.event.inputs.environment}}' -var='secret_paas_app_env_values={"SYSLOG_DRAIN_URL":"${{secrets.SYSLOG_DRAIN_URL}}"}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/staging.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_STAGING}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,7 @@ jobs:
           export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY_BASE }}${{ env.DOCKERHUB_ENV }}:${{ env.TAG }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/dev.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/dev.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}' -var='secret_paas_app_env_values={"SYSLOG_DRAIN_URL":"${{secrets.SYSLOG_DRAIN_URL}}"}'
 
       - name: Deploy review app to dev
         if: ${{ startsWith(github.event.inputs.environment, 'review') }}
@@ -132,7 +132,8 @@ jobs:
           export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY_BASE }}${{ env.DOCKERHUB_ENV }}:${{ env.TAG }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=${{ github.event.inputs.environment }}/terraform.tfstate"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}' -var='secret_paas_app_env_values={"SYSLOG_DRAIN_URL":"${{secrets.SYSLOG_DRAIN_URL}}"}'
+
 
       - name: Deploy to staging
         if: ${{ github.event.inputs.environment == 'staging' }}
@@ -145,4 +146,5 @@ jobs:
           export TF_VAR_paas_app_docker_image=${{ env.DOCKERHUB_REPOSITORY_BASE }}${{ env.DOCKERHUB_ENV }}:${{ env.TAG }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-e2123d0b-d394-4594-8056-315300e7d8a8"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/staging.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_STAGING}}"}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/staging.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_STAGING}}"}' -var='environment=${{github.event.inputs.environment}}' -var='secret_paas_app_env_values={"SYSLOG_DRAIN_URL":"${{secrets.SYSLOG_DRAIN_URL}}"}'
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,6 @@ jobs:
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=${{ github.event.inputs.environment }}/terraform.tfstate"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{github.event.inputs.environment}}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'
 
-
       - name: Deploy to staging
         if: ${{ github.event.inputs.environment == 'staging' }}
         env:

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -19,10 +19,6 @@ resource cloudfoundry_app web_app {
   strategy = var.web_app_deployment_strategy
   timeout = var.app_start_timeout
 
-  service_binding {
-    service_instance = cloudfoundry_user_provided_service.logging.id
-  }
-
   dynamic "service_binding" {
     for_each = local.app_service_bindings
     content {

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -18,6 +18,11 @@ resource cloudfoundry_app web_app {
   stopped = var.app_stopped
   strategy = var.web_app_deployment_strategy
   timeout = var.app_start_timeout
+
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
+  }
+
   dynamic "service_binding" {
     for_each = local.app_service_bindings
     content {
@@ -34,4 +39,10 @@ resource cloudfoundry_route web_app_route {
   domain   = data.cloudfoundry_domain.cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
+}
+
+resource cloudfoundry_user_provided_service logging {
+  name             = local.logging_service_name
+  space            = data.cloudfoundry_space.space.id
+  syslog_drain_url = var.logstash_url
 }

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -37,6 +37,9 @@ variable web_app_memory {
 variable web_app_start_command {
 }
 
+variable logstash_url {
+}
+
 locals {
 
   app_env_domain  = {
@@ -57,6 +60,7 @@ locals {
   app_service_bindings = concat(
     local.app_cloudfoundry_service_instances,
   )
+  logging_service_name     = "${var.service_name}-logit-${var.environment}"
   postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
   web_app_name             = "${var.service_name}-${var.environment}"
 }

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -56,6 +56,7 @@ locals {
   )
   app_cloudfoundry_service_instances = [
     cloudfoundry_service_instance.postgres_instance.id,
+    cloudfoundry_user_provided_service.logging.id,
   ]
   app_service_bindings = concat(
     local.app_cloudfoundry_service_instances,

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -44,4 +44,5 @@ module paas {
   web_app_instances                 = var.paas_web_app_instances
   web_app_memory                    = var.paas_web_app_memory
   web_app_start_command             = var.paas_web_app_start_command
+  logstash_url                      = var.SYSLOG_DRAIN_URL
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -44,5 +44,5 @@ module paas {
   web_app_instances                 = var.paas_web_app_instances
   web_app_memory                    = var.paas_web_app_memory
   web_app_start_command             = var.paas_web_app_start_command
-  logstash_url                      = var.SYSLOG_DRAIN_URL
+  logstash_url                      = var.logstash_url
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -76,6 +76,10 @@ variable paas_worker_app_memory {
   default = 512
 }
 
+variable logstash_url {
+  default = ""
+}
+
 variable secret_paas_app_env_values {
   default = {}
   type = map(string)


### PR DESCRIPTION
### Context
We have a service set up in logit where we are piping our logs. Documentation. However, the configuration gets wiped out everytime the develop branch is deployed. Additionally, we need to replicate the setup for the staging and prod environments.

### Changes proposed in this pull request

This pr stores the config changes in terraform so that we can automatically set up staging and prod as well as making the dev setup persistent.

I've used https://github.com/DFE-Digital/teacher-training-api/blob/7e7c91d55a18790bbb8d7fc0db6a88314441f97e/terraform/modules/paas/main.tf as a reference 