### PR TITLE
Adjust deploy workflow so that master reflects production

### DIFF
--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -40,3 +40,66 @@ jobs:
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-037149fa-bf9a-4577-a066-f627d277d6c4"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/production.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_PRODUCTION}}", "RELEASE_VERSION":"${{github.event.inputs.version}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}'
+
+      - name: Branch protection OFF
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/DFE-Digital/early-careers-framework/branches/master/protection
+          repository: ${{ github.repository }}
+          owner: DFE-Digital
+          required_status_checks: |
+            null
+          required_pull_request_reviews: |
+            null
+          enforce_admins: |
+            null
+          allow_force_pushes: |
+            true
+          required_linear_history: |
+            false
+          allow_deletions: |
+            null
+          restrictions: |
+            null
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
+      - name: Update master
+        run: |
+          git fetch
+          git branch tmp-branch
+          git switch master
+          git reset --hard tmp-branch --
+          git branch --delete --force tmp-branch
+          git push --force origin master
+
+      - name: Branch protection ON
+        uses: octokit/request-action@v2.x
+        if: always() # Force this step to run so we don't leave master unprotected
+        with:
+          route: PUT /repos/DFE-Digital/early-careers-framework/branches/master/protection
+          repository: ${{ github.repository }}
+          owner: DFE-Digital
+          required_status_checks: |
+            strict: true
+            contexts:
+              - Run Cypress
+              - Run frontend JS unit tests
+              - Run rspec
+              - deploy
+              - lint
+          required_pull_request_reviews: |
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+          enforce_admins: |
+            true
+          allow_force_pushes: |
+            null
+          required_linear_history: |
+            false
+          allow_deletions: |
+            null
+          restrictions: |
+            null
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -35,74 +35,12 @@ jobs:
         name: Checkout Code
         with:
           ref: ${{ github.event.inputs.ref }}
-
-      - name: Branch protection OFF
-        uses: octokit/request-action@v2.x
-        with:
-          route: PUT /repos/DFE-Digital/early-careers-framework/branches/master/protection
-          repository: ${{ github.repository }}
-          owner: DFE-Digital
-          required_status_checks: |
-            null
-          required_pull_request_reviews: |
-            null
-          enforce_admins: |
-            null
-          allow_force_pushes: |
-            true
-          required_linear_history: |
-            true
-          allow_deletions: |
-            null
-          restrictions: |
-            null
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
-
-      - name: Update master
+      
+      - name: Tag deployment
         run: |
-          git fetch
-          git branch tmp-branch
-          git switch master
-          git reset --hard tmp-branch --
-          git branch --delete --force tmp-branch
           git tag --force ${{ github.event.inputs.version }}
-
           git push --force origin refs/tags/${{ github.event.inputs.version }}
-          git push --force origin master
-
           echo "HEAD=$(git rev-parse ${{ github.event.inputs.version }})" >> $GITHUB_ENV
-
-      - name: Branch protection ON
-        uses: octokit/request-action@v2.x
-        if: always() # Force this step to run so we don't leave master unprotected
-        with:
-          route: PUT /repos/DFE-Digital/early-careers-framework/branches/master/protection
-          repository: ${{ github.repository }}
-          owner: DFE-Digital
-          required_status_checks: |
-            strict: true
-            contexts:
-              - Run Cypress
-              - Run frontend JS unit tests
-              - Run rspec
-              - deploy
-              - lint
-          required_pull_request_reviews: |
-            dismiss_stale_reviews: true
-            require_code_owner_reviews: true
-          enforce_admins: |
-            true
-          allow_force_pushes: |
-            null
-          required_linear_history: |
-            true
-          allow_deletions: |
-            null
-          restrictions: |
-            null
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
### Context

We currently update `master` to reflect what we are _attempting_ to deploy to staging. If the deploy to staging failed `master` would diverge from what was deployed to staging.

This PR adjusts the deploy workflow so that master reflects what has been _deployed_ to production. I think it is more useful if we have visibility of production than staging like this.

I also needed to relax the linear history constraint default as we had previously changed this protection rule off on develop.

It's worth noting that this is not tested because it needs to be merged first.
