### PR TITLE
CPDRP-418: Notify email validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,4 +154,5 @@ group :test do
   gem "simplecov"
   gem "webdrivers", "~> 4.4", ">= 4.4.1"
   gem "webmock"
+  gem "with_model"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,6 +495,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_model (2.1.5)
+      activerecord (>= 5.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -571,6 +573,7 @@ DEPENDENCIES
   webdrivers (~> 4.4, >= 4.4.1)
   webmock
   webpacker (>= 5.2.1)
+  with_model
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -6,7 +6,7 @@ class NominateInductionTutorForm
   attr_accessor :full_name, :email, :token, :school_id, :user_id
 
   validates :full_name, presence: true
-  validates :email, presence: true, format: { with: Devise.email_regexp }
+  validates :email, presence: true, notify_email: true
   validate :email_is_not_in_use
 
   def school

--- a/app/forms/supplier_user_form.rb
+++ b/app/forms/supplier_user_form.rb
@@ -9,7 +9,7 @@ class SupplierUserForm
   validates :full_name, presence: { message: "Enter a name" }, on: :details
   validates :email,
             presence: { message: "Enter email" },
-            format: { with: Devise.email_regexp, message: "Enter an email address in the correct format, like name@example.com" },
+            notify_email: true,
             on: :details
   validate :email_not_taken, on: :details
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   has_one :mentor_profile, dependent: :destroy
 
   validates :full_name, presence: true
-  validates :email, presence: true, uniqueness: true, format: { with: Devise.email_regexp }
+  validates :email, presence: true, uniqueness: true, notify_email: true
 
   def admin?
     admin_profile.present?

--- a/app/validators/notify_email_validator.rb
+++ b/app/validators/notify_email_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Notify email validation https://github.com/alphagov/notifications-utils/blob/acbe764fb7f12c7a8b0696156283fbcb5073fcd7/notifications_utils/recipients.py#L494
+class NotifyEmailValidator < ActiveModel::EachValidator
+  HOSTNAME_PART_REGEX = /\A(xn|[a-z0-9]+)(-?-[a-z0-9]+)*\z/i.freeze
+  TLD_REGEX = /\A([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)\z/i.freeze
+  EMAIL_REGEX = /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\\-]+@([^.@][^@\s]+)\z/.freeze
+
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, I18n.t("errors.email.invalid")) unless NotifyEmailValidator.valid?(value)
+  end
+
+  def self.valid?(email)
+    return false if email.blank?
+
+    email_match = email.match(EMAIL_REGEX)
+    return false unless email_match
+    return false if email.length > 320
+    return false if email.include?("..")
+
+    hostname = email_match[1]
+
+    parts = hostname.split(".")
+    return false if hostname.length > 253 || parts.length < 2
+    return false if parts.any? { |part| part.blank? || part.length > 63 || part.match(HOSTNAME_PART_REGEX).nil? }
+    return false unless parts.last.match(TLD_REGEX)
+
+    true
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe User, type: :model do
     }
 
     it "rejects an invalid email" do
-      user = FactoryBot.build(:user, email: "invalid")
+      user = FactoryBot.build(:user, email: "invalid@email,com")
 
       expect(user.valid?).to be_falsey
       expect(user.errors.messages[:email]).to match_array ["Enter an email address in the correct format, like name@example.com"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 #
+require "with_model"
 
 RSpec.configure do |config|
   # Configure rutabaga/turnip to find features outside of /features/ folders in
@@ -102,4 +103,5 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+  config.extend WithModel
 end

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotifyEmailValidator do
+  with_model :user do
+    table do |t|
+      t.string :email
+    end
+
+    model do
+      validates :email, notify_email: true
+    end
+  end
+
+  # rubocop:disable Style/AsciiComments
+  # Test cases from https://github.com/alphagov/notifications-utils/blob/2432e1881cf7a5005a8d69c2ddc1597add96acc3/tests/test_recipient_validation.py
+  # The following valid emails addresses are not accepted: japanese-info@例え.テスト, info@german-financial-services.vermögensberatung
+  # This is because we do not transform to punycode
+  # rubocop:enable Style/AsciiComments
+  it "correctly identifies valid email addresses" do
+    valid_email_addresses = %w[email@domain.com email@domain.COM firstname.lastname@domain.com firstname.o\'lastname@domain.com email@subdomain.domain.com firstname+lastname@domain.com 1234567890@domain.com email@domain-one.com _______@domain.com email@domain.name email@domain.superlongtld email@domain.co.jp firstname-lastname@domain.com info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase email@double--hyphen.com]
+    valid_email_addresses.each do |email|
+      expect(User.new(email: email)).to be_valid
+    end
+  end
+
+  it "correctly identifies invalid email addresses" do
+    invalid_email_addresses = [
+      "email@123.123.123.123",
+      "email@[123.123.123.123]",
+      "plainaddress",
+      "@no-local-part.com",
+      "Outlook Contact <outlook-contact@domain.com>",
+      "no-at.domain.com",
+      "no-tld@domain",
+      ";beginning-semicolon@domain.co.uk",
+      "middle-semicolon@domain.co;uk",
+      "trailing-semicolon@domain.com;",
+      '"email+leading-quotes@domain.com',
+      'email+middle"-quotes@domain.com',
+      '"quoted-local-part"@domain.com',
+      '"quoted@domain.com"',
+      "lots-of-dots@domain..gov..uk",
+      "two-dots..in-local@domain.com",
+      "multiple@domains@domain.com",
+      "spaces in local@domain.com",
+      "spaces-in-domain@dom ain.com",
+      "underscores-in-domain@dom_ain.com",
+      "pipe-in-domain@example.com|gov.uk",
+      "comma,in-local@gov.uk",
+      "comma-in-domain@domain,gov.uk",
+      "pound-sign-in-local£@domain.com",
+      "local-with-’-apostrophe@domain.com",
+      "local-with-”-quotes@domain.com",
+      "domain-starts-with-a-dot@.domain.com",
+      "brackets(in)local@domain.com",
+      "email-too-long-#{'a' * 320}@example.com",
+      "incorrect-punycode@xn---something.com",
+    ]
+    invalid_email_addresses.each do |email|
+      expect(User.new(email: email)).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
### Context
CPDRP-418
Users have been entering invalid emails and are presented with an error
page instead of a validation message. This is because our validation
rules do not match Notify's. This is an attempt to bring them in line.

I asked the Notify team if they'd be interested in adding the logic to the client SDKs, but they said no: https://ukgovernmentdigital.slack.com/archives/C0E1ADVPC/p1623151272077400

### Changes proposed in this pull request
- Add NotifyEmailValidator
- Use the validator where we accept emails

### Guidance to review

### Testing
Copied the tests from Notify, with some caveats

### How can I view this in a review app?
Try nominating someone with email "a@b,com"