### PR TITLE
ApiTokens and endpoints can have private access

### DIFF
--- a/app/controllers/api/v1/dqt_records_controller.rb
+++ b/app/controllers/api/v1/dqt_records_controller.rb
@@ -14,6 +14,12 @@ module Api
           head :not_found
         end
       end
+
+    private
+
+      def access_scope
+        ApiToken.where(private_api_access: true)
+      end
     end
   end
 end

--- a/app/controllers/concerns/api_token_authenticatable.rb
+++ b/app/controllers/concerns/api_token_authenticatable.rb
@@ -10,7 +10,7 @@ module ApiTokenAuthenticatable
 
   def authenticate
     authenticate_or_request_with_http_token do |unhashed_token|
-      @current_api_token = ApiToken.find_by_unhashed_token(unhashed_token)
+      @current_api_token = ApiToken.merge(access_scope).find_by_unhashed_token(unhashed_token)
       if @current_api_token
         @current_api_token.update!(
           last_used_at: Time.zone.now,
@@ -21,5 +21,11 @@ module ApiTokenAuthenticatable
 
   def current_user
     @current_api_token.owner
+  end
+
+private
+
+  def access_scope
+    ApiToken.all
   end
 end

--- a/app/models/npq_registration_api_token.rb
+++ b/app/models/npq_registration_api_token.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class NpqRegistrationApiToken < ApiToken
+  attribute :private_api_access, default: true
+
   def owner
     "npq_registration_application"
   end

--- a/db/migrate/20210609094438_add_access_booleans_to_token.rb
+++ b/db/migrate/20210609094438_add_access_booleans_to_token.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAccessBooleansToToken < ActiveRecord::Migration[6.1]
+  def change
+    change_table :api_tokens, bulk: true do |t|
+      t.boolean :private_api_access, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_08_084207) do
+ActiveRecord::Schema.define(version: 2021_06_09_094438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2021_06_08_084207) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "type", default: "LeadProviderApiToken"
+    t.boolean "private_api_access", default: false
     t.index ["hashed_token"], name: "index_api_tokens_on_hashed_token", unique: true
     t.index ["lead_provider_id"], name: "index_api_tokens_on_lead_provider_id"
   end

--- a/spec/requests/api/v1/dqt_records_spec.rb
+++ b/spec/requests/api/v1/dqt_records_spec.rb
@@ -64,5 +64,15 @@ RSpec.describe "DQT records api endpoint", type: :request do
         expect(response.status).to eq 401
       end
     end
+
+    context "using token from different scope" do
+      let(:other_token) { EngageAndLearnApiToken.create_with_random_token! }
+
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer #{other_token}"
+        get "/api/v1/dqt-records/#{trn}"
+        expect(response.status).to eq 401
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- We want certain api endpoint to be private. e.g. for internal use only and not for public consumption
- For example the `DqtRecordsController` api endpoint should only be accessible for internal use

### Changes proposed in this pull request

- On `ApiToken` introduce `private_api_access` to determine if a token can access private api endpoints
- On api controllers one can now define `access_scope` to limit api token to a certain subset
- By default all existing endpoints will continue to be accessible to existing tokens
- The `DqtRecordsController` endpoint is now only accessible to tokens marked with `private_api_access` set to `true`
- By default new `NpqRegistrationApiToken` will have access to private api endpoints
- When adding new endpoints if developers do not want to use this feature there should be no extra burden to them

#### Future suggestions

- No changes has been made to the structure of api endpoints though it may be a good idea to separate private endpoints into a different namespace
- Documentation for public/private api endpoints may also want to be separated

### Guidance to review

- Existing api endpoints should continue to work with no breaking changes except `DqtRecordsController`
- Existing api tokens should continue to work with no break changes except `NpqRegistrationApiToken`
- DQT api endpoint should now have limited access
- The mechanism should be fairly flexible should we want add more constraints/limitation to tokens

### Testing

- Test via review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- Note down the unhashed token, it will be needed later
- Call endpoint with `curl -I -H "Authorization: Bearer UNHASHED_TOKEN" https://ecf-review-pr-486.london.cloudapps.digital/api/v1/dqt-records/100`
- Should return body-less 404 response
- Create another api token with `EngageAndLearnApiToken.create_with_random_token!`
- Note down the unhashed token, it will be needed later
- Call endpoint with `curl -I -H "Authorization: Bearer UNHASHED_TOKEN" https://ecf-review-pr-486.london.cloudapps.digital/api/v1/dqt-records/100`
- Should get 401