### PR TITLE
CPDTP-170 Move sandbox landing page to /sandbox

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,12 @@ Rails.application.routes.draw do
   get "/pages/:page", to: "pages#show", as: :page
   get "check" => "application#check"
 
+  unless Rails.env.production?
+    get "/sandbox", to: "sandbox#show"
+  end
+
   if Rails.env.sandbox?
-    root "sandbox#show"
+    root to: redirect("/sandbox", status: 307)
   else
     root "start#index"
   end

--- a/spec/routing/sandbox_controller_spec.rb
+++ b/spec/routing/sandbox_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe SandboxController do
         Rails.application.reload_routes!
       end
 
-      it "routes GET / to SandboxController#show" do
-        expect(get: "/").to route_to(controller: "sandbox", action: "show")
+      it "routes GET /sandbox to SandboxController#show" do
+        expect(get: "/sandbox").to route_to(controller: "sandbox", action: "show")
       end
     end
   end


### PR DESCRIPTION
### Context

You can't currently preview the sandbox page without deploying to the sandbox env or configuring sandbox correctly locally.

### Changes proposed in this pull request

Move sandbox landing page to `/sandbox`

* Hide sandbox page in production.
* [307 "temporary redirect"](https://httpstatusdogs.com/307-temporary-redirect) from  `/` to `/sandbox` for sandbox environment.

This change means you can preview the sandbox landing page in local development, dev, staging and in review-apps.

### Guidance to review

Go to /sandbox in preview app. https://ecf-review-pr-405.london.cloudapps.digital/sandbox

Check that / still renders normal index. https://ecf-review-pr-405.london.cloudapps.digital/

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?