### PR TITLE
ECF-1-419 Enhance choose-school auto complete

### DIFF
--- a/app/decorators/school_decorator.rb
+++ b/app/decorators/school_decorator.rb
@@ -10,6 +10,10 @@ module Decorators
       @school = school
     end
 
+    def name_with_address
+      "<strong>#{name}</strong> (#{full_address_formatted})"
+    end
+
     def full_address_formatted
       [address_line1, address_line2, address_line3, postcode].reject(&:blank?).join(", ")
     end

--- a/app/decorators/school_decorator.rb
+++ b/app/decorators/school_decorator.rb
@@ -11,7 +11,7 @@ module Decorators
     end
 
     def name_with_address
-      "<strong>#{name}</strong> (#{full_address_formatted})"
+      "#{name} (#{full_address_formatted})"
     end
 
     def full_address_formatted

--- a/app/forms/nomination_request_form.rb
+++ b/app/forms/nomination_request_form.rb
@@ -17,7 +17,9 @@ class NominationRequestForm
   end
 
   def available_schools
-    School.open.joins(:school_local_authorities).where(school_local_authorities: { local_authority_id: local_authority_id })
+    School.open.joins(:school_local_authorities).where(school_local_authorities: { local_authority_id: local_authority_id }).map do |sch|
+      Decorators::SchoolDecorator.new(sch)
+    end
   end
 
   def school

--- a/app/views/nominations/request_nomination_invite/choose_school.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_school.html.erb
@@ -11,7 +11,7 @@
           :id,
           :name_with_address,
           label: { text: "Find your school", tag: "h1", size: "l"  },
-          hint: { text: "Enter name"},
+          hint: { text: "Enter school name"},
           options: { include_blank: true },
           class: ["js-school-select"]) %>
   </div>

--- a/app/views/nominations/request_nomination_invite/choose_school.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_school.html.erb
@@ -9,7 +9,7 @@
           :school_id,
           @nomination_request_form.available_schools,
           :id,
-          :name,
+          :name_with_address,
           label: { text: "Find your school", tag: "h1", size: "l"  },
           hint: { text: "Enter name"},
           options: { include_blank: true },

--- a/app/webpacker/styles/school_search.scss
+++ b/app/webpacker/styles/school_search.scss
@@ -4,6 +4,9 @@
 
 .autocomplete__wrapper {
   background: govuk-colour("white");
+  input {
+    background: govuk-colour("white");
+  }
 }
 
 .card {

--- a/spec/decorators/school_decorator_spec.rb
+++ b/spec/decorators/school_decorator_spec.rb
@@ -3,9 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Decorators::SchoolDecorator do
-  describe "full address_formatted" do
-    let(:school) { create(:school, name: "Western Armstrong", address_line1: "52634 Gloria Circle", address_line2: "Pagac Extensions", postcode: "SE23 1SA") }
-    let(:school_decorator) { Decorators::SchoolDecorator.new(school) }
+  let(:school) { create(:school, name: "Western Armstrong", address_line1: "52634 Gloria Circle", address_line2: "Pagac Extensions", postcode: "SE23 1SA") }
+  let(:school_decorator) { Decorators::SchoolDecorator.new(school) }
+
+  describe "#name_with_address" do
+    let(:expected_name_with_address) do
+      "<strong>#{school.name}</strong> (#{school_decorator.full_address_formatted})"
+    end
+    it "returns the school name with an appended address" do
+      expect(school_decorator.name_with_address).to eq expected_name_with_address
+    end
+  end
+
+  describe "#full_address_formatted" do
     it "outputs correctly formatted full address string" do
       expect(school_decorator.full_address_formatted).to eq "52634 Gloria Circle, Pagac Extensions, SE23 1SA"
     end

--- a/spec/decorators/school_decorator_spec.rb
+++ b/spec/decorators/school_decorator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Decorators::SchoolDecorator do
 
   describe "#name_with_address" do
     let(:expected_name_with_address) do
-      "<strong>#{school.name}</strong> (#{school_decorator.full_address_formatted})"
+      "#{school.name} (#{school_decorator.full_address_formatted})"
     end
     it "returns the school name with an appended address" do
       expect(school_decorator.name_with_address).to eq expected_name_with_address


### PR DESCRIPTION
### Context
We need to display the address as part of the select dropdown  so that users can narrow down their school with less ambiguity.

### Changes proposed in this pull request
Make the choose school dropdown look as in the attachment

### Testing
![image](https://user-images.githubusercontent.com/1547920/114431149-12b36800-9bb7-11eb-8d5d-85bedd1c8a6d.png)


### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be
