### PR TITLE
Nomination email link tracking

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -24,11 +24,11 @@ class School < ApplicationRecord
   scope :eligible, -> { open.eligible_establishment_type.in_england }
 
   scope :with_name_like, lambda { |search_key|
-    School.eligible.where("name ILIKE ?", "%#{search_key}%")
+    where("name ILIKE ?", "%#{search_key}%")
   }
 
   scope :with_urn_like, lambda { |search_key|
-    School.eligible.where("urn ILIKE ?", "%#{search_key}%")
+    where("urn ILIKE ?", "%#{search_key}%")
   }
 
   scope :search_by_name_or_urn, lambda { |search_key|
@@ -41,15 +41,15 @@ class School < ApplicationRecord
   }
 
   scope :partnered, lambda { |year|
-    where(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).pluck(:school_id))
+    where(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
   }
 
   scope :partnered_with_lead_provider, lambda { |lead_provider_id|
-    where(id: Partnership.where(lead_provider_id: lead_provider_id).pluck(:school_id))
+    where(id: Partnership.where(lead_provider_id: lead_provider_id).select(:school_id))
   }
 
   scope :unpartnered, lambda { |year|
-    where.not(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).pluck(:school_id))
+    where.not(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
   }
 
   def lead_provider(year)
@@ -119,7 +119,7 @@ private
   end
 
   def in_england?
-    administrative_district_code.match?(/^[Ee].*/)
+    administrative_district_code.match?(/^[Ee]/)
   end
 
   scope :open, -> { where(school_status_code: ELIGIBLE_STATUS_CODES) }

--- a/app/views/nominations/_school_details.html.erb
+++ b/app/views/nominations/_school_details.html.erb
@@ -1,0 +1,29 @@
+<h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= title %></h2>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= school.name %>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      URN
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= school.urn %>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Address
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= simple_format school.full_address, class: "govuk-body" %>
+    </dd>
+  </div>
+</dl>

--- a/app/views/nominations/nominate_induction_coordinator/start.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/start.html.erb
@@ -1,0 +1,14 @@
+<h1>Nominate an induction tutor</h1>
+
+<%= render partial: 'nominations/school_details', locals: { school: @nominate_induction_tutor_form.school, title: "Your school" } %>
+
+This is someone who is responsible for running induction at your school.
+
+They will:
+<ul>
+  <li>confirm the type of induction programme your school wants to run</li>
+  <li>tell us which early career teachers and mentors are starting a programme</li>
+  <li>receive any future notifications about this service</li>
+</ul>
+
+<%= govuk_link_to "Start", { action: :new }, class: 'govuk-button' %>

--- a/app/views/nominations/request_nomination_invite/review.html.erb
+++ b/app/views/nominations/request_nomination_invite/review.html.erb
@@ -12,36 +12,7 @@
     </p>
 
     <div class="govuk-!-margin-bottom-9">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Your school</h2>
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Name
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= @nomination_request_form.school.name %>
-          </dd>
-        </div>
-
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            URN
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= @nomination_request_form.school.urn %>
-          </dd>
-        </div>
-
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Address
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= simple_format @nomination_request_form.school.full_address, class: "govuk-body" %>
-          </dd>
-        </div>
-      </dl>
-
+      <%= render partial: 'nominations/school_details', locals: { school: @nomination_request_form.school, title: "Your school" } %>
       <%= govuk_link_to "Change school", choose_location_request_nomination_invite_path(continue: true), class: "govuk-link--no-visited-state" %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     end
     resource :nominate_induction_coordinator, controller: :nominate_induction_coordinator, only: %i[new create], path: "/" do
       collection do
+        get "start", action: :start
         get "email-used", action: :email_used
         get "link-expired", action: :link_expired
         post "link-expired", action: :resend_email_after_link_expired

--- a/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
+++ b/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
@@ -2,7 +2,10 @@ Feature: Nominate induction tutor
 
   Scenario: Valid Nomination Link was sent
     Given nomination_email was created with token "foo-bar-baz"
-    And I am on "nominations with token" page
+    And I am on "start nominations with token" page
+    Then the page should be accessible
+
+    When I click on "link" containing "Start"
     Then the page should be accessible
 
     When I type "John Smith" into "name input"
@@ -14,7 +17,7 @@ Feature: Nominate induction tutor
 
   Scenario: Expired Nomination Link was sent
     Given nomination_email was created as "expired_nomination_email" with token "foo-bar-baz"
-    And I am on "nominations with token" page
+    And I am on "start nominations with token" page
     Then "page body" should contain "This link has expired"
     And the page should be accessible
 
@@ -24,13 +27,14 @@ Feature: Nominate induction tutor
 
   Scenario: Nomination Link was sent for which Induction Tutor was already nominated for the same school
     Given nomination_email was created as "already_nominated_induction_tutor" with token "foo-bar-baz"
-    When I am on "nominations with token" page
+    When I am on "start nominations with token" page
     Then "page body" should contain "An induction tutor has already been nominated for your school"
     And the page should be accessible
 
   Scenario: Nomination Link was sent for which Induction Tutor was already nominated for another school
     Given nomination_email was created as "email_address_already_used_for_another_school" with token "foo-bar-baz"
-    When I am on "nominations with token" page
+    When I am on "start nominations with token" page
+    Then I click on "link" containing "Start"
     Then I type "John Wick" into "name input"
     And I type "john-wick@example.com" into "email input"
 

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -31,7 +31,7 @@ const pagePaths = {
   "resend nominations not eligible": "nominations/not-eligible",
   "resend nominations already nominated": "nominations/already-nominated",
   "resend nominations limit reached": "nominations/limit-reached",
-  "nominations with token": "/nominations/new?token=foo-bar-baz",
+  "start nominations with token": "/nominations/start?token=foo-bar-baz",
   "lead provider users index": "/admin/suppliers/users",
   "new lead provider user": "/admin/suppliers/users/new",
   "new lead provider user details": "/admin/suppliers/users/new/user-details",


### PR DESCRIPTION
### Context

When school user has received an email for nomination induction coordinator for their school, we want to track the time they have started the nomination process.

### Changes proposed in this pull request.

When link is clicked, user will be directed to a start page with a single `start` button. Once the button is clicked, notification_email#opened_at column is updated when user is presented with the nomination form.

### Review notes
This PR is depending on https://github.com/DFE-Digital/early-careers-framework/pull/226

### Testing
1) Receive school invite email with nomination link (via `rake schools:send_invites[school_urn]`)
1) Click on the nomination link
1) You should see a nomination start page, showing school's details
1) Check the `opened_at` field of the nomination_email record matching the token from url
1) Click on start button
1) You should see nomination form
1) Check the `opened_at` field has been populated with current time
1) Click the same nomination link in the email again and follow through the start button again
1) Check that the `opened_at` field has not changed

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
