### PR TITLE
Quick typo fix

### DIFF
--- a/app/views/lead_providers/report_schools/csv/show.html.erb
+++ b/app/views/lead_providers/report_schools/csv/show.html.erb
@@ -11,7 +11,7 @@
       <li>no other delivery partners</li>
       <li>no other data</li>
     </ul>
-    <p class="govuk-body"><strong>Maxiumum file size:</strong> 2MB</p>
+    <p class="govuk-body"><strong>Maximum file size:</strong> 2MB</p>
 
     <%= form_with model: @partnership_csv_upload, url: { action: :create } do |f| %>
       <% if !@partnership_csv_upload.errors[:base].empty? %>


### PR DESCRIPTION
### Context
Fixes typo in "Maximum" on CSV upload page.

### Changes proposed in this pull request
Minor content change to correct a typo

### Guidance to review
As a lead provider user, navigate the "Confirm your schools" journey until you get to the CSV upload page, you should see "Maximum file size" not "Maxiumum file size"

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
