### PR TITLE
API endpoint to create users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -10,6 +10,32 @@ module Api
         render json: UserSerializer.new(paginate(users)).serializable_hash.to_json
       end
 
+      def create
+        user = User.find_by(email: params[:data][:attributes][:email])
+
+        if user.present?
+          user.errors.add(:email, :taken)
+
+          hash = {
+            errors: [{
+              status: "409",
+              title: user.errors.full_messages.join(", "),
+            }],
+          }
+
+          render json: hash, status: :conflict and return
+        end
+
+        user = User.create!(
+          email: params[:data][:attributes][:email],
+          full_name: params[:data][:attributes][:full_name],
+        )
+
+        hash = UserSerializer.new(user).serializable_hash
+
+        render json: hash, status: :created
+      end
+
     private
 
       def access_scope

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :participants, only: :index, constraints: ->(_request) { FeatureFlag.active?(:participant_data_api) }
       resources :participant_declarations, only: %i[create], path: "participant-declarations"
-      resources :users, only: :index
+      resources :users, only: %i[index create]
       resources :dqt_records, only: :show, path: "dqt-records"
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -52,17 +52,9 @@ RSpec.describe "API Users", type: :request do
 
       it "returns correct user types" do
         get "/api/v1/users"
-        mentors = 0
-        ects = 0
 
-        parsed_response["data"].each do |user|
-          user_type = user["attributes"]["user_type"]
-          if user_type == "mentor"
-            mentors += 1
-          elsif user_type == "early_career_teacher"
-            ects += 1
-          end
-        end
+        mentors = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "mentor" }
+        ects = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "early_career_teacher" }
 
         expect(mentors).to eql(1)
         expect(ects).to eql(2)

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -3,12 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "API Users", type: :request do
+  let(:parsed_response) { JSON.parse(response.body) }
+  let(:token) { EngageAndLearnApiToken.create_with_random_token! }
+  let(:bearer_token) { "Bearer #{token}" }
+
   describe "#index" do
-    let(:token) { EngageAndLearnApiToken.create_with_random_token! }
-    let(:bearer_token) { "Bearer #{token}" }
-
-    let(:parsed_response) { JSON.parse(response.body) }
-
     before :each do
       # Heads up, for some reason the stored CIP IDs don't match
       cip = create(:core_induction_programme, name: "Teach First")
@@ -71,12 +70,14 @@ RSpec.describe "API Users", type: :request do
         expect(parsed_response["data"].size).to eql(2)
       end
 
-      it "returns different users for each page" do
+      it "returns different users for first page" do
         get "/api/v1/users", params: { page: { per_page: 2, page: 1 } }
         expect(parsed_response["data"].size).to eql(2)
+      end
 
+      it "returns different users for second page" do
         get "/api/v1/users", params: { page: { per_page: 2, page: 2 } }
-        expect(JSON.parse(response.body)["data"].size).to eql(1)
+        expect(parsed_response["data"].size).to eql(1)
       end
 
       it "returns users changed since a particular time, if given a changed_since parameter" do
@@ -101,6 +102,76 @@ RSpec.describe "API Users", type: :request do
         default_headers[:Authorization] = bearer_token
         get "/api/v1/users"
         expect(response.status).to eq 403
+      end
+    end
+  end
+
+  describe "#create" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+        default_headers["Content-Type"] = "application/vnd.api+json"
+      end
+
+      let(:json) do
+        {
+          data: {
+            type: "user",
+            attributes: {
+              full_name: "John Doe",
+              email: "john.doe@example.com",
+            },
+          },
+        }.to_json
+      end
+
+      it "returns a 201" do
+        post "/api/v1/users.json", params: json
+        expect(response).to be_created
+      end
+
+      it "returns correct jsonapi content type header" do
+        post "/api/v1/users.json", params: json
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "creates a user record" do
+        expect {
+          post "/api/v1/users", params: json
+        }.to change(User, :count).by(1)
+
+        user = User.order(:created_at).last
+
+        expect(user.full_name).to eql("John Doe")
+        expect(user.email).to eql("john.doe@example.com")
+      end
+
+      it "returns the created user resource" do
+        post "/api/v1/users.json", params: json
+
+        user = User.order(:created_at).last
+
+        expect(parsed_response["data"]["type"]).to eql("user")
+        expect(parsed_response["data"]["id"]).to eql(user.id)
+        expect(parsed_response["data"]["attributes"]["full_name"]).to eql("John Doe")
+        expect(parsed_response["data"]["attributes"]["email"]).to eql("john.doe@example.com")
+      end
+
+      context "when user with email address already exists" do
+        before do
+          User.create!(email: "john.doe@example.com", full_name: "John Doeeeeee")
+        end
+
+        it "returns a 409" do
+          post "/api/v1/users.json", params: json
+          expect(response.code).to eql("409")
+        end
+
+        it "does not create another record" do
+          expect {
+            post "/api/v1/users", params: json
+          }.not_to change(User, :count)
+        end
       end
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "API Users", type: :request do
     context "when using a lead provider token" do
       let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: create(:lead_provider)) }
 
-      it "returns 401 for invalid bearer token" do
+      it "returns 403 for invalid bearer token" do
         default_headers[:Authorization] = bearer_token
         get "/api/v1/users"
         expect(response.status).to eq 403


### PR DESCRIPTION
### Context

- NPQ registration collects user data which must be pushed into "CPD manage"
- There will be subsequent pull requests to add attach NPQ profiles and data to these users

### Changes proposed in this pull request

- Add a barebones api endpoint to create a user with name and email
- We use email as the "identifier" here

### Guidance to review

- Existing api points should not be affected
- Should required token with private api access permissions
- Should conform to jsonapi spec

### Testing

- Test in the review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- Note down the token
- create a user with `curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" -X POST -d '{ "data": { "type": "user", "attributes": { "full_name": "John Doe", "email": "john.doe@example.com" } } }' https://ecf-review-pr-520.london.cloudapps.digital/api/v1/users`
- response should be 201
- response should have user guid so client can associate with the created user record