### PR TITLE
Use persisted feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,37 +143,10 @@ Where `"name or id"` is a name or id from the `lead_providers` table.
 
 ### Feature Flags
 
-Certain aspects of app behaviour are governed by a minimal implementation of Feature Flags.
-These are activated by having an environment variable FEATURES_(flag name) set to 'active', for example:
-
-```
-# start the rails server with rate limiting active
-FEATURES_rate_limiting=active bundle exec rails s
-```
+Certain aspects of app behaviour are governed by a minimal implementation of feature flags. Feature flag states are persisted in the database with a name and an active state. To activate a new feature you can run `Feature.create!(name: 'rate_limiting', active: true)`.
 
 The available flags are listed in `app/services/feature_flag.rb`, and available in the constant `FeatureFlag::FEATURES`. Each one is tested with a dedicated spec in `spec/features/feature_flags/`.
 
-To display, set and unset feature flags on GOV.UK PaaS:
-
-```
-# display the feature flags
-cf env (app name) | grep FEATURES
-
-# For example:
-cf env early-careers-framework-prod | grep FEATURES
-
-# set an env var
-cf set-env (app name) (environment variable name) (value)
-
-# For example:
-cf set-env early-careers-framework-prod FEATURES_rate_limiting active
-
-# To unset the var:
-cf unset-env (app name) (environment variable name)
-
-# For example:
-cf unset-env early-careers-framework-prod FEATURES_rate_limiting
-```
 ## payment_calculator
 
 The code in [`lib/payment_calculator/`](lib/payment_calculator/) performs payment calculations for both [ECFs (Early Career Framework)](https://www.early-career-framework.education.gov.uk/) and [the reformed NPQs (National Professional Qualification)](https://www.gov.uk/government/publications/national-professional-qualifications-frameworks-from-september-2021) so that training providers can be paid the correct amount.

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Feature < ApplicationRecord
+end

--- a/db/migrate/20210525120431_create_features.rb
+++ b/db/migrate/20210525120431_create_features.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateFeatures < ActiveRecord::Migration[6.1]
+  def change
+    create_table :features do |t|
+      t.string :name, null: false
+      t.boolean :active, default: false, null: false
+      t.timestamps
+    end
+
+    add_index :features, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_143026) do
+ActiveRecord::Schema.define(version: 2021_05_25_120431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -131,6 +131,14 @@ ActiveRecord::Schema.define(version: 2021_05_18_143026) do
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
     t.index ["school_id"], name: "index_early_career_teacher_profiles_on_school_id"
     t.index ["user_id"], name: "index_early_career_teacher_profiles_on_user_id"
+  end
+
+  create_table "features", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "active", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_features_on_name", unique: true
   end
 
   create_table "induction_coordinator_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -11,6 +11,7 @@ namespace :db do
                    .map { |row| row["tablename"] }
       tables.delete "schema_migrations"
       tables.delete "spatial_ref_sys"
+      tables.delete "features"
       tables.each { |table| connection.execute("TRUNCATE #{table} CASCADE;") }
       Rake::Task["db:seed"].invoke
       puts "Re-seeded the database!"

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe FeatureFlag do
         change { FeatureFlag.active?(:add_participants) }.from(false).to(true),
       )
     end
+
+    it "records the change in the database" do
+      feature = Feature.create_or_find_by!(name: "add_participants")
+      feature.update!(active: false)
+      expect { FeatureFlag.activate(:add_participants) }.to(
+        change { feature.reload.active }.from(false).to(true),
+      )
+    end
   end
 
   describe ".deactivate" do
@@ -16,6 +24,14 @@ RSpec.describe FeatureFlag do
       FeatureFlag.activate(:add_participants)
       expect { FeatureFlag.deactivate(:add_participants) }.to(
         change { FeatureFlag.active?(:add_participants) }.from(true).to(false),
+      )
+    end
+
+    it "records the change in the database" do
+      feature = Feature.create_or_find_by!(name: "add_participants")
+      feature.update!(active: true)
+      expect { FeatureFlag.deactivate(:add_participants) }.to(
+        change { feature.reload.active }.from(true).to(false),
       )
     end
   end


### PR DESCRIPTION
### Context

Extending the work in https://github.com/DFE-Digital/early-careers-framework/pull/407

Our current infrastructure set-up made it non-trivial to persist feature flag environment variables across deploys. They would be reset each time. Instead, we can store them in the database. This will allow us to create an interface to display, create and edit them in the future.

We might want a way to seed states in development, but we can figure that out later.

(This was copied from [apply-for-teacher-training](https://github.com/DFE-Digital/apply-for-teacher-training).)