### PR TITLE
ECF-RP-548 pentest fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "foreman"
 gem "canonical-rails", ">= 0.2.11"
 
 gem "listen", ">= 3.0.5", "< 3.4"
+gem "rack-attack", ">=6.5.0"
 
 # GOV.UK Notify
 gem "mail-notify", ">= 1.0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
       rspec-rails (>= 3.0.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-attack (6.5.0)
+      rack (>= 1.0, < 3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -422,6 +424,7 @@ DEPENDENCIES
   puma (~> 5.0)
   pundit
   pundit-matchers (~> 1.6.0)
+  rack-attack (>= 6.5.0)
   rails (~> 6.1.3, >= 6.1.3.1)
   rails-controller-testing (>= 1.0.5)
   rspec-rails (~> 4.0.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ private
   end
 
   def after_sign_in_path_for(user)
-    stored_location_for(user) || helpers.profile_dashboard_url(user)
+    stored_location_for(user) || helpers.profile_dashboard_path(user)
   end
 
   def set_success_message(title: "Success", heading: "", content: "")

--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -26,7 +26,7 @@ class Schools::ChooseProgrammeController < Schools::BaseController
       induction_programme_choice: @induction_choice_form.programme_choice,
     )
 
-    redirect_to helpers.profile_dashboard_url(current_user)
+    redirect_to helpers.profile_dashboard_path(current_user)
   end
 
   def edit; end
@@ -35,6 +35,6 @@ private
 
   def verify_programme_chosen
     school = current_user.induction_coordinator_profile.schools.first
-    redirect_to helpers.profile_dashboard_url(current_user) if school.chosen_programme?(Cohort.current)
+    redirect_to helpers.profile_dashboard_path(current_user) if school.chosen_programme?(Cohort.current)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -29,7 +29,7 @@ class Users::SessionsController < Devise::SessionsController
 private
 
   def redirect_to_dashboard
-    redirect_to helpers.profile_dashboard_url(current_user) if current_user.present?
+    redirect_to helpers.profile_dashboard_path(current_user) if current_user.present?
   end
 
   def ensure_login_token_valid
@@ -51,6 +51,6 @@ private
 
     user = User.find_by_email(email)
     sign_in(user, scope: :user)
-    redirect_to profile_dashboard_url(user)
+    redirect_to profile_dashboard_path(user)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def profile_dashboard_url(user)
+  def profile_dashboard_path(user)
     if user.admin?
-      admin_schools_url
+      admin_schools_path
     elsif user.induction_coordinator?
-      induction_coordinator_dashboard_url(user)
+      induction_coordinator_dashboard_path(user)
     else
-      dashboard_url
+      dashboard_path
     end
   end
 
 private
 
-  def induction_coordinator_dashboard_url(user)
+  def induction_coordinator_dashboard_path(user)
     school = user.induction_coordinator_profile.schools.first
 
-    return advisory_schools_choose_programme_url unless school.chosen_programme?(Cohort.current)
+    return advisory_schools_choose_programme_path unless school.chosen_programme?(Cohort.current)
 
-    schools_dashboard_url
+    schools_dashboard_path
   end
 end

--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -20,7 +20,7 @@
       </thead>
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">_govuk_rails_boilerplate_session</td>
+          <td class="govuk-table__cell">_early_career_framework_session</td>
           <td class="govuk-table__cell" width="50%">Used to keep you signed in</td>
           <td class="govuk-table__cell">2 weeks</td>
         </tr>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ require "govuk/components"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module GovukRailsBoilerplate
+module EarlyCareerFramework
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -40,7 +40,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :delayed_job
-  # config.active_job.queue_name_prefix = "govuk_rails_boilerplate_production"
+  # config.active_job.queue_name_prefix = "early_career_framework_production"
   config.domain = ENV["DOMAIN"]
 
   config.support_email = "continuing-professional-development@digital.education.gov.uk"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "govuk_rails_boilerplate_production"
+  # config.active_job.queue_name_prefix = "early_career_framework_production"
   config.domain = ENV["DOMAIN"]
 
   config.support_email = "continuing-professional-development@digital.education.gov.uk"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -40,7 +40,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "govuk_rails_boilerplate_production"
+  # config.active_job.queue_name_prefix = "early_career_framework_production"
   config.domain = ENV["DOMAIN"]
 
   config.support_email = "continuing-professional-development@digital.education.gov.uk"

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Throttle general requests by IP
+class Rack::Attack
+  throttle("General requests by ip", limit: 300, period: 5.minutes, &:ip)
+
+  throttle("Login attempts by ip", limit: 5, period: 20.seconds) do |request|
+    if request.path == "/users/sign_in" && request.post?
+      request.ip
+    end
+  end
+end
+
+ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, request_id, payload|
+  ip = payload[:request].ip
+  path = payload[:request].fullpath
+
+  Rails.logger.warn("[rack-attack] Throttled request #{request_id} from #{ip} to '#{path}'")
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-in_local_environment = Rails.env.development? || Rails.env.test?
-
-Rails.application.config.session_store :cookie_store, key: "_early_career_framework_session", secure: !in_local_environment, expire_after: 2.weeks

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-Rails.application.config.session_store :cookie_store, key: "_early_career_framework_session", expire_after: 2.weeks
+in_local_environment = Rails.env.development? || Rails.env.test?
+
+Rails.application.config.session_store :cookie_store, key: "_early_career_framework_session", secure: !in_local_environment, expire_after: 2.weeks

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.session_store :cookie_store, key: "_early_career_framework_session", expire_after: 2.weeks

--- a/spec/cypress/support/on-rails.js
+++ b/spec/cypress/support/on-rails.js
@@ -43,10 +43,18 @@ Cypress.Commands.add("appFixtures", (options) => {
 });
 // CypressOnRails: end
 
-beforeEach(() => {
+const reset = () => {
   createdRecords = {};
   cy.app("clean");
   cy.appEval("ActionMailer::Base.deliveries.clear");
+};
+
+beforeEach(() => {
+  reset();
+});
+
+Cypress.on("after:run", () => {
+  reset();
 });
 
 // comment this out if you do not want to attempt to log additional info on test fail

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ApplicationHelper, type: :helper do
     induction_coordinator.induction_coordinator_profile.update!(schools: [school])
   end
 
-  describe "#profile_dashboard_url" do
+  describe "#profile_dashboard_path" do
     it "returns the admin/schools path for admins" do
-      expect(helper.profile_dashboard_url(admin_user)).to eq("http://test.host/admin/schools")
+      expect(helper.profile_dashboard_path(admin_user)).to eq("/admin/schools")
     end
 
     it "returns schools/choose-programme for induction coordinators" do
-      expect(helper.profile_dashboard_url(induction_coordinator)).to eq("http://test.host/schools/choose-programme/advisory")
+      expect(helper.profile_dashboard_path(induction_coordinator)).to eq("/schools/choose-programme/advisory")
     end
 
     context "when a school has chosen a programme" do
@@ -27,7 +27,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "returns schools for induction coordinators" do
-        expect(helper.profile_dashboard_url(induction_coordinator)).to eq("http://test.host/schools")
+        expect(helper.profile_dashboard_path(induction_coordinator)).to eq("/schools")
       end
     end
   end


### PR DESCRIPTION
### Context
We want to fix some vulnerabilities. We won't get a full report until a while in the future, but these fixes are very likely to be needed.

### Changes proposed in this pull request
1. Remove some `xxx_url` helpers - they create full url, as opposed to path helpers, which create relative path. We can't remove all of them, namely the ones that provide links in emails. 
2. Added rack-attack with some basic config
3. Set the session cookie to expire, be http only
4. Set all cookies on deployed envs to be secure, require https in them too
5. Sneaky cypress tests improvement - clean db after cypress run. I got some data from cypress tests interfering with rspecs :/ 

### Guidance to review
Feel free to suggest better / more sophisticated config. For some of the checks I will need the review app to be sure they work. 

### Testing
I am not sure how automatically testable those are.

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
1. Uhh, not sure if you even want to test that.
2. Try logging in more than 5 times in 20 seconds (or whatever the config we set). You can use multiple tabs to make it easier.
3. Check the settings of your cookie, I hope the new settings should be there.
4. Try accessing review app through http, it should fail.
5. You can't.