### PR TITLE
CPDRP-374: send chaser emails

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -50,6 +50,10 @@ class School < ApplicationRecord
     where.not(id: Partnership.unchallenged.in_year(year).select(:school_id))
   }
 
+  scope :without_induction_coordinator, lambda {
+    left_outer_joins(:induction_coordinators).where(induction_coordinators: { id: nil })
+  }
+
   def lead_provider(year)
     partnerships.unchallenged.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
   end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -7,6 +7,7 @@ class InviteSchools
     logger.info "Emailing schools"
 
     school_urns.each do |urn|
+      rate_limit
       school = School.eligible.find_by(urn: urn)
 
       if school.nil?
@@ -31,6 +32,33 @@ class InviteSchools
     latest_nomination_email&.sent_within_last?(EMAIL_COOLDOWN_PERIOD) || false
   end
 
+  def send_chasers
+    logger.info "Sending chaser emails"
+    logger.info "Nomination email count before: #{NominationEmail.count}"
+    School.eligible.without_induction_coordinator.each do |school|
+      additional_emails = school.additional_school_emails.pluck(:email_address)
+      emails = [school.primary_contact_email, school.secondary_contact_email, *additional_emails]
+                 .reject(&:blank?)
+                 .map(&:downcase)
+                 .uniq
+
+      emails.each do |email|
+        rate_limit
+        nomination_email = NominationEmail.create_nomination_email(
+          sent_at: Time.zone.now,
+          sent_to: email,
+          school: school,
+        )
+        send_nomination_email(nomination_email)
+      rescue StandardError
+        logger.info "Error emailing school, urn: #{school.urn}, email: #{email} ... skipping"
+      end
+    end
+
+    logger.info "Chaser emails sent"
+    logger.info "Nomination email count after: #{NominationEmail.count}"
+  end
+
 private
 
   def send_nomination_email(nomination_email)
@@ -46,6 +74,21 @@ private
 
   def email_expiry_date
     NominationEmail::NOMINATION_EXPIRY_TIME.from_now.strftime("%d/%m/%Y")
+  end
+
+  # Notify gives us a 3000/min rate limit. Limit this to 1800/min to allow for other calls and leeway
+  def rate_limit
+    @second_start ||= Time.zone.now
+    @calls_in_second ||= 0
+
+    if @second_start < 1.second.ago
+      @second_start = Time.zone.now
+      @calls_in_second = 1
+      return
+    end
+
+    @calls_in_second += 1
+    sleep((@second_start + 1.second) - Time.zone.now) if @calls_in_second >= 30
   end
 
   def logger

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -5,4 +5,9 @@ namespace :schools do
   task :send_invites, [:school_urns] => :environment do |_task, args|
     InviteSchools.new.run(args.school_urns.split)
   end
+
+  desc "Send chaser nomination invites to schools without induction coordinators"
+  task send_chasers: :environment do
+    InviteSchools.new.send_chasers
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -418,4 +418,14 @@ RSpec.describe School, type: :model do
       end
     end
   end
+
+  describe "scope :without_induction_coordinator" do
+    let!(:school_with_coordinator) { create(:user, :induction_coordinator).schools.first }
+    let!(:school_without_coordinator) { create(:school) }
+
+    it "returns only schools without induction coordinators" do
+      expect(School.without_induction_coordinator).to include school_without_coordinator
+      expect(School.without_induction_coordinator).not_to include school_with_coordinator
+    end
+  end
 end


### PR DESCRIPTION
### Context
CPDRP-374

We want to send chaser emails to school who have not yet nominated a tutor. We send these to every email we have available for the school

### Changes proposed in this pull request
Add a task to email all eligible schools with no nominated tutor

This will need updating once the opt out journey is finished to not email opted out schools

### How can I view this in a review app?
Drop me a message, we can go through this, the additional email CSV (CPDRP-348), and the GIAS email updates (CPDRP-296) all together 