### PR TITLE
ECF-RP-538: cip only schools

### DIFF
--- a/app/controllers/nominations/request_nomination_invite_controller.rb
+++ b/app/controllers/nominations/request_nomination_invite_controller.rb
@@ -28,7 +28,9 @@ class Nominations::RequestNominationInviteController < ApplicationController
 
     session[:nomination_request_form] = @nomination_request_form.serializable_hash
 
-    if !@nomination_request_form.school.eligible?
+    if @nomination_request_form.school.cip_only?
+      redirect_to cip_only_request_nomination_invite_path
+    elsif !@nomination_request_form.school.eligible?
       redirect_to not_eligible_request_nomination_invite_path
     elsif @nomination_request_form.school.registered?
       redirect_to already_nominated_request_nomination_invite_path
@@ -38,6 +40,8 @@ class Nominations::RequestNominationInviteController < ApplicationController
       redirect_to review_request_nomination_invite_path
     end
   end
+
+  def cip_only; end
 
   def not_eligible; end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -2,6 +2,7 @@
 
 class School < ApplicationRecord
   ELIGIBLE_TYPE_CODES = [1, 2, 3, 5, 6, 7, 8, 12, 14, 15, 18, 28, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48].freeze
+  CIP_ONLY_TYPE_CODES = [10, 11, 30, 37].freeze
   ELIGIBLE_STATUS_CODES = [1, 3].freeze
 
   belongs_to :network, optional: true
@@ -83,6 +84,10 @@ class School < ApplicationRecord
     eligible_establishment_type? && open? && in_england?
   end
 
+  def cip_only?
+    open? && cip_only_establishment_type?
+  end
+
   def local_authority
     school_local_authorities.latest.first&.local_authority
   end
@@ -125,6 +130,10 @@ private
 
   def eligible_establishment_type?
     ELIGIBLE_TYPE_CODES.include?(school_type_code)
+  end
+
+  def cip_only_establishment_type?
+    CIP_ONLY_TYPE_CODES.include?(school_type_code)
   end
 
   def in_england?

--- a/app/views/nominations/request_nomination_invite/cip_only.html.erb
+++ b/app/views/nominations/request_nomination_invite/cip_only.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "School eligibility" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-header-xl">
+      Your school is only eligible for 2 of our programmes
+    </h1>
+
+    <p class="govuk-body">Your school is only eligible to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>use the DfE accredited materials</li>
+    </ul>
+    <p class="govuk-body">Or</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>design and deliver your programme based on the early career framework</li>
+    </ul>
+
+    <p class="govuk-body">Your school is not eligible for a programme led by an approved training provider. This
+      programme is only open to state funded schools.</p>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk-body">You will receive an email shortly. If you have decided to use the DfE accredited materials, we
+      will invite you to nominate your induction lead/tutor and access the service.</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
         get "review", action: :review
         post "review", action: :create
         get "success", action: :success
+        get "cip-only", action: :cip_only
         get "not-eligible", action: :not_eligible
         get "limit-reached", action: :limit_reached
         get "already-nominated", action: :already_nominated

--- a/spec/cypress/integration/nominations/ResendNominations.feature
+++ b/spec/cypress/integration/nominations/ResendNominations.feature
@@ -38,3 +38,7 @@ Feature: Resend nominations flow
     When I am on "resend nominations limit reached" page
     Then the page should be accessible
     And percy should be sent snapshot called "Resend nominations limit reached page"
+
+    When I am on "resend nominations cip only" page
+    Then the page should be accessible
+    And percy should be sent snapshot called "Resend nominations cip only page"

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -54,6 +54,7 @@ const pagePaths = {
   "resend nominations not eligible": "nominations/not-eligible",
   "resend nominations already nominated": "nominations/already-nominated",
   "resend nominations limit reached": "nominations/limit-reached",
+  "resend nominations cip only": "nominations/cip-only",
   "start nominations with token": "/nominations/start?token=foo-bar-baz",
   "lead provider users index": "/admin/suppliers/users",
   "new lead provider user": "/admin/suppliers/users/new",

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe School, type: :model do
     let!(:eligible_school_type) { create(:school, school_type_code: 1) }
     let!(:ineligible_school_type) { create(:school, school_type_code: 56) }
     let!(:english_school) { create(:school, administrative_district_code: "E123") }
-    let!(:welsh_school) { create(:school, administrative_district_code: "W123") }
+    let!(:welsh_school) { create(:school, administrative_district_code: "W123", school_type_code: 30) }
     describe "#eligible?" do
       it "should be true for open schools" do
         expect(open_school.eligible?).to be true
@@ -75,6 +75,29 @@ RSpec.describe School, type: :model do
       it "should only include eligible schools" do
         expect(School.eligible.all).to include(open_school, eligible_school_type, english_school)
         expect(School.eligible.all).not_to include(closed_school, ineligible_school_type, welsh_school)
+      end
+    end
+
+    describe "#cip_only?" do
+      it "should be false for fully eligible schools" do
+        expect(open_school.cip_only?).to eql false
+        expect(eligible_school_type.cip_only?).to eql false
+        expect(english_school.cip_only?).to eql false
+      end
+
+      it "should be true for welsh schools" do
+        expect(welsh_school.cip_only?).to eql true
+      end
+
+      it "should be false for closed welsh schools" do
+        welsh_school.update!(school_status_code: 2)
+        expect(welsh_school.cip_only?).to eql false
+      end
+    end
+
+    describe "type codes" do
+      it "should have no overlap between fully eligible and CIP only codes" do
+        expect(School::CIP_ONLY_TYPE_CODES & School::ELIGIBLE_TYPE_CODES).to be_empty
       end
     end
   end

--- a/spec/requests/nominations/request_nomination_invite_spec.rb
+++ b/spec/requests/nominations/request_nomination_invite_spec.rb
@@ -46,11 +46,20 @@ RSpec.describe "Requesting an invitation to nominate an induction tutor", type: 
     end
 
     context "when given an ineligible school" do
-      let(:school) { create(:school, administrative_district_code: "W12") }
+      let(:school) { create(:school, school_type_code: 24) }
 
       it "redirects to not eligible" do
         when_i_choose_the_school
         expect(response).to redirect_to(not_eligible_request_nomination_invite_path)
+      end
+    end
+
+    context "when given a cip eligible only school" do
+      let(:school) { create(:school, school_type_code: 10) }
+
+      it "redirects to cip_only" do
+        when_i_choose_the_school
+        expect(response).to redirect_to(cip_only_request_nomination_invite_path)
       end
     end
 
@@ -113,6 +122,13 @@ RSpec.describe "Requesting an invitation to nominate an induction tutor", type: 
     it "renders the success page" do
       get "/nominations/success"
       expect(response).to render_template(:success)
+    end
+  end
+
+  describe "cip only" do
+    it "renders the cip only page" do
+      get "/nominations/cip-only"
+      expect(response).to render_template(:cip_only)
     end
   end
 


### PR DESCRIPTION
### Context
Some schools are only eligible for the CIP. We'll deal with that properly later. For now, we just show them a special message when they try to trigger an email

### Changes proposed in this pull request
- Add `cip_only?` to `School`
- add guidance page to resend nomination journey for cip only schools

### Guidance to review

### Testing
- Edge case testing for eligibility on School
- Request specs for requesting invitation to nominate
- A11y and snapshot tests on new page

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
https://ecf-review-pr-297.london.cloudapps.digital/nominations/choose-location
Try to resend and email to school with LA: "City of London", name: "City of London School for Girls" (type code 11)