### PR TITLE
CPDTP-168 - Document provider token generation in readme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,8 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -127,3 +127,11 @@ to execute this delayed job in the background.
 ```bash
 bundle exec rake 'schools:send_invites[urn1 urn2 ...]'
 ```
+
+## Generating API access tokens for lead providers
+
+```bash
+bundle exec rake lead_provider:generate_token "name or id"
+```
+
+Where `"name or id"` is a name or id from the `lead_providers` table.


### PR DESCRIPTION
### Context

Follow up to PR #333

### Changes proposed in this pull request

* CPDTP-168 - Document provider token generation in readme
* Also add markdown editorconfig rules (see commit message)

### Guidance to review

:ship: