### PR TITLE
specs for choose programme advisory page

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -25,7 +25,7 @@ private
     )
 
     unless @school_cohort
-      redirect_to schools_choose_programme_path
+      redirect_to advisory_schools_choose_programme_path
     end
   end
 end

--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -4,6 +4,11 @@ class Schools::ChooseProgrammeController < Schools::BaseController
   skip_after_action :verify_authorized
   skip_after_action :verify_policy_scoped
 
+  def advisory
+    school = current_user.induction_coordinator_profile.schools.first
+    redirect_to helpers.profile_dashboard_url(current_user) if school.chosen_programme?(Cohort.current)
+  end
+
   def show
     school = current_user.induction_coordinator_profile.schools.first
 

--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -3,20 +3,12 @@
 class Schools::ChooseProgrammeController < Schools::BaseController
   skip_after_action :verify_authorized
   skip_after_action :verify_policy_scoped
+  before_action :verify_programme_chosen, only: %i[advisory show]
 
-  def advisory
-    school = current_user.induction_coordinator_profile.schools.first
-    redirect_to helpers.profile_dashboard_url(current_user) if school.chosen_programme?(Cohort.current)
-  end
+  def advisory; end
 
   def show
-    school = current_user.induction_coordinator_profile.schools.first
-
-    if school.chosen_programme?(Cohort.current)
-      redirect_to helpers.profile_dashboard_url(current_user)
-    else
-      @induction_choice_form = InductionChoiceForm.new
-    end
+    @induction_choice_form = InductionChoiceForm.new
   end
 
   def create
@@ -34,5 +26,12 @@ class Schools::ChooseProgrammeController < Schools::BaseController
     )
 
     redirect_to helpers.profile_dashboard_url(current_user)
+  end
+
+private
+
+  def verify_programme_chosen
+    school = current_user.induction_coordinator_profile.schools.first
+    redirect_to helpers.profile_dashboard_url(current_user) if school.chosen_programme?(Cohort.current)
   end
 end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -17,7 +17,7 @@ private
 
     # This will need to be updated when more than one cohort is supported
     unless @school_cohorts[0]
-      redirect_to schools_choose_programme_path
+      redirect_to advisory_schools_choose_programme_path
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,7 +16,7 @@ private
   def induction_coordinator_dashboard_url(user)
     school = user.induction_coordinator_profile.schools.first
 
-    return schools_choose_programme_url unless school.chosen_programme?(Cohort.current)
+    return advisory_schools_choose_programme_url unless school.chosen_programme?(Cohort.current)
 
     schools_dashboard_url
   end

--- a/app/views/schools/choose_programme/advisory.html.erb
+++ b/app/views/schools/choose_programme/advisory.html.erb
@@ -14,5 +14,5 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>use the DfE accredited training materials</li>
       </ul>
-      <p class="govuk-body">Not sure> Check our guidance on <%= govuk_link_to "induction programmes for early career teacher.", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %></p>
+      <p class="govuk-body">Not sure? Check our guidance on <%= govuk_link_to "induction programmes for early career teacher.", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %></p>
       <%= govuk_link_to("Continue", schools_choose_programme_path, button: true)  %>

--- a/app/views/schools/choose_programme/advisory.html.erb
+++ b/app/views/schools/choose_programme/advisory.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Check guidance" %
+<% content_for :title, "Check guidance" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Do you know how you want to run your statutory induction programme?</h1>

--- a/app/views/schools/choose_programme/advisory.html.erb
+++ b/app/views/schools/choose_programme/advisory.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Check guidance" %
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Do you know how you want to run your statutory induction programme?</h1>

--- a/app/views/schools/choose_programme/advisory.html.erb
+++ b/app/views/schools/choose_programme/advisory.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: root_url) # what is the back path here, could we use an internal referer helper?
+%>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Do you know how you want to run your statutory induction programme?</h1>
+      <p class="govuk-body">You will be choosing a programme for any new early career teachers. They will complete this programme over 2 years.</p>
+      <p class="govuk-body">Only use this service if your school wants to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>use an approved training provider</li>
+      </ul>
+      <p class="govuk-body">Or</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>use the DfE accredited training materials</li>
+      </ul>
+      <p class="govuk-body">Not sure> Check our guidance on <%= govuk_link_to "induction programmes for early career teacher.", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %></p>
+      <%= govuk_link_to("Continue", schools_choose_programme_path, button: true)  %>

--- a/app/views/schools/choose_programme/advisory.html.erb
+++ b/app/views/schools/choose_programme/advisory.html.erb
@@ -1,18 +1,16 @@
-<% content_for :before_content, govuk_back_link(
-  text: "Back",
-  href: root_url) # what is the back path here, could we use an internal referer helper?
-%>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Do you know how you want to run your statutory induction programme?</h1>
-      <p class="govuk-body">You will be choosing a programme for any new early career teachers. They will complete this programme over 2 years.</p>
-      <p class="govuk-body">Only use this service if your school wants to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>use an approved training provider</li>
-      </ul>
-      <p class="govuk-body">Or</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>use the DfE accredited training materials</li>
-      </ul>
-      <p class="govuk-body">Not sure? Check our guidance on <%= govuk_link_to "induction programmes for early career teacher.", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %></p>
-      <%= govuk_link_to("Continue", schools_choose_programme_path, button: true)  %>
+    <p class="govuk-body">You will be choosing a programme for any new early career teachers. They will complete this programme over 2 years.</p>
+    <p class="govuk-body">Only use this service if your school wants to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>use an approved training provider</li>
+    </ul>
+    <p class="govuk-body">Or</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>use the DfE accredited training materials</li>
+    </ul>
+    <p class="govuk-body">Not sure? Check our guidance on <%= govuk_link_to "induction programmes for early career teacher.", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %></p>
+    <%= govuk_link_to("Continue", schools_choose_programme_path, button: true)  %>
+  </div>
+</div>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: advisory_schools_choose_programme_path)
+%>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Welcome</h1>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Choose Programme" %>
 <% content_for :before_content, govuk_back_link(
   text: "Back",
   href: advisory_schools_choose_programme_path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,11 @@ Rails.application.routes.draw do
 
   namespace :schools do
     resource :dashboard, controller: :dashboard, only: :show, path: "/"
-    resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme"
+    resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme" do
+      member do
+        get "advisory"
+      end
+    end
     resources :cohorts, only: :show do
       resources :partnerships, only: :index
       member do

--- a/spec/cypress/integration/schools/ChooseProgramme.feature
+++ b/spec/cypress/integration/schools/ChooseProgramme.feature
@@ -2,9 +2,13 @@ Feature: Induction tutors choosing programmes
   Induction tutors should be able to choose between the Full and Core
   induction programmes for their school and view cohorts and tasks
 
-  Background: 
+  Background:
     Given cohort was created with start_year "2021"
     And I am logged in as an "induction_coordinator"
+    Then I should be on "choose programme advisory" page
+    And the page should be accessible
+
+    When I click on "link" containing "Continue"
     Then I should be on "choose programme" page
     And the page should be accessible
 

--- a/spec/cypress/integration/schools/ViewPartnerships.feature
+++ b/spec/cypress/integration/schools/ViewPartnerships.feature
@@ -2,8 +2,12 @@ Feature: Induction tutors viewing partnerships
   Induction tutors should be able to view details of their school partnership
 
   Background:
-    Given cohort was created with start_year "2021"
+   Given cohort was created with start_year "2021"
     And I am logged in as an "induction_coordinator"
+    Then I should be on "choose programme advisory" page
+    And the page should be accessible
+
+    When I click on "link" containing "Continue"
     Then I should be on "choose programme" page
     And the page should be accessible
 

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -38,6 +38,7 @@ const pagePaths = {
   "new lead provider user review": "/admin/suppliers/users/new/review",
   "lead provider user delete": /\/lead-providers\/users\/.*\/delete/,
   "choose programme": "/schools/choose-programme",
+  "choose programme advisory": "/schools/choose-programme/advisory",
   schools: "/schools",
   "2021 school cohorts": "/schools/cohorts/2021",
   "2021 school partnerships": "/schools/cohorts/2021/partnerships",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "returns schools/choose-programme for induction coordinators" do
-      expect(helper.profile_dashboard_url(induction_coordinator)).to eq("http://test.host/schools/choose-programme")
+      expect(helper.profile_dashboard_url(induction_coordinator)).to eq("http://test.host/schools/choose-programme/advisory")
     end
 
     context "when a school has chosen a programme" do

--- a/spec/requests/schools/choose_programme_spec.rb
+++ b/spec/requests/schools/choose_programme_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe "Schools::ChooseProgramme", type: :request do
     end
   end
 
+  describe "GET /schools/choose-programme/advisory" do
+    it "renders the choose programme advisory template" do
+      get "/schools/choose-programme/advisory"
+
+      expect(response).to render_template("schools/choose_programme/advisory")
+    end
+
+    context "when the school has chosen provision" do
+      before do
+        SchoolCohort.create!(school: school, cohort: cohort, induction_programme_choice: "full_induction_programme")
+      end
+
+      it "redirects to the dashboard" do
+        get "/schools/choose-programme/advisory"
+
+        expect(response).to redirect_to("/schools")
+      end
+    end
+  end
+
   describe "POST /schools/choose-programme" do
     it "should show an error if nothing is selected" do
       post "/schools/choose-programme", params: { induction_choice_form: { programme_choice: "" } }

--- a/spec/requests/schools/dashboard_spec.rb
+++ b/spec/requests/schools/dashboard_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Schools::Dashboard", type: :request do
     it "should redirect to programme selection if programme not chosen" do
       get "/schools"
 
-      expect(response).to redirect_to("/schools/choose-programme")
+      expect(response).to redirect_to("/schools/choose-programme/advisory")
     end
 
     context "when the programme has been chosen" do

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Users::Sessions", type: :request do
 
       it "redirects to dashboard on successful login" do
         post "/users/sign_in_with_token", params: { login_token: user.login_token }
-        expect(response).to redirect_to(schools_choose_programme_path)
+        expect(response).to redirect_to(advisory_schools_choose_programme_path)
       end
     end
 


### PR DESCRIPTION
### Context
Trello #486
We need to have a speed bump advisory page prior to the /schools/choose-programme page 
### Changes proposed in this pull request
controller method, route and view for /schools/choose-programme/advisory
### Guidance to review
Login as induction coordinator without having chosen a programme....navigate to /schools/choose-programme/advisory
### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
