### PR TITLE
CPDTP-196 Fix error message returned by schema validator.

### DIFF
--- a/app/services/record_participant_event.rb
+++ b/app/services/record_participant_event.rb
@@ -20,7 +20,7 @@ class RecordParticipantEvent
     add_ect_profile_params!
     return :unprocessable_entity unless create_record
 
-    valid_provider!
+    validate_provider!
 
     :no_content
   end
@@ -58,7 +58,7 @@ private
     SchoolCohort.find_by(school: early_career_teacher_profile.school, cohort: early_career_teacher_profile.cohort)&.lead_provider
   end
 
-  def valid_provider!
+  def validate_provider!
     raise ActionController::ParameterMissing, I18n.t(:invalid_participant) unless actual_lead_provider.nil? || lead_provider == actual_lead_provider
   end
 

--- a/app/services/record_participant_event.rb
+++ b/app/services/record_participant_event.rb
@@ -17,9 +17,10 @@ class RecordParticipantEvent
 
   def call
     validate_schema!
-    return :not_found unless add_ect_profile_params
+    add_ect_profile_params!
     return :unprocessable_entity unless create_record
-    return :not_found unless valid_provider
+
+    valid_provider!
 
     :no_content
   end
@@ -32,16 +33,16 @@ private
 
   def validate_schema!
     errors = JsonSchema::ValidateBodyAgainstSchema.call(schema: schema, body: @params[:raw_event])
-    raise ActionController::ParameterMissing, errors unless errors.empty?
-
-    true
+    raise ActionController::ParameterMissing, (errors.map { |error| error.sub(/\sin schema.*$/, "") }) unless errors.empty?
   end
 
   def schema
     JSON.parse(File.read(JsonSchema::VersionEventFileName.call(version: "0.2")))
   end
 
-  def add_ect_profile_params
+  def add_ect_profile_params!
+    raise ActionController::ParameterMissing, I18n.t(:invalid_participant) unless early_career_teacher_profile
+
     @params[:early_career_teacher_profile] = early_career_teacher_profile
   end
 
@@ -57,8 +58,8 @@ private
     SchoolCohort.find_by(school: early_career_teacher_profile.school, cohort: early_career_teacher_profile.cohort)&.lead_provider
   end
 
-  def valid_provider
-    actual_lead_provider.nil? || lead_provider == actual_lead_provider
+  def valid_provider!
+    raise ActionController::ParameterMissing, I18n.t(:invalid_participant) unless actual_lead_provider.nil? || lead_provider == actual_lead_provider
   end
 
   def required_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     retention_4: Retention 4
     completion: Completion
   parameter_required: Parameter is required
+  invalid_participant: "The property '#/participant_id' must be a valid Participant ID"
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults
     not_a_number: *default_message

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
                 "type": "string",
               },
               "declaration_type": {
-                "enum": %w[started],
+                "enum": %w[started retained_1 retained_2 retained_3 retained_4 completed],
               },
               "declaration_date": {
                 "type": "string",
@@ -36,7 +36,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
             "example": {
               "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
               "declaration_type": "started",
-              "declaration_date": "2021-05-31T02:21:32",
+              "declaration_date": "2021-05-31T02:21:32Z",
             },
           },
         },
@@ -51,7 +51,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
       parameter name: :params, in: :body, required: false, schema: {
         type: :object,
         properties: {
-          declaration_type: { enum: %w[started] },
+          declaration_type: { enum: %w[started retained_1 retained_2 retained_3 retained_4 completed] },
         },
       }, description: "The event declaration type"
 
@@ -87,28 +87,6 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
           RecordParticipantEvent.call(HashWithIndifferentAccess.new({ lead_provider: lead_provider, raw_event: params.to_json }).merge(params))
         end
 
-        run_test!
-      end
-
-      response "404", "Missing ID value" do
-        let(:params) do
-          {
-            "participant_id" => "",
-            "declaration_type" => "started",
-            "declaration_date" => "2021-05-31T13:00:00Z",
-          }
-        end
-        run_test!
-      end
-
-      response "404", "Not Found" do
-        let(:params) do
-          {
-            "participant_id" => "db3a7848-7308-4879-942a-c4a70ced400a",
-            "declaration_type" => "started",
-            "declaration_date" => "2021-05-31T13:00:00Z",
-          }
-        end
         run_test!
       end
 

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -62,7 +62,12 @@
                   },
                   "declaration_type": {
                     "enum": [
-                      "started"
+                      "started",
+                      "retained_1",
+                      "retained_2",
+                      "retained_3",
+                      "retained_4",
+                      "completed"
                     ]
                   },
                   "declaration_date": {
@@ -78,7 +83,7 @@
                 "example": {
                   "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
                   "declaration_type": "started",
-                  "declaration_date": "2021-05-31T02:21:32"
+                  "declaration_date": "2021-05-31T02:21:32Z"
                 }
               }
             }
@@ -90,9 +95,6 @@
         "responses": {
           "204": {
             "description": "Successful"
-          },
-          "404": {
-            "description": "Not Found"
           },
           "422": {
             "description": "Bad or Missing parameter",


### PR DESCRIPTION
### Context

Error messages returned by the schema validator include "in schema <GUID_FOR_SCHEMA>" which contains more information than the caller actually needs.
Also, it has been decided to return a 422 if we don't have a valid participant_id (uuid) for the API call.

### Changes proposed in this pull request

- Update errors returned by the validate_schema! to remove the superfluous part of the message.
- Change ect_profiles_params and valid_provider to ! versions and raise 422 with error messages for their failing calls.
- Use I18n to display the new participant_id error message
- Update swagger to reflect the updated 422 only messages on error and correct a mistake in the date parameter

### Guidance to review

add_ect_profile_params! and valid_provider! should now raise a 422 with the participant_id error message.
validate_schema! should iterate through all of the returned errors and truncate the messages
The error message for "invalid_participant" has been chosen to be the same as the format now returned by the schema validator.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

API only.