### PR TITLE
Fix local failure to find id in cypress

### DIFF
--- a/spec/cypress/app_commands/scenarios/cip_cohort_with_school.rb
+++ b/spec/cypress/app_commands/scenarios/cip_cohort_with_school.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+cohort = FactoryBot.create(:cohort, start_year: 2021)
+school = FactoryBot.create(:school, name: "Outstanding school")
+FactoryBot.create(:school_cohort, school: school, cohort: cohort, induction_programme_choice: "core_induction_programme")
+FactoryBot.create(:core_induction_programme, name: "Awesome induction course")

--- a/spec/cypress/integration/schools/core_induction_programme/ChooseMaterials.feature
+++ b/spec/cypress/integration/schools/core_induction_programme/ChooseMaterials.feature
@@ -1,9 +1,6 @@
 Feature: Induction tutors choosing programmes
   Background:
-    Given cohort was created with start_year "2021"
-    And school was created with name "Really awesome school"
-    And school_cohort was created with created cohort, created school and induction_programme_choice "core_induction_programme"
-    And core_induction_programme was created with name "Awesome induction course"
+    Given scenario "cip_cohort_with_school" has been run
     And I am logged in as an induction coordinator for created school
     And I navigate to "2021 school cohorts" page
 

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -1,14 +1,14 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps";
-import OnRails from "../on-rails";
 
 Given("I am logged in as a {string}", (user) => cy.login(user));
 Given("I am logged in as an {string}", (user) => cy.login(user));
 Given("I am logged in as an induction coordinator for created school", () => {
-  const schoolId = OnRails.getCreatedRecord("school").id;
-  cy.appFactories([
-    ["create", "user", "induction_coordinator", { school_ids: [schoolId] }],
-  ]).then(() => {
-    cy.loginCreated("user");
+  cy.appEval("School.all.first").then((school) => {
+    cy.appFactories([
+      ["create", "user", "induction_coordinator", { school_ids: [school.id] }],
+    ]).then(() => {
+      cy.loginCreated("user");
+    });
   });
 });
 


### PR DESCRIPTION
### Context

Oddly it worked on CI but not locally for me.

![cypress fail spec - Google Chrome_20210527-01-4f6464f6464f646](https://user-images.githubusercontent.com/19378/120008345-c8554180-bfd2-11eb-9e30-650b5f309ad9.png)


I'm getting another failure locally at the moment so don't merge till that's been investigated.

### Changes proposed in this pull request

### Guidance to review

Run cypress locally as per https://github.com/DFE-Digital/early-careers-framework/#end-to-end-tests

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?