### PR TITLE
Add a unique index on cohorts start year

### DIFF
--- a/db/migrate/20210407110504_add_index_to_cohorts_on_start_year.rb
+++ b/db/migrate/20210407110504_add_index_to_cohorts_on_start_year.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToCohortsOnStartYear < ActiveRecord::Migration[6.1]
+  def change
+    add_index :cohorts, :start_year, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_06_120453) do
+ActiveRecord::Schema.define(version: 2021_04_07_110504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2021_04_06_120453) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "start_year", limit: 2, null: false
+    t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 
   create_table "cohorts_lead_providers", id: false, force: :cascade do |t|


### PR DESCRIPTION
### Context
I had an exciting time debugging locally and then realised that the cause of the weirdness was that I had 2 cohorts with start year 2021!

In addition, we are doing a lot of look ups on cohorts using the start year. Actually more than we do with the cohort id.

### Changes proposed in this pull request
Add a unique index on the cohort start year.

