### PR TITLE
clear faker limit for failing tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.before do
+    Faker::Number.unique.clear
+  end
   config.include Devise::Test::IntegrationHelpers, type: :request
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/challenge_partnership_spec.rb
+++ b/spec/requests/challenge_partnership_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "Challenging a partnership", type: :request do
   describe "GET /report-incorrect-partnership?partnership=:partnership" do
     before do
       sign_in induction_coordinator
+      Faker::Number.unique.clear
     end
 
     it "renders the challenge partnership template" do
@@ -103,6 +104,10 @@ RSpec.describe "Challenging a partnership", type: :request do
   end
 
   describe "POST /report-incorrect-partnership" do
+    before do
+      Faker::Number.unique.clear
+    end
+
     it "redirects to the success page" do
       when_i_submit_form_with_reason("mistake")
 

--- a/spec/requests/challenge_partnership_spec.rb
+++ b/spec/requests/challenge_partnership_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe "Challenging a partnership", type: :request do
   describe "GET /report-incorrect-partnership?partnership=:partnership" do
     before do
       sign_in induction_coordinator
-      Faker::Number.unique.clear
     end
 
     it "renders the challenge partnership template" do
@@ -104,10 +103,6 @@ RSpec.describe "Challenging a partnership", type: :request do
   end
 
   describe "POST /report-incorrect-partnership" do
-    before do
-      Faker::Number.unique.clear
-    end
-
     it "redirects to the success page" do
       when_i_submit_form_with_reason("mistake")
 


### PR DESCRIPTION
### Context
Fix for intermittent test failures 
### Changes proposed in this pull request
`Faker::Number.unique.clear` in 2 failing test blocks
### Guidance to review
Run spec/requests/challenge_partnership_spec.rb
### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
