### PR TITLE
Fix subnav scrollbar issue

### DIFF
--- a/app/webpacker/styles/subnav.scss
+++ b/app/webpacker/styles/subnav.scss
@@ -6,7 +6,7 @@
 .app-subnav {
   @include govuk-media-query($from: tablet) {
     display: flex;
-    overflow-x: scroll;
+    overflow-x: auto;
     padding-top: govuk-spacing(2);
     padding-bottom: govuk-spacing(7);
   }


### PR DESCRIPTION
### Context

They were appearing always on windows - clearly, this isn't the correct behaviour!

### Guidance to review

### Testing

i miss percy

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
