### PR TITLE
Copy changes: Add lead provider name to partnership notifications

### DIFF
--- a/app/components/school_recruited_transition_component.html.erb
+++ b/app/components/school_recruited_transition_component.html.erb
@@ -1,5 +1,9 @@
 <%= govuk_notification_banner(title: "Important") do |banner| %>
-  <% banner.add_heading(text: "#{delivery_partner.name} has confirmed they will be delivering an induction programme to your early career teachers, starting in #{cohort.display_name}.") %>
-  <p>If this is a mistake, <%= govuk_link_to "report it now", challenge_partnership_path(partnership: partnership.id) %></p>
-  <p>If you do not report this by <%= partnership.challenge_deadline.to_s(:govuk) %>, your programme and next steps will change</p>
+  <% banner.add_heading(text: "#{delivery_partner.name}, with #{lead_provider.name}, has confirmed your school.") %>
+  <p>This means they will be delivering an induction programme to your early career teachers, starting in
+    <%= cohort.start_year %>.</p>
+  <p>If this is a
+    mistake, <%= govuk_link_to "report it now", challenge_partnership_path(partnership: partnership.id) %>.</p>
+  <p>If you do not report this by <%= partnership.challenge_deadline.to_s(:govuk) %>, your programme and next steps will
+    change.</p>
 <% end %>

--- a/app/components/school_recruited_transition_component.rb
+++ b/app/components/school_recruited_transition_component.rb
@@ -23,6 +23,7 @@ private
     )
   end
 
+  delegate :lead_provider, to: :partnership
   delegate :delivery_partner, to: :partnership
   delegate :cohort, to: :school_cohort
 end

--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -46,10 +46,10 @@ private
 
     redirect_to link_expired_challenge_partnership_path and return unless @partnership.in_challenge_window?
 
-    provider_name = @partnership.delivery_partner&.name || @partnership.lead_provider.name
     @challenge_partnership_form = ChallengePartnershipForm.new(
       school_name: @school_name,
-      provider_name: provider_name,
+      lead_provider_name: @partnership.lead_provider.name,
+      delivery_partner_name: @partnership.delivery_partner.name,
       token: @token,
       partnership: @partnership,
     )

--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -3,7 +3,7 @@
 class ChallengePartnershipForm
   include ActiveModel::Model
 
-  attr_accessor :challenge_reason, :token, :school_name, :provider_name, :partnership
+  attr_accessor :challenge_reason, :token, :school_name, :lead_provider_name, :delivery_partner_name, :partnership
   validates :challenge_reason, presence: { message: "Select a reason why you think this confirmation is incorrect" }
 
   def challenge_reason_options

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -38,7 +38,8 @@ class SchoolMailer < ApplicationMailer
 
   def school_partnership_notification_email(
     recipient:,
-    provider_name:,
+    lead_provider_name:,
+    delivery_partner_name:,
     cohort:,
     school_name:,
     nominate_url:,
@@ -51,7 +52,9 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        provider_name: provider_name,
+        provider_name: lead_provider_name, # TODO: remove once template updated
+        lead_provider_name: lead_provider_name,
+        delivery_partner_name: delivery_partner_name,
         cohort: cohort,
         school_name: school_name,
         nominate_url: nominate_url,
@@ -64,7 +67,8 @@ class SchoolMailer < ApplicationMailer
 
   def coordinator_partnership_notification_email(
     recipient:,
-    provider_name:,
+    lead_provider_name:,
+    delivery_partner_name:,
     cohort:,
     school_name:,
     start_url:,
@@ -77,7 +81,9 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        provider_name: provider_name,
+        provider_name: lead_provider_name, # TODO: remove once template updated
+        lead_provider_name: lead_provider_name,
+        delivery_partner_name: delivery_partner_name,
         cohort: cohort,
         school_name: school_name,
         start_url: start_url,

--- a/app/services/partnership_notification_service.rb
+++ b/app/services/partnership_notification_service.rb
@@ -69,7 +69,8 @@ private
 
     notify_id = SchoolMailer.school_partnership_notification_email(
       recipient: notification_email.sent_to,
-      provider_name: provider_name(notification_email),
+      lead_provider_name: notification_email.lead_provider.name,
+      delivery_partner_name: notification_email.delivery_partner.name,
       cohort: notification_email.partnership.cohort.display_name,
       school_name: notification_email.school.name,
       nominate_url: nomination_email.nomination_url,
@@ -83,7 +84,8 @@ private
   def send_notification_email_to_coordinator(notification_email)
     notify_id = SchoolMailer.coordinator_partnership_notification_email(
       recipient: notification_email.sent_to,
-      provider_name: provider_name(notification_email),
+      lead_provider_name: notification_email.lead_provider.name,
+      delivery_partner_name: notification_email.delivery_partner.name,
       cohort: notification_email.partnership.cohort.display_name,
       school_name: notification_email.school.name,
       start_url: Rails.application.routes.url_helpers.root_url(
@@ -95,10 +97,6 @@ private
     ).deliver_now.delivery_method.response.id
 
     notification_email.update!(notify_id: notify_id)
-  end
-
-  def provider_name(notification_email)
-    notification_email.delivery_partner&.name || notification_email.lead_provider.name
   end
 
   def challenge_url(token)

--- a/app/views/challenge_partnerships/show.html.erb
+++ b/app/views/challenge_partnerships/show.html.erb
@@ -4,7 +4,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Report that your school has been signed up incorrectly</h1>
     <p class="govuk-body"><%= @challenge_partnership_form.school_name %>  has received a confirmation
-      from <%= @challenge_partnership_form.provider_name %> but you believe this is incorrect.</p>
+      from <%= @challenge_partnership_form.delivery_partner_name %>,
+      with <%= @challenge_partnership_form.lead_provider_name %>, but you believe this is incorrect.</p>
 
     <%= form_for @challenge_partnership_form, url: challenge_partnership_path do |f| %>
       <%= f.hidden_field :token %>

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -87,7 +87,7 @@ School.find_or_create_by!(urn: "000005") do |school|
   end
   SchoolCohort.find_or_create_by!(cohort: Cohort.current, school: school, induction_programme_choice: "full_induction_programme")
   delivery_partner = DeliveryPartner.find_or_create_by!(name: "Test Delivery Partner")
-  partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner: delivery_partner, school: school, lead_provider: LeadProvider.first)
+  partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner: delivery_partner, school: school, lead_provider: LeadProvider.first, challenge_deadline: 2.weeks.from_now)
   PartnershipNotificationEmail.find_or_create_by!(
     partnership: partnership,
     sent_to: "cpd-test+tutor-2#{DOMAIN}",
@@ -117,7 +117,7 @@ end
 
     SchoolCohort.find_or_create_by!(cohort: Cohort.current, school: school, induction_programme_choice: "full_induction_programme")
     delivery_partner = DeliveryPartner.find_or_create_by!(name: "Mega Delivery Partner")
-    partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner: delivery_partner, school: school, lead_provider: LeadProvider.first)
+    partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner: delivery_partner, school: school, lead_provider: LeadProvider.first, challenge_deadline: 2.weeks.from_now)
     PartnershipNotificationEmail.find_or_create_by!(
       partnership: partnership,
       sent_to: "cpd-test+tutor-3#{DOMAIN}",

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:partnership_notification_email) do
       SchoolMailer.coordinator_partnership_notification_email(
         recipient: recipient,
-        provider_name: provider_name,
+        lead_provider_name: provider_name,
+        delivery_partner_name: provider_name,
         cohort: cohort,
         school_name: school_name,
         start_url: start_url,
@@ -80,7 +81,8 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:partnership_notification_email) do
       SchoolMailer.school_partnership_notification_email(
         recipient: recipient,
-        provider_name: provider_name,
+        lead_provider_name: provider_name,
+        delivery_partner_name: provider_name,
         cohort: cohort,
         school_name: school_name,
         nominate_url: nominate_url,

--- a/spec/services/partnership_notification_service_spec.rb
+++ b/spec/services/partnership_notification_service_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe PartnershipNotificationService do
       it "emails the school primary contact" do
         expect(SchoolMailer).to receive(:school_partnership_notification_email).with(
           hash_including(
-            provider_name: @delivery_partner.name,
+            lead_provider_name: @lead_provider.name,
+            delivery_partner_name: @delivery_partner.name,
             cohort: String,
             nominate_url: String,
             challenge_url: String,
@@ -72,7 +73,8 @@ RSpec.describe PartnershipNotificationService do
       it "emails the induction coordinator" do
         expect(SchoolMailer).to receive(:coordinator_partnership_notification_email).with(
           hash_including(
-            provider_name: @delivery_partner.name,
+            lead_provider_name: @lead_provider.name,
+            delivery_partner_name: @delivery_partner.name,
             cohort: String,
             start_url: String,
             challenge_url: String,
@@ -105,7 +107,8 @@ RSpec.describe PartnershipNotificationService do
       it "emails the school primary contact" do
         expect(SchoolMailer).to receive(:school_partnership_notification_email).with(
           hash_including(
-            provider_name: @delivery_partner.name,
+            lead_provider_name: @lead_provider.name,
+            delivery_partner_name: @delivery_partner.name,
             cohort: String,
             nominate_url: String,
             challenge_url: String,
@@ -139,7 +142,8 @@ RSpec.describe PartnershipNotificationService do
       it "emails the induction coordinator" do
         expect(SchoolMailer).to receive(:coordinator_partnership_notification_email).with(
           hash_including(
-            provider_name: @delivery_partner.name,
+            lead_provider_name: @lead_provider.name,
+            delivery_partner_name: @delivery_partner.name,
             cohort: String,
             start_url: String,
             challenge_url: String,


### PR DESCRIPTION
### Context
Request from Shani to show lead provider name when we tell schools about partnerships

### Changes proposed in this pull request
Add LP name in three places:
- Email notfication
- Challenge form
- Notification banner

### Guidance to review

### Testing
Updated tests 

### Review Checks


### How can I view this in a review app?
Can't check email yet, since that requires template update
Form: <review app url>/report-incorrect-partnership?token=abc123
Banner:
- Sign in as lead-provider@example.com and report partnership with 000003
- Sign in as cpd-test+tutor-1@digital.....