### PR TITLE
Add link to support email in footer

### DIFF
--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -1,9 +1,7 @@
 <h2 class="govuk-heading-m">Support and guidance</h2>
 <p class="govuk-body-s">
   If you have a question, or you've had a problem using this service, please contact us at
-  <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-footer__link">
-    continuing-professional-development@digital.education.gov.uk
-  </a>
+  <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>
 </p>
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -1,4 +1,10 @@
-<h2 class="govuk-visually-hidden">Support links</h2>
+<h2 class="govuk-heading-m">Support and guidance</h2>
+<p class="govuk-body-s">
+  If you have a question, or you've had a problem using this service, please contact us at
+  <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-footer__link">
+    continuing-professional-development@digital.education.gov.uk
+  </a>
+</p>
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
     <%= link_to "Privacy", privacy_policy_path, class: "govuk-footer__link" %>


### PR DESCRIPTION
### Context

https://trello.com/c/zhtQRj3L/532-add-link-support-email-address-to-footer-of-all-pages

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

It's in the footer of every page