### PR TITLE
allow reopened pr to create review app

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -2,7 +2,7 @@ name: Create Review App
 on:
   pull_request:
     branches: [ develop ]
-    types: [ opened, synchronize ]
+    types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'documentation/**'
 


### PR DESCRIPTION
### Context
We need to allow reopened PR's to create review apps
### Changes proposed in this pull request
Alter github workflow
### Guidance to review

### Testing
try to rerun a closed PR and see if it creates a review app
### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
