### PR TITLE
Use smart quotes consistently

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -23,7 +23,7 @@ class CookiesController < ApplicationController
       format.json do
         render json: {
           status: "ok",
-          message: %(You've #{analytics_consent == 'on' ? 'accepted' : 'rejected'} analytics cookies.),
+          message: %(You’ve #{analytics_consent == 'on' ? 'accepted' : 'rejected'} analytics cookies.),
         }
       end
     end

--- a/app/views/accessibility_statements/show.html.erb
+++ b/app/views/accessibility_statements/show.html.erb
@@ -46,7 +46,7 @@
     <p class="govuk-body">This statement was prepared on 16 April 2021.</p>
     <p class="govuk-body">The service was last tested on 1 April 2021 for compliance with WCAG 2.1 AA.</p>
     <p class="govuk-body">Testing was carried out internally by the Department for Education.</p>
-    <p class="govuk-body">We tested the service based on a user's ability to complete key journeys.</p>
+    <p class="govuk-body">We tested the service based on a user’s ability to complete key journeys.</p>
     <p class="govuk-body">All parts of the chosen journeys were tested.</p>
     <p class="govuk-body">Journeys were chosen based on a number of factors, including risk assessments and subject matter.</p>
     <p class="govuk-body">We will have an external accessibility audit carried out by the end of September 2021.</p>

--- a/app/views/layouts/_support_links.html.erb
+++ b/app/views/layouts/_support_links.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m">Support and guidance</h2>
 <p class="govuk-body-s">
-  If you have a question, or you've had a problem using this service, please contact us at
+  If you have a question, or you’ve had a problem using this service, please contact us at
   <%= mail_to Rails.application.config.support_email, Rails.application.config.support_email, class: "govuk-footer__link govuk-link--no-visited-state" %>
 </p>
 <ul class="govuk-footer__inline-list">

--- a/app/views/lead_providers/confirm_schools/show.html.erb
+++ b/app/views/lead_providers/confirm_schools/show.html.erb
@@ -35,7 +35,7 @@
   </tbody>
 </table>
 
-<p>Once you've confirmed, schools will be notified by email.</p>
+<p>Once you’ve confirmed, schools will be notified by email.</p>
 <p>Schools will have the option to notify the Department for Education and the training provider if they think this is incorrect.</p>
 
 <%= govuk_button_to "Confirm", { action: :confirm }, method: :post, class: "govuk-button govuk-!-margin-bottom-3" %>

--- a/app/views/nominations/request_nomination_invite/choose_location.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_location.html.erb
@@ -21,7 +21,7 @@
               @local_authorities,
               :id,
               :name,
-              label: { text: "What is your school's local authority?", class: "govuk-label govuk-label--m" },
+              label: { text: "What is your school’s local authority?", class: "govuk-label govuk-label--m" },
               hint: -> { tag.span do
                 concat("This is the authority or council in your area. For example, Gloucestershire or Barnet. Not sure? ")
                 concat(govuk_link_to("Find your school on our register", "https://get-information-schools.service.gov.uk/"))

--- a/db/seeds/privacy_policy_1.0.html
+++ b/db/seeds/privacy_policy_1.0.html
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">Department for Education (DfE)</h2>
-<p class="govuk-body">Mentions of "us" and "we" mean DfE and "you" means anyone using this service.</p>
+<p class="govuk-body">Mentions of “us” and “we” mean DfE and “you” means anyone using this service.</p>
 <p class="govuk-body">This work is being carried out by Teacher Continuing Professional Development, which is a part of the
  Department for Education (DfE).</p>
 <p class="govuk-body">Any information we collect when you use our services will be used and looked after by:</p>
@@ -27,7 +27,7 @@
 <h2 class="govuk-heading-m">What personal data we collect</h2>
 <p class="govuk-body">The personal data we collect will depend on whether you’re an early career teacher, mentor,
  induction tutor/coordinator or a training provider.</p>
-<h3 class="govuk-heading-s">What data we collect if you're an early career teacher</h3>
+<h3 class="govuk-heading-s">What data we collect if you’re an early career teacher</h3>
 <p class="govuk-body">If you’re an early career teacher using Manage training for early career teachers we may collect
  the following information about you:</p>
 <ul class="govuk-list govuk-list--bullet">
@@ -65,8 +65,8 @@
 </ul>
 <h3 class="govuk-heading-s">Building a better teacher training application process</h3>
 <p class="govuk-body">We’ll use your data to help us build a better process.</p>
-<p class="govuk-body">For example, we'll look at any feedback you give us about our services so we can improve them.</p>
-<p class="govuk-body">If you're an early career teacher or you work at a teacher training provider, we may contact you
+<p class="govuk-body">For example, we’ll look at any feedback you give us about our services so we can improve them.</p>
+<p class="govuk-body">If you’re an early career teacher or you work at a teacher training provider, we may contact you
  to carry out user research.</p>
 <h3 class="govuk-heading-s">Getting insight to make government policy better</h3>
 <p class="govuk-body">We might analyse your data to help us inform government policy around teacher recruitment and
@@ -83,7 +83,7 @@
 <ul class="govuk-list govuk-list--bullet">
  <li>process agreements, which may include contacting candidates</li>
  <li>get statistics for internal use</li>
- <li>get in touch with you if there's a security issue concerning your data</li>
+ <li>get in touch with you if there’s a security issue concerning your data</li>
 </ul>
 
 <h2 class="govuk-heading-m">External organisations who process data</h2>
@@ -98,10 +98,10 @@
 </p>
 
 <h3 class="govuk-heading-s">Google</h3>
-<p class="govuk-body">We'll ask if you agree to cookies so that we can get statistics from Google Analytics. If you
+<p class="govuk-body">We’ll ask if you agree to cookies so that we can get statistics from Google Analytics. If you
  consent, Google may be able to get your IP address. We use Google Analytics for statistics and will not identify you
  personally from these.</p>
-<p class="govuk-body">We also use Google's G Suite to process some personal data. Google processes your data according
+<p class="govuk-body">We also use Google’s G Suite to process some personal data. Google processes your data according
  to our instructions.</p>
 
 <h3 class="govuk-heading-s">Hosting services</h3>
@@ -136,7 +136,7 @@
 <p class="govuk-body">Once an early career teacher has enrolled with a teacher training provider, we will not be able to
  ask them to remove personal data from their systems. Please contact the provider separately.</p>
 <p class="govuk-body">For further information or to raise a concern, visit
- the <a class="govuk-link" href="https://ico.org.uk/">Information Commissioner&#39;s Office</a> (ICO).</p>
+ the <a class="govuk-link" href="https://ico.org.uk/">Information Commissioner’s Office</a> (ICO).</p>
 
 <h2 class="govuk-heading-m">Keeping our privacy policy up to date</h2>
 <p class="govuk-body">We reserve the right to update this privacy notice at any time, and we will provide you with a new

--- a/spec/cypress/integration/Cookies.feature
+++ b/spec/cypress/integration/Cookies.feature
@@ -31,7 +31,7 @@ Feature: Cookie page
     Given I am on "start" page
 
     When I click to accept cookies
-    Then "cookie banner" should contain "You've accepted analytics cookies."
+    Then "cookie banner" should contain "You’ve accepted analytics cookies."
 
     When I hide cookie banner
     Then "cookie banner" should be hidden
@@ -44,7 +44,7 @@ Feature: Cookie page
     Given I am on "start" page
 
     When I click to reject cookies
-    Then "cookie banner" should contain "You've rejected analytics cookies."
+    Then "cookie banner" should contain "You’ve rejected analytics cookies."
 
     When I hide cookie banner
     Then "cookie banner" should be hidden
@@ -62,4 +62,3 @@ Feature: Cookie page
     And I click the submit button
     And I click on "link" containing "Back"
     Then I am on "start" page
-

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Cookies API", type: :request do
       headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
       put "/cookies", params: { "cookies_form": { "analytics_consent": "on" } }.to_json, headers: headers
 
-      expected = { status: "ok", message: "You've accepted analytics cookies." }.to_json
+      expected = { status: "ok", message: "You’ve accepted analytics cookies." }.to_json
       expect(response.content_type).to include("application/json")
       expect(response.body).to eq(expected)
       expect(response.cookies["cookie_consent_1"]).to eq("on")
@@ -18,7 +18,7 @@ RSpec.describe "Cookies API", type: :request do
       headers = { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
       put "/cookies", params: { "cookies_form": { "analytics_consent": "off" } }.to_json, headers: headers
 
-      expected = { status: "ok", message: "You've rejected analytics cookies." }.to_json
+      expected = { status: "ok", message: "You’ve rejected analytics cookies." }.to_json
       expect(response.content_type).to include("application/json")
       expect(response.body).to eq(expected)
       expect(response.cookies["cookie_consent_1"]).to eq("off")


### PR DESCRIPTION
There are many uses of smart quotes already, but some inconsistencies in the privacy policy, accessibility statement and the cookie banner.