### PR TITLE
Pending partnerships

### DIFF
--- a/app/controllers/schools/partnerships_controller.rb
+++ b/app/controllers/schools/partnerships_controller.rb
@@ -6,7 +6,7 @@ class Schools::PartnershipsController < Schools::BaseController
 
   def index
     @school = current_user.induction_coordinator_profile.schools.first
-    @partnership = @school.partnerships.unchallenged.find_by(cohort: cohort)
+    @partnership = @school.partnerships.active.find_by(cohort: cohort)
 
     if @partnership&.in_challenge_window?
       @report_mistake_link = challenge_partnership_path(partnership: @partnership)

--- a/app/forms/confirm_schools_form.rb
+++ b/app/forms/confirm_schools_form.rb
@@ -9,22 +9,14 @@ class ConfirmSchoolsForm
   def save!
     ActiveRecord::Base.transaction do
       school_ids.each do |school_id|
-        partnership = if SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id)&.core_induction_programme?
-                        Partnership.create!(
-                          school_id: school_id,
-                          cohort_id: cohort_id,
-                          delivery_partner_id: delivery_partner_id,
-                          lead_provider_id: lead_provider_id,
-                          pending: true,
-                        )
-                      else
-                        Partnership.create!(
-                          school_id: school_id,
-                          cohort_id: cohort_id,
-                          delivery_partner_id: delivery_partner_id,
-                          lead_provider_id: lead_provider_id,
-                        )
-                      end
+        partnership_is_pending = SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id)&.core_induction_programme? || false
+        partnership = Partnership.create!(
+          school_id: school_id,
+          cohort_id: cohort_id,
+          delivery_partner_id: delivery_partner_id,
+          lead_provider_id: lead_provider_id,
+          pending: partnership_is_pending,
+        )
 
         PartnershipNotificationService.schedule_notifications(partnership)
       end

--- a/app/forms/confirm_schools_form.rb
+++ b/app/forms/confirm_schools_form.rb
@@ -9,12 +9,22 @@ class ConfirmSchoolsForm
   def save!
     ActiveRecord::Base.transaction do
       school_ids.each do |school_id|
-        partnership = Partnership.create!(
-          school_id: school_id,
-          cohort_id: cohort_id,
-          delivery_partner_id: delivery_partner_id,
-          lead_provider_id: lead_provider_id,
-        )
+        partnership = if SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id)&.core_induction_programme?
+                        Partnership.create!(
+                          school_id: school_id,
+                          cohort_id: cohort_id,
+                          delivery_partner_id: delivery_partner_id,
+                          lead_provider_id: lead_provider_id,
+                          started_at: Time.zone.now + Partnership::CHALLENGE_WINDOW,
+                        )
+                      else
+                        Partnership.create!(
+                          school_id: school_id,
+                          cohort_id: cohort_id,
+                          delivery_partner_id: delivery_partner_id,
+                          lead_provider_id: lead_provider_id,
+                        )
+                      end
 
         PartnershipNotificationService.schedule_notifications(partnership)
       end

--- a/app/forms/confirm_schools_form.rb
+++ b/app/forms/confirm_schools_form.rb
@@ -9,7 +9,8 @@ class ConfirmSchoolsForm
   def save!
     ActiveRecord::Base.transaction do
       school_ids.each do |school_id|
-        partnership_is_pending = SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id)&.core_induction_programme? || false
+        school_cohort = SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id)
+        partnership_is_pending = school_cohort&.core_induction_programme? || false
         partnership = Partnership.create!(
           school_id: school_id,
           cohort_id: cohort_id,
@@ -17,6 +18,14 @@ class ConfirmSchoolsForm
           lead_provider_id: lead_provider_id,
           pending: partnership_is_pending,
         )
+
+        if school_cohort.nil?
+          SchoolCohort.create!(
+            school_id: school_id,
+            cohort_id: cohort_id,
+            induction_programme_choice: "full_induction_programme",
+          )
+        end
 
         PartnershipNotificationService.schedule_notifications(partnership)
       end

--- a/app/forms/confirm_schools_form.rb
+++ b/app/forms/confirm_schools_form.rb
@@ -15,7 +15,7 @@ class ConfirmSchoolsForm
                           cohort_id: cohort_id,
                           delivery_partner_id: delivery_partner_id,
                           lead_provider_id: lead_provider_id,
-                          started_at: Time.zone.now + Partnership::CHALLENGE_WINDOW,
+                          pending: true,
                         )
                       else
                         Partnership.create!(

--- a/app/jobs/partnership_activation_job.rb
+++ b/app/jobs/partnership_activation_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PartnershipActivationJob < ApplicationJob
+  discard_on ActiveJob::DeserializationError
+
+  def perform(partnership)
+    return if partnership.challenged?
+    return unless partnership.pending
+
+    ActiveRecord::Base.transaction do
+      partnership.update!(pending: false)
+      school_cohort = SchoolCohort.find_by!(school_id: partnership.school_id, cohort_id: partnership.cohort_id)
+      school_cohort.update!(induction_programme_choice: "full_induction_programme", core_induction_programme: nil)
+    end
+  end
+end

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -3,7 +3,6 @@
 class Partnership < ApplicationRecord
   CHALLENGE_WINDOW = 14.days.freeze
 
-  before_create :set_started_at
   before_create :set_challenge_deadline
 
   enum challenge_reason: {
@@ -38,18 +37,9 @@ class Partnership < ApplicationRecord
     challenge_deadline > Time.zone.now
   end
 
-  def pending?
-    !challenged? && started_at > Time.zone.now
-  end
-
-  scope :pending, -> { unchallenged.where(started_at: Time.zone.now..) }
-  scope :active, -> { unchallenged.where(started_at: ..Time.zone.now) }
+  scope :active, -> { unchallenged.where(pending: false) }
 
 private
-
-  def set_started_at
-    self.started_at ||= Time.zone.now
-  end
 
   def set_challenge_deadline
     self.challenge_deadline ||= Time.zone.now + CHALLENGE_WINDOW

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -4,6 +4,7 @@ class Partnership < ApplicationRecord
   CHALLENGE_WINDOW = 14.days.freeze
 
   before_create :set_challenge_deadline
+  after_create :schedule_activation
 
   enum challenge_reason: {
     another_provider: "another_provider",
@@ -43,5 +44,11 @@ private
 
   def set_challenge_deadline
     self.challenge_deadline ||= Time.zone.now + CHALLENGE_WINDOW
+  end
+
+  def schedule_activation
+    return unless pending
+
+    PartnershipActivationJob.new.delay(run_at: CHALLENGE_WINDOW.from_now).perform(self)
   end
 end

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -3,6 +3,7 @@
 class Partnership < ApplicationRecord
   CHALLENGE_WINDOW = 14.days.freeze
 
+  before_create :set_started_at
   before_create :set_challenge_deadline
 
   enum challenge_reason: {
@@ -37,7 +38,18 @@ class Partnership < ApplicationRecord
     challenge_deadline > Time.zone.now
   end
 
+  def pending?
+    !challenged? && started_at > Time.zone.now
+  end
+
+  scope :pending, -> { unchallenged.where(started_at: Time.zone.now..) }
+  scope :active, -> { unchallenged.where(started_at: ..Time.zone.now) }
+
 private
+
+  def set_started_at
+    self.started_at ||= Time.zone.now
+  end
 
   def set_challenge_deadline
     self.challenge_deadline ||= Time.zone.now + CHALLENGE_WINDOW

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,19 +47,19 @@ class School < ApplicationRecord
   }
 
   scope :partnered, lambda { |year|
-    where(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
+    where(id: Partnership.unchallenged.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
   }
 
   scope :partnered_with_lead_provider, lambda { |lead_provider_id|
-    where(id: Partnership.where(lead_provider_id: lead_provider_id).select(:school_id))
+    where(id: Partnership.unchallenged.where(lead_provider_id: lead_provider_id).select(:school_id))
   }
 
   scope :unpartnered, lambda { |year|
-    where.not(id: Partnership.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
+    where.not(id: Partnership.unchallenged.joins(:cohort).where(cohorts: { start_year: year }).select(:school_id))
   }
 
   def lead_provider(year)
-    partnerships.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
+    partnerships.unchallenged.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
   end
 
   def full_address

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -15,7 +15,7 @@ class SchoolCohort < ApplicationRecord
   belongs_to :core_induction_programme, optional: true
 
   def training_provider_status
-    school.partnerships&.unchallenged&.exists?(cohort: cohort) ? "Done" : "To do"
+    school.partnerships&.active&.exists?(cohort: cohort) ? "Done" : "To do"
   end
 
   def add_participants_status

--- a/db/migrate/20210514100703_add_started_at_to_partnerships.rb
+++ b/db/migrate/20210514100703_add_started_at_to_partnerships.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddStartedAtToPartnerships < ActiveRecord::Migration[6.1]
+  def change
+    add_column :partnerships, :started_at, :datetime
+    add_index :partnerships, :started_at
+  end
+end

--- a/db/migrate/20210514100703_add_started_at_to_partnerships.rb
+++ b/db/migrate/20210514100703_add_started_at_to_partnerships.rb
@@ -2,7 +2,7 @@
 
 class AddStartedAtToPartnerships < ActiveRecord::Migration[6.1]
   def change
-    add_column :partnerships, :started_at, :datetime
-    add_index :partnerships, :started_at
+    add_column :partnerships, :pending, :boolean, null: false, default: false
+    add_index :partnerships, :pending
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_161800) do
+ActiveRecord::Schema.define(version: 2021_05_14_100703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -229,12 +229,27 @@ ActiveRecord::Schema.define(version: 2021_05_06_161800) do
     t.string "notify_id"
     t.string "notify_status"
     t.datetime "delivered_at"
-    t.uuid "partnership_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "partnerable_type"
+    t.uuid "partnerable_id"
     t.index ["notify_id"], name: "index_partnership_notification_emails_on_notify_id"
-    t.index ["partnership_id"], name: "index_partnership_notification_emails_on_partnership_id"
+    t.index ["partnerable_type", "partnerable_id"], name: "index_partnership_notification_emails_on_partnerable"
     t.index ["token"], name: "index_partnership_notification_emails_on_token", unique: true
+  end
+
+  create_table "partnership_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "lead_provider_id", null: false
+    t.uuid "delivery_partner_id", null: false
+    t.uuid "school_id", null: false
+    t.uuid "cohort_id", null: false
+    t.datetime "challenge_deadline"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cohort_id"], name: "index_partnership_requests_on_cohort_id"
+    t.index ["delivery_partner_id"], name: "index_partnership_requests_on_delivery_partner_id"
+    t.index ["lead_provider_id"], name: "index_partnership_requests_on_lead_provider_id"
+    t.index ["school_id"], name: "index_partnership_requests_on_school_id"
   end
 
   create_table "partnerships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -247,10 +262,12 @@ ActiveRecord::Schema.define(version: 2021_05_06_161800) do
     t.datetime "challenged_at"
     t.string "challenge_reason"
     t.datetime "challenge_deadline"
+    t.datetime "started_at"
     t.index ["cohort_id"], name: "index_partnerships_on_cohort_id"
     t.index ["delivery_partner_id"], name: "index_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_partnerships_on_lead_provider_id"
     t.index ["school_id"], name: "index_partnerships_on_school_id"
+    t.index ["started_at"], name: "index_partnerships_on_started_at"
   end
 
   create_table "privacy_policies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -404,7 +421,10 @@ ActiveRecord::Schema.define(version: 2021_05_06_161800) do
   add_foreign_key "lead_provider_profiles", "users"
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
-  add_foreign_key "partnership_notification_emails", "partnerships"
+  add_foreign_key "partnership_requests", "cohorts"
+  add_foreign_key "partnership_requests", "delivery_partners"
+  add_foreign_key "partnership_requests", "lead_providers"
+  add_foreign_key "partnership_requests", "schools"
   add_foreign_key "partnerships", "cohorts"
   add_foreign_key "partnerships", "delivery_partners"
   add_foreign_key "partnerships", "lead_providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -247,12 +247,12 @@ ActiveRecord::Schema.define(version: 2021_05_14_100703) do
     t.datetime "challenged_at"
     t.string "challenge_reason"
     t.datetime "challenge_deadline"
-    t.datetime "started_at"
+    t.boolean "pending", default: false, null: false
     t.index ["cohort_id"], name: "index_partnerships_on_cohort_id"
     t.index ["delivery_partner_id"], name: "index_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_partnerships_on_lead_provider_id"
+    t.index ["pending"], name: "index_partnerships_on_pending"
     t.index ["school_id"], name: "index_partnerships_on_school_id"
-    t.index ["started_at"], name: "index_partnerships_on_started_at"
   end
 
   create_table "privacy_policies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -229,27 +229,12 @@ ActiveRecord::Schema.define(version: 2021_05_14_100703) do
     t.string "notify_id"
     t.string "notify_status"
     t.datetime "delivered_at"
+    t.uuid "partnership_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "partnerable_type"
-    t.uuid "partnerable_id"
     t.index ["notify_id"], name: "index_partnership_notification_emails_on_notify_id"
-    t.index ["partnerable_type", "partnerable_id"], name: "index_partnership_notification_emails_on_partnerable"
+    t.index ["partnership_id"], name: "index_partnership_notification_emails_on_partnership_id"
     t.index ["token"], name: "index_partnership_notification_emails_on_token", unique: true
-  end
-
-  create_table "partnership_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "lead_provider_id", null: false
-    t.uuid "delivery_partner_id", null: false
-    t.uuid "school_id", null: false
-    t.uuid "cohort_id", null: false
-    t.datetime "challenge_deadline"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["cohort_id"], name: "index_partnership_requests_on_cohort_id"
-    t.index ["delivery_partner_id"], name: "index_partnership_requests_on_delivery_partner_id"
-    t.index ["lead_provider_id"], name: "index_partnership_requests_on_lead_provider_id"
-    t.index ["school_id"], name: "index_partnership_requests_on_school_id"
   end
 
   create_table "partnerships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -421,10 +406,7 @@ ActiveRecord::Schema.define(version: 2021_05_14_100703) do
   add_foreign_key "lead_provider_profiles", "users"
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
-  add_foreign_key "partnership_requests", "cohorts"
-  add_foreign_key "partnership_requests", "delivery_partners"
-  add_foreign_key "partnership_requests", "lead_providers"
-  add_foreign_key "partnership_requests", "schools"
+  add_foreign_key "partnership_notification_emails", "partnerships"
   add_foreign_key "partnerships", "cohorts"
   add_foreign_key "partnerships", "delivery_partners"
   add_foreign_key "partnerships", "lead_providers"

--- a/spec/factories/partnership.rb
+++ b/spec/factories/partnership.rb
@@ -14,6 +14,6 @@ FactoryBot.define do
   end
 
   trait :pending do
-    started_at { 2.weeks.from_now }
+    pending { true }
   end
 end

--- a/spec/factories/partnership.rb
+++ b/spec/factories/partnership.rb
@@ -12,4 +12,8 @@ FactoryBot.define do
     challenged_at { 2.days.ago }
     challenge_reason { "mistake" }
   end
+
+  trait :pending do
+    started_at { 2.weeks.from_now }
+  end
 end

--- a/spec/forms/confirm_schools_form_spec.rb
+++ b/spec/forms/confirm_schools_form_spec.rb
@@ -32,10 +32,17 @@ RSpec.describe ConfirmSchoolsForm, type: :model do
         created_partnership = Partnership.order(:created_at).last
         expect(created_partnership.school).to eql schools.first
       end
+
+      it "creates a school cohort with FIP" do
+        expect { form.save! }.to change { SchoolCohort.count }.by(1)
+        created_school_cohort = SchoolCohort.order(:created_at).last
+        expect(created_school_cohort.school).to eql schools.first
+        expect(created_school_cohort.induction_programme_choice).to eql "full_induction_programme"
+      end
     end
 
     context "when the school has chosen FIP" do
-      let(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme") }
+      let!(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme") }
       let(:schools) { [school_cohort.school] }
 
       it "creates a (not pending) partnership for the school" do
@@ -52,10 +59,14 @@ RSpec.describe ConfirmSchoolsForm, type: :model do
         expect(created_partnership.school).to eql schools.first
         expect(created_partnership.pending).to eql false
       end
+
+      it "does not create a school cohort" do
+        expect { form.save! }.not_to(change { SchoolCohort.count })
+      end
     end
 
     context "when the school has chosen CIP" do
-      let(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "core_induction_programme") }
+      let!(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "core_induction_programme") }
       let(:schools) { [school_cohort.school] }
 
       it "creates a pending partnership for the school" do
@@ -71,6 +82,10 @@ RSpec.describe ConfirmSchoolsForm, type: :model do
         created_partnership_request = Partnership.order(:created_at).last
         expect(created_partnership_request.school).to eql schools.first
         expect(created_partnership_request.pending).to eql true
+      end
+
+      it "does not create a school cohort" do
+        expect { form.save! }.not_to(change { SchoolCohort.count })
       end
     end
   end

--- a/spec/forms/confirm_schools_form_spec.rb
+++ b/spec/forms/confirm_schools_form_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConfirmSchoolsForm, type: :model do
+  describe "save!" do
+    let(:lead_provider) { create(:lead_provider) }
+    let(:delivery_partner) { create(:delivery_partner) }
+    let(:cohort) { create(:cohort, :current) }
+    let(:form) do
+      ConfirmSchoolsForm.new(
+        lead_provider_id: lead_provider.id,
+        delivery_partner_id: delivery_partner.id,
+        school_ids: schools.map(&:id),
+        cohort_id: cohort.id,
+      )
+    end
+
+    context "when the school has not chosen provision" do
+      let(:schools) { [create(:school)] }
+
+      it "creates a partnership for the school" do
+        expect(PartnershipNotificationService).to receive(:schedule_notifications)
+                                                    .with(an_object_having_attributes(
+                                                            class: Partnership,
+                                                            cohort_id: cohort.id,
+                                                            school_id: schools.first.id,
+                                                            lead_provider_id: lead_provider.id,
+                                                            delivery_partner_id: delivery_partner.id,
+                                                          ))
+        expect { form.save! }.to change { Partnership.count }.by(1)
+        created_partnership = Partnership.order(:created_at).last
+        expect(created_partnership.school).to eql schools.first
+      end
+    end
+
+    context "when the school has chosen FIP" do
+      let(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme") }
+      let(:schools) { [school_cohort.school] }
+
+      it "creates a (not pending) partnership for the school" do
+        expect(PartnershipNotificationService).to receive(:schedule_notifications)
+                                                    .with(an_object_having_attributes(
+                                                            class: Partnership,
+                                                            cohort_id: cohort.id,
+                                                            school_id: schools.first.id,
+                                                            lead_provider_id: lead_provider.id,
+                                                            delivery_partner_id: delivery_partner.id,
+                                                          ))
+        expect { form.save! }.to change { Partnership.count }.by(1)
+        created_partnership = Partnership.order(:created_at).last
+        expect(created_partnership.school).to eql schools.first
+        expect(created_partnership.pending).to eql false
+      end
+    end
+
+    context "when the school has chosen CIP" do
+      let(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "core_induction_programme") }
+      let(:schools) { [school_cohort.school] }
+
+      it "creates a pending partnership for the school" do
+        expect(PartnershipNotificationService).to receive(:schedule_notifications)
+                                                    .with(an_object_having_attributes(
+                                                            class: Partnership,
+                                                            cohort_id: cohort.id,
+                                                            school_id: schools.first.id,
+                                                            lead_provider_id: lead_provider.id,
+                                                            delivery_partner_id: delivery_partner.id,
+                                                          ))
+        expect { form.save! }.to change { Partnership.count }.by(1)
+        created_partnership_request = Partnership.order(:created_at).last
+        expect(created_partnership_request.school).to eql schools.first
+        expect(created_partnership_request.pending).to eql true
+      end
+    end
+  end
+end

--- a/spec/jobs/partnership_activation_job_spec.rb
+++ b/spec/jobs/partnership_activation_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "PartnershipFinalisationJob" do
+  describe "#perform" do
+    let(:pending_partnership) { create(:partnership, :pending) }
+    let!(:school_cohort) do
+      SchoolCohort.create!(
+        school: pending_partnership.school,
+        cohort: pending_partnership.cohort,
+        induction_programme_choice: "core_induction_programme",
+      )
+    end
+
+    it "updates the partnership and school cohort" do
+      PartnershipActivationJob.new.perform(pending_partnership)
+
+      expect(pending_partnership.reload.pending).to eql false
+      expect(school_cohort.reload.induction_programme_choice).to eql "full_induction_programme"
+    end
+
+    it "does nothing when the partnership request has been challenged" do
+      challenged_partnership = create(:partnership, :pending, :challenged)
+      school_cohort = SchoolCohort.create!(
+        school: challenged_partnership.school,
+        cohort: challenged_partnership.cohort,
+        induction_programme_choice: "core_induction_programme",
+      )
+
+      PartnershipActivationJob.new.perform(pending_partnership)
+
+      expect(challenged_partnership.reload.pending).to eql true
+      expect(school_cohort.reload.induction_programme_choice).to eql "core_induction_programme"
+    end
+  end
+end

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -110,50 +110,6 @@ RSpec.describe Partnership, type: :model do
     let!(:partnership) { create(:partnership) }
     let!(:challenged_partnership) { create(:partnership, :challenged, :pending) }
 
-    it "sets started_at to creation time" do
-      freeze_time
-      partnership = Partnership.create!(
-        lead_provider: create(:lead_provider),
-        school: create(:school),
-        delivery_partner: create(:delivery_partner),
-        cohort: create(:cohort),
-      )
-      expect(partnership.started_at).to eql Time.zone.now
-    end
-
-    it "allows started_at to be overridden" do
-      freeze_time
-      expected_started_at = 3.days.from_now
-      partnership = Partnership.create!(
-        lead_provider: create(:lead_provider),
-        school: create(:school),
-        delivery_partner: create(:delivery_partner),
-        cohort: create(:cohort),
-        started_at: expected_started_at,
-      )
-      expect(partnership.started_at).to eql expected_started_at
-    end
-
-    describe "#pending?" do
-      it "returns true for pending partnerships" do
-        expect(pending_partnership.pending?).to eql true
-      end
-
-      it "returns false for challenged partnerships" do
-        expect(challenged_partnership.pending?).to eql false
-      end
-
-      it "returns false for partnerships that are not pending" do
-        expect(partnership.pending?).to eql false
-      end
-    end
-
-    describe "scope :pending" do
-      it "returns only pending partnerships, without challenged partnerships" do
-        expect(Partnership.pending).to contain_exactly(pending_partnership)
-      end
-    end
-
     describe "scope :active" do
       it "returns only unchallenged, not pending partnerships" do
         expect(Partnership.active).to contain_exactly(partnership)

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -110,6 +110,28 @@ RSpec.describe Partnership, type: :model do
     let!(:partnership) { create(:partnership) }
     let!(:challenged_partnership) { create(:partnership, :challenged, :pending) }
 
+    it "schedules a PartnershipActivationJob" do
+      freeze_time
+
+      partnership = Partnership.create!(
+        school: create(:school),
+        lead_provider: create(:lead_provider),
+        delivery_partner: create(:delivery_partner),
+        cohort: create(:cohort),
+        pending: true,
+      )
+
+      expect(an_instance_of(PartnershipActivationJob)).to delay_execution_of(:perform)
+                                                            .with(an_object_having_attributes(
+                                                                    class: Partnership,
+                                                                    cohort_id: partnership.cohort.id,
+                                                                    school_id: partnership.school.id,
+                                                                    lead_provider_id: partnership.lead_provider.id,
+                                                                    delivery_partner_id: partnership.delivery_partner.id,
+                                                                  ))
+                                                            .at(2.weeks.from_now)
+    end
+
     describe "scope :active" do
       it "returns only unchallenged, not pending partnerships" do
         expect(Partnership.active).to contain_exactly(partnership)


### PR DESCRIPTION
### Context
Replaces #328 as a method for having pending partnerships

When a lead provider declares a partnership with a school who has told us they are doing CIP, we wait 2 weeks before doing anything about it.

### Changes proposed in this pull request
- Add pending boolean to partnerships
- Add job to convert pending partnerships

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
