### PR TITLE
Regenerate swagger docs and fix preloader

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -17,7 +17,7 @@ module Api
     end
 
     def missing_parameter_response(exception)
-      render json: { missing_parameter: exception.param }, status: :unprocessable_entity
+      render json: { missing_parameters: exception.param }, status: :unprocessable_entity
     end
   end
 end

--- a/app/services/induct_participant.rb
+++ b/app/services/induct_participant.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "initialize_with_config"
+
 class InductParticipant
   include InitializeWithConfig
 

--- a/app/services/record_participant_event.rb
+++ b/app/services/record_participant_event.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "initialize_with_config"
+
 class RecordParticipantEvent
   include InitializeWithConfig
   class << self

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
         run_test!
       end
 
-      response 204, "Duplicate successful" do
+      response 204, "Successful" do
         let(:params) do
           {
             "participant_id" => user.id,

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Participant Declarations", type: :request do
       it "returns 422 when a required parameter is missing" do
         post "/api/v1/participant-declarations", params: missing_required_parameter
         expect(response.status).to eq 422
-        expect(response.body).to eq({ missing_parameter: %w[participant_id] }.to_json)
+        expect(response.body).to eq({ missing_parameters: %w[participant_id] }.to_json)
       end
     end
 

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -170,7 +170,7 @@
                   },
                   "declaration_date": {
                     "type": "string",
-                    "format": "date"
+                    "format": "date-time"
                   }
                 },
                 "required": [
@@ -192,7 +192,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Duplicate successful"
+            "description": "Successful"
           },
           "404": {
             "description": "Not Found"


### PR DESCRIPTION
### Context

API generation for swagger had a couple of errors and omissions.
The 2nd 204 status description was being picked up so rather than successful, it was showing "Duplicate successful". 
The format for the `declaration_date` was 'date', rather than 'date-time'.
Also, as we're  not using zeitwerk, we need to be more explicit in the require locations, otherwise we get a 500 error when trying to send a new event.

### Changes proposed in this pull request

Add in the correct 'date-time' and description and regenerate swagger docs.
Explicitly require 'initialize_with_config' in the RecordParticipantEvent service and InductParticipant services.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
  The api-docs/index.html endpoint shows the correct status for 204 in the participant-declarations API return values.