### PR TITLE
Case insensitive user email field

### DIFF
--- a/db/migrate/20210506161800_case_insensitive_user_emails.rb
+++ b/db/migrate/20210506161800_case_insensitive_user_emails.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CaseInsensitiveUserEmails < ActiveRecord::Migration[6.1]
+  def up
+    enable_extension("citext")
+
+    change_column :users, :email, :citext, null: false
+  end
+
+  def down
+    change_column :users, :email, :string, null: false, default: ""
+
+    # GovUK PaaS has "citext" extension enabled by default which cannot be disabled.
+    # See: https://docs.cloud.service.gov.uk/deploying_services/postgresql/#force-a-failover
+    # disable_extension("citext")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_04_150201) do
+ActiveRecord::Schema.define(version: 2021_05_06_161800) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -358,7 +359,7 @@ ActiveRecord::Schema.define(version: 2021_05_04_150201) do
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "full_name", null: false
-    t.string "email", default: "", null: false
+    t.citext "email", default: "", null: false
     t.string "login_token"
     t.datetime "login_token_valid_until"
     t.datetime "remember_created_at"

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -31,10 +31,14 @@ RSpec.describe "Users::Sessions", type: :request do
       allow(UserMailer).to receive(:sign_in_email).and_call_original
     end
 
-    context "when email matches a user" do
-      it "renders the login_email_sent template" do
-        post "/users/sign_in", params: { user: { email: user.email } }
-        expect(response).to render_template(:login_email_sent)
+    it "renders the login_email_sent template regardless of email match" do
+      post "/users/sign_in", params: { user: { email: Faker::Internet.email } }
+      expect(response).to render_template(:login_email_sent)
+    end
+
+    context "when email case-insensitively matches a user" do
+      def randomize_case(string)
+        string.chars.map { |char| char.send(%i[upcase downcase].sample) }.join
       end
 
       it "sends a log_in email request to User Mailer" do
@@ -45,7 +49,7 @@ RSpec.describe "Users::Sessions", type: :request do
             token_expiry: token_expiry_regex,
           ),
         )
-        post "/users/sign_in", params: { user: { email: user.email } }
+        post "/users/sign_in", params: { user: { email: randomize_case(user.email) } }
       end
     end
 


### PR DESCRIPTION
### Context

User could not log in by entering their email address with any capital letter.

### Changes proposed in this pull request

As devise is already down-casing all email I've decided to use citext for users email column - this way case insenstive search is now enabled on email column by default (in case we'd ever need to do sth similar in other places)