### PR TITLE
updated README.md to reflect what the new payment calculator is actually doing

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ The available flags are listed in `app/services/feature_flag.rb`, and available 
 
 ## payment_calculator
 
-The code in [`lib/payment_calculator/`](lib/payment_calculator/) performs payment calculations for both [ECFs (Early Career Framework)](https://www.early-career-framework.education.gov.uk/) and [the reformed NPQs (National Professional Qualification)](https://www.gov.uk/government/publications/national-professional-qualifications-frameworks-from-september-2021) so that training providers can be paid the correct amount.
+The code in[`lib/payment_calculator/ecf/`](lib/payment_calculator/ecf/)performs payment calculations for [ECFs (Early Career Framework)](https://www.early-career-framework.education.gov.uk/) using commercial information so that training providers can be paid the correct amount.
 
-The output includes the result of each intermediary step in the calculation so that any questions over how the final totals were reached can be answered by interested parties.
+The calculator can generate each intermediary step in the calculation so that any questions over how the final totals were reached can be answered by interested parties. 
+
+Output from `PaymentCalculation.new(contract: <ContractObject>)` will instantiate a calculator for that specific contract. This can then be called, passing in the retention event type, and total number of participants to calculate for. (There is also a class level call shortcut for this.) which means that for a one off calculation you can call `PaymentCalculation.new(contract: <ContractObject>).call(event_type:, total_participants:)`, or `PaymentCalculation.call({contract: <ContractObject>}, event_type:, total_participants:)`. (Note the brackets around the first hash. In this call format, that is what determines what is passed to the initializer and what goes to the call.)
 
 ### Payment entity naming
 
@@ -160,8 +162,8 @@ Here are the names we are using in the code and specs for the different concepts
 > Per participant price £995 >>
 per participant service fee £398 (40%) >> monthly service fee £27k >> total service fee £796k
 >
-> Per participant price £995 >> per participant output payment £597 (60%) >> per participant output payment for a retention period £119 (20% of 60%) >> output payment subtotal for a retention period with 1900 retained participants £226k
+> Per participant price £995 >> per participant output payment £597 (60%) >> per participant output payment for a retention period £119 (20% (or 15% depending on the period) of 60%) >> output payment total for the retention period with 1900 retained participants £226k
 
 * "Participants" includes both teachers and mentors.
 * "Output payments" are payments made based on the performance of the training provider (i.e. their output).
-* "Payment type" for start/retention/completion output payments.
+* "Payment type" for start/retention_x/completion output payments.


### PR DESCRIPTION
The payment_calculator section in the readme file has been updated to reflect what is actually happening in the code.

Specifically, it now expands on usage and scope of the calculator, since that has now been updated to require a contract object to be passed in.