### PR TITLE
ECF-RP-490: Lead provider welcome email

### DIFF
--- a/app/forms/supplier_user_form.rb
+++ b/app/forms/supplier_user_form.rb
@@ -22,18 +22,12 @@ class SupplierUserForm
   end
 
   def save!
-    profile = LeadProviderProfile.new(lead_provider: chosen_supplier)
-
-    user = ActiveRecord::Base.transaction do
-      user = User.create!(
-        full_name: full_name,
-        email: email,
-      )
-      profile.user = user
-      profile.save!
-      user
-    end
-    user
+    LeadProviderProfile.create_lead_provider_user(
+      full_name,
+      email,
+      chosen_supplier,
+      Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain),
+    )
   end
 
 private

--- a/app/mailers/lead_provider_mailer.rb
+++ b/app/mailers/lead_provider_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class LeadProviderMailer < ApplicationMailer
+  WELCOME_EMAIL_TEMPLATE = "07773cdf-9db6-4880-9ac6-ab4454a71d65"
+
+  def welcome_email(user:, lead_provider_name:, start_url:)
+    template_mail(
+      WELCOME_EMAIL_TEMPLATE,
+      to: user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: user.full_name,
+        lead_provider_name: lead_provider_name,
+        start_url: start_url,
+      },
+    )
+  end
+end

--- a/app/models/lead_provider_profile.rb
+++ b/app/models/lead_provider_profile.rb
@@ -3,4 +3,12 @@
 class LeadProviderProfile < BaseProfile
   belongs_to :user
   belongs_to :lead_provider
+
+  def self.create_lead_provider_user(full_name, email, lead_provider, start_url)
+    ActiveRecord::Base.transaction do
+      user = User.create!(full_name: full_name, email: email)
+      LeadProviderProfile.create!(user: user, lead_provider: lead_provider)
+      LeadProviderMailer.welcome_email(user: user, lead_provider_name: lead_provider.name, start_url: start_url).deliver_now
+    end
+  end
 end

--- a/spec/mailers/lead_provider_mailer_spec.rb
+++ b/spec/mailers/lead_provider_mailer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LeadProviderMailer, type: :mailer do
+  describe "#welcome_email_confirmation" do
+    let(:lead_provider) { build(:lead_provider) }
+    let(:user) { create(:user, :lead_provider) }
+    let(:start_url) { "https://ecf-dev.london.cloudapps" }
+
+    let(:nomination_confirmation_email) do
+      LeadProviderMailer.welcome_email(
+        user: user,
+        lead_provider_name: lead_provider.name,
+        start_url: start_url,
+      ).deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(nomination_confirmation_email.to).to eq([user.email])
+      expect(nomination_confirmation_email.from).to eq(["mail@example.com"])
+    end
+  end
+end

--- a/spec/models/lead_provider_profile_spec.rb
+++ b/spec/models/lead_provider_profile_spec.rb
@@ -11,4 +11,33 @@ RSpec.describe LeadProviderProfile, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:lead_provider) }
   end
+
+  describe ".create_lead_provider_user" do
+    let(:name) { Faker::Name.name }
+    let(:email) { Faker::Internet.email }
+    let(:lead_provider) { create(:lead_provider) }
+    let(:start_url) { "www.example.com" }
+    let(:created_user) { User.find_by(email: email) }
+
+    it "creates a lead provider user" do
+      expect {
+        LeadProviderProfile.create_lead_provider_user(name, email, lead_provider, start_url)
+      }.to change { LeadProviderProfile.count }.by(1)
+    end
+
+    it "creates a user with the correct details" do
+      LeadProviderProfile.create_lead_provider_user(name, email, lead_provider, start_url)
+
+      expect(created_user.present?).to be(true)
+      expect(created_user.full_name).to eql(name)
+    end
+
+    it "sends an email to the new user" do
+      allow(LeadProviderMailer).to receive(:welcome_email).and_call_original
+      LeadProviderProfile.create_lead_provider_user(name, email, lead_provider, start_url)
+
+      expect(LeadProviderMailer).to have_received(:welcome_email)
+                                .with(user: created_user, lead_provider_name: lead_provider.name, start_url: start_url)
+    end
+  end
 end


### PR DESCRIPTION
### Context
Much like with the admins, when a lead provider user is created, we want to send them a welcome email.

### Changes proposed in this pull request
- Copy the setup from the admin and induction coordinator profiles
- Create welcome email template in notify

### How can I view this in a review app?
Sign in as admin@example.com. On the suppliers tab, add a new user with email cpd-test+school-1@digital.education.gov.uk (any whitelisted email that doesn't have an account). Ensure you get the email