### PR TITLE
Change induction tutor

### DIFF
--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -25,6 +25,23 @@ module Admin
       redirect_to email_used_admin_school_induction_coordinators_path
     end
 
+    def choose_replace_or_update
+      @replace_or_update_tutor_form = ReplaceOrUpdateTutorForm.new
+    end
+
+    def replace_or_update
+      @replace_or_update_tutor_form = ReplaceOrUpdateTutorForm.new(replace_or_update_params)
+      if @replace_or_update_tutor_form.valid?
+        if @replace_or_update_tutor_form.replace_tutor?
+          redirect_to new_admin_school_induction_coordinator_path(@school)
+        else
+          redirect_to edit_admin_school_induction_coordinator_path(id: @school.id)
+        end
+      else
+        render "choose_replace_or_update"
+      end
+    end
+
     def edit
       @induction_tutor = school_induction_tutor
     end
@@ -51,6 +68,10 @@ module Admin
 
     def form_params
       params.require(:tutor_details).permit(:full_name, :email)
+    end
+
+    def replace_or_update_params
+      params.require(:replace_or_update_tutor_form).permit(:choice)
     end
   end
 end

--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -25,14 +25,32 @@ module Admin
       redirect_to email_used_admin_school_induction_coordinators_path
     end
 
+    def edit
+      @induction_tutor = school_induction_tutor
+    end
+
+    def update
+      @induction_tutor = school_induction_tutor
+      if @induction_tutor.update(form_params)
+        set_success_message(content: "Induction tutor details updated", title: "Success")
+        redirect_to admin_school_path(@school)
+      else
+        render :edit
+      end
+    end
+
   private
 
     def set_school
       @school = School.find params[:school_id]
     end
 
+    def school_induction_tutor
+      @school.induction_coordinators.first
+    end
+
     def form_params
-      params.require(:nominate_induction_tutor_form).permit(:full_name, :email)
+      params.require(:tutor_details).permit(:full_name, :email)
     end
   end
 end

--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -36,13 +36,13 @@ module Admin
       @induction_tutor_form = NominateInductionTutorForm.new(school_induction_tutor_attributes.merge(tutor_form_params))
 
       if @induction_tutor_form.valid?
-        school_induction_tutor.update!(full_name: @induction_tutor_form.full_name,
+        @school.induction_tutor.update!(full_name: @induction_tutor_form.full_name,
                                        email: @induction_tutor_form.email)
         set_success_message(content: "Induction tutor details updated", title: "Success")
         redirect_to admin_school_path(@school)
       elsif @induction_tutor_form.email_already_taken?
         render_email_used_page(email: @induction_tutor_form.email,
-                               action_path: edit_admin_school_induction_coordinator_path(@school, school_induction_tutor))
+                               action_path: edit_admin_school_induction_coordinator_path(@school, @school.induction_tutor))
       else
         render :edit
       end
@@ -54,12 +54,8 @@ module Admin
       @school = School.find params[:school_id]
     end
 
-    def school_induction_tutor
-      @school.induction_coordinators.first
-    end
-
     def school_induction_tutor_attributes
-      user = @school.induction_coordinators.first
+      user = @school.induction_tutor
       if user
         {
           user_id: user.id,

--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -37,7 +37,7 @@ module Admin
 
       if @induction_tutor_form.valid?
         @school.induction_tutor.update!(full_name: @induction_tutor_form.full_name,
-                                       email: @induction_tutor_form.email)
+                                        email: @induction_tutor_form.email)
         set_success_message(content: "Induction tutor details updated", title: "Success")
         redirect_to admin_school_path(@school)
       elsif @induction_tutor_form.email_already_taken?

--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -16,7 +16,6 @@ module Admin
       @nominate_induction_tutor_form = NominateInductionTutorForm.new(
         form_params.merge(school_id: params[:school_id]),
       )
-      # render :new and return unless @nominate_induction_tutor_form.valid?
 
       if @nominate_induction_tutor_form.valid?
         if email_already_used?(@nominate_induction_tutor_form.email)
@@ -35,11 +34,11 @@ module Admin
       end
     end
 
-    def create_school_induction_tutor!(school:, email:, name:)
+    def create_school_induction_tutor!(school:, email:, full_name:)
       school.induction_coordinators.first.destroy! if school.induction_coordinators.first
 
       InductionCoordinatorProfile.create_induction_coordinator(
-        name,
+        full_name,
         email,
         school,
         Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain),
@@ -53,13 +52,6 @@ module Admin
     def email_already_used?(email)
       User.exists?(email: email)
     end
-
-    #   @nominate_induction_tutor_form.save!
-    #   set_success_message(content: "New induction tutor added. They will get an email with next steps.", title: "Success")
-    #   redirect_to admin_school_path(@school)
-    # rescue UserExistsError
-    #   redirect_to email_used_admin_school_induction_coordinators_path
-    # end
 
     def choose_replace_or_update
       @replace_or_update_tutor_form = ReplaceOrUpdateTutorForm.new

--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -14,7 +14,7 @@ module Admin
 
     def create
       @nominate_induction_tutor_form = NominateInductionTutorForm.new(
-        form_params.merge(school_id: params[:school_id]),
+        tutor_form_params.merge(school_id: params[:school_id]),
       )
 
       if @nominate_induction_tutor_form.valid?
@@ -43,7 +43,7 @@ module Admin
         if @replace_or_update_tutor_form.replace_tutor?
           redirect_to new_admin_school_induction_coordinator_path(@school)
         else
-          redirect_to edit_admin_school_induction_coordinator_path(id: @school.id)
+          redirect_to edit_admin_school_induction_coordinator_path(@school, school_induction_tutor)
         end
       else
         render "choose_replace_or_update"
@@ -56,7 +56,7 @@ module Admin
 
     def update
       @induction_tutor = school_induction_tutor
-      @induction_tutor.assign_attributes(form_params)
+      @induction_tutor.assign_attributes(tutor_form_params)
       if @induction_tutor.changed?
         if @induction_tutor.email_changed?
           user = User.find_by(email: @induction_tutor.email)
@@ -115,7 +115,7 @@ module Admin
       render "email_used"
     end
 
-    def form_params
+    def tutor_form_params
       params.require(:tutor_details).permit(:full_name, :email)
     end
 

--- a/app/controllers/admin/schools/replace_or_update_induction_tutor_controller.rb
+++ b/app/controllers/admin/schools/replace_or_update_induction_tutor_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Admin
+  class Schools::ReplaceOrUpdateInductionTutorController < Admin::BaseController
+    skip_after_action :verify_authorized
+    skip_after_action :verify_policy_scoped
+    before_action :set_school
+
+    def show
+      @replace_or_update_tutor_form = ReplaceOrUpdateTutorForm.new
+    end
+
+    def choose
+      @replace_or_update_tutor_form = ReplaceOrUpdateTutorForm.new(replace_or_update_params)
+      if @replace_or_update_tutor_form.valid?
+        if @replace_or_update_tutor_form.replace_tutor?
+          redirect_to new_admin_school_induction_coordinator_path(@school)
+        else
+          redirect_to edit_admin_school_induction_coordinator_path(@school, school_induction_tutor)
+        end
+      else
+        render :show
+      end
+    end
+
+  private
+
+    def set_school
+      @school = School.find params[:school_id]
+    end
+
+    def school_induction_tutor
+      @school.induction_coordinators.first
+    end
+
+    def replace_or_update_params
+      params.require(:replace_or_update_tutor_form).permit(:choice)
+    end
+  end
+end

--- a/app/controllers/nominations/nominate_induction_coordinator_controller.rb
+++ b/app/controllers/nominations/nominate_induction_coordinator_controller.rb
@@ -26,12 +26,15 @@ class Nominations::NominateInductionCoordinatorController < ApplicationControlle
   def create
     load_nominate_induction_tutor_form
 
-    render :new and return unless @nominate_induction_tutor_form.valid?
-
-    @nominate_induction_tutor_form.save!
-    redirect_to nominate_school_lead_success_nominate_induction_coordinator_path
-  rescue UserExistsError
-    redirect_to email_used_nominate_induction_coordinator_path
+    if @nominate_induction_tutor_form.valid?
+      CreateInductionTutor.call(school: @nominate_induction_tutor_form.school,
+                                email: @nominate_induction_tutor_form.email,
+                                full_name: @nominate_induction_tutor_form.full_name)
+    elsif @nominate_induction_tutor_form.email_already_taken?
+      redirect_to email_used_nominate_induction_coordinator_path
+    else
+      render :new
+    end
   end
 
   def link_expired

--- a/app/controllers/nominations/nominate_induction_coordinator_controller.rb
+++ b/app/controllers/nominations/nominate_induction_coordinator_controller.rb
@@ -30,6 +30,7 @@ class Nominations::NominateInductionCoordinatorController < ApplicationControlle
       CreateInductionTutor.call(school: @nominate_induction_tutor_form.school,
                                 email: @nominate_induction_tutor_form.email,
                                 full_name: @nominate_induction_tutor_form.full_name)
+      redirect_to nominate_school_lead_success_nominate_induction_coordinator_path
     elsif @nominate_induction_tutor_form.email_already_taken?
       redirect_to email_used_nominate_induction_coordinator_path
     else

--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -5,8 +5,8 @@ class NominateInductionTutorForm
 
   attr_accessor :full_name, :email, :token, :school_id
 
-  validates :full_name, presence: { message: "Enter a full name" }
-  validates :email, presence: { message: "Enter email" }, format: { with: Devise.email_regexp, message: "Enter an email address in the correct format, like name@example.com" }
+  validates :full_name, presence: true
+  validates :email, presence: true, format: { with: Devise.email_regexp }
 
   def school
     if school_id

--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -19,6 +19,8 @@ class NominateInductionTutorForm
   def save!
     raise UserExistsError if User.exists?(email: email)
 
+    school.induction_coordinators.first.destroy! if school.induction_coordinators.first
+
     InductionCoordinatorProfile.create_induction_coordinator(
       full_name,
       email,

--- a/app/forms/replace_or_update_tutor_form.rb
+++ b/app/forms/replace_or_update_tutor_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ReplaceOrUpdateTutorForm
+  include ActiveModel::Model
+
+  attr_accessor :choice
+
+  validates :choice, presence: true
+
+  def replace_tutor?
+    choice == "replace"
+  end
+
+  def update_tutor?
+    choice == "update"
+  end
+
+  def choices
+    [
+      OpenStruct.new(id: "replace", name: "Replace tutor with someone new"),
+      OpenStruct.new(id: "update", name: "Update tutor’s details"),
+    ]
+  end
+end

--- a/app/forms/replace_or_update_tutor_form.rb
+++ b/app/forms/replace_or_update_tutor_form.rb
@@ -17,8 +17,8 @@ class ReplaceOrUpdateTutorForm
 
   def choices
     [
-      OpenStruct.new(id: "replace", name: "Replace tutor with someone new"),
-      OpenStruct.new(id: "update", name: "Update tutor’s details"),
+      OpenStruct.new(id: "replace", name: "Replace induction tutor with someone new"),
+      OpenStruct.new(id: "update", name: "Update induction tutor’s details"),
     ]
   end
 end

--- a/app/models/induction_coordinator_profile.rb
+++ b/app/models/induction_coordinator_profile.rb
@@ -6,12 +6,4 @@ class InductionCoordinatorProfile < ApplicationRecord
   belongs_to :user
   has_many :induction_coordinator_profiles_schools, dependent: :destroy
   has_many :schools, through: :induction_coordinator_profiles_schools
-
-  def self.create_induction_coordinator(full_name, email, school, start_url)
-    ActiveRecord::Base.transaction do
-      user = User.create!(full_name: full_name, email: email)
-      InductionCoordinatorProfile.create!(user: user, schools: [school])
-      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_now
-    end
-  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -143,10 +143,14 @@ class School < ApplicationRecord
 
   def contact_email
     if induction_coordinators.any?
-      induction_coordinators.first.email
+      induction_tutor.email
     else
       primary_contact_email.presence || secondary_contact_email
     end
+  end
+
+  def induction_tutor
+    induction_coordinators.first
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,9 +15,6 @@ class User < ApplicationRecord
   validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: Devise.email_regexp }
 
-  # validates :full_name, presence: { message: "Enter a full name" }
-  # validates :email, presence: { message: "Enter email" }, uniqueness: true, format: { with: Devise.email_regexp, message: "Enter an email address in the correct format, like name@example.com" }
-
   def admin?
     admin_profile.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,11 @@ class User < ApplicationRecord
   has_one :early_career_teacher_profile, dependent: :destroy
   has_one :core_induction_programme, through: :early_career_teacher_profile
 
-  validates :full_name, presence: { message: "Enter a full name" }
+  validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: Devise.email_regexp }
+
+  # validates :full_name, presence: { message: "Enter a full name" }
+  # validates :email, presence: { message: "Enter email" }, uniqueness: true, format: { with: Devise.email_regexp, message: "Enter an email address in the correct format, like name@example.com" }
 
   def admin?
     admin_profile.present?

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BaseService
+  def self.call(*args, &block)
+    new(*args, &block).call
+  end
+end

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CreateInductionTutor < BaseService
-  attr_accessor :school, :email, :full_name, :profile
+  attr_accessor :school, :email, :full_name
 
   def initialize(school:, email:, full_name:)
     @school = school
@@ -10,19 +10,16 @@ class CreateInductionTutor < BaseService
   end
 
   def call
-    ic_profile = nil
-
     ActiveRecord::Base.transaction do
       school.induction_coordinators.first.destroy! if school.induction_coordinators.first
 
       user = User.create!(full_name: full_name, email: email)
-      ic_profile = InductionCoordinatorProfile.create!(user: user, schools: [school])
+      InductionCoordinatorProfile.create!(user: user, schools: [school])
+
       # TODO: This should really be using deliver_later, but this can't be tested via Cypress
       # After discussion leaving this as deliver_now with  this comment
       SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_now
     end
-
-    self.profile = ic_profile
   end
 
   def start_url

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -17,13 +17,13 @@ class CreateInductionTutor < BaseService
 
       user = User.create!(full_name: full_name, email: email)
       ic_profile = InductionCoordinatorProfile.create!(user: user, schools: [school])
-      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_now
+      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_later
     end
 
     self.profile = ic_profile
   end
 
   def start_url
-    @start_url ||= Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain)
+    Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain)
   end
 end

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CreateInductionTutor < BaseService
+  attr_accessor :school, :email, :full_name, :profile
+
+  def initialize(school:, email:, full_name:)
+    @school = school
+    @email = email
+    @full_name = full_name
+  end
+
+  def call
+    ic_profile = nil
+
+    ActiveRecord::Base.transaction do
+      school.induction_coordinators.first.destroy! if school.induction_coordinators.first
+
+      user = User.create!(full_name: full_name, email: email)
+      ic_profile = InductionCoordinatorProfile.create!(user: user, schools: [school])
+      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_now
+    end
+
+    self.profile = ic_profile
+  end
+
+  def start_url
+    @start_url ||= Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain)
+  end
+end

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -17,7 +17,9 @@ class CreateInductionTutor < BaseService
 
       user = User.create!(full_name: full_name, email: email)
       ic_profile = InductionCoordinatorProfile.create!(user: user, schools: [school])
-      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_later
+      # TODO: This should really be using deliver_later, but this can't be tested via Cypress
+      # After discussion leaving this as deliver_now with  this comment
+      SchoolMailer.nomination_confirmation_email(user: user, school: school, start_url: start_url).deliver_now
     end
 
     self.profile = ic_profile

--- a/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
+++ b/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_for(form_object, as: :tutor_details, url: form_url) do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_text_field( :full_name, label: { text: "Full name" }) %>
+  <%= f.govuk_email_field( :email, label: { text: "Email" }) %>
+  <%= f.govuk_submit "Save" %>
+<% end %>

--- a/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
+++ b/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(form_object, as: :tutor_details, url: form_url) do |f| %>
+<%= form_for(form_object, as: :tutor_details, url: form_url, method: form_method) do |f| %>
   <%= f.govuk_error_summary %>
   <h1 class="govuk-heading-xl"><%= heading %></h1>
   <%= f.govuk_text_field( :full_name, label: { text: "Full name" }) %>

--- a/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
+++ b/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_for(form_object, as: :tutor_details, url: form_url) do |f| %>
   <%= f.govuk_error_summary %>
+  <h1 class="govuk-heading-xl"><%= heading %></h1>
   <%= f.govuk_text_field( :full_name, label: { text: "Full name" }) %>
   <%= f.govuk_email_field( :email, label: { text: "Email address" }) %>
   <%= f.govuk_submit submit_label %>

--- a/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
+++ b/app/views/admin/schools/induction_coordinators/_induction_tutor_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(form_object, as: :tutor_details, url: form_url) do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_text_field( :full_name, label: { text: "Full name" }) %>
-  <%= f.govuk_email_field( :email, label: { text: "Email" }) %>
-  <%= f.govuk_submit "Save" %>
+  <%= f.govuk_email_field( :email, label: { text: "Email address" }) %>
+  <%= f.govuk_submit submit_label %>
 <% end %>

--- a/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
+++ b/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
@@ -1,0 +1,21 @@
+<% title = "Are you replacing a tutor or updating their details?" %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: admin_school_path(@school)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @replace_or_update_tutor_form, url: replace_or_update_admin_school_induction_coordinators_path(@school), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+      <%= f.govuk_collection_radio_buttons(
+            :choice,
+            @replace_or_update_tutor_form.choices,
+            :id,
+            :name,
+            legend: { text: "" },
+            # legend: { text: title, size: "xl", tag: "h1" },
+          ) %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
+++ b/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
@@ -13,7 +13,6 @@
             :id,
             :name,
             legend: { text: "" },
-            # legend: { text: title, size: "xl", tag: "h1" },
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
+++ b/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
@@ -1,4 +1,4 @@
-<% title = "Are you replacing a tutor or updating their details?" %>
+<% title = "Are you replacing an induction tutor or updating their details?" %>
 <% content_for :title, title %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_school_path(@school)) %>
 

--- a/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
+++ b/app/views/admin/schools/induction_coordinators/choose_replace_or_update.html.erb
@@ -12,7 +12,7 @@
             @replace_or_update_tutor_form.choices,
             :id,
             :name,
-            legend: { text: "" },
+            legend: { hidden: true },
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/admin/schools/induction_coordinators/edit.html.erb
+++ b/app/views/admin/schools/induction_coordinators/edit.html.erb
@@ -1,12 +1,12 @@
-<% content_for :title, "Add or change induction tutor" %>
+<% content_for :title, "Change induction tutor" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Induction tutor for <%= @school.name %></h1>
     <%= render partial: 'induction_tutor_form', locals: {
-      form_object: @nominate_induction_tutor_form,
-      form_url: admin_school_induction_coordinators_path(@school)
+      form_object: @induction_tutor,
+      form_url: admin_school_induction_coordinator_path(@school)
     } %>
   </div>
 </div>

--- a/app/views/admin/schools/induction_coordinators/edit.html.erb
+++ b/app/views/admin/schools/induction_coordinators/edit.html.erb
@@ -1,12 +1,14 @@
-<% content_for :title, "Change induction tutor" %>
+<% title = "Update induction tutor for #{@school.name}" %>
+<% content_for :title, title %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Induction tutor for <%= @school.name %></h1>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
     <%= render partial: 'induction_tutor_form', locals: {
       form_object: @induction_tutor,
-      form_url: admin_school_induction_coordinator_path(@school)
+      form_url: admin_school_induction_coordinator_path(@school),
+      submit_label: "Save changes"
     } %>
   </div>
 </div>

--- a/app/views/admin/schools/induction_coordinators/edit.html.erb
+++ b/app/views/admin/schools/induction_coordinators/edit.html.erb
@@ -6,8 +6,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'induction_tutor_form', locals: {
       heading: title,
-      form_object: @induction_tutor,
+      form_object: @induction_tutor_form,
       form_url: admin_school_induction_coordinator_path(@school),
+      form_method: :patch,
       submit_label: "Save changes"
     } %>
   </div>

--- a/app/views/admin/schools/induction_coordinators/edit.html.erb
+++ b/app/views/admin/schools/induction_coordinators/edit.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
     <%= render partial: 'induction_tutor_form', locals: {
+      heading: title,
       form_object: @induction_tutor,
       form_url: admin_school_induction_coordinator_path(@school),
       submit_label: "Save changes"

--- a/app/views/admin/schools/induction_coordinators/email_used.html.erb
+++ b/app/views/admin/schools/induction_coordinators/email_used.html.erb
@@ -6,7 +6,12 @@
       That email address is already associated with another school
     </h1>
 
-    <p class="govuk-body"> The email address <%= govuk_mail_to @email_address, @email_address %> is already used by a user at <%= govuk_link_to @another_school.name, admin_school_path(@another_school) %></p>
+    <% if @another_school.present? %>
+      <p class="govuk-body">The email address <%= govuk_mail_to @email_address, @email_address %> is already used by a user at <%= govuk_link_to @another_school.name, admin_school_path(@another_school) %></p>
+    <% else %>
+      <p class="govuk-body">The email address <%= govuk_mail_to @email_address, @email_address %> is already in use</p>
+    <% end %>
+
     <p>You need to use a different email address.</p>
     <%= govuk_link_to "Change email address",  new_admin_school_induction_coordinator_path(@school), button: true %>
   </div>

--- a/app/views/admin/schools/induction_coordinators/email_used.html.erb
+++ b/app/views/admin/schools/induction_coordinators/email_used.html.erb
@@ -13,6 +13,6 @@
     <% end %>
 
     <p>You need to use a different email address.</p>
-    <%= govuk_link_to "Change email address",  new_admin_school_induction_coordinator_path(@school), button: true %>
+    <%= govuk_link_to "Change email address",  @action_path, button: true %>
   </div>
 </div>

--- a/app/views/admin/schools/induction_coordinators/email_used.html.erb
+++ b/app/views/admin/schools/induction_coordinators/email_used.html.erb
@@ -3,9 +3,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-header-xl">
-      The email you entered is used by another school
+      That email address is already associated with another school
     </h1>
 
+    <p class="govuk-body"> The email address <%= govuk_mail_to @email_address, @email_address %> is already used by a user at <%= govuk_link_to @another_school.name, admin_school_path(@another_school) %></p>
     <p>You need to use a different email address.</p>
     <%= govuk_link_to "Change email address",  new_admin_school_induction_coordinator_path(@school), button: true %>
   </div>

--- a/app/views/admin/schools/induction_coordinators/new.html.erb
+++ b/app/views/admin/schools/induction_coordinators/new.html.erb
@@ -6,8 +6,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'induction_tutor_form', locals: {
       heading: title,
-      form_object: @nominate_induction_tutor_form,
+      form_object: @induction_tutor_form,
       form_url: admin_school_induction_coordinators_path(@school),
+      form_method: :post,
       submit_label: "Confirm new tutor"
     } %>
   </div>

--- a/app/views/admin/schools/induction_coordinators/new.html.erb
+++ b/app/views/admin/schools/induction_coordinators/new.html.erb
@@ -4,8 +4,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
     <%= render partial: 'induction_tutor_form', locals: {
+      heading: title,
       form_object: @nominate_induction_tutor_form,
       form_url: admin_school_induction_coordinators_path(@school),
       submit_label: "Confirm new tutor"

--- a/app/views/admin/schools/induction_coordinators/new.html.erb
+++ b/app/views/admin/schools/induction_coordinators/new.html.erb
@@ -1,12 +1,14 @@
-<% content_for :title, "Add or change induction tutor" %>
+<% title = "New induction tutor for #{@school.name}" %>
+<% content_for :title, title %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: admin_school_path(@school)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Induction tutor for <%= @school.name %></h1>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
     <%= render partial: 'induction_tutor_form', locals: {
       form_object: @nominate_induction_tutor_form,
-      form_url: admin_school_induction_coordinators_path(@school)
+      form_url: admin_school_induction_coordinators_path(@school),
+      submit_label: "Confirm new tutor"
     } %>
   </div>
 </div>

--- a/app/views/admin/schools/replace_or_update_induction_tutor/show.html.erb
+++ b/app/views/admin/schools/replace_or_update_induction_tutor/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @replace_or_update_tutor_form, url: replace_or_update_admin_school_induction_coordinators_path(@school), method: :post do |f| %>
+    <%= form_for @replace_or_update_tutor_form, url: admin_school_replace_or_update_induction_tutor_path(@school), method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl"><%= title %></h1>
       <%= f.govuk_collection_radio_buttons(

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -15,7 +15,7 @@
       </td>
       <td class="govuk-table__cell">
         <% if @induction_coordinator %>
-          <%= govuk_link_to "Change", choose_replace_or_update_admin_school_induction_coordinators_path(@school) %>
+          <%= govuk_link_to "Change", admin_school_replace_or_update_induction_tutor_path(@school) %>
         <% else %>
           <%= govuk_link_to "Add induction tutor", new_admin_school_induction_coordinator_path(@school) %>
         <% end %>

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -15,10 +15,9 @@
       </td>
       <td class="govuk-table__cell">
         <% if @induction_coordinator %>
-        <!-- TODO: Add link to change induction coordinator for a school -->
-        <%= govuk_link_to "Change", "#" %>
+          <%= govuk_link_to "Change", edit_admin_school_induction_coordinator_path(@school) %>
         <% else %>
-        <%= govuk_link_to "Add induction tutor", new_admin_school_induction_coordinator_path(@school) %>
+          <%= govuk_link_to "Add induction tutor", new_admin_school_induction_coordinator_path(@school) %>
         <% end %>
       </td>
     </tr>

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -15,7 +15,7 @@
       </td>
       <td class="govuk-table__cell">
         <% if @induction_coordinator %>
-          <%= govuk_link_to "Change", edit_admin_school_induction_coordinator_path(@school) %>
+          <%= govuk_link_to "Change", choose_replace_or_update_admin_school_induction_coordinators_path(@school) %>
         <% else %>
           <%= govuk_link_to "Add induction tutor", new_admin_school_induction_coordinator_path(@school) %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,15 +36,32 @@ en:
     less_than: *default_message
     greater_than_or_equal_to: *default_message
 
+  errors:
+    email: &email_error_messages
+      blank: "Enter an email"
+      taken: "This email address is already in use"
+      invalid: "Enter an email address in the correct format, like name@example.com"
+    full_name: &full_name_error_messages
+      blank: "Enter a full name"
+
+  activemodel:
+    errors:
+      models:
+        nominate_induction_tutor_form:
+          attributes:
+            email:
+              <<: *email_error_messages
+            full_name:
+              <<: *full_name_error_messages
   activerecord:
     errors:
       models:
         user:
           attributes:
             email:
-              blank: "Enter an email"
-              taken: "This email address is already in use"
-              invalid: "Enter a valid email address"
+              <<: *email_error_messages
+            full_name:
+              <<: *full_name_error_messages
         school_cohort_form:
           attributes:
             estimated_mentor_count:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,10 @@ en:
               <<: *email_error_messages
             full_name:
               <<: *full_name_error_messages
+        replace_or_update_tutor_form:
+          attributes:
+            choice:
+              blank: "Choose whether to replace or update the tutor"
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :schools, only: %i[index show] do
-      resources :induction_coordinators, controller: "schools/induction_coordinators", only: %i[new create], path: "induction-coordinators" do
+      resources :induction_coordinators, controller: "schools/induction_coordinators", only: %i[new create edit update], path: "induction-coordinators" do
         collection do
           get "email-used", action: :email_used
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Rails.application.routes.draw do
     resources :schools, only: %i[index show] do
       resources :induction_coordinators, controller: "schools/induction_coordinators", only: %i[new create edit update], path: "induction-coordinators" do
         collection do
+          get "choose-replace-or-update", action: :choose_replace_or_update
+          post "replace-or-update", action: :replace_or_update
           get "email-used", action: :email_used
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,13 +102,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :schools, only: %i[index show] do
-      resources :induction_coordinators, controller: "schools/induction_coordinators", only: %i[new create edit update], path: "induction-coordinators" do
-        collection do
-          get "choose-replace-or-update", action: :choose_replace_or_update
-          post "replace-or-update", action: :replace_or_update
-          get "email-used", action: :email_used
-        end
-      end
+      resources :induction_coordinators, controller: "schools/induction_coordinators", only: %i[new create edit update], path: "induction-coordinators"
+      get "/replace-or-update-induction-tutor", to: "schools/replace_or_update_induction_tutor#show"
+      post "/replace-or-update-induction-tutor", to: "schools/replace_or_update_induction_tutor#choose"
     end
 
     scope :suppliers, module: "suppliers" do

--- a/spec/cypress/app_commands/scenarios/school_with_induction_tutor.rb
+++ b/spec/cypress/app_commands/scenarios/school_with_induction_tutor.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+school = FactoryBot.create(:school, urn: "987654", name: "Induction High School", address_line1: "23 Credibility St.", postcode: "AB1 2EE")
+
+local_authority = FactoryBot.create(:local_authority)
+SchoolLocalAuthority.create!(school: school, local_authority: local_authority, start_year: 2021)
+
+FactoryBot.create(:user, :induction_coordinator, schools: [school], full_name: "Brenda Walsh", email: "brenda.walsh@school.org")

--- a/spec/cypress/integration/admin/InductionCoordinatorManagment.feature
+++ b/spec/cypress/integration/admin/InductionCoordinatorManagment.feature
@@ -3,10 +3,11 @@ Feature: Admin user creating induction tutor
 
   Background:
     Given I am logged in as an "admin"
-    And scenario "school_with_local_authority" has been run
-    And I am on "admin schools" page
 
   Scenario: Create an induction tutor
+    Given scenario "school_with_local_authority" has been run
+    And I am on "admin schools" page
+
     When I click on "link" containing "Test school"
     Then I should be on "admin school overview" page
     And "page body" should contain "Test school"
@@ -24,6 +25,71 @@ Feature: Admin user creating induction tutor
     And the page should be accessible
     And "page body" should contain "John Smith"
     And "page body" should contain "j.smith@example.com"
+    And "notification banner" should contain "Success"
+    And "notification banner" should contain "New induction tutor added"
+    And "notification banner" should contain "They will get an email with next steps"
+
+  Scenario: Update an induction tutor
+    Given scenario "school_with_induction_tutor" has been run
+    And I am on "admin schools" page
+
+    When I click on "link" containing "Induction High School"
+    Then I should be on "admin school overview" page
+    And "page body" should contain "Induction High School"
+    And the page should be accessible
+
+    When I click on "link" containing "Change"
+    Then I should be on "choose replace or update induction tutor" page
+    And the page should be accessible
+    And percy should be sent snapshot called "choose replace or update induction tutor"
+
+    When I click on "update induction tutor" 
+    And I click the submit button
+    Then I should be on "edit admin school induction coordinator" page
+    And "name input" should have value "Brenda Walsh"
+    And "email input" should have value "brenda.walsh@school.org"
+    And the page should be accessible
+    And percy should be sent snapshot called "update induction tutor"
+
+    When I clear "name input"
+    And I type "Brenda Jones" into "name input"
+    And I clear "email input"
+    And I type "brenda.jones@school.org" into "email input"
+    And I click the submit button
+    Then I should be on "admin school overview" page
+    And the page should be accessible
+    And "page body" should contain "Brenda Jones"
+    And "page body" should contain "brenda.jones@school.org"
+    And "notification banner" should contain "Success"
+    And "notification banner" should contain "Induction tutor details updated"
+
+  Scenario: Replace an induction tutor
+    Given scenario "school_with_induction_tutor" has been run
+    And I am on "admin schools" page
+
+    When I click on "link" containing "Induction High School"
+    Then I should be on "admin school overview" page
+    And "page body" should contain "Induction High School"
+    And the page should be accessible
+
+    When I click on "link" containing "Change"
+    Then I should be on "choose replace or update induction tutor" page
+    And the page should be accessible
+
+    When I click on "replace induction tutor" 
+    And I click the submit button
+    Then I should be on "new admin school induction coordinator" page
+
+    When I type "Megan Johnson" into "name input"
+    And I clear "email input"
+    And I type "megan.johnson@school.org" into "email input"
+    And I click the submit button
+    Then I should be on "admin school overview" page
+    And the page should be accessible
+    And "page body" should contain "Megan Johnson"
+    And "page body" should contain "megan.johnson@school.org"
+    And "page body" should not contain "Brenda Walsh"
+    And "page body" should not contain "brenda.walsh@school.org"
     And "notification banner" should contain "Success"
     And "notification banner" should contain "New induction tutor added"
     And "notification banner" should contain "They will get an email with next steps"

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -20,6 +20,8 @@ const buttons = {
   "create supplier user button": '.govuk-button:contains("Add a new user")',
   "search button": "[data-test=search-button]",
   "remove button": ".govuk-button[value=Remove]",
+  "replace induction tutor": "input[value=replace].govuk-radios__input",
+  "update induction tutor": "input[value=update].govuk-radios__input",
 };
 
 const links = {

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -9,6 +9,8 @@ const inputs = {
   "school input": "#nomination-request-form-school-id-field",
   "supplier name input": "#supplier-user-form-supplier-field",
   "search box": "input[name=query]",
+  "replace induction tutor": "input[value=replace].govuk-radios__input",
+  "update induction tutor": "input[value=update].govuk-radios__input",
 };
 
 const buttons = {
@@ -20,8 +22,6 @@ const buttons = {
   "create supplier user button": '.govuk-button:contains("Add a new user")',
   "search button": "[data-test=search-button]",
   "remove button": ".govuk-button[value=Remove]",
-  "replace induction tutor": "input[value=replace].govuk-radios__input",
-  "update induction tutor": "input[value=update].govuk-radios__input",
 };
 
 const links = {

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -35,7 +35,7 @@ const pagePaths = {
   "edit admin school induction coordinator":
     "/admin/schools/:id/induction-coordinators/:id/edit",
   "choose replace or update induction tutor":
-    "/admin/schools/:id/induction-coordinators/choose-replace-or-update",
+    "/admin/schools/:id/replace-or-update-induction-tutor",
   "admin index": "/admin/administrators",
   "admin induction coordinator edit": "/admin/induction-coordinators/:id/edit",
   "admin creation": "/admin/administrators/new",

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -32,6 +32,10 @@ const pagePaths = {
   "admin school overview": "/admin/schools/:id",
   "new admin school induction coordinator":
     "/admin/schools/:id/induction-coordinators/new",
+  "edit admin school induction coordinator":
+    "/admin/schools/:id/induction-coordinators/:id/edit",
+  "choose replace or update induction tutor":
+    "/admin/schools/:id/induction-coordinators/choose-replace-or-update",
   "admin index": "/admin/administrators",
   "admin induction coordinator edit": "/admin/induction-coordinators/:id/edit",
   "admin creation": "/admin/administrators/new",
@@ -124,7 +128,7 @@ const assertOnPage = (page) => {
 
   if (path.includes(":id")) {
     const pathRegex = new RegExp(
-      path.replace(/\//g, "\\/").replace(":id", "[^/]+")
+      path.replace(/\//g, "\\/").replace(/:id/g, "[^/]+")
     );
     cy.location("pathname").should("match", pathRegex);
   } else {

--- a/spec/forms/nominate_induction_tutor_form_spec.rb
+++ b/spec/forms/nominate_induction_tutor_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NominateInductionTutorForm, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
-    it { is_expected.to validate_presence_of(:email).with_message("Enter email") }
+    it { is_expected.to validate_presence_of(:email).with_message("Enter an email") }
   end
 
   describe "#school" do

--- a/spec/models/induction_coordinator_profile_spec.rb
+++ b/spec/models/induction_coordinator_profile_spec.rb
@@ -9,33 +9,4 @@ RSpec.describe InductionCoordinatorProfile, type: :model do
   it "enables paper trail" do
     is_expected.to be_versioned
   end
-
-  describe ".create_induction_coordinator" do
-    let(:name) { Faker::Name.name }
-    let(:email) { Faker::Internet.email }
-    let(:school) { create(:school) }
-    let(:start_url) { "www.example.com" }
-    let(:created_user) { User.find_by(email: email) }
-
-    it "creates an induction coordinator" do
-      expect {
-        InductionCoordinatorProfile.create_induction_coordinator(name, email, school, start_url)
-      }.to change { InductionCoordinatorProfile.count }.by(1)
-    end
-
-    it "creates a user with the correct details" do
-      InductionCoordinatorProfile.create_induction_coordinator(name, email, school, start_url)
-
-      expect(created_user.present?).to be(true)
-      expect(created_user.full_name).to eql(name)
-    end
-
-    it "sends an email to the new user" do
-      allow(SchoolMailer).to receive(:nomination_confirmation_email).and_call_original
-      InductionCoordinatorProfile.create_induction_coordinator(name, email, school, start_url)
-
-      expect(SchoolMailer).to have_received(:nomination_confirmation_email)
-                                .with(user: created_user, school: school, start_url: start_url)
-    end
-  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -437,4 +437,22 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "#induction_tutor" do
+    let(:school) { create(:school) }
+
+    context "when an induction tutor exists" do
+      let!(:tutor) { create(:induction_coordinator_profile, schools: [school]) }
+
+      it "returns the first induction tutor" do
+        expect(school.induction_tutor).to eq(tutor.user)
+      end
+    end
+
+    context "when an induction tutor does not exist" do
+      it "returns nil" do
+        expect(school.induction_tutor).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe User, type: :model do
       user = FactoryBot.build(:user, email: "invalid")
 
       expect(user.valid?).to be_falsey
-      expect(user.errors.full_messages[0]).to include("Enter a valid email address")
+      expect(user.errors.messages[:email]).to match_array ["Enter an email address in the correct format, like name@example.com"]
     end
   end
 

--- a/spec/requests/admin/schools/induction_coordinators_spec.rb
+++ b/spec/requests/admin/schools/induction_coordinators_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
           email: "jo@example.com",
         },
       }
-      post admin_school_induction_coordinators_path(school.id), params: form_params
+      post admin_school_induction_coordinators_path(school), params: form_params
 
       created_user = User.order(:created_at).last
       expect(created_user.full_name).to eq "jo"
       expect(created_user.email).to eq "jo@example.com"
       expect(created_user.induction_coordinator?).to be_truthy
-      expect(response).to redirect_to admin_school_path(school.id)
+      expect(response).to redirect_to admin_school_path(school)
       expect(flash[:success][:content]).to eq "New induction tutor added. They will get an email with next steps."
     end
   end
@@ -54,9 +54,6 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
     it "renders the choose replace or update template" do
       get "/admin/schools/#{school.id}/induction-coordinators/choose-replace-or-update"
 
-      expect(response.body).to include("Are you replacing an induction tutor or updating their details?")
-      expect(response.body).to include("Replace induction tutor with someone new")
-      expect(response.body).to include("Update induction tutor’s details")
       expect(response).to render_template("admin/schools/induction_coordinators/choose_replace_or_update")
     end
   end
@@ -71,11 +68,15 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
         }
         post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
 
-        expect(response).to redirect_to new_admin_school_induction_coordinator_path(school.id)
+        expect(response).to redirect_to new_admin_school_induction_coordinator_path(school)
       end
     end
 
     context "when 'update' is selected" do
+      before do
+        induction_tutor
+      end
+
       it "redirects to the edit induction coordinator method" do
         form_params = {
           replace_or_update_tutor_form: {
@@ -84,7 +85,7 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
         }
         post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
 
-        expect(response).to redirect_to edit_admin_school_induction_coordinator_path(id: school.id)
+        expect(response).to redirect_to edit_admin_school_induction_coordinator_path(school, induction_tutor)
       end
     end
 

--- a/spec/requests/admin/schools/induction_coordinators_spec.rb
+++ b/spec/requests/admin/schools/induction_coordinators_spec.rb
@@ -39,64 +39,17 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
   end
 
   describe "GET /admin/schools/:school_id/induction-coordinators/:id/edit" do
+    before do
+      induction_tutor
+    end
+
     it "renders the edit template" do
       get "/admin/schools/#{school.id}/induction-coordinators/#{induction_tutor.id}/edit"
 
       expect(response).to render_template("admin/schools/induction_coordinators/edit")
-      expect(assigns(:induction_tutor)).to eq induction_tutor
-    end
-  end
-
-  describe "GET /admin/schools/:school_id/induction-coordinators/choose-replace-or-update" do
-    it "renders the choose replace or update template" do
-      get "/admin/schools/#{school.id}/induction-coordinators/choose-replace-or-update"
-
-      expect(response).to render_template("admin/schools/induction_coordinators/choose_replace_or_update")
-    end
-  end
-
-  describe "POST /admin/schools/:school_id/induction-coordinators/replace-or-update" do
-    context "when 'replace' is selected" do
-      it "redirects to the new induction coordinator method" do
-        form_params = {
-          replace_or_update_tutor_form: {
-            choice: "replace",
-          },
-        }
-        post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
-
-        expect(response).to redirect_to new_admin_school_induction_coordinator_path(school)
-      end
-    end
-
-    context "when 'update' is selected" do
-      before do
-        induction_tutor
-      end
-
-      it "redirects to the edit induction coordinator method" do
-        form_params = {
-          replace_or_update_tutor_form: {
-            choice: "update",
-          },
-        }
-        post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
-
-        expect(response).to redirect_to edit_admin_school_induction_coordinator_path(school, induction_tutor)
-      end
-    end
-
-    context "when no choice is made" do
-      it "renders the choose replace or update template" do
-        form_params = {
-          replace_or_update_tutor_form: {
-            choice: "",
-          },
-        }
-        post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
-
-        expect(response).to render_template("admin/schools/induction_coordinators/choose_replace_or_update")
-      end
+      expect(assigns(:induction_tutor_form).user_id).to eq induction_tutor.id
+      expect(assigns(:induction_tutor_form).email).to eq induction_tutor.email
+      expect(assigns(:induction_tutor_form).full_name).to eq induction_tutor.full_name
     end
   end
 

--- a/spec/requests/admin/schools/induction_coordinators_spec.rb
+++ b/spec/requests/admin/schools/induction_coordinators_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:school) { create(:school) }
+  let(:induction_tutor) { create(:user, :induction_coordinator, full_name: "May Weather", email: "may.weather@school.org", schools: [school]) }
 
   before do
     sign_in admin_user
@@ -22,7 +23,7 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
   describe "POST /admin/schools/:school_id/induction-coordinators" do
     it "creates the induction tutor and redirects to admin/schools#show" do
       form_params = {
-        nominate_induction_tutor_form: {
+        tutor_details: {
           full_name: "jo",
           email: "jo@example.com",
         },
@@ -34,6 +35,35 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
       expect(created_user.email).to eq "jo@example.com"
       expect(created_user.induction_coordinator?).to be_truthy
       expect(response).to redirect_to admin_school_path(school.id)
+    end
+  end
+
+  describe "GET /admin/schools/:school_id/induction-coordinators/:id/edit" do
+    it "renders the edit template" do
+      get "/admin/schools/#{school.id}/induction-coordinators/#{induction_tutor.id}/edit"
+
+      expect(response.body).to include("Induction tutor for #{school.name}")
+      expect(response.body).to include(induction_tutor.full_name)
+      expect(response.body).to include(induction_tutor.email)
+      expect(response).to render_template("admin/schools/induction_coordinators/edit")
+    end
+  end
+
+  describe "PATCH /admin/schools/:school_id/induction-coordinators/:id" do
+    it "updates the induction tutor and redirects to admin/schools#show" do
+      form_params = {
+        tutor_details: {
+          full_name: "Arthur Chigley",
+          email: "arthur.chigley@example.com",
+        },
+      }
+      patch admin_school_induction_coordinator_path(school.id, induction_tutor.id), params: form_params
+
+      expect(response).to redirect_to admin_school_path(school.id)
+      expect(flash[:success][:content]).to eq "Induction tutor details updated"
+      induction_tutor.reload
+      expect(induction_tutor.full_name).to eq "Arthur Chigley"
+      expect(induction_tutor.email).to eq "arthur.chigley@example.com"
     end
   end
 end

--- a/spec/requests/admin/schools/induction_coordinators_spec.rb
+++ b/spec/requests/admin/schools/induction_coordinators_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
     it "renders the new template" do
       get "/admin/schools/#{school.id}/induction-coordinators/new"
 
-      expect(response.body).to include(CGI.escapeHTML("Induction tutor for #{school.name}"))
+      expect(response.body).to include("New induction tutor for #{school.name}")
       expect(response).to render_template("admin/schools/induction_coordinators/new")
     end
   end
@@ -35,6 +35,7 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
       expect(created_user.email).to eq "jo@example.com"
       expect(created_user.induction_coordinator?).to be_truthy
       expect(response).to redirect_to admin_school_path(school.id)
+      expect(flash[:success][:content]).to eq "New induction tutor added. They will get an email with next steps."
     end
   end
 
@@ -42,10 +43,63 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
     it "renders the edit template" do
       get "/admin/schools/#{school.id}/induction-coordinators/#{induction_tutor.id}/edit"
 
-      expect(response.body).to include("Induction tutor for #{school.name}")
+      expect(response.body).to include("Update induction tutor for #{school.name}")
       expect(response.body).to include(induction_tutor.full_name)
       expect(response.body).to include(induction_tutor.email)
       expect(response).to render_template("admin/schools/induction_coordinators/edit")
+    end
+  end
+
+  describe "GET /admin/schools/:school_id/induction-coordinators/choose-replace-or-update" do
+    it "renders the choose replace or update template" do
+      get "/admin/schools/#{school.id}/induction-coordinators/choose-replace-or-update"
+
+      expect(response.body).to include("Are you replacing an induction tutor or updating their details?")
+      expect(response.body).to include("Replace induction tutor with someone new")
+      expect(response.body).to include("Update induction tutor’s details")
+      expect(response).to render_template("admin/schools/induction_coordinators/choose_replace_or_update")
+    end
+  end
+
+  describe "POST /admin/schools/:school_id/induction-coordinators/replace-or-update" do
+    context "when 'replace' is selected" do
+      it "redirects to the new induction coordinator method" do
+        form_params = {
+          replace_or_update_tutor_form: {
+            choice: "replace",
+          },
+        }
+        post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
+
+        expect(response).to redirect_to new_admin_school_induction_coordinator_path(school.id)
+      end
+    end
+
+    context "when 'update' is selected" do
+      it "redirects to the edit induction coordinator method" do
+        form_params = {
+          replace_or_update_tutor_form: {
+            choice: "update",
+          },
+        }
+        post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
+
+        expect(response).to redirect_to edit_admin_school_induction_coordinator_path(id: school.id)
+      end
+    end
+
+    context "when no choice is made" do
+      it "renders the choose replace or update template" do
+        form_params = {
+          replace_or_update_tutor_form: {
+            choice: "",
+          },
+        }
+        post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
+
+        expect(response).to render_template("admin/schools/induction_coordinators/choose_replace_or_update")
+        expect(response.body).to include("Choose whether to replace or update the tutor")
+      end
     end
   end
 

--- a/spec/requests/admin/schools/induction_coordinators_spec.rb
+++ b/spec/requests/admin/schools/induction_coordinators_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
     it "renders the new template" do
       get "/admin/schools/#{school.id}/induction-coordinators/new"
 
-      expect(response.body).to include("New induction tutor for #{school.name}")
       expect(response).to render_template("admin/schools/induction_coordinators/new")
     end
   end
@@ -43,10 +42,8 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
     it "renders the edit template" do
       get "/admin/schools/#{school.id}/induction-coordinators/#{induction_tutor.id}/edit"
 
-      expect(response.body).to include("Update induction tutor for #{school.name}")
-      expect(response.body).to include(induction_tutor.full_name)
-      expect(response.body).to include(induction_tutor.email)
       expect(response).to render_template("admin/schools/induction_coordinators/edit")
+      expect(assigns(:induction_tutor)).to eq induction_tutor
     end
   end
 
@@ -99,7 +96,6 @@ RSpec.describe "Admin::Schools::InductionCoodinators", type: :request do
         post "/admin/schools/#{school.id}/induction-coordinators/replace-or-update", params: form_params
 
         expect(response).to render_template("admin/schools/induction_coordinators/choose_replace_or_update")
-        expect(response.body).to include("Choose whether to replace or update the tutor")
       end
     end
   end

--- a/spec/requests/admin/schools/replace_or_update_induction_tutor_spec.rb
+++ b/spec/requests/admin/schools/replace_or_update_induction_tutor_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Schools::ReplaceOrUpdateInductionTutor", type: :request do
+  let(:admin_user) { create(:user, :admin) }
+  let(:school) { create(:school) }
+  let(:induction_tutor) { create(:user, :induction_coordinator, full_name: "May Weather", email: "may.weather@school.org", schools: [school]) }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /admin/schools/:school_id/replace-or-update-induction-tutor" do
+    it "renders the show template" do
+      get "/admin/schools/#{school.id}/replace-or-update-induction-tutor"
+
+      expect(response).to render_template("admin/schools/replace_or_update_induction_tutor/show")
+    end
+  end
+
+  describe "POST /admin/schools/:school_id/replace-or-update-induction-tutor" do
+    context "when 'replace' is selected" do
+      it "redirects to the new induction coordinator method" do
+        form_params = {
+          replace_or_update_tutor_form: {
+            choice: "replace",
+          },
+        }
+        post "/admin/schools/#{school.id}/replace-or-update-induction-tutor", params: form_params
+        expect(response).to redirect_to new_admin_school_induction_coordinator_path(school)
+      end
+    end
+
+    context "when 'update' is selected" do
+      before do
+        induction_tutor
+      end
+
+      it "redirects to the edit induction coordinator method" do
+        form_params = {
+          replace_or_update_tutor_form: {
+            choice: "update",
+          },
+        }
+        post "/admin/schools/#{school.id}/replace-or-update-induction-tutor", params: form_params
+
+        expect(response).to redirect_to edit_admin_school_induction_coordinator_path(school, induction_tutor)
+      end
+    end
+
+    context "when no choice is made" do
+      it "renders the choose replace or update template" do
+        form_params = {
+          replace_or_update_tutor_form: {
+            choice: "",
+          },
+        }
+        post "/admin/schools/#{school.id}/replace-or-update-induction-tutor", params: form_params
+
+        expect(response).to render_template("admin/schools/replace_or_update_induction_tutor/show")
+      end
+    end
+  end
+end

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
       } }
 
       expect(response).to render_template("nominations/nominate_induction_coordinator/new")
-      expect(response.body).to include(CGI.escapeHTML("Enter email"))
+      expect(response.body).to include(CGI.escapeHTML("Enter an email"))
     end
 
     it "shows a validation error when the name is blank" do

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -144,8 +144,11 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
     end
 
     context "when a user already exists with the provided email" do
+      before do
+        create(:user, email: email)
+      end
+
       it "redirects to the email-used page" do
-        expect_any_instance_of(NominateInductionTutorForm).to receive(:save!).and_raise(UserExistsError)
         expect {
           post "/nominations", params: { nominate_induction_tutor_form: {
             full_name: name,

--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CreateInductionTutor do
       service.call
 
       expect(SchoolMailer).to have_received(:nomination_confirmation_email)
-        .with(user: service.profile.user, school: school, start_url: service.start_url)
+        .with(user: User.find_by(email: email), school: school, start_url: service.start_url)
     end
 
     context "when an induction coordinator exists" do
@@ -35,9 +35,10 @@ RSpec.describe CreateInductionTutor do
       it "removes the existing induction coordinator" do
         expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
 
-        profile = CreateInductionTutor.call(school: school, email: email, full_name: name)
+        CreateInductionTutor.call(school: school, email: email, full_name: name)
 
-        expect(school.reload.induction_coordinator_profiles.first).to eq(profile)
+        user = User.find_by(email: email)
+        expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
       end
     end
   end

--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CreateInductionTutor do
+  let(:school) { create(:school) }
+  let(:name) { Faker::Name.name }
+  let(:email) { Faker::Internet.email }
+
+  describe ".call" do
+    it "creates a user with an induction coordinator profile" do
+      expect {
+        CreateInductionTutor.call(school: school, email: email, full_name: name)
+      }.to change { InductionCoordinatorProfile.count }.by(1)
+        .and change { User.count }.by(1)
+    end
+
+    it "emails the new induction tutor" do
+      allow(SchoolMailer).to receive(:nomination_confirmation_email).and_call_original
+
+      service = CreateInductionTutor.new(school: school, email: email, full_name: name)
+      service.call
+
+      expect(SchoolMailer).to have_received(:nomination_confirmation_email)
+        .with(user: service.profile.user, school: school, start_url: service.start_url)
+    end
+
+    context "when an induction coordinator exists" do
+      let!(:existing_profile) { create(:induction_coordinator_profile, schools: [school]) }
+
+      before do
+        existing_profile
+      end
+
+      it "removes the existing induction coordinator" do
+        expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
+
+        profile = CreateInductionTutor.call(school: school, email: email, full_name: name)
+
+        expect(school.reload.induction_coordinator_profiles.first).to eq(profile)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?selectedIssue=CPDRP-346)
Enable changing and replacing of induction tutors (coordinators)

### Changes proposed in this pull request
Add admin journey to `Change` the induction tutor for a school
Change link on induction tutor leads to an interstitial page which asks you to choose between replacing the existing tutor or updating the existing tutors details
Edit/Update functionality for induction tutor
Replacing creates new user and deletes the existing one.

### Guidance to review

### Testing
As an admin user, select a school with an induction tutor (or add an induction tutor)
When viewing that school, click the `Change` link next to the induction tutor
Make a selection to replace or update
Replace will work in the same way as adding an induction tutor and email will be sent - the existing tutor will be deleted
Update enables changing the full name and/or email - no emails are sent in this case.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
