### PR TITLE
CPDTP-110 Add output payment for banding

### DIFF
--- a/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
@@ -12,19 +12,19 @@ module PaymentCalculator
           include HasDIParameters
         end
 
-        delegate :band_a, to: :contract
+        delegate :bands, to: :contract
 
-        def output_payment_per_participant
-          band_a.per_participant * output_payment_contribution_percentage
+        def output_payment_per_participant(band)
+          band.per_participant * output_payment_contribution_percentage
         end
 
-        def output_payment_for_event(event_type:, total_participants:)
-          total_participants * output_payment_per_participant_for_event(event_type: event_type)
+        def output_payment_for_event(event_type:, total_participants:, band:)
+          total_participants * output_payment_per_participant_for_event(event_type: event_type, band: band)
         end
 
-        def output_payment_per_participant_for_event(event_type:)
+        def output_payment_per_participant_for_event(event_type:, band:)
           event_type = event_type.parameterize.underscore.intern if event_type.is_a?(String)
-          send(event_type) * output_payment_per_participant
+          send(event_type) * output_payment_per_participant(band)
         end
 
       private

--- a/lib/payment_calculator/ecf/output_payment_aggregator.rb
+++ b/lib/payment_calculator/ecf/output_payment_aggregator.rb
@@ -8,15 +8,21 @@ module PaymentCalculator
     class OutputPaymentAggregator
       include Contract::OutputPaymentCalculations
 
+      delegate :bands, to: :contract
+
       # @param [Symbol] event_type
       # @param [Integer] total_participants
       # This is end number of participants who will be used to make the payment calculation.
       # All invalid users will have already been filtered out before this number is generated and passed here.
       def call(event_type:, total_participants:)
-        {
-          per_participant: output_payment_per_participant.round(2),
-          event_type => output_payment_retention_event.call(params, event_type: event_type, total_participants: total_participants),
-        }
+        bands.map do |band|
+          {
+            per_participant: output_payment_per_participant(band).round(0),
+            event_type => output_payment_retention_event.call(
+              params, event_type: event_type, total_participants: total_participants, band: band
+            ),
+          }
+        end
       end
 
     private

--- a/lib/payment_calculator/ecf/output_payment_retention_event.rb
+++ b/lib/payment_calculator/ecf/output_payment_retention_event.rb
@@ -7,11 +7,11 @@ module PaymentCalculator
     class OutputPaymentRetentionEvent
       include PaymentCalculator::Ecf::Contract::OutputPaymentCalculations
 
-      def call(total_participants:, event_type:)
+      def call(total_participants:, event_type:, band:)
         {
           retained_participants: total_participants,
-          per_participant: output_payment_per_participant_for_event(event_type: event_type).round(2),
-          subtotal: output_payment_for_event(total_participants: total_participants, event_type: event_type).round(2),
+          per_participant: output_payment_per_participant_for_event(event_type: event_type, band: band).round(0),
+          subtotal: output_payment_for_event(total_participants: total_participants, event_type: event_type, band: band).round(0),
         }
       end
     end

--- a/lib/payment_calculator/ecf/payment_calculation.rb
+++ b/lib/payment_calculator/ecf/payment_calculation.rb
@@ -19,7 +19,7 @@ module PaymentCalculator
       def call(total_participants: 0, event_type: :started)
         {
           service_fees: @service_fee_calculator.call(contract: contract),
-          output_payment: @output_payment_calculator.call({ contract: contract }, event_type: event_type, total_participants: total_participants),
+          output_payments: @output_payment_calculator.call({ contract: contract }, event_type: event_type, total_participants: total_participants),
         }
       end
 

--- a/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
@@ -11,14 +11,14 @@ describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
     contract = double("Contract Double", band_a: band_a)
     call_off_contract = DummyClass.new({ contract: contract })
 
-    expect(call_off_contract.output_payment_per_participant.round(0)).to eq(598.00)
+    expect(call_off_contract.output_payment_per_participant(band_a).round(0)).to eq(598.00)
 
     %i[started completion].each do |event_type|
-      expect(call_off_contract.output_payment_per_participant_for_event(event_type: event_type).round(0)).to eq(120.00)
+      expect(call_off_contract.output_payment_per_participant_for_event(event_type: event_type, band: band_a).round(0)).to eq(120.00)
     end
 
     %i[retention_1 retention_2 retention_3 retention_4].each do |event_type|
-      expect(call_off_contract.output_payment_per_participant_for_event(event_type: event_type).round(0)).to eq(90.00)
+      expect(call_off_contract.output_payment_per_participant_for_event(event_type: event_type, band: band_a).round(0)).to eq(90.00)
     end
   end
 end

--- a/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
@@ -31,16 +31,14 @@ describe ::PaymentCalculator::Ecf::PaymentCalculation do
     retained_event_aggregations.each do |key, value|
       result = described_class.call(lead_provider: contract.lead_provider, event_type: key, total_participants: value)
 
-      expect(result.dig(:service_fees, :service_fee_per_participant)).to be_a(BigDecimal)
-      expect(result.dig(:service_fees, :service_fee_total)).to be_a(BigDecimal)
-      expect(result.dig(:service_fees, :service_fee_monthly)).to be_a(BigDecimal)
+      result.dig(:service_fees).each do |service_fee|
+        expect(service_fee[:service_fee_per_participant]).to be_a(BigDecimal)
+        expect(service_fee[:service_fee_total]).to be_a(BigDecimal)
+        expect(service_fee[:service_fee_monthly]).to be_a(BigDecimal)
+      end
     end
 
     result = described_class.call(lead_provider: contract.lead_provider, event_type: start_event_name, total_participants: participant_for_event)
-
-    expect(result.dig(:service_fees, :service_fee_per_participant)).to be_a(BigDecimal)
-    expect(result.dig(:service_fees, :service_fee_total)).to be_a(BigDecimal)
-    expect(result.dig(:service_fees, :service_fee_monthly)).to be_a(BigDecimal)
 
     result.dig(:output_payments).each do |output_payment|
       expect(output_payment.dig(start_event_name, :retained_participants)).to be_an(Integer)

--- a/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
@@ -7,6 +7,9 @@ describe ::PaymentCalculator::Ecf::PaymentCalculation do
     FactoryBot.create(:call_off_contract)
   end
 
+  let(:start_event_name) { "Started" }
+  let(:participant_for_event) { 1900 }
+
   let(:retained_event_aggregations) do
     {
       "Started" => 1900,
@@ -25,26 +28,23 @@ describe ::PaymentCalculator::Ecf::PaymentCalculation do
   end
 
   it "returns the expected types for all outputs" do
-    @combined_results = nil
     retained_event_aggregations.each do |key, value|
       result = described_class.call(lead_provider: contract.lead_provider, event_type: key, total_participants: value)
 
-      if @combined_results.nil?
-        expect(result.dig(:service_fees, 0, :service_fee_per_participant)).to be_a(BigDecimal)
-        expect(result.dig(:service_fees, 1, :service_fee_total)).to be_a(BigDecimal)
-        expect(result.dig(:service_fees, 2, :service_fee_monthly)).to be_a(BigDecimal)
-        expect(result.dig(:output_payment, :per_participant)).to be_a(BigDecimal)
-      end
-
-      @combined_results ||= { service_fees: result[:service_fees], output_payment: {} }
-      @combined_results[:output_payment][key] = result.dig(:output_payment, key)
+      expect(result.dig(:service_fees, :service_fee_per_participant)).to be_a(BigDecimal)
+      expect(result.dig(:service_fees, :service_fee_total)).to be_a(BigDecimal)
+      expect(result.dig(:service_fees, :service_fee_monthly)).to be_a(BigDecimal)
     end
 
-    @combined_results[:output_payment].each do |key, value|
-      expect(key).to be_a(String)
-      expect(value[:retained_participants]).to be_an(Integer)
-      expect(value[:per_participant]).to be_a(BigDecimal)
-      expect(value[:subtotal]).to be_a(BigDecimal)
+    result = described_class.call(lead_provider: contract.lead_provider, event_type: start_event_name, total_participants: participant_for_event)
+
+    expect(result.dig(:service_fees, :service_fee_per_participant)).to be_a(BigDecimal)
+    expect(result.dig(:service_fees, :service_fee_total)).to be_a(BigDecimal)
+    expect(result.dig(:service_fees, :service_fee_monthly)).to be_a(BigDecimal)
+
+    result.dig(:output_payments).each do |output_payment|
+      expect(output_payment.dig(start_event_name, :retained_participants)).to be_an(Integer)
+      expect(output_payment.dig(start_event_name, :per_participant)).to be_an(BigDecimal)
     end
   end
 end

--- a/spec/lib/payment_calculator/turnip_features/ecf/output_payments.feature
+++ b/spec/lib/payment_calculator/turnip_features/ecf/output_payments.feature
@@ -7,12 +7,12 @@ Feature: ECF payment calculation engine
       And Band A per-participant price is £995
       And there are the following retention numbers:
         | Payment Type | Month    | Retained Participants | Expected Per-Participant Output Payment | Expected Output Payment Subtotal |
-        | Started      | Jan 2021 | 1900                  | £119.40                                 | £226,860                         |
-        | Retention 1  | Jun 2021 | 1700                  | £89.55                                  | £152,235                         |
-        | Retention 2  | Feb 2022 | 1500                  | £89.55                                  | £134,325                         |
-        | Retention 3  | Jul 2022 | 1000                  | £89.55                                  | £89,550                          |
-        | Retention 4  | Mar 2023 | 800                   | £89.55                                  | £71,640                          |
-        | Completion   | Aug 2023 | 500                   | £119.40                                 | £59,700                          |
+        | Started      | Jan 2021 | 1900                  | £119.00                                 | £226,860                         |
+        | Retention 1  | Jun 2021 | 1700                  | £90.00                                  | £152,235                         |
+        | Retention 2  | Feb 2022 | 1500                  | £90.00                                  | £134,325                         |
+        | Retention 3  | Jul 2022 | 1000                  | £90.00                                  | £89,550                          |
+        | Retention 4  | Mar 2023 | 800                   | £90.00                                  | £71,640                          |
+        | Completion   | Aug 2023 | 500                   | £119.00                                 | £59,700                          |
     When I run each calculation
     Then the output payment per-participant should be £597
      And the output payment schedule should be as above
@@ -24,10 +24,10 @@ Feature: ECF payment calculation engine
       And there are the following retention numbers:
         | Payment Type | Month    | Retained Participants | Expected Per-Participant Output Payment | Expected Output Payment Subtotal |
         | Started      | Jan 2021 | 1900                  | £162.00                                 | £307,800                         |
-        | Retention 1  | Jun 2021 | 1700                  | £121.50                                 | £206,550                         |
-        | Retention 2  | Feb 2022 | 1500                  | £121.50                                 | £182,250                         |
-        | Retention 3  | Jul 2022 | 1000                  | £121.50                                 | £121,500                         |
-        | Retention 4  | Mar 2023 | 800                   | £121.50                                 | £97,200                          |
+        | Retention 1  | Jun 2021 | 1700                  | £122.00                                 | £206,550                         |
+        | Retention 2  | Feb 2022 | 1500                  | £122.00                                 | £182,250                         |
+        | Retention 3  | Jul 2022 | 1000                  | £122.00                                 | £121,500                         |
+        | Retention 4  | Mar 2023 | 800                   | £122.00                                 | £97,200                          |
         | Completion   | Aug 2023 | 500                   | £162.00                                 | £81,000                          |
     When I run each calculation
     Then the monthly service fee should be £32,069

--- a/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
@@ -43,11 +43,7 @@ module CallOffContractSteps
   step :assert_output_per_participant, "the output payment per-participant should be unchanged at £:decimal_placeholder"
 
   def assert_service_fee_per_participant(expected_value)
-<<<<<<< HEAD
     expect(@call_off_contract.service_fee_per_participant(@band_a).round(2)).to eq(expected_value)
-=======
-    expect(@call_off_contract.service_fee_per_participant.round(0)).to eq(expected_value)
->>>>>>> Rebase
   end
 
   def assert_output_per_participant(expected_value)

--- a/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
@@ -25,7 +25,7 @@ module CallOffContractSteps
                       set_up_fee: @set_up_fee,
                       band_a: @band_a,
                       set_up_recruitment_basis: 2000)
-    @call_off_contract = DummyClass.new({ contract: contract })
+    @call_off_contract = DummyClass.new({ contract: contract, per_participant: @per_participant_value })
   end
 
   step :assert_service_fee_per_participant, "the per-participant service fee should be reduced to £:decimal_placeholder"
@@ -43,11 +43,15 @@ module CallOffContractSteps
   step :assert_output_per_participant, "the output payment per-participant should be unchanged at £:decimal_placeholder"
 
   def assert_service_fee_per_participant(expected_value)
+<<<<<<< HEAD
     expect(@call_off_contract.service_fee_per_participant(@band_a).round(2)).to eq(expected_value)
+=======
+    expect(@call_off_contract.service_fee_per_participant.round(0)).to eq(expected_value)
+>>>>>>> Rebase
   end
 
   def assert_output_per_participant(expected_value)
-    expect(@call_off_contract.output_payment_per_participant.round(2)).to eq(expected_value)
+    expect(@call_off_contract.output_payment_per_participant(@band_a).round(0)).to eq(expected_value)
   end
 end
 

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -31,11 +31,11 @@ module OutputPaymentsSteps
   step "the output payment schedule should be as above" do
     aggregate_failures "output payments" do
       expect(@result.length).to eq(@retention_table.length)
-      @retention_table.length.times.each do |x|
-        key = @retention_table[x][:payment_type]
-        @result[x][:output_payments].each_with_index do |output_payment, _index|
+      @retention_table.length.times.each do |row|
+        key = @retention_table[row][:payment_type]
+        @result[row][:output_payments].each do |output_payment|
           actual_values = output_payment[key]
-          expectation = @retention_table[x]
+          expectation = @retention_table[row]
           expect_with_context(actual_values[:retained_participants], expectation[:retained_participants], "#{expectation[:payment_type]} retention numbers passthrough")
           expect_with_context(actual_values[:per_participant], expectation[:expected_per_participant_output_payment], "#{expectation[:payment_type]} per participant payment")
           expect_with_context(actual_values[:subtotal], expectation[:expected_output_payment_subtotal], "#{expectation[:payment_type]} output payment")

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -19,7 +19,7 @@ module OutputPaymentsSteps
 
   step "I run each calculation" do
     @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
-    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a, set_up_recruitment_basis: 2000)
+    contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a, set_up_recruitment_basis: 2000, bands: [@band_a])
     @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)
@@ -33,11 +33,13 @@ module OutputPaymentsSteps
       expect(@result.length).to eq(@retention_table.length)
       @retention_table.length.times.each do |x|
         key = @retention_table[x][:payment_type]
-        actual_values = @result[x][:output_payment][key]
-        expectation = @retention_table[x]
-        expect_with_context(actual_values[:retained_participants], expectation[:retained_participants], "#{expectation[:payment_type]} retention numbers passthrough")
-        expect_with_context(actual_values[:per_participant], expectation[:expected_per_participant_output_payment], "#{expectation[:payment_type]} per participant payment")
-        expect_with_context(actual_values[:subtotal], expectation[:expected_output_payment_subtotal], "#{expectation[:payment_type]} output payment")
+        @result[x][:output_payments].each_with_index do |output_payment, _index|
+          actual_values = output_payment[key]
+          expectation = @retention_table[x]
+          expect_with_context(actual_values[:retained_participants], expectation[:retained_participants], "#{expectation[:payment_type]} retention numbers passthrough")
+          expect_with_context(actual_values[:per_participant], expectation[:expected_per_participant_output_payment], "#{expectation[:payment_type]} per participant payment")
+          expect_with_context(actual_values[:subtotal], expectation[:expected_output_payment_subtotal], "#{expectation[:payment_type]} output payment")
+        end
       end
     end
   end

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -18,7 +18,7 @@ module OutputPaymentsSteps
   end
 
   step "I run each calculation" do
-    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
+    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true)
     contract = double("Contract Double", recruitment_target: @recruitment_target, set_up_fee: @set_up_fee, band_a: @band_a, set_up_recruitment_basis: 2000, bands: [@band_a])
     @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
     lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -12,6 +12,7 @@ module ServiceFeeSteps
                       recruitment_target: @recruitment_target,
                       set_up_fee: @set_up_fee,
                       band_a: @band_a,
+                      bands: [@band_a],
                       set_up_recruitment_basis: 2000)
     @call_off_contract = DummyClass.new({ contract: contract,
                                           bands: [@band_a] })

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -7,7 +7,7 @@ module ServiceFeeSteps
   end
 
   step "I run the calculation" do
-    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true, upper_boundary: 2000)
+    @band_a = double("Band Double", per_participant: @per_participant_value, number_of_participants_in_this_band: 2000, deduction_for_setup?: true)
     contract = double("Contract Double",
                       recruitment_target: @recruitment_target,
                       set_up_fee: @set_up_fee,

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -6,12 +6,23 @@ RSpec.describe CalculationOrchestrator do
   let(:call_off_contract) { create(:call_off_contract) }
   let(:expected_result) do
     {
-      service_fees: [{
-        service_fee_monthly: 22_288.0,
-        service_fee_per_participant: 323.0,
-        service_fee_total: 646_349.0,
-        service_fee_monthly: 22_287.9,
-      },
+      service_fees: [
+        {
+          service_fee_monthly: 22_288.0,
+          service_fee_per_participant: 323.0,
+          service_fee_total: 646_349.0,
+        },
+        {
+          service_fee_monthly: 0.0,
+          service_fee_per_participant: 392.0,
+          service_fee_total: 0.0,
+        },
+        {
+          service_fee_monthly: 0.0,
+          service_fee_per_participant: 386.0,
+          service_fee_total: 0.0,
+        },
+      ],
       output_payments: [
         {
           per_participant: 597.0,

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -10,25 +10,34 @@ RSpec.describe CalculationOrchestrator do
         service_fee_monthly: 22_288.0,
         service_fee_per_participant: 323.0,
         service_fee_total: 646_349.0,
+        service_fee_monthly: 22_287.9,
       },
-                     {
-                       service_fee_monthly: 0.0,
-                       service_fee_per_participant: 392.0,
-                       service_fee_total: 0.0,
-                     },
-                     {
-                       service_fee_monthly: 0.0,
-                       service_fee_per_participant: 386.0,
-                       service_fee_total: 0.0,
-                     }],
-      output_payment: {
-        per_participant: 597.0,
-        started: {
-          per_participant: 119.4,
-          retained_participants: 10,
-          subtotal: 1_194.0,
+      output_payments: [
+        {
+          per_participant: 597.0,
+          started: {
+            retained_participants: 10,
+            per_participant: 119.0,
+            subtotal: 1194.0,
+          },
         },
-      },
+        {
+          per_participant: 587.0,
+          started: {
+            retained_participants: 10,
+            per_participant: 117.0,
+            subtotal: 1175.0,
+          },
+        },
+        {
+          per_participant: 580.0,
+          started: {
+            retained_participants: 10,
+            per_participant: 116.0,
+            subtotal: 1159.0,
+          },
+        },
+      ],
     }
   end
 


### PR DESCRIPTION
### Context

Add bands for output payment in the breakdown calculation

### How can I view this in a review app?

Run the following rake task:

```rake payment_calculation:breakdown Capita 4500```

should print out the following breakdown:

```
+--------------------------------------------------------+
|                   Breakdown Payments                   |
+---------+--------------------+-------------------------+
| Banding |  Service fee (PP)  |  Service fee (monthly)  |
+---------+--------------------+-------------------------+
| Band A  |        £558        |         £38,448         |
| Band B  |        £520        |         £35,862         |
| Band C  |        £480        |         £8,276          |
+---------+--------------------+-------------------------+
| Banding | Output price  (PP) | Output price  (monthly) |
+---------+--------------------+-------------------------+
| Band A  |        £168        |        £756,000         |
| Band B  |        £156        |        £702,000         |
| Band C  |        £144        |        £648,000         |
+---------+--------------------+-------------------------+
Based on 4,500 participants and £1400 per participant in Band A, £1300 per participant in Band B, £1200 per participant in Band C
```
