### PR TITLE
add api endpoint to create npq profiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,8 @@ gem "aws-sdk-s3", require: false
 
 gem "activerecord-session_store"
 
+gem "jsonapi-resources"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,10 @@ GEM
     jmespath (1.4.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jsonapi-resources (0.10.5)
+      activerecord (>= 4.1)
+      concurrent-ruby
+      railties (>= 4.1)
     jsonapi-rspec (0.0.11)
       rspec-core
       rspec-expectations
@@ -537,6 +541,7 @@ DEPENDENCIES
   health_check!
   httpclient (~> 2.8, >= 2.8.3)
   json-schema
+  jsonapi-resources
   jsonapi-rspec
   jsonapi-serializer
   kaminari (>= 1.2.0)

--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NpqProfilesController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include JSONAPI::ActsAsResourceController
+
+    private
+
+      def access_scope
+        ApiToken.where(private_api_access: true)
+      end
+    end
+  end
+end

--- a/app/models/npq_course.rb
+++ b/app/models/npq_course.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class NpqCourse < ApplicationRecord
+  has_many :npq_profiles
+end

--- a/app/models/npq_lead_provider.rb
+++ b/app/models/npq_lead_provider.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class NpqLeadProvider < ApplicationRecord
+end

--- a/app/models/npq_profile.rb
+++ b/app/models/npq_profile.rb
@@ -4,4 +4,10 @@ class NpqProfile < ApplicationRecord
   belongs_to :user
   belongs_to :npq_lead_provider
   belongs_to :npq_course
+
+  enum headteacher_status: {
+    no: "no",
+    yes_in_first_two_years: "yes_in_first_two_years",
+    yes_over_two_years: "yes_over_two_years",
+  }
 end

--- a/app/models/npq_profile.rb
+++ b/app/models/npq_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NpqProfile < ApplicationRecord
+  belongs_to :user
+  belongs_to :npq_lead_provider
+  belongs_to :npq_course
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_one :admin_profile, dependent: :destroy
   has_one :early_career_teacher_profile, dependent: :destroy
   has_one :mentor_profile, dependent: :destroy
+  has_many :npq_profiles, dependent: :destroy
 
   validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, notify_email: true

--- a/app/resources/api/v1/npq_course_resource.rb
+++ b/app/resources/api/v1/npq_course_resource.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NpqCourseResource < JSONAPI::Resource
+      has_many :npq_profiles
+    end
+  end
+end

--- a/app/resources/api/v1/npq_lead_provider_resource.rb
+++ b/app/resources/api/v1/npq_lead_provider_resource.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NpqLeadProviderResource < JSONAPI::Resource
+      has_many :npq_profiles
+    end
+  end
+end

--- a/app/resources/api/v1/npq_profile_resource.rb
+++ b/app/resources/api/v1/npq_profile_resource.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NpqProfileResource < JSONAPI::Resource
+      attributes :date_of_birth,
+                 :teacher_reference_number,
+                 :teacher_reference_number_verified,
+                 :school_urn,
+                 :headteacher_status
+
+      has_one :user
+      has_one :npq_lead_provider
+      has_one :npq_course
+    end
+  end
+end

--- a/app/resources/api/v1/user_resource.rb
+++ b/app/resources/api/v1/user_resource.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UserResource < JSONAPI::Resource
+      has_many :npq_profiles
+    end
+  end
+end

--- a/config/initializers/json_api.rb
+++ b/config/initializers/json_api.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+JSONAPI.configure do |config|
+  # built in key format options are :underscored_key, :camelized_key and :dasherized_key
+  config.json_key_format = :underscored_key
+
+  config.resource_key_type = :uuid
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,8 @@ Rails.application.routes.draw do
       resources :participant_declarations, only: %i[create], path: "participant-declarations"
       resources :users, only: %i[index create]
       resources :dqt_records, only: :show, path: "dqt-records"
+
+      jsonapi_resources :npq_profiles, only: [:create]
     end
   end
 

--- a/db/migrate/20210616103630_create_npq_lead_providers.rb
+++ b/db/migrate/20210616103630_create_npq_lead_providers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateNpqLeadProviders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :npq_lead_providers do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210616103631_create_npq_profiles.rb
+++ b/db/migrate/20210616103631_create_npq_profiles.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateNpqProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :npq_profiles do |t|
+      t.references :user
+      t.references :npq_lead_provider
+      t.references :npq_course
+
+      t.date :date_of_birth
+      t.text :teacher_reference_number
+      t.boolean :teacher_reference_number_verified, default: false
+      t.text :school_urn
+      t.text :headteacher_status # no, yes_in_first_two_years, yes_over_two_years
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210616144524_create_npq_courses.rb
+++ b/db/migrate/20210616144524_create_npq_courses.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateNpqCourses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :npq_courses do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_135010) do
+ActiveRecord::Schema.define(version: 2021_06_16_144524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -289,6 +289,34 @@ ActiveRecord::Schema.define(version: 2021_06_15_135010) do
     t.index ["partnership_notification_email_id"], name: "index_nomination_emails_on_partnership_notification_email_id"
     t.index ["school_id"], name: "index_nomination_emails_on_school_id"
     t.index ["token"], name: "index_nomination_emails_on_token", unique: true
+  end
+
+  create_table "npq_courses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "npq_lead_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "npq_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "npq_lead_provider_id", null: false
+    t.uuid "npq_course_id", null: false
+    t.date "date_of_birth"
+    t.text "teacher_reference_number"
+    t.boolean "teacher_reference_number_verified", default: false
+    t.text "school_urn"
+    t.text "headteacher_status"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
+    t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
+    t.index ["user_id"], name: "index_npq_profiles_on_user_id"
   end
 
   create_table "participant_bands", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -34,3 +34,28 @@ LeadProviderCip.find_or_create_by!(lead_provider: ucl, cohort: cohort_2021, core
 PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)
   .tap { |pp| pp.html = Rails.root.join("db/seeds/privacy_policy_1.0.html").read }
   .save!
+
+[
+  "Ambition Institute",
+  "Best Practice Network",
+  "Church of England",
+  "Education Development Trust",
+  "School-Led Network",
+  "Leadership Learning South East",
+  "Teacher Development Trust",
+  "Teach First",
+  "UCL Institute of Education",
+].each do |npq_lead_provider_name|
+  NpqLeadProvider.find_or_create_by!(name: npq_lead_provider_name)
+end
+
+[
+  "NPQ Leading Teaching (NPQLT)",
+  "NPQ Leading Behaviour and Culture (NPQLBC)",
+  "NPQ Leading Teacher Development (NPQLTD)",
+  "NPQ for Senior Leadership (NPQSL)",
+  "NPQ for Headship (NPQH)",
+  "NPQ for Executive Leadership (NPQEL)",
+].each do |course_name|
+  NpqCourse.find_or_create_by!(name: course_name)
+end

--- a/spec/factories/npq_courses.rb
+++ b/spec/factories/npq_courses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :npq_course do
+    sequence(:name) { |n| "NPQ Course #{n}" }
+  end
+end

--- a/spec/factories/npq_lead_providers.rb
+++ b/spec/factories/npq_lead_providers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :npq_lead_provider do
+    sequence(:name) { |n| "NPQ Lead Provider #{n}" }
+  end
+end

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NPQ profiles api endpoint", type: :request do
+  let(:token) { NpqRegistrationApiToken.create_with_random_token! }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:parsed_response) { JSON.parse(response.body) }
+
+  describe "#create" do
+    let(:user) { create(:user) }
+    let(:npq_lead_provider) { create(:npq_lead_provider) }
+    let(:npq_course) { create(:npq_course) }
+
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+        default_headers["Content-Type"] = "application/vnd.api+json"
+      end
+
+      let(:json) do
+        {
+          data: {
+            type: "npq_profiles",
+            attributes: {
+              teacher_reference_number: "1234567",
+              teacher_reference_number_verified: true,
+              date_of_birth: "1990-12-13",
+              school_urn: "123456",
+              headteacher_status: "no",
+            },
+            relationships: {
+              user: {
+                data: {
+                  type: "users",
+                  id: user.id,
+                },
+              },
+              npq_lead_provider: {
+                data: {
+                  type: "npq_lead_providers",
+                  id: npq_lead_provider.id,
+                },
+              },
+              npq_course: {
+                data: {
+                  type: "npq_courses",
+                  id: npq_course.id,
+                },
+              },
+            },
+          },
+        }.to_json
+      end
+
+      it "creates the npq_profile" do
+        expect {
+          post "/api/v1/npq-profiles", params: json
+        }.to change(NpqProfile, :count).by(1)
+
+        profile = NpqProfile.order(created_at: :desc).first
+
+        expect(profile.user).to eql(user)
+        expect(profile.npq_lead_provider).to eql(npq_lead_provider)
+        expect(profile.date_of_birth).to eql(Date.new(1990, 12, 13))
+        expect(profile.teacher_reference_number).to eql("1234567")
+        expect(profile.teacher_reference_number_verified).to be_truthy
+        expect(profile.school_urn).to eql("123456")
+        expect(profile.headteacher_status).to eql("no")
+        expect(profile.npq_course).to eql(npq_course)
+      end
+
+      it "returns a 201" do
+        post "/api/v1/npq-profiles", params: json
+        expect(response).to be_created
+      end
+
+      it "returns correct jsonapi content type header" do
+        post "/api/v1/npq-profiles", params: json
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns correct type" do
+        post "/api/v1/npq-profiles", params: json
+        expect(parsed_response["data"]).to have_type("npq_profiles")
+      end
+
+      it "response has correct attributes" do
+        post "/api/v1/npq-profiles", params: json
+
+        profile = NpqProfile.order(created_at: :desc).first
+
+        expect(parsed_response["data"]["id"]).to eql(profile.id)
+        expect(parsed_response["data"]).to have_jsonapi_attributes(
+          :teacher_reference_number,
+          :headteacher_status,
+          :date_of_birth,
+          :school_urn,
+        )
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        post "/api/v1/npq-profiles"
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "using valid token but for different scope" do
+      let(:other_token) { ApiToken.create_with_random_token! }
+
+      it "returns 403" do
+        default_headers[:Authorization] = "Bearer #{other_token}"
+        post "/api/v1/npq-profiles"
+        expect(response.status).to eq 403
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- NPQ registration collects data on applications of NPQ courses
- We need to push these applications into ECF with profiles (`NpqProfile`)
- A user can have multiple applications therefore are able to have multiple `NpqProfile`s

### Changes proposed in this pull request

-  add `jsonapi-resources` gem which does all the heavy lifting of ingesting and producing jsonapi compliant requests and responses
- I have been able to call this endpoint successfully with `json_api_client`

### Guidance to review

- Of all the libraries looked at, this ones seems the most mature and ticked most of the boxes I feel for our needs
- I can revisit other api endpoints I have recently created and swap out to use this framework instead at a later PR
- I did attempt load the seeds file at before the test suite ran but this cause many failures. Is this something we want to consider since the app seems to depends on a load of static data why don't we load these seeds before the test suite kicks in?

### Testing

- create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- note down the token
- create a user with

```
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" -X POST -d '{ "data": { "type": "user", "attributes": { "full_name": "John Doe", "email": "john.doe@example.com" } } }' http://localhost:3001/api/v1/users
```

- note down the id of the newly created user

```
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" -X POST -d '{"data":{"type":"npq_profiles","attributes":{"teacher_reference_number":"1234567","teacher_reference_number_verified":true,"date_of_birth":"1990-12-13","school_urn":"123456","headteacher_status":"no"},"relationships":{"user":{"data":{"type":"users","id":"USER_ID_HERE"}},"npq_lead_provider":{"data":{"type":"npq_lead_providers","id":"NPQ_LEAD_PROVIDER_ID"}},"npq_course":{"data":{"type":"npq_courses","id":"NPQ_COURSE_ID"}}}}}' http://localhost:3001/api/v1/npq-profiles
```

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- cant test in review app as i modified a migration and forced push and now db is out of sync. i have no idea how to teardown and setup review app again to fix this. just wasted 30 minutes figuring this out