### PR TITLE
Add full induction programme users to dummy structures

### DIFF
--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -38,6 +38,19 @@ school_two = School.find_or_create_by!(
 
 SchoolCohort.find_or_create_by!(cohort: Cohort.current, school: school_two, induction_programme_choice: "core_induction_programme")
 
+school_three = School.find_or_create_by!(
+  name: "Example school three",
+  postcode: "WA1 1AA",
+  address_line1: "100 Warrington Road",
+  primary_contact_email: "school-3-info@example.com",
+  school_status_code: 1,
+  school_type_code: 1,
+  administrative_district_code: "W123",
+  urn: "5555555",
+)
+
+SchoolCohort.find_or_create_by!(cohort: Cohort.current, school: school_three, induction_programme_choice: "full_induction_programme")
+
 User.find_or_create_by!(email: "school-leader@example.com") do |user|
   user.update!(full_name: "InductionTutor User")
   InductionCoordinatorProfile.find_or_create_by!(user: user) do |profile|
@@ -52,17 +65,17 @@ mentor = User.find_or_create_by!(email: "rp-mentor-ambition@example.com") do |us
   end
 end
 
-User.find_or_create_by!(email: "rp-mentor-ucl@example.com") do |user|
-  user.update!(full_name: "Abdul Mentor")
-  MentorProfile.find_or_create_by!(user: user) do |profile|
-    profile.update!(school: school, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"))
-  end
-end
-
-User.find_or_create_by!(email: "rp-mentor-edt@example.com") do |user|
+mentor_two = User.find_or_create_by!(email: "rp-mentor-edt@example.com") do |user|
   user.update!(full_name: "Jane Doe")
   MentorProfile.find_or_create_by!(user: user) do |profile|
     profile.update!(school: school_two, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"))
+  end
+end
+
+mentor_three = User.find_or_create_by!(email: "rp-mentor-ucl@example.com") do |user|
+  user.update!(full_name: "Abdul Mentor")
+  MentorProfile.find_or_create_by!(user: user) do |profile|
+    profile.update!(school: school_three, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"))
   end
 end
 
@@ -76,14 +89,14 @@ end
 User.find_or_create_by!(email: "rp-ect-edt@example.com") do |user|
   user.update!(full_name: "John Doe")
   EarlyCareerTeacherProfile.find_or_create_by!(user: user) do |profile|
-    profile.update!(school: school_two, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), mentor_profile: mentor.mentor_profile)
+    profile.update!(school: school_two, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), mentor_profile: mentor_two.mentor_profile)
   end
 end
 
 User.find_or_create_by!(email: "rp-ect-ucl@example.com") do |user|
   user.update!(full_name: "Dan Smith")
   EarlyCareerTeacherProfile.find_or_create_by!(user: user) do |profile|
-    profile.update!(school: school, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), mentor_profile: mentor.mentor_profile)
+    profile.update!(school: school_three, cohort: Cohort.current, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), mentor_profile: mentor_three.mentor_profile)
   end
 end
 


### PR DESCRIPTION
### Context

I forgot to change a school cohort in the dummy structures back to a full induction programme when i was testing with insomnia. This is needed so i can properly test the response on Engage and Learn side so that we're not allowing full induction programme users to log in. 

### Changes proposed in this pull request

Adding a third school with a cohort on a full induction programme.
Making each mentor and ect match up.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
