### PR TITLE
CPDRP-275: Add UTM parameters to all links to the service in emails

### DIFF
--- a/app/controllers/admin/administrators/administrators_controller.rb
+++ b/app/controllers/admin/administrators/administrators_controller.rb
@@ -41,7 +41,11 @@ module Admin
         authorize User
         authorize AdminProfile
 
-        AdminProfile.create_admin(params[:user][:full_name], params[:user][:email], new_user_session_url)
+        AdminProfile.create_admin(
+          params[:user][:full_name],
+          params[:user][:email],
+          new_user_session_url(**UTMService.email(:new_admin)),
+        )
         session.delete(:administrator_user)
 
         set_success_message(heading: "User added", content: "They have been sent an email to sign in")

--- a/app/forms/supplier_user_form.rb
+++ b/app/forms/supplier_user_form.rb
@@ -26,7 +26,10 @@ class SupplierUserForm
       full_name,
       email,
       chosen_supplier,
-      Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain),
+      Rails.application.routes.url_helpers.root_url(
+        host: Rails.application.config.domain,
+        **UTMService.email(:new_lead_provider),
+      ),
     )
   end
 

--- a/app/models/nomination_email.rb
+++ b/app/models/nomination_email.rb
@@ -28,6 +28,7 @@ class NominationEmail < ApplicationRecord
     Rails.application.routes.url_helpers.start_nominate_induction_coordinator_url(
       token: token,
       host: Rails.application.config.domain,
+      **UTMService.email(:nominate_tutor),
     )
   end
 

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -23,6 +23,9 @@ class CreateInductionTutor < BaseService
   end
 
   def start_url
-    Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain)
+    Rails.application.routes.url_helpers.root_url(
+      host: Rails.application.config.domain,
+      **UTMService.email(:new_induction_tutor),
+    )
   end
 end

--- a/app/services/partnership_notification_service.rb
+++ b/app/services/partnership_notification_service.rb
@@ -93,7 +93,10 @@ private
       provider_name: provider_name(notification_email),
       cohort: notification_email.partnership.cohort.display_name,
       school_name: notification_email.school.name,
-      start_url: Rails.application.routes.url_helpers.root_url(host: Rails.application.config.domain),
+      start_url: Rails.application.routes.url_helpers.root_url(
+        host: Rails.application.config.domain,
+        **UTMService.email(:partnership_notification),
+      ),
       challenge_url: challenge_url(notification_email.token),
       challenge_deadline: notification_email.challenge_deadline.strftime("%d/%m/%Y"),
     ).deliver_now.delivery_method.response.id
@@ -109,6 +112,7 @@ private
     Rails.application.routes.url_helpers.challenge_partnership_url(
       token: token,
       host: Rails.application.config.domain,
+      **UTMService.email(:challenge_partnership),
     )
   end
 end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UTMService
+  CAMPAIGNS = {
+    new_admin: "new-admin",
+    new_lead_provider: "new-lead-provider",
+    nominate_tutor: "nominate-tutor",
+    new_induction_tutor: "new-induction-tutor",
+    sign_in: "sign-in",
+    challenge_partnership: "challenge-partnership",
+    partnership_notification: "partnership-notification",
+  }.freeze
+
+  def self.email(campaign)
+    {
+      utm_source: "cpdservice",
+      utm_medium: "email",
+      utm_campaign: CAMPAIGNS[campaign] || "none",
+    }
+  end
+end

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -26,6 +26,7 @@ module Devise
             url = Rails.application.routes.url_helpers.users_confirm_sign_in_url(
               login_token: user.login_token,
               host: Rails.application.config.domain,
+              **UTMService.email(:sign_in),
             )
 
             UserMailer.sign_in_email(user: user, url: url, token_expiry: token_expiry.localtime.to_s(:time)).deliver_now

--- a/lib/tasks/manage_admins.rake
+++ b/lib/tasks/manage_admins.rake
@@ -8,7 +8,7 @@ namespace :admin do
     default_url_options[:host] = Rails.configuration.domain
 
     puts "Creating user"
-    AdminProfile.create_admin(args[:full_name], args[:email], new_user_session_url)
+    AdminProfile.create_admin(args[:full_name], args[:email], new_user_session_url(**UTMService.email(:new_admin)))
     puts "User created; email sent"
   end
 end

--- a/spec/requests/admin/administrators/administrators_spec.rb
+++ b/spec/requests/admin/administrators/administrators_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Admin::Administrators::Administrators", type: :request do
     end
 
     it "sends new admin an account created email" do
-      url = "http://www.example.com/users/sign_in"
+      url = "http://www.example.com/users/sign_in?utm_campaign=new-admin&utm_medium=email&utm_source=cpdservice"
       allow(AdminMailer).to receive(:account_created_email).and_call_original
 
       given_a_user_is_created

--- a/spec/tasks/manage_admins_spec.rb
+++ b/spec/tasks/manage_admins_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "rake admin:create", type: :task do
   let(:email) { Faker::Internet.email }
 
   it "calls create_admin" do
-    url = "http://www.example.com/users/sign_in"
+    url = "http://www.example.com/users/sign_in?utm_campaign=new-admin&utm_medium=email&utm_source=cpdservice"
     expect(AdminProfile).to receive(:create_admin).with(name, email, url)
 
     capture_output { task.execute(to_task_arguments(name, email)) }


### PR DESCRIPTION
### Context
Chris wants UTM params on links to the service in emails to help with GA: https://dfedigital.atlassian.net/browse/CPDRP-275

### Changes proposed in this pull request
- Add a UTMService to centralise information about UTM params and campaigns
- Add UTM params to all email links


### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Easiest way is to sign in with one of the cpd-test email addresses and check the sign in link. 

I've added the params to:
- New admin welcome email
- New lead provider welcome email
- New induction tutor welcome email
- Initial email to school (invitation to nominate)
- Sign in email
- Partnership notification email
