### PR TITLE
add NpqRegistrationApiToken to seeds for dev env

### DIFF
--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -49,6 +49,7 @@ end
 # The tokens below have different unhashed version to avoid worrying about clever cryptographic attacks
 if Rails.env.deployed_development?
   EngageAndLearnApiToken.find_or_create_by!(hashed_token: "dfce9a34c6f982e8adb4b903f8b6064682e6ad1f7858c41ed8a0a7468abc8896")
+  NpqRegistrationApiToken.find_or_create_by!(hashed_token: "1dae3836ed90df4b796eff1f4a4713247ac5bc8a00352ea46eee621d74cd4fcf")
 elsif Rails.env.development?
   EngageAndLearnApiToken.find_or_create_by!(hashed_token: "f4a16cd7fc10918fbc7d869d7a83df36059bb98fac7c82502d797b1f1dd73e86")
 end


### PR DESCRIPTION
### Context

- NPQ registration requires api access in the deployed dev environment
- So integration environments work with one another

### Changes proposed in this pull request

- Add Npq api token to seeds so they added to the deployed dev environment

### Guidance to review

n/a

### Testing

- Test on review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- `cf login --sso`
- `cf ssh ecf-review-pr-462`
- `export PATH="/usr/local/bundle/bin:/usr/local/bundle/gems/bin:/usr/local/bin:$PATH"`
- `cd /app`
- `bundle exec rails c`
- `NpqRegistrationApiToken.find_by(hashed_token: "1dae3836ed90df4b796eff1f4a4713247ac5bc8a00352ea46eee621d74cd4fcf")`
- Should return a token