### PR TITLE
Adding instructions for reviewers on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,5 @@
 ### Review Checks
 - [ ] All pages have automated accessibility checks via cypress
 - [ ] All `School` queries are correctly scoped - `eligible` when they need to be
+
+### How can I view this in a review app?


### PR DESCRIPTION
We need to make it easy for non-developer reviewers (for example POs or URs) to
review the changes in PRs.

This last section can include a link to the exact place where the change can be
viewed and also instructions on how to get to that page with the right test
email or any other change/selection you have to do to view it.