### PR TITLE
Removing missing bit of non-determinative data from percy tests

### DIFF
--- a/spec/cypress/app_commands/scenarios/admin/schools.rb
+++ b/spec/cypress/app_commands/scenarios/admin/schools.rb
@@ -3,7 +3,7 @@
 school = FactoryBot.create(:school, name: "Include this school", urn: 123_456)
 local_authority = FactoryBot.create(:local_authority)
 SchoolLocalAuthority.create!(school: school, local_authority: local_authority, start_year: 2021)
-FactoryBot.create(:user, :induction_coordinator, full_name: "Sarah Smith", schools: [school])
+FactoryBot.create(:user, :induction_coordinator, full_name: "Sarah Smith", email: "sarah.smith@example.com", schools: [school])
 
 Faker::UniqueGenerator.clear
 Faker::Config.random = Random.new(42)


### PR DESCRIPTION
### Context

Saw this failing on other pull requests.

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
