### PR TITLE
CPDEL-438: Add authentication to users endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,8 @@ bundle exec rake lead_provider:generate_token "name or id"
 ```
 
 Where `"name or id"` is a name or id from the `lead_providers` table.
+
+## Generating a token for E&L api
+1. Get into Rails console for the environment you want to generate the token for.
+2. Run `EngageAndLearnApiToken.create_with_random_token!`
+3. Rails console should output a string, that's your unhashed token, you can keep it and use it to access E&L endpoints.

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class UsersController < Api::ApiController
+      include EngageAndLearnAuthenticatable
+
       def index
         render json: UserSerializer.new(User.all).serializable_hash.to_json
       end

--- a/app/controllers/concerns/engage_and_learn_authenticatable.rb
+++ b/app/controllers/concerns/engage_and_learn_authenticatable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module EngageAndLearnAuthenticatable
+  extend ActiveSupport::Concern
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  included do
+    before_action :authenticate
+  end
+
+  def authenticate
+    authenticate_or_request_with_http_token do |unhashed_token|
+      @current_api_token = EngageAndLearnApiToken.find_by_unhashed_token(unhashed_token)
+      if @current_api_token
+        @current_api_token.update!(
+          last_used_at: Time.zone.now,
+        )
+      end
+    end
+  end
+end

--- a/app/models/engage_and_learn_api_token.rb
+++ b/app/models/engage_and_learn_api_token.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class EngageAndLearnApiToken < ApplicationRecord
+  def self.create_with_random_token!
+    unhashed_token, hashed_token = Devise.token_generator.generate(EngageAndLearnApiToken, :hashed_token)
+    create!(hashed_token: hashed_token)
+    unhashed_token
+  end
+
+  def self.find_by_unhashed_token(unhashed_token)
+    hashed_token = Devise.token_generator.digest(EngageAndLearnApiToken, :hashed_token, unhashed_token)
+    find_by(hashed_token: hashed_token)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       resources :early_career_teacher_participants, only: %i[create], path: "early-career-teacher-participants"
-      resources :users, only: :index unless %w[sandbox staging production].include?(Rails.env)
+      resources :users, only: :index
     end
   end
 

--- a/db/migrate/20210518103603_create_engage_and_learn_tokens.rb
+++ b/db/migrate/20210518103603_create_engage_and_learn_tokens.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEngageAndLearnTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :engage_and_learn_api_tokens do |t|
+      t.string :hashed_token, null: false
+      t.datetime :last_used_at
+      t.index :hashed_token, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_103622) do
+ActiveRecord::Schema.define(version: 2021_05_18_103603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -120,6 +120,14 @@ ActiveRecord::Schema.define(version: 2021_05_13_103622) do
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
     t.index ["school_id"], name: "index_early_career_teacher_profiles_on_school_id"
     t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
+  end
+
+  create_table "engage_and_learn_api_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "hashed_token", null: false
+    t.datetime "last_used_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["hashed_token"], name: "index_engage_and_learn_api_tokens_on_hashed_token", unique: true
   end
 
   create_table "induction_coordinator_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/docs/users_spec.rb
+++ b/spec/docs/users_spec.rb
@@ -3,7 +3,9 @@
 require "swagger_helper"
 
 describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
-  let(:Authorization) { "token" }
+  let(:token) { EngageAndLearnApiToken.create_with_random_token! }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:Authorization) { bearer_token }
 
   path "/api/v1/users" do
     get "Returns all users" do
@@ -37,6 +39,11 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                  },
                }
 
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
         run_test!
       end
     end

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Early Career Teacher Participants", type: :request do
 
     context "when unauthorized" do
       it "returns 401 for invalid bearer token" do
-        default_headers[:Authorization] = "Bearer: ugLPicDrpGZdD_w7hhCL"
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
         post "/api/v1/early-career-teacher-participants", params: { id: payload.user_id }
         expect(response.status).to eq 401
       end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -4,35 +4,52 @@ require "rails_helper"
 
 RSpec.describe "API Users", type: :request do
   describe "#index" do
+    let(:token) { EngageAndLearnApiToken.create_with_random_token! }
+    let(:bearer_token) { "Bearer #{token}" }
+
     let(:parsed_response) { JSON.parse(response.body) }
 
     before :each do
       3.times { create(:user) }
     end
 
-    it "returns correct jsonapi content type header" do
-      get "/api/v1/users"
-      expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+      end
+
+      it "returns correct jsonapi content type header" do
+        get "/api/v1/users"
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns all users" do
+        get "/api/v1/users"
+        expect(parsed_response["data"].size).to eql(3)
+      end
+
+      it "returns correct type" do
+        get "/api/v1/users"
+        expect(parsed_response["data"][0]).to have_type("user")
+      end
+
+      it "returns IDs" do
+        get "/api/v1/users"
+        expect(parsed_response["data"][0]["id"]).to be_in(User.pluck(:id))
+      end
+
+      it "returns only email and full name in attributes" do
+        get "/api/v1/users"
+        expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name).exactly
+      end
     end
 
-    it "returns all users" do
-      get "/api/v1/users"
-      expect(parsed_response["data"].size).to eql(3)
-    end
-
-    it "returns correct type" do
-      get "/api/v1/users"
-      expect(parsed_response["data"][0]).to have_type("user")
-    end
-
-    it "returns IDs" do
-      get "/api/v1/users"
-      expect(parsed_response["data"][0]["id"]).to be_in(User.pluck(:id))
-    end
-
-    it "returns only email and full name in attributes" do
-      get "/api/v1/users"
-      expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name).exactly
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v1/users"
+        expect(response.status).to eq 401
+      end
     end
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -127,6 +127,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }


### PR DESCRIPTION
### Context
We want to hide users api behind authentication.

### Changes proposed in this pull request
Copy-paste the approach of Track and Pay.

### Guidance to review
I went for the simplest approach - making a carbon copy of lead provider tokens and authentication in parallel. The problem is, I am not convinced it is a good idea - I think at least in principle LPs will want to have access to the same APIs that E&L will have access to. And perhaps vice versa.

Of course the difficulty with that is that E&L is not _really_ a lead provider - and the current lead provider tokens belong to lead providers.

I would be tempted to make a single table inheritance, where we get a `ApiToken` as the parent class, and `LeadProviderApiToken` and `EngageAndLearnApiToken` are child classes of that, but it looked like some work and potentially controversial decision, so I opted for talking it through first.

### Testing
Added unit tests, updated docs. 

### How can I view this in a review app?
Try making unauthenticated request to the users endpoint (you can go to `/api-docs` and `execute` as a shortcut). You should get a 401.
Follow the readme to get a token. Make a request with curl or postman, with `Authentication` header being `Bearer your-token`. You should get a list of users.