### PR TITLE
Ensure design of "your training provider page" matches designs

### DIFF
--- a/app/views/schools/partnerships/_signed_up_with_provider.html.erb
+++ b/app/views/schools/partnerships/_signed_up_with_provider.html.erb
@@ -1,16 +1,29 @@
-<h1 class="govuk-heading-xl">Your training provider</h1>
-<p class="govuk-body-l"><%= @partnership.delivery_partner.name %> with <%= @partnership.lead_provider.name %></p>
+<h1 class="govuk-heading-xl">Sign up with a training provider</h1>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m">Your provider details</caption>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Delivery partner</th>
+      <td class="govuk-table__cell"><%= @partnership.delivery_partner.name %></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Lead provider</th>
+      <td class="govuk-table__cell"><%= @partnership.lead_provider.name %></td>
+    </tr>
+  </tbody>
+</table>
 
 <% if @report_mistake_link.present? %>
   <p class="govuk-body">
-    If this is a mistake, <%= govuk_link_to "report that your school has been confirmed incorrectly", @report_mistake_link %>.
+    If this doesn’t look right, <%= govuk_link_to "report that your school has been confirmed incorrectly", @report_mistake_link %>.
   </p>
 
   <p class="govuk-body">
-    This link will expire on <%= @mistake_link_expiry %>
+    This link will expire on <%= @mistake_link_expiry %>.
   </p>
 <% else %>
   <p class="govuk-body">
-    If this is a mistake, contact: <%= render MailToSupportComponent.new %>
+    If this doesn’t look right, contact: <%= render MailToSupportComponent.new %>
   </p>
 <% end %>

--- a/spec/cypress/app_commands/scenarios/confirm_cip.rb
+++ b/spec/cypress/app_commands/scenarios/confirm_cip.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+cohort = FactoryBot.create(:cohort, start_year: 2021)
+
+unconfirmed_user = FactoryBot.create(:user, :induction_coordinator, email: "confirm-provider@example.com")
+SchoolCohort.find_or_create_by!(
+  cohort: cohort,
+  school: unconfirmed_user.induction_coordinator_profile.schools.first,
+  induction_programme_choice: "full_induction_programme",
+)
+
+confirmed_user = FactoryBot.create(:user, :induction_coordinator, email: "signed-up-provider@example.com")
+confirmed_school = confirmed_user.induction_coordinator_profile.schools.first
+SchoolCohort.find_or_create_by!(
+  cohort: cohort,
+  school: confirmed_school,
+  induction_programme_choice: "full_induction_programme",
+)
+delivery_partner = FactoryBot.create(:delivery_partner, name: "Test delivery partner")
+lead_provider = FactoryBot.create(:lead_provider, name: "Test lead provider")
+
+FactoryBot.create(
+  :partnership,
+  school: confirmed_school,
+  cohort: cohort,
+  delivery_partner: delivery_partner,
+  lead_provider: lead_provider,
+  created_at: 2.days.ago,
+  challenge_deadline: 6.days.from_now,
+)

--- a/spec/cypress/integration/schools/ViewPartnerships.feature
+++ b/spec/cypress/integration/schools/ViewPartnerships.feature
@@ -2,25 +2,22 @@ Feature: Induction tutors viewing partnerships
   Induction tutors should be able to view details of their chosen induction programme
 
   Background:
-    Given cohort was created with start_year "2021"
-    And I am logged in as an "induction_coordinator"
-    Then I should be on "choose programme advisory" page
+    Given scenario "confirm_cip" has been run
 
-    When I click on "link" containing "Continue"
-    Then I should be on "choose programme" page
-
-    When I click on "training provider" label
-    And I click the submit button
-    And I click the submit button
-    And I click on "link" containing "Continue"
-    Then I should be on "schools" page
-
-    When I click on "link" containing "2021"
-    Then I am on "2021 school cohorts" page
-
-  Scenario: View chosen programme
-    When I click on "link" containing "Sign up with a training provider"
+  Scenario: View confirm with provider page
+    Given I am logged in as existing user with email "confirm-provider@example.com"
+    And I am on "2021 school partnerships" page
     Then I should be on "2021 school partnerships" page
     And "page body" should contain "Have you signed up with a training provider?"
+    And the page should be accessible
+    And percy should be sent snapshot
+
+  Scenario: View confirmed with provider page
+    Given I am logged in as existing user with email "signed-up-provider@example.com"
+    And I am on "2021 school partnerships" page
+    Then I should be on "2021 school partnerships" page
+    And "page title" should contain "Sign up with a training provider"
+    And "page body" should contain "Test delivery partner"
+    And "page body" should contain "Test lead provider"
     And the page should be accessible
     And percy should be sent snapshot

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -38,6 +38,7 @@ const elements = {
   ...links,
   "page body": "main",
   "cookie banner": ".js-cookie-banner",
+  "page title": "h1",
   "notification banner": "[data-test=notification-banner]",
   "autocomplete dropdown item": ".autocomplete__menu li",
   "success panel": "[data-test=success-panel]",

--- a/spec/requests/schools/partnerships_spec.rb
+++ b/spec/requests/schools/partnerships_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Schools::Partnerships", type: :request do
 
         expect(response.body).to include(CGI.escapeHTML(lead_provider.name))
         expect(response.body).to include(CGI.escapeHTML(delivery_partner1.name))
-        expect(response.body).to include(CGI.escapeHTML("Your training provider"))
+        expect(response.body).to include(CGI.escapeHTML("Sign up with a training provider"))
       end
 
       context "when the school has recently entered a partnership" do


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDRP-395

### Changes proposed in this pull request

This page wasn't tested in Cypress so I added a test (and improved the existing one).

![image](https://user-images.githubusercontent.com/472830/120474891-a37d1780-c3a0-11eb-9e9f-6738e71724ef.png)

Waiting on feedback around the "This link will expire" text and whether it should stay as it isn't in the designs.

### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [ x All pages have visual tests via cypress + percy
- [ x All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Sign in as induction coordinator
- Sign up to FIP
- Create partnership in database
- Navigate to page

(Or just look at it in cypress like I did)
