### PR TITLE
Privacy policy on first sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,7 +40,9 @@ protected
   end
 
   def check_privacy_policy_accepted
-    return if !current_user || current_user.admin? || current_user.privacy_policy_acceptance.present?
+    return if !current_user || current_user.admin?
+    return unless current_user.induction_coordinator_profile
+    return if current_user.privacy_policy_acceptance.present?
 
     session[:original_path] = request.fullpath
     redirect_to privacy_policy_path

--- a/app/controllers/privacy_policies_controller.rb
+++ b/app/controllers/privacy_policies_controller.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
 class PrivacyPoliciesController < ApplicationController
+  skip_before_action :check_privacy_policy_accepted
+
   def show; end
+
+  def update
+    current_user.update!(privacy_policy_acceptance: {
+      accepted_at: Time.zone.now,
+      version: params[:pp_version],
+    })
+    redirect_to session.delete(:original_path)
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,20 +3,16 @@
 class Users::SessionsController < Devise::SessionsController
   include ApplicationHelper
 
-  class EmailNotFoundError < StandardError; end
-  class LoginIncompleteError < StandardError; end
-
   TEST_USERS = %w[admin@example.com lead-provider@example.com school-leader@example.com early-career-teacher@example.com].freeze
 
+  skip_before_action :check_privacy_policy_accepted
   before_action :mock_login, only: :create, if: -> { Rails.env.development? || Rails.env.deployed_development? }
   before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]
   before_action :ensure_login_token_valid, only: %i[sign_in_with_token redirect_from_magic_link]
 
   def create
     super
-  rescue LoginIncompleteError
-    render :login_email_sent
-  rescue EmailNotFoundError
+  rescue Devise::Strategies::PasswordlessAuthenticatable::Error
     render :login_email_sent
   end
 

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -1,4 +1,6 @@
-<% content_for :before_content, govuk_back_link( text: "Back", href: :back) %>
+<% if !current_user || current_user.privacy_policy_acceptance %>
+  <% content_for :before_content, govuk_back_link( text: "Back", href: :back) %>
+<% end %>
 <h1 class="govuk-heading-l">How we look after your personal data</h1>
   <h2 class="govuk-heading-m">Department for Education (DfE)</h2>
     <p class="govuk-body">Mentions of "us" and "we" mean DfE and "you" means anyone using this service.</p>
@@ -99,7 +101,7 @@
   <h2 class="govuk-heading-m">Keeping our privacy policy up to date</h2>
   <p class="govuk-body">We reserve the right to update this privacy notice at any time, and we will provide you with a new privacy notice when we make any substantial updates. We will also notify you in other ways from time to time about the processing of your personal information.</p>
 
-<% if current_user&.privacy_policy_acceptance.blank? %>
+<% if current_user && current_user.privacy_policy_acceptance.blank? %>
   <%= form_tag({action: :update}, method: :put) do %>
     <%= hidden_field_tag :pp_version, '1.0' %>
 

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -98,3 +98,11 @@
 
   <h2 class="govuk-heading-m">Keeping our privacy policy up to date</h2>
   <p class="govuk-body">We reserve the right to update this privacy notice at any time, and we will provide you with a new privacy notice when we make any substantial updates. We will also notify you in other ways from time to time about the processing of your personal information.</p>
+
+<% if current_user&.privacy_policy_acceptance.blank? %>
+  <%= form_tag({action: :update}, method: :put) do %>
+    <%= hidden_field_tag :pp_version, '1.0' %>
+
+    <%= submit_tag "Continue", class: "govuk-button" %>
+  <% end %>
+<% end %>

--- a/app/views/schools/core_programme/materials/success.html.erb
+++ b/app/views/schools/core_programme/materials/success.html.erb
@@ -1,0 +1,3 @@
+<%= govuk_panel title: "Your choice of training materials for the #{@cohort.start_year} cohort has been saved", body: nil, classes: "govuk-!-margin-bottom-8" %>
+
+<%= govuk_link_to "Back to #{@cohort.start_year}", schools_cohort_path(@cohort.start_year) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get "/check-account", to: "check_account#show"
 
   resource :cookies, only: %i[show update]
-  resource :privacy_policy, only: %i[show update], path: 'privacy-policy'
+  resource :privacy_policy, only: %i[show update], path: "privacy-policy"
   resource :accessibility_statement, only: :show, path: "accessibility-statement"
   resource :dashboard, controller: :dashboard, only: :show
   resource :supplier_dashboard, controller: :supplier_dashboard, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get "/check-account", to: "check_account#show"
 
   resource :cookies, only: %i[show update]
-  resource :privacy_policy, only: %i[show update]
+  resource :privacy_policy, only: %i[show update], path: 'privacy-policy'
   resource :accessibility_statement, only: :show, path: "accessibility-statement"
   resource :dashboard, controller: :dashboard, only: :show
   resource :supplier_dashboard, controller: :supplier_dashboard, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get "/check-account", to: "check_account#show"
 
   resource :cookies, only: %i[show update]
-  resource :privacy_policy, only: %i[show]
+  resource :privacy_policy, only: %i[show update]
   resource :accessibility_statement, only: :show, path: "accessibility-statement"
   resource :dashboard, controller: :dashboard, only: :show
   resource :supplier_dashboard, controller: :supplier_dashboard, only: :show

--- a/db/migrate/20210414125405_add_privacy_policy_to_users.rb
+++ b/db/migrate/20210414125405_add_privacy_policy_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrivacyPolicyToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :privacy_policy_acceptance, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_182348) do
+ActiveRecord::Schema.define(version: 2021_04_14_125405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -291,6 +291,7 @@ ActiveRecord::Schema.define(version: 2021_04_07_182348) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
+    t.json "privacy_policy_acceptance"
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -6,23 +6,29 @@ require_relative "../../../app/mailers/user_mailer"
 module Devise
   module Strategies
     class PasswordlessAuthenticatable < Authenticatable
+      class Error < StandardError; end
+      class EmailNotFoundError < Error; end
+      class LoginIncompleteError < Error; end
+
       def authenticate!
         if params[:user].present?
           user = User.find_by(email: params[:user][:email])
 
-          if user&.update(
+          result = user&.update(
             login_token: SecureRandom.hex(10),
-            login_token_valid_until: 60.minutes.from_now)
+            login_token_valid_until: 60.minutes.from_now,
+          )
 
+          if result
             url = Rails.application.routes.url_helpers.users_confirm_sign_in_url(
               login_token: user.login_token,
               host: Rails.application.config.domain,
             )
 
             UserMailer.sign_in_email(user, url).deliver_now
-            raise Users::SessionsController::LoginIncompleteError
+            raise LoginIncompleteError
           else
-            raise Users::SessionsController::EmailNotFoundError
+            raise EmailNotFoundError
           end
         end
       end

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -8,7 +8,7 @@ Given("scenario {string} has been run", (scenario) => cy.appScenario(scenario));
 const pagePaths = {
   cookie: "/cookies",
   start: "/",
-  privacy: "/privacy_policy",
+  privacy: "/privacy-policy",
   accessibility: "/accessibility-statement",
   "check account": "/check-account",
   "admin schools": "/admin/schools",

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     full_name { Faker::Name.name }
     login_token { Faker::Alphanumeric.alpha(number: 10) }
     login_token_valid_until { 1.hour.from_now }
+    privacy_policy_acceptance { { accepted_at: 1.hour.ago, version: "1.0" } }
 
     trait :admin do
       admin_profile { build(:admin_profile) }

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe "Cookies API", type: :request do
     context "from a different page" do
       it "sets the session[:return_to] as previous url" do
         get privacy_policy_path
-        expect(session[:return_to]).to eq("http://www.example.com/privacy_policy")
+        expect(session[:return_to]).to eq("http://www.example.com/privacy-policy")
         get cookies_path
-        expect(session[:return_to]).to eq("http://www.example.com/privacy_policy")
+        expect(session[:return_to]).to eq("http://www.example.com/privacy-policy")
       end
     end
 

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -31,6 +31,21 @@ module TaskExampleGroup
   def to_task_arguments(*task_args)
     Rake::TaskArguments.new(task.arg_names, task_args)
   end
+
+  def capture_output
+    stdout = $stdout
+    $stdout = StringIO.new
+    stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    {
+      stdout: $stdout.string,
+      stderr: $stderr.string,
+    }
+  ensure
+    $stdout = stdout
+    $stderr = stderr
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/tasks/manage_admins_spec.rb
+++ b/spec/tasks/manage_admins_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe "rake admin:create", type: :task do
     url = "http://www.example.com/users/sign_in"
     expect(AdminProfile).to receive(:create_admin).with(name, email, url)
 
-    task.execute(to_task_arguments(name, email))
+    capture_output { task.execute(to_task_arguments(name, email)) }
   end
 end


### PR DESCRIPTION
### Context

Implements: https://trello.com/c/yZsndlKq/460-add-privacy-policy-interstitial-page-to-first-sign-in-journey-for-induction-tutor

This PR ensures user must read (or rather be presented an opportunity to read) privacy policy before accessing any of the page. This satisfies acceptance criteria of user being presented Privacy Policy after the first sign up, but also prevents user from skipping the acceptance and provides a hook for re-acceptance on policy change.

### Changes proposed in this pull request

PP Acceptance data is stored on new `privacy_policy_acceptance` column. I've decided on json for now, as there is no point of creating two new columns, especially given the changes in the next PP task: https://trello.com/c/MwoYUPCi/507-store-privacypolicy-versions-in-the-database.

### Guidance to review

The check is implemented in global before_action, which caused a bit of friction with our passwordless authentication method, as `current_user` throwing exceptions (`SignInIncomplete`)in the `session_controller` which is why I've decided to skip that `before_action` in this controller. I've attempted into fixing `current_user` to return `nil` instead but this has somehow broken the warden strategy and decided not to follow the white rabbit on this occasion.

NOTE: I have confirmed that the copy on the card (attached png file) is not a copy designed for this system but example of similar page implemented on another service. The copy displayed should be identical to our current `/privacy_policy` page.

### Testing

Log in as any user and try accessing any path - you will be redirected to `/privacy_policy`. Upon clicking `continue` your user record will be updated with acceptance information and you will be allowed to see any other page you'd normally expect to have access to. The `/privacy_policy` should not display the `continue` button once the policy is approved.