### PR TITLE
CIP + FIP next steps pages

### DIFF
--- a/app/controllers/schools/cohorts_controller.rb
+++ b/app/controllers/schools/cohorts_controller.rb
@@ -12,5 +12,9 @@ class Schools::CohortsController < Schools::BaseController
       cohort: @cohort,
       school: @school,
     )
+
+    unless @school_cohort
+      redirect_to schools_choose_programme_path
+    end
   end
 end

--- a/app/controllers/schools/cohorts_controller.rb
+++ b/app/controllers/schools/cohorts_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Schools::CohortsController < Schools::BaseController
+  skip_after_action :verify_authorized
+  skip_after_action :verify_policy_scoped
+
+  def show
+    @school = current_user.induction_coordinator_profile.schools.first
+    @cohort = Cohort.find_by(start_year: params[:id])
+
+    @school_cohort = SchoolCohort.find_by(
+      cohort: @cohort,
+      school: @school,
+    )
+  end
+end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -18,5 +18,10 @@ class Schools::DashboardController < Schools::BaseController
         school_cohort: school_cohort,
       }
     end
+
+    # This will need to be updated when more than one cohort is supported
+    unless @cohorts[0][:school_cohort]
+      redirect_to schools_choose_programme_path
+    end
   end
 end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -7,20 +7,14 @@ class Schools::DashboardController < Schools::BaseController
   def show
     @school = current_user.induction_coordinator_profile.schools.first
 
-    @cohorts = [Cohort.current].map do |cohort|
-      school_cohort = SchoolCohort.find_by(
-        cohort: cohort,
-        school: @school,
-      )
-
-      {
-        cohort: cohort,
-        school_cohort: school_cohort,
-      }
+    @school_cohorts = [Cohort.current].map do |cohort|
+      @school.school_cohorts.detect do |school_cohort|
+        school_cohort.cohort_id == cohort.id
+      end
     end
 
     # This will need to be updated when more than one cohort is supported
-    unless @cohorts[0][:school_cohort]
+    unless @school_cohorts[0]
       redirect_to schools_choose_programme_path
     end
   end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -4,5 +4,19 @@ class Schools::DashboardController < Schools::BaseController
   skip_after_action :verify_authorized
   skip_after_action :verify_policy_scoped
 
-  def show; end
+  def show
+    @school = current_user.induction_coordinator_profile.schools.first
+
+    @cohorts = [Cohort.current].map do |cohort|
+      school_cohort = SchoolCohort.find_by(
+        cohort: cohort,
+        school: @school,
+      )
+
+      {
+        cohort: cohort,
+        school_cohort: school_cohort,
+      }
+    end
+  end
 end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -3,15 +3,17 @@
 class Schools::DashboardController < Schools::BaseController
   skip_after_action :verify_authorized
   skip_after_action :verify_policy_scoped
+  before_action :set_school_cohorts
 
-  def show
+  def show; end
+
+private
+
+  def set_school_cohorts
     @school = current_user.induction_coordinator_profile.schools.first
 
-    @school_cohorts = [Cohort.current].map do |cohort|
-      @school.school_cohorts.detect do |school_cohort|
-        school_cohort.cohort_id == cohort.id
-      end
-    end
+    cohort_list = [Cohort.current]
+    @school_cohorts = @school.school_cohorts.where(cohort: cohort_list)
 
     # This will need to be updated when more than one cohort is supported
     unless @school_cohorts[0]

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -32,11 +32,15 @@ class SchoolCohort < ApplicationRecord
   end
 
   def status
-    if induction_programme_choice == "core_induction_programme"
+    if school_chose_cip?
       cip_status
     else
       fip_status
     end
+  end
+
+  def school_chose_cip?
+    induction_programme_choice == "core_induction_programme"
   end
 
 private

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -10,4 +10,51 @@ class SchoolCohort < ApplicationRecord
 
   belongs_to :cohort
   belongs_to :school
+
+  def number_of_participants_status
+    "cannot start yet"
+  end
+
+  def training_provider_status
+    "cannot start yet"
+  end
+
+  def accept_legal_status
+    "cannot start yet"
+  end
+
+  def add_participants_status
+    "cannot start yet"
+  end
+
+  def choose_training_materials_status
+    "cannot start yet"
+  end
+
+  def status
+    if induction_programme_choice == "core_induction_programme"
+      cip_status
+    else
+      fip_status
+    end
+  end
+
+private
+
+  def cip_status
+    if choose_training_materials_status == "done" && add_participants_status == "done"
+      "done"
+    else
+      "to do"
+    end
+  end
+
+  def fip_status
+    if number_of_participants_status == "done" && training_provider_status == "done" &&
+        accept_legal_status == "done" && add_participants_status == "done"
+      "done"
+    else
+      "to do"
+    end
+  end
 end

--- a/app/views/schools/cohorts/show.html.erb
+++ b/app/views/schools/cohorts/show.html.erb
@@ -4,9 +4,9 @@
 
     <p class="govuk-body-l govuk-!-margin-bottom-8">
     <% if @school_cohort[:induction_programme_choice] === "core_induction_programme" %>
-      Using accredited materials
+      Training using accredited materials.
     <% else %>
-      Training provider funded by DfE
+      Using a training provider funded by the DfE.
     <% end %>
     </p>
 
@@ -17,22 +17,44 @@
         </h2>
         <ul class="app-task-list__items">
 
+          <% if @school_cohort[:induction_programme_choice] === "core_induction_programme" %>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <%= govuk_link_to "Choose your training materials", "#" %>
+              </span>
+
+              <%= render AutoTagComponent.new(text: @school_cohort.choose_training_materials_status) %>
+            </li>
+          <% else %>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <%= govuk_link_to "Add estimated numbers of teachers and mentors", "#" %>
+              </span>
+
+              <%= render AutoTagComponent.new(text: @school_cohort.number_of_participants_status) %>
+            </li>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <%= govuk_link_to "Sign up with a training provider", "#" %>
+              </span>
+
+              <%= render AutoTagComponent.new(text: @school_cohort.training_provider_status) %>
+            </li>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <%= govuk_link_to "Read and accept privacy and data policy", "#" %>
+              </span>
+
+              <%= render AutoTagComponent.new(text: @school_cohort.accept_legal_status) %>
+            </li>
+          <% end %>
+
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
-              <a class="govuk-link--no-visited-state" href="#" aria-describedby="eligibility-status">
-                Choose your training materials
-              </a>
+              <%= govuk_link_to "Add teachers and mentors", "#" %>
             </span>
 
-            <%= render AutoTagComponent.new(text: "To do") %>
-          </li>
-
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              <a class="govuk-link--no-visited-state" href="#">Add teachers and mentors</a>
-            </span>
-
-            <%= render AutoTagComponent.new(text: "Cannot start yet") %>
+            <%= render AutoTagComponent.new(text: @school_cohort.add_participants_status) %>
           </li>
 
         </ul>

--- a/app/views/schools/cohorts/show.html.erb
+++ b/app/views/schools/cohorts/show.html.erb
@@ -1,0 +1,42 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%= @cohort.start_year %></h1>
+
+    <p class="govuk-body-l govuk-!-margin-bottom-8">
+    <% if @school_cohort[:induction_programme_choice] === "core_induction_programme" %>
+      Using accredited materials
+    <% else %>
+      Training provider funded by DfE
+    <% end %>
+    </p>
+
+    <ol class="app-task-list">
+      <li>
+        <h2 class="app-task-list__section">
+          Next steps
+        </h2>
+        <ul class="app-task-list__items">
+
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a class="govuk-link--no-visited-state" href="#" aria-describedby="eligibility-status">
+                Choose your training materials
+              </a>
+            </span>
+
+            <%= render AutoTagComponent.new(text: "To do") %>
+          </li>
+
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <a class="govuk-link--no-visited-state" href="#">Add teachers and mentors</a>
+            </span>
+
+            <%= render AutoTagComponent.new(text: "Cannot start yet") %>
+          </li>
+
+        </ul>
+      </li>
+    </ol>
+  </div>
+</div>

--- a/app/views/schools/cohorts/show.html.erb
+++ b/app/views/schools/cohorts/show.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%= @cohort.start_year %></h1>
 
     <p class="govuk-body-l govuk-!-margin-bottom-8">
-    <% if @school_cohort[:induction_programme_choice] === "core_induction_programme" %>
+    <% if @school_cohort.school_chose_cip? %>
       Training using accredited materials.
     <% else %>
       Using a training provider funded by the DfE.
@@ -17,7 +17,7 @@
         </h2>
         <ul class="app-task-list__items">
 
-          <% if @school_cohort[:induction_programme_choice] === "core_induction_programme" %>
+          <% if @school_cohort.school_chose_cip? %>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <%= govuk_link_to "Choose your training materials", "#" %>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -14,20 +14,20 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @cohorts.each do |cohort| %>
+    <% @school_cohorts.each do |school_cohort| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <%= govuk_link_to cohort[:cohort].start_year, schools_cohort_path(cohort[:cohort].start_year) %>
+          <%= govuk_link_to school_cohort.cohort.start_year, schools_cohort_path(school_cohort.cohort.start_year) %>
         </td>
         <td class="govuk-table__cell">
-          <% if cohort[:school_cohort][:induction_programme_choice] === 'core_induction_programme' %>
+          <% if school_cohort.school_chose_cip? %>
             Using accredited materials
           <% else %>
             Training provider funded by DfE
           <% end %>
         </td>
         <td class="govuk-table__cell">
-          <%= render AutoTagComponent.new(text: cohort[:school_cohort].status) %>
+          <%= render AutoTagComponent.new(text: school_cohort.status) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -3,7 +3,7 @@
 
 <p class="govuk-body govuk-!-margin-bottom-5">Check and add details for every academic year/cohort.</p>
 
-<h3 class="govuk-heading-m govuk-!-margin-bottom-1">Your cohorts</h3>
+<h2 class="govuk-heading-m govuk-!-margin-bottom-1">Your cohorts</h2>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -1,1 +1,35 @@
-<h1>Dashboard goes here</h1>
+<span class="govuk-caption-l"><%= @school.name %></span>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-7">Manage your training</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-5">Check and add details for every academic year/cohort.</p>
+
+<h3 class="govuk-heading-m govuk-!-margin-bottom-1">Your cohorts</h3>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Year</th>
+      <th class="govuk-table__header" scope="col">Programme</th>
+      <th class="govuk-table__header" scope="col">Status</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @cohorts.each do |cohort| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= govuk_link_to cohort[:cohort].start_year, schools_cohort_path(cohort[:cohort].start_year) %>
+        </td>
+        <td class="govuk-table__cell">
+          <% if cohort[:school_cohort][:induction_programme_choice] === 'core_induction_programme' %>
+            Using accredited materials
+          <% else %>
+            Training provider funded by DfE
+          <% end %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= render AutoTagComponent.new(text: "To do") %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -27,7 +27,7 @@
           <% end %>
         </td>
         <td class="govuk-table__cell">
-          <%= render AutoTagComponent.new(text: "To do") %>
+          <%= render AutoTagComponent.new(text: cohort[:school_cohort].status) %>
         </td>
       </tr>
     <% end %>

--- a/app/webpacker/styles/app_task_list.scss
+++ b/app/webpacker/styles/app_task_list.scss
@@ -10,7 +10,7 @@
 }
 
 .app-task-list__item {
-  $border: 1px solid #b1b4b6;
+  $border: 1px solid $govuk-border-colour;
 
   border-bottom: $border;
   margin-bottom: 0;

--- a/app/webpacker/styles/app_task_list.scss
+++ b/app/webpacker/styles/app_task_list.scss
@@ -1,23 +1,30 @@
 .app-task-list {
+  padding-left: 0;
   list-style: none;
 }
 
 .app-task-list__items {
-  padding-left: 30px;
+  padding-left: 0;
   margin-bottom: 60px;
   list-style: none;
 }
 
 .app-task-list__item {
-  border-bottom: 1px solid #b1b4b6;
+  $border: 1px solid #b1b4b6;
+
+  border-bottom: $border;
   margin-bottom: 0;
   padding-top: 10px;
   padding-bottom: 10px;
   display: flex;
-}
 
-.app-task-list__tag {
-  height: 1rem;
-  margin-left: auto;
-  margin-right: 0;
+  &:first-child {
+    border-top: $border;
+  }
+
+  .govuk-tag {
+    height: 1rem;
+    margin-left: auto;
+    margin-right: 0;
+  }
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,11 @@ Rails.application.routes.draw do
   namespace :schools do
     resource :dashboard, controller: :dashboard, only: :show, path: "/"
     resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme"
+    resources :cohorts do
+      member do
+        get "/:start_year", action: :show
+      end
+    end
   end
 
   get "/403", to: "errors#forbidden", via: :all

--- a/spec/cypress/app_commands/scenarios/schools/choose_programme.rb
+++ b/spec/cypress/app_commands/scenarios/schools/choose_programme.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.create(:cohort, start_year: 2021)

--- a/spec/cypress/integration/schools/ChooseProgramme.feature
+++ b/spec/cypress/integration/schools/ChooseProgramme.feature
@@ -1,15 +1,14 @@
 Feature: Induction tutors choosing programmes
   Induction tutors should be able to choose between the Full and Core
-  induction programmes for their school
+  induction programmes for their school and view cohorts and tasks
 
   Background: 
-    Given scenario "schools/choose_programme" has been run
-
-  Scenario: Choosing Core Induction Programme
-    Given I am logged in as an "induction_coordinator"
+    Given cohort was created with start_year "2021"
+    And I am logged in as an "induction_coordinator"
     Then I should be on "choose programme" page
     And the page should be accessible
-    
+
+  Scenario: Choosing Core Induction Programme
     When I click on "accredited materials" label
     And I click the submit button
     Then I should be on "schools" page
@@ -18,12 +17,21 @@ Feature: Induction tutors choosing programmes
     When I am on "choose programme" page
     Then I should have been redirected to "schools" page
 
-  Scenario: Choosing Full Induction Programme
-    Given I am logged in as an "induction_coordinator"
-    Then I should be on "choose programme" page
+    When I click on "link" containing "2021"
+    Then I am on "2021 school cohorts" page
     And the page should be accessible
+    And "page body" should contain "Choose your training"
+    And "page body" should contain "Add teachers"
+    And "page body" should not contain "estimated number of teachers"
 
+  Scenario: Choosing Full Induction Programme
     When I click on "training provider" label
     And I click the submit button
     Then I should be on "schools" page
     And the page should be accessible
+
+    When I click on "link" containing "2021"
+    Then I am on "2021 school cohorts" page
+    And "page body" should contain "estimated numbers of teachers"
+    And "page body" should contain "Add teachers"
+    And "page body" should not contain "Choose your training"

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -36,6 +36,7 @@ const pagePaths = {
   "lead provider user delete": /\/lead-providers\/users\/.*\/delete/,
   "choose programme": "/schools/choose-programme",
   schools: "/schools",
+  "2021 school cohorts": "/schools/cohorts/2021",
 };
 
 Given("I am on {string} page", (page) => {

--- a/spec/cypress/support/step_definitions/factory-bot.js
+++ b/spec/cypress/support/step_definitions/factory-bot.js
@@ -1,0 +1,29 @@
+import { Given } from "cypress-cucumber-preprocessor/steps";
+
+const parseArgs = (argsString) => {
+  const args = {};
+  argsString.split(/ and |, /).forEach((argString) => {
+    const [, key, value] = /([^ ]+) "([^"]+)"/.exec(argString);
+    args[key] = value;
+  });
+
+  return args;
+};
+
+expect(parseArgs('start_year "2021"')).to.deep.equal({ start_year: "2021" });
+expect(parseArgs('a "a b" and b "b c"')).to.deep.equal({ a: "a b", b: "b c" });
+expect(parseArgs('a "a b", b "b" and c "d"')).to.deep.equal({
+  a: "a b",
+  b: "b",
+  c: "d",
+});
+
+Given("{word} was created as {string} with {}", (factory, traits, args) => {
+  cy.appFactories([
+    ["create", factory, ...traits.split(", "), parseArgs(args)],
+  ]);
+});
+
+Given("{word} was created with {}", (factory, args) => {
+  cy.appFactories([["create", factory, parseArgs(args)]]);
+});

--- a/spec/factories/school_cohort.rb
+++ b/spec/factories/school_cohort.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :school_cohort do
+    cohort
+    school
+    induction_programme_choice { "core_induction_programme" }
+  end
+end

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Schools::Dashboard", type: :request do
+  let(:user) { create(:user, :induction_coordinator) }
+
   before do
-    @user = create(:user, :induction_coordinator)
-    sign_in @user
+    sign_in user
   end
 
   describe "GET /schools" do
@@ -15,12 +16,17 @@ RSpec.describe "Schools::Dashboard", type: :request do
       expect(response).to redirect_to("/schools/choose-programme")
     end
 
-    it "should render the dashboard when programme chosen" do
-      cohort = create(:cohort, start_year: "2021")
-      create(:school_cohort, cohort: cohort, school: @user.induction_coordinator_profile.schools[0])
-      get "/schools"
+    context "when the programme has been chosen" do
+      before do
+        cohort = create(:cohort, start_year: "2021")
+        create(:school_cohort, cohort: cohort, school: user.induction_coordinator_profile.schools[0])
+      end
 
-      expect(response).to render_template("schools/dashboard/show")
+      it "should render the dashboard when programme chosen" do
+        get "/schools"
+
+        expect(response).to render_template("schools/dashboard/show")
+      end
     end
   end
 end

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -4,12 +4,20 @@ require "rails_helper"
 
 RSpec.describe "Schools::Dashboard", type: :request do
   before do
-    user = create(:user, :induction_coordinator)
-    sign_in user
+    @user = create(:user, :induction_coordinator)
+    sign_in @user
   end
 
   describe "GET /schools" do
-    it "should render the dashboard" do
+    it "should redirect to programme selection if programme not chosen" do
+      get "/schools"
+
+      expect(response).to redirect_to("/schools/choose-programme")
+    end
+
+    it "should render the dashboard when programme chosen" do
+      cohort = create(:cohort, start_year: "2021")
+      create(:school_cohort, cohort: cohort, school: @user.induction_coordinator_profile.schools[0])
       get "/schools"
 
       expect(response).to render_template("schools/dashboard/show")


### PR DESCRIPTION
### Context

Branched off ECF-RP-396_choose-programme, will point this PR at develop once that is merged.

### Changes proposed in this pull request

Adds generic "Manage your training" and "Next steps" pages that are used for both CIP and FIP.

Also adds some kind of unrelated step definitions allowing us to create simple factories directly from our cucumber specs.

### Guidance to review

`SchoolCohort.first.destroy` will undo the CIP/FIP selection when testing.

### Testing

Not sure there's any point adding tests until the statuses can change / the user journey is a bit more complete.
