### PR TITLE
CPDEL-438: Add different token for deployed dev

### DIFF
--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -30,4 +30,10 @@ User.find_or_create_by!(email: "school-leader@example.com") do |user|
 end
 
 # We clear the database on a regular basis, but we want a stable token that E&L can use in its dev environments
-EngageAndLearnApiToken.find_or_create_by!(hashed_token: "f4a16cd7fc10918fbc7d869d7a83df36059bb98fac7c82502d797b1f1dd73e86")
+# Tokens are hashed using another secret, so hashed token with the same unhashed version will be different in different environments
+# To avoid
+if Rails.env.deployed_development?
+  EngageAndLearnApiToken.find_or_create_by!(hashed_token: "dfce9a34c6f982e8adb4b903f8b6064682e6ad1f7858c41ed8a0a7468abc8896")
+elsif Rails.env.development?
+  EngageAndLearnApiToken.find_or_create_by!(hashed_token: "f4a16cd7fc10918fbc7d869d7a83df36059bb98fac7c82502d797b1f1dd73e86")
+end


### PR DESCRIPTION
### Context

In my haste to get a token working I forgot that devise uses another secret to generate tokens, and that it is different for different environments. For good reasons too.

So I made a new token using rails console in our dev environment, and put that in too. I checked that that one actually works on https://github.com/DFE-Digital/ecf-engage-and-learn/pull/110. 

I wanna keep the dev one too, so when someone from E&L seeds the db they have a token they can use for development without fuss of making a new one.