### PR TITLE
CPDRP-309: Update copy on sign in successful page

### DIFF
--- a/app/views/users/sessions/redirect_from_magic_link.html.erb
+++ b/app/views/users/sessions/redirect_from_magic_link.html.erb
@@ -1,8 +1,7 @@
 <% content_for :title, "Complete sign in" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sign in successful</h1>
-    <p class="govuk-body">Continue to your account for guidance, next steps and updates. </p>
+    <h1 class="govuk-heading-l">You are now signed in</h1>
     <%= form_tag(users_sign_in_with_token_path) do %>
       <div class="field">
         <%= hidden_field_tag :login_token, @login_token %>

--- a/spec/cypress/support/step_definitions/notifications.js
+++ b/spec/cypress/support/step_definitions/notifications.js
@@ -71,7 +71,7 @@ When(
           ""
         )
       );
-      cy.get("h1").should("contain", "Sign in successful");
+      cy.get("h1").should("contain", "You are now signed in");
     });
   }
 );


### PR DESCRIPTION
### Context
Just a copy change on the interstitial page after following a sign in link


### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Sign in using email. e.g. cpd-test+tutor-1@digital....
