### PR TITLE
CPDRP-498 Fix issue with Change link for mentor

### DIFF
--- a/app/views/schools/add_participants/confirm.html.erb
+++ b/app/views/schools/add_participants/confirm.html.erb
@@ -57,7 +57,7 @@
             </div>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <% unless add_participant_form.type == :self || add_participant_form.mentor_options.blank? %>
+            <% if add_participant_form.type != :self && add_participant_form.mentor_options.any? %>
               <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
               <%= govuk_link_to({ action: :show, step: "choose-mentor" }, button: false) do %>
                 Change <span class="govuk-visually-hidden">mentor</span>

--- a/app/views/schools/add_participants/confirm.html.erb
+++ b/app/views/schools/add_participants/confirm.html.erb
@@ -17,6 +17,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% unless add_participant_form.type == :self %>
+            <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
             <%= govuk_link_to({ action: :show, step: "details" }, button: false) do %>
               Change <span class="govuk-visually-hidden">personal details</span>
             <% end %>
@@ -33,6 +34,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% unless add_participant_form.type == :self %>
+            <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
             <%= govuk_link_to({ action: :show, step: "type" }, button: false) do %>
               Change <span class="govuk-visually-hidden">participant type</span>
             <% end %>
@@ -56,6 +58,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% unless add_participant_form.type == :self || add_participant_form.mentor_options.blank? %>
+              <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
               <%= govuk_link_to({ action: :show, step: "choose-mentor" }, button: false) do %>
                 Change <span class="govuk-visually-hidden">mentor</span>
               <% end %>

--- a/app/views/schools/add_participants/confirm.html.erb
+++ b/app/views/schools/add_participants/confirm.html.erb
@@ -17,7 +17,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% unless add_participant_form.type == :self %>
-            <%= govuk_link_to({ action: :show, step: "details" }) do %>
+            <%= govuk_link_to({ action: :show, step: "details" }, button: false) do %>
               Change <span class="govuk-visually-hidden">personal details</span>
             <% end %>
           <% end %>
@@ -33,7 +33,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% unless add_participant_form.type == :self %>
-            <%= govuk_link_to({ action: :show, step: "type" }) do %>
+            <%= govuk_link_to({ action: :show, step: "type" }, button: false) do %>
               Change <span class="govuk-visually-hidden">participant type</span>
             <% end %>
           <% end %>
@@ -55,9 +55,9 @@
             </div>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <% unless add_participant_form.type == :self %>
-              <%= govuk_link_to({ action: :show, step: "details" }) do %>
-                Change <span class="govuk-visually-hidden">personal details</span>
+            <% unless add_participant_form.type == :self || add_participant_form.mentor_options.blank? %>
+              <%= govuk_link_to({ action: :show, step: "choose-mentor" }, button: false) do %>
+                Change <span class="govuk-visually-hidden">mentor</span>
               <% end %>
             <% end %>
           </dd>

--- a/spec/cypress/app_commands/scenarios/no_mentors_for_participants.rb
+++ b/spec/cypress/app_commands/scenarios/no_mentors_for_participants.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+school = School.find_by(name: "Hogwarts Academy")
+if school.present?
+  school.mentor_profiles.each do |profile|
+    EarlyCareerTeacherProfile.where(mentor_profile: profile).update_all(mentor_profile_id: nil)
+    profile.user.destroy!
+  end
+  school.reload
+end

--- a/spec/cypress/app_commands/scenarios/no_mentors_for_participants.rb
+++ b/spec/cypress/app_commands/scenarios/no_mentors_for_participants.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# expects "school_participants" to have been previously run
+#
 school = School.find_by(name: "Hogwarts Academy")
 if school.present?
   school.mentor_profiles.each do |profile|

--- a/spec/cypress/integration/schools/AddParticipants.feature
+++ b/spec/cypress/integration/schools/AddParticipants.feature
@@ -37,6 +37,7 @@ Feature: School leaders should be able to manage participants
     When I click on "Abdul Mentor" label
     And I click the submit button
     Then I should be on "2021 school participant confirm" page
+    And "page body" should contain "Change mentor"
     And the page should be accessible
     And percy should be sent snapshot called "school ect participant confirmation page"
 
@@ -118,3 +119,22 @@ Feature: School leaders should be able to manage participants
     Then "page body" should contain "You have been added to the 2021 cohort"
     And the page should be accessible
     And percy should be sent snapshot called "school self as a mentor participant added"
+
+  Scenario: Should not have change link when no mentors available
+    Given scenario "no_mentors_for_participants" has been run
+
+    When I click the submit button
+    Then "page body" should contain "Please select type of the new participant"
+
+    When I set "new participant type radio" to "ect"
+    And I click the submit button
+    Then I should be on "2021 school participant details" page
+
+    When I type "Arthur Hall" into field labelled "Full name"
+    And I type "arthur.hall@school.gov.uk" into field labelled "Email"
+    And I click the submit button
+
+    Then I should be on "2021 school participant confirm" page
+    And "page body" should not contain "Change mentor"
+    And the page should be accessible
+    And percy should be sent snapshot called "school ect participant without mentor confirmation page"


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?selectedIssue=CPDRP-498)
Fix wrong link action and remove link when no mentor available to select.  Also add workaround for `govuk_link_to` [issue](https://github.com/DFE-Digital/govuk-components/issues/193)

### Changes proposed in this pull request
Make Change mentor link point to the mentor selection step.
Remove Change mentor link when no mentors available.
Workaround for `govuk_link_to` issue by adding `button: false` to method params so it can correctly handle `url_options`.

### Guidance to review
As an induction tutor, for a school with no mentors, add an ECT.
On the confirmation step, there should be no "Change" link for the Mentor.
Repeat once a mentor has been added and the Change link should be visible.
Clicking the Change link takes you to the mentor selection step.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
