### PR TITLE
Handle pagy overflow

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "pagy/extras/overflow"
+
+# Return an empty page when page number too high (other options :last_page and :exception )
+Pagy::VARS[:overflow] = :empty_page

--- a/spec/docs/participants_spec.rb
+++ b/spec/docs/participants_spec.rb
@@ -57,7 +57,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_fl
                 style: :deepObject,
                 explode: true,
                 required: false,
-                example: { page: 2, per_page: 10 },
+                example: { page: 1, per_page: 5 },
                 description: "Pagination options to navigate through the collection."
 
       response "200", "Collection of participants." do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -176,8 +176,8 @@
             "explode": true,
             "required": false,
             "example": {
-              "page": 2,
-              "per_page": 10
+              "page": 1,
+              "per_page": 5
             },
             "description": "Pagination options to navigate through the collection."
           }


### PR DESCRIPTION
Couple of related things here:
- Change Pagy to return an empty page when requesting a page with no contents
- Update the swagger docs to match the data on sandbox

Previously Pagy would throw an exception when it ran out of pages. Sandbox has 10 ppts per lead provider, so we were seeing exceptions in the swagger examples