### PR TITLE
ECF-RP-523: Report schools

### DIFF
--- a/app/controllers/lead_providers/report_schools_controller.rb
+++ b/app/controllers/lead_providers/report_schools_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module LeadProviders
+  class ReportSchoolsController < ::LeadProviders::BaseController
+    def start; end
+  end
+end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="index-group">
           <h2 class="govuk-heading-m">
-            <%= govuk_link_to "Check your schools for #{@lead_provider.cohorts.find_by(start_year: Time.zone.now.year)&.start_year}", lead_providers_your_schools_path(selected_cohort_id: @lead_provider.cohorts.find_by(start_year: Time.zone.now.year)&.id) %>
+            <%= govuk_link_to "Check your schools for #{@lead_provider.cohorts.current.display_name}", lead_providers_your_schools_path(selected_cohort_id: @lead_provider.cohorts.current.id) %>
           </h2>
           <p class="govuk-body">See which schools have added their early career teachers and mentors.</p>
         </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -7,8 +7,7 @@
         </h1>
         <div class="index-group">
           <h2 class="govuk-heading-m">
-<!--            TODO Fix after Ethan code merge for lead providers-->
-            <%= govuk_link_to "Find and add schools", nil %>
+            <%= govuk_link_to "Find and add schools", start_lead_providers_report_schools_path %>
           </h2>
           <p class="govuk-body">Search for schools you want to recruit and add schools you have partnered with.</p>
         </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="index-group">
           <h2 class="govuk-heading-m">
-            <%= govuk_link_to "Check your schools for #{@lead_provider.cohorts.find_by(start_year: Time.zone.now.year).start_year}", lead_providers_your_schools_path(selected_cohort_id: @lead_provider.cohorts.find_by(start_year: Time.zone.now.year).id) %>
+            <%= govuk_link_to "Check your schools for #{@lead_provider.cohorts.find_by(start_year: Time.zone.now.year)&.start_year}", lead_providers_your_schools_path(selected_cohort_id: @lead_provider.cohorts.find_by(start_year: Time.zone.now.year)&.id) %>
           </h2>
           <p class="govuk-body">See which schools have added their early career teachers and mentors.</p>
         </div>

--- a/app/views/lead_providers/report_schools/start.html.erb
+++ b/app/views/lead_providers/report_schools/start.html.erb
@@ -3,8 +3,6 @@
     <h1 class="govuk-heading-xl">You can only confirm schools for the cohort that starts in the next academic year
       (<%= Cohort.current.display_name %>).</h1>
 
-    <p>To report a school to the current academic year, contact DfE support.</p>
-
-    <%= govuk_link_to "Continue", '#', class: 'govuk-button' %>
+    <%= govuk_link_to "Continue", '#', button: true%>
   </div>
 </div>

--- a/app/views/lead_providers/report_schools/start.html.erb
+++ b/app/views/lead_providers/report_schools/start.html.erb
@@ -1,7 +1,19 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render TabsComponent.new do |component| %>
+      <%= component.tab(path: dashboard_path) do %>
+        <strong>Overview</strong>
+      <% end %>
+      <%= component.tab(path: start_lead_providers_report_schools_path) do %>
+        <strong>Schools</strong>
+      <% end %>
+    <% end %>
+
     <h1 class="govuk-heading-xl">You can only confirm schools for the cohort that starts in the next academic year
       (<%= Cohort.current.display_name %>).</h1>
+
+    <p>If you want to add schools to your 2021 cohort after October 31st, you need to contact:
+      <%= render MailToSupportComponent.new %></p>
 
     <%= govuk_link_to "Continue", '#', button: true%>
   </div>

--- a/app/views/lead_providers/report_schools/start.html.erb
+++ b/app/views/lead_providers/report_schools/start.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      You can only report schools you've recruited for the cohort that starts in the next academic year (2021)
+    </h1>
+
+    <p>
+      To report a school to the current academic year, contact DfE support.
+    </p>
+
+    <%= govuk_link_to "Continue", '#', class: 'govuk-button' %>
+  </div>
+</div>

--- a/app/views/lead_providers/report_schools/start.html.erb
+++ b/app/views/lead_providers/report_schools/start.html.erb
@@ -1,12 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      You can only report schools you've recruited for the cohort that starts in the next academic year (2021)
-    </h1>
+    <h1 class="govuk-heading-l">You can only report schools you've recruited for the cohort that starts in the next
+      academic year (<%= Cohort.current.display_name %>)</h1>
 
-    <p>
-      To report a school to the current academic year, contact DfE support.
-    </p>
+    <p>To report a school to the current academic year, contact DfE support.</p>
 
     <%= govuk_link_to "Continue", '#', class: 'govuk-button' %>
   </div>

--- a/app/views/lead_providers/report_schools/start.html.erb
+++ b/app/views/lead_providers/report_schools/start.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">You can only report schools you've recruited for the cohort that starts in the next
-      academic year (<%= Cohort.current.display_name %>)</h1>
+    <h1 class="govuk-heading-xl">You can only confirm schools for the cohort that starts in the next academic year
+      (<%= Cohort.current.display_name %>).</h1>
 
     <p>To report a school to the current academic year, contact DfE support.</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :lead_providers do
+  namespace :lead_providers, path: "lead-providers" do
     resources :your_schools, only: %i[index create]
     resources :school_details, only: %i[show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,10 @@ Rails.application.routes.draw do
   namespace :lead_providers do
     resources :your_schools, only: %i[index create]
     resources :school_details, only: %i[show]
+
+    resource :report_schools, path: "report-schools", only: [] do
+      get "start", action: :start
+    end
   end
 
   namespace :admin do

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -1,0 +1,4 @@
+Feature: Report Schools flow
+  Scenario: Visiting the start page
+    Given I am on "lead providers report schools start" page
+    Then the page should be accessible

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -7,5 +7,6 @@ Feature: Report Schools flow
     Given I am on "dashboard" page
     When I click on "link" containing "Find and add schools"
     Then I should be on "lead providers report schools start" page
+    And "page body" should contain "2021"
     And the page should be accessible
     And percy should be sent snapshot called "Lead provider report schools start page"

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -8,4 +8,4 @@ Feature: Report Schools flow
     When I click on "link" containing "Find and add schools"
     Then I should be on "lead providers report schools start" page
     And the page should be accessible
-    And percy should be sent snapshot
+    And percy should be sent snapshot called "Lead provider report schools start page"

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -1,4 +1,11 @@
 Feature: Report Schools flow
+  Background:
+    Given cohort was created with start_year "2021"
+    And I am logged in as a "lead_provider"
+
   Scenario: Visiting the start page
-    Given I am on "lead providers report schools start" page
-    Then the page should be accessible
+    Given I am on "dashboard" page
+    When I click on "link" containing "Find and add schools"
+    Then I should be on "lead providers report schools start" page
+    And the page should be accessible
+    And percy should be sent snapshot

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -60,6 +60,7 @@ const pagePaths = {
   schools: "/schools",
   "2021 school cohorts": "/schools/cohorts/2021",
   "2021 school partnerships": "/schools/cohorts/2021/partnerships",
+  "lead providers report schools start": "lead_providers/report-schools/start",
 };
 
 Given("I am on {string} page", (page) => {

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -19,6 +19,7 @@ const pagePaths = {
   start: "/",
   privacy: "/privacy-policy",
   accessibility: "/accessibility-statement",
+  dashboard: "/dashboard",
   "2021 cohort CIP materials info":
     "/schools/cohorts/2021/core-programme/materials/info",
   "2021 cohort CIP materials selection":
@@ -60,7 +61,7 @@ const pagePaths = {
   schools: "/schools",
   "2021 school cohorts": "/schools/cohorts/2021",
   "2021 school partnerships": "/schools/cohorts/2021/partnerships",
-  "lead providers report schools start": "lead_providers/report-schools/start",
+  "lead providers report schools start": "/lead-providers/report-schools/start",
 };
 
 Given("I am on {string} page", (page) => {

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :cohort do
-    start_year { Faker::Date.unique.between(from: "2020-01-01", to: "2099-12-31").year }
+    start_year { 2020 + Faker::Number.unique.between(from: 1, to: 79) }
   end
 end

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :cohort do
-    start_year { 2020 + Faker::Number.unique.between(from: 1, to: 79) }
+    start_year { Faker::Number.unique.between(from: 2021, to: 2100) }
   end
 end

--- a/spec/factories/lead_provider.rb
+++ b/spec/factories/lead_provider.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :lead_provider do
     name  { "Lead Provider" }
+    cohorts { Cohort.all }
   end
 end

--- a/spec/requests/lead_providers/report_schools_spec.rb
+++ b/spec/requests/lead_providers/report_schools_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Report schools spec", type: :request do
+  describe "GET /lead_providers/report-schools/start" do
+    it "should show the start page" do
+      get start_lead_providers_report_schools_path
+
+      expect(response).to render_template :start
+    end
+  end
+end

--- a/spec/requests/lead_providers/report_schools_spec.rb
+++ b/spec/requests/lead_providers/report_schools_spec.rb
@@ -3,8 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Report schools spec", type: :request do
+  let(:user) { create(:user, :lead_provider) }
+
   describe "GET /lead_providers/report-schools/start" do
-    it "should show the start page" do
+    it "should show the start page to a lead provider" do
+      sign_in user
       get start_lead_providers_report_schools_path
 
       expect(response).to render_template :start

--- a/spec/requests/lead_providers/report_schools_spec.rb
+++ b/spec/requests/lead_providers/report_schools_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe "Report schools spec", type: :request do
   let(:user) { create(:user, :lead_provider) }
 
+  before do
+    create(:cohort, start_year: 2021)
+  end
+
   describe "GET /lead-providers/report-schools/start" do
     it "should show the start page to a lead provider" do
       sign_in user

--- a/spec/requests/lead_providers/report_schools_spec.rb
+++ b/spec/requests/lead_providers/report_schools_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Report schools spec", type: :request do
   let(:user) { create(:user, :lead_provider) }
 
-  describe "GET /lead_providers/report-schools/start" do
+  describe "GET /lead-providers/report-schools/start" do
     it "should show the start page to a lead provider" do
       sign_in user
       get start_lead_providers_report_schools_path


### PR DESCRIPTION
### Context
We want the start page to the 'report schools' lead provider journey.

### Changes proposed in this pull request
Add a static page, controller, route, tests. Mostly as foundations for another multi-page flow. 

### Guidance to review
Lots of stuff is copy-pasted, so double check that naming makes sense. I'm also open to suggestions on how you would define the routes in this flow. 

### Testing
Added simple request specs and cucumber tests.

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Log in as `lead-provider@example.com`. Click 'Find and add schools'. You should see the start page. The button should do nothing. 