### PR TITLE
Add pagination and changed_since to users api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ gem "delayed_job_active_record"
 # Acts as State Machine for participant states
 gem "aasm"
 
+# Pagination for API
+gem "pagy", "~> 3.13"
+
 gem "jsonapi-serializer"
 
 # OpenApi Swagger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,7 @@ GEM
       actionpack (>= 3.1, < 7.0)
       railties (>= 3.1, < 7.0)
     orm_adapter (0.5.0)
+    pagy (3.13.0)
     paper_trail (11.1.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
@@ -523,6 +524,7 @@ DEPENDENCIES
   open_api-rswag-api (>= 0.1.0)
   open_api-rswag-specs (>= 0.1.0)
   open_api-rswag-ui (>= 0.1.0)
+  pagy (~> 3.13)
   paper_trail
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,10 +4,51 @@ module Api
   module V1
     class UsersController < Api::ApiController
       include ApiTokenAuthenticatable
+      include Pagy::Backend
 
       def index
-        user_query = User.all.includes(:early_career_teacher_profile, :core_induction_programme)
-        render json: UserSerializer.new(user_query).serializable_hash.to_json
+        render json: UserSerializer.new(paginate(users)).serializable_hash.to_json
+      end
+
+    private
+
+      def updated_since
+        @updated_since ||= params.dig(:filter, :updated_since)
+      end
+
+      def users
+        @users = User.all.includes(:early_career_teacher_profile, :core_induction_programme)
+
+        if updated_since.present?
+          @users = @users.changed_since(updated_since)
+        end
+
+        @users
+      end
+
+      def paginate(scope)
+        _pagy, paginated_records = pagy(scope, items: per_page, page: page)
+
+        paginated_records
+      end
+
+      def per_page
+        params[:page] ||= {}
+
+        [(params.dig(:page, :per_page) || default_per_page).to_i, max_per_page].min
+      end
+
+      def default_per_page
+        100
+      end
+
+      def max_per_page
+        100
+      end
+
+      def page
+        params[:page] ||= {}
+        (params.dig(:page, :page) || 1).to_i
       end
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -13,17 +13,17 @@ module Api
     private
 
       def updated_since
-        @updated_since ||= params.dig(:filter, :updated_since)
+        params.dig(:filter, :updated_since)
       end
 
       def users
-        @users = User.all.includes(:early_career_teacher_profile, :core_induction_programme)
+        users = User.all.includes(:early_career_teacher_profile, :core_induction_programme)
 
         if updated_since.present?
-          @users = @users.changed_since(updated_since)
+          users = users.changed_since(updated_since)
         end
 
-        @users
+        users
       end
 
       def paginate(scope)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,4 +39,12 @@ class User < ApplicationRecord
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }
   scope :early_career_teachers, -> { joins(:early_career_teacher_profile).includes(:early_career_teacher_profile) }
+
+  scope :changed_since, lambda { |timestamp|
+    if timestamp.present?
+      where("updated_at > ?", timestamp)
+    else
+      where("updated_at is not null")
+    end.order(:updated_at, :id)
+  }
 end

--- a/spec/docs/users_spec.rb
+++ b/spec/docs/users_spec.rb
@@ -14,6 +14,52 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
       produces "application/vnd.api+json"
       security [bearerAuth: []]
 
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  type: :object,
+                  example: "",
+                  description: "This schema is used to search within collections to return more specific results.",
+                  properties: {
+                    updated_since: {
+                      description: "Return users that have been updated since the date (ISO 8601 date format)",
+                      type: :string,
+                      example: "2021-05-13T11:21:55Z",
+                    },
+                  },
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine users to return.",
+                example: { updated_since: "2020-11-13T11:21:55Z" }
+
+      parameter name: :page,
+                in: :query,
+                schema: {
+                  type: :object,
+                  descripiton: "This schema used to paginate through a collection.",
+                  properties: {
+                    page: {
+                      type: :integer,
+                      description: "The page number to paginate to in the collection. If no value is specified it defaults to the first page.",
+                      example: 3,
+                    },
+                    per_page: {
+                      type: :integer,
+                      description: "The number items to display on a page. Defaults to 100. Maximum is 500, if the value is greater that the maximum allowed it will fallback to 500.",
+                      example: 10,
+                    },
+                  },
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                example: { page: 2, per_page: 10 },
+                description: "Pagination options to navigate through the collection."
+
       response "200", "Collection of users." do
         schema type: :object,
                required: %w[data],

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,4 +103,46 @@ RSpec.describe User, type: :model do
       expect(user.lead_provider?).to be false
     end
   end
+
+  describe "#changed_since" do
+    context "with no parameters" do
+      let!(:old_user) { create(:user, updated_at: 1.hour.ago) }
+      let!(:user) { create(:user, updated_at: 1.hour.ago) }
+
+      subject { User.changed_since(nil) }
+
+      it { should include user }
+      it { should include old_user }
+    end
+
+    context "with a user that was just updated" do
+      let!(:user) { create(:user, updated_at: 1.hour.ago) }
+      let!(:old_user) { create(:user, updated_at: 1.hour.ago) }
+
+      before { user.touch }
+
+      subject { User.changed_since(10.minutes.ago) }
+
+      it { should include user }
+      it { should_not include old_user }
+    end
+
+    context "with a user that has been updated less than a second after the given timestamp" do
+      let(:timestamp) { 5.minutes.ago }
+      let(:user) { create(:user, updated_at: timestamp + 0.001.seconds) }
+
+      subject { User.changed_since(timestamp) }
+
+      it { should include user }
+    end
+
+    context "with a user that has been updated exactly at the given timestamp" do
+      let(:timestamp) { 10.minutes.ago }
+      let(:user) { create(:user, updated_at: timestamp) }
+
+      subject { User.changed_since(timestamp) }
+
+      it { should_not include user }
+    end
+  end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe "API Users", type: :request do
 
       it "returns users changed since a particular time, if given a changed_since parameter" do
         User.first.update!(updated_at: 2.days.ago)
-        get "/api/v1/users", params: { filter: { changed_since: 1.day.ago.iso8601 } }
+        get "/api/v1/users", params: { filter: { updated_since: 1.day.ago.iso8601 } }
+        expect(parsed_response["data"].size).to eql(2)
       end
     end
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe "API Users", type: :request do
         get "/api/v1/users", params: { page: { per_page: 2, page: 2 } }
         expect(JSON.parse(response.body)["data"].size).to eql(1)
       end
+
+      it "returns users changed since a particular time, if given a changed_since parameter" do
+        User.first.update!(updated_at: 2.days.ago)
+        get "/api/v1/users", params: { filter: { changed_since: 1.day.ago.iso8601 } }
+      end
     end
 
     context "when unauthorized" do

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe "API Users", type: :request do
         get "/api/v1/users"
         expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name, :user_type, :core_induction_programme).exactly
       end
+
+      it "returns the right number of users per page" do
+        get "/api/v1/users", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
+      end
+
+      it "returns different users for each page" do
+        User.delete_all
+        3.times { create(:user) }
+
+        get "/api/v1/users", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
+
+        get "/api/v1/users", params: { page: { per_page: 2, page: 2 } }
+        expect(JSON.parse(response.body)["data"].size).to eql(1)
+      end
     end
 
     context "when unauthorized" do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -85,6 +85,59 @@
             ]
           }
         ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "example": "",
+              "description": "This schema is used to search within collections to return more specific results.",
+              "properties": {
+                "updated_since": {
+                  "description": "Return users that have been updated since the date (ISO 8601 date format)",
+                  "type": "string",
+                  "example": "2021-05-13T11:21:55Z"
+                }
+              }
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine users to return.",
+            "example": {
+              "updated_since": "2020-11-13T11:21:55Z"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "descripiton": "This schema used to paginate through a collection.",
+              "properties": {
+                "page": {
+                  "type": "integer",
+                  "description": "The page number to paginate to in the collection. If no value is specified it defaults to the first page.",
+                  "example": 3
+                },
+                "per_page": {
+                  "type": "integer",
+                  "description": "The number items to display on a page. Defaults to 100. Maximum is 500, if the value is greater that the maximum allowed it will fallback to 500.",
+                  "example": 10
+                }
+              }
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": {
+              "page": 2,
+              "per_page": 10
+            },
+            "description": "Pagination options to navigate through the collection."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Collection of users.",


### PR DESCRIPTION
### Context
The number of users can probably get quite big, so much so that we won't really want to fetch all of them at all times. This adds a few ways to manage that - pagination is one, sending `updated_since ` parameter being the other. Also generates some fancy api docs for params.

### Changes proposed in this pull request
Add pagination gem
Add pagination params to users api
Add changed_since param to users api
Update the api docs

### Guidance to review
I have stolen almost all of it from another repo, https://github.com/DFE-Digital/teacher-training-api

I noticed they are using a `yml` file for all their schemas, which they then share between requests. We don't really do much reusing yet, but do we want this? yml is nicer to write those specs in than ruby in my personal opinion.

### Testing
Added unit tests for pagination, still need to add them for the time-based filtering.

### How can I view this in a review app?
Get a token, hit the users api with the new parameters. Swagger docs should be quite helpful.
