### PR TITLE
Remove default school scope

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,7 @@
 ### Guidance to review
 
 ### Testing
+
+### Review Checks
+- [ ] All pages have automated accessibility checks via cypress
+- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

--- a/app/controllers/api/school_search_controller.rb
+++ b/app/controllers/api/school_search_controller.rb
@@ -3,7 +3,7 @@
 class Api::SchoolSearchController < Api::ApiController
   def index
     if params[:search_key]
-      schools = School.search_by_name_or_urn(params[:search_key]).limit(10)
+      schools = School.eligible.search_by_name_or_urn(params[:search_key]).limit(10)
       decorated_schools = schools.map { |school| ::Decorators::SchoolDecorator.new(school) }
       render json: SchoolSerializer.render(decorated_schools)
     else

--- a/app/controllers/lead_providers/school_details_controller.rb
+++ b/app/controllers/lead_providers/school_details_controller.rb
@@ -3,7 +3,7 @@
 module LeadProviders
   class SchoolDetailsController < ::LeadProviders::BaseController
     def show
-      @school = School.find(params[:id])
+      @school = School.eligible.find(params[:id])
       @selected_cohort = Cohort.find(params[:selected_cohort_id])
     end
   end

--- a/app/controllers/registrations/school_profile_controller.rb
+++ b/app/controllers/registrations/school_profile_controller.rb
@@ -24,7 +24,7 @@ private
 
   def load_school
     session["school_urn"] = school_params[:urn]
-    @school = School.find_by(urn: school_params[:urn])
+    @school = School.eligible.find_by(urn: school_params[:urn])
   end
 
   def redirect

--- a/app/controllers/registrations/user_profile_controller.rb
+++ b/app/controllers/registrations/user_profile_controller.rb
@@ -30,7 +30,7 @@ private
   end
 
   def load_school
-    @school = School.find_by(urn: session[:school_urn])
+    @school = School.eligible.find_by(urn: session[:school_urn])
     raise ActionController::BadRequest if @school.nil?
   end
 end

--- a/app/forms/nomination_request_form.rb
+++ b/app/forms/nomination_request_form.rb
@@ -17,11 +17,11 @@ class NominationRequestForm
   end
 
   def available_schools
-    School.unscoped.open.joins(:school_local_authorities).where(school_local_authorities: { local_authority_id: local_authority_id })
+    School.open.joins(:school_local_authorities).where(school_local_authorities: { local_authority_id: local_authority_id })
   end
 
   def school
-    School.unscoped.find(school_id)
+    School.find(school_id)
   end
 
   def save!

--- a/app/forms/school_profile_form.rb
+++ b/app/forms/school_profile_form.rb
@@ -11,7 +11,7 @@ class SchoolProfileForm
 private
 
   def urn_matches_school
-    school = School.find_by(urn: urn)
+    school = School.eligible.find_by(urn: urn)
     errors.add(:urn, :invalid, message: "No school matched that URN") if school.nil?
   end
 end

--- a/app/forms/school_search_form.rb
+++ b/app/forms/school_search_form.rb
@@ -15,10 +15,10 @@ class SchoolSearchForm
                 :with_school_partnerships
 
   def find_schools(page)
-    schools = School.where("lower(name) LIKE ? OR
+    schools = School.eligible.where("lower(name) LIKE ? OR
                             lower(urn) LIKE ?",
-                           "%#{(school_name || '').downcase}%",
-                           "%#{(school_name || '').downcase}%")
+                                    "%#{(school_name || '').downcase}%",
+                                    "%#{(school_name || '').downcase}%")
                     .includes(:network, :lead_providers)
 
     schools = schools.partnered(year) if with_school_partnerships

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -22,16 +22,14 @@ class School < ApplicationRecord
   has_many :early_career_teacher_profiles
   has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
 
-  default_scope -> { eligible }
-
   scope :eligible, -> { open.eligible_establishment_type.in_england }
 
   scope :with_name_like, lambda { |search_key|
-    School.where("name ILIKE ?", "%#{search_key}%")
+    School.eligible.where("name ILIKE ?", "%#{search_key}%")
   }
 
   scope :with_urn_like, lambda { |search_key|
-    School.where("urn ILIKE ?", "%#{search_key}%")
+    School.eligible.where("urn ILIKE ?", "%#{search_key}%")
   }
 
   scope :search_by_name_or_urn, lambda { |search_key|

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -6,7 +6,7 @@ class InviteSchools
     logger.info "Emailing schools"
 
     school_urns.each do |urn|
-      school = School.find_by(urn: urn)
+      school = School.eligible.find_by(urn: urn)
 
       if school.nil?
         logger.info "School not found, urn: #{urn} ... skipping"

--- a/app/services/pupil_premium_importer.rb
+++ b/app/services/pupil_premium_importer.rb
@@ -27,7 +27,7 @@ private
 
   def update_school_premium(row)
     urn = row.fetch("URN")
-    school = School.unscoped.find_by(urn: urn)
+    school = School.find_by(urn: urn)
     logger.info "Could not find school with URN #{urn}" and return unless school
 
     total_pupils = row.fetch("Number of pupils on roll (7)").delete(",").to_i

--- a/app/services/school_data_importer.rb
+++ b/app/services/school_data_importer.rb
@@ -34,7 +34,7 @@ private
   end
 
   def row_to_school(row)
-    school = School.unscoped.find_or_initialize_by(urn: row.fetch("URN"))
+    school = School.find_or_initialize_by(urn: row.fetch("URN"))
     school.name = row.fetch("EstablishmentName")
     school.school_type_code = row.fetch("TypeOfEstablishment (code)").to_i
     school.school_type_name = row.fetch("TypeOfEstablishment (name)")

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -71,14 +71,9 @@ RSpec.describe School, type: :model do
       let(:eligible_school) { open_school }
       let(:ineligible_school) { closed_school }
 
-      it "should be the default scope" do
-        expect(School.all).to include(eligible_school)
-        expect(School.all).not_to include(ineligible_school)
-      end
-
       it "should only include eligible schools" do
-        expect(School.all).to include(open_school, eligible_school_type, english_school)
-        expect(School.all).not_to include(closed_school, ineligible_school_type, welsh_school)
+        expect(School.eligible.all).to include(open_school, eligible_school_type, english_school)
+        expect(School.eligible.all).not_to include(closed_school, ineligible_school_type, welsh_school)
       end
     end
   end

--- a/spec/services/pupil_premium_importer_spec.rb
+++ b/spec/services/pupil_premium_importer_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe PupilPremiumImporter do
       end
 
       it "updates the school" do
-        expect(School.unscoped.find_by(urn: 100_000).pupil_premiums.first).to be_present
+        expect(School.find_by(urn: 100_000).pupil_premiums.first).to be_present
       end
     end
   end


### PR DESCRIPTION
### Context
Default school scope that we chose a while ago, namely schools that are eligible, just isn't working for us anymore. There are many surprising places it gets in, like school import. 

### Changes proposed in this pull request
1. Remove default school scope. 
2. Add `eligible` to all places making school queries without a scope. 
3. Remove `unscoped` from all school queries using it. 

### Guidance to review
If you think I missed something do let me know. 

### Testing
School import won't load more than 3k schools without it, or so I think. So if there are more in review app, it probably worked. 
