### PR TITLE
CPDTP-133 Add a new PaymentService that generates payment html

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ Where `"name or id"` is a name or id from the `lead_providers` table.
 2. Run `EngageAndLearnApiToken.create_with_random_token!`
 3. Rails console should output a string, that's your unhashed token, you can keep it and use it to access E&L endpoints.
 
+## Generating html payment information
+
+```bash
+bundle exec rails console
+```
+
+```ruby
+PaymentService.new().generate_html({ service_fee: BigDecimal(123, 2), output_payment: BigDecimal(345, 2), total_payment: BigDecimal(567, 2) })
+```
+
+This will in future aggregate received events and do the payment calculations. Currently it just outputs the supplied numbers in html to "standard out" ready for copying into an email for finance etc. to review.
+
 ### Feature Flags
 
 Certain aspects of app behaviour are governed by a minimal implementation of feature flags. Feature flag states are persisted in the database with a name and an active state. To activate a new feature you can run `Feature.create!(name: 'rate_limiting', active: true)`.

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PaymentService
+  def generate_html(payment)
+    template = ERB.new(File.read("app/views/payments/payments.html.erb"))
+    template.result(binding)
+  end
+end

--- a/app/views/payments/payments.html.erb
+++ b/app/views/payments/payments.html.erb
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <tr>
+      <th>Payment type</th>
+      <th>Payment amount</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Service fee (monthly)</th>
+      <td>£<%= payment[:service_fee] %></td>
+    </tr>
+    <tr>
+      <th>Output payment (started)</th>
+      <td>£<%= payment[:output_payment] %></td>
+    </tr>
+    <tr>
+      <th>Total payment amount</th>
+      <td>£<%= payment[:total_payment] %></td>
+    </tr>
+  </tbody>
+</table>

--- a/spec/services/payment_service_spec.rb
+++ b/spec/services/payment_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rspec"
+
+describe PaymentService do
+  subject(:payment_service) { described_class.new }
+
+  describe "#generate_html" do
+    it "produces correct html output" do
+      expected_html = <<~HTML
+        <table>
+          <thead>
+            <tr>
+              <th>Payment type</th>
+              <th>Payment amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Service fee (monthly)</th>
+              <td>£19655.0</td>
+            </tr>
+            <tr>
+              <th>Output payment (started)</th>
+              <td>£216000.0</td>
+            </tr>
+            <tr>
+              <th>Total payment amount</th>
+              <td>£285655.0</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+
+      payment = {
+        service_fee: BigDecimal(19_655, 2),
+        output_payment: BigDecimal(216_000, 2),
+        total_payment: BigDecimal(285_655, 2),
+      }
+      html = payment_service.generate_html(payment)
+      expect(html).to eq(expected_html)
+    end
+  end
+end


### PR DESCRIPTION
### Context

This method of output is just enough to allow testing a minimum viable output with relevant end users.

It is intended to be called from the rails console and writes html to standard-out.

This intended to be connected to the event aggregation that is a work in progress on another branch to supply real numbers.

I've PR'd this piece to keep the overall PR sizes down rather than wait for the whole end to end journey.

https://dfedigital.atlassian.net/browse/CPDTP-133

### Changes proposed in this pull request

Add a new PaymentService that generates payment html

### Guidance to review

```bash
bundle exec rails console
```

```ruby
PaymentService.new().generate_html({ service_fee: BigDecimal(123, 2), output_payment: BigDecimal(345, 2), total_payment: BigDecimal(567, 2) })
```