### PR TITLE
Tweak creation of participation record when called more than once

### DIFF
--- a/app/controllers/api/v1/early_career_teacher_participants_controller.rb
+++ b/app/controllers/api/v1/early_career_teacher_participants_controller.rb
@@ -11,7 +11,9 @@ module Api
         return head :not_found unless params[:id]
 
         user = User.find(params[:id])
-        InductParticipant.call(user.early_career_teacher_profile)
+
+        return head :not_modified unless InductParticipant.call(user.early_career_teacher_profile)
+
         head :no_content
       end
     end

--- a/app/services/induct_participant.rb
+++ b/app/services/induct_participant.rb
@@ -11,11 +11,13 @@ class InductParticipant
 
   def call
     participant_profile.join!
+  rescue AASM::InvalidTransition
+    # ignore it for now as it's possible the client may call the same API more than once
   end
 
 private
 
   def initialize(early_career_teacher_profile)
-    self.participant_profile = ParticipationRecord.new(early_career_teacher_profile: early_career_teacher_profile)
+    self.participant_profile = ParticipationRecord.find_or_initialize_by(early_career_teacher_profile: early_career_teacher_profile)
   end
 end

--- a/spec/docs/early_career_teacher_participation_spec.rb
+++ b/spec/docs/early_career_teacher_participation_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe "Early Career Teacher Participation", type: :request, swagger_doc
       }, description: "The unique id of the participant"
 
       response 204, "Successful" do
+        let(:fresh_user) { create(:user, :early_career_teacher) }
+        let(:params) { { "id" => fresh_user.id } }
+        run_test!
+      end
+
+      response 304, "Not Modified" do
+        before do
+          InductParticipant.call(user.early_career_teacher_profile)
+        end
         let(:params) { { "id" => user.id } }
         run_test!
       end


### PR DESCRIPTION
Shouldn't create a new ```ParticipationRecord``` on every call with the same ```id```