### PR TITLE
Bugfix: Ensure we don't return any nil schools after CSV upload

### DIFF
--- a/spec/models/partnership_csv_upload_spec.rb
+++ b/spec/models/partnership_csv_upload_spec.rb
@@ -142,6 +142,13 @@ RSpec.describe PartnershipCsvUpload, type: :model do
 
       expect(@subject.valid_schools).to contain_exactly(valid_school)
     end
+
+    it "deals with leading zeros in URNs" do
+      school_with_leading_zero = create(:school, urn: "20001")
+      given_the_csv_contains_urns(%w[020001])
+
+      expect(@subject.valid_schools).to contain_exactly(school_with_leading_zero)
+    end
   end
 
 private


### PR DESCRIPTION
A user reported an issue uploading a URN with a leading zero. This
should handle now, but I've added some Sentry logging to catch if I've
missed anything

