### PR TITLE
Set up grafana monitoring for dev

### DIFF
--- a/.github/workflows/deploy_monitoring_dev.yml
+++ b/.github/workflows/deploy_monitoring_dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to Environment
+name: Deploy monitoring stack to Dev
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   deploy:
-    name: build docker image and deploy
+    name: deploy monitoring stack
     needs: turnstyle
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/deploy_monitoring_dev.yml
+++ b/.github/workflows/deploy_monitoring_dev.yml
@@ -1,0 +1,43 @@
+name: Deploy to Environment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  turnstyle:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+      - uses: softprops/turnstyle@v1
+        name: Check workflow concurrency
+        with:
+          poll-interval-seconds: 20
+          same-branch-only: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  deploy:
+    name: build docker image and deploy
+    needs: turnstyle
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Code
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_version: 0.14.0
+
+      - name: Deploy to dev
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
+          TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          TF_VAR_grafana_admin_password: ${{ secrets.GRAFANA_ADMIN_PASSWORD_DEV }}
+        run: |
+          cd terraform/monitoring
+          terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b"
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/monitoring/dev.tfvars

--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -1,0 +1,13 @@
+module "prometheus_all" {
+  source = "git::https://github.com/DFE-Digital/cf-monitoring.git//prometheus_all"
+
+  monitoring_instance_name = var.monitoring_instance_name
+  monitoring_org_name = "dfe"
+  monitoring_space_name = var.paas_space_name
+  paas_exporter_username = var.paas_user
+  paas_exporter_password = var.paas_password
+  grafana_admin_password = var.grafana_admin_password
+  grafana_google_client_id = var.google_client_id
+  grafana_google_client_secret = var.google_client_secret
+  grafana_runtime_version = "7.2.2"
+}

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -10,8 +10,6 @@ terraform {
 provider cloudfoundry {
   api_url           = var.paas_api_url
   password          = var.paas_password
-  sso_passcode      = ""
   store_tokens_path = "./tokens"
   user              = var.paas_user
-
 }

--- a/terraform/monitoring/terraform.tf
+++ b/terraform/monitoring/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+
+  backend "s3" {
+    key     = "monitoring/terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = "true"
+  }
+}
+
+provider cloudfoundry {
+  api_url           = var.paas_api_url
+  password          = var.paas_password
+  sso_passcode      = ""
+  store_tokens_path = "./tokens"
+  user              = var.paas_user
+
+}

--- a/terraform/monitoring/variables.tf
+++ b/terraform/monitoring/variables.tf
@@ -1,0 +1,24 @@
+variable paas_api_url {
+  default = "https://api.london.cloud.service.gov.uk"
+}
+
+variable paas_space_name {
+}
+
+variable monitoring_instance_name {
+}
+
+variable paas_user {
+}
+
+variable paas_password {
+}
+
+variable google_client_id {
+}
+
+variable google_client_secret {
+}
+
+variable grafana_admin_password {
+}

--- a/terraform/monitoring/versions.tf
+++ b/terraform/monitoring/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = ">= 0.13.0"
+    }
+  }
+}

--- a/terraform/workspace-variables/monitoring/dev.tfvars
+++ b/terraform/workspace-variables/monitoring/dev.tfvars
@@ -1,0 +1,2 @@
+paas_space_name = "earlycareers-framework-dev"
+monitoring_instance_name = "cpd-monitoring-dev"


### PR DESCRIPTION
### Context
This is a combination of stuff from https://github.com/DFE-Digital/cf-monitoring, teaching vacancies, and Get Into Teaching, tweaked for our needs. It gives a fancy grafana monitoring dashboard. I'll like to get this in to play with before doing staging and prod

### Changes proposed in this pull request

### Guidance to review

### Testing
I've run this terraform locally, you should be able to sign in with google here: https://grafana-cpd-monitoring-dev.london.cloudapps.digital/?orgId=1
It lets in anyone with a digital.education.gov.uk email to view
