### PR TITLE
api/v1/users controller now requires private token

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -6,16 +6,14 @@ module Api
       include ApiTokenAuthenticatable
       include Pagy::Backend
 
-      before_action :ensure_engage_and_learn
-
       def index
         render json: UserSerializer.new(paginate(users)).serializable_hash.to_json
       end
 
     private
 
-      def ensure_engage_and_learn
-        head :forbidden unless current_user == "Engage and learn application"
+      def access_scope
+        ApiToken.where(private_api_access: true)
       end
 
       def updated_since

--- a/app/controllers/concerns/api_token_authenticatable.rb
+++ b/app/controllers/concerns/api_token_authenticatable.rb
@@ -6,11 +6,12 @@ module ApiTokenAuthenticatable
 
   included do
     before_action :authenticate
+    before_action :check_access_scope
   end
 
   def authenticate
     authenticate_or_request_with_http_token do |unhashed_token|
-      @current_api_token = ApiToken.merge(access_scope).find_by_unhashed_token(unhashed_token)
+      @current_api_token = ApiToken.find_by_unhashed_token(unhashed_token)
       if @current_api_token
         @current_api_token.update!(
           last_used_at: Time.zone.now,
@@ -24,6 +25,10 @@ module ApiTokenAuthenticatable
   end
 
 private
+
+  def check_access_scope
+    head :forbidden unless access_scope.include?(@current_api_token)
+  end
 
   def access_scope
     ApiToken.all

--- a/app/models/engage_and_learn_api_token.rb
+++ b/app/models/engage_and_learn_api_token.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EngageAndLearnApiToken < ApiToken
+  attribute :private_api_access, default: true
+
   def owner
     "Engage and learn application"
   end

--- a/db/migrate/20210611133458_change_default_api_token_type.rb
+++ b/db/migrate/20210611133458_change_default_api_token_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeDefaultApiTokenType < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :api_tokens, :type, to: "ApiToken", from: "LeadProviderApiToken"
+  end
+end

--- a/db/migrate/20210611141524_update_e_and_l_tokens_with_private_access.rb
+++ b/db/migrate/20210611141524_update_e_and_l_tokens_with_private_access.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateEAndLTokensWithPrivateAccess < ActiveRecord::Migration[6.1]
+  def up
+    EngageAndLearnApiToken.update_all(private_api_access: true)
+  end
+
+  def down
+    EngageAndLearnApiToken.update_all(private_api_access: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_094438) do
+ActiveRecord::Schema.define(version: 2021_06_11_141524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2021_06_09_094438) do
     t.datetime "last_used_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "type", default: "LeadProviderApiToken"
+    t.string "type", default: "ApiToken"
     t.boolean "private_api_access", default: false
     t.index ["hashed_token"], name: "index_api_tokens_on_hashed_token", unique: true
     t.index ["lead_provider_id"], name: "index_api_tokens_on_lead_provider_id"

--- a/spec/requests/api/v1/dqt_records_spec.rb
+++ b/spec/requests/api/v1/dqt_records_spec.rb
@@ -58,20 +58,20 @@ RSpec.describe "DQT records api endpoint", type: :request do
     end
 
     context "when unauthorized" do
-      it "returns 401 for invalid bearer token" do
+      it "returns 401" do
         default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
         get "/api/v1/dqt-records/#{trn}"
         expect(response.status).to eq 401
       end
     end
 
-    context "using token from different scope" do
-      let(:other_token) { EngageAndLearnApiToken.create_with_random_token! }
+    context "using valid token but for different scope" do
+      let(:other_token) { ApiToken.create_with_random_token! }
 
-      it "returns 401 for invalid bearer token" do
+      it "returns 403" do
         default_headers[:Authorization] = "Bearer #{other_token}"
         get "/api/v1/dqt-records/#{trn}"
-        expect(response.status).to eq 401
+        expect(response.status).to eq 403
       end
     end
   end


### PR DESCRIPTION
### Context

- NPQ requires access to api/v1/users endpoint
- It will need to be able to create users
- Currently this is not possible as endpoint has been restricted to `EngageAndLearnApiToken` tokens only

### Changes proposed in this pull request

- Valid api tokens but with incorrect permissions based off the `access_scope` now get a 403 instead of a 401
- `app/controllers/api/v1/users_controller.rb` now requires a token with `private_api_access` set to `true`
- Default `type` on `ApiToken` is now `ApiToken` not `LeadProviderApiToken`
- New `EngageAndLearnApiToken` tokens will have have `private_api_access` with `true` and there is migration to update any existing tokens to this state

### Guidance to review

- Change of default on `type` on `ApiToken` should not cause issues
- Access to api endpoints should continue to work

### Testing

- Test via review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- Note down the unhashed token, it will be needed later
- Call endpoint with `curl -I -H "Authorization: Bearer UNHASHED_TOKEN" https://ecf-review-pr-508.london.cloudapps.digital/api/v1/users`
- Should return 200 response
- Create another api token with `ApiToken.create_with_random_token!`
- Note down the unhashed token, it will be needed later
- Call endpoint with `curl -I -H "Authorization: Bearer UNHASHED_TOKEN" https://ecf-review-pr-508.london.cloudapps.digital/api/v1/users`
- Should get 403
- Call endpoint with `curl -I -H "Authorization: Bearer TOKEN_THAT_DOES_NOT_EXIST" https://ecf-review-pr-508.london.cloudapps.digital/api/v1/users`
- Should get 401