### PR TITLE
ECF-RP-501: Use notify id for callbacks on nomination emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Ruby 2.7.2
+-  Ruby 2.7.2
 - PostgreSQL
 - NodeJS 14.16.0
 - Yarn 1.12.x

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -6,11 +6,10 @@ class SchoolMailer < ApplicationMailer
   SCHOOL_PARTNERSHIP_NOTIFICATION_EMAIL_TEMPLATE = "99991fd9-fb41-48cf-846d-98a1fee7762a"
   COORDINATOR_PARTNERSHIP_NOTIFICATION_EMAIL_TEMPLATE = "076e8486-cbcc-44ee-8a6e-d2a721ee1460"
 
-  def nomination_email(recipient:, reference:, school_name:, nomination_url:, expiry_date:)
+  def nomination_email(recipient:, school_name:, nomination_url:, expiry_date:)
     template_mail(
       NOMINATION_EMAIL_TEMPLATE,
       to: recipient,
-      reference: reference,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -113,7 +113,7 @@ class School < ApplicationRecord
     if induction_coordinators.any?
       induction_coordinators.first.email
     else
-      primary_contact_email || secondary_contact_email
+      primary_contact_email.presence || secondary_contact_email
     end
   end
 

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -34,13 +34,14 @@ class InviteSchools
 private
 
   def send_nomination_email(nomination_email)
-    SchoolMailer.nomination_email(
+    notify_id = SchoolMailer.nomination_email(
       recipient: nomination_email.sent_to,
-      reference: nomination_email.token,
       school_name: nomination_email.school.name,
       nomination_url: nomination_email.nomination_url,
       expiry_date: email_expiry_date,
-    ).deliver_now
+    ).deliver_now.delivery_method.response.id
+
+    nomination_email.update!(notify_id: notify_id)
   end
 
   def email_expiry_date

--- a/db/migrate/20210415163231_add_notify_fields_to_nomination_email.rb
+++ b/db/migrate/20210415163231_add_notify_fields_to_nomination_email.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddNotifyFieldsToNominationEmail < ActiveRecord::Migration[6.1]
+  def change
+    change_table :nomination_emails, bulk: true do
+      add_column :nomination_emails, :notify_id, :string
+      add_column :nomination_emails, :delivered_at, :datetime
+    end
+
+    add_index :nomination_emails, :notify_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -176,6 +176,9 @@ ActiveRecord::Schema.define(version: 2021_04_19_142255) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "partnership_notification_email_id"
+    t.string "notify_id"
+    t.datetime "delivered_at"
+    t.index ["notify_id"], name: "index_nomination_emails_on_notify_id"
     t.index ["partnership_notification_email_id"], name: "index_nomination_emails_on_partnership_notification_email_id"
     t.index ["school_id"], name: "index_nomination_emails_on_school_id"
     t.index ["token"], name: "index_nomination_emails_on_token", unique: true

--- a/spec/factories/nomination_email.rb
+++ b/spec/factories/nomination_email.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     sent_to { "John-Doe@example.com" }
     sent_at { Time.zone.now }
     school { build(:school, urn: "0922081", name: "Nominated School", primary_contact_email: "primary-contact-email@example.com", address_line1: "50 Olivia Drive", postcode: "CV37 9HE") }
+    notify_id { Faker::Internet.uuid }
 
     trait :expired_nomination_email do
       sent_at { 22.days.ago }

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -4,15 +4,13 @@ require "rails_helper"
 
 RSpec.describe SchoolMailer, type: :mailer do
   describe "#nomination_email" do
-    let(:token) { "fedd83c06d5747f1" }
     let(:primary_contact_email) { "contact@example.com" }
-    let(:nomination_url) { "https://ecf-dev.london.cloudapps/nominations?token=#{token}" }
+    let(:nomination_url) { "https://ecf-dev.london.cloudapps/nominations?token=abc123" }
 
     let(:nomination_email) do
       SchoolMailer.nomination_email(
         recipient: primary_contact_email,
         nomination_url: nomination_url,
-        reference: token,
         school_name: "Great Ouse Academy",
         expiry_date: "1/1/2000",
       ).deliver_now

--- a/spec/requests/api/notify_callback_spec.rb
+++ b/spec/requests/api/notify_callback_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Nominations::NotifyCallbacks", type: :request do
 
       it "updates matching nomination email" do
         post "/api/notify-callback", params: {
-          reference: nomination_email.token,
+          id: nomination_email.notify_id,
           status: "failed",
         }
 

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe InviteSchools do
       travel_to Time.utc("2000-1-1")
       expect(SchoolMailer).to receive(:nomination_email).with(
         hash_including(
-          reference: String,
           school_name: String,
           nomination_url: String,
           recipient: school.primary_contact_email,
@@ -52,7 +51,6 @@ RSpec.describe InviteSchools do
       it "sends the nomination email to the secondary contact" do
         expect(SchoolMailer).to receive(:nomination_email).with(
           hash_including(
-            reference: String,
             school_name: String,
             nomination_url: String,
             recipient: school.secondary_contact_email,


### PR DESCRIPTION
### Context
Per this comment: https://github.com/DFE-Digital/early-careers-framework/pull/248#discussion_r615936569

### Changes proposed in this pull request
- Change nomination emails callback to use notify id
- Record delivered_at for nomination emails

### Guidance to review

### Testing
Unit tests

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
N/A