### PR TITLE
Add swagger docs for /api/v1/dqt-records endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ bundle exec rspec
 It auto-generates swagger/*/api_spec.json from the schema files located in spec/docs
 
 ```bash
-bundle exec rake rswag
+bundle exec rake rswag:specs:swaggerize
 ```
 
 ## Linting

--- a/spec/docs/dqt_records_spec.rb
+++ b/spec/docs/dqt_records_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
+  let(:token) { NpqRegistrationApiToken.create_with_random_token! }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:Authorization) { bearer_token }
+  let(:teacher_reference_number) { "1234567" }
+
+  before do
+    stub_request(:get, "http://api/qualified-teachers/qualified-teaching-status?ni&trn=1234567")
+      .to_return(status: 200, body: response_body, headers: {})
+
+    stub_request(:get, "http://api/qualified-teachers/qualified-teaching-status?ni&trn=123456")
+      .to_return(status: 404, body: "", headers: {})
+  end
+
+  let(:response_body) do
+    {
+      data: [
+        {
+          trn: "1234567",
+          name: "John Doe",
+          doB: "1960-12-13",
+          niNumber: "AB123456C",
+          qtsAwardDate: "1990-12-13",
+          activeAlert: false,
+        },
+      ],
+    }.to_json
+  end
+
+  path "/api/v1/dqt-records/{teacher_reference_number}" do
+    get "Returns a specific DQT record" do
+      operationId :api_v1_dqt_record_show
+      tags "dqt_record"
+      produces "application/vnd.api+json"
+      security [bearerAuth: []]
+
+      parameter name: :teacher_reference_number,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "Teacher Reference Number",
+                example: "1234567"
+
+      response "200", "A DQT record" do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: {
+                   type: :object,
+                   required: %w[id type attributes],
+                   properties: {
+                     id: { type: :string },
+                     type: { type: :string },
+                     attributes: {
+                       type: :object,
+                       required: %w[teacher_reference_number full_name date_of_birth national_insurance_number qts_date active_alert],
+                       properties: {
+                         teacher_reference_number: { type: :string },
+                         full_name: { type: :string },
+                         date_of_birth: { type: :string },
+                         national_insurance_number: { type: :string },
+                         qts_date: { type: :string },
+                         active_alert: { type: :boolean },
+                       },
+                     },
+                   },
+                 },
+               }
+
+        run_test! do |response|
+          parsed_body = JSON.parse(response.body)
+
+          expect(parsed_body).to eql(
+            {
+              "data" => {
+                "id" => "1234567",
+                "type" => "dqt_record",
+                "attributes" => {
+                  "teacher_reference_number" => "1234567",
+                  "full_name" => "John Doe",
+                  "date_of_birth" => "1960-12-13",
+                  "national_insurance_number" => "AB123456C",
+                  "qts_date" => "1990-12-13",
+                  "active_alert" => false,
+                },
+              },
+            },
+          )
+        end
+      end
+
+      response "404", "No DQT record found for Teacher Reference Number" do
+        let(:teacher_reference_number) { "123456" }
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/docs/users_spec.rb
+++ b/spec/docs/users_spec.rb
@@ -39,7 +39,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                 in: :query,
                 schema: {
                   type: :object,
-                  descripiton: "This schema used to paginate through a collection.",
+                  description: "This schema used to paginate through a collection.",
                   properties: {
                     page: {
                       type: :integer,

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -184,6 +184,7 @@
                                 "type": "string",
                                 "enum": [
                                   "early_career_teacher",
+                                  "mentor",
                                   "other"
                                 ]
                               },

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -114,7 +114,7 @@
             "in": "query",
             "schema": {
               "type": "object",
-              "descripiton": "This schema used to paginate through a collection.",
+              "description": "This schema used to paginate through a collection.",
               "properties": {
                 "page": {
                   "type": "integer",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -22,6 +22,104 @@
     }
   ],
   "paths": {
+    "/api/v1/dqt-records/{teacher_reference_number}": {
+      "get": {
+        "summary": "Returns a specific DQT record",
+        "operationId": "api_v1_dqt_record_show",
+        "tags": [
+          "dqt_record"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "teacher_reference_number",
+            "in": "path",
+            "required": true,
+            "description": "Teacher Reference Number",
+            "example": "1234567",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A DQT record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "required": [
+                        "id",
+                        "type",
+                        "attributes"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "required": [
+                            "teacher_reference_number",
+                            "full_name",
+                            "date_of_birth",
+                            "national_insurance_number",
+                            "qts_date",
+                            "active_alert"
+                          ],
+                          "properties": {
+                            "teacher_reference_number": {
+                              "type": "string"
+                            },
+                            "full_name": {
+                              "type": "string"
+                            },
+                            "date_of_birth": {
+                              "type": "string"
+                            },
+                            "national_insurance_number": {
+                              "type": "string"
+                            },
+                            "qts_date": {
+                              "type": "string"
+                            },
+                            "active_alert": {
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No DQT record found for Teacher Reference Number"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
     "/api/v1/participant-declarations": {
       "post": {
         "summary": "Create participant declarations",


### PR DESCRIPTION
### Context

- Missing swagger docs for DQT records endpoint

### Changes proposed in this pull request

- Add missing swagger docs for DQT records endpoint

### Guidance to review

- Current swagger output is not valid but is outside the context of this PR

### Testing

- Fire up the rails app
- Visit http://localhost:3001/api-docs/index.html
- Should see additional documentation for endpoint 

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Visit https://ecf-review-pr-447.london.cloudapps.digital/api-docs/index.html
- Should see additional documentation for endpoint 