### PR TITLE
[ECF-1-513] Remove back button from choose location

### DIFF
--- a/app/views/nominations/request_nomination_invite/choose_location.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_location.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, "Search school location" %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: root_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Context
Removed back button from the Resend nomination: search location page

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
No new seed data needed
Go to: https://ecf-review-pr-265.london.cloudapps.digital/
/nominations/limit-reached
/nominations/choose-location
/nominations/not-eligible
and confirm these don't have a back button.
