### PR TITLE
Add data layer info for analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,17 @@ module ApplicationHelper
     end
   end
 
+  def data_layer
+    @data_layer ||= build_data_layer
+  end
+
+  def build_data_layer
+    analytics_data = AnalyticsDataLayer.new
+    analytics_data.add_user_info(current_user) if current_user
+    analytics_data.add_school_info(assigns["school"]) if assigns["school"]
+    analytics_data
+  end
+
 private
 
   def induction_coordinator_dashboard_path(user)

--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -30,7 +30,7 @@ class AnalyticsDataLayer
 
   def add_user_info(user)
     @analytics_data[:userType] = user.user_type if user
-    @analytics_data[:providerId] = user.lead_provider.id if user&.lead_provider?
+    @analytics_data[:providerName] = user.lead_provider.name if user&.lead_provider?
   end
 
   def add_school_info(school)

--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+##
+# The AnalyticsDataLayer enables pushing key value pairs to the Google Analytics `dataLayer`
+# The app/helpers/application_helper.rb sets up an instance of this class named "data_layer"
+# The js variable dataLayer is initialised in app/views/layouts/_application.html.erb and by default will
+# be populated with `current_user` info and also the URN of any school in the view assigns hash.
+# To add any additional view specific key/value pairs from any view:
+#
+#   <% data_layer.add(mykey: "my value", my_hash: { a: 1, b: 2}) %>
+#
+# The collected data is split into an array of key value pairs when rendered in the layout using .to_json
+#
+# e.g.
+# <script>
+#   dataLayer = [{"mykey":"my value"},{"my_hash":{"a":1,"b":2}}];
+# </script>
+#
+
+class AnalyticsDataLayer
+  attr_accessor :analytics_data
+
+  def initialize
+    @analytics_data = {}
+  end
+
+  def add(data = {})
+    @analytics_data.merge!(data)
+  end
+
+  def add_user_info(user)
+    @analytics_data[:userType] = user.user_type if user
+    @analytics_data[:providerId] = user.lead_provider.id if user&.lead_provider?
+  end
+
+  def add_school_info(school)
+    @analytics_data[:schoolId] = school.urn if school
+  end
+
+  def as_json(_opts = nil)
+    analytics_data.map { |k, v| { k => v } }
+  end
+end

--- a/app/models/analytics_data_layer.rb
+++ b/app/models/analytics_data_layer.rb
@@ -29,7 +29,7 @@ class AnalyticsDataLayer
   end
 
   def add_user_info(user)
-    @analytics_data[:userType] = user.user_type if user
+    @analytics_data[:userType] = user.user_description if user
     @analytics_data[:providerName] = user.lead_provider.name if user&.lead_provider?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,20 @@ class User < ApplicationRecord
     return mentor_profile.core_induction_programme if mentor?
   end
 
+  def user_type
+    if admin?
+      "DfE admin"
+    elsif induction_coordinator?
+      "Induction tutor"
+    elsif lead_provider?
+      "Lead provider"
+    elsif early_career_teacher?
+      "Early career teacher"
+    else
+      "Unknown"
+    end
+  end
+
   scope :induction_coordinators, -> { joins(:induction_coordinator_profile) }
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
     return mentor_profile.core_induction_programme if mentor?
   end
 
-  def user_type
+  def user_description
     if admin?
       "DfE admin"
     elsif induction_coordinator?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,8 @@ class User < ApplicationRecord
       "Lead provider"
     elsif early_career_teacher?
       "Early career teacher"
+    elsif mentor?
+      "Mentor"
     else
       "Unknown"
     end

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -18,6 +18,10 @@
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application', defer: true unless params[:nojs] === "nojs" %>
 
+    <script>
+      dataLayer = <%= data_layer.to_json.html_safe %>;
+    </script>
+
     <!-- Google Tag Manager (doesn't store personal info until permission given) -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
+  include Devise::Test::ControllerHelpers
+
   let(:admin_user) { create(:user, :admin) }
   let(:induction_coordinator) { create(:user, :induction_coordinator) }
   let(:school) { induction_coordinator.induction_coordinator_profile.schools.first }
@@ -29,6 +31,50 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns schools for induction coordinators" do
         expect(helper.profile_dashboard_path(induction_coordinator)).to eq("/schools")
       end
+    end
+  end
+
+  describe "#data_layer" do
+    context "when the analytics data does not exist" do
+      before do
+        assign("data_layer", nil)
+      end
+
+      it "creates a new AnalyticsDataLayer instance" do
+        analytics_data = helper.data_layer
+        expect(analytics_data).to be_an_instance_of AnalyticsDataLayer
+      end
+    end
+
+    context "when the analytics data exists" do
+      let(:analytics_data) { AnalyticsDataLayer.new }
+
+      before do
+        assign("data_layer", analytics_data)
+      end
+
+      it "returns the current instance" do
+        expect(helper.data_layer).to eq(analytics_data)
+      end
+    end
+  end
+
+  describe "#build_data_layer" do
+    let(:school) { create(:school) }
+
+    before do
+      sign_in admin_user
+      assign("school", school)
+    end
+
+    it "creates an AnalyticsDataLayer model" do
+      expect(helper.build_data_layer).to be_an_instance_of AnalyticsDataLayer
+    end
+
+    it "populates the analytics data with common data" do
+      data = helper.build_data_layer
+      expect(data.analytics_data[:userType]).to eq("DfE admin")
+      expect(data.analytics_data[:schoolId]).to eq(school.urn)
     end
   end
 end

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe AnalyticsDataLayer, type: :model do
     context "when the user is a lead provider" do
       let(:user) { create(:user, :lead_provider) }
 
-      it "add the associated lead provider id to the analytics data" do
+      it "add the associated lead provider name to the analytics data" do
         data_layer.add_user_info(user)
-        expect(data_layer.analytics_data[:providerId]).to eq(user.lead_provider.id)
+        expect(data_layer.analytics_data[:providerName]).to eq(user.lead_provider.name)
       end
     end
 
@@ -57,14 +57,14 @@ RSpec.describe AnalyticsDataLayer, type: :model do
   describe "#to_json" do
     before do
       data_layer.add(schoolId: "012345",
-                     providerId: "12345-12345-12345",
+                     providerName: "Super Provider Inc.",
                      errors: { a: "error", b: "bad file" })
     end
 
     it "returns the analytics data as an array of key value pairs in JSON format" do
       result = JSON.parse(data_layer.to_json)
       expect(result).to match_array [{ "schoolId" => "012345" },
-                                     { "providerId" => "12345-12345-12345" },
+                                     { "providerName" => "Super Provider Inc." },
                                      { "errors" => { "a" => "error", "b" => "bad file" } }]
     end
   end

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AnalyticsDataLayer, type: :model do
+  subject(:data_layer) { described_class.new }
+
+  describe "#add" do
+    it "adds a hash to the analytics data" do
+      data_layer.add(urn: "123456")
+
+      expect(data_layer.analytics_data[:urn]).to eq("123456")
+    end
+  end
+
+  describe "#add_user_info" do
+    let(:user) { create(:user) }
+
+    it "adds the user type to the analytics data" do
+      data_layer.add_user_info(user)
+      expect(data_layer.analytics_data[:userType]).to eq(user.user_type)
+    end
+
+    context "when the user is a lead provider" do
+      let(:user) { create(:user, :lead_provider) }
+
+      it "add the associated lead provider id to the analytics data" do
+        data_layer.add_user_info(user)
+        expect(data_layer.analytics_data[:providerId]).to eq(user.lead_provider.id)
+      end
+    end
+
+    context "when the supplied user is nil" do
+      it "does not add anything to the analytics data" do
+        data_layer.add_user_info(nil)
+        expect(data_layer.analytics_data.key?(:userType)).to be false
+      end
+    end
+  end
+
+  describe "#add_school_info" do
+    let(:school) { create(:school) }
+
+    it "adds the school URN to the analytics data" do
+      data_layer.add_school_info(school)
+      expect(data_layer.analytics_data[:schoolId]).to eq(school.urn)
+    end
+
+    context "when the supplied school is nil" do
+      it "does not add anything to the analytics data" do
+        data_layer.add_school_info(nil)
+        expect(data_layer.analytics_data.key?(:schoolId)).to be false
+      end
+    end
+  end
+
+  describe "#to_json" do
+    before do
+      data_layer.add(schoolId: "012345",
+                     providerId: "12345-12345-12345",
+                     errors: { a: "error", b: "bad file" })
+    end
+
+    it "returns the analytics data as an array of key value pairs in JSON format" do
+      result = JSON.parse(data_layer.to_json)
+      expect(result).to match_array [{ "schoolId" => "012345" },
+                                     { "providerId" => "12345-12345-12345" },
+                                     { "errors" => { "a" => "error", "b" => "bad file" } }]
+    end
+  end
+end

--- a/spec/models/analytics_data_layer_spec.rb
+++ b/spec/models/analytics_data_layer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AnalyticsDataLayer, type: :model do
 
     it "adds the user type to the analytics data" do
       data_layer.add_user_info(user)
-      expect(data_layer.analytics_data[:userType]).to eq(user.user_type)
+      expect(data_layer.analytics_data[:userType]).to eq(user.user_description)
     end
 
     context "when the user is a lead provider" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -182,4 +182,46 @@ RSpec.describe User, type: :model do
       it { should_not include user }
     end
   end
+
+  describe "#user_type" do
+    context "when the user is an admin" do
+      subject(:user) { create(:user, :admin) }
+
+      it "returns DfE admin" do
+        expect(user.user_type).to eq("DfE admin")
+      end
+    end
+
+    context "when the user is an induction tutor" do
+      subject(:user) { create(:user, :induction_coordinator) }
+
+      it "returns Induction tutor" do
+        expect(user.user_type).to eq("Induction tutor")
+      end
+    end
+
+    context "when the user is a lead provider" do
+      subject(:user) { create(:user, :lead_provider) }
+
+      it "returns Lead provider" do
+        expect(user.user_type).to eq("Lead provider")
+      end
+    end
+
+    context "when the user is an early career teacher" do
+      subject(:user) { create(:user, :early_career_teacher) }
+
+      it "returns Early career teacher" do
+        expect(user.user_type).to eq("Early career teacher")
+      end
+    end
+
+    context "when the user does not have an identified role" do
+      subject(:user) { create(:user) }
+
+      it "returns Unknown" do
+        expect(user.user_type).to eq("Unknown")
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -183,12 +183,12 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#user_type" do
+  describe "#user_description" do
     context "when the user is an admin" do
       subject(:user) { create(:user, :admin) }
 
       it "returns DfE admin" do
-        expect(user.user_type).to eq("DfE admin")
+        expect(user.user_description).to eq("DfE admin")
       end
     end
 
@@ -196,7 +196,7 @@ RSpec.describe User, type: :model do
       subject(:user) { create(:user, :induction_coordinator) }
 
       it "returns Induction tutor" do
-        expect(user.user_type).to eq("Induction tutor")
+        expect(user.user_description).to eq("Induction tutor")
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe User, type: :model do
       subject(:user) { create(:user, :lead_provider) }
 
       it "returns Lead provider" do
-        expect(user.user_type).to eq("Lead provider")
+        expect(user.user_description).to eq("Lead provider")
       end
     end
 
@@ -212,7 +212,7 @@ RSpec.describe User, type: :model do
       subject(:user) { create(:user, :early_career_teacher) }
 
       it "returns Early career teacher" do
-        expect(user.user_type).to eq("Early career teacher")
+        expect(user.user_description).to eq("Early career teacher")
       end
     end
 
@@ -220,7 +220,7 @@ RSpec.describe User, type: :model do
       subject(:user) { create(:user, :mentor) }
 
       it "returns Mentor" do
-        expect(user.user_type).to eq("Mentor")
+        expect(user.user_description).to eq("Mentor")
       end
     end
 
@@ -228,7 +228,7 @@ RSpec.describe User, type: :model do
       subject(:user) { create(:user) }
 
       it "returns Unknown" do
-        expect(user.user_type).to eq("Unknown")
+        expect(user.user_description).to eq("Unknown")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -216,6 +216,14 @@ RSpec.describe User, type: :model do
       end
     end
 
+    context "when the user is a mentor" do
+      subject(:user) { create(:user, :mentor) }
+
+      it "returns Mentor" do
+        expect(user.user_type).to eq("Mentor")
+      end
+    end
+
     context "when the user does not have an identified role" do
       subject(:user) { create(:user) }
 


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?selectedIssue=CPDRP-276)
Enable surfacing information to GA

### Changes proposed in this pull request
Adds a `AnalyticsDataLayer` class to manage the information
Adds helpers to the `ApplicationHelper` to construct the basic information
Adds `user_type` to `User` model to provide a description of the user
Renders the output of the analytics into a JS variable in the application layout partial

### Guidance to review
On any page (assuming it is rendered using the application layout) if you inspect the page in a browser you will see in the `<head>` section a `<script>` tag that populates a `dataLayer` variable.  If you are signed in this will include your user "type", if not signed in it will be an empty array.

e.g. signed in as a Lead provider
```html
<script>
      dataLayer = [{"userType":"Lead provider"},{"providerName":"Super Provider Ltd"}];
</script>
```

### Testing
I did not find a simple way to check that this was rendered in the layout, without just adding an arbitrary view test for one of the pages which didn't seem right. Open to ideas, although I would expect tests to be added for relevant views if/when they add more data to the analytics info.
Perhaps the best way to test is to view the data in GA if it is immediately available (or with the GTAG.JS plugin as used by @callumacrae) ?

e.g. Lead provider viewing a school
![image](https://user-images.githubusercontent.com/333931/119992362-5e34a080-bfc2-11eb-80a7-1cab9ae55226.png)

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
