### PR TITLE
Set domains so emails etc have links to the right place

### DIFF
--- a/terraform/workspace-variables/production_app_env.yml
+++ b/terraform/workspace-variables/production_app_env.yml
@@ -7,3 +7,6 @@ RAILS_MAX_THREADS: 5
 RAILS_SERVE_STATIC_FILES: true
 SERVICE_TYPE: web
 DATABASE_URL: postgres://postgres@localhost:5432
+DOMAIN: manage-training-for-early-career-teachers.education.gov.uk
+GOVUK_WEBSITE_ROOT: manage-training-for-early-career-teachers.education.gov.uk
+GOVUK_APP_DOMAIN: manage-training-for-early-career-teachers.education.gov.uk

--- a/terraform/workspace-variables/staging_app_env.yml
+++ b/terraform/workspace-variables/staging_app_env.yml
@@ -7,3 +7,6 @@ RAILS_MAX_THREADS: 5
 RAILS_SERVE_STATIC_FILES: true
 SERVICE_TYPE: web
 DATABASE_URL: postgres://postgres@localhost:5432
+DOMAIN: s-manage-training-for-early-career-teachers.education.gov.uk
+GOVUK_WEBSITE_ROOT: s-manage-training-for-early-career-teachers.education.gov.uk
+GOVUK_APP_DOMAIN: s-manage-training-for-early-career-teachers.education.gov.uk


### PR DESCRIPTION
### Context
Our sign in emails on staging (and prod) always link to the london.cloudapps.digital domain currently. Now they always link to the proper domain, which isn't perfect, but better

