### PR TITLE
Rename participant declaration endpoint

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class EarlyCareerTeacherParticipantsController < Api::ApiController
+    class ParticipantDeclarationsController < Api::ApiController
       include ApiTokenAuthenticatable
       before_action :set_paper_trail_whodunnit
 
@@ -11,6 +11,8 @@ module Api
 
         user = User.find(params[:id])
 
+        # TODO: Switch on declaration type
+        # TODO: Confirm that this participant is relevant to this lead provider
         return head :not_modified unless InductParticipant.call(user.early_career_teacher_profile)
 
         head :no_content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
     resource :notify_callback, only: :create, path: "notify-callback"
 
     namespace :v1 do
-      resources :early_career_teacher_participants, only: %i[create], path: "early-career-teacher-participants"
+      resources :participant_declarations, only: %i[create], path: "participant-declarations"
       resources :users, only: :index
     end
   end

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -2,17 +2,17 @@
 
 require "swagger_helper"
 
-RSpec.describe "Early Career Teacher Participation", type: :request, swagger_doc: "v1/api_spec.json" do
+RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_spec.json" do
   let(:user) { create(:user) }
   let(:lead_provider) { create(:lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider) }
   let(:bearer_token) { "Bearer #{token}" }
   let(:Authorization) { bearer_token }
 
-  path "/api/v1/early-career-teacher-participants" do
-    post "Add Early Career Teacher to Course" do
+  path "/api/v1/participant-declarations" do
+    post "Create participant declarations" do
       operationId :api_v1_create_ect_participant
-      tags "ect_participant"
+      tags "participant_declarations"
       consumes "application/json"
       security [bearerAuth: []]
       request_body content: {

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe "Early Career Teacher Participants", type: :request do
-  describe "early-career-teacher-participants" do
+RSpec.describe "Participant Declarations", type: :request do
+  describe "participant-declarations" do
     let(:lead_provider) { create(:lead_provider) }
     let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
@@ -17,17 +17,17 @@ RSpec.describe "Early Career Teacher Participants", type: :request do
       end
 
       it "returns 404 when trying to create with no content" do
-        post "/api/v1/early-career-teacher-participants", params: {}
+        post "/api/v1/participant-declarations", params: {}
         expect(response.status).to eq 404
       end
 
       it "returns 204 status" do
-        post "/api/v1/early-career-teacher-participants", params: { id: payload.user_id }
+        post "/api/v1/participant-declarations", params: { id: payload.user_id }
         expect(response.status).to eq 204
       end
 
       it "returns 404 when trying to create for an invalid user id" do # Expectes the user uuid. Pass the early_career_teacher_profile_id
-        post "/api/v1/early-career-teacher-participants", params: { id: payload.id }
+        post "/api/v1/participant-declarations", params: { id: payload.id }
         expect(response.status).to eq 404
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe "Early Career Teacher Participants", type: :request do
     context "when unauthorized" do
       it "returns 401 for invalid bearer token" do
         default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
-        post "/api/v1/early-career-teacher-participants", params: { id: payload.user_id }
+        post "/api/v1/participant-declarations", params: { id: payload.user_id }
         expect(response.status).to eq 401
       end
     end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -22,12 +22,12 @@
     }
   ],
   "paths": {
-    "/api/v1/early-career-teacher-participants": {
+    "/api/v1/participant-declarations": {
       "post": {
-        "summary": "Add Early Career Teacher to Course",
+        "summary": "Create participant declarations",
         "operationId": "api_v1_create_ect_participant",
         "tags": [
-          "ect_participant"
+          "participant_declarations"
         ],
         "security": [
           {


### PR DESCRIPTION
### Context

The previous path at `/api/v1/early-career-teacher-participants` was temporary and doesn't accurately describe collecting declarations that relate to a participant. This action will be expanded later to accept a declaration type.

### Changes proposed in this pull request

- Rename route `/api/v1/early-career-teacher-participants` to `/api/v1/participant-declarations`
- Rename controller `EarlyCareerTeacherParticipantsController` to `ParticipantDeclarationsController`