### PR TITLE
Add missing sandbox_app_env.yaml for terraform deploy step

### DIFF
--- a/terraform/workspace-variables/sandbox_app_env.yml
+++ b/terraform/workspace-variables/sandbox_app_env.yml
@@ -1,0 +1,12 @@
+---
+RACK_ENV: production
+RAILS_ENV: sandbox
+NODE_ENV: production
+RAILS_LOG_TO_STDOUT: true
+RAILS_MAX_THREADS: 5
+RAILS_SERVE_STATIC_FILES: true
+SERVICE_TYPE: web
+DATABASE_URL: postgres://postgres@localhost:5432
+DOMAIN: sandbox-manage-training-for-early-career-teachers.education.gov.uk
+GOVUK_WEBSITE_ROOT: sandbox-manage-training-for-early-career-teachers.education.gov.uk
+GOVUK_APP_DOMAIN: sandbox-manage-training-for-early-career-teachers.education.gov.uk


### PR DESCRIPTION
```
If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
/home/runner/work/_temp/49805c3b-c0fc-41d8-9ba1-851cf307647d/terraform-bin apply -input=false -auto-approve -var-file ../workspace-variables/sandbox.tfvars -var=secret_paas_app_env_values={"RAILS_MASTER_KEY":"***", "RELEASE_VERSION":"9531f52967214eba0081345b3cdb57783fdf77eb"} -var logstash_url=***

Error: Invalid function argument

  on variables.tf line 110, in locals:
 110:   paas_app_env_yml_values = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
    |----------------
    | path.module is "."
    | var.app_environment is "sandbox"

Invalid value for "path" parameter: no file exists at
../workspace-variables/sandbox_app_env.yml; this function works only with
files that are distributed as part of the configuration source code, so if
this file will be created by a resource in this configuration you must instead
obtain this result from an attribute of that resource.
```