### PR TITLE
Add swagger doc generation rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,10 @@ gem "daemons"
 gem "delayed_cron_job"
 gem "delayed_job_active_record"
 
+# OpenApi Swagger
+gem "open_api-rswag-api"
+gem "open_api-rswag-ui"
+
 platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end
@@ -97,6 +101,11 @@ group :development, :test do
   gem "dotenv-rails", ">= 2.7.6"
 
   gem "factory_bot_rails", ">= 6.1.0"
+
+  # Swagger generator
+  gem "multi_json"
+  gem "open_api-rswag-specs"
+  gem "rswag"
 end
 
 group :development do
@@ -110,6 +119,7 @@ end
 
 group :test do
   gem "faker"
+  gem "jsonapi-rspec"
   gem "pundit-matchers", "~> 1.6.0"
   gem "rails-controller-testing", ">= 1.0.5"
   gem "shoulda-matchers", "~> 4.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,12 +143,18 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.1)
+    hashie (4.1.0)
     httpclient (2.8.3)
     httpi (2.4.5)
       rack
       socksify
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    jsonapi-rspec (0.0.11)
+      rspec-core
+      rspec-expectations
     jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -189,6 +195,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.3.3)
+    multi_json (1.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
@@ -196,6 +203,16 @@ GEM
     nori (2.6.0)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
+    open_api-rswag-api (0.1.0)
+      railties (>= 3.1, < 7.0)
+    open_api-rswag-specs (0.1.0)
+      activesupport (>= 3.1, < 7.0)
+      hashie
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.0)
+    open_api-rswag-ui (0.1.0)
+      actionpack (>= 3.1, < 7.0)
+      railties (>= 3.1, < 7.0)
     orm_adapter (0.5.0)
     paper_trail (11.1.0)
       activerecord (>= 5.2)
@@ -272,7 +289,7 @@ GEM
     rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.1)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-rails (4.0.2)
@@ -283,7 +300,20 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
-    rspec-support (3.10.1)
+    rspec-support (3.10.2)
+    rswag (2.4.0)
+      rswag-api (= 2.4.0)
+      rswag-specs (= 2.4.0)
+      rswag-ui (= 2.4.0)
+    rswag-api (2.4.0)
+      railties (>= 3.1, < 7.0)
+    rswag-specs (2.4.0)
+      activesupport (>= 3.1, < 7.0)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.0)
+    rswag-ui (2.4.0)
+      actionpack (>= 3.1, < 7.0)
+      railties (>= 3.1, < 7.0)
     rubocop (0.87.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
@@ -413,11 +443,16 @@ DEPENDENCIES
   govuk_design_system_formbuilder (~> 2.3.0b1)
   health_check!
   httpclient (~> 2.8, >= 2.8.3)
+  jsonapi-rspec
   kaminari (>= 1.2.0)
   listen (>= 3.0.5, < 3.4)
   lograge
   logstash-event
   mail-notify (>= 1.0.3)
+  multi_json
+  open_api-rswag-api
+  open_api-rswag-specs
+  open_api-rswag-ui
   paper_trail
   pg (>= 0.18, < 2.0)
   pry-byebug
@@ -428,6 +463,7 @@ DEPENDENCIES
   rails (~> 6.1.3, >= 6.1.3.1)
   rails-controller-testing (>= 1.0.5)
   rspec-rails (~> 4.0.1)
+  rswag
   rubocop-govuk (>= 3.17.2)
   rubyzip (~> 2.3, >= 2.3.0)
   savon (~> 2.12, >= 2.12.1)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ bundle exec rake
 bundle exec rspec
 ```
 
+## Running swagger doc generator
+
+It auto-generates swagger/*/api_spec.json from the schema files located in spec/docs
+
+```bash
+bundle exec rake rswag:specs:swaggerize
+```
+
 ## Linting
 
 It's best to lint just your app directories and not those belonging to the framework, e.g.
@@ -119,4 +127,3 @@ to execute this delayed job in the background.
 ```bash
 bundle exec rake 'schools:send_invites[urn1 urn2 ...]'
 ```
-

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+OpenApi::Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + "/swagger"
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+OpenApi::Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # JSON endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.swagger_endpoint "/api-docs/v1/api_spec.json", "API V1 Docs"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,5 +181,8 @@ Rails.application.routes.draw do
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
 
+  mount OpenApi::Rswag::Ui::Engine => "/api-docs"
+  mount OpenApi::Rswag::Api::Engine => "/api-docs"
+
   resource :school_search, only: %i[show create], path: "school-search", controller: :school_search
 end

--- a/lib/tasks/swaggerize.rake
+++ b/lib/tasks/swaggerize.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if defined?(RSpec)
+  require "rspec/core/rake_task"
+
+  Rake::Task["rswag:specs:swaggerize"].clear
+
+  namespace :rswag do
+    namespace :specs do
+      desc "Generate Swagger JSON files from integration specs"
+      RSpec::Core::RakeTask.new("swaggerize") do |t|
+        t.pattern = "spec/docs/**/*_spec.rb"
+
+        t.rspec_opts = ["--format OpenApi::Rswag::Specs::SwaggerFormatter", "--order defined"]
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  config.swagger_root = Rails.root.join("swagger").to_s
+  config.swagger_docs = {
+    "v1/api_spec.json" => {
+      swagger: "2.0",
+      info: {
+        title: "API documentation",
+        version: "v1",
+        description: "Auto generated doc",
+        definitions: Dir[Rails.root.join("spec/docs/schemas/*.yaml")]
+                        .map { |f| { File.basename(f, ".yaml").titleize.gsub(/\W+/, "") => YAML.safe_load(File.read(f)) } }
+                        .reduce(&:merge),
+      },
+      basePath: "/api/v1",
+    },
+  }
+
+  config.swagger_format = :json
+end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1,0 +1,10 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "API documentation",
+    "version": "v1",
+    "description": "Auto generated doc",
+    "definitions": null
+  },
+  "basePath": "/api/v1"
+}


### PR DESCRIPTION
### Context

Rake task: **rswag:specs:swaggerize**

### Changes proposed in this pull request

This was mainly borrowed from the [teacher-training-api](https://github.com/DFE-Digital/teacher-training-api) project

### Guidance to review

Place you spec request files into spec/docs directory
Run the task ```rswag:specs:swaggerize```
The open api spec will be written into the ```swagger``` directory

https://ecf-review-pr-306.london.cloudapps.digital/api-docs/index.html

![Selection_20210430-01-10bd710bd710bd7](https://user-images.githubusercontent.com/19378/116683717-eade4580-a9a7-11eb-8a29-12d16f051a1a.png)

(operation definitions will come in other PRs)
