### PR TITLE
specs for accessibility statement page

### DIFF
--- a/app/controllers/accessibility_statements_controller.rb
+++ b/app/controllers/accessibility_statements_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AccessibilityStatementsController < ApplicationController
+  def show; end
+end

--- a/app/views/accessibility_statements/show.html.erb
+++ b/app/views/accessibility_statements/show.html.erb
@@ -50,6 +50,5 @@
     <p class="govuk-body">All parts of the chosen journeys were tested.</p>
     <p class="govuk-body">Journeys were chosen based on a number of factors, including risk assessments and subject matter.</p>
     <p class="govuk-body">We will have an external accessibility audit carried out by the end of September 2021.</p>
-
-
-
+  </div>
+</div>

--- a/app/views/accessibility_statements/show.html.erb
+++ b/app/views/accessibility_statements/show.html.erb
@@ -1,0 +1,55 @@
+<% content_for :title, "Accessibility statement for the Manage training for early career teachers service" %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: :back) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Accessibility statement for Manage training for early career teachers service</h1>
+    <p class="govuk-body">This statement applies to the Manage training for early career teachers service.</p>
+    <p class="govuk-body">This service is run by the Department for Education. We want as many people as possible to be able to use it. You should be able to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>change colours, contrast levels and fonts</li>
+      <li>zoom in up to 300% without the text spillin of the screen</li>
+      <li>navigate most of the service using just a keyboard</li>
+      <li>navigate most of the service using speech recognition software</li>
+      <li>listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+    </ul>
+    <p class="govuk-body">We have also made the service text as simple as possible to understand.</p>
+    <p class="govuk-body"><%= govuk_link_to 'AbilityNet', "https://mcmw.abilitynet.org.uk/" %> has advice on making your device easier to use if you have an access need.</p>
+
+    <h2 class="govuk-heading-l">How accessible this service is</h2>
+    <p class="govuk-body">All parts of this service are fully accessible.</p>
+
+    <h2 class="govuk-heading-l">Reporting accessibility problems with this service</h2>
+    <p class="govuk-body">We are always looking to improve the accessibility of this service.</p>
+    <p class="govuk-body">If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:</p>
+    <p class="govuk-body">Email:<br>
+    <%= render MailToSupportComponent.new %></p>
+    <p class="govuk-body"><%= govuk_link_to 'Read tips on contacting organisations about inaccessible websites', "http://www.w3.org/WAI/users/inaccessible" %></p>
+
+    <h2 class="govuk-heading-l">Enforcement procedure</h2>
+    <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').</p>
+    <p class="govuk-body">If you are not happy with how we respond to your complaint, <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS)', "https://www.equalityadvisoryservice.com/" %></p>
+
+    <h2 class="govuk-heading-l">Technical information about this service’s accessibility</h2>
+    <p class="govuk-body">The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No.2) Accessibility Regulations 2018.</p>
+
+    <h2 class="govuk-heading-l">Compliance status</h2>
+    <p class="govuk-body">This service is fully compliant with the <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard.', "https://www.w3.org/TR/WCAG21/" %>
+    <p class="govuk-body">There may be accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.</p>
+
+    <h3 class="govuk-heading-m">Disproportionate burden</h3>
+    <p class="govuk-body">Not applicable</p>
+
+    <h3 class="govuk-heading-m">Content not within scope of this accessibility statement</h3>
+    <p class="govuk-body">Not applicable</p>
+
+    <h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
+    <p class="govuk-body">This statement was prepared on 16 April 2021.</p>
+    <p class="govuk-body">The service was last tested on 1 April 2021 for compliance with WCAG 2.1 AA.</p>
+    <p class="govuk-body">Testing was carried out internally by the Department for Education.</p>
+    <p class="govuk-body">We tested the service based on a user's ability to complete key journeys.</p>
+    <p class="govuk-body">All parts of the chosen journeys were tested.</p>
+    <p class="govuk-body">Journeys were chosen based on a number of factors, including risk assessments and subject matter.</p>
+    <p class="govuk-body">We will have an external accessibility audit carried out by the end of September 2021.</p>
+
+
+

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -6,4 +6,7 @@
   <li class="govuk-footer__inline-list-item">
     <%= link_to "Cookies", cookies_path, class: "govuk-footer__link" %>
   </li>
+  <li class="govuk-footer__inline-list-item">
+    <%= link_to "Accessibility", accessibility_statement_path, class: "govuk-footer__link" %>
+  </li>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   resource :cookies, only: %i[show update]
   resource :privacy_policy, only: %i[show]
-  resource :accessibility_statement, only: %i[show], path: "accessibility-statement"
+  resource :accessibility_statement, only: :show, path: "accessibility-statement"
   resource :dashboard, controller: :dashboard, only: :show
   resource :supplier_dashboard, controller: :supplier_dashboard, only: :show
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
   resource :cookies, only: %i[show update]
   resource :privacy_policy, only: %i[show]
+  resource :accessibility_statement, only: %i[show], path: "accessibility-statement"
   resource :dashboard, controller: :dashboard, only: :show
   resource :supplier_dashboard, controller: :supplier_dashboard, only: :show
 

--- a/spec/cypress/integration/AccessibilityStatement.feature
+++ b/spec/cypress/integration/AccessibilityStatement.feature
@@ -1,0 +1,6 @@
+Feature: Accessibility statement page
+  Scenario: Visiting the accessibility statement policy page
+    Given I am on "start" page
+    When I click on "link" containing "Accessibility"
+    Then I should be on "accessibility" page
+    And the page should be accessible

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -9,6 +9,7 @@ const pagePaths = {
   cookie: "/cookies",
   start: "/",
   privacy: "/privacy_policy",
+  accessibility: "/accessibility-statement",
   "check account": "/check-account",
   "admin schools": "/admin/schools",
   "admin index": "/admin/administrators",

--- a/spec/requests/accessibility_statement_spec.rb
+++ b/spec/requests/accessibility_statement_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Accessibility statement", type: :request do
+  describe "GET /accessibility-statement" do
+    it "should show the assessment statement" do
+      get accessibility_statement_path
+
+      expect(response).to render_template :show
+      expect(response.body).to include("Accessibility statement for Manage training for early career teachers service")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Trello #284
We need to add an accessibility statement page available from a link the footer
### Changes proposed in this pull request

### Guidance to review
Click on Accessibility link in footer
### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
