### PR TITLE
Added migration to replace integer id with uuid

### DIFF
--- a/db/migrate/20210608084207_change_primary_key_to_uuid_on_induction_coordinator_profiles_schools.rb
+++ b/db/migrate/20210608084207_change_primary_key_to_uuid_on_induction_coordinator_profiles_schools.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangePrimaryKeyToUuidOnInductionCoordinatorProfilesSchools < ActiveRecord::Migration[6.1]
   def up
     add_column :induction_coordinator_profiles_schools, :uuid_id, :uuid, default: "gen_random_uuid()", null: false

--- a/db/migrate/20210608084207_change_primary_key_to_uuid_on_induction_coordinator_profiles_schools.rb
+++ b/db/migrate/20210608084207_change_primary_key_to_uuid_on_induction_coordinator_profiles_schools.rb
@@ -1,0 +1,23 @@
+class ChangePrimaryKeyToUuidOnInductionCoordinatorProfilesSchools < ActiveRecord::Migration[6.1]
+  def up
+    add_column :induction_coordinator_profiles_schools, :uuid_id, :uuid, default: "gen_random_uuid()", null: false
+    rename_column :induction_coordinator_profiles_schools, :id, :integer_id
+    rename_column :induction_coordinator_profiles_schools, :uuid_id, :id
+    execute "ALTER TABLE induction_coordinator_profiles_schools DROP CONSTRAINT induction_coordinator_profiles_schools_pkey;"
+    execute "ALTER TABLE induction_coordinator_profiles_schools ADD PRIMARY KEY (id);"
+
+    remove_column :induction_coordinator_profiles_schools, :integer_id
+    execute "DROP SEQUENCE IF EXISTS induction_coordinator_profiles_schools_id_seq;"
+  end
+
+  def down
+    execute "CREATE SEQUENCE IF NOT EXISTS induction_coordinator_profiles_schools_id_seq;"
+    execute "ALTER TABLE induction_coordinator_profiles_schools ADD COLUMN integer_id bigint NOT NULL DEFAULT nextval('induction_coordinator_profiles_schools_id_seq');"
+    rename_column :induction_coordinator_profiles_schools, :id, :uuid_id
+    rename_column :induction_coordinator_profiles_schools, :integer_id, :id
+    execute "ALTER TABLE induction_coordinator_profiles_schools DROP CONSTRAINT induction_coordinator_profiles_schools_pkey;"
+    execute "ALTER TABLE induction_coordinator_profiles_schools ADD PRIMARY KEY (id);"
+
+    remove_column :induction_coordinator_profiles_schools, :uuid_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_03_094324) do
+ActiveRecord::Schema.define(version: 2021_06_08_084207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 2021_06_03_094324) do
     t.index ["user_id"], name: "index_induction_coordinator_profiles_on_user_id"
   end
 
-  create_table "induction_coordinator_profiles_schools", force: :cascade do |t|
+  create_table "induction_coordinator_profiles_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "induction_coordinator_profile_id", null: false
     t.uuid "school_id", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
### Context
[Jira ticket](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?selectedIssue=CPDRP-393)
Fix issue with integer primary key

The `induction_coordinator_profiles_schools` is a join table that had an `id` added so that paper trail could record it. We are using a gem `ar-uuid` which is supposed to automagically make primary keys uuids but for reasons unknown it didn't pick up the `primary_key` statement in that migration and so it was created as a `bigint`.

Worth noting is that the `versions` table managed by paper trail was configured to expect `item_id` to be a `uuid` but this also has a default to automatically generate a uuid so any existing paper trails for `induction_coordinator_profiles_schools` will not be easily reconciled.

### Guidance to review
Look at the migration steps

### Changes proposed in this pull request
Adds a migration to replace the current integer `id` with a `uuid` one.

### Testing


### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
You can't really 
