### PR TITLE
Call confirm inside the transaction

### DIFF
--- a/app/models/admin_profile.rb
+++ b/app/models/admin_profile.rb
@@ -5,9 +5,9 @@ class AdminProfile < BaseProfile
 
   def self.create_admin(full_name, email, sign_in_url)
     user = User.new(full_name: full_name, email: email)
-    user.confirm
 
     ActiveRecord::Base.transaction do
+      user.confirm
       user.save!
       AdminProfile.create!(user: user)
       AdminMailer.account_created_email(user, sign_in_url).deliver_now

--- a/spec/models/admin_profile_spec.rb
+++ b/spec/models/admin_profile_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe AdminProfile, type: :model do
     let(:name) { Faker::Name.name }
     let(:email) { Faker::Internet.email }
     let(:sign_in_url) { "www.example.com/sign-in" }
+    let(:created_user) { User.find_by(email: email) }
 
     it "creates an admin user" do
       expect {
@@ -16,10 +17,15 @@ RSpec.describe AdminProfile, type: :model do
       }.to change { AdminProfile.count }.by(1)
     end
 
+    it "confirms the newly created user" do
+      AdminProfile.create_admin(name, email, sign_in_url)
+
+      expect(created_user.confirmed?).to be true
+    end
+
     it "creates a user with the correct details" do
       AdminProfile.create_admin(name, email, sign_in_url)
 
-      created_user = User.find_by(email: email)
       expect(created_user.present?).to be(true)
       expect(created_user.full_name).to eql(name)
     end
@@ -29,7 +35,6 @@ RSpec.describe AdminProfile, type: :model do
 
       AdminProfile.create_admin(name, email, sign_in_url)
 
-      created_user = User.find_by(email: email)
       expect(AdminMailer).to have_received(:account_created_email).with(created_user, sign_in_url)
     end
   end


### PR DESCRIPTION
### Context
When email sending fails, you currently end up with an orphaned user with no profiles 

### Changes proposed in this pull request
Confirm calls save, so this should be inside the transaction
