### PR TITLE
Choose cip materials

### DIFF
--- a/app/controllers/schools/core_programme/materials_controller.rb
+++ b/app/controllers/schools/core_programme/materials_controller.rb
@@ -4,7 +4,7 @@ class Schools::CoreProgramme::MaterialsController < Schools::BaseController
   before_action :set_school_cohort
   before_action :prevent_double_submission, only: %i[advisory info edit update]
 
-  def advisory;end
+  def advisory; end
 
   def info; end
 

--- a/app/controllers/schools/core_programme/materials_controller.rb
+++ b/app/controllers/schools/core_programme/materials_controller.rb
@@ -2,7 +2,9 @@
 
 class Schools::CoreProgramme::MaterialsController < Schools::BaseController
   before_action :set_school_cohort
-  before_action :prevent_double_submission, only: %i[info edit update]
+  before_action :prevent_double_submission, only: %i[advisory info edit update]
+
+  def advisory;end
 
   def info; end
 

--- a/app/policies/school_cohort_policy.rb
+++ b/app/policies/school_cohort_policy.rb
@@ -12,6 +12,7 @@ class SchoolCohortPolicy < ApplicationPolicy
   alias_method :info?, :update?
   alias_method :edit?, :update?
   alias_method :success?, :update?
+  alias_method :advisory?, :update?
 
   class Scope < Scope
     def resolve

--- a/app/views/schools/cohorts/show.html.erb
+++ b/app/views/schools/cohorts/show.html.erb
@@ -40,7 +40,7 @@
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <%= govuk_link_to "Choose your training materials",
-                  @school_cohort.core_induction_programme_id ? schools_cohort_core_programme_materials_path(@cohort.start_year) : info_schools_cohort_core_programme_materials_path(@cohort.start_year) %>
+                  @school_cohort.core_induction_programme_id ? schools_cohort_core_programme_materials_path(@cohort.start_year) : advisory_schools_cohort_core_programme_materials_path(@cohort.start_year) %>
               </span>
 
               <%= render AutoTagComponent.new(text: @school_cohort.choose_training_materials_status) %>

--- a/app/views/schools/core_programme/materials/advisory.html.erb
+++ b/app/views/schools/core_programme/materials/advisory.html.erb
@@ -1,0 +1,14 @@
+<% content_for :before_content, govuk_back_link(
+   text: "Back",
+   href: schools_cohort_path(@cohort.start_year)
+   ) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @cohort.start_year %> cohort</span>
+    <h1 class="govuk-heading-xl">Do you know which accredited materials you want to use?</h1>
+    <p class="govuk-body">You will be choosing materials for any new early career teachers. They will access these materials on our service and complete a programme over 2 years.</p>
+    <p class="govuk-body">Not sure? <%= link_to 'Check our guidance on materials', info_schools_cohort_core_programme_materials_path(@cohort.start_year) %><p>
+
+    <%= govuk_link_to "Continue", { action: :edit }, class: "govuk-button" %>
+  </div>
+</div>

--- a/app/views/schools/core_programme/materials/info.html.erb
+++ b/app/views/schools/core_programme/materials/info.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content, govuk_back_link( text: "Back", href: schools_cohort_path(@cohort.start_year)) %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: advisory_schools_cohort_core_programme_materials_path(@cohort.start_year)) %>
 
 <span class="govuk-caption-xl"><%= @cohort.start_year %> cohort</span>
 <h1 class="govuk-heading-xl">Choose study materials for your early career teachers</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,7 @@ Rails.application.routes.draw do
 
       namespace :core_programme, path: "core-programme" do
         resource :materials, only: %i[edit update show] do
+          get :advisory
           get :info
           get :success
         end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_30_095331) do
+ActiveRecord::Schema.define(version: 2021_05_04_150201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "admin_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -184,6 +212,15 @@ ActiveRecord::Schema.define(version: 2021_04_30_095331) do
     t.index ["token"], name: "index_nomination_emails_on_token", unique: true
   end
 
+  create_table "partnership_csv_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "lead_provider_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.uuid "delivery_partner_id", null: false
+    t.index ["delivery_partner_id"], name: "index_partnership_csv_uploads_on_delivery_partner_id"
+    t.index ["lead_provider_id"], name: "index_partnership_csv_uploads_on_lead_provider_id"
+  end
+
   create_table "partnership_notification_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "token", null: false
     t.string "sent_to", null: false
@@ -348,6 +385,8 @@ ActiveRecord::Schema.define(version: 2021_04_30_095331) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "admin_profiles", "users"
   add_foreign_key "cohorts_lead_providers", "cohorts"
   add_foreign_key "cohorts_lead_providers", "lead_providers"

--- a/spec/cypress/integration/schools/core_induction_programme/ChooseMaterials.feature
+++ b/spec/cypress/integration/schools/core_induction_programme/ChooseMaterials.feature
@@ -9,9 +9,9 @@ Feature: Induction tutors choosing programmes
 
   Scenario: Choosing materails for Core Induction Programme
     When I click on "link" containing "Choose your training materials"
-    Then I should be on "2021 cohort CIP materials info" page
+    Then I should be on "2021 cohort CIP materials advisory" page
     And the page should be accessible
-    And percy should be sent snapshot called "2021 cohort CIP materials info page"
+    And percy should be sent snapshot called "2021 cohort CIP materials advisory page"
 
     When I click on "link" containing "Continue"
     Then I should be on "2021 cohort CIP materials selection" page

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -27,7 +27,8 @@ const pagePaths = {
   "2021 cohort CIP materials success":
     "/schools/cohorts/2021/core-programme/materials/success",
   "2021 cohort CIP materials": "/schools/cohorts/2021/core-programme/materials",
-  "2021 cohort CIP materials advisory": "/schools/cohorts/2021/core-programme/materials/advisory",
+  "2021 cohort CIP materials advisory":
+    "/schools/cohorts/2021/core-programme/materials/advisory",
   "check account": "/check-account",
   "admin schools": "/admin/schools",
   "admin school overview": "/admin/schools/:id",

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -27,6 +27,7 @@ const pagePaths = {
   "2021 cohort CIP materials success":
     "/schools/cohorts/2021/core-programme/materials/success",
   "2021 cohort CIP materials": "/schools/cohorts/2021/core-programme/materials",
+  "2021 cohort CIP materials advisory": "/schools/cohorts/2021/core-programme/materials/advisory",
   "check account": "/check-account",
   "admin schools": "/admin/schools",
   "admin school overview": "/admin/schools/:id",

--- a/spec/requests/schools/core_programme/materials_spec.rb
+++ b/spec/requests/schools/core_programme/materials_spec.rb
@@ -13,6 +13,27 @@ RSpec.describe "Schools::CoreProgramme::Materials", type: :request do
     sign_in user
   end
 
+  describe "GET /schools/cohorts/:id/core-programme/materials/advisory" do
+    context "when cohort has no materials selected yet" do
+      it "renders the material advisory template" do
+        get "/schools/cohorts/2021/core-programme/materials/advisory"
+
+        expect(response).to render_template("schools/core_programme/materials/advisory")
+      end
+    end
+    context "when cohort already has selected materials" do
+      before do
+        school_cohort.update(core_induction_programme: cip)
+      end
+
+      it "redirects to the materials page" do
+        get "/schools/cohorts/2021/core-programme/materials/advisory"
+
+        expect(response).to redirect_to("/schools/cohorts/2021/core-programme/materials")
+      end
+    end
+  end
+
   describe "GET /schools/cohorts/:id/core-programme/materials/info" do
     context "when cohort has no materials selected yet" do
       it "renders the materials info template" do


### PR DESCRIPTION
### Context
Trello #567 - We need to add an advisory page to the /core-programme/materials flow
### Changes proposed in this pull request
Addition of static page at /schools/cohorts/2021/core-programme/materials/advisory
### Guidance to review
Sign in as induction tutor, take the "choose CIP" path and page will be visible on clicking "Choose your training materials" link
### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
See guidance to review above.