### PR TITLE
Change sandbox subdomain from sanbdox-api to sandbox

### DIFF
--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -1,5 +1,5 @@
 # Platform
-environment = "sandbox-api"
+environment = "sandbox"
 app_environment = "sandbox"
 
 # Gov.UK PaaS


### PR DESCRIPTION
Updated subdomain to 'sandbox' as it was taken previously so the sandbox URL will be https://ecf-sandbox.london.cloudapps.digital/