### PR TITLE
Cpdrp 421 use opt out decision in chaser emails

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -57,6 +57,10 @@ class School < ApplicationRecord
     left_outer_joins(:induction_coordinators).where(induction_coordinators: { id: nil })
   }
 
+  scope :not_opted_out, lambda { |cohort = Cohort.current|
+    left_outer_joins(:school_cohorts).where(school_cohorts: { cohort_id: [cohort.id, nil], opt_out_of_updates: [false, nil] })
+  }
+
   def lead_provider(year)
     partnerships.unchallenged.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -428,4 +428,16 @@ RSpec.describe School, type: :model do
       expect(School.without_induction_coordinator).not_to include school_with_coordinator
     end
   end
+
+  describe "scope :not_opted_out" do
+    let!(:cohort) { create(:cohort, :current) }
+    let!(:opted_out_school) { create(:school_cohort, opt_out_of_updates: true, induction_programme_choice: "design_our_own", cohort: cohort).school }
+    let!(:school_without_cohort) { create(:school) }
+    let!(:cip_school) { create(:school_cohort, induction_programme_choice: "core_induction_programme", cohort: cohort).school }
+
+    it "returns only schools who have not opted out" do
+      expect(School.not_opted_out).to include(school_without_cohort, cip_school)
+      expect(School.not_opted_out).not_to include opted_out_school
+    end
+  end
 end


### PR DESCRIPTION
### Context
Now that we're giving schools the ability to opt out, we need to honour that in chaser emails.

### Changes proposed in this pull request
- Scope for schools that have not opted out
- Send emails using delayed job
- Only send emails to schools who have not opted out

### Guidance to review

### Testing
Updated unit tests

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
