### PR TITLE
Add support for named params in Cucumber

### DIFF
--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -1,4 +1,5 @@
 import { Given, When, Then } from "cypress-cucumber-preprocessor/steps";
+import { parseArgs } from "./database";
 
 Given("I am logged in as a {string}", (user) => cy.login(user));
 Given("I am logged in as an {string}", (user) => cy.login(user));
@@ -121,8 +122,11 @@ Given("I am on {string} error page", (page) => {
   });
 });
 
-Given("I am on {string} page with id {string}", (page, id) => {
-  const path = pagePaths[page].replace(":id", id);
+const ID_REGEX = /:([a-z_]+)/g;
+
+Given("I am on {string} page with {}", (page, argsString) => {
+  const args = parseArgs(argsString);
+  const path = pagePaths[page].replace(ID_REGEX, (_, key) => args[key]);
   cy.visit(path);
 });
 
@@ -143,9 +147,9 @@ const assertOnPage = (page) => {
     throw new Error(`Path not found for ${page}`);
   }
 
-  if (path.includes(":id")) {
+  if (path.includes(":")) {
     const pathRegex = new RegExp(
-      path.replace(/\//g, "\\/").replace(/:id/g, "[^/]+")
+      path.replace(/\//g, "\\/").replace(ID_REGEX, "[^/]+")
     );
     cy.location("pathname").should("match", pathRegex);
   } else {

--- a/spec/cypress/support/step_definitions/database.js
+++ b/spec/cypress/support/step_definitions/database.js
@@ -1,7 +1,8 @@
 import { Given } from "cypress-cucumber-preprocessor/steps";
 import OnRails from "../on-rails";
 
-const parseArgs = (argsString) => {
+// eslint-disable-next-line import/prefer-default-export
+export const parseArgs = (argsString) => {
   const args = {};
   argsString.split(/ and |, /).forEach((argString) => {
     if (argString.split(" ").includes("created")) {


### PR DESCRIPTION
Will be used to rename :id to :slug in #517 but will also be useful in the future if we ever want to specify more than one param