### PR TITLE
CPDRP-311: Format sign in form errors correctly

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,6 +10,16 @@ class Users::SessionsController < Devise::SessionsController
   before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]
   before_action :ensure_login_token_valid, only: %i[sign_in_with_token redirect_from_magic_link]
 
+  def new
+    super do
+      if flash.present?
+        flash.clear
+        resource.valid?
+        resource.errors.delete(:full_name)
+      end
+    end
+  end
+
   def create
     super
   rescue Devise::Strategies::PasswordlessAuthenticatable::Error

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -6,8 +6,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sign in</h1>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Sign in</h1>
       <div class="govuk-form-group">
         <%= f.govuk_email_field :email, label: { text: "Email address" } %>
       </div>


### PR DESCRIPTION
### Context
Replace the flash alert with some proper design system error messages when the sign in email is blank

### Changes proposed in this pull request
Before:
![image](https://user-images.githubusercontent.com/40488007/118649543-8579b980-b7db-11eb-9de1-42338af8e545.png)

After:
![image](https://user-images.githubusercontent.com/40488007/118649506-7abf2480-b7db-11eb-9e88-cd068e8388af.png)


### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
try to sign in with a blank email
