### PR TITLE
ECF-RP-564: Worker app to run delayed jobs

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -11,6 +11,7 @@ resource cloudfoundry_app web_app {
   docker_image = var.app_docker_image
   health_check_type = "http"
   health_check_http_endpoint = "/check"
+  health_check_timeout = 60
   instances = var.web_app_instances
   memory = var.web_app_memory
 
@@ -38,20 +39,42 @@ resource cloudfoundry_app web_app {
 }
 
 resource cloudfoundry_route web_app_route {
-  domain   = data.cloudfoundry_domain.cloudapps_digital.id
-  space    = data.cloudfoundry_space.space.id
+  domain = data.cloudfoundry_domain.cloudapps_digital.id
+  space = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
 }
 
 resource cloudfoundry_route web_app_route_gov_uk {
   for_each = toset(var.govuk_hostnames)
-  domain   = data.cloudfoundry_domain.education_gov_uk.id
-  space    = data.cloudfoundry_space.space.id
+  domain = data.cloudfoundry_domain.education_gov_uk.id
+  space = data.cloudfoundry_space.space.id
   hostname = each.value
 }
 
+resource "cloudfoundry_app" "worker_app" {
+  name = local.worker_app_name
+  command = var.worker_app_start_command
+  docker_image = var.app_docker_image
+  health_check_type = "process"
+  health_check_timeout = 10
+  instances = var.worker_app_instances
+  memory = var.worker_app_memory
+
+  space = data.cloudfoundry_space.space.id
+  stopped = var.app_stopped
+  strategy = var.worker_app_deployment_strategy
+  timeout = var.app_start_timeout
+  dynamic "service_binding" {
+    for_each = local.app_service_bindings
+    content {
+      service_instance = service_binding.value
+    }
+  }
+  environment = local.app_environment
+}
+
 resource cloudfoundry_user_provided_service logging {
-  name             = local.logging_service_name
-  space            = data.cloudfoundry_space.space.id
+  name = local.logging_service_name
+  space = data.cloudfoundry_space.space.id
   syslog_drain_url = var.logstash_url
 }

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -37,19 +37,15 @@ variable web_app_start_command {
 
 
 variable worker_app_start_command {
-  default = ""
 }
 
 variable worker_app_instances {
-  default = 0
 }
 
 variable worker_app_memory {
-  default = 2048
 }
 
 variable worker_app_deployment_strategy {
-  default = "standard"
 }
 
 variable logstash_url {

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -27,32 +27,47 @@ variable web_app_deployment_strategy {
 }
 
 variable web_app_instances {
-  default = 1
 }
 
 variable web_app_memory {
-  default = 512
 }
 
 variable web_app_start_command {
+}
+
+
+variable worker_app_start_command {
+  default = ""
+}
+
+variable worker_app_instances {
+  default = 0
+}
+
+variable worker_app_memory {
+  default = 2048
+}
+
+variable worker_app_deployment_strategy {
+  default = "standard"
 }
 
 variable logstash_url {
 }
 
 variable govuk_hostnames {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 locals {
 
-  app_env_domain  = {
-    "DOMAIN" = "ecf-${var.environment}.london.cloudapps.digital"
-    "GIAS_API_SCHEMA" = "https://ea-edubase-api-prod.azurewebsites.net/edubase/schema/service.wsdl"
-    "GIAS_EXTRACT_ID" = 13904
-    "GIAS_API_USER" = "ecftech"
-    "GOVUK_APP_DOMAIN" = "ecf-${var.environment}.london.cloudapps.digital"
+  app_env_domain = {
+    "DOMAIN"             = "ecf-${var.environment}.london.cloudapps.digital"
+    "GIAS_API_SCHEMA"    = "https://ea-edubase-api-prod.azurewebsites.net/edubase/schema/service.wsdl"
+    "GIAS_EXTRACT_ID"    = 13904
+    "GIAS_API_USER"      = "ecftech"
+    "GOVUK_APP_DOMAIN"   = "ecf-${var.environment}.london.cloudapps.digital"
     "GOVUK_WEBSITE_ROOT" = "ecf-${var.environment}.london.cloudapps.digital"
   }
   app_environment = merge(
@@ -66,7 +81,8 @@ locals {
   app_service_bindings = concat(
     local.app_cloudfoundry_service_instances,
   )
-  logging_service_name     = "${var.service_name}-logit-${var.environment}"
-  postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
-  web_app_name             = "${var.service_name}-${var.environment}"
+  logging_service_name  = "${var.service_name}-logit-${var.environment}"
+  postgres_service_name = "${var.service_name}-postgres-${var.environment}"
+  web_app_name          = "${var.service_name}-${var.environment}"
+  worker_app_name       = "${var.service_name}-${var.environment}-worker"
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -51,6 +51,7 @@ module paas {
   worker_app_start_command          = var.paas_worker_app_start_command
   worker_app_instances              = var.paas_worker_app_instances
   worker_app_memory                 = var.paas_worker_app_memory
+  worker_app_deployment_strategy    = var.paas_worker_app_deployment_strategy
   logstash_url                      = var.logstash_url
   govuk_hostnames                   = var.govuk_hostnames
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -48,6 +48,9 @@ module paas {
   web_app_instances                 = var.paas_web_app_instances
   web_app_memory                    = var.paas_web_app_memory
   web_app_start_command             = var.paas_web_app_start_command
+  worker_app_start_command          = var.paas_worker_app_start_command
+  worker_app_instances              = var.paas_worker_app_instances
+  worker_app_memory                 = var.paas_worker_app_memory
   logstash_url                      = var.logstash_url
   govuk_hostnames                   = var.govuk_hostnames
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -65,15 +65,19 @@ variable paas_web_app_start_command {
 }
 
 variable paas_worker_app_deployment_strategy {
-  default = "blue-green-v2"
+  default = "standard"
 }
 
 variable paas_worker_app_instances {
-  default = 1
+  default = 0
 }
 
 variable paas_worker_app_memory {
-  default = 512
+  default = 2048
+}
+
+variable paas_worker_app_start_command {
+  default = ""
 }
 
 variable logstash_url {

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -11,7 +11,10 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 8192
+paas_worker_app_instances = 1
+paas_worker_app_start_command = "bundle exec rake jobs:work"
 govuk_hostnames = ["manage-training-for-early-career-teachers"]
+
 statuscake_alerts = {
   "prod" = {
     website_name  = "manage-training-for-early-career-teachers-production"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,4 +10,6 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 512
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && /app/bin/delayed_job start && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && rails s"
+paas_worker_app_instances = 1
+paas_worker_app_start_command = "bundle exec rake jobs:work"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,6 +10,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 512
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && rails s"
-paas_worker_app_instances = 1
-paas_worker_app_start_command = "bundle exec rake jobs:work"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && rails db:safe_reset && /app/bin/delayed_job start && rails s"

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -11,4 +11,6 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 8192
+paas_worker_app_instances = 1
+paas_worker_app_start_command = "bundle exec rake jobs:work"
 govuk_hostnames = ["s-manage-training-for-early-career-teachers"]


### PR DESCRIPTION
### Context
This is PR 1/3 for this ticket.
Inspired by TVS, we want to run background jobs in a different instance. We do this in staging and prod. Review and dev have the background jobs running in the web container already.

### Changes proposed in this pull request

### Guidance to review

### Testing
Added the worker app to review in the first commit, checked it worked:
![image](https://user-images.githubusercontent.com/40488007/116276034-07963580-a77c-11eb-878c-2dc2feed12f0.png)


### How can I view this in a review app?
N/A