### PR TITLE
[ECF-1-401] view partnership

### DIFF
--- a/app/controllers/schools/partnerships_controller.rb
+++ b/app/controllers/schools/partnerships_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Schools::PartnershipsController < Schools::BaseController
+  skip_after_action :verify_authorized
+  skip_after_action :verify_policy_scoped
+
+  def index
+    school = current_user.induction_coordinator_profile.schools.first
+
+    # if school.chosen_programme?(Cohort.current)
+    #   redirect_to helpers.profile_dashboard_url(current_user)
+    # else
+    #   @induction_choice_form = InductionChoiceForm.new
+    # end
+  end
+end

--- a/app/controllers/schools/partnerships_controller.rb
+++ b/app/controllers/schools/partnerships_controller.rb
@@ -6,7 +6,7 @@ class Schools::PartnershipsController < Schools::BaseController
 
   def index
     @school = current_user.induction_coordinator_profile.schools.first
-    @partnership = @school.partnerships&.find_by(cohort: cohort)
+    @partnership = @school.partnerships.find_by(cohort: cohort)
   end
 
 private

--- a/app/controllers/schools/partnerships_controller.rb
+++ b/app/controllers/schools/partnerships_controller.rb
@@ -6,18 +6,13 @@ class Schools::PartnershipsController < Schools::BaseController
 
   def index
     @school = current_user.induction_coordinator_profile.schools.first
-    @partnership = Partnership.find_by(school: @school, cohort: cohort)
-
-    # if school.chosen_programme?(Cohort.current)
-    #   redirect_to helpers.profile_dashboard_url(current_user)
-    # else
-    #   @induction_choice_form = InductionChoiceForm.new
-    # end
+    @partnership = @school.partnerships&.find_by(cohort: cohort)
+    @delivery_partner = @partnership&.lead_provider&.delivery_partners&.find_by(provider_relationships: { cohort: cohort })
   end
 
 private
 
   def cohort
-    @cohort ||= Cohort.find_by(start_year: params[:id])
+    @cohort ||= Cohort.find_by(start_year: params[:cohort_id])
   end
 end

--- a/app/controllers/schools/partnerships_controller.rb
+++ b/app/controllers/schools/partnerships_controller.rb
@@ -5,12 +5,19 @@ class Schools::PartnershipsController < Schools::BaseController
   skip_after_action :verify_policy_scoped
 
   def index
-    school = current_user.induction_coordinator_profile.schools.first
+    @school = current_user.induction_coordinator_profile.schools.first
+    @partnership = Partnership.find_by(school: @school, cohort: cohort)
 
     # if school.chosen_programme?(Cohort.current)
     #   redirect_to helpers.profile_dashboard_url(current_user)
     # else
     #   @induction_choice_form = InductionChoiceForm.new
     # end
+  end
+
+private
+
+  def cohort
+    @cohort ||= Cohort.find_by(start_year: params[:id])
   end
 end

--- a/app/controllers/schools/partnerships_controller.rb
+++ b/app/controllers/schools/partnerships_controller.rb
@@ -7,7 +7,6 @@ class Schools::PartnershipsController < Schools::BaseController
   def index
     @school = current_user.induction_coordinator_profile.schools.first
     @partnership = @school.partnerships&.find_by(cohort: cohort)
-    @delivery_partner = @partnership&.lead_provider&.delivery_partners&.find_by(provider_relationships: { cohort: cohort })
   end
 
 private

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -4,6 +4,7 @@ class Partnership < ApplicationRecord
   belongs_to :school
   belongs_to :lead_provider
   belongs_to :cohort
+  belongs_to :delivery_partner
 
   has_paper_trail
 end

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -20,11 +20,7 @@ class SchoolCohort < ApplicationRecord
   end
 
   def training_provider_status
-    if school.partnerships.exists?(cohort: cohort)
-      "done"
-    else
-      "to do"
-    end
+    school.partnerships&.exists?(cohort: cohort) ? "done" : "to do"
   end
 
   def accept_legal_status

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -20,7 +20,11 @@ class SchoolCohort < ApplicationRecord
   end
 
   def training_provider_status
-    "cannot start yet"
+    if school.partnerships.exists?(cohort: cohort)
+      "done"
+    else
+      "to do"
+    end
   end
 
   def accept_legal_status

--- a/app/views/schools/cohorts/show.html.erb
+++ b/app/views/schools/cohorts/show.html.erb
@@ -35,7 +35,7 @@
             </li>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= govuk_link_to "Sign up with a training provider", "#" %>
+                <%= govuk_link_to "Sign up with a training provider", schools_cohort_partnerships_path(@cohort.start_year) %>
               </span>
 
               <%= render AutoTagComponent.new(text: @school_cohort.training_provider_status) %>

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -15,7 +15,7 @@
           Delivery partner
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @delivery_partner.name %>
+          <%= @partnership.delivery_partner.name %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -7,6 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-m">2021</span>
     <h1 class="govuk-heading-l">Sign up with a training provider</h1>
+    <% unless @partnership %>
     <p class="govuk-body">You need to sign a contract with a training provider so they can deliver your programme.</p>
     <p class="govuk-body">You can find out more about what they’re offering and contact them directly:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -22,5 +23,6 @@
       <li>you'll get an email when the provider has confirmed your contract with the DfE</li>
       <li>this may take a few weeks but this page will automatically update</li>
     </ul>
+    <% end %>
   </div>
 </div>

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -1,11 +1,11 @@
 <% content_for :before_content, govuk_back_link(
   text: "Back",
-  href: schools_cohort_path("2021"))
+  href: schools_cohort_path(@cohort.start_year))
 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-m">2021</span>
+    <span class="govuk-caption-m">@cohort.start_year</span>
     <h1 class="govuk-heading-l">Sign up with a training provider</h1>
     <% if @partnership %>
     <h3 class="govuk-heading-m">Partnership details</h3>

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: schools_cohort_path("2021"))
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-m">2021</span>
+    <h1 class="govuk-heading-l">Sign up with a training provider</h1>
+    <p class="govuk-body">You need to sign a contract with a training provider so they can deliver your programme.</p>
+    <p class="govuk-body">You can find out more about what they’re offering and contact them directly:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= govuk_link_to "Ambition Institute", "https://www2.ambition.org.uk/l/330231/2021-02-24/4mvx6", class: "govuk-link--no-visited-state" %></li>
+      <li><%= govuk_link_to "Best Practice Network", "https://bestpracticenet.co.uk/early-career-framework", class: "govuk-link--no-visited-state" %></li>
+      <li><%= govuk_link_to "Capita with lead academic partner the University of Birmingham", "https://www.capita.com/expertise/supporting-teachers-in-early-career", class: "govuk-link--no-visited-state" %></li>
+      <li><%= govuk_link_to "Education Development Trust", "https://www.educationdevelopmenttrust.com/ecf", class: "govuk-link--no-visited-state" %></li>
+      <li><%= govuk_link_to "Teach First", "https://www.teachfirst.org.uk/early-career-framework", class: "govuk-link--no-visited-state" %></li>
+      <li><%= govuk_link_to "UCL Institute of Education", "https://www.ucl.ac.uk/ioe-early-career-framework", class: "govuk-link--no-visited-state" %></li>
+    </ul>
+    <h3 class="govuk-heading-m">Updates</h3>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you'll get an email when the provider has confirmed your contract with the DfE</li>
+      <li>this may take a few weeks but this page will automatically update</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -5,10 +5,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-m">@cohort.start_year</span>
+    <span class="govuk-caption-m"><%= @cohort.start_year %></span>
     <h1 class="govuk-heading-l">Sign up with a training provider</h1>
     <% if @partnership %>
-    <h3 class="govuk-heading-m">Partnership details</h3>
+    <h2 class="govuk-heading-m">Partnership details</h2>
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -43,7 +43,7 @@
       <li><%= govuk_link_to "Teach First", "https://www.teachfirst.org.uk/early-career-framework", class: "govuk-link--no-visited-state" %></li>
       <li><%= govuk_link_to "UCL Institute of Education", "https://www.ucl.ac.uk/ioe-early-career-framework", class: "govuk-link--no-visited-state" %></li>
     </ul>
-    <h3 class="govuk-heading-m">Updates</h3>
+    <h2 class="govuk-heading-m">Updates</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li>you'll get an email when the provider has confirmed your contract with the DfE</li>
       <li>this may take a few weeks but this page will automatically update</li>

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -7,7 +7,32 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-m">2021</span>
     <h1 class="govuk-heading-l">Sign up with a training provider</h1>
-    <% unless @partnership %>
+    <% if @partnership %>
+    <h3 class="govuk-heading-m">Partnership details</h3>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Delivery partner
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @delivery_partner.name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Lead provider
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @partnership.lead_provider.name %>
+        </dd>
+      </div>
+    </dl>
+
+    <p>
+    <!-- TODO: Add link to challenge partnership -->
+    If this doesn't look right you can <%= govuk_link_to "report that your school has been signed up incorrectly", "#" %>
+    </p>
+    <% else %>
     <p class="govuk-body">You need to sign a contract with a training provider so they can deliver your programme.</p>
     <p class="govuk-body">You can find out more about what they’re offering and contact them directly:</p>
     <ul class="govuk-list govuk-list--bullet">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,7 +131,8 @@ Rails.application.routes.draw do
   namespace :schools do
     resource :dashboard, controller: :dashboard, only: :show, path: "/"
     resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme"
-    resources :cohorts do
+    resources :cohorts, only: :show do
+      resources :partnerships, only: :index
       member do
         get "legal"
         get "add_participants"

--- a/db/migrate/20210406120453_add_delivery_partner_to_partnership.rb
+++ b/db/migrate/20210406120453_add_delivery_partner_to_partnership.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeliveryPartnerToPartnership < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :partnerships, :delivery_partner, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -276,16 +276,6 @@ ActiveRecord::Schema.define(version: 2021_04_06_120453) do
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
-  create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "name", null: false
-    t.string "status", default: "TO DO", null: false
-    t.string "description", null: false
-    t.uuid "school_cohort_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["school_cohort_id"], name: "index_tasks_on_school_cohort_id"
-  end
-
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "full_name", null: false
     t.string "email", default: "", null: false
@@ -349,5 +339,4 @@ ActiveRecord::Schema.define(version: 2021_04_06_120453) do
   add_foreign_key "school_local_authority_districts", "local_authority_districts"
   add_foreign_key "school_local_authority_districts", "schools"
   add_foreign_key "schools", "networks"
-  add_foreign_key "tasks", "school_cohorts"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_182656) do
+ActiveRecord::Schema.define(version: 2021_04_06_120453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -184,7 +184,9 @@ ActiveRecord::Schema.define(version: 2021_03_24_182656) do
     t.uuid "school_id", null: false
     t.uuid "lead_provider_id", null: false
     t.uuid "cohort_id", null: false
+    t.uuid "delivery_partner_id"
     t.index ["cohort_id"], name: "index_partnerships_on_cohort_id"
+    t.index ["delivery_partner_id"], name: "index_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_partnerships_on_lead_provider_id"
     t.index ["school_id"], name: "index_partnerships_on_school_id"
   end
@@ -274,6 +276,16 @@ ActiveRecord::Schema.define(version: 2021_03_24_182656) do
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
+  create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "status", default: "TO DO", null: false
+    t.string "description", null: false
+    t.uuid "school_cohort_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_cohort_id"], name: "index_tasks_on_school_cohort_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "full_name", null: false
     t.string "email", default: "", null: false
@@ -323,6 +335,7 @@ ActiveRecord::Schema.define(version: 2021_03_24_182656) do
   add_foreign_key "lead_provider_profiles", "users"
   add_foreign_key "nomination_emails", "schools"
   add_foreign_key "partnerships", "cohorts"
+  add_foreign_key "partnerships", "delivery_partners"
   add_foreign_key "partnerships", "lead_providers"
   add_foreign_key "partnerships", "schools"
   add_foreign_key "provider_relationships", "cohorts"
@@ -336,4 +349,5 @@ ActiveRecord::Schema.define(version: 2021_03_24_182656) do
   add_foreign_key "school_local_authority_districts", "local_authority_districts"
   add_foreign_key "school_local_authority_districts", "schools"
   add_foreign_key "schools", "networks"
+  add_foreign_key "tasks", "school_cohorts"
 end

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -57,14 +57,14 @@ LeadProviderProfile.find_or_create_by!(user: user, lead_provider: LeadProvider.f
 school_urns_twenty_twenty_one = %w[136089 105448 128702 113280 138229 143094 140667 127834 146786 113199 126346 133936 132971 107126 102887 102418 129369 140980 116848 112236]
 
 School.where(urn: school_urns_twenty_twenty_one).each do |school|
-  delivery_partner = DeliveryPartner.create(name: "delivery partner 2021")
+  delivery_partner = DeliveryPartner.create!(name: "delivery partner 2021")
   Partnership.find_or_create_by!(school: school, lead_provider: LeadProvider.first, cohort: Cohort.find_or_create_by!(start_year: 2021), delivery_partner: delivery_partner)
 end
 
 school_urns_twenty_twenty_two = %w[119378 134847 113870 127979 144744 121499 147505 105626 402027 100173]
 
 School.where(urn: school_urns_twenty_twenty_two).each do |school|
-  delivery_partner = DeliveryPartner.create(name: "delivery partner 2022")
+  delivery_partner = DeliveryPartner.create!(name: "delivery partner 2022")
   Partnership.find_or_create_by!(school: school, lead_provider: LeadProvider.first, cohort: Cohort.find_or_create_by!(start_year: 2022), delivery_partner: delivery_partner)
 end
 

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -57,13 +57,15 @@ LeadProviderProfile.find_or_create_by!(user: user, lead_provider: LeadProvider.f
 school_urns_twenty_twenty_one = %w[136089 105448 128702 113280 138229 143094 140667 127834 146786 113199 126346 133936 132971 107126 102887 102418 129369 140980 116848 112236]
 
 School.where(urn: school_urns_twenty_twenty_one).each do |school|
-  Partnership.find_or_create_by!(school: school, lead_provider: LeadProvider.first, cohort: Cohort.find_or_create_by!(start_year: 2021))
+  delivery_partner = DeliveryPartner.create(name: "delivery partner 2021")
+  Partnership.find_or_create_by!(school: school, lead_provider: LeadProvider.first, cohort: Cohort.find_or_create_by!(start_year: 2021), delivery_partner: delivery_partner)
 end
 
 school_urns_twenty_twenty_two = %w[119378 134847 113870 127979 144744 121499 147505 105626 402027 100173]
 
 School.where(urn: school_urns_twenty_twenty_two).each do |school|
-  Partnership.find_or_create_by!(school: school, lead_provider: LeadProvider.first, cohort: Cohort.find_or_create_by!(start_year: 2022))
+  delivery_partner = DeliveryPartner.create(name: "delivery partner 2022")
+  Partnership.find_or_create_by!(school: school, lead_provider: LeadProvider.first, cohort: Cohort.find_or_create_by!(start_year: 2022), delivery_partner: delivery_partner)
 end
 
 user = User.with_discarded.find_or_create_by!(email: "second-school-leader@example.com") do |u|

--- a/spec/components/school_information/your_schools/participants_school_search_component_spec.rb
+++ b/spec/components/school_information/your_schools/participants_school_search_component_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe ::SchoolInformation::YourSchools::ParticipantsSchoolSearchCompone
   let(:cohort_2) { create(:cohort, start_year: 2022) }
   let(:school_1) { create(:school) }
   let(:school_2) { create(:school) }
+  let(:delivery_partner) { create(:delivery_partner) }
   let(:lead_provider) { create(:lead_provider, cohorts: [cohort_1, cohort_2]) }
   let(:schools) { school_search_form.find_schools(nil) }
   let(:selected_cohort) { cohort_1 }
   let(:component) { described_class.new(schools: schools, selected_cohort: cohort_1, school_search_form: school_search_form) }
   let(:rendered_component) { render_inline(component).to_html }
-  let(:partnership_1) { create(:partnership, cohort: cohort_1, school: school_1, lead_provider: lead_provider) }
-  let(:partnership_2) { create(:partnership, cohort: cohort_1, school: school_2, lead_provider: lead_provider) }
+  let(:partnership_1) { create(:partnership, cohort: cohort_1, school: school_1, lead_provider: lead_provider, delivery_partner: delivery_partner) }
+  let(:partnership_2) { create(:partnership, cohort: cohort_1, school: school_2, lead_provider: lead_provider, delivery_partner: delivery_partner) }
 
   let(:school_search_form) do
     search_form = SchoolSearchForm.new

--- a/spec/cypress/integration/schools/ViewPartnerships.feature
+++ b/spec/cypress/integration/schools/ViewPartnerships.feature
@@ -19,6 +19,7 @@ Feature: Induction tutors viewing partnerships
     And "page body" should contain "estimated numbers of teachers"
     And "page body" should contain "Add teachers"
     And "page body" should not contain "Choose your training"
+    And the page should be accessible
 
     When I click on "link" containing "Sign up with a training provider"
     Then I should be on "2021 school partnerships" page

--- a/spec/cypress/integration/schools/ViewPartnerships.feature
+++ b/spec/cypress/integration/schools/ViewPartnerships.feature
@@ -1,0 +1,26 @@
+Feature: Induction tutors viewing partnerships
+  Induction tutors should be able to view details of their school partnership
+
+  Background:
+    Given cohort was created with start_year "2021"
+    And I am logged in as an "induction_coordinator"
+    Then I should be on "choose programme" page
+    And the page should be accessible
+
+  Scenario: View partnerships
+    When I click on "training provider" label
+    And I click the submit button
+    Then I should be on "schools" page
+    And the page should be accessible
+
+    When I click on "link" containing "2021"
+    Then I am on "2021 school cohorts" page
+    And "page body" should contain "Sign up with a training provider"
+    And "page body" should contain "estimated numbers of teachers"
+    And "page body" should contain "Add teachers"
+    And "page body" should not contain "Choose your training"
+
+    When I click on "link" containing "Sign up with a training provider"
+    Then I should be on "2021 school partnerships" page
+    And "page body" should contain "You need to sign a contract with a training provider so they can deliver your programme"
+    And the page should be accessible

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -38,6 +38,7 @@ const pagePaths = {
   schools: "/schools",
   "2021 school cohorts": "/schools/cohorts/2021",
   "estimate participants": /\/schools\/estimate-participants\/.*\/edit/,
+  "2021 school partnerships": "/schools/cohorts/2021/partnerships",
 };
 
 Given("I am on {string} page", (page) => {

--- a/spec/forms/school_search_form_spec.rb
+++ b/spec/forms/school_search_form_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe SchoolSearchForm, type: :model do
       school = schools[2]
       lead_provider = create(:lead_provider)
       cohort = create(:cohort, start_year: 2021)
-      Partnership.create!(school: school, lead_provider: lead_provider, cohort: cohort)
+      delivery_partner = create(:delivery_partner)
+      Partnership.create!(school: school, lead_provider: lead_provider, cohort: cohort, delivery_partner: delivery_partner)
 
       form = SchoolSearchForm.new(partnership: ["", "in_a_partnership"])
       search_result = form.find_schools(1)
@@ -53,7 +54,8 @@ RSpec.describe SchoolSearchForm, type: :model do
       school = schools[2]
       lead_provider = create(:lead_provider)
       cohort = create(:cohort, start_year: 2021)
-      Partnership.create!(school: school, lead_provider: lead_provider, cohort: cohort)
+      delivery_partner = create(:delivery_partner)
+      Partnership.create!(school: school, lead_provider: lead_provider, cohort: cohort, delivery_partner: delivery_partner)
 
       form = SchoolSearchForm.new(school_name: "Test school one", partnership: ["", "in_a_partnership"])
       search_result = form.find_schools(1)

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe Partnership, type: :model do
     it { is_expected.to belong_to(:school) }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to belong_to(:delivery_partner) }
   end
 end

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -25,4 +25,30 @@ RSpec.describe SchoolCohort, type: :model do
   it { is_expected.to respond_to(:number_of_participants_status) }
   it { is_expected.to respond_to(:status) }
   it { is_expected.to respond_to(:school_chose_cip?) }
+
+  describe "#training_provider_status" do
+    subject(:school_cohort) { create(:school_cohort) }
+
+    it "returns 'to do' by default" do
+      expect(subject.training_provider_status).to eq "to do"
+    end
+
+    context "when school is in a partnership" do
+      let(:lead_provider) { create(:lead_provider) }
+      let(:delivery_partner) { create(:delivery_partner) }
+
+      before do
+        Partnership.create!(
+          cohort: school_cohort.cohort,
+          lead_provider: lead_provider,
+          school: school_cohort.school,
+          delivery_partner: delivery_partner,
+        )
+      end
+
+      it "returns 'done' by default" do
+        expect(subject.training_provider_status).to eq "done"
+      end
+    end
+  end
 end

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Schools::Partnerships", type: :request do
   end
 
   describe "GET /schools/cohorts/:start_year/partnerships" do
-    it "shows available delivery partners" do
+    it "renders the partnerships template" do
       get "/schools/cohorts/#{cohort.start_year}/partnerships"
 
       expect(response).to render_template("schools/partnerships/index")

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -13,10 +13,30 @@ RSpec.describe "Schools::Partnerships", type: :request do
   end
 
   describe "GET /schools/cohorts/:start_year/partnerships" do
+    let(:header) { "You need to sign a contract with a training provider so they can deliver your programme" }
+
     it "renders the partnerships template" do
       get "/schools/cohorts/#{cohort.start_year}/partnerships"
 
       expect(response).to render_template("schools/partnerships/index")
+      expect(response.body).to include(CGI.escapeHTML(header))
+    end
+
+    context "when the school is in a partnership" do
+      let(:delivery_partner) { create(:delivery_partner) }
+      let(:lead_provider) { create(:lead_provider) }
+
+      before do
+        Partnership.create!(cohort: cohort, lead_provider: lead_provider, school: school)
+        ProviderRelationship.create!(cohort: cohort, lead_provider: lead_provider, delivery_partner: delivery_partner)
+      end
+
+      it "renders partnership details" do
+        get "/schools/cohorts/#{cohort.start_year}/partnerships"
+
+        expect(response.body).to include(CGI.escapeHTML(lead_provider.name))
+        expect(response.body).to include(CGI.escapeHTML(delivery_partner.name))
+      end
     end
   end
 end

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -23,19 +23,26 @@ RSpec.describe "Schools::Partnerships", type: :request do
     end
 
     context "when the school is in a partnership" do
-      let(:delivery_partner) { create(:delivery_partner) }
       let(:lead_provider) { create(:lead_provider) }
+      let(:another_school) { create(:school) }
+      let(:delivery_partner1) { delivery_partners.third }
+      let(:delivery_partner2) { delivery_partners.fourth }
+      let(:delivery_partners) { create_list(:delivery_partner, 5) }
 
       before do
-        Partnership.create!(cohort: cohort, lead_provider: lead_provider, school: school)
-        ProviderRelationship.create!(cohort: cohort, lead_provider: lead_provider, delivery_partner: delivery_partner)
+        Partnership.create!(cohort: cohort, lead_provider: lead_provider, school: school, delivery_partner: delivery_partner1)
+        Partnership.create!(cohort: cohort, lead_provider: lead_provider, school: another_school, delivery_partner: delivery_partner2)
+
+        delivery_partners.each do |partner|
+          ProviderRelationship.create!(cohort: cohort, lead_provider: lead_provider, delivery_partner: partner)
+        end
       end
 
       it "renders partnership details" do
         get "/schools/cohorts/#{cohort.start_year}/partnerships"
 
         expect(response.body).to include(CGI.escapeHTML(lead_provider.name))
-        expect(response.body).to include(CGI.escapeHTML(delivery_partner.name))
+        expect(response.body).to include(CGI.escapeHTML(delivery_partner1.name))
       end
     end
   end

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Schools::Partnerships", type: :request do
+  let(:user) { create(:user, :induction_coordinator) }
+  let(:school) { user.induction_coordinator_profile.schools.first }
+  let(:cohort) { create(:cohort, start_year: 2021) }
+
+  before do
+    school
+    sign_in user
+  end
+
+  describe "GET /schools/cohorts/:start_year/partnerships" do
+    it "shows available delivery partners" do
+      get "/schools/cohorts/#{cohort.start_year}/partnerships"
+
+      expect(response).to render_template("schools/partnerships/index")
+    end
+  end
+end


### PR DESCRIPTION
### Changes proposed in this pull request

A new page that school tutors can access by going to /schools/cohort/2021/partnerships 

If the school is already in a partnership the page shows the details of the partnership else it just gives information of which lead providers to contact.
<img width="833" alt="Screenshot 2021-04-01 at 11 45 36" src="https://user-images.githubusercontent.com/1547920/113283216-e3ac1500-92df-11eb-84e4-17b753c22fe3.png">
<img width="865" alt="Screenshot 2021-04-01 at 11 46 05" src="https://user-images.githubusercontent.com/1547920/113283220-e60e6f00-92df-11eb-86e2-34d9a5ab2045.png">


