### PR TITLE
CPDEL-385: Add very basic users endpoint

### DIFF
--- a/app/controllers/admin/administrators/administrators_controller.rb
+++ b/app/controllers/admin/administrators/administrators_controller.rb
@@ -34,7 +34,7 @@ module Admin
           render :new and return
         end
 
-        session[:administrator_user] = @user
+        session[:administrator_user] = @user.as_json
       end
 
       def create

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class Api::V1::UsersController < Api::ApiController
       def index
-        render json: { users: User.all.as_json }
+        render json: { users: User.all.as_json(only: %i[id email full_name]) }
       end
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class Api::V1::UsersController < Api::ApiController
+      def index
+        render json: { users: User.all.as_json }
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,14 @@ class User < ApplicationRecord
     early_career_teacher_profile.present?
   end
 
+  def as_json
+    {
+      id: id,
+      full_name: full_name,
+      email: email,
+    }
+  end
+
   scope :induction_coordinators, -> { joins(:induction_coordinator_profile) }
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,14 +44,6 @@ class User < ApplicationRecord
     early_career_teacher_profile.present?
   end
 
-  def as_json
-    {
-      id: id,
-      full_name: full_name,
-      email: email,
-    }
-  end
-
   scope :induction_coordinators, -> { joins(:induction_coordinator_profile) }
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,12 @@ Rails.application.routes.draw do
   namespace :api do
     resources :school_search, only: %i[index]
     resource :notify_callback, only: :create, path: "notify-callback"
+
+    namespace :v1 do
+      unless Rails.env.staging? || Rails.env.production?
+        resources :users, only: :index
+      end
+    end
   end
 
   namespace :demo do

--- a/spec/docs/users_spec.rb
+++ b/spec/docs/users_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+describe "API", type: :request do
+  path "/api/v1/users" do
+    get "Returns all users" do
+      operationId :public_api_v1_user_index
+      tags "user"
+      produces "application/json"
+
+      response "200", "Collection of users." do
+        schema type: :object,
+               properties: {
+                 users: {
+                   type: :array,
+                   items: {
+                     properties: {
+                       id: { type: :string },
+                       email: { type: :string },
+                       full_name: { type: :string },
+                     },
+                     required: %w[id email full_name],
+                   },
+                 },
+               }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/docs/users_spec.rb
+++ b/spec/docs/users_spec.rb
@@ -3,7 +3,7 @@
 require "swagger_helper"
 
 describe "API", type: :request do
-  path "/api/v1/users" do
+  path "/users" do
     get "Returns all users" do
       operationId :public_api_v1_user_index
       tags "user"

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API Users", type: :request do
+  describe "index" do
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    before :each do
+      10.times { create(:user) }
+    end
+
+    it "returns all users in 'users' field" do
+      get "/api/v1/users"
+      expect(parsed_response["users"].count).to eq 10
+    end
+
+    it "returns only id, email and full name" do
+      get "/api/v1/users"
+      expect(parsed_response["users"][0].keys).to contain_exactly("id", "full_name", "email")
+    end
+  end
+end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -8,7 +8,7 @@
   },
   "basePath": "/api/v1",
   "paths": {
-    "/api/v1/users": {
+    "/users": {
       "get": {
         "summary": "Returns all users",
         "operationId": "public_api_v1_user_index",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -6,5 +6,47 @@
     "description": "Auto generated doc",
     "definitions": null
   },
-  "basePath": "/api/v1"
+  "basePath": "/api/v1",
+  "paths": {
+    "/api/v1/users": {
+      "get": {
+        "summary": "Returns all users",
+        "operationId": "public_api_v1_user_index",
+        "tags": [
+          "user"
+        ],
+        "responses": {
+          "200": {
+            "description": "Collection of users.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "full_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "email",
+                      "full_name"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Context
E&L will need to know the list of users from R&P. Coupled with https://github.com/DFE-Digital/ecf-engage-and-learn/pull/79 to actually hit the client.

### Changes proposed in this pull request
Add Users controller to our API. Generate docs for it. Hide it in any environments with real data.

### Guidance to review
What that list exactly is, what fields they will need, which subset of users depending on time, whether it is paginated, and so on are all great questions, but they can be tackled one by one in later PRs. 

### Testing
I checked that I receive and deserialize the data correctly in E&L app, when running both things locally. Other than that, not sure how much there is to test here. I guess I should add a unit test in rspec for it. 

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Hit `/api-docs` and look at our nice swagger doc. 