### PR TITLE
CPDTP-166 Add bands to service fees and tweak payment breakdown rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,10 @@ gem "open_api-rswag-ui", ">= 0.1.0"
 
 gem "ransack"
 
+# Payment breackdown
+
+gem "terminal-table"
+
 platform :mswin, :mingw, :x64_mingw do
   gem "wdm", ">= 0.1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,6 +460,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (3.0.1)
+      unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     thread_safe (0.3.6)
     turnip (4.3.0)
@@ -571,6 +573,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  terminal-table
   tzinfo-data
   view_component
   wdm (>= 0.1.0)

--- a/app/models/call_off_contract.rb
+++ b/app/models/call_off_contract.rb
@@ -8,8 +8,6 @@ class CallOffContract < ApplicationRecord
     bands.first
   end
 
-private
-
   def bands
     participant_bands.min_nulls_first
   end

--- a/app/models/call_off_contract.rb
+++ b/app/models/call_off_contract.rb
@@ -11,4 +11,6 @@ class CallOffContract < ApplicationRecord
   def bands
     participant_bands.min_nulls_first
   end
+
+  delegate :set_up_recruitment_basis, to: :band_a
 end

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -14,6 +14,10 @@ class ParticipantBand < ApplicationRecord
     end
   end
 
+  def deduction_for_setup?
+    lower_boundary.zero?
+  end
+
 private
 
   def smaller_than_lower_boundary(total_number_of_participants)

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -18,6 +18,10 @@ class ParticipantBand < ApplicationRecord
     lower_boundary.zero?
   end
 
+  def set_up_recruitment_basis
+    deduction_for_setup? ? upper_boundary : 0
+  end
+
 private
 
   def smaller_than_lower_boundary(total_number_of_participants)

--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -41,7 +41,7 @@ def create_school_and_associations(lead_provider, cohort, index)
     s.postcode = Faker::Address.postcode
   end
 
-  Partnership.create!(
+  Partnership.find_or_create_by!(
     school: school,
     lead_provider: lead_provider,
     cohort: cohort,

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -30,15 +30,15 @@ module PaymentCalculator
       private
 
         def deduction_for_band(band)
-          band.deduction_for_setup? ? set_up_cost_per_participant : 0
+          band.deduction_for_setup? ? set_up_cost_per_participant(band) : 0
         end
 
         def service_fee_payment_contribution_percentage
           0.4
         end
 
-        def set_up_cost_per_participant
-          set_up_fee / recruitment_target
+        def set_up_cost_per_participant(band)
+          set_up_fee / band.number_of_participants_in_this_band(recruitment_target)
         end
 
         def number_of_service_fee_payments

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -13,8 +13,7 @@ module PaymentCalculator
         end
 
         delegate :recruitment_target,
-                 :set_up_fee,
-                 :band_a, to: :contract
+                 :set_up_fee, to: :contract
 
         def service_fee_total(band)
           band.number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant(band)

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -13,7 +13,7 @@ module PaymentCalculator
         end
 
         delegate :recruitment_target,
-                 :set_up_fee, :band_a, to: :contract
+                 :set_up_fee, :set_up_recruitment_basis, to: :contract
 
         def service_fee_total(band)
           band.number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant(band)
@@ -38,7 +38,7 @@ module PaymentCalculator
         end
 
         def set_up_cost_per_participant
-          set_up_fee / band_a.send(:upper_boundary)
+          set_up_fee / set_up_recruitment_basis
         end
 
         def number_of_service_fee_payments

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -13,7 +13,7 @@ module PaymentCalculator
         end
 
         delegate :recruitment_target,
-                 :set_up_fee, to: :contract
+                 :set_up_fee, :band_a, to: :contract
 
         def service_fee_total(band)
           band.number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant(band)
@@ -30,15 +30,15 @@ module PaymentCalculator
       private
 
         def deduction_for_band(band)
-          band.deduction_for_setup? ? set_up_cost_per_participant(band) : 0
+          band.deduction_for_setup? ? set_up_cost_per_participant : 0
         end
 
         def service_fee_payment_contribution_percentage
           0.4
         end
 
-        def set_up_cost_per_participant(band)
-          set_up_fee / band.number_of_participants_in_this_band(recruitment_target)
+        def set_up_cost_per_participant
+          set_up_fee / band_a.send(:upper_boundary)
         end
 
         def number_of_service_fee_payments

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -16,19 +16,23 @@ module PaymentCalculator
                  :set_up_fee,
                  :band_a, to: :contract
 
-        def service_fee_total
-          recruitment_target * service_fee_per_participant
+        def service_fee_total(band)
+          band.number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant(band)
         end
 
-        def service_fee_monthly
-          (service_fee_total / number_of_service_fee_payments)
+        def service_fee_monthly(band)
+          (service_fee_total(band) / number_of_service_fee_payments)
         end
 
-        def service_fee_per_participant
-          band_a.per_participant * service_fee_payment_contribution_percentage - set_up_cost_per_participant
+        def service_fee_per_participant(band)
+          band.per_participant * service_fee_payment_contribution_percentage - deduction_for_band(band)
         end
 
       private
+
+        def deduction_for_band(band)
+          band.deduction_for_setup? ? set_up_cost_per_participant : 0
+        end
 
         def service_fee_payment_contribution_percentage
           0.4

--- a/lib/payment_calculator/ecf/service_fees.rb
+++ b/lib/payment_calculator/ecf/service_fees.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
-require "initialize_with_config"
 require "payment_calculator/ecf/service_fees_for_band"
 
 module PaymentCalculator
   module Ecf
     class ServiceFees
-      include InitializeWithConfig
+      include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
       # required_config :contract # TODO: Uncomment this when the updated InitializeWithConfig is added from the other PR
       delegate :bands, to: :contract
 
       def call
         bands.map do |band|
-          Ecf::ServiceFeesForBand.call(config, band: band)
+          Ecf::ServiceFeesForBand.call(params, band: band)
         end
       end
     end

--- a/lib/payment_calculator/ecf/service_fees.rb
+++ b/lib/payment_calculator/ecf/service_fees.rb
@@ -6,7 +6,6 @@ module PaymentCalculator
   module Ecf
     class ServiceFees
       include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
-      # required_config :contract # TODO: Uncomment this when the updated InitializeWithConfig is added from the other PR
       delegate :bands, to: :contract
 
       def call

--- a/lib/payment_calculator/ecf/service_fees.rb
+++ b/lib/payment_calculator/ecf/service_fees.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-require "payment_calculator/ecf/contract/service_fee_calculations"
+require "initialize_with_config"
+require "payment_calculator/ecf/service_fees_for_band"
 
 module PaymentCalculator
   module Ecf
     class ServiceFees
-      include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
+      include InitializeWithConfig
+      # required_config :contract # TODO: Uncomment this when the updated InitializeWithConfig is added from the other PR
+      delegate :bands, to: :contract
 
       def call
-        {
-          service_fee_per_participant: service_fee_per_participant.round(2),
-          service_fee_total: service_fee_total.round(2),
-          service_fee_monthly: service_fee_monthly.round(2),
-        }
+        bands.map do |band|
+          Ecf::ServiceFeesForBand.call(config, band: band)
+        end
       end
     end
   end

--- a/lib/payment_calculator/ecf/service_fees_for_band.rb
+++ b/lib/payment_calculator/ecf/service_fees_for_band.rb
@@ -9,9 +9,9 @@ module PaymentCalculator
 
       def call(band:)
         {
-          service_fee_total: service_fee_total(band).round(0),
-          service_fee_per_participant: service_fee_per_participant(band).round(0),
           service_fee_monthly: service_fee_monthly(band).round(0),
+          service_fee_per_participant: service_fee_per_participant(band).round(0),
+          service_fee_total: service_fee_total(band).round(0),
         }
       end
     end

--- a/lib/payment_calculator/ecf/service_fees_for_band.rb
+++ b/lib/payment_calculator/ecf/service_fees_for_band.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "payment_calculator/ecf/contract/service_fee_calculations"
+
+module PaymentCalculator
+  module Ecf
+    class ServiceFeesForBand
+      include Ecf::Contract::ServiceFeeCalculations
+
+      def call(band:)
+        {
+          service_fee_total: service_fee_total(band).round(0),
+          service_fee_per_participant: service_fee_per_participant(band).round(0),
+          service_fee_monthly: service_fee_monthly(band).round(0),
+        }
+      end
+    end
+  end
+end

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -33,8 +33,8 @@ namespace :payment_calculation do
     service_fees = breakdown.dig(:service_fees).each_with_object([]) do |hash, bands|
       bands << [
         band_name_from_index(bands.length),
-        "£#{number_to_delimited(hash[:service_fee_monthly].to_i)}",
         "£#{number_to_delimited(hash[:service_fee_per_participant].to_i)}",
+        "£#{number_to_delimited(hash[:service_fee_monthly].to_i)}",
       ]
     end
     output_payment = number_to_delimited(breakdown.dig(:output_payment, :started, :subtotal).to_i)

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -23,9 +23,7 @@ namespace :payment_calculation do
     per_participant_in_bands = lead_provider.call_off_contract.bands.each_with_index.map { |b, i| "£#{b.per_participant.to_i} per participant in #{band_name_from_index(i)}" }.join(", ")
 
     breakdown = PaymentCalculator::Ecf::PaymentCalculation.call(
-      {
-        lead_provider: lead_provider,
-      },
+      lead_provider: lead_provider,
       total_participants: total_participants,
       event_type: :started,
     )

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -20,7 +20,7 @@ namespace :payment_calculation do
     end
 
     total_participants = (ARGV[2] || 2000).to_i
-    per_participant_in_bands = lead_provider.call_off_contract.bands.each_with_index.map{|b, i| "£#{b.per_participant.to_i} per participant in #{band_name_from_index(i)}"}.join(", ")
+    per_participant_in_bands = lead_provider.call_off_contract.bands.each_with_index.map { |b, i| "£#{b.per_participant.to_i} per participant in #{band_name_from_index(i)}" }.join(", ")
 
     breakdown = PaymentCalculator::Ecf::PaymentCalculation.call(
       {
@@ -34,18 +34,17 @@ namespace :payment_calculation do
       bands << [
         band_name_from_index(bands.length),
         "£#{number_to_delimited(hash[:service_fee_monthly].to_i)}",
-        "£#{number_to_delimited(hash[:service_fee_per_participant].to_i)}"
+        "£#{number_to_delimited(hash[:service_fee_per_participant].to_i)}",
       ]
     end
     output_payment = number_to_delimited(breakdown.dig(:output_payment, :started, :subtotal).to_i)
 
     table = Terminal::Table.new(
       title: "Breakdown Payments",
-      headings: ['Banding', 'Service fee (PP)', 'Service fee (monthly)'],
-      rows: service_fees
+      headings: ["Banding", "Service fee (PP)", "Service fee (monthly)"],
+      rows: service_fees,
     )
-    table.style = {alignment: :center}
-
+    table.style = { alignment: :center }
 
     output = <<~RESULT
       Output payment (started) £#{output_payment}
@@ -59,8 +58,8 @@ namespace :payment_calculation do
   ensure
     exit(0)
   end
+end
 
-  def band_name_from_index(i)
-    "Band #{("A".."Z").to_a[i]}"
-  end
+def band_name_from_index(index)
+  "Band #{('A'..'Z').to_a[index]}"
 end

--- a/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
@@ -8,7 +8,9 @@ end
 
 describe ::PaymentCalculator::Ecf::Contract::ServiceFeeCalculations do
   it "performs calculations of the service fees" do
-    band_a = double("Band Double", per_participant: 996.00).mock(number_of_participants_in_this_band: 2000)
+    band_a = double("Band Double", per_participant: 996.00,
+                                   number_of_participants_in_this_band: 2000,
+                                   deduction_for_setup?: true)
     contract = double("Contract Double", recruitment_target: 2000, set_up_fee: 149_651.00, band_a: band_a)
     call_off_contract = DummyClass.new({ contract: contract })
 

--- a/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
@@ -8,12 +8,12 @@ end
 
 describe ::PaymentCalculator::Ecf::Contract::ServiceFeeCalculations do
   it "performs calculations of the service fees" do
-    band_a = double("Band Double", per_participant: 996.00)
+    band_a = double("Band Double", per_participant: 996.00).mock(number_of_participants_in_this_band: 2000)
     contract = double("Contract Double", recruitment_target: 2000, set_up_fee: 149_651.00, band_a: band_a)
     call_off_contract = DummyClass.new({ contract: contract })
 
-    expect(call_off_contract.service_fee_total.round(2)).to eq(647_149.00)
-    expect(call_off_contract.service_fee_monthly.round(0)).to eq(22_315.00)
-    expect(call_off_contract.service_fee_per_participant.round(0)).to eq(324.00)
+    expect(call_off_contract.service_fee_total(band_a).round(0)).to eq(647_149.00)
+    expect(call_off_contract.service_fee_monthly(band_a).round(0)).to eq(22_315.00)
+    expect(call_off_contract.service_fee_per_participant(band_a).round(0)).to eq(324.00)
   end
 end

--- a/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
@@ -8,15 +8,19 @@ end
 
 describe ::PaymentCalculator::Ecf::Contract::ServiceFeeCalculations do
   it "performs calculations of the service fees" do
-    band_a = double("Band Double", per_participant: 996.00,
-                                   number_of_participants_in_this_band: 2000,
-                                   deduction_for_setup?: true,
-                                   upper_boundary: 2000)
-    contract = double("Contract Double", recruitment_target: 2000, set_up_fee: 149_651.00, band_a: band_a)
+    band_a = double("Band Double",
+                    per_participant: 996.00,
+                    number_of_participants_in_this_band: 2000,
+                    deduction_for_setup?: true)
+    contract = double("Contract Double",
+                      recruitment_target: 2000,
+                      set_up_fee: 149_651.00,
+                      band_a: band_a,
+                      set_up_recruitment_basis: 2000)
     call_off_contract = DummyClass.new({ contract: contract })
 
-    expect(call_off_contract.service_fee_total(band_a).round(0)).to eq(647_149.00)
-    expect(call_off_contract.service_fee_monthly(band_a).round(0)).to eq(22_315.00)
-    expect(call_off_contract.service_fee_per_participant(band_a).round(0)).to eq(324.00)
+    expect(call_off_contract.service_fee_total(band_a).round(2)).to eq(647_149.00)
+    expect(call_off_contract.service_fee_monthly(band_a).round(2)).to eq(22_315.48)
+    expect(call_off_contract.service_fee_per_participant(band_a).round(2)).to eq(323.57)
   end
 end

--- a/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
@@ -10,7 +10,8 @@ describe ::PaymentCalculator::Ecf::Contract::ServiceFeeCalculations do
   it "performs calculations of the service fees" do
     band_a = double("Band Double", per_participant: 996.00,
                                    number_of_participants_in_this_band: 2000,
-                                   deduction_for_setup?: true)
+                                   deduction_for_setup?: true,
+                                   upper_boundary: 2000)
     contract = double("Contract Double", recruitment_target: 2000, set_up_fee: 149_651.00, band_a: band_a)
     call_off_contract = DummyClass.new({ contract: contract })
 

--- a/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
@@ -30,9 +30,9 @@ describe ::PaymentCalculator::Ecf::PaymentCalculation do
       result = described_class.call(lead_provider: contract.lead_provider, event_type: key, total_participants: value)
 
       if @combined_results.nil?
-        expect(result.dig(:service_fees, :service_fee_per_participant)).to be_a(BigDecimal)
-        expect(result.dig(:service_fees, :service_fee_total)).to be_a(BigDecimal)
-        expect(result.dig(:service_fees, :service_fee_monthly)).to be_a(BigDecimal)
+        expect(result.dig(:service_fees, 0, :service_fee_per_participant)).to be_a(BigDecimal)
+        expect(result.dig(:service_fees, 1, :service_fee_total)).to be_a(BigDecimal)
+        expect(result.dig(:service_fees, 2, :service_fee_monthly)).to be_a(BigDecimal)
         expect(result.dig(:output_payment, :per_participant)).to be_a(BigDecimal)
       end
 

--- a/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
@@ -19,7 +19,7 @@ module CallOffContractSteps
   end
 
   step "I setup the contract" do
-    @band_a = double("Band Double", number_of_participants_in_this_band: 2000, per_participant: @per_participant_value, deduction_for_setup?: true)
+    @band_a = double("Band Double", number_of_participants_in_this_band: 2000, per_participant: @per_participant_value, deduction_for_setup?: true, upper_boundary: 2000)
     contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
     @call_off_contract = DummyClass.new({ contract: contract })
   end

--- a/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
@@ -15,12 +15,12 @@ module CallOffContractSteps
   end
 
   step "Band A per-participant price is £:decimal_placeholder" do |value|
-    @band_a = value
+    @per_participant_value = value
   end
 
   step "I setup the contract" do
-    band_a = double("Band Double", per_participant: @band_a)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: band_a)
+    @band_a = double("Band Double", number_of_participants_in_this_band: 2000, per_participant: @per_participant_value, deduction_for_setup?: true)
+    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
     @call_off_contract = DummyClass.new({ contract: contract })
   end
 
@@ -28,18 +28,18 @@ module CallOffContractSteps
   step :assert_service_fee_per_participant, "the per-participant service fee should be £:decimal_placeholder"
 
   step "the total service fee should be £:decimal_placeholder" do |expected_value|
-    expect(@call_off_contract.service_fee_total.round(0)).to eq(expected_value)
+    expect(@call_off_contract.service_fee_total(@band_a).round(0)).to eq(expected_value)
   end
 
   step "the monthly service fee should be £:decimal_placeholder" do |expected_value|
-    expect(@call_off_contract.service_fee_monthly.round(0)).to eq(expected_value)
+    expect(@call_off_contract.service_fee_monthly(@band_a).round(0)).to eq(expected_value)
   end
 
   step :assert_output_per_participant, "the output payment per-participant should be £:decimal_placeholder"
   step :assert_output_per_participant, "the output payment per-participant should be unchanged at £:decimal_placeholder"
 
   def assert_service_fee_per_participant(expected_value)
-    expect(@call_off_contract.service_fee_per_participant.round(2)).to eq(expected_value)
+    expect(@call_off_contract.service_fee_per_participant(@band_a).round(2)).to eq(expected_value)
   end
 
   def assert_output_per_participant(expected_value)

--- a/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
@@ -19,8 +19,12 @@ module CallOffContractSteps
   end
 
   step "I setup the contract" do
-    @band_a = double("Band Double", number_of_participants_in_this_band: 2000, per_participant: @per_participant_value, deduction_for_setup?: true, upper_boundary: 2000)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
+    @band_a = double("Band Double", number_of_participants_in_this_band: 2000, per_participant: @per_participant_value, deduction_for_setup?: true)
+    contract = double("Contract Double",
+                      recruitment_target: @recruitment_target,
+                      set_up_fee: @set_up_fee,
+                      band_a: @band_a,
+                      set_up_recruitment_basis: 2000)
     @call_off_contract = DummyClass.new({ contract: contract })
   end
 

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -18,7 +18,7 @@ module OutputPaymentsSteps
   end
 
   step "I run each calculation" do
-    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true)
+    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
     contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
     @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -18,9 +18,9 @@ module OutputPaymentsSteps
   end
 
   step "I run each calculation" do
-    band_a = double("Band Double", per_participant: @band_a)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: band_a)
-    @call_off_contract = DummyClass.new({ contract: contract })
+    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true)
+    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
+    @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)
     @result = @retention_table.map do |row|

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -19,7 +19,7 @@ module OutputPaymentsSteps
 
   step "I run each calculation" do
     @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
+    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a, set_up_recruitment_basis: 2000)
     @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -7,9 +7,9 @@ module ServiceFeeSteps
   end
 
   step "I run the calculation" do
-    band_a = double("Band Double", per_participant: @band_a)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: band_a)
-    @call_off_contract = DummyClass.new({ contract: contract })
+    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true)
+    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
+    @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)
     @result = calculator.call

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -8,8 +8,13 @@ module ServiceFeeSteps
 
   step "I run the calculation" do
     @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
-    @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
+    contract = double("Contract Double",
+                      recruitment_target: @recruitment_target,
+                      set_up_fee: @set_up_fee,
+                      band_a: @band_a,
+                      set_up_recruitment_basis: 2000)
+    @call_off_contract = DummyClass.new({ contract: contract,
+                                          bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)
     @result = calculator.call

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -7,7 +7,7 @@ module ServiceFeeSteps
   end
 
   step "I run the calculation" do
-    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true)
+    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
     contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a)
     @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -6,11 +6,21 @@ RSpec.describe CalculationOrchestrator do
   let(:call_off_contract) { create(:call_off_contract) }
   let(:expected_result) do
     {
-      service_fees: {
-        service_fee_monthly: 22_287.90,
-        service_fee_per_participant: 323.17,
+      service_fees: [{
+        service_fee_monthly: 22_288.0,
+        service_fee_per_participant: 323.0,
         service_fee_total: 646_349.0,
       },
+                     {
+                       service_fee_monthly: 0.0,
+                       service_fee_per_participant: 392.0,
+                       service_fee_total: 0.0,
+                     },
+                     {
+                       service_fee_monthly: 0.0,
+                       service_fee_per_participant: 386.0,
+                       service_fee_total: 0.0,
+                     }],
       output_payment: {
         per_participant: 597.0,
         started: {


### PR DESCRIPTION
### Context

Previously only Band A was used in calculation, this change includes all the banding and generates payment breakdown as the following:

```
+----------------------------------------------------+
|                 Breakdown Payments                 |
+---------+------------------+-----------------------+
| Banding | Service fee (PP) | Service fee (monthly) |
+---------+------------------+-----------------------+
| Band A  |     £558      |         £38,448          |
| Band B  |     £520      |         £35,862          |
| Band C  |      £480     |         £8,276           |
+---------+------------------+-----------------------+
Output payment (started) £756,000
Based on 4,500 participants and £1400 per participant in Band A, £1300 per participant in Band B, £1200 per participant in Band C
```

### How can I view this in a review app?

Run the rake task ```rake payment_calculation:breakdown Capita 4500``` with the contract as per [jira ticket](https://dfedigital.atlassian.net/browse/CPDTP-166):

```
{
  "uplift_target": 0,
  "uplift_amount": 0,
  "recruitment_target": 4500,
  "set_up_fee": 5_000,
  "band_a": {
    "max": 2000,
    "per_participant": 1400,
  },
  "band_b": {
    "min": 2001,
    "max": 4000,
    "per_participant": 1300,
  },
  "band_c": {
    "min": 4001,
    "per_participant": 1200,
  },
}
```
