### PR TITLE
CPDEL-438: Add a stable E&L token to dummy environments

### DIFF
--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -28,3 +28,6 @@ User.find_or_create_by!(email: "school-leader@example.com") do |user|
     profile.update!(schools: [school])
   end
 end
+
+# We clear the database on a regular basis, but we want a stable token that E&L can use in its dev environments
+EngageAndLearnApiToken.find_or_create_by!(hashed_token: "f4a16cd7fc10918fbc7d869d7a83df36059bb98fac7c82502d797b1f1dd73e86")


### PR DESCRIPTION
### Context
On development (and review) apps we wipe the database each time we push - and then reseed it. This is to make testing non-reversible scenarios painless.

It has a side effect of wiping away any tokens that we might want to set up on `dev`. I would very much like to have some versions of E&L pointing at dev R&P to fetch their users, and for that I need a stable token.

### Changes proposed in this pull request
Add a token with a fixed hash to the part of seed files that only get run on dev, deployed dev and in test. Fixed hash = fixed unhashed token, which I can then use to authenticate without worries of R&P db getting recreated.

### Guidance to review
I checked that the token works. Not sure how public we want to make it - it should not work in staging or prod, unless someone makes a mistake in code and then also seeds staging/prod db...

### Testing
I checked that it works in our local setup.

### How can I view this in a review app?
You can ask me for the unhashed token, and make a request that's authenticated with it (I recommend postman). 