### PR TITLE
CPDRP-312: invalid sign-in link

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,6 +26,8 @@ class Users::SessionsController < Devise::SessionsController
     @login_token = params[:login_token] if params[:login_token].present?
   end
 
+  def link_invalid; end
+
 private
 
   def redirect_to_dashboard
@@ -36,8 +38,7 @@ private
     @user = User.find_by(login_token: params[:login_token])
 
     if @user.blank? || login_token_expired?
-      flash[:alert] = "There was an error while logging you in. Please enter your email again."
-      redirect_to new_user_session_path
+      redirect_to users_link_invalid_path
     end
   end
 

--- a/app/views/users/sessions/link_invalid.html.erb
+++ b/app/views/users/sessions/link_invalid.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl">This link has expired</h1>
+
+<%= govuk_link_to "Sign in", new_user_session_path, button: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     get "/users/confirm_sign_in", to: "users/sessions#redirect_from_magic_link"
     post "/users/sign_in_with_token", to: "users/sessions#sign_in_with_token"
+    get "/users/link-invalid", to: "users/sessions#link_invalid"
   end
 
   get "/pages/:page", to: "pages#show", as: :page

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_103622) do
+ActiveRecord::Schema.define(version: 2021_05_14_100703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -276,9 +276,11 @@ ActiveRecord::Schema.define(version: 2021_05_13_103622) do
     t.datetime "challenged_at"
     t.string "challenge_reason"
     t.datetime "challenge_deadline"
+    t.boolean "pending", default: false, null: false
     t.index ["cohort_id"], name: "index_partnerships_on_cohort_id"
     t.index ["delivery_partner_id"], name: "index_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_partnerships_on_lead_provider_id"
+    t.index ["pending"], name: "index_partnerships_on_pending"
     t.index ["school_id"], name: "index_partnerships_on_school_id"
   end
 

--- a/spec/cypress/integration/accessibility.js
+++ b/spec/cypress/integration/accessibility.js
@@ -49,4 +49,10 @@ describe("Accessibility", () => {
     cy.get("h1").should("contain", "User dashboard");
     cy.checkA11y();
   });
+
+  it("Login link invalid page should be accessible", () => {
+    cy.visit("/users/link-invalid");
+    cy.checkA11y();
+    cy.percySnapshot();
+  });
 });

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -74,21 +74,19 @@ RSpec.describe "Users::Sessions", type: :request do
       expect(response).to render_template(:redirect_from_magic_link)
     end
 
-    it "redirects to sign in when the token doesn't match" do
+    it "redirects to link invalid when the token doesn't match" do
       get "/users/confirm_sign_in?login_token=aaaaaaaaaa"
 
-      expect(response).to redirect_to "/users/sign_in"
-      expect(flash[:alert]).to eq "There was an error while logging you in. Please enter your email again."
+      expect(response).to redirect_to "/users/link-invalid"
     end
 
     context "when the token has expired" do
       before { user.update!(login_token_valid_until: 1.hour.ago) }
 
-      it "redirects to sign in" do
+      it "redirects to link invalid" do
         get "/users/confirm_sign_in?login_token=#{user.login_token}"
 
-        expect(response).to redirect_to "/users/sign_in"
-        expect(flash[:alert]).to eq "There was an error while logging you in. Please enter your email again."
+        expect(response).to redirect_to "/users/link-invalid"
       end
     end
 
@@ -143,9 +141,9 @@ RSpec.describe "Users::Sessions", type: :request do
     context "when the login_token has expired" do
       before { user.update(login_token_valid_until: 2.days.ago) }
 
-      it "redirects to sign_in page" do
+      it "redirects to link invalid page" do
         post "/users/sign_in_with_token", params: { login_token: user.login_token }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(users_link_invalid_path)
       end
     end
   end


### PR DESCRIPTION
### Context
Replace the flash notice with a dedicated page when a sign in link is expired/invalid

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
http://ecf-review-pr-380.london.cloudapps.digital/users/confirm_sign_in?login_token=6b90d44386421d48e29c