### PR TITLE
Refactor LeadProvider/YourSchool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,8 @@ gem "jsonapi-serializer"
 gem "open_api-rswag-api", ">= 0.1.0"
 gem "open_api-rswag-ui", ">= 0.1.0"
 
+gem "ransack"
+
 platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.3)
+    ransack (2.4.1)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -545,6 +549,7 @@ DEPENDENCIES
   rack-attack (>= 6.5.0)
   rails (~> 6.1.3, >= 6.1.3.2)
   rails-controller-testing (>= 1.0.5)
+  ransack
   rspec-default_http_header
   rspec-rails (~> 4.0.2)
   rubocop-govuk (>= 3.17.2)

--- a/app/components/lead_providers/your_schools/table.html.erb
+++ b/app/components/lead_providers/your_schools/table.html.erb
@@ -9,8 +9,8 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <%= render LeadProviders::YourSchools::TableRow.with_collection(schools, cohort: cohort) %>
+    <%= render LeadProviders::YourSchools::TableRow.with_collection(partnerships) %>
   </tbody>
 </table>
 
-<%= govuk_paginate schools %>
+<%= govuk_paginate partnerships %>

--- a/app/components/lead_providers/your_schools/table.rb
+++ b/app/components/lead_providers/your_schools/table.rb
@@ -5,14 +5,13 @@ module LeadProviders
     class Table < BaseComponent
       include PaginationHelper
 
-      def initialize(schools:, cohort:, page:)
-        @schools = schools.page(page).per(20)
-        @cohort = cohort
+      def initialize(partnerships:, page:)
+        @partnerships = partnerships.page(page).per(20)
       end
 
     private
 
-      attr_reader :schools, :cohort
+      attr_reader :partnerships
     end
   end
 end

--- a/app/components/lead_providers/your_schools/table_row.html.erb
+++ b/app/components/lead_providers/your_schools/table_row.html.erb
@@ -1,9 +1,9 @@
 <tr class="govuk-table__row">
-  <td class="school-name-cell govuk-table__cell" >
+  <td class="govuk-table__cell" >
     <%= govuk_link_to school.name, lead_providers_school_detail_path(school, selected_cohort: cohort.id) %>
   </td>
   <td class="govuk-table__cell"><%= school.urn %></td>
-  <td class="govuk-table__cell"><%= school.delivery_partner_for(cohort.start_year)&.name %></td>
+  <td class="govuk-table__cell"><%= partnership.delivery_partner.name %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= school.early_career_teacher_profiles_for(cohort.start_year).count %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
 </tr>

--- a/app/components/lead_providers/your_schools/table_row.rb
+++ b/app/components/lead_providers/your_schools/table_row.rb
@@ -3,16 +3,16 @@
 module LeadProviders
   module YourSchools
     class TableRow < BaseComponent
-      with_collection_parameter :school
+      with_collection_parameter :partnership
 
-      def initialize(school:, cohort:)
-        @school = school
-        @cohort = cohort
+      def initialize(partnership:)
+        @partnership = partnership
       end
 
     private
 
-      attr_reader :school, :cohort
+      attr_reader :partnership
+      delegate :school, :cohort, to: :partnership
     end
   end
 end

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -9,13 +9,12 @@ module Admin
 
     def index
       @query = params[:query]
-      @schools = policy_scope(School).includes(:induction_coordinators, :local_authority)
-                                     .order(:name)
-                                     .page(params[:page])
-                                     .per(20)
-      if @query.present?
-        @schools = @schools.search_by_name_or_urn(@query)
-      end
+      @schools = policy_scope(School)
+        .includes(:induction_coordinators, :local_authority)
+        .order(:name)
+        .ransack(name_or_urn_cont: @query).result
+        .page(params[:page])
+        .per(20)
     end
 
     def show

--- a/app/controllers/api/school_search_controller.rb
+++ b/app/controllers/api/school_search_controller.rb
@@ -3,7 +3,10 @@
 class Api::SchoolSearchController < Api::ApiController
   def index
     if params[:search_key]
-      schools = School.eligible.search_by_name_or_urn(params[:search_key]).limit(10)
+      schools = School
+        .eligible
+        .ransack(name_or_urn_cont: params[:search_key]).result
+        .limit(10)
       decorated_schools = schools.map { |school| ::Decorators::SchoolDecorator.new(school) }
       render json: SchoolSerializer.render(decorated_schools)
     else

--- a/app/controllers/lead_providers/your_schools_controller.rb
+++ b/app/controllers/lead_providers/your_schools_controller.rb
@@ -12,17 +12,20 @@ module LeadProviders
                            @cohorts.find_by(start_year: Time.zone.today.year)
                          end
 
-      @schools = School.eligible.partnered_with_lead_provider(@lead_provider.id, @selected_cohort.start_year)
-        .includes(:early_career_teachers)
-        .order(:name)
+      @partnerships = Partnership
+        .includes(school: :early_career_teachers)
+        .order("schools.name")
+        .where(
+          cohort: @selected_cohort,
+          lead_provider: @lead_provider,
+        )
 
-      @total_provider_schools = @schools.count
+      @total_provider_schools = @partnerships.count
 
       @query = params[:query]
-
-      if @query.present?
-        @schools = @schools.search_by_name_or_urn_or_delivery_partner_for_year(@query, @selected_cohort.start_year)
-      end
+      @partnerships = @partnerships.ransack(
+        school_name_or_school_urn_or_delivery_partner_name_cont: @query,
+      ).result
     end
 
   private

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -31,28 +31,6 @@ class School < ApplicationRecord
 
   scope :eligible, -> { open.eligible_establishment_type.in_england }
 
-  scope :with_name_like, lambda { |search_key|
-    where("schools.name ILIKE ?", "%#{search_key}%")
-  }
-
-  scope :with_urn_like, lambda { |search_key|
-    where("schools.urn ILIKE ?", "%#{search_key}%")
-  }
-
-  scope :with_delivery_partner_for_year_like, lambda { |name, year|
-    joins(partnerships: %i[delivery_partner cohort])
-      .where("cohorts.start_year = ? AND delivery_partners.name ILIKE ?", year, "%#{name}%")
-  }
-
-  scope :search_by_name_or_urn, lambda { |search_key|
-    with_name_like(search_key).or(with_urn_like(search_key))
-  }
-
-  scope :search_by_name_or_urn_or_delivery_partner_for_year, lambda { |search_key, year|
-    joins(partnerships: %i[delivery_partner cohort])
-      .with_name_like(search_key).or(with_urn_like(search_key)).or(with_delivery_partner_for_year_like(search_key, year))
-  }
-
   scope :with_local_authority, lambda { |local_authority|
     joins(%i[school_local_authorities local_authorities])
       .where(school_local_authorities: { end_year: nil }, local_authorities: local_authority)

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -51,7 +51,7 @@
     <% end %>
   </div>
 
-  <% if @schools.count.zero? %>
+  <% if @partnerships.count.zero? %>
     <h2 class="govuk-heading-s govuk-!-margin-top-4">There are no matching results</h2>
     <p class="govuk-body">Improve your search results by:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -60,6 +60,6 @@
       <li>searching for something less specific</li>
     </ul>
   <% else %>
-    <%= render LeadProviders::YourSchools::Table.new(schools: @schools, cohort: @selected_cohort, page: params[:page]) %>
+    <%= render LeadProviders::YourSchools::Table.new(partnerships: @partnerships, page: params[:page]) %>
   <% end %>
 <% end %>

--- a/spec/components/lead_providers/your_schools/table_row_spec.rb
+++ b/spec/components/lead_providers/your_schools/table_row_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe LeadProviders::YourSchools::TableRow, type: :view_component do
-  let(:school) { create :school }
-  let(:cohort) { create :cohort }
-  let!(:partnership) { create :partnership, school: school, cohort: cohort }
+  let(:partnership) { create :partnership }
+  let(:school) { partnership.school }
+  let(:cohort) { partnership.cohort }
 
-  let(:component) { described_class.new school: school, cohort: cohort }
+  component { described_class.new partnership: partnership }
 
   it { is_expected.to have_link school.name, href: lead_providers_school_detail_path(school, selected_cohort: cohort.id) }
   it { is_expected.to have_content school.urn }

--- a/spec/components/lead_providers/your_schools/table_spec.rb
+++ b/spec/components/lead_providers/your_schools/table_spec.rb
@@ -1,25 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe LeadProviders::YourSchools::Table, type: :view_component do
-  let(:schools) { Array.new(rand(20..25)) { |i| double("School #{i}") } }
-  let(:cohort) { double "Cohort" }
+  let(:partnerships) { Array.new(rand(20..30)) { |i| double "Partnership #{i}" } }
   let(:page) { rand(1..2) }
 
-  component { described_class.new schools: Kaminari.paginate_array(schools), cohort: cohort, page: page }
+  component { described_class.new partnerships: Kaminari.paginate_array(partnerships), page: page }
   request_path "/lead-providers/your-schools"
 
   stub_component LeadProviders::YourSchools::TableRow
 
-  it "renders table row for each school from given page" do
-    expected_schools = schools.each_slice(20).to_a[page - 1]
+  it "renders table row for each school" do
+    expected_partnerships = partnerships.each_slice(20).to_a[page - 1]
 
-    expected_schools.each do |school|
-      expect(rendered).to have_rendered(LeadProviders::YourSchools::TableRow).with(school: school, cohort: cohort)
+    expected_partnerships.each do |partnership|
+      expect(rendered).to have_rendered(LeadProviders::YourSchools::TableRow).with(partnership: partnership)
     end
 
-    (schools - expected_schools).each do |other_page_school|
+    (partnerships - expected_partnerships).each do |other_page_partnership|
       expect(rendered).not_to have_rendered(LeadProviders::YourSchools::TableRow)
-        .with(hash_including(school: other_page_school))
+        .with(hash_including(partnership: other_page_partnership))
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -276,44 +276,6 @@ RSpec.describe School, type: :model do
     end
   end
 
-  describe "School.search_by_name_or_urn" do
-    let!(:school_1) { create(:school, name: "foooschool", urn: "666666") }
-    let!(:school_2) { create(:school, name: "barschool", urn: "99999") }
-
-    it "searches correctly by partial urn" do
-      expect(School.search_by_name_or_urn("foo").first).eql?(school_1)
-    end
-
-    it "searches correctly by partial name" do
-      expect(School.search_by_name_or_urn("999").first).eql?(school_2)
-    end
-  end
-
-  describe "School.search_by_name_or_urn_or_delivery_partner_for_year" do
-    let(:cohort) { create(:cohort, start_year: Time.zone.now.year) }
-    let(:lead_provider) { create(:lead_provider, cohorts: [cohort]) }
-    let(:delivery_partner) { create(:delivery_partner, name: "Big Delivery Co.") }
-    let!(:school_1) { create(:school, name: "foooschool", urn: "666666") }
-    let!(:school_2) { create(:school, name: "barschool", urn: "99999") }
-
-    before do
-      create(:partnership, school: school_1, lead_provider: lead_provider, cohort: cohort)
-      create(:partnership, school: school_2, lead_provider: lead_provider, delivery_partner: delivery_partner, cohort: cohort)
-    end
-
-    it "searches correctly by partial urn" do
-      expect(School.search_by_name_or_urn_or_delivery_partner_for_year("foo", cohort.start_year)).to match_array [school_1]
-    end
-
-    it "searches correctly by partial name" do
-      expect(School.search_by_name_or_urn_or_delivery_partner_for_year("999", cohort.start_year)).to match_array [school_2]
-    end
-
-    it "searches correctly by partial delivery partner name" do
-      expect(School.search_by_name_or_urn_or_delivery_partner_for_year("del", cohort.start_year)).to match_array [school_2]
-    end
-  end
-
   describe "School.partnered_with_lead_provider" do
     let(:cohort) { create(:cohort, start_year: Time.zone.now.year) }
     let(:lead_provider) { create(:lead_provider, cohorts: [cohort]) }


### PR DESCRIPTION
### Context

As written, lead_providers/your_schools queried schools that has partnership with current lead_provider only to query partnership-related data for each school later on.

### Changes proposed in this pull request

This PR brings no behaviour change, but makes the controller query the partnerships instead of school. This fixes a  umber of N+1 issues as it makes all the partnership data easy to access.

I have also added ransack for more streamlined search forms. This made a number of scopes on school obsolete.