### PR TITLE
Fix privacy page content width

### DIFF
--- a/app/views/cookies/show.html.erb
+++ b/app/views/cookies/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: @backlink) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Cookies</h1>
+    <h1 class="govuk-heading-xl">Cookies</h1>
     <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
     <p>We use cookies to make the Manage training for early career teachers service (the service) work and collect information about how you use our service.</p>
 

--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -1,21 +1,25 @@
 <% content_for :title, "Privacy policy" %>
 
-<% if !@policy.acceptance_required?(current_user) %>
-  <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
-  <h1 class="govuk-heading-xl">How we look after your personal data</h1>
-<% else %>
-  <h1 class="govuk-heading-xl">Privacy policy</h1>
-  <p>Before you continue, please check our privacy policy</p>
-  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@policy.acceptance_required?(current_user) %>
+      <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
+      <h1 class="govuk-heading-xl">How we look after your personal data</h1>
+    <% else %>
+      <h1 class="govuk-heading-xl">Privacy policy</h1>
+      <p>Before you continue, please check our privacy policy</p>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-  <h2 class="govuk-heading-xl">How we look after your personal data</h2>
-<% end %>
+      <h2 class="govuk-heading-l">How we look after your personal data</h2>
+    <% end %>
 
-<%= @policy.html.html_safe %>
+    <%= @policy.html.html_safe %>
 
-<% if @policy.acceptance_required?(current_user) %>
-  <%= form_tag({action: :update}, method: :put) do %>
-    <%= hidden_field_tag :policy_id, @policy.id %>
-    <%= submit_tag "Continue", class: "govuk-button" %>
-  <% end %>
-<% end %>
+    <% if @policy.acceptance_required?(current_user) %>
+      <%= form_tag({action: :update}, method: :put) do %>
+        <%= hidden_field_tag :policy_id, @policy.id %>
+        <%= submit_tag "Continue", class: "govuk-button govuk-!-margin-top-4" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### Changes proposed in this pull request

- Use two-thirds page width for privacy policy. Constrain text to 2/3rds grid to give a readable line-length. Without this the line are too long and reading the text is more difficult
- Increase font-size of title on Cookies page

Ignore whitespace when reviewing.

![Screen Shot 2021-05-20 at 15 56 40](https://user-images.githubusercontent.com/319055/119001579-007dd400-b984-11eb-93af-0ef1e4766c35.png)
![Screen Shot 2021-05-20 at 15 56 27](https://user-images.githubusercontent.com/319055/119001585-02479780-b984-11eb-9f03-0066cddb755f.png)

