### PR TITLE
hardcode NPQ ids for resources

### DIFF
--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -36,26 +36,26 @@ PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)
   .save!
 
 [
-  "Ambition Institute",
-  "Best Practice Network",
-  "Church of England",
-  "Education Development Trust",
-  "School-Led Network",
-  "Leadership Learning South East",
-  "Teacher Development Trust",
-  "Teach First",
-  "UCL Institute of Education",
-].each do |npq_lead_provider_name|
-  NpqLeadProvider.find_or_create_by!(name: npq_lead_provider_name)
+  { name: "Ambition Institute", id: "9e35e998-c63b-4136-89c4-e9e18ddde0ea" },
+  { name: "Best Practice Network", id: "57ba9e86-559f-4ff4-a6d2-4610c7259b67" },
+  { name: "Church of England", id: "79cb41ca-cb6d-405c-b52c-b6f7c752388d" },
+  { name: "Education Development Trust", id: "21e61f53-9b34-4384-a8f5-d8224dbf946d" },
+  { name: "School-Led Network", id: "bc5e4e37-1d64-4149-a06b-ad10d3c55fd0" },
+  { name: "Leadership Learning South East", id: "230e67c0-071a-4a48-9673-9d043d456281" },
+  { name: "Teacher Development Trust", id: "30fd937e-b93c-4f81-8fff-3c27544193f1" },
+  { name: "Teach First", id: "a02ae582-f939-462f-90bc-cebf20fa8473" },
+  { name: "UCL Institute of Education", id: "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7" },
+].each do |hash|
+  NpqLeadProvider.find_or_create_by!(name: hash[:name], id: hash[:id])
 end
 
 [
-  "NPQ Leading Teaching (NPQLT)",
-  "NPQ Leading Behaviour and Culture (NPQLBC)",
-  "NPQ Leading Teacher Development (NPQLTD)",
-  "NPQ for Senior Leadership (NPQSL)",
-  "NPQ for Headship (NPQH)",
-  "NPQ for Executive Leadership (NPQEL)",
-].each do |course_name|
-  NpqCourse.find_or_create_by!(name: course_name)
+  { name: "NPQ Leading Teaching (NPQLT)", id: "15c52ed8-06b5-426e-81a2-c2664978a0dc" },
+  { name: "NPQ Leading Behaviour and Culture (NPQLBC)", id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" },
+  { name: "NPQ Leading Teacher Development (NPQLTD)", id: "29fee78b-30ce-4b93-ba21-80be2fde286f" },
+  { name: "NPQ for Senior Leadership (NPQSL)", id: "a42736ad-3d0b-401d-aebe-354ef4c193ec" },
+  { name: "NPQ for Headship (NPQH)", id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768" },
+  { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
+].each do |hash|
+  NpqCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
 end


### PR DESCRIPTION
### Context

- database is constantly teared down so identifiers keep changing in certain environments
- which means external references to these resources will not be in sync

### Changes proposed in this pull request

- hardcode ids on NPQ resources so integration environments do not break 
- Might cause dupes in staging and prod but I can resolve those by hand

### Guidance to review

- Seeding process should continue to work

### Testing

- Should be able to run seeds multiple times

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Log onto box
- Seeded data should match that of seeds file