### PR TITLE
Banding entries with nil sort as the highest values.

### DIFF
--- a/app/models/call_off_contract.rb
+++ b/app/models/call_off_contract.rb
@@ -5,6 +5,12 @@ class CallOffContract < ApplicationRecord
   belongs_to :lead_provider
 
   def band_a
-    participant_bands.order(:min).first
+    bands.first
+  end
+
+private
+
+  def bands
+    participant_bands.min_nulls_first
   end
 end

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -2,6 +2,7 @@
 
 class ParticipantBand < ApplicationRecord
   belongs_to :call_off_contract
+  scope :min_nulls_first, -> { order("min asc nulls first") }
 
   def number_of_participants_in_this_band(total_number_of_participants)
     if smaller_than_lower_boundary(total_number_of_participants)

--- a/spec/models/call_off_contract_spec.rb
+++ b/spec/models/call_off_contract_spec.rb
@@ -4,11 +4,12 @@ require "rails_helper"
 
 RSpec.describe CallOffContract, type: :model do
   let(:call_off_contract) { create(:call_off_contract) }
-  let(:band_a) { create(:participant_band, :band_a, call_off_contract: call_off_contract) }
-  let(:band_b) { create(:participant_band, :band_b, call_off_contract: call_off_contract) }
-  let(:band_c) { create(:participant_band, :band_c, call_off_contract: call_off_contract) }
 
   describe "associations" do
     it { is_expected.to have_many(:participant_bands) }
+
+    it "is expected to have band_a with nil as the lowest min value" do
+      expect(call_off_contract.band_a.min).to eq(nil)
+    end
   end
 end

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe CalculationOrchestrator do
   let(:expected_result) do
     {
       service_fees: {
-        service_fee_monthly: 21_846.52,
-        service_fee_per_participant: 316.77,
-        service_fee_total: 633_549.00,
+        service_fee_monthly: 22_287.90,
+        service_fee_per_participant: 323.17,
+        service_fee_total: 646_349.0,
       },
       output_payment: {
-        per_participant: 587.40,
+        per_participant: 597.0,
         start: {
-          per_participant: 117.48,
+          per_participant: 119.4,
           retained_participants: 10,
-          subtotal: 1_174.80,
+          subtotal: 1_194.0,
         },
       },
     }


### PR DESCRIPTION
### Context

PostgreSQL orders with NULL values being compared as higher than any other numeric.
Ref: https://stackoverflow.com/questions/5826210/rails-order-with-nulls-last/7055259

### Changes proposed in this pull request
Force NULLS to be treated first as a sort for band ordering

### Guidance to review

### Testing
Validate in Console with the Banding model. CalloffContract model test has been updated to use unnamed bands and force the lookup.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
You can't