### PR TITLE
Remove n+1 queries from users api

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -47,7 +47,7 @@ module Api
       end
 
       def users
-        users = User.all.includes(early_career_teacher_profile: [:core_induction_programme], mentor_profile: [:core_induction_programme])
+        users = User.includes_school
 
         if updated_since.present?
           users = users.changed_since(updated_since)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -46,9 +46,10 @@ class UserSerializer
   end
 
   attributes :induction_programme_choice do |user|
+    @school_cohorts ||= SchoolCohort.all.to_a
     if user.participant?
-      school_cohort = SchoolCohort.find_by(school: user.school, cohort: user.cohort)
-      school_cohort.induction_programme_choice
+      school_cohort = @school_cohorts.find { |sc| (sc.school_id == user.school&.id) && (sc.cohort_id == user.cohort&.id) }
+      school_cohort&.induction_programme_choice
     end
   end
 end


### PR DESCRIPTION
### Context
I played with the users api for other reasons, and noticed n+1 queries

### Changes proposed in this pull request
Cache school cohorts in the user serialiser. Use existing scope to get user schools alongside their profiles.

### Guidance to review

If there is a way to accomplish adding a `school_cohort` to the relevant profiles in a railsy association, I would love to know about it. We have a school, we have a cohort, but I don't know how to tell Rails 'and by the way, that defines a school_cohort'.

And that would be imo a neater solution - cause then we could just include `school_cohort` in our query for users.
