### PR TITLE
ECF-RP-512: Add programme choice confirmation and success pages

### DIFF
--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -3,38 +3,53 @@
 class Schools::ChooseProgrammeController < Schools::BaseController
   skip_after_action :verify_authorized
   skip_after_action :verify_policy_scoped
+  before_action :load_programme_form
   before_action :verify_programme_chosen, only: %i[advisory show]
-  before_action :set_school_cohort, only: %i[edit]
 
   def advisory; end
 
-  def show
-    @induction_choice_form = InductionChoiceForm.new
-  end
+  def show; end
 
   def create
-    @induction_choice_form = InductionChoiceForm.new(params.require(:induction_choice_form).permit(:programme_choice))
-
     render :show and return unless @induction_choice_form.valid?
 
+    session[:induction_choice_form] = @induction_choice_form.serializable_hash
+    redirect_to action: :confirm_programme
+  end
+
+  def confirm_programme; end
+
+  def save_programme
     cohort = Cohort.current
     school = current_user.induction_coordinator_profile.schools.first
 
     SchoolCohort.find_or_create_by!(
       cohort: cohort,
       school: school,
-      induction_programme_choice: @induction_choice_form.programme_choice,
+      induction_programme_choice: induction_programme_choice,
     )
 
-    redirect_to helpers.profile_dashboard_path(current_user)
+    session.delete(:induction_choice_form)
+    redirect_to success_schools_choose_programme_path
   end
 
-  def edit; end
+  def success; end
 
 private
 
   def verify_programme_chosen
     school = current_user.induction_coordinator_profile.schools.first
     redirect_to helpers.profile_dashboard_path(current_user) if school.chosen_programme?(Cohort.current)
+  end
+
+  def load_programme_form
+    session_params = session[:induction_choice_form] || {}
+    @induction_choice_form = InductionChoiceForm.new(session_params.merge(programme_choice_form_params))
+  end
+
+  def programme_choice_form_params
+    return {} unless params.key?(:induction_choice_form)
+
+    params.require(:induction_choice_form).permit(:programme_choice)
   end
 end

--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -26,7 +26,7 @@ class Schools::ChooseProgrammeController < Schools::BaseController
     SchoolCohort.find_or_create_by!(
       cohort: cohort,
       school: school,
-      induction_programme_choice: induction_programme_choice,
+      induction_programme_choice: @induction_choice_form.programme_choice,
     )
 
     session.delete(:induction_choice_form)

--- a/app/forms/induction_choice_form.rb
+++ b/app/forms/induction_choice_form.rb
@@ -2,8 +2,13 @@
 
 class InductionChoiceForm
   include ActiveModel::Model
+  include ActiveModel::Serialization
 
   attr_accessor :programme_choice
+
+  def attributes
+    { programme_choice: nil }
+  end
 
   validates :programme_choice, presence: { message: "Select how you want to run your induction" }
 

--- a/app/views/schools/choose_programme/confirm_programme.html.erb
+++ b/app/views/schools/choose_programme/confirm_programme.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Choose Programme" %>
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: schools_choose_programme_path)
+%>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Confirm your induction programme</h1>
+    <p class="govuk-body">You have chosen to:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <% if @induction_choice_form.programme_choice == "full_induction_programme" %>
+        <li>Use an approved training provider</li>
+      <% else %>
+        <li>Use DfE accredited materials</li>
+      <% end %>
+    </ul>
+
+    <%= form_for @induction_choice_form, url: save_programme_schools_choose_programme_path do |f| %>
+      <%= f.hidden_field :programme_choice %>
+      <%= f.govuk_submit "Confirm" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/choose_programme/confirm_programme.html.erb
+++ b/app/views/schools/choose_programme/confirm_programme.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Choose Programme" %>
+<% content_for :title, "Confirm Programme" %>
 <% content_for :before_content, govuk_back_link(
   text: "Back",
   href: schools_choose_programme_path)

--- a/app/views/schools/choose_programme/success.html.erb
+++ b/app/views/schools/choose_programme/success.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Programme confirmed" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel(

--- a/app/views/schools/choose_programme/success.html.erb
+++ b/app/views/schools/choose_programme/success.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(
+      title: "Induction programme confirmed",
+      body: "You can now view the next steps for your programme.",
+      classes: "govuk-!-margin-bottom-8") %>
+
+    <%= govuk_link_to("Continue", schools_dashboard_path, button: true)  %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,9 +137,11 @@ Rails.application.routes.draw do
   namespace :schools do
     resource :dashboard, controller: :dashboard, only: :show, path: "/"
     resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme" do
-      member do
-        get "advisory"
-      end
+      get :advisory
+
+      get :confirm_programme, path: "confirm-programme"
+      post :save_programme, path: "save-programme"
+      get :success
     end
     resources :cohorts, only: :show do
       resources :partnerships, only: :index

--- a/spec/cypress/integration/schools/ChooseProgramme.feature
+++ b/spec/cypress/integration/schools/ChooseProgramme.feature
@@ -18,6 +18,16 @@ Feature: Induction tutors choosing programmes
 
     When I click on "accredited materials" label
     And I click the submit button
+    Then I should be on "choose programme confirm" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Confirm materials CIP page"
+
+    When I click the submit button
+    Then I should be on "choose programme success" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Choose materials success"
+
+    When I click on "link" containing "Continue"
     Then I should be on "schools" page
     And the page should be accessible
     And percy should be sent snapshot called "Schools page"
@@ -38,6 +48,14 @@ Feature: Induction tutors choosing programmes
 
     When I click on "training provider" label
     And I click the submit button
+    Then I should be on "choose programme confirm" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Confirm materials FIP page"
+
+    When I click the submit button
+    Then I should be on "choose programme success" page
+
+    When I click on "link" containing "Continue"
     Then I should be on "schools" page
     And the page should be accessible
 

--- a/spec/cypress/integration/schools/ViewPartnerships.feature
+++ b/spec/cypress/integration/schools/ViewPartnerships.feature
@@ -11,6 +11,8 @@ Feature: Induction tutors viewing partnerships
 
     When I click on "training provider" label
     And I click the submit button
+    And I click the submit button
+    And I click on "link" containing "Continue"
     Then I should be on "schools" page
 
     When I click on "link" containing "2021"

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -62,6 +62,8 @@ const pagePaths = {
   "lead provider user delete": "/lead-providers/users/:id/delete",
   "choose programme": "/schools/choose-programme",
   "choose programme advisory": "/schools/choose-programme/advisory",
+  "choose programme confirm": "/schools/choose-programme/confirm-programme",
+  "choose programme success": "/schools/choose-programme/success",
   schools: "/schools",
   "2021 school cohorts": "/schools/cohorts/2021",
   "2021 school partnerships": "/schools/cohorts/2021/partnerships",

--- a/spec/requests/schools/choose_programme_spec.rb
+++ b/spec/requests/schools/choose_programme_spec.rb
@@ -60,14 +60,48 @@ RSpec.describe "Schools::ChooseProgramme", type: :request do
       expect(response.body).to include("Select how you want to run your induction")
     end
 
+    it "should redirect to confirmation page" do
+      induction_programme_choice = "full_induction_programme"
+      post "/schools/choose-programme", params: { induction_choice_form: { programme_choice: induction_programme_choice } }
+      expect(response).to redirect_to(action: :confirm_programme)
+    end
+  end
+
+  describe "GET /schools/choose-programme/confirm-programme" do
+    it "should render the show template when selecting FIP" do
+      induction_programme_choice = "full_induction_programme"
+      post "/schools/choose-programme", params: { induction_choice_form: { programme_choice: induction_programme_choice } }
+      get "/schools/choose-programme/confirm-programme"
+
+      expect(response).to render_template(:confirm_programme)
+      expect(response.body).to include("Use an approved training provider")
+    end
+
+    it "should render the show template when selecting CIP" do
+      induction_programme_choice = "core_induction_programme"
+      post "/schools/choose-programme", params: { induction_choice_form: { programme_choice: induction_programme_choice } }
+      get "/schools/choose-programme/confirm-programme"
+
+      expect(response).to render_template(:confirm_programme)
+      expect(response.body).to include("Use DfE accredited materials")
+    end
+  end
+
+  describe "POST /schools/choose-programme/save-programme" do
     it "should store the induction choice" do
       induction_programme_choice = "full_induction_programme"
       expect {
-        post "/schools/choose-programme", params: { induction_choice_form: { programme_choice: induction_programme_choice } }
+        post "/schools/choose-programme/save-programme", params: { induction_choice_form: { programme_choice: induction_programme_choice } }
       }.to change { SchoolCohort.count }.by(1)
+      expect(response).to redirect_to(action: :success)
+    end
+  end
 
-      created_school_cohort = school.school_cohorts.find_by(cohort: cohort)
-      expect(created_school_cohort.induction_programme_choice).to eq induction_programme_choice
+  describe "GET /schools/choose-programme/success" do
+    it "should render the success template" do
+      get "/schools/choose-programme/success"
+
+      expect(response).to render_template(:success)
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/7ZwF2Isr/512-bug-12-additional-confirmation-and-success-page-when-choosing-a-programme
We want some confirmation and success pages for selecting the type of induction a school will run.

### Changes proposed in this pull request
Add a confirmation page.
Add a new 'save programme' endpoint
Add a success page

### Guidance to review
Miro suggests having different sets of pages for FIP and CIP, but Shani thinks those pages are going to be very similar, and suggested commonising them - which I did and I like. It means we need to store the choice - which I do in session.

### Testing
I updated request specs and cypress tests.

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Log in as `school-leader@example.com`, follow your nose:
- continue
- pick a programme + continue
- should be on the confirm page (to test)
- confirm
- should be on the success page (to test)

If you want to re-test, I guess we would need to reset the db :/ 