### PR TITLE
CPDTP-168 Add sandbox environment

### DIFF
--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -1,0 +1,39 @@
+name: Deploy to Sandbox
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to deploy
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: softprops/turnstyle@v1
+        name: Check workflow concurrency
+        with:
+          poll-interval-seconds: 20
+          same-branch-only: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_version: 0.14.0
+
+      - name: Deploy to Sandbox
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SANDBOX }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SANDBOX }}
+          TF_VAR_paas_user: ${{ secrets.GOVPAAS_SAND_USERNAME }}
+          TF_VAR_paas_password: ${{ secrets.GOVPAAS_SAND_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+        run: |
+          export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
+          cd terraform/app
+          terraform init -reconfigure -input=false -backend-config="bucket=TODO"
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/sandbox.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_SANDBOX}}", "RELEASE_VERSION":"${{github.event.inputs.version}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -35,5 +35,5 @@ jobs:
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
           cd terraform/app
-          terraform init -reconfigure -input=false -backend-config="bucket=TODO"
+          terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-d25ff054-929d-4206-8c6f-d5c4a93ed5c3"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/sandbox.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_SANDBOX}}", "RELEASE_VERSION":"${{github.event.inputs.version}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'

--- a/config/credentials/sandbox.yml.enc
+++ b/config/credentials/sandbox.yml.enc
@@ -1,0 +1,1 @@
+RW3IroXq3Kq989wFZeG2MCiIG5bk3V78/8q7lTWwfE1/ANbPB35BdfEbaTGE5mEwzfOytsv6QylyqLZFkrawveilgTk=--nHaXUFgD5PmTig3d--W9f2od3o/mIn3u6QxhycJg==

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/integer/time"
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  config.require_master_key = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  # Compress CSS using a preprocessor.
+  # config.assets.css_compressor = :sass
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Store uploaded files on the local file system (see config/storage.yml for options).
+  config.active_storage.service = :amazon
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = true
+  config.session_store :cookie_store, key: "_early_career_framework_session", secure: true, expire_after: 2.weeks
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment).
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "early_career_framework_production"
+  config.domain = ENV["DOMAIN"]
+
+  config.support_email = "continuing-professional-development@digital.education.gov.uk"
+
+  config.gias_api_schema = ENV["GIAS_API_SCHEMA"]
+  config.gias_extract_id = ENV["GIAS_EXTRACT_ID"]
+  config.gias_api_user = ENV["GIAS_API_USER"]
+  config.gias_api_password = Rails.application.credentials.GIAS_API_PASSWORD
+
+  config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: Rails.application.credentials.GOVUK_NOTIFY_API_KEY,
+  }
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Log disallowed deprecations.
+  config.active_support.disallowed_deprecation = :log
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  # Logging
+  config.log_level = :info
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+  config.active_record.logger = nil # Don't log SQL in production
+
+  # Use Lograge for cleaner logging
+  config.lograge.enabled = true
+  config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.lograge.ignore_actions = ["ApplicationController#check"]
+  config.lograge.logger = ActiveSupport::Logger.new($stdout)
+
+  # Include params in logs: https://github.com/roidrage/lograge#what-it-doesnt-do
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w[controller action format id]
+    {
+      params: event.payload[:params].except(*exceptions),
+      exception: event.payload[:exception], # ["ExceptionClass", "the message"]
+    }
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # Inserts middleware to perform automatic connection switching.
+  # The `database_selector` hash is used to pass options to the DatabaseSelector
+  # middleware. The `delay` is used to determine how long to wait after a write
+  # to send a subsequent read to the primary.
+  #
+  # The `database_resolver` class is used by the middleware to determine which
+  # database is appropriate to use based on the time delay.
+  #
+  # The `database_resolver_context` class is used by the middleware to set
+  # timestamps for the last write to the primary. The resolver uses the context
+  # class timestamps to determine how long to wait before reading from the
+  # replica.
+  #
+  # By default Rails will store a last write timestamp in the session. The
+  # DatabaseSelector middleware is designed as such you can define your own
+  # strategy for connection switching and pass that into the middleware through
+  # these configuration options.
+  # config.active_record.database_selector = { delay: 2.seconds }
+  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+end

--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -13,4 +13,3 @@ paas_web_app_instances = 1
 paas_web_app_memory = 8192
 paas_worker_app_instances = 1
 paas_worker_app_start_command = "bundle exec rake jobs:work"
-govuk_hostnames = ["s-manage-training-for-early-career-teachers"]

--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -1,0 +1,16 @@
+# Platform
+environment = "sandbox"
+app_environment = "sandbox"
+
+# Gov.UK PaaS
+paas_api_url = "https://api.london.cloud.service.gov.uk"
+paas_space_name = "early-careers-framework-sandbox"
+paas_postgres_service_plan = "small-11"
+paas_app_start_timeout = "180"
+paas_app_stopped = false
+paas_web_app_deployment_strategy = "blue-green-v2"
+paas_web_app_instances = 1
+paas_web_app_memory = 8192
+paas_worker_app_instances = 1
+paas_worker_app_start_command = "bundle exec rake jobs:work"
+govuk_hostnames = ["s-manage-training-for-early-career-teachers"]


### PR DESCRIPTION
### Context

We want a sandbox environment in order to allow lead providers to develop and test their integrations against our code.

The action hasn't been tested as it has to be in `develop` to be able to run it.

The GovPaaS space and terraform state bucket have been created and configured as per https://github.com/DFE-Digital/early-careers-framework/blob/197413ab705b207d7d1ce6dafb2c00690efff415/documentation/terraform.md

https://dfedigital.atlassian.net/browse/CPDTP-168

### Changes proposed in this pull request

* New Github action for deploying to new environment (mostly copied from staging/production actions)
* New terraform vars (mostly copied from staging)

### Guidance to review

:ship:

### Testing

* merge it then test it by running the new action