### PR TITLE
back link from cookies page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,15 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :previous_url_for_cookies_page
+
+  def previous_url_for_cookies_page
+    if request.get? && controller_name == "cookies"
+      session[:return_to] ||= root_url
+    elsif request.get?
+      session[:return_to] = request.original_url
+    end
+  end
 
   def check
     render json: { status: "OK", version: release_version, sha: ENV["SHA"], environment: Rails.env }, status: :ok

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -16,8 +16,8 @@ class CookiesController < ApplicationController
     respond_to do |format|
       format.html do
         set_cookie_form
-        @consent_updated = true # TODO: remove this and style notice
-        redirect_to cookies_path, notice: "You’ve set your cookie preferences."
+        set_success_message(content: "You’ve set your cookie preferences.", title: "Success")
+        redirect_to cookies_path
       end
 
       format.json do

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -16,8 +16,8 @@ class CookiesController < ApplicationController
     respond_to do |format|
       format.html do
         set_cookie_form
-        @consent_updated = true
-        redirect_to cookies_path, notice: "Cookie preferences upated successfully"
+        @consent_updated = true # TODO: remove this and style notice
+        redirect_to cookies_path, notice: "You’ve set your cookie preferences."
       end
 
       format.json do

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -3,7 +3,9 @@
 class CookiesController < ApplicationController
   before_action :set_cookie_form, only: :show
 
-  def show; end
+  def show
+    @backlink = session[:return_to]
+  end
 
   def update
     analytics_consent = params[:cookies_form][:analytics_consent]
@@ -15,7 +17,7 @@ class CookiesController < ApplicationController
       format.html do
         set_cookie_form
         @consent_updated = true
-        render :show
+        redirect_to cookies_path, notice: "Cookie preferences upated successfully"
       end
 
       format.json do

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -1,3 +1,8 @@
+<%= render GovukComponent::BackLink.new(
+      text: 'Back',
+      href: @backlink,
+    )
+%>
 <% content_for :title, "Cookies" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -1,12 +1,8 @@
-<%= render GovukComponent::BackLink.new(
-      text: 'Back',
-      href: @backlink,
-    )
-%>
+<% content_for :before_content, govuk_back_link( text: "Back", href: @backlink) %>
 <% content_for :title, "Cookies" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @consent_updated %>
+    <% if @consent_updated %> <% #TODO: should we set the notices to this? %>
       <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
           <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -1,8 +1,8 @@
-<% content_for :before_content, govuk_back_link( text: "Back", href: @backlink) %>
 <% content_for :title, "Cookies" %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: @backlink) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @consent_updated %> <% #TODO: should we set the notices to this? %>
+    <% if @consent_updated %> <!-- TODO: remove this and style notice -->
       <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
           <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -2,21 +2,6 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: @backlink) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @consent_updated %> <!-- TODO: remove this and style notice -->
-      <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Success
-          </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-          <p class="govuk-notification-banner__heading">
-            You’ve set your cookie preferences.
-          </p>
-        </div>
-      </div>
-    <% end %>
-
     <h1 class="govuk-heading-l">Cookies</h1>
     <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
     <p>We use cookies to make the Manage training for early career teachers service (the service) work and collect information about how you use our service.</p>

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -1,3 +1,8 @@
+<%= render GovukComponent::BackLink.new(
+      text: 'Back',
+      href: :back,
+    )
+%>
 <h1 class="govuk-heading-l">How we look after your personal data</h1>
   <h2 class="govuk-heading-m">Department for Education (DfE)</h2>
     <p class="govuk-body">Mentions of "us" and "we" mean DfE and "you" means anyone using this service.</p>

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -1,8 +1,4 @@
-<%= render GovukComponent::BackLink.new(
-      text: 'Back',
-      href: :back,
-    )
-%>
+<% content_for :before_content, govuk_back_link( text: "Back", href: :back) %>
 <h1 class="govuk-heading-l">How we look after your personal data</h1>
   <h2 class="govuk-heading-m">Department for Education (DfE)</h2>
     <p class="govuk-body">Mentions of "us" and "we" mean DfE and "you" means anyone using this service.</p>

--- a/spec/cypress/integration/Cookies.feature
+++ b/spec/cypress/integration/Cookies.feature
@@ -49,3 +49,14 @@ Feature: Cookie page
     When I navigate to "cookie" page
     Then "cookie banner" should not exist
     And "cookie consent radio" with value "off" is checked
+
+  Scenario: Returning from cookie show page
+    Given I am on "start" page
+    When I click on "link" containing "Cookies"
+    Then I am on "cookie" page
+
+    When I set "cookie consent radio" to "off"
+    And I click the submit button
+    And I click on "link" containing "Back"
+    Then I am on "start" page
+

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Cookies API", type: :request do
 
   describe "GET /cookies" do
     context "from a different page" do
-      it "sets the session[:return_to] previous url" do
+      it "sets the session[:return_to] as previous url" do
         get privacy_policy_path
         expect(session[:return_to]).to eq("http://www.example.com/privacy_policy")
         get cookies_path
@@ -45,7 +45,7 @@ RSpec.describe "Cookies API", type: :request do
     end
 
     context "from the same page with empty session" do
-      it "sets the session[:return_to] root url" do
+      it "sets the session[:return_to] as root url" do
         get cookies_path
         expect(session[:return_to]).to eq("http://www.example.com/")
       end

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -23,5 +23,32 @@ RSpec.describe "Cookies API", type: :request do
       expect(response.body).to eq(expected)
       expect(response.cookies["cookie_consent_1"]).to eq("off")
     end
+
+    it "does not affect session[:return_to] variable" do
+      get cookies_path
+
+      headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
+      put "/cookies", params: { "cookies_form": { "analytics_consent": "on" } }.to_json, headers: headers
+
+      expect(session[:return_to]).to eq("http://www.example.com/")
+    end
+  end
+
+  describe "GET /cookies" do
+    context "from a different page" do
+      it "sets the session[:return_to] previous url" do
+        get privacy_policy_path
+        expect(session[:return_to]).to eq("http://www.example.com/privacy_policy")
+        get cookies_path
+        expect(session[:return_to]).to eq("http://www.example.com/privacy_policy")
+      end
+    end
+
+    context "from the same page with empty session" do
+      it "sets the session[:return_to] root url" do
+        get cookies_path
+        expect(session[:return_to]).to eq("http://www.example.com/")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
Trello #485
We need to return to the previous page after visiting the"/cookies" page and viewing/updating our preferences
### Changes proposed in this pull request
Introduces an application controller method to set session[:return_to] in all get actions apart from under CookiesController. Can also be extended to privacy policy if needed ?
### Guidance to review
There are several ways of doing this...not all cover all use cases.
### Testing
Noted some of the CookieFeature cypress tests are failing locally, as @consent_updated is not being set...
### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
