### PR TITLE
CPDTP-196 JSON Schema URI to Local Filename Converter and reader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,9 @@ gem "aasm"
 # Pagination for API
 gem "pagy", "~> 3.13"
 
+# Json Schema for api validation
+gem "json-schema"
+
 gem "jsonapi-serializer"
 
 # OpenApi Swagger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,6 +534,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (~> 2.3.0b1)
   health_check!
   httpclient (~> 2.8, >= 2.8.3)
+  json-schema
   jsonapi-rspec
   jsonapi-serializer
   kaminari (>= 1.2.0)

--- a/etc/schema/0.1/ecf/participant_declarations/create/request_schema.json
+++ b/etc/schema/0.1/ecf/participant_declarations/create/request_schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://digital.education.gov.uk/schema/ecf/participant_declarations/create/request_schema.json/#",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "https://digital.education.gov.uk/schema/",
+  "$ref": "https://digital.education.gov.uk/schema/participant_declarations",
   "type": "object",
   "properties": {
     "id": {

--- a/etc/schema/0.2/ecf/participant_declarations/create/request_schema.json
+++ b/etc/schema/0.2/ecf/participant_declarations/create/request_schema.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://digital.education.gov.uk/schema/ecf/participant_declarations/create/request_schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "https://digital.education.gov.uk/schema/participant_declarations",
   "type": "object",
   "properties": {
     "declaration_type": {

--- a/lib/json_schema/version_event_file_name.rb
+++ b/lib/json_schema/version_event_file_name.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "initialize_with_config"
+
+module JsonSchema
+  class VersionEventFileName
+    include InitializeWithConfig
+    required_config :version, :event
+
+    def call
+      Rails.root.join(schema_root, version.to_s, schema_path, event.to_s, schema_file)
+    end
+
+  private
+
+    def default_config
+      {
+        schema_root: "etc/schema",
+        schema_path: "ecf/participant_declarations",
+        schema_file: "request_schema.json",
+      }
+    end
+  end
+end

--- a/lib/json_schema/versioned_schema_reader.rb
+++ b/lib/json_schema/versioned_schema_reader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module JsonSchema
+  class VersionedSchemaReader < ::JSON::Schema::Reader
+    def read(schema_uri)
+      super(::JSON::Util::URI.normalized_uri(uri_to_file(schema_uri.path)))
+    end
+
+  private
+
+    attr_reader :version
+
+    def initialize(version: 1.0, options: {})
+      @version = version
+      super(options)
+    end
+
+    def uri_to_file(uri_from_schema)
+      uri_from_schema.gsub("/schema/", Rails.root.join("etc/schema/#{version}/").to_s)
+    end
+  end
+end

--- a/spec/lib/initialize_with_config_spec.rb
+++ b/spec/lib/initialize_with_config_spec.rb
@@ -25,6 +25,10 @@ class InheritedStructure < CorrectStructure
   end
 end
 
+class MissingParameter < CorrectStructure
+  required_config :version, :event
+end
+
 describe "InitializeWithConfig" do
   let(:input) do
     {
@@ -46,6 +50,10 @@ describe "InitializeWithConfig" do
 
   it "creates an exception if the #call method is not defined for the class" do
     expect { MissingCallMethod.call(input) }.to raise_error(RuntimeError, "override abstract call method")
+  end
+
+  it "creates an exception if a required configuration parameter is not specified" do
+    expect { MissingParameter.call(input) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required dependency injected items [:version, :event] in class MissingParameter")
   end
 
   it "creates an internal hash called 'config'" do

--- a/spec/lib/json_schema/version_event_file_name_spec.rb
+++ b/spec/lib/json_schema/version_event_file_name_spec.rb
@@ -13,7 +13,7 @@ describe JsonSchema::VersionEventFileName do
       expect { described_class.call }.to raise_error(ArgumentError)
       expect { described_class.call({}) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required dependency injected items [:version, :event] in class JsonSchema::VersionEventFileName")
       expect { described_class.call(version: current) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required dependency injected items [:event] in class JsonSchema::VersionEventFileName")
-      expect { described_class.call(event: event) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required  dependency injected items [:version] in class JsonSchema::VersionEventFileName")
+      expect { described_class.call(event: event) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required dependency injected items [:version] in class JsonSchema::VersionEventFileName")
     end
 
     it "maps to the participant_declarations schema for the required version" do

--- a/spec/lib/json_schema/version_event_file_name_spec.rb
+++ b/spec/lib/json_schema/version_event_file_name_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "json_schema/version_event_file_name"
+
+describe JsonSchema::VersionEventFileName do
+  context "passed in a version and json event type" do
+    let(:previous_version) { 0.1 }
+    let(:current) { 0.2 }
+    let(:event) { :create }
+
+    it "requires both version and event to be specified in the config hash" do
+      expect { described_class.call }.to raise_error(ArgumentError)
+      expect { described_class.call({}) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required dependency injected items [:version, :event] in class JsonSchema::VersionEventFileName")
+      expect { described_class.call(version: current) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required dependency injected items [:event] in class JsonSchema::VersionEventFileName")
+      expect { described_class.call(event: event) }.to raise_error(::InitializeWithConfig::MissingRequiredArguments, "missing required  dependency injected items [:version] in class JsonSchema::VersionEventFileName")
+    end
+
+    it "maps to the participant_declarations schema for the required version" do
+      expect(described_class.call(version: current, event: event)).to eq Rails.root.join("etc/schema/0.2/ecf/participant_declarations/create/request_schema.json")
+      expect(described_class.call(version: previous_version, event: event)).to eq Rails.root.join("etc/schema/0.1/ecf/participant_declarations/create/request_schema.json")
+    end
+
+    it "allows an override to schema_path path fragment" do
+      expect(described_class.call(schema_path: "ecf/contracts", version: previous_version, event: event)).to eq Rails.root.join("etc/schema/0.1/ecf/contracts/create/request_schema.json")
+    end
+
+    it "allows an override to schema_root path fragment" do
+      expect(described_class.call(schema_root: "config/schemas", version: previous_version, event: event)).to eq Rails.root.join("config/schemas/0.1/ecf/participant_declarations/create/request_schema.json")
+    end
+
+    it "allows an override to the schema_file name" do
+      expect(described_class.call(schema_file: "response_schema.json", version: previous_version, event: event)).to eq Rails.root.join("etc/schema/0.1/ecf/participant_declarations/create/response_schema.json")
+    end
+  end
+end

--- a/spec/lib/json_schema/versioned_schema_reader_spec.rb
+++ b/spec/lib/json_schema/versioned_schema_reader_spec.rb
@@ -8,7 +8,7 @@ describe ::JsonSchema::VersionedSchemaReader do
   let(:parsed_schema_file) { ::JSON::Util::URI.normalized_uri(original_schema_file) }
   let(:current_schema_file) { Rails.root.join("etc/schema/1.0/ecf/contracts/create/request_schema.json").to_s }
   let(:versioned_schema_file) { Rails.root.join("etc/schema/0.2/ecf/contracts/create/request_schema.json").to_s }
-  let(:minimal_url_file) { "https://digital.education.gov.uk/schema/../../../swagger/v1/api_spec.json" }
+  let(:minimal_url_file) { "https://digital.education.gov.uk/schema/ecf/contracts/create/request_schema.json" }
 
   it "maps uri to default path when passed an empty config" do
     mapper = described_class.new
@@ -20,9 +20,9 @@ describe ::JsonSchema::VersionedSchemaReader do
     expect(mapper.send(:uri_to_file, parsed_schema_file.path)).to eq(versioned_schema_file)
   end
 
-  it "reads the disk based file when passed an mappable url" do
+  it "reads the disk based file when passed a mappable url" do
     mapper = described_class.new
-    swagger_schema = mapper.read(URI(minimal_url_file))
-    expect(swagger_schema).to be_a(JSON::Schema)
+    test_schema = mapper.read(URI(minimal_url_file))
+    expect(test_schema).to be_a(JSON::Schema)
   end
 end

--- a/spec/lib/json_schema/versioned_schema_reader_spec.rb
+++ b/spec/lib/json_schema/versioned_schema_reader_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "json_schema/versioned_schema_reader"
+
+describe ::JsonSchema::VersionedSchemaReader do
+  let(:original_schema_file) { "https://digital.education.gov.uk/schema/ecf/contracts/create/request_schema.json" }
+  let(:parsed_schema_file) { ::JSON::Util::URI.normalized_uri(original_schema_file) }
+  let(:current_schema_file) { Rails.root.join("etc/schema/1.0/ecf/contracts/create/request_schema.json").to_s }
+  let(:versioned_schema_file) { Rails.root.join("etc/schema/0.2/ecf/contracts/create/request_schema.json").to_s }
+  let(:minimal_url_file) { "https://digital.education.gov.uk/schema/../../../swagger/v1/api_spec.json" }
+
+  it "maps uri to default path when passed an empty config" do
+    mapper = described_class.new
+    expect(mapper.send(:uri_to_file, parsed_schema_file.path)).to eq(current_schema_file)
+  end
+
+  it "maps uri to version path" do
+    mapper = described_class.new(version: "0.2")
+    expect(mapper.send(:uri_to_file, parsed_schema_file.path)).to eq(versioned_schema_file)
+  end
+
+  it "reads the disk based file when passed an mappable url" do
+    mapper = described_class.new
+    swagger_schema = mapper.read(URI(minimal_url_file))
+    expect(swagger_schema).to be_a(JSON::Schema)
+  end
+end


### PR DESCRIPTION
### Context

incoming json can be validated against a schema document to ensure that the content and format are as expected before passing bad data to the underlying code.
This puts in place the ability to use the JSON::Schema gem to validate against a set of connected json schema documents and to have those local file based and translate http uris to file uris.
In addition, it has been proposed that we allow current API version + 2 ancestors, and this will help ensure that versioning is managed correctly by comparing incoming json documents against the correctly versioned schema.

### Changes proposed in this pull request

- Slight enhancement to InitializeWithConfig to allow it to raise more verbose error messages when required configuration items (Dependency Injection) are required and support for classes which include them to optionally declare them as such.
- Versioned schema reader. JSON::Schema will use this as the reader for when it tries to pull in files.
- Versioned event file name. Set up the baseline filenames for the schema files with everything overridable, but mainly (version=>schema version and event=>create) for the incoming json document.
- Slight change to the request_schema.json files to add in $refs where they were missing or point to too high a level.

### Guidance to review

Run and read the tests. They describe how things work and can be changed.

### Testing

Tests are supplied for the version_event_file_name and the versioned_schema_reader which show how names are constructed and converted from the uri.
InitializeWithConfig tests have been enhanced to show the new errors coming back when required_config is used.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

You can't