### PR TITLE
ECF-1-402 Added notify callback

### DIFF
--- a/app/controllers/nominations/notify_callbacks_controller.rb
+++ b/app/controllers/nominations/notify_callbacks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Nominations::NotifyCallbacksController < ActionController::API
+  def create
+    email = NominationEmail.find_by(token: params[:reference])
+    email.update!(notify_status: params[:status])
+
+    head :no_content
+  end
+end

--- a/app/controllers/nominations/notify_callbacks_controller.rb
+++ b/app/controllers/nominations/notify_callbacks_controller.rb
@@ -2,9 +2,27 @@
 
 class Nominations::NotifyCallbacksController < ActionController::API
   def create
+    return head :no_content unless params[:reference]
+
     email = NominationEmail.find_by(token: params[:reference])
-    email.update!(notify_status: params[:status])
+    email.update!(notify_status: params[:status]) if email
+    log_email if failed_email?(email) 
 
     head :no_content
+  end
+
+  private
+
+  def log_email
+    Rails.logger.info "Email could not be sent"
+    Rails.logger.info "notify_id: #{params[:id]}"
+    Rails.logger.info "reference: #{params[:reference]}"
+    Rails.logger.info "template_id: #{params[:template_id]}"
+  end
+
+  def failed_email?(email)
+    return false if email.nil?
+  
+    params[:status] != "sending" && params[:status] != "delivered"
   end
 end

--- a/app/controllers/nominations/notify_callbacks_controller.rb
+++ b/app/controllers/nominations/notify_callbacks_controller.rb
@@ -14,10 +14,7 @@ class Nominations::NotifyCallbacksController < ActionController::API
 private
 
   def log_email
-    Rails.logger.info "Email could not be sent"
-    Rails.logger.info "notify_id: #{params[:id]}"
-    Rails.logger.info "reference: #{params[:reference]}"
-    Rails.logger.info "template_id: #{params[:template_id]}"
+    Rails.logger.info "Email could not be sent - notify_id: #{params[:id]}, reference: #{params[:reference]}, template_id: #{params[:template_id]}"
   end
 
   def failed_email?(email)

--- a/app/controllers/nominations/notify_callbacks_controller.rb
+++ b/app/controllers/nominations/notify_callbacks_controller.rb
@@ -6,12 +6,12 @@ class Nominations::NotifyCallbacksController < ActionController::API
 
     email = NominationEmail.find_by(token: params[:reference])
     email.update!(notify_status: params[:status]) if email
-    log_email if failed_email?(email) 
+    log_email if failed_email?(email)
 
     head :no_content
   end
 
-  private
+private
 
   def log_email
     Rails.logger.info "Email could not be sent"
@@ -22,7 +22,7 @@ class Nominations::NotifyCallbacksController < ActionController::API
 
   def failed_email?(email)
     return false if email.nil?
-  
+
     params[:status] != "sending" && params[:status] != "delivered"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   end
 
   scope :nominations, module: :nominations do
+    resource :notify_callback, only: :create, path: "notify-callback"
     resource :request_nomination_invite, controller: :request_nomination_invite, only: [], path: "/" do
       collection do
         get "choose-location", action: :choose_location

--- a/spec/requests/nominations/notify_callback_spec.rb
+++ b/spec/requests/nominations/notify_callback_spec.rb
@@ -7,13 +7,12 @@ RSpec.describe "Nominations::NotifyCallbacks", type: :request do
     let(:nomination_email) { create(:nomination_email) }
 
     it "updates matching nomination email" do
-      post "/nominations/notify-callback", params: { 
+      post "/nominations/notify-callback", params: {
         reference: nomination_email.token,
         status: "failure",
       }
-      
+
       expect(nomination_email.reload.notify_status).to eq "failure"
     end
   end
 end
-

--- a/spec/requests/nominations/notify_callback_spec.rb
+++ b/spec/requests/nominations/notify_callback_spec.rb
@@ -9,10 +9,32 @@ RSpec.describe "Nominations::NotifyCallbacks", type: :request do
     it "updates matching nomination email" do
       post "/nominations/notify-callback", params: {
         reference: nomination_email.token,
-        status: "failure",
+        status: "failed",
       }
 
-      expect(nomination_email.reload.notify_status).to eq "failure"
+      expect(nomination_email.reload.notify_status).to eq "failed"
+    end
+
+    context "when reference is nil" do
+      it "returns successfully" do
+        post "/nominations/notify-callback", params: {
+          reference: nil,
+          status: "delivered",
+        }
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when reference does not match any records" do
+      it "returns successfully" do
+        post "/nominations/notify-callback", params: {
+          reference: "reference",
+          status: "delivered",
+        }
+
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 end

--- a/spec/requests/nominations/notify_callback_spec.rb
+++ b/spec/requests/nominations/notify_callback_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Nominations::NotifyCallbacks", type: :request do
+  describe "POST /nominations/notify-callback" do
+    let(:nomination_email) { create(:nomination_email) }
+
+    it "updates matching nomination email" do
+      post "/nominations/notify-callback", params: { 
+        reference: nomination_email.token,
+        status: "failure",
+      }
+      
+      expect(nomination_email.reload.notify_status).to eq "failure"
+    end
+  end
+end
+


### PR DESCRIPTION
### Context
We want to track the status of the nomination emails we send to schools.

### Changes proposed in this pull request
I have explored 2 approaches. The first, https://docs.notifications.service.gov.uk/ruby.html#get-message-status, involves making API calls to Notify via the Notify client. The call would give us the latest 250 emails sent in the last 7 days. Based on the oldest of those records we would then need to fetch the next 250 records older than the oldest in the previous batch. It would be more difficult to get the status of all our nomination emails as there could be thousands of them. We would also need a rake task to run as a cron job to keep updating the statuses of our emails.

The other approach is to let Notify let us know the status of our emails via a callback and this is what has been implemented in this pr. https://docs.notifications.service.gov.uk/ruby.html#callbacks 


