### PR TITLE
Only run webpacker once for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Set up test database
         run: bin/rails db:create db:schema:load
 
+      - name: Webpacker
+        run: bin/webpack
+
       - name: Run Cypress
         uses: cypress-io/github-action@v2
         with:

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -76,7 +76,7 @@ development:
 
 test:
   <<: *default
-  compile: true
+  compile: false
 
 production: &production
   <<: *default

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "test": "jest --passWithNoTests",
     "cypress:open": "cypress open --project ./spec",
-    "cypress:run": "cypress run --project ./spec",
+    "cypress:run": "cypress run --project ./spec --config video=false,screenshotOnRunFailure=false",
     "lint": "eslint --max-warnings 0 '{app,spec}/**/*.js' && prettier --check '{app,spec}/**/*.js'"
   },
   "jest": {

--- a/spec/cypress/cypress_helper.rb
+++ b/spec/cypress/cypress_helper.rb
@@ -13,3 +13,4 @@ CypressOnRails::SmartFactoryWrapper.configure(
     Rails.root.join("spec/factories/**/*.rb"),
   ],
 )
+Webpacker.compile

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -91,4 +91,8 @@ RSpec.configure do |config|
   config.before :each do
     clear_enqueued_jobs
   end
+
+  config.before(:suite) do
+    Webpacker.compile
+  end
 end


### PR DESCRIPTION
### Context
Turns out if you run webpacker once up-front for all the tests things are faster than compiling every test. On my machine `rspec` goes from about 2min30 to around 17 seconds. Cypress will see a small improvement but less noticeable 
