### PR TITLE
Add a db reset task for dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,22 +108,13 @@ Check the [documentation](./documentation/terraform.md) for detailed information
 Note: running `db:seed` schedules the `schools_data:import` as a delayed job. You can run `bin/delayed_job start --exit-on-complete`
 to execute this delayed job in the background.
 
-## Dealing with cip content
-
-### Seeding cip content / anything else
+## Resetting the database on a dev environment
 
 1. Make sure you are ok with the content in seed files to be created in your db.
 2. Run `cf login -a api.london.cloud.service.gov.uk -u USERNAME`, `USERNAME` is your personal GOV.UK PaaS account email address
-3. Run `cf run-task ecf-dev "cd .. && cd app && ../usr/local/bundle/bin/bundle exec rails db:seed"` to start the task.
+3. Run `cf run-task ecf-dev "cd .. && cd app && ../usr/local/bundle/bin/bundle exec rails db:safe_reset"` to start the task.
 
-### Updating cip content from changes on an app
-
-1. Download the file to your machine - log in as admin, go to cip page, press the button to download content.
-1. Copy the file or its contents into `cip_seed.rb`.
-1. Add an option `on_duplicate_key_ignore` to lead providers, think carefully which ones from seed dump are needed.
-1. Commit, push, run seeding job from above in the deployed app.
-
-### Sending school nomination invites
+## Sending school nomination invites
 
 ```bash
 bundle exec rake 'schools:send_invites[urn1 urn2 ...]'

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :db do
+  desc "Drop, create, migrate then seed the development database"
+  task safe_reset: :environment do
+    if Rails.env.development? || Rails.env.deployed_development?
+      Rake::Task["db:reset"].invoke
+      puts "Reseeded the database!"
+    else
+      puts "You should think twice before recreating staging or production database!"
+      puts "Use 'db:reset' task to do it if you really want to."
+    end
+  end
+end

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -12,7 +12,7 @@ namespace :db do
       tables.delete "schema_migrations"
       tables.each { |table| connection.execute("TRUNCATE #{table} CASCADE;") }
       Rake::Task["db:seed"].invoke
-      puts "Reseeded the database!"
+      puts "Re-seeded the database!"
     else
       puts "You should think twice before recreating staging or production database!"
       puts "Use 'db:reset' task to do it if you really want to."

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :db do
-  desc "Drop, create, migrate then seed the development database"
+  desc "Remove all database content, then seed it. Only for dev environments."
   task safe_reset: :environment do
     if Rails.env.development? || Rails.env.deployed_development?
       connection = ActiveRecord::Base.connection
@@ -15,7 +15,8 @@ namespace :db do
       puts "Re-seeded the database!"
     else
       puts "You should think twice before recreating staging or production database!"
-      puts "Use 'db:reset' task to do it if you really want to."
+      puts "Fire off Rails console and copy the code from this task if you really have to."
+      puts "Make sure you know what you are doing and maybe do a back-up first."
     end
   end
 end

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -4,7 +4,13 @@ namespace :db do
   desc "Drop, create, migrate then seed the development database"
   task safe_reset: :environment do
     if Rails.env.development? || Rails.env.deployed_development?
-      Rake::Task["db:reset"].invoke
+      connection = ActiveRecord::Base.connection
+      tables = connection
+                   .execute("SELECT * FROM pg_catalog.pg_tables;")
+                   .filter { |row| row["schemaname"].include?("public") }
+                   .map { |row| row["tablename"] }
+      tables.delete "schema_migrations"
+      tables.each { |table| connection.execute("TRUNCATE #{table} CASCADE;") }
       puts "Reseeded the database!"
     else
       puts "You should think twice before recreating staging or production database!"

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -11,6 +11,7 @@ namespace :db do
                    .map { |row| row["tablename"] }
       tables.delete "schema_migrations"
       tables.each { |table| connection.execute("TRUNCATE #{table} CASCADE;") }
+      Rake::Task["db:seed"].invoke
       puts "Reseeded the database!"
     else
       puts "You should think twice before recreating staging or production database!"

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -11,3 +11,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "standard"
 paas_web_app_instances = 1
 paas_web_app_memory = 512
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && /app/bin/delayed_job start && rails s"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,4 +10,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "standard"
 paas_web_app_instances = 1
 paas_web_app_memory = 512
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:seed && /app/bin/delayed_job start && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && /app/bin/delayed_job start && rails s"


### PR DESCRIPTION
### Context
We want a way to re-create the database for testing and re-testing purposes.

### Changes proposed in this pull request
Use `db:reset` task, https://stackoverflow.com/a/10302357
Wrap it in an environment check, so the task we use won't work on staging or prod.

### Guidance to review
I went with a rake task, because the last thing I want to worry about is foreign key constraints. I sure hope our paas user lets us do that.
This PR adds a db reset on a rake task, and on deploy on dev and review apps.

### Testing
I want a PR app to see it working in practice. But that might be hard to do since our dockerhub is malfunctioning atm...

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be
