### PR TITLE
CPDRP-443 notification banners for opted-out schools

### DIFF
--- a/app/components/school_recruited_transition_component.rb
+++ b/app/components/school_recruited_transition_component.rb
@@ -6,8 +6,8 @@ class SchoolRecruitedTransitionComponent < BaseComponent
   end
 
   def render?
-    return false unless school_cohort.school_chose_cip?
     return false if partnership.blank?
+    return false unless could_show_banner_for_programme_choice?
 
     partnership.in_challenge_window? && !partnership.challenged?
   end
@@ -21,6 +21,10 @@ private
       school_id: school_cohort.school_id,
       cohort_id: school_cohort.cohort_id,
     )
+  end
+
+  def could_show_banner_for_programme_choice?
+    school_cohort.induction_programme_choice.in? %w[core_induction_programme design_our_own no_early_career_teachers]
   end
 
   delegate :lead_provider, to: :partnership

--- a/app/jobs/partnership_activation_job.rb
+++ b/app/jobs/partnership_activation_job.rb
@@ -10,7 +10,9 @@ class PartnershipActivationJob < ApplicationJob
     ActiveRecord::Base.transaction do
       partnership.update!(pending: false)
       school_cohort = SchoolCohort.find_by!(school_id: partnership.school_id, cohort_id: partnership.cohort_id)
-      school_cohort.update!(induction_programme_choice: "full_induction_programme", core_induction_programme: nil)
+      school_cohort.update!(induction_programme_choice: "full_induction_programme",
+                            core_induction_programme: nil,
+                            opt_out_of_updates: false)
     end
   end
 end

--- a/spec/components/school_recruited_transition_component_spec.rb
+++ b/spec/components/school_recruited_transition_component_spec.rb
@@ -12,12 +12,12 @@ RSpec.shared_examples "school has chosen a challengable programme" do |induction
   end
 
   context "with fip partnership within challenge window" do
-    let!(:partnership) { create :partnership, :in_challenge_window, school: school, cohort: cohort }
+    let!(:partnership) { create :partnership, :in_challenge_window, :pending, school: school, cohort: cohort }
 
     it { is_expected.to render }
 
     context "and the partnership has been challenged" do
-      let!(:partnership) { create :partnership, :challenged, school: school, cohort: cohort }
+      let!(:partnership) { create :partnership, :challenged, :pending, school: school, cohort: cohort }
 
       it { is_expected.not_to render }
     end

--- a/spec/components/school_recruited_transition_component_spec.rb
+++ b/spec/components/school_recruited_transition_component_spec.rb
@@ -2,36 +2,40 @@
 
 require "rails_helper"
 
-RSpec.describe SchoolRecruitedTransitionComponent, type: :component do
-  subject(:component) { described_class.new school_cohort: school_cohort }
-
+RSpec.shared_examples "school has chosen a challengable programme" do |induction_choice|
   let(:school_cohort) { create :school_cohort, induction_programme_choice: induction_choice }
   let(:school) { school_cohort.school }
   let(:cohort) { school_cohort.cohort }
 
-  context "when school did not choose cip" do
-    let(:induction_choice) { SchoolCohort.induction_programme_choices.keys.without("core_induction_programme").sample }
+  context "without fip partnership for given school" do
+    it { is_expected.not_to render }
+  end
+
+  context "with fip partnership within challenge window" do
+    let!(:partnership) { create :partnership, :in_challenge_window, school: school, cohort: cohort }
+
+    it { is_expected.to render }
+
+    context "and the partnership has been challenged" do
+      let!(:partnership) { create :partnership, :challenged, school: school, cohort: cohort }
+
+      it { is_expected.not_to render }
+    end
+  end
+end
+
+RSpec.describe SchoolRecruitedTransitionComponent, type: :component do
+  subject(:component) { described_class.new school_cohort: school_cohort }
+
+  let(:school_cohort) { create :school_cohort, induction_programme_choice: induction_choice }
+
+  context "when school did not choose CIP or an opt-out programme" do
+    let(:induction_choice) { SchoolCohort.induction_programme_choices.keys.without("core_induction_programme", "design_our_own", "no_early_career_teachers").sample }
 
     it { is_expected.not_to render }
   end
 
-  context "when school has chosen core induction programme" do
-    let(:induction_choice) { "core_induction_programme" }
-
-    context "without fip partnership for given school" do
-      it { is_expected.not_to render }
-    end
-
-    context "with fip partnership within challenge window" do
-      let!(:partnership) { create :partnership, :in_challenge_window, school: school, cohort: cohort }
-
-      it { is_expected.to render }
-
-      context "and the partnership has been challenged" do
-        let!(:partnership) { create :partnership, :challenged, school: school, cohort: cohort }
-
-        it { is_expected.not_to render }
-      end
-    end
-  end
+  include_examples "school has chosen a challengable programme", "core_induction_programme"
+  include_examples "school has chosen a challengable programme", "design_our_own"
+  include_examples "school has chosen a challengable programme", "no_early_career_teachers"
 end

--- a/spec/cypress/app_commands/scenarios/school_opted_out_but_was_recruited.rb
+++ b/spec/cypress/app_commands/scenarios/school_opted_out_but_was_recruited.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+school = FactoryBot.create(:school, urn: "900499", name: "Optout High School")
+lead_provider = FactoryBot.create(:lead_provider, name: "Fab Provider")
+delivery_partner = FactoryBot.create(:delivery_partner, name: "Ranchero Partners")
+
+FactoryBot.create(:user, :induction_coordinator, schools: [school], full_name: "Ted Tutor", email: "ted.tutor@example.com")
+
+SchoolCohort.create!(school: school,
+                     induction_programme_choice: "design_our_own",
+                     opt_out_of_updates: true,
+                     cohort: Cohort.current)
+
+FactoryBot.create(:partnership,
+                  :in_challenge_window,
+                  delivery_partner: delivery_partner,
+                  lead_provider: lead_provider,
+                  school: school,
+                  cohort: Cohort.current) 

--- a/spec/cypress/app_commands/scenarios/school_opted_out_but_was_recruited.rb
+++ b/spec/cypress/app_commands/scenarios/school_opted_out_but_was_recruited.rb
@@ -16,4 +16,4 @@ FactoryBot.create(:partnership,
                   delivery_partner: delivery_partner,
                   lead_provider: lead_provider,
                   school: school,
-                  cohort: Cohort.current) 
+                  cohort: Cohort.current)

--- a/spec/cypress/integration/schools/SeeChallengeBanners.feature
+++ b/spec/cypress/integration/schools/SeeChallengeBanners.feature
@@ -1,0 +1,19 @@
+Feature: Induction tutors seeing challenge banners
+  Induction tutors should be able to see a banner informing them that
+  they have ben recruited by a provider when they have chosen an opt-out
+  programme
+
+  Background:
+    Given cohort was created with start_year "2021"
+    And scenario "school_opted_out_but_was_recruited" has been run
+    And I am logged in as existing user with email "ted.tutor@example.com"
+    Then I should be on "schools" page
+    And the page should be accessible
+
+  Scenario: Viewing the next steps page
+    When I click on "link" containing "2021"
+    Then I should be on "2021 school cohorts" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Opted out with banner"
+    And "page body" should contain "Important"
+    And "page body" should contain "Ranchero Partners, with Fab Provider, has confirmed your school"

--- a/spec/jobs/partnership_activation_job_spec.rb
+++ b/spec/jobs/partnership_activation_job_spec.rb
@@ -17,13 +17,28 @@ RSpec.describe PartnershipActivationJob do
 
     def execute
       subject.perform(partnership: partnership, report_id: report_id)
+      partnership.reload
+      school_cohort.reload
     end
 
     it "updates the partnership and school cohort" do
       execute
 
-      expect(partnership.reload.pending).to eql false
-      expect(school_cohort.reload.induction_programme_choice).to eql "full_induction_programme"
+      expect(partnership).not_to be_pending
+      expect(school_cohort).to be_full_induction_programme
+    end
+
+    context "when school had chosen to opt-out" do
+      before do
+        school_cohort.update!(induction_programme_choice: "no_early_career_teachers",
+                              opt_out_of_updates: true)
+      end
+
+      it "opts the school back in" do
+        execute
+
+        expect(school_cohort).not_to be_opt_out_of_updates
+      end
     end
 
     context "when partnership has been challenged" do


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?selectedIssue=CPDRP-443)
Show notification banners to schools that have chosen to opt-out (diy or no ECTs) if they have been recruited by a provider

### Changes proposed in this pull request
Change  condition under which the `SchoolRecruitedTransitionComponent` decides whether to render or not
Change `PartnershipActivationJob` to clear the `opt_out_of_updates` flag on `SchoolCohort`

### Guidance to review
Given a school that has chosen either the DIY or no ECTs programme choice for the current cohort:
1. create a partnership for the current cohort
2. Observe that during the challenge window, when you visit the schools dashboard and select the opted out cohort you should see the banner warning the school of the recruitment and providing the ability to challenge it.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
