### PR TITLE
Switch to CPD email address on sandbox landing page

### DIFF
--- a/app/views/sandbox/show.html.erb
+++ b/app/views/sandbox/show.html.erb
@@ -20,7 +20,8 @@
             <p><a href="/api-docs/">Review our API documentation</a>.</p>
 
             <h2 class="govuk-heading-m">Help and support</h2>
-            <p>Email us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov</a> for support using this sandbox.</p>
+            <p>Email us at <%= render MailToSupportComponent.new %>
+              for support using this sandbox.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Context

One that is in there belongs to a different team.

Follow up to #404 

### Changes proposed in this pull request

* correction to email address

![Selection_20210525-01-07e3e07e3e07e3e](https://user-images.githubusercontent.com/19378/119513195-e705cf00-bd6b-11eb-9f2d-9ee083e0c9e1.png)

### Guidance to review

https://ecf-review-pr-412.london.cloudapps.digital/sandbox

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?