### PR TITLE
add bucket for csv uploads

### DIFF
--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -18,3 +18,7 @@ data cloudfoundry_domain education_gov_uk {
 data cloudfoundry_service postgres {
   name = "postgres"
 }
+
+data cloudfoundry_service aws-s3-bucket {
+  name = "aws-s3-bucket"
+}

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -5,6 +5,12 @@ resource cloudfoundry_service_instance postgres_instance {
   json_params = "{\"enable_extensions\": [\"pgcrypto\", \"fuzzystrmatch\", \"plpgsql\"]}"
 }
 
+resource cloudfoundry_service_instance csv_bucket {
+  name = local.csv_bucket_name
+  space = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.aws-s3-bucket.service_plans["default"]
+}
+
 resource cloudfoundry_app web_app {
   name = local.web_app_name
   command = var.web_app_start_command

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -61,6 +61,7 @@ locals {
   )
   app_cloudfoundry_service_instances = [
     cloudfoundry_service_instance.postgres_instance.id,
+    cloudfoundry_service_instance.csv_bucket.id,
     cloudfoundry_user_provided_service.logging.id,
   ]
   app_service_bindings = concat(
@@ -69,4 +70,5 @@ locals {
   logging_service_name     = "${var.service_name}-logit-${var.environment}"
   postgres_service_name    = "${var.service_name}-postgres-${var.environment}"
   web_app_name             = "${var.service_name}-${var.environment}"
+  csv_bucket_name          = "${var.service_name}-csv-${var.environment}"
 }


### PR DESCRIPTION
### Context
We need to add a store for partnership_csv_uploads
### Changes proposed in this pull request
Add s3 bucket to terraform build
### Guidance to review

### Testing
aws-s3-bucket config should be available in cf $VCAP_SERVICES
### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
