### PR TITLE
Fixed silent conflict causing wrong constant lookup scope

### DIFF
--- a/app/forms/lead_providers/report_schools_form.rb
+++ b/app/forms/lead_providers/report_schools_form.rb
@@ -17,7 +17,7 @@ module LeadProviders
     def save!
       ActiveRecord::Base.transaction do
         school_ids.each do |school_id|
-          Partnerships::Report.call(
+          ::Partnerships::Report.call(
             school_id: school_id,
             cohort_id: cohort_id,
             delivery_partner_id: delivery_partner_id,


### PR DESCRIPTION
### Context

Out LeadProviders::ReportSchoolsForm was accessing Partnerships::Report constant. It was a no-problem lookup in the PR which introduced `Partnerships::Report`, however another PR introduced `LeadProviders::Partnerships` namespace, which is now causing `Partnership` constant to resolve to `LeadProviders::Partnerships` rather than `::Partnerships`. Most likely we need a bit more thinking about the namespaces, but this will fix the issue for now. 
