### PR TITLE
Add lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,19 @@ ruby File.read(".ruby-version").chomp
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.1.2", ">= 6.1.2.1"
 
+# User management and rbac
 gem "devise", ">= 4.7.3"
-gem "kaminari", ">= 1.2.0"
 gem "pundit"
+
+# Pagination
+gem "kaminari", ">= 1.2.0"
 
 # Adds health check functionality
 gem "health_check", github: "/ianheggie/health_check", ref: "0b799ead604f900ed50685e9b2d469cd2befba5b"
+
+# Cleaner logs, one line per request
+gem "lograge"
+gem "logstash-event"
 
 # Use postgresql as the database for Active Record
 gem "pg", ">= 0.18", "< 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,12 @@ GEM
     listen (3.3.4)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -251,6 +257,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.8.2)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -403,6 +411,8 @@ DEPENDENCIES
   httpclient (~> 2.8, >= 2.8.3)
   kaminari (>= 1.2.0)
   listen (>= 3.0.5, < 3.4)
+  lograge
+  logstash-event
   mail-notify (>= 1.0.3)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -42,13 +42,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -93,10 +86,26 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  # Logging
+  config.log_level = :debug # Debug logging in dev
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
+  # Use Lograge for cleaner logging
+  config.lograge.enabled = true
+  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.lograge.ignore_actions = ["ApplicationController#check"]
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
+
+  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w[controller action format id]
+    {
+      params: event.payload[:params].except(*exceptions),
+    }
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -105,6 +105,7 @@ Rails.application.configure do
     exceptions = %w[controller action format id]
     {
       params: event.payload[:params].except(*exceptions),
+      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
     }
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,13 +42,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -95,10 +88,27 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  # Logging
+  config.log_level = :info
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+  config.active_record.logger = nil # Don't log SQL in production
+
+  # Use Lograge for cleaner logging
+  config.lograge.enabled = true
+  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.lograge.ignore_actions = ["ApplicationController#check"]
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
+
+  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w[controller action format id]
+    {
+      params: event.payload[:params].except(*exceptions),
+    }
   end
 
   # Do not dump schema after migrations.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,6 +108,7 @@ Rails.application.configure do
     exceptions = %w[controller action format id]
     {
       params: event.payload[:params].except(*exceptions),
+      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
     }
   end
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -106,6 +106,7 @@ Rails.application.configure do
     exceptions = %w[controller action format id]
     {
       params: event.payload[:params].except(*exceptions),
+      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
     }
   end
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -42,13 +42,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -93,10 +86,27 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  # Logging
+  config.log_level = :info
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+  config.active_record.logger = nil # Don't log SQL in production
+
+  # Use Lograge for cleaner logging
+  config.lograge.enabled = true
+  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.lograge.ignore_actions = ["ApplicationController#check"]
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
+
+  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w[controller action format id]
+    {
+      params: event.payload[:params].except(*exceptions),
+    }
   end
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
### Context
Rails currently gives three separate logs per request. This makes life very difficult. Lograge makes life easier again. 
Also both Teaching Vacancies AND Apply are doing it, so it must be a good idea!

### Guidance to review
Take a look at logit if you're curious, I recommend the following filter: `cf.app:"ecf-review-pr-164" and not cf_tags.source_type:"RTR"`

I've excluded /check logs, which I think is a good idea. Do you disagree?
