### PR TITLE
Change nomination email lifespan to 21 days

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -4,7 +4,7 @@ class SchoolMailer < ApplicationMailer
   NOMINATION_EMAIL_TEMPLATE = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
   NOMINATION_CONFIRMATION_EMAIL_TEMPLATE = "240c5685-5cb0-40a9-9bd4-1a595d991cbc"
 
-  def nomination_email(recipient:, reference:, school_name:, nomination_url:)
+  def nomination_email(recipient:, reference:, school_name:, nomination_url:, expiry_date:)
     template_mail(
       NOMINATION_EMAIL_TEMPLATE,
       to: recipient,
@@ -14,6 +14,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         school_name: school_name,
         nomination_link: nomination_url,
+        expiry_date: expiry_date,
       },
     )
   end

--- a/app/models/nomination_email.rb
+++ b/app/models/nomination_email.rb
@@ -3,7 +3,7 @@
 class NominationEmail < ApplicationRecord
   belongs_to :school
 
-  NOMINATION_EXPIRY_TIME = 7.days
+  NOMINATION_EXPIRY_TIME = 21.days
 
   def expired?
     !sent_within_last?(NOMINATION_EXPIRY_TIME)

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -23,6 +23,7 @@ class InviteSchools
         nomination_email.sent_to,
         nomination_email.token,
         school.name,
+        email_expiry_date,
       )
     rescue StandardError
       logger.info "Error emailing school, urn: #{urn} ... skipping"
@@ -36,12 +37,13 @@ class InviteSchools
 
 private
 
-  def send_nomination_email(recipient, token, school_name)
+  def send_nomination_email(recipient, token, school_name, email_expiry_date)
     SchoolMailer.nomination_email(
       recipient: recipient,
       reference: token,
       school_name: school_name,
       nomination_url: nomination_url(token),
+      expiry_date: email_expiry_date,
     ).deliver_now
   end
 
@@ -61,6 +63,10 @@ private
       token: token,
       host: Rails.application.config.domain,
     )
+  end
+
+  def email_expiry_date
+    NominationEmail::NOMINATION_EXPIRY_TIME.from_now.strftime("%d/%m/%Y")
   end
 
   def logger

--- a/app/views/nominations/request_nomination_invite/success.html.erb
+++ b/app/views/nominations/request_nomination_invite/success.html.erb
@@ -7,7 +7,7 @@
     <h2 class="govuk-heading-m">What happens next</h2>
     <ul class="govuk-list govuk-list--bullet">
       <li>your school will receive an email with a link to nominate an induction tutor</li>
-      <li>this link will expire in 7 days</li>
+      <li>this link will expire in 21 days</li>
       <li>
         we cannot disclose the email address. It will be an administration email, for example, office@, admin@ or head@
       </li>

--- a/spec/factories/nomination_email.rb
+++ b/spec/factories/nomination_email.rb
@@ -8,7 +8,12 @@ FactoryBot.define do
     school { build(:school, name: "Nominated School", primary_contact_email: "primary-contact-email@example.com") }
 
     trait :expired_nomination_email do
-      sent_at { 1.year.ago }
+      sent_at { 22.days.ago }
+      school { build(:school, :with_local_authority, name: "Nominated School", primary_contact_email: "primary-contact-email@example.com") }
+    end
+
+    trait :nearly_expired_nomination_email do
+      sent_at { 20.days.ago }
       school { build(:school, :with_local_authority, name: "Nominated School", primary_contact_email: "primary-contact-email@example.com") }
     end
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SchoolMailer, type: :mailer do
         nomination_url: nomination_url,
         reference: token,
         school_name: "Great Ouse Academy",
+        expiry_date: "1/1/2000",
       ).deliver_now
     end
 

--- a/spec/models/nomination_email_spec.rb
+++ b/spec/models/nomination_email_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe NominationEmail, type: :model do
     end
   end
 
+  describe "nearly expired email" do
+    let!(:nearly_expired_nomination_email) { create(:nomination_email, :nearly_expired_nomination_email) }
+
+    it "is not expired" do
+      expect(nearly_expired_nomination_email.expired?).to eq false
+    end
+
+    it "expires when time passes" do
+      travel_to 2.days.from_now
+
+      expect(nearly_expired_nomination_email.expired?).to eq true
+    end
+  end
+
   describe "not expired email" do
     let(:new_nomination_email) { create(:nomination_email) }
 

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -41,13 +41,24 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
     end
 
     context "with an expired token" do
-      let(:nomination_email) { create(:nomination_email, sent_at: 6.weeks.ago) }
+      let(:nomination_email) { create(:nomination_email, :expired_nomination_email) }
       let(:token) { nomination_email.token }
 
       it "redirects to link-expired" do
         get "/nominations/start?token=#{token}"
 
         expect(response).to redirect_to("/nominations/link-expired?school_id=#{nomination_email.school.id}")
+      end
+    end
+
+    context "with a nearly expired token" do
+      let(:nomination_email) { create(:nomination_email, :nearly_expired_nomination_email) }
+      let(:token) { nomination_email.token }
+
+      it "renders the start nomination template" do
+        get "/nominations/start?token=#{token}"
+
+        expect(response).to render_template("nominations/nominate_induction_coordinator/start")
       end
     end
   end

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -32,12 +32,14 @@ RSpec.describe InviteSchools do
     end
 
     it "sends the nomination email" do
+      travel_to Time.utc("2000-1-1")
       expect(SchoolMailer).to receive(:nomination_email).with(
         hash_including(
           reference: String,
           school_name: String,
           nomination_url: String,
           recipient: school.primary_contact_email,
+          expiry_date: "22/01/2000",
         ),
       ).and_call_original
 


### PR DESCRIPTION
### Context
Per call just now, nomination emails should be valid for 21 days

### Changes proposed in this pull request
- Change nomination email lifetime to 21 days
- Add some extra tests around email expiry

### Guidance to review
 

### Testing
Unit tested

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
We can't change the notify email template for this email to show the expiry date until this code has been promoted through to staging, else nomination emails will stop working for UR. Once that has been done, a nomination email can be triggered as follows:
- From https://ecf-dev.london.cloudapps.digital/nominations/choose-location select "ZZ Test Local Authority"
- Select "ZZ Test School 1"
- Confirm, and receive email 