### PR TITLE
Remove Users controller from Sandbox

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       resources :early_career_teacher_participants, only: %i[create], path: "early-career-teacher-participants"
-      resources :users, only: :index unless Rails.env.staging? || Rails.env.production?
+      resources :users, only: :index unless %w[sandbox staging production].include?(Rails.env)
     end
   end
 


### PR DESCRIPTION
### Context

Bringing the routing table for the sandbox environment In line with the other outward facing services

### Changes proposed in this pull request

Remove users from rails routing for sandbox and make the configuration for those environment flags slightly cleaner.

### Guidance to review

:ship: