### PR TITLE
Setup and readme for automerge of schema.rb

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+db/schema.rb merge=merge_db_schema

--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,8 @@ group :development, :test do
   gem "multi_json"
   gem "open_api-rswag-specs"
   gem "rswag"
+
+  gem "merge_db_schema"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -106,8 +106,6 @@ group :development, :test do
   gem "multi_json"
   gem "open_api-rswag-specs"
   gem "rswag"
-
-  gem "merge_db_schema"
 end
 
 group :development do
@@ -117,6 +115,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"
+
+  gem "merge_db_schema"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
       notifications-ruby-client (~> 5.1)
       rack (>= 2.1.4)
     marcel (1.0.0)
+    merge_db_schema (0.1.1)
+      rainbow
     method_source (1.0.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
@@ -449,6 +451,7 @@ DEPENDENCIES
   lograge
   logstash-event
   mail-notify (>= 1.0.3)
+  merge_db_schema
   multi_json
   open_api-rswag-api
   open_api-rswag-specs
@@ -484,4 +487,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.8
+   2.2.14

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Run `git config core.hooksPath .githooks` to use the included git hooks.
 bundle exec rake
 ```
 
+### Configure automerge of `schema.rb`
+
+Configure `[merge_db_schema](https://github.com/pocke/merge_db_schema)` with `merge_db_schema-init --force`
+
 ## Running specs
 ```
 bundle exec rspec


### PR DESCRIPTION
### Context

The schema.rb will conflict often, this aims to smooth this.

https://github.com/pocke/merge_db_schema

It requires some local setup to work, documented in the readme.

I'm not yet 100% sure if this is an improvement as it's a little tricky to test. If anyone has the opportunity to try it that would be good. I don't want to rush this one in in case it turns out to be worse rather than better.

### Changes proposed in this pull request

* Enable merge_db_schema
* Document usage in readme under developer setup

### Guidance to review

* See if pulling this in and *not* doing the setup causes any problems (I don't want to make dev setup harder)
* Find a conflicting branch with schema changes and try a merge, see if this makes it any easier.

Please report back in the PR comments.

We should also consider whether https://gist.github.com/jeromedalbert/afab24e80102b41d75d5f5538f1459c4 is a better solution. I'm wondering if it will be as it doesn't require any local modification of `.git/config` which this PR does.