### PR TITLE
Clear location field when changing school in resend nomination flow

### DIFF
--- a/app/views/nominations/request_nomination_invite/review.html.erb
+++ b/app/views/nominations/request_nomination_invite/review.html.erb
@@ -13,7 +13,7 @@
 
     <div class="govuk-!-margin-bottom-9">
       <%= render partial: 'nominations/school_details', locals: { school: @nomination_request_form.school, title: "Your school" } %>
-      <%= govuk_link_to "Change school", choose_location_request_nomination_invite_path(continue: true), class: "govuk-link--no-visited-state" %>
+      <%= govuk_link_to "Change school", choose_location_request_nomination_invite_path, class: "govuk-link--no-visited-state", "data-test": "change-school" %>
     </div>
 
     <%= form_for :confirmation, url: review_request_nomination_invite_path, method: :post do |f| %>

--- a/spec/cypress/integration/nominations/ResendNominations.feature
+++ b/spec/cypress/integration/nominations/ResendNominations.feature
@@ -21,6 +21,18 @@ Feature: Resend nominations flow
     And the page should be accessible
     And percy should be sent snapshot called "Resend nominations review page"
 
+    # Clicking change school link should reset location input
+    When I click on "change school link"
+    Then "location input" should have value ""
+
+    When I type "test" into "location input"
+    And I click on "autocomplete dropdown item" containing "Test"
+    And I click the submit button
+    And I type "test" into "school input"
+    And I click on "autocomplete dropdown item" containing "Test"
+    And I click the submit button
+    Then I am on "resend nominations review" page
+
     When I click the submit button
     Then I am on "resend nominations success" page
     And the page should be accessible

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -26,6 +26,7 @@ const links = {
   "edit admin link": "[data-test=edit-admin-link]",
   "change name link": 'a:contains("Change name")',
   "edit supplier user link": "[data-test=edit-supplier-user-link]",
+  "change school link": "[data-test=change-school]",
 };
 
 const elements = {


### PR DESCRIPTION
### Context

https://trello.com/c/cm5YvYr9

### Guidance to review

### Testing

yes

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

not sure - i worked in cypress
