### PR TITLE
Schema file correction.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -150,7 +150,7 @@ ActiveRecord::Schema.define(version: 2021_05_25_120431) do
     t.index ["user_id"], name: "index_induction_coordinator_profiles_on_user_id"
   end
 
-  create_table "induction_coordinator_profiles_schools", force: :cascade do |t|
+  create_table "induction_coordinator_profiles_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "induction_coordinator_profile_id", null: false
     t.uuid "school_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
This schema file is the one that is actually generated when you run
a schema:dump or migration against the current database. A previous
PR changing the induction_coordinator_profiles_schools id to not be
nullable, should have included this.

Previous PR#382 modified the schema, but it didn't include the uuid default as part of the change until you do a rails db:schema:dump. This line keeps getting added to other commits that perform migrations, so it gets it's own PR.

