### PR TITLE
Update error copy, check a11y

### DIFF
--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,1 +1,9 @@
-<h1>Forbidden</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Page not found</h1>
+    <p class="govuk-body">If you typed the web address, check it is correct.</p>
+    <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+    <p class="govuk-body">If the web address is correct or you selected a link or button,
+      contact: <%= render MailToSupportComponent.new %></p>
+  </div>
+</div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,9 +1,7 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
-      <p class="govuk-body">Try again later.</p>
-      <p class="govuk-body">If you need to do something urgently, contact: <%= render MailToSupportComponent.new %></p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">Try again later.</p>
+    <p class="govuk-body">If you need to do something urgently, contact: <%= render MailToSupportComponent.new %></p>
   </div>
-</main>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,4 +1,3 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Page not found</h1>
@@ -7,4 +6,3 @@
       <p class="govuk-body">If the web address is correct or you selected a link or button, contact: <%= render MailToSupportComponent.new %></p>
     </div>
   </div>
-</main>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,8 +1,9 @@
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Page not found</h1>
-      <p class="govuk-body">If you typed the web address, check it is correct.</p>
-      <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
-      <p class="govuk-body">If the web address is correct or you selected a link or button, contact: <%= render MailToSupportComponent.new %></p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Page not found</h1>
+    <p class="govuk-body">If you typed the web address, check it is correct.</p>
+    <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+    <p class="govuk-body">If the web address is correct or you selected a link or button,
+      contact: <%= render MailToSupportComponent.new %></p>
   </div>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,9 +1,7 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
-      <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
+    <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
+    <p class="govuk-body">If you are the application owner check the logs for more information.</p>
   </div>
-</main>
+</div>

--- a/spec/cypress/integration/Errors.feature
+++ b/spec/cypress/integration/Errors.feature
@@ -1,0 +1,15 @@
+Feature: Error pages
+  Scenario: Seeing the Not Found page
+    Given I am on "not found" error page
+    Then the page should be accessible
+    And percy should be sent snapshot
+
+  Scenario: Seeing the Internal Server Error page
+    Given I am on "internal server error" error page
+    Then the page should be accessible
+    And percy should be sent snapshot
+
+  Scenario: Seeing the Forbidden page
+    Given I am on "forbidden" error page
+    Then the page should be accessible
+    And percy should be sent snapshot

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -66,11 +66,22 @@ const pagePaths = {
   "2021 school cohorts": "/schools/cohorts/2021",
   "2021 school partnerships": "/schools/cohorts/2021/partnerships",
   "lead providers report schools start": "/lead-providers/report-schools/start",
+  "not found": "/404",
+  "internal server error": "/500",
+  forbidden: "/403",
 };
 
 Given("I am on {string} page", (page) => {
   const path = pagePaths[page];
   cy.visit(path);
+});
+
+Given("I am on {string} error page", (page) => {
+  const path = pagePaths[page];
+  cy.visit({
+    url: path,
+    failOnStatusCode: false,
+  });
 });
 
 Given("I am on {string} page with id {string}", (page, id) => {


### PR DESCRIPTION
### Context
Update the copy on the 403 page to match 404. Get rid of the double `<main>` and do some a11y tests


### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy

### How can I view this in a review app?
Go to `/403`, `/404`, `/500`