### PR TITLE
CPDRP-348: Import additional school emails from a CSV file

### DIFF
--- a/app/models/additional_school_email.rb
+++ b/app/models/additional_school_email.rb
@@ -2,4 +2,5 @@
 
 class AdditionalSchoolEmail < ApplicationRecord
   belongs_to :school
+  validates :email_address, uniqueness: { scope: :school }
 end

--- a/app/models/additional_school_email.rb
+++ b/app/models/additional_school_email.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AdditionalSchoolEmail < ApplicationRecord
+  belongs_to :school
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -29,6 +29,8 @@ class School < ApplicationRecord
   has_many :early_career_teacher_profiles
   has_many :early_career_teachers, through: :early_career_teacher_profiles, source: :user
 
+  has_many :additional_school_emails
+
   scope :eligible, -> { open.eligible_establishment_type.in_england }
 
   scope :with_name_like, lambda { |search_key|

--- a/app/services/additional_email_importer.rb
+++ b/app/services/additional_email_importer.rb
@@ -33,7 +33,7 @@ private
     email.gsub!(/[\/:]/, "")
     return unless email_good?(email)
 
-    AdditionalSchoolEmail.find_or_create_by!(school: school, email: email)
+    AdditionalSchoolEmail.find_or_create_by!(school: school, email_address: email)
   end
 
   def email_good?(email)

--- a/app/services/additional_email_importer.rb
+++ b/app/services/additional_email_importer.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class AdditionalEmailImporter
+  attr_reader :logger
+  attr_reader :source_file
+
+  def initialize(logger, source_file = nil)
+    @logger = logger
+    @source_file = source_file
+  end
+
+  def run
+    CSV.foreach(data_file, headers: true, encoding: "ISO-8859-1:UTF-8") do |row|
+      import_email(row)
+    end
+  end
+
+private
+
+  def data_file
+    source_file || Rails.root.join("data/emails.csv")
+  end
+
+  def import_email(row)
+    urn = row.fetch("urn")
+    school = School.find_by(urn: urn)
+    logger.info "Could not find school with URN #{urn}" and return unless school
+
+    email = row.fetch("email")
+    email.downcase!
+    email.gsub!(/[\/:]/, "")
+    return unless email_good?(email)
+
+    AdditionalSchoolEmail.find_or_create_by!(school: school, email: email)
+  end
+
+  def email_good?(email)
+    return false if email.blank?
+
+    return false unless matches_keywords(email)
+    return false if matches_banned_words(email)
+
+    true
+  end
+
+  def matches_keywords(email)
+    keywords = %w[head info enquiries office admin hello principal secretary reception]
+    keywords.any? { |keyword| email.include?(keyword) }
+  end
+
+  def matches_banned_words(email)
+    banned_words = %w[covid corona emergency admissions recruitment absences officer mailto]
+    banned_words.any? { |banned_word| email.include?(banned_word) }
+  end
+end

--- a/db/migrate/20210527113042_create_additional_school_emails.rb
+++ b/db/migrate/20210527113042_create_additional_school_emails.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAdditionalSchoolEmails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :additional_school_emails do |t|
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.string :email, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210527113042_create_additional_school_emails.rb
+++ b/db/migrate/20210527113042_create_additional_school_emails.rb
@@ -4,9 +4,11 @@ class CreateAdditionalSchoolEmails < ActiveRecord::Migration[6.1]
   def change
     create_table :additional_school_emails do |t|
       t.references :school, null: false, foreign_key: true, type: :uuid
-      t.string :email, null: false
+      t.string :email_address, null: false
 
       t.timestamps
     end
+
+    add_index :additional_school_emails, %i[email_address school_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_27_102930) do
+ActiveRecord::Schema.define(version: 2021_05_27_113042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -43,6 +43,14 @@ ActiveRecord::Schema.define(version: 2021_05_27_102930) do
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "additional_school_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "school_id", null: false
+    t.string "email", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_id"], name: "index_additional_school_emails_on_school_id"
   end
 
   create_table "admin_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -475,6 +483,7 @@ ActiveRecord::Schema.define(version: 2021_05_27_102930) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "additional_school_emails", "schools"
   add_foreign_key "admin_profiles", "users"
   add_foreign_key "api_tokens", "lead_providers", on_delete: :cascade
   add_foreign_key "cohorts_lead_providers", "cohorts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,9 +47,10 @@ ActiveRecord::Schema.define(version: 2021_05_27_113042) do
 
   create_table "additional_school_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id", null: false
-    t.string "email", null: false
+    t.string "email_address", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email_address", "school_id"], name: "index_additional_school_emails_on_email_address_and_school_id", unique: true
     t.index ["school_id"], name: "index_additional_school_emails_on_school_id"
   end
 

--- a/lib/tasks/additional_emails.rake
+++ b/lib/tasks/additional_emails.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :additional_emails do
+  desc "Import additional school emails from CSV"
+  task import: :environment do
+    logger = Logger.new($stdout)
+    logger.info "Importing additional school emails, this may take a couple of minutes..."
+    AdditionalEmailImporter.new(logger).run
+    logger.info "Additional school email import complete!"
+    logger.info "Additional email count: #{AdditionalSchoolEmail.count}"
+  end
+end

--- a/spec/fixtures/files/example_emails.csv
+++ b/spec/fixtures/files/example_emails.csv
@@ -1,0 +1,6 @@
+"urn","email","original"
+100000,"head@example.com","mailto:head@example.com"
+100000,"admin@example.com","mailto:admin@example.com"
+100001,"info@example.com/","mailto:info@example.com"
+100002,"covid-info@example.com","mailto:covid-info@example.com"
+100003,"admissions@example.com","mailto:admission@example.com"

--- a/spec/models/additional_school_email_spec.rb
+++ b/spec/models/additional_school_email_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdditionalSchoolEmail, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:local_authorities).through(:school_local_authorities) }
     it { is_expected.to have_many(:school_local_authority_districts) }
     it { is_expected.to have_many(:local_authority_districts).through(:school_local_authority_districts) }
+    it { is_expected.to have_many(:additional_school_emails) }
   end
 
   describe "eligibility" do

--- a/spec/services/addional_email_importer_spec.rb
+++ b/spec/services/addional_email_importer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe AdditionalEmailImporter do
+  let(:example_csv_file) { "spec/fixtures/files/example_emails.csv" }
+  let(:additional_email_importer) { AdditionalEmailImporter.new(Logger.new($stdout), example_csv_file) }
+
+  before do
+    create(:school, urn: 100_000)
+    create(:school, urn: 100_001)
+    create(:school, urn: 100_002)
+    create(:school, urn: 100_003)
+  end
+
+  describe "#run" do
+    before do
+      additional_email_importer.run
+    end
+
+    it "adds multiple emails to a single school" do
+      created_emails = School.find_by(urn: 100_000).additional_school_emails
+      expect(created_emails.length).to eql 2
+      expect(created_emails.map(&:email)).to match_array %w[head@example.com admin@example.com]
+    end
+
+    it "strips slashes from emails" do
+      created_email = School.find_by(urn: 100_001).additional_school_emails.first
+
+      expect(created_email.email).to eql "info@example.com"
+    end
+
+    it "does not create emails with banned words" do
+      expect(AdditionalSchoolEmail.where(email: "covid-info@example.com").count).to eql 0
+      expect(AdditionalSchoolEmail.where(email: "admissions@example.com").count).to eql 0
+    end
+  end
+end

--- a/spec/services/addional_email_importer_spec.rb
+++ b/spec/services/addional_email_importer_spec.rb
@@ -22,18 +22,18 @@ RSpec.describe AdditionalEmailImporter do
     it "adds multiple emails to a single school" do
       created_emails = School.find_by(urn: 100_000).additional_school_emails
       expect(created_emails.length).to eql 2
-      expect(created_emails.map(&:email)).to match_array %w[head@example.com admin@example.com]
+      expect(created_emails.map(&:email_address)).to match_array %w[head@example.com admin@example.com]
     end
 
     it "strips slashes from emails" do
       created_email = School.find_by(urn: 100_001).additional_school_emails.first
 
-      expect(created_email.email).to eql "info@example.com"
+      expect(created_email.email_address).to eql "info@example.com"
     end
 
     it "does not create emails with banned words" do
-      expect(AdditionalSchoolEmail.where(email: "covid-info@example.com").count).to eql 0
-      expect(AdditionalSchoolEmail.where(email: "admissions@example.com").count).to eql 0
+      expect(AdditionalSchoolEmail.where(email_address: "covid-info@example.com").count).to eql 0
+      expect(AdditionalSchoolEmail.where(email_address: "admissions@example.com").count).to eql 0
     end
   end
 end


### PR DESCRIPTION
### Context
CPDRP-348

Matt provided a CSV of emails scraped from school websites. This cleans and imports that list to a new table. When we come to import these emails in production we will transfer the CSV to the server via SCP and run the job there.

### Changes proposed in this pull request
- Create model for additional emails for a school
- Define a ruleset for cleaning additional emails
- Add a task to import emails from a CSV

### Guidance to review

### Testing
Unit testing, manually tested

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
This can be tested as part of CPDRP-374
