### PR TITLE
/api/v1/users returns valid jsonapi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ gem "delayed_job_active_record"
 # Acts as State Machine for participant states
 gem "aasm"
 
+gem "jsonapi-serializer"
+
 # OpenApi Swagger
 gem "open_api-rswag-api", ">= 0.1.0"
 gem "open_api-rswag-ui", ">= 0.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
     jsonapi-rspec (0.0.11)
       rspec-core
       rspec-expectations
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -473,6 +475,7 @@ DEPENDENCIES
   health_check!
   httpclient (~> 2.8, >= 2.8.3)
   jsonapi-rspec
+  jsonapi-serializer
   kaminari (>= 1.2.0)
   listen (>= 3.0.5, < 3.4)
   lograge (>= 0.11.2)

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,12 +2,17 @@
 
 module Api
   class ApiController < ActionController::API
+    before_action :set_jsonapi_content_type_header
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
   private
 
     def not_found
       head :not_found
+    end
+
+    def set_jsonapi_content_type_header
+      headers["Content-Type"] = "application/vnd.api+json"
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class UsersController < Api::ApiController
       def index
-        render json: { users: User.all.as_json(only: %i[id email full_name]) }
+        render json: UserSerializer.new(User.all).serializable_hash.to_json
       end
     end
   end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UserSerializer
+  include JSONAPI::Serializer
+
+  set_id :id
+  attributes :email, :full_name
+end

--- a/spec/docs/users_spec.rb
+++ b/spec/docs/users_spec.rb
@@ -9,24 +9,34 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
     get "Returns all users" do
       operationId :api_v1_user_index
       tags "user"
-      produces "application/json"
+      produces "application/vnd.api+json"
       security [bearerAuth: []]
 
       response "200", "Collection of users." do
         schema type: :object,
+               required: %w[data],
                properties: {
-                 users: {
+                 data: {
                    type: :array,
                    items: {
+                     type: :object,
+                     required: %w[id type attributes],
                      properties: {
                        id: { type: :string },
-                       email: { type: :string },
-                       full_name: { type: :string },
+                       type: { type: :string },
+                       attributes: {
+                         type: :object,
+                         required: %w[email full_name],
+                         properties: {
+                           email: { type: :string },
+                           full_name: { type: :string },
+                         },
+                       },
                      },
-                     required: %w[id email full_name],
                    },
                  },
                }
+
         run_test!
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ end
 RSpec.configure do |config|
   config.include RSpec::DefaultHttpHeader, type: :request
 
+  config.include JSONAPI::RSpec
+
   config.before do
     Faker::Number.unique.clear
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -3,21 +3,36 @@
 require "rails_helper"
 
 RSpec.describe "API Users", type: :request do
-  describe "index" do
+  describe "#index" do
     let(:parsed_response) { JSON.parse(response.body) }
 
     before :each do
-      10.times { create(:user) }
+      3.times { create(:user) }
     end
 
-    it "returns all users in 'users' field" do
+    it "returns correct jsonapi content type header" do
       get "/api/v1/users"
-      expect(parsed_response["users"].count).to eq 10
+      expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
     end
 
-    it "returns only id, email and full name" do
+    it "returns all users" do
       get "/api/v1/users"
-      expect(parsed_response["users"][0].keys).to contain_exactly("id", "full_name", "email")
+      expect(parsed_response["data"].size).to eql(3)
+    end
+
+    it "returns correct type" do
+      get "/api/v1/users"
+      expect(parsed_response["data"][0]).to have_type("user")
+    end
+
+    it "returns IDs" do
+      get "/api/v1/users"
+      expect(parsed_response["data"][0]["id"]).to be_in(User.pluck(:id))
+    end
+
+    it "returns only email and full name in attributes" do
+      get "/api/v1/users"
+      expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name).exactly
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,12 +50,14 @@ RSpec.configure do |config|
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
-  #   # This allows you to limit a spec run to individual examples or groups
-  #   # you care about by tagging them with `:focus` metadata. When nothing
-  #   # is tagged with `:focus`, all examples get run. RSpec also provides
-  #   # aliases for `it`, `describe`, and `context` that include `:focus`
-  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -87,26 +87,42 @@
             "description": "Collection of users.",
             "schema": {
               "type": "object",
+              "required": [
+                "data"
+              ],
               "properties": {
-                "users": {
+                "data": {
                   "type": "array",
                   "items": {
+                    "type": "object",
+                    "required": [
+                      "id",
+                      "type",
+                      "attributes"
+                    ],
                     "properties": {
                       "id": {
                         "type": "string"
                       },
-                      "email": {
+                      "type": {
                         "type": "string"
                       },
-                      "full_name": {
-                        "type": "string"
+                      "attributes": {
+                        "type": "object",
+                        "required": [
+                          "email",
+                          "full_name"
+                        ],
+                        "properties": {
+                          "email": {
+                            "type": "string"
+                          },
+                          "full_name": {
+                            "type": "string"
+                          }
+                        }
                       }
-                    },
-                    "required": [
-                      "id",
-                      "email",
-                      "full_name"
-                    ]
+                    }
                   }
                 }
               }


### PR DESCRIPTION
### Context

- I gather we want to conform to jsonapi spec defined at https://jsonapi.org

### Changes proposed in this pull request

- Change existing `/api/v1/users` endpoint so it conforms to jsonapi spec
- Added `jsonapi-serializer` it seems far better maintained compared to https://github.com/jsonapi-rb/jsonapi-rails and https://github.com/jsonapi-rb/jsonapi-rb despite the fact it only deals with the serialisation part I feel this is the better option
- Uncommented an rspec config so developers can focus on tests

### Guidance to review

- This is a breaking change to the API but as far as I'm aware is not in use so should be safe to change

### Testing

### Review Checks
- [X] All pages have automated accessibility checks via cypress
- [X] All pages have visual tests via cypress + percy
- [X] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- curl -I https://ecf-review-pr-341.london.cloudapps.digital/api/v1/users
- check `Content-Type` header
- should match spec defined at https://jsonapi.org/format/#content-negotiation-servers
- curl https://ecf-review-pr-341.london.cloudapps.digital/api/v1/users
- check reponse body
- should match spec defined at https://jsonapi.org/format/#document-structure