### PR TITLE
CPDTP-188 Inverse link to participation_declarations from early_career_teacher_profile and lead_provider

### DIFF
--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -10,4 +10,5 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   belongs_to :mentor_profile, optional: true
   has_one :mentor, through: :mentor_profile, source: :user
   has_one :participation_record, dependent: :destroy
+  has_many :participant_declarations
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -14,6 +14,7 @@ class LeadProvider < ApplicationRecord
   has_many :lead_provider_api_tokens
   has_many :participation_records
   has_one :call_off_contract
+  has_many :participant_declarations
 
   validates :name, presence: { message: "Enter a name" }
 end


### PR DESCRIPTION
### Context

Missing links from `ect_profiles` and `lead_provider`

### Changes proposed in this pull request

Only had `belongs_to` links in `participations_declarations`. This completes the link by adding in the inverse too

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
