### PR TITLE
ecf-1-524 Lead providers can choose delivery partners for a school

### DIFF
--- a/app/controllers/lead_providers/report_schools_controller.rb
+++ b/app/controllers/lead_providers/report_schools_controller.rb
@@ -2,7 +2,9 @@
 
 module LeadProviders
   class ReportSchoolsController < ::LeadProviders::BaseController
-    def start; end
+    def start
+      session.delete(:delivery_partner_id)
+    end
 
     def choose_delivery_partner
       @delivery_partner_form = LeadProviderDeliveryPartnerForm.new

--- a/app/controllers/lead_providers/report_schools_controller.rb
+++ b/app/controllers/lead_providers/report_schools_controller.rb
@@ -3,5 +3,24 @@
 module LeadProviders
   class ReportSchoolsController < ::LeadProviders::BaseController
     def start; end
+
+    def choose_delivery_partner
+      @delivery_partner_form = LeadProviderDeliveryPartnerForm.new
+      @delivery_partners = current_user.lead_provider.delivery_partners
+    end
+
+    def check_delivery_partner
+      @delivery_partner_form = LeadProviderDeliveryPartnerForm.new(
+        params.require(:lead_provider_delivery_partner_form).permit(:delivery_partner_id),
+      )
+
+      if @delivery_partner_form.valid?
+        session[:delivery_partner_id] = @delivery_partner_form.delivery_partner_id
+        redirect_to action: :choose_delivery_partner
+      else
+        @delivery_partners = current_user.lead_provider.delivery_partners
+        render :choose_delivery_partner
+      end
+    end
   end
 end

--- a/app/forms/lead_provider_delivery_partner_form.rb
+++ b/app/forms/lead_provider_delivery_partner_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LeadProviderDeliveryPartnerForm
+  include ActiveModel::Model
+
+  attr_accessor :delivery_partner_id
+
+  validates :delivery_partner_id, presence: { message: "Choose a delivery partner" }
+end

--- a/app/views/lead_providers/report_schools/choose_delivery_partner.html.erb
+++ b/app/views/lead_providers/report_schools/choose_delivery_partner.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Choose delivery partner" %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: start_lead_providers_report_schools_path) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Choose the delivery partner</h1>
+    <p>Select the delivery partner that these schools have confirmed an agreement with.</p>
+    <%= form_with model: @delivery_partner_form, url: check_delivery_partner_lead_providers_report_schools_path, method: :post do |f| %>
+      <%= f.govuk_collection_radio_buttons(
+        :delivery_partner_id,
+        @delivery_partners,
+        :id,
+        :name,
+        legend: nil) %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/lead_providers/report_schools/start.html.erb
+++ b/app/views/lead_providers/report_schools/start.html.erb
@@ -15,6 +15,6 @@
     <p>If you want to add schools to your 2021 cohort after October 31st, you need to contact:
       <%= render MailToSupportComponent.new %></p>
 
-    <%= govuk_link_to "Continue", '#', button: true%>
+    <%= govuk_link_to "Continue", choose_delivery_partner_lead_providers_report_schools_path, button: true%>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
 
     resource :report_schools, path: "report-schools", only: [] do
       get "start", action: :start
+      post "check-delivery-partner", action: :check_delivery_partner
+      get "choose-delivery-partner", action: :choose_delivery_partner
     end
   end
 

--- a/spec/cypress/app_commands/scenarios/lead_provider_with_delivery_partners.rb
+++ b/spec/cypress/app_commands/scenarios/lead_provider_with_delivery_partners.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+profile = LeadProviderProfile.last
+lead_provider = profile.lead_provider
+delivery_partner = FactoryBot.create(:delivery_partner, name: "Delivery Partner 1")
+ProviderRelationship.create!(delivery_partner: delivery_partner, lead_provider: lead_provider, cohort: Cohort.current)

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -2,6 +2,7 @@ Feature: Report Schools flow
   Background:
     Given cohort was created with start_year "2021"
     And I am logged in as a "lead_provider"
+    And scenario "lead_provider_with_delivery_partners" has been run
 
   Scenario: Visiting the start page
     Given I am on "dashboard" page
@@ -12,7 +13,6 @@ Feature: Report Schools flow
     And percy should be sent snapshot called "Lead provider report schools start page"
 
   Scenario: Selecting a delivery partner
-    Given scenario "lead_provider_with_delivery_partners" has been run
     And I am on "lead providers report schools start" page
     When I click on "link" containing "Continue"
     Then I should be on "lead providers report schools choose delivery partner" page

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -10,3 +10,14 @@ Feature: Report Schools flow
     And "page body" should contain "2021"
     And the page should be accessible
     And percy should be sent snapshot called "Lead provider report schools start page"
+
+  Scenario: Selecting a delivery partner
+    Given scenario "lead_provider_with_delivery_partners" has been run
+    And I am on "lead providers report schools start" page
+    When I click on "link" containing "Continue"
+    Then I should be on "lead providers report schools choose delivery partner" page
+    And "page body" should contain "Choose the delivery partner"
+    And "page body" should contain "Delivery Partner 1"
+    And the page should be accessible
+    And percy should be sent snapshot called "Lead provider report schools choose delivery partner page"
+

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -71,6 +71,7 @@ const pagePaths = {
   "not found": "/404",
   "internal server error": "/500",
   forbidden: "/403",
+  "lead providers report schools choose delivery partner": "/lead-providers/report-schools/choose-delivery-partner",
 };
 
 Given("I am on {string} page", (page) => {

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -71,7 +71,8 @@ const pagePaths = {
   "not found": "/404",
   "internal server error": "/500",
   forbidden: "/403",
-  "lead providers report schools choose delivery partner": "/lead-providers/report-schools/choose-delivery-partner",
+  "lead providers report schools choose delivery partner":
+    "/lead-providers/report-schools/choose-delivery-partner",
 };
 
 Given("I am on {string} page", (page) => {

--- a/spec/forms/lead_provider_delivery_partner_form_spec.rb
+++ b/spec/forms/lead_provider_delivery_partner_form_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LeadProviderDeliveryPartnerForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:delivery_partner_id).with_message("Choose a delivery partner") }
+  end
+end

--- a/spec/requests/lead_providers/report_schools_spec.rb
+++ b/spec/requests/lead_providers/report_schools_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Report schools spec", type: :request do
         ProviderRelationship.create(lead_provider: lead_provider, delivery_partner: delivery_partner, cohort: Cohort.current)
       end
 
-      it "shows an error if nothing is selected" do
+      it "redirects to the csv upload page" do
         post "/lead-providers/report-schools/check-delivery-partner", params: {
           lead_provider_delivery_partner_form: { delivery_partner_id: delivery_partner.id },
         }


### PR DESCRIPTION
### Context
DfE need Lead Providers to specify which delivery partner is assigned to which school so that schools don't mistakenly challenge the partnership because they only know about the delivery partner.

### Changes proposed in this pull request
A form with radio buttons that select the delivery partner for a school

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Login as lead-provider@example.com. From the dashboard click on find schools
![image (2)](https://user-images.githubusercontent.com/1547920/115885537-f54c8c80-a447-11eb-8689-819b4c96ea03.png)

