### PR TITLE
Fix calculation of band's subtotal in output payment

### DIFF
--- a/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
@@ -19,7 +19,7 @@ module PaymentCalculator
         end
 
         def output_payment_for_event(event_type:, total_participants:, band:)
-          total_participants * output_payment_per_participant_for_event(event_type: event_type, band: band)
+          [band.number_of_participants_in_this_band(total_participants), total_participants].min * output_payment_per_participant_for_event(event_type: event_type, band: band)
         end
 
         def output_payment_per_participant_for_event(event_type:, band:)

--- a/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
@@ -19,7 +19,7 @@ module PaymentCalculator
         end
 
         def output_payment_for_event(event_type:, total_participants:, band:)
-          [band.number_of_participants_in_this_band(total_participants), total_participants].min * output_payment_per_participant_for_event(event_type: event_type, band: band)
+          band.number_of_participants_in_this_band(total_participants) * output_payment_per_participant_for_event(event_type: event_type, band: band)
         end
 
         def output_payment_per_participant_for_event(event_type:, band:)

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -28,8 +28,6 @@ namespace :payment_calculation do
       event_type: :started,
     )
 
-    puts "*** breakdown #{JSON.pretty_generate(breakdown)}"
-
     service_fees = breakdown.dig(:service_fees).each_with_object([]) do |hash, bands|
       bands << [
         band_name_from_index(bands.length),

--- a/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
@@ -6,6 +6,11 @@ class DummyClass
 end
 
 describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
+  let(:contract) { create(:call_off_contract) }
+  let(:band_a) { create(:participant_band, min: 0, max: 200, per_participant: 100, call_off_contract: contract) }
+  let(:band_b) { create(:participant_band, min: 201, max: 400, per_participant: 200, call_off_contract: contract) }
+  let(:band_c) { create(:participant_band, min: 401, max: 500, per_participant: 300, call_off_contract: contract) }
+
   it "performs calculations of the output payments" do
     band_a = double("Band Double", per_participant: 996.00)
     contract = double("Contract Double", band_a: band_a)
@@ -20,5 +25,17 @@ describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
     %i[retention_1 retention_2 retention_3 retention_4].each do |event_type|
       expect(call_off_contract.output_payment_per_participant_for_event(event_type: event_type, band: band_a).round(0)).to eq(90.00)
     end
+  end
+
+  it "calculates subtotal based on banding total participants" do
+    contract = double("Contract Double", band_a: band_a)
+    call_off_contract = DummyClass.new({ contract: contract, band_a: band_a, band_b: band_b, band_c: band_c })
+
+    expect(call_off_contract.output_payment_for_event(event_type: :started, total_participants: 500, band: band_a)).to eq(2400.00)
+    expect(call_off_contract.output_payment_for_event(event_type: :started, total_participants: 500, band: band_b)).to eq(4800.00)
+    expect(call_off_contract.output_payment_for_event(event_type: :started, total_participants: 500, band: band_c)).to eq(3600.00)
+
+    expect(call_off_contract.output_payment_for_event(event_type: :started, total_participants: 50, band: band_a)).to eq(600.00)
+    expect(call_off_contract.output_payment_for_event(event_type: :started, total_participants: 90, band: band_a)).to eq(1080.00)
   end
 end

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CalculationOrchestrator do
           started: {
             retained_participants: 10,
             per_participant: 117.0,
-            subtotal: 1175.0,
+            subtotal: 0.0,
           },
         },
         {
@@ -45,7 +45,7 @@ RSpec.describe CalculationOrchestrator do
           started: {
             retained_participants: 10,
             per_participant: 116.0,
-            subtotal: 1159.0,
+            subtotal: 0.0,
           },
         },
       ],


### PR DESCRIPTION
### Context

The bug in the calculation when total number of participants was used for each band's subtotal

### How can I view this in a review app?

```rake payment_calculation:breakdown Capita 4500```

Should return correct result as per jira [ticket](https://dfedigital.atlassian.net/browse/CPDTP-110) 