### PR TITLE
Stop the hook from thinking hashes are keys, so I can commit again

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,8 @@ KEY=$(
     git diff --cached --name-only -z $against |
         tr '\0' '\n' |
         grep --invert-match --fixed-strings 'yarn.lock' |
+        grep --invert-match --fixed-strings 'Gemfile' |
+        grep --invert-match --fixed-strings 'Gemfile.lock' |
         xargs ls -d 2> /dev/null |
         xargs cat |
         perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])|(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}'


### PR DESCRIPTION
### Context
`gem "health_check", github: "/ianheggie/health_check", ref: "0b799ead604f900ed50685e9b2d469cd2befba5b"` does NOT contain an AWS key