### PR TITLE
Fixed back link on the first add-participant step when there are no participants

### DIFF
--- a/app/controllers/schools/add_participants_controller.rb
+++ b/app/controllers/schools/add_participants_controller.rb
@@ -64,10 +64,12 @@ module Schools
     end
 
     def back_link_path
-      previous_step = add_participant_form.previous_step(current_step)
-      return schools_cohort_participants_path unless previous_step
-
-      { action: :show, step: step_param(previous_step) }
+      if (previous_step = add_participant_form.previous_step(current_step))
+        { action: :show, step: step_param(previous_step) }
+      else
+        participants = User.order(:full_name).is_participant.in_school(@school.id)
+        participants.any? ? schools_cohort_participants_path : schools_cohort_path(id: @cohort.start_year)
+      end
     end
 
     def add_participant_form_params


### PR DESCRIPTION
When there are no participants, participant list page automatically redirects to the first step of the add-participant journey. Previously, link was fixed to return user to the participant index page, so it would be redirected back to the first step.