### PR TITLE
Set up statuscake monitoring for production

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -90,6 +90,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.sha }}
           cd terraform/app

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -33,6 +33,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_PROD_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_PROD_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
           cd terraform/app

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -122,6 +122,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_STAG_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
           cd terraform/app

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -22,6 +22,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=review-pr-${{ github.event.number }}/terraform.tfstate"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -95,6 +95,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-dev:${{ github.sha }}
           cd terraform/app

--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -1,0 +1,12 @@
+resource "statuscake_test" "alert" {
+  for_each      = var.statuscake_alerts
+  website_name  = each.value.website_name
+  website_url   = each.value.website_url
+  test_type     = "HTTP"
+  check_rate    = 30
+  contact_group = each.value.contact_group
+  trigger_rate  = 0
+  find_string   = lookup(each.value, "find_string", null)
+  do_not_find   = lookup(each.value, "do_not_find", false)
+  confirmations = 1
+}

--- a/terraform/app/modules/statuscake/providers.tf
+++ b/terraform/app/modules/statuscake/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 1.0.1"
+    }
+  }
+}

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -1,0 +1,9 @@
+variable "environment" {
+}
+
+variable "service_name" {
+}
+
+variable "statuscake_alerts" {
+  description = "Define Statuscake alerts with the attributes below"
+}

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -13,7 +13,11 @@ provider cloudfoundry {
   sso_passcode      = var.paas_sso_passcode != "" ? var.paas_sso_passcode : null
   store_tokens_path = "./tokens"
   user              = var.paas_user != "" ? var.paas_user : null
+}
 
+provider "statuscake" {
+  username = var.statuscake_username
+  apikey   = var.statuscake_apikey
 }
 
 /*
@@ -46,4 +50,12 @@ module paas {
   web_app_start_command             = var.paas_web_app_start_command
   logstash_url                      = var.logstash_url
   govuk_hostnames                   = var.govuk_hostnames
+}
+
+module "statuscake" {
+  source = "./modules/statuscake"
+
+  environment       = var.environment
+  service_name      = local.service_name
+  statuscake_alerts = var.statuscake_alerts
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -90,6 +90,18 @@ variable govuk_hostnames {
   default = []
 }
 
+# Statuscake
+variable "statuscake_alerts" {
+  description = "Define Statuscake alerts with the attributes below"
+  default     = {}
+}
+
+variable statuscake_username {
+}
+
+variable statuscake_apikey {
+}
+
 locals {
   paas_app_env_yml_values = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
   paas_app_env_values = merge(

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "cloudfoundry-community/cloudfoundry"
       version = ">= 0.13.0"
     }
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "~> 1.0.1"
+    }
   }
 }

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -12,3 +12,23 @@ paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 8192
 govuk_hostnames = ["manage-training-for-early-career-teachers"]
+statuscake_alerts = {
+  "prod" = {
+    website_name  = "manage-training-for-early-career-teachers-production"
+    website_url   = "https://manage-training-for-early-career-teachers.education.gov.uk/check"
+    contact_group = [206487]
+  }
+  "stringmatch" = {
+    website_name  = "manage-training-for-early-career-teachers-production"
+    website_url   = "https://manage-training-for-early-career-teachers.education.gov.uk"
+    contact_group = [206487]
+    find_string   = "Manage training for early career teachers"
+  }
+  "PaaS500String" = {
+    website_name  = "manage-training-for-early-career-teachers-production"
+    website_url   = "https://manage-training-for-early-career-teachers.education.gov.uk"
+    contact_group = [206487]
+    find_string   = "500 Internal Server Error"
+    do_not_find   = true
+  }
+}


### PR DESCRIPTION
### Context
Statuscake provides uptime monitoring by polling your site. When we have production, we want to make sure we keep production up...

### Changes proposed in this pull request
This was lifted almost verbatim from Teaching Vacancies (thanks!). We're only monitoring prod, but we need to pass the API keys in for all envs to keep terraform happy. It's only uptime monitoring, so I'm not too fussed about that. 

There are a couple of steps that need to be done manually here:
- @cfq is sorting out a slack hook for alerting
- I think we will need to go in to statuscake and give the tests sensible names once this is deployed. @csutter sorry for the ping, I noticed your test names were totally different to what's in the code. Am I right in thinking you manually updated?
