### PR TITLE
ECF-1-401 Send nomination email to schools

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -3,16 +3,16 @@
 class SchoolMailer < ApplicationMailer
   NOMINATION_EMAIL_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
 
-  def nomination_email(params)
+  def nomination_email(recipient:, reference:, school_name:, nomination_url:)
     template_mail(
       NOMINATION_EMAIL_TEMPLATE,
-      to: params[:recipient],
-      reference: params[:reference],
+      to: recipient,
+      reference: reference,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        school_name: params[:school_name],
-        nomination_link: params[:nomination_url],
+        school_name: school_name,
+        nomination_link: nomination_url,
       },
     )
   end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -3,15 +3,16 @@
 class SchoolMailer < ApplicationMailer
   NOMINATION_EMAIL_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
 
-  def nomination_email(recipient_email, nomination_url, reference)
+  def nomination_email(params)
     template_mail(
       NOMINATION_EMAIL_TEMPLATE,
-      to: recipient_email,
-      reference: reference,
+      to: params[:recipient],
+      reference: params[:reference],
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        nomination_link: nomination_url,
+        school_name: params[:school_name],
+        nomination_link: params[:nomination_url],
       },
     )
   end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class SchoolMailer < ApplicationMailer
+  NOMINATION_EMAIL_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
+
+  def nomination_email(recipient_email, nomination_url, reference)
+    template_mail(
+      NOMINATION_EMAIL_TEMPLATE,
+      to: recipient_email,
+      reference: reference,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        nomination_link: nomination_url,
+      },
+    )
+  end
+end

--- a/app/models/nomination_email.rb
+++ b/app/models/nomination_email.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class NominationEmail < ApplicationRecord
+  belongs_to :school
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -16,6 +16,7 @@ class School < ApplicationRecord
   has_many :lead_providers, through: :partnerships
   has_many :school_cohorts
   has_many :pupil_premiums
+  has_many :nomination_emails
   has_and_belongs_to_many :induction_coordinator_profiles
 
   has_many :early_career_teacher_profiles

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class InviteSchools
+  def run(school_ids)
+    logger = Rails.logger
+    logger.info "Emailing schools"
+
+    school_ids.each do |school_id|
+      school = School.find_by(id: school_id)
+
+      if school.nil?
+        logger.info "School not found: #{school_id} ... skipping"
+        next
+      end
+
+      token = reference
+      recipient = recipient_email(school)
+
+      school.nomination_emails.create!(
+        token: token,
+        sent_to: recipient,
+        sent_at: Time.zone.now,
+      )
+      send_nomination_email(recipient, token)
+    rescue StandardError
+      logger.info "Error emailing school: #{school_id} ... skipping"
+    end
+  end
+
+private
+
+  def send_nomination_email(recipient, token)
+    SchoolMailer.nomination_email(
+      recipient, nomination_url(token), token
+    ).deliver_now
+  end
+
+  def recipient_email(school)
+    return school.secondary_contact_email unless school.primary_contact_email
+
+    school.primary_contact_email
+  end
+
+  def reference
+    loop do
+      value = SecureRandom.hex(16)
+      break value unless NominationEmail.exists?(token: value)
+    end
+  end
+
+  def nomination_url(token)
+    Rails.application.routes.url_helpers.nominations_url(
+      token: token,
+      host: Rails.application.config.domain,
+    )
+  end
+end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class InviteSchools
-  def run(school_ids)
+  def run(school_urns)
     logger = Rails.logger
     logger.info "Emailing schools"
 
-    school_ids.each do |school_id|
-      school = School.find_by(id: school_id)
+    school_urns.each do |urn|
+      school = School.find_by(urn: urn)
 
       if school.nil?
-        logger.info "School not found: #{school_id} ... skipping"
+        logger.info "School not found, urn: #{urn} ... skipping"
         next
       end
 
@@ -23,7 +23,7 @@ class InviteSchools
       )
       send_nomination_email(recipient, token, school.name)
     rescue StandardError
-      logger.info "Error emailing school: #{school_id} ... skipping"
+      logger.info "Error emailing school, urn: #{urn} ... skipping"
     end
   end
 

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -21,7 +21,7 @@ class InviteSchools
         sent_to: recipient,
         sent_at: Time.zone.now,
       )
-      send_nomination_email(recipient, token)
+      send_nomination_email(recipient, token, school.name)
     rescue StandardError
       logger.info "Error emailing school: #{school_id} ... skipping"
     end
@@ -29,9 +29,12 @@ class InviteSchools
 
 private
 
-  def send_nomination_email(recipient, token)
+  def send_nomination_email(recipient, token, school_name)
     SchoolMailer.nomination_email(
-      recipient, nomination_url(token), token
+      recipient: recipient,
+      reference: token,
+      school_name: school_name,
+      nomination_url: nomination_url(token),
     ).deliver_now
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
     resources :school_search, only: %i[index]
   end
 
+  resources :nominations, only: %i[index]
+
   namespace :registrations do
     root to: "start#index"
     resource :account_not_found, only: :show, controller: :account_not_found, path: "/account-not-found"

--- a/db/migrate/20210324105239_create_nomination_emails.rb
+++ b/db/migrate/20210324105239_create_nomination_emails.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateNominationEmails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :nomination_emails, id: :uuid do |t|
+      t.string     :token, null: false
+      t.string     :notify_status
+      t.string     :sent_to, null: false
+      t.datetime   :sent_at
+      t.datetime   :opened_at
+      t.references :school, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+    add_index :nomination_emails, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_23_180540) do
+ActiveRecord::Schema.define(version: 2021_03_24_105239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -165,6 +165,19 @@ ActiveRecord::Schema.define(version: 2021_03_23_180540) do
     t.string "secondary_contact_email"
   end
 
+  create_table "nomination_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "token", null: false
+    t.string "notify_status"
+    t.string "sent_to", null: false
+    t.datetime "sent_at"
+    t.datetime "opened_at"
+    t.uuid "school_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_id"], name: "index_nomination_emails_on_school_id"
+    t.index ["token"], name: "index_nomination_emails_on_token", unique: true
+  end
+
   create_table "partnerships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -308,6 +321,7 @@ ActiveRecord::Schema.define(version: 2021_03_23_180540) do
   add_foreign_key "lead_provider_cips", "lead_providers"
   add_foreign_key "lead_provider_profiles", "lead_providers"
   add_foreign_key "lead_provider_profiles", "users"
+  add_foreign_key "nomination_emails", "schools"
   add_foreign_key "partnerships", "cohorts"
   add_foreign_key "partnerships", "lead_providers"
   add_foreign_key "partnerships", "schools"

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :schools do
+  desc "Send nomination invitations to schools"
+  task send_invites: :environment do
+    InviteSchool.run(ARGV[1..-1])
+  end
+end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolMailer, type: :mailer do
+  describe "#nomination_email" do
+    let(:token) { "fedd83c06d5747f1" }
+    let(:primary_contact_email) { "contact@example.com" }
+    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations?token=#{token}" }
+
+    let(:nomination_email) do
+      SchoolMailer.nomination_email(primary_contact_email, nomination_link, token)
+    end
+
+    it "renders the right headers" do
+      expect(nomination_email.from).to eq(["mail@example.com"])
+      expect(nomination_email.to).to eq([primary_contact_email])
+    end
+  end
+end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -6,10 +6,15 @@ RSpec.describe SchoolMailer, type: :mailer do
   describe "#nomination_email" do
     let(:token) { "fedd83c06d5747f1" }
     let(:primary_contact_email) { "contact@example.com" }
-    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations?token=#{token}" }
+    let(:nomination_url) { "https://ecf-dev.london.cloudapps/nominations?token=#{token}" }
 
     let(:nomination_email) do
-      SchoolMailer.nomination_email(primary_contact_email, nomination_link, token)
+      SchoolMailer.nomination_email(
+        recipient: primary_contact_email,
+        nomination_url: nomination_url,
+        reference: token,
+        school_name: "Great Ouse Academy",
+      ).deliver_now
     end
 
     it "renders the right headers" do

--- a/spec/models/nomination_email_spec.rb
+++ b/spec/models/nomination_email_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NominationEmail, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:early_career_teachers).through(:early_career_teacher_profiles) }
     it { is_expected.to have_many(:pupil_premiums) }
     it { is_expected.to have_many(:school_cohorts) }
+    it { is_expected.to have_many(:nomination_emails) }
     it { is_expected.to have_many(:school_local_authorities) }
     it { is_expected.to have_many(:local_authorities).through(:school_local_authorities) }
     it { is_expected.to have_many(:school_local_authority_districts) }

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe InviteSchools do
 
     it "creates a record for the nomination email" do
       expect {
-        invite_schools.run [school.id]
+        invite_schools.run [school.urn]
       }.to change { school.nomination_emails.count }.by 1
     end
 
     it "creates a nomination email with the correct fields" do
-      invite_schools.run [school.id]
+      invite_schools.run [school.urn]
       expect(nomination_email.sent_to).to eq school.primary_contact_email
       expect(nomination_email.sent_at).to be_present
       expect(nomination_email.token).to be_present
@@ -41,7 +41,7 @@ RSpec.describe InviteSchools do
         ),
       ).and_call_original
 
-      invite_schools.run [school.id]
+      invite_schools.run [school.urn]
     end
 
     context "when school primary contact email is null" do
@@ -57,7 +57,7 @@ RSpec.describe InviteSchools do
           ),
         ).and_call_original
 
-        invite_schools.run [school.id]
+        invite_schools.run [school.urn]
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe InviteSchools do
       let(:another_school) { create(:school) }
 
       it "skips to the next school_id" do
-        invite_schools.run [school.id, another_school.id]
+        invite_schools.run [school.urn, another_school.urn]
         expect(school.nomination_emails).to be_empty
         expect(another_school.nomination_emails).not_to be_empty
       end

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe InviteSchools do
 
     it "sends the nomination email" do
       expect(SchoolMailer).to receive(:nomination_email).with(
-        school.primary_contact_email, String, String
+        hash_including(
+          reference: String,
+          school_name: String,
+          nomination_url: String,
+          recipient: school.primary_contact_email,
+        ),
       ).and_call_original
 
       invite_schools.run [school.id]
@@ -44,7 +49,12 @@ RSpec.describe InviteSchools do
 
       it "sends the nomination email to the secondary contact" do
         expect(SchoolMailer).to receive(:nomination_email).with(
-          school.secondary_contact_email, String, String
+          hash_including(
+            reference: String,
+            school_name: String,
+            nomination_url: String,
+            recipient: school.secondary_contact_email,
+          ),
         ).and_call_original
 
         invite_schools.run [school.id]

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InviteSchools do
+  subject(:invite_schools) { described_class.new }
+  let(:primary_contact_email) { Faker::Internet.email }
+  let(:secondary_contact_email) { Faker::Internet.email }
+
+  let(:school) do
+    create(
+      :school,
+      primary_contact_email: primary_contact_email,
+      secondary_contact_email: secondary_contact_email,
+    )
+  end
+
+  describe "#run" do
+    let(:nomination_email) { school.nomination_emails.last }
+
+    it "creates a record for the nomination email" do
+      expect {
+        invite_schools.run [school.id]
+      }.to change { school.nomination_emails.count }.by 1
+    end
+
+    it "creates a nomination email with the correct fields" do
+      invite_schools.run [school.id]
+      expect(nomination_email.sent_to).to eq school.primary_contact_email
+      expect(nomination_email.sent_at).to be_present
+      expect(nomination_email.token).to be_present
+    end
+
+    it "sends the nomination email" do
+      expect(SchoolMailer).to receive(:nomination_email).with(
+        school.primary_contact_email, String, String
+      ).and_call_original
+
+      invite_schools.run [school.id]
+    end
+
+    context "when school primary contact email is null" do
+      let(:primary_contact_email) { nil }
+
+      it "sends the nomination email to the secondary contact" do
+        expect(SchoolMailer).to receive(:nomination_email).with(
+          school.secondary_contact_email, String, String
+        ).and_call_original
+
+        invite_schools.run [school.id]
+      end
+    end
+
+    context "when there is an error creating the nomination email" do
+      let(:primary_contact_email) { nil }
+      let(:secondary_contact_email) { nil }
+      let(:another_school) { create(:school) }
+
+      it "skips to the next school_id" do
+        invite_schools.run [school.id, another_school.id]
+        expect(school.nomination_emails).to be_empty
+        expect(another_school.nomination_emails).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We need to send invitation / nomination emails to school primary contacts to invite them to register on our service.

The email will contain a unique token that will be used to track the school and some fields to allow us to track when the email was opened.