### PR TITLE
Add placeholder pages for legal + add participants pages

### DIFF
--- a/app/controllers/schools/cohorts_controller.rb
+++ b/app/controllers/schools/cohorts_controller.rb
@@ -17,4 +17,8 @@ class Schools::CohortsController < Schools::BaseController
       redirect_to schools_choose_programme_path
     end
   end
+
+  def legal; end
+
+  def add_participants; end
 end

--- a/app/views/schools/cohorts/add_participants.html.erb
+++ b/app/views/schools/cohorts/add_participants.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: schools_cohort_path("2021"))
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-m">2021</span>
+    <h1 class="govuk-heading-l">Add teachers and mentors</h1>
+
+    <p class="govuk-body">From <strong>July</strong>, you can confirm which early career teachers and mentors are starting a programme this year.</p>
+    <p class="govuk-body">We will let you know when you can get started.</p>
+
+    <p class="govuk-body">For each person, you will need:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>first name</li>
+      <li>last name</li>
+      <li>teacher reference number (TRN)</li>
+      <li>date of birth</li>
+    </ul>
+
+  </div>
+</div>

--- a/app/views/schools/cohorts/legal.html.erb
+++ b/app/views/schools/cohorts/legal.html.erb
@@ -1,0 +1,13 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: schools_cohort_path("2021"))
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-m">2021</span>
+    <h1 class="govuk-heading-l">Read and accept our privacy policy</h1>
+
+    <p class="govuk-body">...</p>
+  </div>
+</div>

--- a/app/views/schools/cohorts/show.html.erb
+++ b/app/views/schools/cohorts/show.html.erb
@@ -42,7 +42,7 @@
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= govuk_link_to "Read and accept privacy and data policy", "#" %>
+                <%= govuk_link_to "Read and accept privacy and data policy", legal_schools_cohort_path(@cohort.start_year) %>
               </span>
 
               <%= render AutoTagComponent.new(text: @school_cohort.accept_legal_status) %>
@@ -51,7 +51,7 @@
 
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
-              <%= govuk_link_to "Add teachers and mentors", "#" %>
+              <%= govuk_link_to "Add teachers and mentors", add_participants_schools_cohort_path(@cohort.start_year) %>
             </span>
 
             <%= render AutoTagComponent.new(text: @school_cohort.add_participants_status) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,9 @@ Rails.application.routes.draw do
     resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme"
     resources :cohorts do
       member do
-        get "/:start_year", action: :show
+        get "show"
+        get "legal"
+        get "add_participants"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,6 @@ Rails.application.routes.draw do
     resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme"
     resources :cohorts do
       member do
-        get "show"
         get "legal"
         get "add_participants"
       end


### PR DESCRIPTION
### Context

https://trello.com/c/ewjKniov/408-placeholders-for-add-participants-and-gdpr

Branched from https://github.com/DFE-Digital/early-careers-framework/pull/190

### Changes proposed in this pull request

- Adds "Read and accept privacy and data policy" placeholder page
- Adds "Add teachers and mentors" placeholder page

### Guidance to review

### Testing

These will need visual tests when we have them, but as they're placeholder pages for now I'm not sure anything else is necessary.
