### PR TITLE
Update master with deployed tag

### DIFF
--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.version }}
 
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v1.2.1


### PR DESCRIPTION
We weren't checking out the correct code when deploying to production. This had two implications:

1. We weren't updating `master` with the deployed code
2. We weren't applying Terraform scripts from the target deploy tag but instead from `develop`.

This PR checks out the correct target version before deploying.

Hat tip to @ethanmills for spotting this!