### PR TITLE
Don't check the yarn.lock file for AWS keys

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,10 +14,16 @@ fi
 exec 1>&2
 
 # Check changed files for an AWS keys
-KEY_ID=$(git diff --cached --name-only -z $against | xargs -0 cat | perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])}')
-KEY=$(git diff --cached --name-only -z $against | xargs -0 cat | perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])}')
+KEY=$(
+    git diff --cached --name-only -z HEAD~2 |
+        tr '\0' '\n' |
+        grep --invert-match --fixed-strings 'yarn.lock' |
+        xargs ls -d 2> /dev/null |
+        xargs cat |
+        perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])|(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}'
+    )
 
-if [ "$KEY_ID" != "" -o "$KEY" != "" ]; then
+if [ "$KEY" != "" ]; then
     echo "Found patterns for AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
     echo "Please check your code and remove API keys."
     exit 1


### PR DESCRIPTION
### Context

There are loads of AWS keys in the yarn.lock file, according to the old version of this script. This stops that script from checking the yarn.lock file.

### Changes proposed in this pull request

### Guidance to review

### Testing
