### PR TITLE
ECF-RP-564: Create partnership request

### DIFF
--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -31,9 +31,9 @@ private
       notification_email = PartnershipNotificationEmail.find_by(token: @token)
       raise ActionController::RoutingError, "Not Found" if notification_email.blank?
 
-      @partnership = notification_email.partnership
+      @partnership = notification_email.partnerable
     elsif partnership_id.present?
-      @partnership = Partnership.find(partnership_id)
+      @partnership = Partnership.find_by(id: partnership_id) || PartnershipRequest.find_by(id: partnership_id)
       authorize(@partnership, :update?)
     else
       raise ActionController::RoutingError, "Not Found"

--- a/app/forms/confirm_schools_form.rb
+++ b/app/forms/confirm_schools_form.rb
@@ -9,12 +9,21 @@ class ConfirmSchoolsForm
   def save!
     ActiveRecord::Base.transaction do
       school_ids.each do |school_id|
-        partnership = Partnership.create!(
-          school_id: school_id,
-          cohort_id: cohort_id,
-          delivery_partner_id: delivery_partner_id,
-          lead_provider_id: lead_provider_id,
-        )
+        partnership = if SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id)&.core_induction_programme?
+                        PartnershipRequest.create!(
+                          school_id: school_id,
+                          cohort_id: cohort_id,
+                          delivery_partner_id: delivery_partner_id,
+                          lead_provider_id: lead_provider_id,
+                        )
+                      else
+                        Partnership.create!(
+                          school_id: school_id,
+                          cohort_id: cohort_id,
+                          delivery_partner_id: delivery_partner_id,
+                          lead_provider_id: lead_provider_id,
+                        )
+                      end
 
         PartnershipNotificationService.schedule_notifications(partnership)
       end

--- a/app/jobs/partnership_finalisation_job.rb
+++ b/app/jobs/partnership_finalisation_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PartnershipFinalisationJob < ApplicationJob
+  discard_on ActiveJob::DeserializationError
+
   def perform(partnership_request)
     return if partnership_request.reload.blank?
 

--- a/app/jobs/partnership_finalisation_job.rb
+++ b/app/jobs/partnership_finalisation_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class PartnershipFinalisationJob < ApplicationJob
+  def perform(partnership_request)
+    return if partnership_request.reload.blank?
+
+    originator = partnership_request.versions.first.whodunnit
+    PaperTrail.request(whodunnit: originator) do
+      partnership_request.finalise!
+    end
+  end
+end

--- a/app/jobs/partnership_reminder_job.rb
+++ b/app/jobs/partnership_reminder_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PartnershipReminderJob < ApplicationJob
+  discard_on ActiveJob::DeserializationError
+
   def perform(partnership)
     return if partnership.challenged?
 

--- a/app/models/base_partnership.rb
+++ b/app/models/base_partnership.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class BasePartnership < ApplicationRecord
+  self.abstract_class = true
+
+  CHALLENGE_WINDOW = 14.days.freeze
+
+  before_create :set_challenge_deadline
+
+  belongs_to :school
+  belongs_to :lead_provider
+  belongs_to :cohort
+  belongs_to :delivery_partner
+
+  has_paper_trail
+
+  def in_challenge_window?
+    challenge_deadline > Time.zone.now
+  end
+
+protected
+
+  def set_challenge_deadline
+    self.challenge_deadline ||= Time.zone.now + CHALLENGE_WINDOW
+  end
+end

--- a/app/models/base_partnership.rb
+++ b/app/models/base_partnership.rb
@@ -11,6 +11,7 @@ class BasePartnership < ApplicationRecord
   belongs_to :lead_provider
   belongs_to :cohort
   belongs_to :delivery_partner
+  has_many :partnership_notification_emails, as: :partnerable
 
   has_paper_trail
 

--- a/app/models/base_partnership.rb
+++ b/app/models/base_partnership.rb
@@ -19,6 +19,10 @@ class BasePartnership < ApplicationRecord
     challenge_deadline > Time.zone.now
   end
 
+  def challenged?
+    false
+  end
+
 protected
 
   def set_challenge_deadline

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-class Partnership < ApplicationRecord
-  CHALLENGE_WINDOW = 14.days.freeze
-
-  before_create :set_challenge_deadline
-
+class Partnership < BasePartnership
   enum challenge_reason: {
     another_provider: "another_provider",
     not_confirmed: "not_confirmed",
@@ -13,13 +9,7 @@ class Partnership < ApplicationRecord
     mistake: "mistake",
   }
 
-  belongs_to :school
-  belongs_to :lead_provider
-  belongs_to :cohort
-  belongs_to :delivery_partner
   has_many :partnership_notification_emails
-
-  has_paper_trail
 
   def challenged?
     challenge_reason.present?
@@ -31,15 +21,5 @@ class Partnership < ApplicationRecord
     raise ArgumentError if reason.blank?
 
     update!(challenge_reason: reason, challenged_at: Time.zone.now)
-  end
-
-  def in_challenge_window?
-    challenge_deadline > Time.zone.now
-  end
-
-private
-
-  def set_challenge_deadline
-    self.challenge_deadline ||= Time.zone.now + CHALLENGE_WINDOW
   end
 end

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -9,8 +9,6 @@ class Partnership < BasePartnership
     mistake: "mistake",
   }
 
-  has_many :partnership_notification_emails
-
   def challenged?
     challenge_reason.present?
   end

--- a/app/models/partnership_csv_upload.rb
+++ b/app/models/partnership_csv_upload.rb
@@ -53,9 +53,9 @@ private
         errors << { urn: urn, message: "School not eligible for funding", school_name: school.name, row_number: index + 1 }
       elsif !school.eligible?
         errors << { urn: urn, message: "School not eligible for inductions", school_name: school.name, row_number: index + 1 }
-      elsif school.lead_provider(Cohort.current.start_year) == lead_provider
+      elsif partnered_with_current_lead_provider?(school)
         errors << { urn: urn, message: "Your school - already confirmed", school_name: school.name, row_number: index + 1 }
-      elsif school.lead_provider(Cohort.current.start_year).present?
+      elsif partnered_with_other_lead_provider?(school)
         errors << { urn: urn, message: "Recruited by other provider", school_name: school.name, row_number: index + 1 }
       end
     end
@@ -65,5 +65,15 @@ private
 
   def strip_bom(string)
     string.force_encoding("UTF-8").gsub(/\xEF\xBB\xBF/, "")
+  end
+
+  def partnered_with_current_lead_provider?(school)
+    school.lead_provider(Cohort.current.start_year) == lead_provider ||
+      PartnershipRequest.where(lead_provider: lead_provider, school: school, cohort: Cohort.current).any?
+  end
+
+  def partnered_with_other_lead_provider?(school)
+    school.lead_provider(Cohort.current.start_year).present? ||
+      PartnershipRequest.where(school: school, cohort: Cohort.current).any?
   end
 end

--- a/app/models/partnership_notification_email.rb
+++ b/app/models/partnership_notification_email.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class PartnershipNotificationEmail < ApplicationRecord
-  belongs_to :partnership
+  belongs_to :partnerable, polymorphic: true
   has_one :nomination_email
-  delegate :school, to: :partnership, allow_nil: false
-  delegate :lead_provider, to: :partnership, allow_nil: false
-  delegate :delivery_partner, to: :partnership, allow_nil: true
-  delegate :cohort, to: :partnership, allow_nil: false
-  delegate :challenge_deadline, to: :partnership
+  delegate :school, to: :partnerable, allow_nil: false
+  delegate :lead_provider, to: :partnerable, allow_nil: false
+  delegate :delivery_partner, to: :partnerable, allow_nil: true
+  delegate :cohort, to: :partnerable, allow_nil: false
+  delegate :challenge_deadline, to: :partnerable
 
   enum email_type: {
     induction_coordinator_email: "induction_coordinator_email",

--- a/app/models/partnership_request.rb
+++ b/app/models/partnership_request.rb
@@ -5,7 +5,7 @@ class PartnershipRequest < BasePartnership
 
   def finalise!
     ActiveRecord::Base.transaction do
-      Partnership.create!(
+      partnership = Partnership.create!(
         delivery_partner: delivery_partner,
         lead_provider: lead_provider,
         school: school,
@@ -15,6 +15,7 @@ class PartnershipRequest < BasePartnership
       school_cohort = SchoolCohort.find_by!(school_id: school_id, cohort_id: cohort_id)
       school_cohort.update!(induction_programme_choice: "full_induction_programme", core_induction_programme: nil)
 
+      update_notification_emails(partnership)
       destroy!
     end
   end
@@ -23,7 +24,7 @@ class PartnershipRequest < BasePartnership
     raise ArgumentError if reason.blank?
 
     ActiveRecord::Base.transaction do
-      Partnership.create!(
+      partnership = Partnership.create!(
         delivery_partner: delivery_partner,
         lead_provider: lead_provider,
         school: school,
@@ -32,6 +33,7 @@ class PartnershipRequest < BasePartnership
         challenged_at: Time.zone.now,
       )
 
+      update_notification_emails(partnership)
       destroy!
     end
   end
@@ -40,5 +42,11 @@ private
 
   def schedule
     PartnershipFinalisationJob.set(wait: Partnership::CHALLENGE_WINDOW).perform_later(self)
+  end
+
+  def update_notification_emails(partnership)
+    partnership_notification_emails.each do |email|
+      email.update!(partnerable: partnership)
+    end
   end
 end

--- a/app/models/partnership_request.rb
+++ b/app/models/partnership_request.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class PartnershipRequest < BasePartnership
+  after_create :schedule
+
+  def finalise!
+    ActiveRecord::Base.transaction do
+      Partnership.create!(
+        delivery_partner: delivery_partner,
+        lead_provider: lead_provider,
+        school: school,
+        cohort: cohort,
+        challenge_deadline: Time.zone.now,
+      )
+      school_cohort = SchoolCohort.find_by!(school_id: school_id, cohort_id: cohort_id)
+      school_cohort.update!(induction_programme_choice: "full_induction_programme", core_induction_programme: nil)
+
+      destroy!
+    end
+  end
+
+  def challenge!(reason)
+    raise ArgumentError if reason.blank?
+
+    ActiveRecord::Base.transaction do
+      Partnership.create!(
+        delivery_partner: delivery_partner,
+        lead_provider: lead_provider,
+        school: school,
+        cohort: cohort,
+        challenge_reason: reason,
+        challenged_at: Time.zone.now,
+      )
+
+      destroy!
+    end
+  end
+
+private
+
+  def schedule
+    PartnershipFinalisationJob.set(wait: Partnership::CHALLENGE_WINDOW).perform_later(self)
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,19 +47,19 @@ class School < ApplicationRecord
   }
 
   scope :partnered, lambda { |year|
-    where(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
+    where(id: Partnership.unchallenged.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
   }
 
   scope :partnered_with_lead_provider, lambda { |lead_provider_id|
-    where(id: Partnership.where(lead_provider_id: lead_provider_id).select(:school_id))
+    where(id: Partnership.unchallenged.where(lead_provider_id: lead_provider_id).select(:school_id))
   }
 
   scope :unpartnered, lambda { |year|
-    where.not(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
+    where.not(id: Partnership.unchallenged.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
   }
 
   def lead_provider(year)
-    partnerships.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
+    partnerships.unchallenged.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
   end
 
   def full_address

--- a/app/policies/partnership_request_policy.rb
+++ b/app/policies/partnership_request_policy.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PartnershipRequestPolicy < PartnershipPolicy
+end

--- a/app/services/partnership_notification_service.rb
+++ b/app/services/partnership_notification_service.rb
@@ -54,7 +54,7 @@ private
     PartnershipNotificationEmail.create!(
       token: generate_token,
       sent_to: partnership.school.contact_email,
-      partnership: partnership,
+      partnerable: partnership,
       email_type: type,
     )
   end
@@ -70,14 +70,14 @@ private
     nomination_email = NominationEmail.create_nomination_email(
       sent_at: notification_email.created_at,
       sent_to: notification_email.sent_to,
-      school: notification_email.partnership.school,
+      school: notification_email.partnerable.school,
       partnership_notification_email: notification_email,
     )
 
     notify_id = SchoolMailer.school_partnership_notification_email(
       recipient: notification_email.sent_to,
       provider_name: provider_name(notification_email),
-      cohort: notification_email.partnership.cohort.display_name,
+      cohort: notification_email.partnerable.cohort.display_name,
       school_name: notification_email.school.name,
       nominate_url: nomination_email.nomination_url,
       challenge_url: challenge_url(notification_email.token),
@@ -91,7 +91,7 @@ private
     notify_id = SchoolMailer.coordinator_partnership_notification_email(
       recipient: notification_email.sent_to,
       provider_name: provider_name(notification_email),
-      cohort: notification_email.partnership.cohort.display_name,
+      cohort: notification_email.partnerable.cohort.display_name,
       school_name: notification_email.school.name,
       start_url: Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain),
       challenge_url: challenge_url(notification_email.token),

--- a/db/migrate/20210506203908_create_partnership_requests.rb
+++ b/db/migrate/20210506203908_create_partnership_requests.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreatePartnershipRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :partnership_requests do |t|
+      t.references :lead_provider, null: false, foreign_key: true, type: :uuid
+      t.references :delivery_partner, null: false, foreign_key: true, type: :uuid
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.references :cohort, null: false, foreign_key: true, type: :uuid
+      t.datetime :challenge_deadline
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210507112704_add_partnerable_to_partnership_notification_emails.rb
+++ b/db/migrate/20210507112704_add_partnerable_to_partnership_notification_emails.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddPartnerableToPartnershipNotificationEmails < ActiveRecord::Migration[6.1]
+  def up
+    add_reference :partnership_notification_emails, :partnerable, polymorphic: true, index: true
+    PartnershipNotificationEmail.all.each do |email|
+      email.update!(partnerable_type: "Partnership", partnerable_id: email.partnership_id)
+    end
+    remove_index :partnership_notification_emails, :partnership_id
+    remove_column :partnership_notification_emails, :partnership_id
+  end
+
+  def down
+    add_reference :partnership_notification_emails, :partnership, index: true, foreign_key: true
+    PartnershipNotificationEmail.all.each do |email|
+      email.update!(partnership_id: email.partnerable_id) if email.partnerable_type == "Partnership"
+    end
+    change_table :partnership_notification_emails, bulk: true do
+      remove_index :partnership_notification_emails, column: %i[partnerable_type partnerable_id]
+      remove_column :partnership_notification_emails, :partnerable_type
+      remove_column :partnership_notification_emails, :partnerable_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_203908) do
+ActiveRecord::Schema.define(version: 2021_05_07_112704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -229,11 +229,12 @@ ActiveRecord::Schema.define(version: 2021_05_06_203908) do
     t.string "notify_id"
     t.string "notify_status"
     t.datetime "delivered_at"
-    t.uuid "partnership_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "partnerable_type"
+    t.uuid "partnerable_id"
     t.index ["notify_id"], name: "index_partnership_notification_emails_on_notify_id"
-    t.index ["partnership_id"], name: "index_partnership_notification_emails_on_partnership_id"
+    t.index ["partnerable_type", "partnerable_id"], name: "index_partnership_notification_emails_on_partnerable"
     t.index ["token"], name: "index_partnership_notification_emails_on_token", unique: true
   end
 
@@ -418,7 +419,6 @@ ActiveRecord::Schema.define(version: 2021_05_06_203908) do
   add_foreign_key "lead_provider_profiles", "users"
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
-  add_foreign_key "partnership_notification_emails", "partnerships"
   add_foreign_key "partnership_requests", "cohorts"
   add_foreign_key "partnership_requests", "delivery_partners"
   add_foreign_key "partnership_requests", "lead_providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_161800) do
+ActiveRecord::Schema.define(version: 2021_05_06_203908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -237,6 +237,20 @@ ActiveRecord::Schema.define(version: 2021_05_06_161800) do
     t.index ["token"], name: "index_partnership_notification_emails_on_token", unique: true
   end
 
+  create_table "partnership_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "lead_provider_id", null: false
+    t.uuid "delivery_partner_id", null: false
+    t.uuid "school_id", null: false
+    t.uuid "cohort_id", null: false
+    t.datetime "challenge_deadline"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cohort_id"], name: "index_partnership_requests_on_cohort_id"
+    t.index ["delivery_partner_id"], name: "index_partnership_requests_on_delivery_partner_id"
+    t.index ["lead_provider_id"], name: "index_partnership_requests_on_lead_provider_id"
+    t.index ["school_id"], name: "index_partnership_requests_on_school_id"
+  end
+
   create_table "partnerships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -405,6 +419,10 @@ ActiveRecord::Schema.define(version: 2021_05_06_161800) do
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
   add_foreign_key "partnership_notification_emails", "partnerships"
+  add_foreign_key "partnership_requests", "cohorts"
+  add_foreign_key "partnership_requests", "delivery_partners"
+  add_foreign_key "partnership_requests", "lead_providers"
+  add_foreign_key "partnership_requests", "schools"
   add_foreign_key "partnerships", "cohorts"
   add_foreign_key "partnerships", "delivery_partners"
   add_foreign_key "partnerships", "lead_providers"

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -87,7 +87,7 @@ School.find_or_create_by!(urn: "000005") do |school|
   delivery_partner = DeliveryPartner.find_or_create_by!(name: "Test Delivery Partner")
   partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner: delivery_partner, school: school, lead_provider: LeadProvider.first)
   PartnershipNotificationEmail.find_or_create_by!(
-    partnership: partnership,
+    partnerable: partnership,
     sent_to: "cpd-test+tutor-2#{DOMAIN}",
     email_type: PartnershipNotificationEmail.email_types[:induction_coordinator_email],
     token: "abc123",

--- a/spec/cypress/app_commands/scenarios/challenge_partnership.rb
+++ b/spec/cypress/app_commands/scenarios/challenge_partnership.rb
@@ -9,7 +9,7 @@ SchoolCohort.create!(school: school, cohort: cohort, induction_programme_choice:
 PartnershipNotificationEmail.create!(
   token: "abc123",
   sent_to: user.email,
-  partnership: partnership,
+  partnerable: partnership,
   email_type: PartnershipNotificationEmail.email_types[:induction_coordinator_email],
 )
 
@@ -26,7 +26,7 @@ partnership = FactoryBot.create(
 PartnershipNotificationEmail.create!(
   token: "expired",
   sent_to: user.email,
-  partnership: partnership,
+  partnerable: partnership,
   email_type: PartnershipNotificationEmail.email_types[:induction_coordinator_email],
   created_at: 20.days.ago,
 )

--- a/spec/factories/partnership_notification_emails.rb
+++ b/spec/factories/partnership_notification_emails.rb
@@ -2,14 +2,14 @@
 
 FactoryBot.define do
   factory :partnership_notification_email do
-    partnership
+    partnerable { build(:partnership) }
     token { Faker::Alphanumeric.alphanumeric(number: 16) }
     sent_to { Faker::Internet.email }
     notify_id { Faker::Internet.uuid }
     email_type { "school_email" }
 
     trait :challenged do
-      partnership { build(:partnership, :challenged) }
+      partnerable { build(:partnership, :challenged) }
     end
   end
 end

--- a/spec/factories/partnership_request.rb
+++ b/spec/factories/partnership_request.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :partnership_request do
+    school
+    lead_provider
+    delivery_partner
+    cohort
+  end
+end

--- a/spec/forms/confirm_schools_form_spec.rb
+++ b/spec/forms/confirm_schools_form_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InductionChoiceForm, type: :model do
+  describe "save!" do
+    let(:lead_provider) { create(:lead_provider) }
+    let(:delivery_partner) { create(:delivery_partner) }
+    let(:cohort) { create(:cohort, :current) }
+    let(:form) do
+      ConfirmSchoolsForm.new(
+        lead_provider_id: lead_provider.id,
+        delivery_partner_id: delivery_partner.id,
+        school_ids: schools.map(&:id),
+        cohort_id: cohort.id,
+      )
+    end
+
+    context "when the school has not chosen provision" do
+      let(:schools) { [create(:school)] }
+
+      it "creates a partnership for the school" do
+        expect(PartnershipNotificationService).to receive(:schedule_notifications)
+                                                    .with(an_object_having_attributes(
+                                                            class: Partnership,
+                                                            cohort_id: cohort.id,
+                                                            school_id: schools.first.id,
+                                                            lead_provider_id: lead_provider.id,
+                                                            delivery_partner_id: delivery_partner.id,
+                                                          ))
+        expect { form.save! }.to change { Partnership.count }.by(1)
+        created_partnership = Partnership.order(:created_at).last
+        expect(created_partnership.school).to eql schools.first
+      end
+    end
+
+    context "when the school has chosen FIP" do
+      let(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme") }
+      let(:schools) { [school_cohort.school] }
+
+      it "creates a partnership for the school" do
+        expect(PartnershipNotificationService).to receive(:schedule_notifications)
+                                                    .with(an_object_having_attributes(
+                                                            class: Partnership,
+                                                            cohort_id: cohort.id,
+                                                            school_id: schools.first.id,
+                                                            lead_provider_id: lead_provider.id,
+                                                            delivery_partner_id: delivery_partner.id,
+                                                          ))
+        expect { form.save! }.to change { Partnership.count }.by(1)
+        created_partnership = Partnership.order(:created_at).last
+        expect(created_partnership.school).to eql schools.first
+      end
+    end
+
+    context "when the school has chosen CIP" do
+      let(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "core_induction_programme") }
+      let(:schools) { [school_cohort.school] }
+
+      it "creates a partnership request for the school" do
+        expect(PartnershipNotificationService).to receive(:schedule_notifications)
+                                                    .with(an_object_having_attributes(
+                                                            class: PartnershipRequest,
+                                                            cohort_id: cohort.id,
+                                                            school_id: schools.first.id,
+                                                            lead_provider_id: lead_provider.id,
+                                                            delivery_partner_id: delivery_partner.id,
+                                                          ))
+        expect { form.save! }.to change { PartnershipRequest.count }.by(1)
+        created_partnership_request = PartnershipRequest.order(:created_at).last
+        expect(created_partnership_request.school).to eql schools.first
+      end
+    end
+  end
+end

--- a/spec/jobs/partnership_finalisation_job_spec.rb
+++ b/spec/jobs/partnership_finalisation_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "PartnershipFinalisationJob" do
+  describe "#perform" do
+    it "calls finalise! on the partnership request" do
+      with_versioning do
+        partnership_request = create(:partnership_request)
+        expect(partnership_request).to receive(:finalise!)
+
+        PartnershipFinalisationJob.new.perform(partnership_request)
+      end
+    end
+
+    it "does nothing when the partnership request has been destroyed" do
+      with_versioning do
+        partnership_request = create(:partnership_request)
+        expect(partnership_request).not_to receive(:finalise!)
+        PartnershipFinalisationJob.perform_later(partnership_request)
+        partnership_request.destroy!
+
+        expect { Delayed::Worker.new.work_off }.not_to(change { Partnership.count })
+        expect(PartnershipRequest.count).to eql 0
+        expect(Partnership.count).to eql 0
+      end
+    end
+  end
+end

--- a/spec/jobs/partnership_reminder_job_spec.rb
+++ b/spec/jobs/partnership_reminder_job_spec.rb
@@ -4,6 +4,13 @@ require "rails_helper"
 
 RSpec.describe "PartnershipReminderJob" do
   describe "#perform" do
+    it "calls send_reminder" do
+      partnership = create(:partnership)
+      expect_any_instance_of(PartnershipNotificationService).to receive(:send_reminder)
+
+      PartnershipReminderJob.new.perform(partnership)
+    end
+
     it "Does nothing if the partnership has been challenged" do
       partnership = create(:partnership, :challenged)
       expect_any_instance_of(PartnershipNotificationService).not_to receive(:send_reminder)

--- a/spec/models/partnership_csv_upload_spec.rb
+++ b/spec/models/partnership_csv_upload_spec.rb
@@ -96,9 +96,46 @@ RSpec.describe PartnershipCsvUpload, type: :model do
       )
     end
 
+    it "finds schools with a partnership request for the lead provider" do
+      partnered_school = create(:school)
+      given_the_csv_contains_urns([partnered_school.urn])
+      PartnershipRequest.create!(
+        school: partnered_school,
+        lead_provider: @subject.lead_provider,
+        delivery_partner: @subject.delivery_partner,
+        cohort: current_cohort,
+      )
+
+      expect(@subject.invalid_schools.length).to eql 1
+      expect(@subject.invalid_schools).to contain_exactly(
+        {
+          urn: partnered_school.urn,
+          row_number: 1,
+          school_name: partnered_school.name,
+          message: "Your school - already confirmed",
+        },
+      )
+    end
+
     it "finds schools already in a partnership with a different lead provider" do
       partnership = create(:partnership, cohort: current_cohort)
       partnered_school = partnership.school
+      given_the_csv_contains_urns([partnered_school.urn])
+
+      expect(@subject.invalid_schools.length).to eql 1
+      expect(@subject.invalid_schools).to contain_exactly(
+        {
+          urn: partnered_school.urn,
+          row_number: 1,
+          school_name: partnered_school.name,
+          message: "Recruited by other provider",
+        },
+      )
+    end
+
+    it "finds schools with a partnership request from a different lead provider" do
+      partnership_request = create(:partnership_request, cohort: current_cohort)
+      partnered_school = partnership_request.school
       given_the_csv_contains_urns([partnered_school.urn])
 
       expect(@subject.invalid_schools.length).to eql 1

--- a/spec/models/partnership_notification_email_spec.rb
+++ b/spec/models/partnership_notification_email_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe PartnershipNotificationEmail, type: :model do
   describe "associations" do
-    it { is_expected.to belong_to(:partnership) }
+    it { is_expected.to belong_to(:partnerable) }
     it { is_expected.to have_one(:nomination_email) }
-    it { is_expected.to delegate_method(:school).to(:partnership) }
-    it { is_expected.to delegate_method(:lead_provider).to(:partnership) }
-    it { is_expected.to delegate_method(:delivery_partner).to(:partnership).allow_nil }
-    it { is_expected.to delegate_method(:cohort).to(:partnership) }
-    it { is_expected.to delegate_method(:challenge_deadline).to(:partnership) }
+    it { is_expected.to delegate_method(:school).to(:partnerable) }
+    it { is_expected.to delegate_method(:lead_provider).to(:partnerable) }
+    it { is_expected.to delegate_method(:delivery_partner).to(:partnerable).allow_nil }
+    it { is_expected.to delegate_method(:cohort).to(:partnerable) }
+    it { is_expected.to delegate_method(:challenge_deadline).to(:partnerable) }
   end
 end

--- a/spec/models/partnership_request_spec.rb
+++ b/spec/models/partnership_request_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PartnershipRequest, type: :model do
+  let(:lead_provider) { create(:lead_provider) }
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:school) { create(:school) }
+  let(:cohort) { create(:cohort) }
+  let(:partnership_request) do
+    PartnershipRequest.create!(
+      lead_provider: lead_provider,
+      delivery_partner: delivery_partner,
+      school: school,
+      cohort: cohort,
+    )
+  end
+  let!(:school_cohort) { create(:school_cohort, school: school, cohort: cohort, induction_programme_choice: "core_induction_programme") }
+
+  it "enables paper trail" do
+    is_expected.to be_versioned
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to belong_to(:delivery_partner) }
+  end
+
+  describe "create" do
+    it "should create a partnership finalisation job" do
+      freeze_time
+      partnership_request
+
+      expect(PartnershipFinalisationJob).to have_been_enqueued.with(partnership_request).at(2.weeks.from_now)
+    end
+  end
+
+  describe "#finalize!" do
+    it "creates a partnership with the correct attributes" do
+      expect { partnership_request.finalise! }.to change { Partnership.count }.by(1)
+
+      created_partnership = Partnership.order(:created_at).last
+      expect(created_partnership.lead_provider).to eql lead_provider
+      expect(created_partnership.delivery_partner).to eql delivery_partner
+      expect(created_partnership.school).to eql school
+      expect(created_partnership.cohort).to eql cohort
+    end
+
+    it "updates the school cohort to FIP" do
+      partnership_request.finalise!
+      expect(school_cohort.reload.induction_programme_choice).to eql "full_induction_programme"
+    end
+
+    it "should destroy the partnership request" do
+      partnership_request.finalise!
+      expect(partnership_request.destroyed?).to be true
+    end
+  end
+
+  describe "challenge!" do
+    it "should create a challenged partnership" do
+      freeze_time
+      expect { partnership_request.challenge!("mistake") }.to change { Partnership.count }.by(1)
+
+      created_partnership = Partnership.order(:created_at).last
+      expect(created_partnership.lead_provider).to eql lead_provider
+      expect(created_partnership.delivery_partner).to eql delivery_partner
+      expect(created_partnership.school).to eql school
+      expect(created_partnership.cohort).to eql cohort
+      expect(created_partnership.challenge_reason).to eql "mistake"
+      expect(created_partnership.challenged_at).to eql Time.zone.now
+    end
+
+    it "should destroy the partnership request" do
+      partnership_request.challenge!("mistake")
+      expect(partnership_request.destroyed?).to be true
+    end
+
+    it "should raise an error if called with a blank reason" do
+      expect { partnership_request.challenge!("") }.to raise_error(ArgumentError)
+      expect(partnership_request.destroyed?).to be false
+    end
+  end
+end

--- a/spec/models/partnership_request_spec.rb
+++ b/spec/models/partnership_request_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe PartnershipRequest, type: :model do
       partnership_request.finalise!
       expect(partnership_request.destroyed?).to be true
     end
+
+    it "associates any notification emails with the new partnership" do
+      email = create(:partnership_notification_email, partnerable: partnership_request)
+      partnership_request.finalise!
+
+      created_partnership = Partnership.order(:created_at).last
+      expect(created_partnership.partnership_notification_emails).to contain_exactly email
+    end
   end
 
   describe "challenge!" do
@@ -81,6 +89,14 @@ RSpec.describe PartnershipRequest, type: :model do
     it "should raise an error if called with a blank reason" do
       expect { partnership_request.challenge!("") }.to raise_error(ArgumentError)
       expect(partnership_request.destroyed?).to be false
+    end
+
+    it "associates any notification emails with the new partnership" do
+      email = create(:partnership_notification_email, partnerable: partnership_request)
+      partnership_request.challenge!("mistake")
+
+      created_partnership = Partnership.order(:created_at).last
+      expect(created_partnership.partnership_notification_emails).to contain_exactly email
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -315,4 +315,87 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "#lead_provider" do
+    it "returns the lead provider when there is a partnership" do
+      partnership = create(:partnership)
+      school = partnership.school
+      lead_provider = partnership.lead_provider
+      year = partnership.cohort.start_year
+
+      expect(school.lead_provider(year)).to eql lead_provider
+    end
+
+    it "returns nil when there is no partnership" do
+      school = create(:school)
+
+      expect(school.lead_provider(2021)).to be_nil
+    end
+
+    it "returns nil when there is no partnership for the specified year" do
+      partnership = create(:partnership)
+      school = partnership.school
+      year = partnership.cohort.start_year + 1
+
+      expect(school.lead_provider(year)).to be_nil
+    end
+
+    it "returns nil when the partnership has been challenged" do
+      partnership = create(:partnership, :challenged)
+      school = partnership.school
+      year = partnership.cohort.start_year
+
+      expect(school.lead_provider(year)).to be_nil
+    end
+  end
+
+  describe "scope :partnered" do
+    it "includes schools for the given year" do
+      partnership = create(:partnership)
+      school = partnership.school
+      year = partnership.cohort.start_year
+
+      expect(School.partnered(year)).to include(school)
+    end
+
+    it "does not include schools with challenged partnerships" do
+      partnership = create(:partnership, :challenged)
+      school = partnership.school
+      year = partnership.cohort.start_year
+
+      expect(School.partnered(year)).not_to include(school)
+    end
+
+    it "does not include schools only partnered in a different year" do
+      partnership = create(:partnership)
+      school = partnership.school
+      year = partnership.cohort.start_year + 1
+
+      expect(School.partnered(year)).not_to include(school)
+    end
+  end
+
+  describe "scope :unpartnered" do
+    it "includes schools with no partnership for a year" do
+      school = create(:school)
+
+      expect(School.unpartnered(2021)).to include(school)
+    end
+
+    it "includes schools with only challenged partnerships for a year" do
+      partnership = create(:partnership, :challenged)
+      school = partnership.school
+      year = partnership.cohort.start_year
+
+      expect(School.unpartnered(year)).to include(school)
+    end
+
+    it "does not include schools with an active partnership for a year" do
+      partnership = create(:partnership)
+      school = partnership.school
+      year = partnership.cohort.start_year
+
+      expect(School.unpartnered(year)).not_to include(school)
+    end
+  end
 end

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Admin::Schools", type: :request do
       get "/admin/schools/#{school.id}"
 
       expect(response).to render_template("admin/schools/show")
-      expect(response.body).to include(school.name)
+      expect(response.body).to include(CGI.escapeHTML(school.name))
       expect(response.body).to include("Add induction tutor")
     end
 

--- a/spec/requests/challenge_partnership_spec.rb
+++ b/spec/requests/challenge_partnership_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Challenging a partnership", type: :request do
   let(:partnership_notification_email) { create(:partnership_notification_email) }
-  let(:partnership) { partnership_notification_email.partnership }
+  let(:partnership) { partnership_notification_email.partnerable }
   let(:induction_coordinator) { create(:user, :induction_coordinator, schools: [partnership.school]) }
 
   describe "GET /report-incorrect-partnership?token=:token" do
@@ -20,7 +20,7 @@ RSpec.describe "Challenging a partnership", type: :request do
 
     context "when the link has expired" do
       let!(:partnership) { create(:partnership) }
-      let!(:partnership_notification_email) { create(:partnership_notification_email, partnership: partnership) }
+      let!(:partnership_notification_email) { create(:partnership_notification_email, partnerable: partnership) }
 
       it "redirects to link-expired" do
         travel 4.weeks
@@ -113,9 +113,9 @@ RSpec.describe "Challenging a partnership", type: :request do
       freeze_time
       when_i_submit_form_with_reason("mistake")
 
-      partnership_notification_email.partnership.reload
-      expect(partnership_notification_email.partnership.challenge_reason).to eql "mistake"
-      expect(partnership_notification_email.partnership.challenged_at).to eql Time.zone.now
+      partnership_notification_email.partnerable.reload
+      expect(partnership_notification_email.partnerable.challenge_reason).to eql "mistake"
+      expect(partnership_notification_email.partnerable.challenged_at).to eql Time.zone.now
     end
 
     it "shows an error message when no option is selected" do

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Schools::Partnerships", type: :request do
           PartnershipNotificationEmail.create!(
             token: "abc123",
             sent_to: user.email,
-            partnership: @partnership,
+            partnerable: @partnership,
             email_type: PartnershipNotificationEmail.email_types[:induction_coordinator_email],
           )
         end
@@ -68,7 +68,7 @@ RSpec.describe "Schools::Partnerships", type: :request do
           PartnershipNotificationEmail.create!(
             token: "abc123",
             sent_to: user.email,
-            partnership: @partnership,
+            partnerable: @partnership,
             email_type: PartnershipNotificationEmail.email_types[:induction_coordinator_email],
           )
         end


### PR DESCRIPTION
### Context
When a lead provider declares a partnership with a school who said they were doing CIP, we essentially ignore it for two weeks to give the school time to challenge. This introduces a data structure to represent that

### Changes proposed in this pull request
- Create a new PartnershipRequest, which inherits from a common base with Partnership
- Create mechanisms for a PartnershipRequest to become a Partnership, or be challenged
- Create PartnershipRequests when a CIP school is reported by an LP

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
