### PR TITLE
CPDRP-392: Safelist notify API callbacks

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,10 @@
 
 # Throttle general requests by IP
 class Rack::Attack
+  safelist("Allow notify callbacks at any rate") do |request|
+    request.path == "/api/notify-callback" && request.post?
+  end
+
   throttle("General requests by ip", limit: 300, period: 5.minutes, &:ip)
 
   throttle("Login attempts by ip", limit: 5, period: 20.seconds) do |request|


### PR DESCRIPTION
Don't throttle Notify API callbacks, as they've been hitting the rate limit
