### PR TITLE
Fix issue where cookie banner couldn't be accepted from privacy page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ protected
     policy = PrivacyPolicy.current
     return if policy.nil?
 
-    return if request.format == "application/json"
+    return if request.format.json?
 
     return unless policy.acceptance_required?(current_user)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,6 @@ protected
     return if policy.nil?
 
     return if request.format == "application/json"
-    return if controller_name == "cookies"
 
     return unless policy.acceptance_required?(current_user)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,6 +50,9 @@ protected
     policy = PrivacyPolicy.current
     return if policy.nil?
 
+    return if request.format == "application/json"
+    return if controller_name == "cookies"
+
     return unless policy.acceptance_required?(current_user)
 
     session[:original_path] = request.fullpath

--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CookiesController < ApplicationController
+  skip_before_action :check_privacy_policy_accepted
+
   before_action :set_cookie_form, only: :show
 
   def show


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDRP-407

### Guidance to review

To replicate the original issue:

- Go to e.g. https://ecf-review-pr-493.london.cloudapps.digital/
- DON'T TOUCH the cookies
- log in as school-leader@example.com
- On priv policy page, try to accept cookies

### Testing

Unsure if this needs request specs. I can't see how this would change in the future without invalidating the tests.

### How can I view this in a review app?

see pr app below