### PR TITLE
Add rake task to run payment calculator to get payment breakdown for a lead provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ bundle exec rake 'schools:send_invites[urn1 urn2 ...]'
 bundle exec rake lead_provider:generate_token "name or id"
 ```
 
-## Run payment calculator for a given lead provider to generate the payment breakdown
+## Run payment calculator for a given lead provider with an optional number of participants (default is 2,000) to generate the payment breakdown
 
 ```bash
-bundle exec rake payment_calculation:breakdown "name or id"
+bundle exec rake payment_calculation:breakdown "<name or id>" "<number of participants>"
 ```
 
 Where `"name or id"` is a name or id from the `lead_providers` table.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ bundle exec rake 'schools:send_invites[urn1 urn2 ...]'
 bundle exec rake lead_provider:generate_token "name or id"
 ```
 
+## Run payment calculator for a given lead provider to generate the payment breakdown
+
+```bash
+bundle exec rake payment_calculation:breakdown "name or id"
+```
+
 Where `"name or id"` is a name or id from the `lead_providers` table.
 
 ## Generating a token for E&L api
@@ -151,7 +157,7 @@ The available flags are listed in `app/services/feature_flag.rb`, and available 
 
 The code in[`lib/payment_calculator/ecf/`](lib/payment_calculator/ecf/)performs payment calculations for [ECFs (Early Career Framework)](https://www.early-career-framework.education.gov.uk/) using commercial information so that training providers can be paid the correct amount.
 
-The calculator can generate each intermediary step in the calculation so that any questions over how the final totals were reached can be answered by interested parties. 
+The calculator can generate each intermediary step in the calculation so that any questions over how the final totals were reached can be answered by interested parties.
 
 Output from `PaymentCalculation.new(contract: <ContractObject>)` will instantiate a calculator for that specific contract. This can then be called, passing in the retention event type, and total number of participants to calculate for. (There is also a class level call shortcut for this.) which means that for a one off calculation you can call `PaymentCalculation.new(contract: <ContractObject>).call(event_type:, total_participants:)`, or `PaymentCalculation.call({contract: <ContractObject>}, event_type:, total_participants:)`. (Note the brackets around the first hash. In this call format, that is what determines what is passed to the initializer and what goes to the call.)
 

--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -18,15 +18,16 @@ def generate_provider_token(lead_provider, cohort, logger)
   existing_user_uuids = lead_provider.partnerships.map(&:school).map { |s| s.early_career_teacher_profiles.first&.user_id }
 
   unless existing_user_uuids.any?
-    user_uuids = 10.times.each_with_object([]) do |_i, uuids|
+    user_uuids = 10.times.each_with_object([]) do |i, uuids|
       user = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
 
-      school = School.create!(
-        urn: Faker::Internet.uuid,
-        name: Faker::Company.name,
-        address_line1: Faker::Address.street_address,
-        postcode: Faker::Address.postcode,
-      )
+      school = School.find_or_create_by!(
+        urn: sprintf("%06d", (10_000 + i)),
+      ) do |s|
+        s.name = Faker::Company.name
+        s.address_line1 = Faker::Address.street_address
+        s.postcode = Faker::Address.postcode
+      end
 
       Partnership.create!(
         school: school,

--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -21,13 +21,12 @@ def generate_provider_token(lead_provider, cohort, logger)
     user_uuids = 10.times.each_with_object([]) do |i, uuids|
       user = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
 
-      school = School.find_or_create_by!(
-        urn: sprintf("%06d", (10_000 + i)),
-      ) do |s|
-        s.name = Faker::Company.name
-        s.address_line1 = Faker::Address.street_address
-        s.postcode = Faker::Address.postcode
-      end
+      school = School.create!(
+        urn: Faker::Internet.uuid,
+        name: Faker::Company.name,
+        address_line1: Faker::Address.street_address,
+        postcode: Faker::Address.postcode,
+      )
 
       Partnership.create!(
         school: school,

--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -18,7 +18,7 @@ def generate_provider_token(lead_provider, cohort, logger)
   existing_user_uuids = lead_provider.partnerships.map(&:school).map { |s| s.early_career_teacher_profiles.first&.user_id }
 
   unless existing_user_uuids.any?
-    user_uuids = 10.times.each_with_object([]) do |i, uuids|
+    user_uuids = 10.times.each_with_object([]) do |_i, uuids|
       user = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
 
       school = School.create!(

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -17,7 +17,7 @@ namespace :payment_calculation do
       lead_provider = LeadProvider.find_by(name: ARGV[1])
     end
 
-    total_participants = ARGV[2].to_i || 2000
+    total_participants = (ARGV[2] || 2000).to_i
     per_participant = number_to_delimited(lead_provider.call_off_contract.band_a.per_participant.to_i)
 
     breakdown = PaymentCalculator::Ecf::PaymentCalculation.call(

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "payment_calculator/ecf/payment_calculation"
+include ActiveSupport::NumberHelper
+
 namespace :payment_calculation do
   desc "run payment calculator for a given lead provider"
   task breakdown: :environment do
@@ -14,8 +17,31 @@ namespace :payment_calculation do
       lead_provider = LeadProvider.find_by(name: ARGV[1])
     end
 
-    breakdown = CalculationOrchestrator.call({ lead_provider: lead_provider }, event_type: :start)
-    logger.info JSON.pretty_generate(breakdown)
+    total_participants = ARGV[2].to_i || 2000
+    per_participant = number_to_delimited(lead_provider.call_off_contract.band_a.per_participant.to_i)
+
+    breakdown = PaymentCalculator::Ecf::PaymentCalculation.call(
+      {
+        lead_provider: lead_provider,
+      },
+      total_participants: total_participants,
+      event_type: :start,
+    )
+
+    service_fee = number_to_delimited(breakdown.dig(:service_fees, :service_fee_monthly).to_i)
+    output_payment = number_to_delimited(breakdown.dig(:output_payment, :start, :subtotal).to_i)
+
+    output = <<-RESULT
+      ---------------------------------------------
+      |  Payment type            | Payment amount |
+      ---------------------------------------------
+      | Service fee (monthly)    |   £#{service_fee}      |
+      | Output payment (started) |   £#{output_payment}     |
+      ---------------------------------------------
+      Based on #{number_to_delimited(total_participants.to_i)} participants and £#{per_participant} per participant
+    RESULT
+
+    logger.info output
   rescue StandardError
     logger.info "Lead provider for '#{ARGV[1]}' not found"
   ensure

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :payment_calculation do
+  desc "run payment calculator for a given lead provider"
+  task breakdown: :environment do
+    logger = Logger.new($stdout)
+    logger.formatter = proc do |_severity, _datetime, _progname, msg|
+      "#{msg}\n"
+    end
+
+    begin
+      lead_provider = LeadProvider.find(ARGV[1])
+    rescue StandardError
+      lead_provider = LeadProvider.find_by(name: ARGV[1])
+    end
+
+    breakdown = CalculationOrchestrator.call({ lead_provider: lead_provider }, event_type: :start)
+    logger.info JSON.pretty_generate(breakdown)
+  rescue StandardError
+    logger.info "Lead provider for '#{ARGV[1]}' not found"
+  ensure
+    exit(0)
+  end
+end


### PR DESCRIPTION
Depends on [this branch](https://github.com/DFE-Digital/early-careers-framework/tree/CPDTP-131)

```
rake payment_calculation:breakdown Capita
```

Result:

```
{
  "service_fees": {
    "service_fee_per_participant": "316.67",
    "service_fee_total": "633339.0",
    "service_fee_monthly": "21839.28"
  },
  "output_payment": {
    "per_participant": "587.4",
    "start": {
      "retained_participants": 0,
      "per_participant": "117.48",
      "subtotal": "0.0"
    }
  }
}
```