### PR TITLE
DQT record api returns 404 if no record is found

### DIFF
--- a/app/controllers/api/v1/dqt_records_controller.rb
+++ b/app/controllers/api/v1/dqt_records_controller.rb
@@ -8,7 +8,11 @@ module Api
       def show
         hash = Dqt::Client.new.api.dqt_record.show(params: { teacher_reference_number: params[:id] })
 
-        render json: DqtRecordSerializer.new(OpenStruct.new(hash)).serializable_hash.to_json
+        if hash.present?
+          render json: DqtRecordSerializer.new(OpenStruct.new(hash)).serializable_hash.to_json
+        else
+          head :not_found
+        end
       end
     end
   end

--- a/lib/dqt.rb
+++ b/lib/dqt.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# The contents of this file and ./dqt have mostly been copied from
+# github.com/DFE-Digital/claim-additional-payments-for-teaching/tree/master/lib
+# there is no independent library available at the moment of writing this
+
 module Dqt
   def self.configuration
     @configuration ||= Configuration.new


### PR DESCRIPTION
### Context

- API endpoint currently returns data if no DQT record is found
- the client would need to parse this to figure out there is no record

### Changes proposed in this pull request

- API now returns 404 if no DQT record is found
- This makes it easier for clients to handle such cases

### Guidance to review

- n/a

### Testing

- Setup DQT api keys so it can call into the sandbox
- Create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- Note down the unhashed token, it will be needed later
- Call endpoint with `curl -H "Authorization: Bearer UNHASHED_TOKEN" localhost:3001/api/v1/dqt-records/100`
- Should return body-less 404 response

### Review Checks
- [X] All pages have automated accessibility checks via cypress
- [X] All pages have visual tests via cypress + percy
- [X] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- NOTE: not sure if review apps are hooked up to DQT sandbox? if not this won't work
- Create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- Note down the unhashed token, it will be needed later
- Call endpoint with `curl -H "Authorization: Bearer UNHASHED_TOKEN" localhost:3001/api/v1/dqt-records/100`
- Should return body-less 404 response