### PR TITLE
ECF-RP-404: nominate induction coordinator

### DIFF
--- a/app/controllers/nominations/nominate_induction_coordinator_controller.rb
+++ b/app/controllers/nominations/nominate_induction_coordinator_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class Nominations::NominateInductionCoordinatorController < ApplicationController
+  def new
+    @token = params[:token]
+    @nomination_email = NominationEmail.find_by(token: @token)
+
+    if @nomination_email.nil?
+      redirect_to link_invalid_nominate_induction_coordinator_path
+    elsif @nomination_email.expired?
+      redirect_to link_expired_nominate_induction_coordinator_path(school_id: @nomination_email.school_id)
+    elsif @nomination_email.school.fully_registered?
+      redirect_to already_nominated_request_nomination_invite_path
+    else
+      load_nominate_induction_tutor_form
+      @nominate_induction_tutor_form.token = @token
+    end
+  end
+
+  def create
+    load_nominate_induction_tutor_form
+
+    render :new and return unless @nominate_induction_tutor_form.valid?
+
+    @nominate_induction_tutor_form.save!
+    redirect_to nominate_school_lead_success_nominate_induction_coordinator_path
+  rescue UserExistsError
+    redirect_to email_used_nominate_induction_coordinator_path(token: @nominate_induction_tutor_form.token)
+  end
+
+  def link_expired
+    @school_id = params[:school_id]
+  end
+
+  def resend_email_after_link_expired
+    nomination_request_form = build_nomination_request_form
+    nomination_request_form.save!
+
+    redirect_to success_request_nomination_invite_path
+  rescue TooManyEmailsError
+    redirect_to limit_reached_request_nomination_invite_path
+  end
+
+  def email_used
+    @token = params[:token]
+  end
+
+  def nominate_school_lead_success; end
+
+private
+
+  def load_nominate_induction_tutor_form
+    @nominate_induction_tutor_form = ::NominateInductionTutorForm.new
+    @nominate_induction_tutor_form.assign_attributes(nominate_induction_tutor_form_params)
+  end
+
+  def nominate_induction_tutor_form_params
+    return {} unless params.key?(:nominate_induction_tutor_form)
+
+    params.require(:nominate_induction_tutor_form).permit(:full_name, :email, :token)
+  end
+
+  def build_nomination_request_form
+    school = School.find(params[:resend_email_after_link_expired][:school_id])
+    NominationRequestForm.new(
+      local_authority_id: school.local_authority.id,
+      school_id: school.id,
+    )
+  end
+end

--- a/app/controllers/nominations/nominate_induction_coordinator_controller.rb
+++ b/app/controllers/nominations/nominate_induction_coordinator_controller.rb
@@ -3,13 +3,13 @@
 class Nominations::NominateInductionCoordinatorController < ApplicationController
   def new
     @token = params[:token]
-    @nomination_email = NominationEmail.find_by(token: @token)
+    nomination_email = NominationEmail.find_by(token: @token)
 
-    if @nomination_email.nil?
+    if nomination_email.nil?
       redirect_to link_invalid_nominate_induction_coordinator_path
-    elsif @nomination_email.expired?
-      redirect_to link_expired_nominate_induction_coordinator_path(school_id: @nomination_email.school_id)
-    elsif @nomination_email.school.registered?
+    elsif nomination_email.expired?
+      redirect_to link_expired_nominate_induction_coordinator_path(school_id: nomination_email.school_id)
+    elsif nomination_email.school.registered?
       redirect_to already_nominated_request_nomination_invite_path
     else
       load_nominate_induction_tutor_form

--- a/app/controllers/nominations/nominate_induction_coordinator_controller.rb
+++ b/app/controllers/nominations/nominate_induction_coordinator_controller.rb
@@ -9,7 +9,7 @@ class Nominations::NominateInductionCoordinatorController < ApplicationControlle
       redirect_to link_invalid_nominate_induction_coordinator_path
     elsif @nomination_email.expired?
       redirect_to link_expired_nominate_induction_coordinator_path(school_id: @nomination_email.school_id)
-    elsif @nomination_email.school.fully_registered?
+    elsif @nomination_email.school.registered?
       redirect_to already_nominated_request_nomination_invite_path
     else
       load_nominate_induction_tutor_form

--- a/app/controllers/nominations/request_nomination_invite_controller.rb
+++ b/app/controllers/nominations/request_nomination_invite_controller.rb
@@ -30,7 +30,7 @@ class Nominations::RequestNominationInviteController < ApplicationController
 
     if !@nomination_request_form.school.eligible?
       redirect_to not_eligible_request_nomination_invite_path
-    elsif @nomination_request_form.school.fully_registered?
+    elsif @nomination_request_form.school.registered?
       redirect_to already_nominated_request_nomination_invite_path
     elsif @nomination_request_form.email_limit_reached?
       redirect_to limit_reached_request_nomination_invite_path

--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class NominateInductionTutorForm
+  include ActiveModel::Model
+
+  attr_accessor :full_name, :email, :token
+
+  validates :full_name, presence: { message: "Enter a full name" }
+  validates :email, presence: { message: "Enter email" }
+
+  def school
+    NominationEmail.find_by(token: token).school
+  end
+
+  def save!
+    raise UserExistsError if User.with_discarded.exists?(email: email)
+
+    InductionCoordinatorProfile.create_induction_coordinator(
+      full_name,
+      email,
+      school,
+      Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain),
+    )
+  end
+end
+
+class UserExistsError < StandardError
+end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -18,15 +18,15 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def nomination_confirmation_email(tutor:, school:, sign_in_url:)
+  def nomination_confirmation_email(user:, school:, start_url:)
     template_mail(
       NOMINATION_CONFIRMATION_EMAIL_TEMPLATE,
-      to: tutor.email,
+      to: user.email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
         school_name: school.name,
-        sign_in_url: sign_in_url,
+        start_url: start_url,
       },
     )
   end

--- a/app/models/induction_coordinator_profile.rb
+++ b/app/models/induction_coordinator_profile.rb
@@ -3,4 +3,12 @@
 class InductionCoordinatorProfile < BaseProfile
   belongs_to :user
   has_and_belongs_to_many :schools
+
+  def self.create_induction_coordinator(full_name, email, school, start_url)
+    ActiveRecord::Base.transaction do
+      user = User.create!(full_name: full_name, email: email)
+      InductionCoordinatorProfile.create!(user: user, schools: [school])
+      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_now
+    end
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -66,7 +66,7 @@ class School < ApplicationRecord
     address.squeeze("\n")
   end
 
-  def fully_registered?
+  def registered?
     induction_coordinator_profiles.any?
   end
 

--- a/app/views/nominations/nominate_induction_coordinator/email_used.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/email_used.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Error: email address used" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-header-l">
+      The email you entered is used by another school
+    </h1>
+
+    <p>You need to use a different email address.</p>
+    <%= govuk_link_to "Change email address", new_nominate_induction_coordinator_path(token: @token), button: true %>
+  </div>
+</div>

--- a/app/views/nominations/nominate_induction_coordinator/link_expired.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/link_expired.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Error: Link expired" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">This link has expired</h1>
+
+    <%= form_for :resend_email_after_link_expired, url: link_expired_nominate_induction_coordinator_path, method: :post do |f| %>
+      <%= f.hidden_field :school_id, value: @school_id %>
+      <%= f.govuk_submit "Resend email" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/nominations/nominate_induction_coordinator/link_invalid.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/link_invalid.html.erb
@@ -1,5 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">The link provided is invalid</h1>
+    <h1 class="govuk-heading-l">The link provided is invalid</h1>
+
+    <%= govuk_link_to "Resend email", choose_location_request_nomination_invite_path, button: true %>
   </div>
 </div>

--- a/app/views/nominations/nominate_induction_coordinator/link_invalid.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/link_invalid.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">The link provided is invalid</h1>
+  </div>
+</div>

--- a/app/views/nominations/nominate_induction_coordinator/new.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/new.html.erb
@@ -1,0 +1,52 @@
+<% content_for :title, "Nominate induction tutor" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Nominate an induction tutor</h1>
+
+    <div class="govuk-!-margin-bottom-9">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">School details</h2>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Name
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= @nominate_induction_tutor_form.school.name %>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <abbr title="Unique reference number">URN</abbr>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= @nominate_induction_tutor_form.school.urn %>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Address
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= simple_format @nominate_induction_tutor_form.school.full_address, class: "govuk-body" %>
+          </dd>
+        </div>
+      </dl>
+    </div>
+    <%= form_with model: @nominate_induction_tutor_form, url: nominate_induction_coordinator_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <div class="govuk-form-group">
+        <h2 class="govuk-heading-m">Your induction tutor</h2>
+        <div class="govuk-form-group">
+          <%= f.govuk_text_field(:full_name, label: { text: "Full name" }) %>
+        </div>
+        <div class="govuk-form-group">
+          <%= f.govuk_email_field(:email, label: { text: "Email address", hint: "They will sign in with this email and get future notifications about this service" }) %>
+        </div>
+      </div>
+      <%= f.hidden_field :token, value: @nominate_induction_tutor_form.token %>
+      <%= f.govuk_submit "Confirm" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, "Nomination complete" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel title: "Induction tutor nominated", body: nil, classes: "govuk-!-margin-bottom-8" %>
+
+    <h3 class="govuk-heading-m">What happens next</h3>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the person you nominated will be notified</li>
+      <li>they can sign in and complete tasks for your induction programme</li>
+      <li>they will receive any future notifications about the service</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_panel title: "Induction tutor nominated", body: nil, classes: "govuk-!-margin-bottom-8" %>
+    <%= govuk_panel title: "Induction tutor nominated", body: nil, classes: "govuk-!-margin-bottom-8", html_attributes: { "data-test": "success-panel" } %>
 
     <h3 class="govuk-heading-m">What happens next</h3>
     <ul class="govuk-list govuk-list--bullet">

--- a/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/nominate_school_lead_success.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel title: "Induction tutor nominated", body: nil, classes: "govuk-!-margin-bottom-8", html_attributes: { "data-test": "success-panel" } %>
 
-    <h3 class="govuk-heading-m">What happens next</h3>
+    <h2 class="govuk-heading-m">What happens next</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li>the person you nominated will be notified</li>
       <li>they can sign in and complete tasks for your induction programme</li>

--- a/app/views/nominations/request_nomination_invite/already_nominated.html.erb
+++ b/app/views/nominations/request_nomination_invite/already_nominated.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-header-l">
-      An Induction Tutor has already been nominated for your school
+      An induction tutor has already been nominated for your school
     </h1>
 
     <h2 class="govuk-heading-m">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,15 @@ Rails.application.routes.draw do
         get "already-nominated", action: :already_nominated
       end
     end
+    resource :nominate_induction_coordinator, controller: :nominate_induction_coordinator, only: %i[new create], path: "/" do
+      collection do
+        get "email-used", action: :email_used
+        get "link-expired", action: :link_expired
+        post "link-expired", action: :resend_email_after_link_expired
+        get "link-invalid", action: :link_invalid
+        get "nominate-school-lead-success", action: :nominate_school_lead_success
+      end
+    end
   end
 
   namespace :lead_providers do

--- a/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
+++ b/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
@@ -1,0 +1,34 @@
+Feature: Nominate induction tutor
+
+  Scenario: Valid Nomination Link was sent
+    Given nomination_email was created with token "foo-bar-baz"
+    And I am on "nominations with token" page
+
+    When I type "John Smith" into "name input"
+    And I type "john-smith@example.com" into "email input"
+    And I click the submit button
+    Then "success panel" should contain "Induction tutor nominated"
+    And Email should be sent to Nominated School Induction Coordinator to email "john-smith@example.com"
+
+  Scenario: Expired Nomination Link was sent
+    Given nomination_email was created as "expired_nomination_email" with token "foo-bar-baz"
+    And I am on "nominations with token" page
+    Then "page body" should contain "This link has expired"
+
+    When I click the submit button
+    Then "page body" should contain "Your school has been sent a link"
+    And Email should be sent to Primary Email Contact of the School belonging to "primary-contact-email@example.com"
+
+  Scenario: Nomination Link was sent for which Induction Tutor was already nominated for the same school
+    Given nomination_email was created as "already_nominated_induction_tutor" with token "foo-bar-baz"
+    When I am on "nominations with token" page
+    Then "page body" should contain "An induction tutor has already been nominated for your school"
+
+  Scenario: Nomination Link was sent for which Induction Tutor was already nominated for another school
+    Given nomination_email was created as "email_address_already_used_for_another_school" with token "foo-bar-baz"
+    When I am on "nominations with token" page
+    Then I type "John Wick" into "name input"
+    And I type "john-wick@example.com" into "email input"
+
+    When I click the submit button
+    Then "page body" should contain "The email you entered is used by another school"

--- a/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
+++ b/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
@@ -3,17 +3,20 @@ Feature: Nominate induction tutor
   Scenario: Valid Nomination Link was sent
     Given nomination_email was created with token "foo-bar-baz"
     And I am on "nominations with token" page
+    Then the page should be accessible
 
     When I type "John Smith" into "name input"
     And I type "john-smith@example.com" into "email input"
     And I click the submit button
     Then "success panel" should contain "Induction tutor nominated"
     And Email should be sent to Nominated School Induction Coordinator to email "john-smith@example.com"
+    And the page should be accessible
 
   Scenario: Expired Nomination Link was sent
     Given nomination_email was created as "expired_nomination_email" with token "foo-bar-baz"
     And I am on "nominations with token" page
     Then "page body" should contain "This link has expired"
+    And the page should be accessible
 
     When I click the submit button
     Then "page body" should contain "Your school has been sent a link"
@@ -23,6 +26,7 @@ Feature: Nominate induction tutor
     Given nomination_email was created as "already_nominated_induction_tutor" with token "foo-bar-baz"
     When I am on "nominations with token" page
     Then "page body" should contain "An induction tutor has already been nominated for your school"
+    And the page should be accessible
 
   Scenario: Nomination Link was sent for which Induction Tutor was already nominated for another school
     Given nomination_email was created as "email_address_already_used_for_another_school" with token "foo-bar-baz"
@@ -32,3 +36,4 @@ Feature: Nominate induction tutor
 
     When I click the submit button
     Then "page body" should contain "The email you entered is used by another school"
+    And the page should be accessible

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -50,7 +50,9 @@ Cypress.Commands.add("clickCommitButton", () => {
 
 const SIGN_IN_EMAIL_TEMPLATE = "7ab8db5b-9842-4bc3-8dbb-f590a3198d9e";
 const ADMIN_ACCOUNT_CREATED_TEMPLATE = "3620d073-d2cc-4d65-9a51-e12770cf25d9";
-const PRIMARY_CONTACT_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f";
+const NOMINATION_EMAIL_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f";
+const NOMINATION_CONFIRMATION_EMAIL_TEMPLATE =
+  "240c5685-5cb0-40a9-9bd4-1a595d991cbc";
 
 const computeHeadersFromEmail = (email) =>
   email.header.reduce(
@@ -91,5 +93,6 @@ module.exports = {
   computeHeadersFromEmail,
   SIGN_IN_EMAIL_TEMPLATE,
   ADMIN_ACCOUNT_CREATED_TEMPLATE,
-  PRIMARY_CONTACT_TEMPLATE,
+  NOMINATION_EMAIL_TEMPLATE,
+  NOMINATION_CONFIRMATION_EMAIL_TEMPLATE,
 };

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -37,6 +37,7 @@ const elements = {
   "cookie banner": ".js-cookie-banner",
   "notification banner": "[data-test=notification-banner]",
   "autocomplete dropdown item": ".autocomplete__menu li",
+  "success panel": "[data-test=success-panel]",
 };
 
 const get = (element) => cy.get(elements[element] || element);

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -30,6 +30,7 @@ const pagePaths = {
   "resend nominations not eligible": "nominations/not-eligible",
   "resend nominations already nominated": "nominations/already-nominated",
   "resend nominations limit reached": "nominations/limit-reached",
+  "nominations with token": "/nominations/new?token=foo-bar-baz",
   "lead provider users index": "/admin/suppliers/users",
   "new lead provider user": "/admin/suppliers/users/new",
   "new lead provider user details": "/admin/suppliers/users/new/user-details",

--- a/spec/cypress/support/step_definitions/notifications.js
+++ b/spec/cypress/support/step_definitions/notifications.js
@@ -3,7 +3,8 @@ import {
   computeHeadersFromEmail,
   SIGN_IN_EMAIL_TEMPLATE,
   ADMIN_ACCOUNT_CREATED_TEMPLATE,
-  PRIMARY_CONTACT_TEMPLATE,
+  NOMINATION_EMAIL_TEMPLATE,
+  NOMINATION_CONFIRMATION_EMAIL_TEMPLATE,
 } from "../commands";
 
 Given(
@@ -34,9 +35,23 @@ Given(
   "Email should be sent to Primary Email Contact of the School belonging to {string}",
   (email) => {
     cy.appSentEmails().then((emails) => {
-      expect(emails).to.have.lengthOf(2);
-      const headersHash = computeHeadersFromEmail(emails[1]);
-      expect(headersHash["template-id"]).to.eq(PRIMARY_CONTACT_TEMPLATE);
+      expect(emails).to.have.lengthOf(1);
+      const headersHash = computeHeadersFromEmail(emails[0]);
+      expect(headersHash["template-id"]).to.eq(NOMINATION_EMAIL_TEMPLATE);
+      expect(headersHash.To).to.eq(email);
+    });
+  }
+);
+
+Given(
+  "Email should be sent to Nominated School Induction Coordinator to email {string}",
+  (email) => {
+    cy.appSentEmails().then((emails) => {
+      expect(emails).to.have.lengthOf(1);
+      const headersHash = computeHeadersFromEmail(emails[0]);
+      expect(headersHash["template-id"]).to.eq(
+        NOMINATION_CONFIRMATION_EMAIL_TEMPLATE
+      );
       expect(headersHash.To).to.eq(email);
     });
   }

--- a/spec/factories/nomination_email.rb
+++ b/spec/factories/nomination_email.rb
@@ -9,21 +9,19 @@ FactoryBot.define do
 
     trait :expired_nomination_email do
       sent_at { 1.year.ago }
+      school { build(:school, :with_local_authority, name: "Nominated School", primary_contact_email: "primary-contact-email@example.com") }
     end
 
     trait :already_nominated_induction_tutor do
       after(:build) do |nomination_email|
-        create(:user, :induction_coordinator) do |user|
-          user.induction_coordinator_profile.schools << nomination_email.school
-        end
+        create(:user, :induction_coordinator, schools: [nomination_email.school])
       end
     end
 
     trait :email_address_already_used_for_another_school do
       after(:build) do
-        create(:user, :induction_coordinator, email: "john-wick@example.com") do |user|
-          school = create(:school, name: "Another Registered School")
-          user.induction_coordinator_profile.schools << school
+        create(:school, name: "Another Registered School") do |school|
+          create(:user, :induction_coordinator, email: "john-wick@example.com", schools: [school])
         end
       end
     end

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     trait :sparsity_uplift do
       school_local_authority_districts { [build(:school_local_authority_district, :sparse)] }
     end
+
+    trait :with_local_authority do
+      school_local_authorities { [build(:school_local_authority)] }
+    end
   end
 end

--- a/spec/forms/nominate_induction_tutor_form_spec.rb
+++ b/spec/forms/nominate_induction_tutor_form_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NominateInductionTutorForm, type: :model do
+  let(:nomination_email) { create(:nomination_email) }
+  let(:token) { nomination_email.token }
+  let(:school) { nomination_email.school }
+  let(:name) { Faker::Name.name }
+  let(:email) { Faker::Internet.email }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
+    it { is_expected.to validate_presence_of(:email).with_message("Enter email") }
+  end
+
+  describe "#school" do
+    it "returns the correct school" do
+      form = NominateInductionTutorForm.new(token: token)
+
+      expect(form.school).to eql school
+    end
+  end
+
+  describe "#save!" do
+    let(:form) { NominateInductionTutorForm.new(token: token, full_name: name, email: email) }
+
+    it "creates an induction coordinator with the correct details" do
+      expect { form.save! }
+        .to change { User.count }
+              .by(1)
+              .and change { InductionCoordinatorProfile.count }.by(1)
+
+      created_user = User.find_by(email: email)
+      expect(created_user).not_to be_nil
+      expect(created_user.full_name).to eql name
+      expect(created_user.induction_coordinator_profile.schools).to contain_exactly(school)
+    end
+
+    context "when a user with the specified email already exists" do
+      before do
+        create(:user, email: email)
+      end
+
+      it "raises UserExistsError" do
+        expect { form.save! }.to raise_error(UserExistsError)
+                                   .and(not_change { User.unscoped.count })
+                                   .and(not_change { InductionCoordinatorProfile.unscoped.count })
+      end
+    end
+
+    context "when a discarded user with the specified email exists" do
+      before do
+        user = create(:user, email: email)
+        user.discard!
+      end
+
+      it "raises UserExistsError" do
+        expect { form.save! }.to raise_error(UserExistsError)
+                                   .and(not_change { User.unscoped.count })
+                                   .and(not_change { InductionCoordinatorProfile.unscoped.count })
+      end
+    end
+  end
+end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe SchoolMailer, type: :mailer do
   describe "#nomination_email_confirmation" do
     let(:school) { create(:school) }
     let(:user) { create(:user, :induction_coordinator) }
-    let(:sign_in_url) { "https://ecf-dev.london.cloudapps/users/sign_in" }
+    let(:start_url) { "https://ecf-dev.london.cloudapps" }
 
     let(:nomination_confirmation_email) do
       SchoolMailer.nomination_confirmation_email(
-        tutor: user,
+        user: user,
         school: school,
-        sign_in_url: sign_in_url,
+        start_url: start_url,
       ).deliver_now
     end
 

--- a/spec/models/induction_coordinator_profile_spec.rb
+++ b/spec/models/induction_coordinator_profile_spec.rb
@@ -9,4 +9,33 @@ RSpec.describe InductionCoordinatorProfile, type: :model do
   it "enables paper trail" do
     is_expected.to be_versioned
   end
+
+  describe ".create_induction_coordinator" do
+    let(:name) { Faker::Name.name }
+    let(:email) { Faker::Internet.email }
+    let(:school) { create(:school) }
+    let(:start_url) { "www.example.com" }
+    let(:created_user) { User.find_by(email: email) }
+
+    it "creates an induction coordinator" do
+      expect {
+        InductionCoordinatorProfile.create_induction_coordinator(name, email, school, start_url)
+      }.to change { InductionCoordinatorProfile.count }.by(1)
+    end
+
+    it "creates a user with the correct details" do
+      InductionCoordinatorProfile.create_induction_coordinator(name, email, school, start_url)
+
+      expect(created_user.present?).to be(true)
+      expect(created_user.full_name).to eql(name)
+    end
+
+    it "sends an email to the new user" do
+      allow(SchoolMailer).to receive(:nomination_confirmation_email).and_call_original
+      InductionCoordinatorProfile.create_induction_coordinator(name, email, school, start_url)
+
+      expect(SchoolMailer).to have_received(:nomination_confirmation_email)
+                                .with(user: created_user, school: school, start_url: start_url)
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -94,10 +94,10 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe "#fully_registered?" do
+  describe "#registered?" do
     let(:school) { create(:school) }
     it "returns false if there are no induction coordinators for the school" do
-      expect(school.fully_registered?).to be false
+      expect(school.registered?).to be false
     end
 
     context "when school has an induction coordinator" do
@@ -106,7 +106,7 @@ RSpec.describe School, type: :model do
       end
 
       it "returns true" do
-        expect(school.fully_registered?).to be true
+        expect(school.registered?).to be true
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,8 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ActiveSupport::Testing::TimeHelpers

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Nominating an induction coordinator", type: :request do
+  describe "GET /nominations/new" do
+    it "redirects to link-invalid when no token is provided" do
+      get "/nominations/new"
+      expect(response).to redirect_to("/nominations/link-invalid")
+    end
+
+    it "redirects to link-invalid when an invalid token is provided" do
+      get "/nominations/new?token=abc123"
+      expect(response).to redirect_to("/nominations/link-invalid")
+    end
+
+    context "with a valid token" do
+      let(:nomination_email) { create(:nomination_email) }
+      let(:token) { nomination_email.token }
+
+      it "renders the new nomination template" do
+        get "/nominations/new?token=#{token}"
+
+        expect(response).to render_template("nominations/nominate_induction_coordinator/new")
+      end
+
+      context "when an induction tutor for the school has already been nominated" do
+        before do
+          school = nomination_email.school
+          create(:user, :induction_coordinator, schools: [school])
+        end
+
+        it "redirects to already-nominated" do
+          get "/nominations/new?token=#{token}"
+
+          expect(response).to redirect_to("/nominations/already-nominated")
+          follow_redirect!
+          expect(response).to render_template("nominations/request_nomination_invite/already_nominated")
+        end
+      end
+    end
+
+    context "with an expired token" do
+      let(:nomination_email) { create(:nomination_email, sent_at: 6.weeks.ago) }
+      let(:token) { nomination_email.token }
+
+      it "redirects to link-expired" do
+        get "/nominations/new?token=#{token}"
+
+        expect(response).to redirect_to("/nominations/link-expired?school_id=#{nomination_email.school.id}")
+      end
+    end
+  end
+
+  describe "POST /nominations" do
+    let(:nomination_email) { create(:nomination_email) }
+    let(:token) { nomination_email.token }
+    let(:school) { nomination_email.school }
+    let(:name) { Faker::Name.name }
+    let(:email) { Faker::Internet.email }
+
+    it "creates a user and induction coordinator profile with the given details" do
+      expect {
+        post "/nominations", params: { nominate_induction_tutor_form: {
+          full_name: name,
+          email: email,
+          token: token,
+        } }
+      }
+        .to change { User.count }
+              .by(1)
+              .and change { InductionCoordinatorProfile.count }.by(1)
+
+      created_user = User.find_by(email: email)
+      expect(created_user).not_to be_nil
+      expect(created_user.full_name).to eql name
+      expect(created_user.induction_coordinator_profile.schools).to contain_exactly(school)
+    end
+
+    it "shows a validation error when the email is blank" do
+      post "/nominations", params: { nominate_induction_tutor_form: {
+        full_name: name,
+        email: "",
+        token: token,
+      } }
+
+      expect(response).to render_template("nominations/nominate_induction_coordinator/new")
+      expect(response.body).to include(CGI.escapeHTML("Enter email"))
+    end
+
+    it "shows a validation error when the name is blank" do
+      post "/nominations", params: { nominate_induction_tutor_form: {
+        full_name: "",
+        email: email,
+        token: token,
+      } }
+
+      expect(response).to render_template("nominations/nominate_induction_coordinator/new")
+      expect(response.body).to include(CGI.escapeHTML("Enter a full name"))
+    end
+
+    context "when a user already exists with the provided email" do
+      it "redirects to the email-used page" do
+        expect_any_instance_of(NominateInductionTutorForm).to receive(:save!).and_raise(UserExistsError)
+        expect {
+          post "/nominations", params: { nominate_induction_tutor_form: {
+            full_name: name,
+            email: email,
+            token: token,
+          } }
+        }
+          .not_to(change { User.count })
+
+        expect(response).to redirect_to("/nominations/email-used?token=#{token}")
+      end
+    end
+  end
+
+  describe "GET /nominations/link-expired" do
+    let(:school) { create(:school) }
+
+    it "renders the link-expired template" do
+      get "/nominations/link-expired?school=#{school.id}"
+
+      expect(response).to render_template("nominations/nominate_induction_coordinator/link_expired")
+    end
+  end
+
+  describe "POST /nominations/link-expired" do
+    let(:school) { create(:school, :with_local_authority) }
+
+    it "calls save! on the form" do
+      expect_any_instance_of(NominationRequestForm).to receive(:save!)
+      post "/nominations/link-expired", params: { resend_email_after_link_expired: {
+        school_id: school.id,
+      } }
+    end
+
+    it "redirects to limit-reached" do
+      expect_any_instance_of(NominationRequestForm).to receive(:save!).and_raise(TooManyEmailsError)
+
+      post "/nominations/link-expired", params: { resend_email_after_link_expired: {
+        school_id: school.id,
+      } }
+      expect(response).to redirect_to(limit_reached_request_nomination_invite_path)
+    end
+  end
+
+  describe "GET /nominations/email-used" do
+    it "renders the email used template" do
+      get "/nominations/email-used"
+      expect(response).to render_template("nominations/nominate_induction_coordinator/email_used")
+    end
+  end
+
+  describe "GET /nominations/nominate-school-lead-success" do
+    it "renders the success template" do
+      get "/nominations/nominate-school-lead-success"
+      expect(response).to render_template("nominations/nominate_induction_coordinator/nominate_school_lead_success")
+    end
+  end
+end

--- a/spec/requests/nominations/request_nomination_invite_spec.rb
+++ b/spec/requests/nominations/request_nomination_invite_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe "Requesting an invitation to nominate an induction tutor", type: 
       post "/nominations/review"
       expect(response).to redirect_to(success_request_nomination_invite_path)
     end
+
+    it "calls save! on the form" do
+      expect_any_instance_of(NominationRequestForm).to receive(:save!)
+      post "/nominations/review"
+    end
+
+    it "redirects to limit-reached" do
+      expect_any_instance_of(NominationRequestForm).to receive(:save!).and_raise(TooManyEmailsError)
+
+      post "/nominations/review"
+      expect(response).to redirect_to(limit_reached_request_nomination_invite_path)
+    end
   end
 
   describe "success" do


### PR DESCRIPTION
## Context
This is a rework of Seb's PR to nominate an induction coordinator

## Testing
### Automated Testing
#### Request specs
- Check the correct redirects happen
- Check the correct templates are rendered
- High level sanity checks on model creation
#### Form specs
-Validation checks
- Detailed model creation checks
#### Model specs
- Check model is created correctly
- Mailer checks
#### Cypress tests
- Valid nomination (success journey)
- Expired link
- Already nominated
- Email in use

### Manual testing
I'm going to write some seed data for this and other scenarios, but that will be a separate PR 

## Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be
