### PR TITLE
ECF-410 Fix paper trail audit schema datatype

### DIFF
--- a/db/migrate/20210323180540_change_item_id_type_to_uuid.rb
+++ b/db/migrate/20210323180540_change_item_id_type_to_uuid.rb
@@ -4,7 +4,7 @@ class ChangeItemIdTypeToUuid < ActiveRecord::Migration[6.1]
   def change
     remove_column :versions, :item_id, :bigint
     remove_index :versions, column: %i[item_type item_id], if_exists: true
-    add_column :versions, :item_id, :uuid, null: false
+    add_column :versions, :item_id, :uuid, default: "gen_random_uuid()", null: false
     add_index :versions, %i[item_type item_id]
   end
 end

--- a/db/migrate/20210323180540_change_item_id_type_to_uuid.rb
+++ b/db/migrate/20210323180540_change_item_id_type_to_uuid.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeItemIdTypeToUuid < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :versions, :item_id, :bigint
+    remove_index :versions, column: %i[item_type item_id], if_exists: true
+    add_column :versions, :item_id, :uuid, null: false
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -290,7 +290,7 @@ ActiveRecord::Schema.define(version: 2021_03_23_180540) do
     t.json "object"
     t.json "object_changes"
     t.datetime "created_at"
-    t.uuid "item_id", null: false
+    t.uuid "item_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_19_153015) do
+ActiveRecord::Schema.define(version: 2021_03_23_180540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -285,12 +285,12 @@ ActiveRecord::Schema.define(version: 2021_03_19_153015) do
 
   create_table "versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "item_type", null: false
-    t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.json "object"
     t.json "object_changes"
     t.datetime "created_at"
+    t.uuid "item_id", null: false
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
### Context

Item Id / record Id in the paper-trail generated schema were generated as bigint whereas we use uuids. Everything still worked as rails was automatically casting to big int but sooner or later we were going to have a key collision. This ticket corrects the datatype to uuid.