### PR TITLE
Change worker deploys to blue green

### DIFF
--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -65,7 +65,7 @@ variable paas_web_app_start_command {
 }
 
 variable paas_worker_app_deployment_strategy {
-  default = "standard"
+  default = "blue-green-v2"
 }
 
 variable paas_worker_app_instances {


### PR DESCRIPTION
Changed to the image of our worker app don't cause a restage, so the app isn't actually updated