### PR TITLE
Update canonical url host with domain name

### DIFF
--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -9,8 +9,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  # TODO: update when we have domain
-  config.host = "www.education.gov.uk"
+  config.host = "manage-training-for-early-career-teachers.education.gov.uk"
   config.port # = '3000'
 
   # http://en.wikipedia.org/wiki/URL_normalization


### PR DESCRIPTION
### Context
This was something we got from the boilerplate, and should have been updated when we got our domain name

### How can I view this in a review app?
Check the link tag in the head of any page
