### PR TITLE
CPDRP-343: Track CSV errors in GA data layer

### DIFF
--- a/app/views/lead_providers/report_schools/csv/errors.html.erb
+++ b/app/views/lead_providers/report_schools/csv/errors.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "CSV results" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: lead_providers_report_schools_csv_path) %>
+<% data_layer.add(
+     csv_rows_with_errors: @errors.count,
+     csv_valid_rows: @valid_schools.count,
+     csv_errors: @errors.map {|error| error[:message].parameterize.underscore}.tally,
+   ) %>
 <h1 class="govuk-heading-xl">Your CSV has errors</h1>
 
 <p class="govuk-body">We have found <%= @urns.count %> rows in your CSV:</p>

--- a/app/views/lead_providers/report_schools/csv/show.html.erb
+++ b/app/views/lead_providers/report_schools/csv/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "Upload partnership csv" %>
-<% content_for :before_content, govuk_back_link( text: "Back", href: lead_providers_report_schools_delivery_partner_path ) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: lead_providers_report_schools_delivery_partner_path) %>
+
+<% data_layer.add(
+  csv_file_errors: @partnership_csv_upload.errors.map { |error| error.type.parameterize.underscore }
+) if @partnership_csv_upload.errors.any? %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -21,11 +25,11 @@
           </h2>
           <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
-            <% @partnership_csv_upload.errors[:base].each do |error| %>
-              <li>
-                <a href="#csv-error"><%= error %></a>
-              </li>
-            <% end %>
+              <% @partnership_csv_upload.errors[:base].each do |error| %>
+                <li>
+                  <a href="#csv-error"><%= error %></a>
+                </li>
+              <% end %>
             </ul>
           </div>
         </div>

--- a/spec/requests/lead_providers/report_schools/csv_spec.rb
+++ b/spec/requests/lead_providers/report_schools/csv_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe "Lead Provider school reporting: uploading csv", type: :request d
 
   describe "POST /lead-providers/report-schools/csv" do
     context "with no file selected" do
-      it "renders :new with error mesage" do
+      it "renders :new with error message" do
+        expect_any_instance_of(AnalyticsDataLayer).to receive(:add).with(csv_file_errors: %w[please_select_a_csv_file_to_upload])
+
         post "/lead-providers/report-schools/csv", params: {}
 
         expect(response).to render_template :show

--- a/spec/requests/lead_providers/report_schools/csv_spec.rb
+++ b/spec/requests/lead_providers/report_schools/csv_spec.rb
@@ -81,5 +81,15 @@ RSpec.describe "Lead Provider school reporting: uploading csv", type: :request d
       get "/lead-providers/report-schools/csv/errors"
       expect(response).to render_template :errors
     end
+
+    it "adds the correct values to the data layer" do
+      expect_any_instance_of(AnalyticsDataLayer).to receive(:add).with(
+        csv_rows_with_errors: 4,
+        csv_valid_rows: 0,
+        csv_errors: { "urn_is_not_valid" => 4 },
+      )
+
+      get "/lead-providers/report-schools/csv/errors"
+    end
   end
 end


### PR DESCRIPTION
### Context
CPDRP-343
Our data analyst needs information on the errors displayed to users to measure the performance of new features.

### Changes proposed in this pull request
- Track number and type of errors on CSV rows
- Track CSV file errors

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Sign in as lead-provider@example.com, upload a CSV with errors, check the datalayer using dev tools
