### PR TITLE
Add school detail view for Lead providers

### DIFF
--- a/app/components/primary_nav_component.rb
+++ b/app/components/primary_nav_component.rb
@@ -8,12 +8,13 @@ class PrimaryNavComponent < ViewComponent::Base
   class NavItemComponent < ViewComponent::Base
     attr_reader :path
 
-    def initialize(path:)
+    def initialize(path:, selected: false)
       @path = path
+      @selected = selected
     end
 
     def current_section?(path)
-      request.path.include?(path)
+      @selected || request.path.include?(path)
     end
   end
 end

--- a/app/controllers/lead_providers/base_controller.rb
+++ b/app/controllers/lead_providers/base_controller.rb
@@ -5,12 +5,12 @@ module LeadProviders
     include Pundit
 
     before_action :authenticate_user!
-    before_action :ensure_lead_provider_or_admin
+    before_action :ensure_lead_provider
 
   private
 
-    def ensure_lead_provider_or_admin
-      return if current_user&.admin? || current_user&.lead_provider?
+    def ensure_lead_provider
+      return if current_user&.lead_provider?
 
       raise Pundit::NotAuthorizedError, "Forbidden"
     end

--- a/app/controllers/lead_providers/school_details_controller.rb
+++ b/app/controllers/lead_providers/school_details_controller.rb
@@ -3,8 +3,22 @@
 module LeadProviders
   class SchoolDetailsController < ::LeadProviders::BaseController
     def show
-      @school = School.eligible.find(params[:id])
-      @selected_cohort = Cohort.find(params[:selected_cohort_id])
+      @school = find_school
+      @selected_cohort = selected_cohort_or_current
+    end
+
+  private
+
+    def selected_cohort_or_current
+      Cohort.find_by(id: params[:selected_cohort_id]) || Cohort.current
+    end
+
+    def find_school
+      year = selected_cohort_or_current.start_year
+      search_scope = School.eligible
+
+      search_scope = search_scope.partnered_with_lead_provider(current_user.lead_provider.id, year) if current_user.lead_provider?
+      search_scope.find(params[:id])
     end
   end
 end

--- a/app/controllers/lead_providers/school_details_controller.rb
+++ b/app/controllers/lead_providers/school_details_controller.rb
@@ -15,10 +15,7 @@ module LeadProviders
 
     def find_school
       year = selected_cohort_or_current.start_year
-      search_scope = School.eligible
-
-      search_scope = search_scope.partnered_with_lead_provider(current_user.lead_provider.id, year) if current_user.lead_provider?
-      search_scope.find(params[:id])
+      School.eligible.partnered_with_lead_provider(current_user.lead_provider.id, year).find(params[:id])
     end
   end
 end

--- a/app/controllers/lead_providers/your_schools_controller.rb
+++ b/app/controllers/lead_providers/your_schools_controller.rb
@@ -12,7 +12,7 @@ module LeadProviders
                            @cohorts.find_by(start_year: Time.zone.today.year)
                          end
 
-      @schools = School.partnered_with_lead_provider(@lead_provider.id, @selected_cohort.start_year)
+      @schools = School.eligible.partnered_with_lead_provider(@lead_provider.id, @selected_cohort.start_year)
         .includes(:early_career_teachers)
         .order(:name)
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -124,6 +124,13 @@ class School < ApplicationRecord
     local_authority_district&.sparse?(year) || false
   end
 
+  def characteristics_for(year)
+    characteristics = []
+    characteristics << "Pupil premium above 40%" if pupil_premium_uplift?(year)
+    characteristics << "Remote school" if sparsity_uplift?(year)
+    characteristics.join(" and ")
+  end
+
   scope :with_pupil_premium_uplift, lambda { |start_year|
     joins(:pupil_premiums)
       .merge(PupilPremium.only_with_uplift(start_year))

--- a/app/views/lead_providers/school_details/show.html.erb
+++ b/app/views/lead_providers/school_details/show.html.erb
@@ -24,14 +24,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m"><%= @selected_cohort.start_year %> participants</h2>
+    <h2 class="govuk-heading-m"><%= @selected_cohort.display_name %> participants</h2>
   </div>
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-one-third">
     <div class="dashboard-numbers key-number">
-      <p class="govuk-heading-xl">0</p>
+      <p class="govuk-heading-xl">
+        <%= @school.early_career_teacher_profiles_for(@selected_cohort.start_year).count -%>
+      </p>
       <p class="govuk-heading-s">ECTs added</p>
     </div>
   </div>

--- a/app/views/lead_providers/school_details/show.html.erb
+++ b/app/views/lead_providers/school_details/show.html.erb
@@ -98,7 +98,7 @@
         <dd class="govuk-summary-list__value">
           <% if @school.induction_coordinators.any? %>
             <%= mail_to @school.induction_coordinators.first.email %>
-          <% end -%>
+          <% end %>
         </dd>
       </div>
     </dl>

--- a/app/views/lead_providers/school_details/show.html.erb
+++ b/app/views/lead_providers/school_details/show.html.erb
@@ -1,3 +1,104 @@
-<%= render ::SchoolInformation::Details::BreadcrumbComponent.new(selected_cohort: @selected_cohort) %>
-<%= render ::SchoolInformation::Details::HeadComponent.new(school: @school, selected_cohort: @selected_cohort) %>
-<%= render ::SchoolInformation::Details::MainInfoComponent.new(school: @school) %>
+<% content_for :title, @school.name %>
+<% content_for :before_content, govuk_breadcrumbs(breadcrumbs: {
+  "Schools" => lead_providers_your_schools_path,
+  @school.name => nil
+}) %>
+<% content_for :nav_bar do %>
+  <%= render PrimaryNavComponent.new do |component| %>
+    <%= component.nav_item(path: dashboard_path) do %>
+      Overview
+    <% end %>
+    <%= component.nav_item(path: lead_providers_your_schools_path, selected: true) do %>
+      Schools
+    <% end %>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+      <%= @school.name %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m"><%= @selected_cohort.start_year %> participants</h2>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-6">
+  <div class="govuk-grid-column-one-third">
+    <div class="dashboard-numbers key-number">
+      <p class="govuk-heading-xl">0</p>
+      <p class="govuk-heading-s">ECTs added</p>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <div class="dashboard-numbers key-number">
+      <p class="govuk-heading-xl">0</p>
+      <p class="govuk-heading-s">mentors added</p>
+    </div>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      School details
+    </h2>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          URN
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @school.urn %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Delivery partner
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @school.delivery_partner_for(@selected_cohort.start_year)&.name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Local authority
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @school.local_authority&.name || "No local authority assigned" %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          MAT/Network
+        </dt>
+        <dd class="govuk-summary-list__value">
+          tbc
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Characteristics
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @school.characteristics_for(@selected_cohort.start_year) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Induction tutor
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <% if @school.induction_coordinators.any? %>
+            <%= mail_to @school.induction_coordinators.first.email %>
+          <% end -%>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -73,7 +73,7 @@
       <tbody class="govuk-table__body">
         <% @schools.each do |school| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= govuk_link_to school.name, admin_school_path(school) %></td>
+            <td class="govuk-table__cell"><%= govuk_link_to school.name, lead_providers_school_detail_path(school, selected_cohort_id: @selected_cohort.id) %></td>
             <td class="govuk-table__cell"><%= school.urn %></td>
             <td class="govuk-table__cell"><%= school.delivery_partner_for(@selected_cohort.start_year)&.name %></td>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= school.early_career_teacher_profiles_for(@selected_cohort.start_year).count %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
 
   namespace :lead_providers, path: "lead-providers" do
     resources :your_schools, path: "/your-schools", only: %i[index create]
-    resources :school_details, only: %i[show]
+    resources :school_details, path: "school-details", only: %i[show]
 
     resource :report_schools, path: "report-schools", only: [] do
       post "check-delivery-partner", action: :check_delivery_partner

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -96,7 +96,7 @@ end
 
 30.times do |idx|
   urn = (100 + idx).to_s.rjust(6, "0")
-  item_num = 6 + idx
+  item_num = 7 + idx
   School.find_or_create_by!(urn: urn) do |school|
     school.update!(
       name: "ZZ Test School #{item_num}",
@@ -122,6 +122,33 @@ end
       token: "abc424#{item_num}",
     )
   end
+end
+
+School.find_or_create_by!(urn: "000006") do |school|
+  school.update!(
+    name: "ZZ Test School 6",
+    postcode: "AX4 9AB",
+    address_line1: "27 School Lane",
+    primary_contact_email: "cpd-test+school-6#{DOMAIN}",
+    school_status_code: 1,
+    school_type_code: 1,
+    administrative_district_code: "E901",
+  )
+  SchoolLocalAuthority.find_or_create_by!(school: school, local_authority: local_authority, start_year: 2019)
+  user = User.find_or_create_by!(full_name: "Induction Tutor for School 6", email: "cpd-test+tutor-3#{DOMAIN}")
+  InductionCoordinatorProfile.find_or_create_by!(user: user) do |profile|
+    profile.update!(schools: [school])
+  end
+  SchoolCohort.find_or_create_by!(cohort: Cohort.current, school: school, induction_programme_choice: "full_induction_programme")
+  delivery_partner = DeliveryPartner.find_or_create_by!(name: "Mega Delivery Partner")
+  partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner: delivery_partner, school: school, lead_provider: LeadProvider.first)
+  PartnershipNotificationEmail.find_or_create_by!(
+    partnership: partnership,
+    sent_to: "cpd-test+tutor-3#{DOMAIN}",
+    email_type: PartnershipNotificationEmail.email_types[:induction_coordinator_email],
+    token: "abc424",
+  )
+  PupilPremium.find_or_create_by!(school: school, start_year: 2021, total_pupils: 500, eligible_pupils: 300)
 end
 
 delivery_partner = DeliveryPartner.find_or_create_by!(name: "Amazing Delivery Partner")

--- a/spec/cypress/app_commands/scenarios/lead_provider_with_schools.rb
+++ b/spec/cypress/app_commands/scenarios/lead_provider_with_schools.rb
@@ -3,12 +3,13 @@
 profile = LeadProviderProfile.order(:created_at).last
 lead_provider = profile.lead_provider
 schools = [
-  FactoryBot.create(:school, name: "Big School", urn: 900_001),
-  FactoryBot.create(:school, name: "Middle School", urn: 900_002),
-  FactoryBot.create(:school, name: "Small School", urn: 900_003),
+  FactoryBot.create(:school, :pupil_premium_uplift, name: "Big School", urn: 900_001),
+  FactoryBot.create(:school, :sparsity_uplift, name: "Middle School", urn: 900_002),
+  FactoryBot.create(:school, :pupil_premium_uplift, :sparsity_uplift, name: "Small School", urn: 900_003),
 ]
 delivery_partner = FactoryBot.create(:delivery_partner, name: "Ace Delivery Partner")
 
-schools.each do |school|
+schools.each_with_index do |school, index|
   FactoryBot.create(:partnership, school: school, lead_provider: lead_provider, delivery_partner: delivery_partner, cohort: Cohort.find_by(start_year: 2021))
+  FactoryBot.create(:user, :induction_coordinator, schools: [schools[index]], email: "induction.tutor_#{index + 1}@example.com")
 end

--- a/spec/cypress/integration/lead_providers/YourSchools.feature
+++ b/spec/cypress/integration/lead_providers/YourSchools.feature
@@ -34,8 +34,10 @@ Feature: Your schools flow
     And I type "ace" into "search box"
     And I click on "search button"
     Then "page body" should contain "Big School"
-    Then "page body" should contain "Middle School"
-    Then "page body" should contain "Small School"
+    And "page body" should contain "Middle School"
+    And "page body" should contain "Small School"
+    And "page body" should contain "900001"
+    And "page body" should contain "900002"
     And "page body" should contain "900003"
     And "page body" should contain "Ace Delivery Partner"
     And the table should have 3 rows
@@ -45,3 +47,36 @@ Feature: Your schools flow
     And I click on "search button"
     Then "page body" should contain "There are no matching results"
     And "schools table" should not exist
+
+  Scenario: Viewing school with pupil premium uplift
+    When I click on "link" containing "Big School"
+    Then "page body" should contain "Big School"
+    And "page body" should contain "2021 participants"
+    And "page body" should contain "900001"
+    And "page body" should contain "Ace Delivery Partner"
+    And "page body" should contain "Pupil premium above 40%"
+    And "page body" should contain "induction.tutor_1@example.com"
+    And the page should be accessible
+    And percy should be sent snapshot called "Lead providers school with pupil premium uplift details"
+
+  Scenario: Viewing school with sparsity uplift
+    When I click on "link" containing "Middle School"
+    Then "page body" should contain "Middle School"
+    And "page body" should contain "2021 participants"
+    And "page body" should contain "900002"
+    And "page body" should contain "Ace Delivery Partner"
+    And "page body" should contain "Remote school"
+    And "page body" should contain "induction.tutor_2@example.com"
+    And the page should be accessible
+    And percy should be sent snapshot called "Lead providers school with sparsity uplift details"
+
+  Scenario: Viewing school with pupil premium and sparsity uplifts
+    When I click on "link" containing "Small School"
+    Then "page body" should contain "Small School"
+    And "page body" should contain "2021 participants"
+    And "page body" should contain "900003"
+    And "page body" should contain "Ace Delivery Partner"
+    And "page body" should contain "Pupil premium above 40% and Remote school"
+    And "page body" should contain "induction.tutor_3@example.com"
+    And the page should be accessible
+    And percy should be sent snapshot called "Lead providers school with pupil premium and sparsity uplift details"

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe School, type: :model do
   describe "#characteristics_for" do
     context "when pupil premium uplift applies" do
       let(:school) { create(:school, :pupil_premium_uplift) }
-      
+
       it "returns the correct characteristic for pupil premium" do
         expect(school.characteristics_for(2021)).to eq "Pupil premium above 40%"
       end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -403,4 +403,38 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "#characteristics_for" do
+    context "when pupil premium uplift applies" do
+      let(:school) { create(:school, :pupil_premium_uplift) }
+      
+      it "returns the correct characteristic for pupil premium" do
+        expect(school.characteristics_for(2021)).to eq "Pupil premium above 40%"
+      end
+    end
+
+    context "when sparsity uplift applies" do
+      let(:school) { create(:school, :sparsity_uplift) }
+
+      it "returns the correct characteristic" do
+        expect(school.characteristics_for(2021)).to eq "Remote school"
+      end
+    end
+
+    context "when pupil premium and sparcity uplifts apply" do
+      let(:school) { create(:school, :pupil_premium_uplift, :sparsity_uplift) }
+
+      it "returns the correct characteristics" do
+        expect(school.characteristics_for(2021)).to eq "Pupil premium above 40% and Remote school"
+      end
+    end
+
+    context "when neither pupil premium nor sparcity uplifts apply" do
+      let(:school) { create(:school) }
+
+      it "returns an empty string" do
+        expect(school.characteristics_for(2021)).to be_blank
+      end
+    end
+  end
 end

--- a/spec/requests/lead_providers/school_details_spec.rb
+++ b/spec/requests/lead_providers/school_details_spec.rb
@@ -13,11 +13,25 @@ RSpec.describe "School details spec", type: :request do
   describe "GET /lead-providers/school-details/:id" do
     let(:school) { create(:school) }
 
-    it "should show the school detail page" do
-      get lead_providers_school_detail_path(school)
+    context "when the user is the lead provider for the school" do
+      before do
+        create(:partnership, school: school, lead_provider: user.lead_provider, cohort: cohort)
+      end
 
-      expect(response).to render_template :show
-      expect(assigns(:school)).to eq school
+      it "should show the school detail page" do
+        get lead_providers_school_detail_path(school)
+
+        expect(response).to render_template :show
+        expect(assigns(:school)).to eq school
+      end
+    end
+
+    context "when school is not in a partnership with the lead provider" do
+      it "should return not found" do
+        expect {
+          get lead_providers_school_detail_path(school)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end

--- a/spec/requests/lead_providers/school_details_spec.rb
+++ b/spec/requests/lead_providers/school_details_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "School details spec", type: :request do
   let(:user) { create(:user, :lead_provider) }
-  let!(:cohort) { create(:cohort, :current) }
+  let!(:cohort) { create(:cohort, start_year: 2021) }
 
   before do
     sign_in user

--- a/spec/requests/lead_providers/school_details_spec.rb
+++ b/spec/requests/lead_providers/school_details_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "School details spec", type: :request do
+  let(:user) { create(:user, :lead_provider) }
+  let!(:cohort) { create(:cohort, :current) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /lead-providers/school-details/:id" do
+    let(:school) { create(:school) }
+
+    it "should show the school detail page" do
+      get lead_providers_school_detail_path(school)
+
+      expect(response).to render_template :show
+      expect(assigns(:school)).to eq school
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Trello card](https://trello.com/c/oLsN0lH9/581-view-and-manage-schools-school-detail)
Builds upon the __Your schools__ functionality from PR #323 

### Changes proposed in this pull request
Add school detail view

### Guidance to review
When signed-in as a lead provider, visit `/lead-providers/your-schools` (there is no direct link to the page currently) then clicking on one of the school links in the table of schools will show the school details page for that school.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
