### PR TITLE
CPDRP-394: Bugfix - issue with pairing LPs and DPs

### DIFF
--- a/spec/forms/delivery_partner_form_spec.rb
+++ b/spec/forms/delivery_partner_form_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeliveryPartnerForm, type: :model do
+  describe "#save!" do
+    it "does not affect provider relationships for other delivery partners" do
+      lead_provider = create(:lead_provider)
+      other_delivery_partner = create(:delivery_partner)
+      cohort = create(:cohort, :current)
+      ProviderRelationship.create!(lead_provider: lead_provider, delivery_partner: other_delivery_partner, cohort: cohort)
+
+      form = DeliveryPartnerForm.new(
+        name: "new delivery partner",
+        lead_provider_ids: [lead_provider.id],
+        provider_relationship_hashes: [{ "lead_provider_id" => lead_provider.id, "cohort_id" => cohort.id }.to_json],
+      )
+      form.save!
+
+      expect(other_delivery_partner.provider_relationships.count).to eql 1
+    end
+  end
+end


### PR DESCRIPTION
### Context
CPDRP-394

This fixes an issue where assigning a Lead Provider to one Delivery Partner would unassign it from all others

### Changes proposed in this pull request

### Guidance to review

### Testing
Added new spec to prevent regression

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Sign in as admin@example.com, tick the same LP for two DPs. Ensure it persists