### PR TITLE
CPDTP-109 Display ECF uplift payments

### DIFF
--- a/app/services/calculation_orchestrator.rb
+++ b/app/services/calculation_orchestrator.rb
@@ -1,25 +1,20 @@
 # frozen_string_literal: true
 
 require "participant_event_aggregator"
-require "contract_event_payment_calculator"
+require "payment_calculator/ecf/payment_calculation"
 
 class CalculationOrchestrator
   class << self
-    def call(lead_provider:, aggregator: ::ParticipantEventAggregator, calculator: ::ContractEventPaymentCalculator, event_type: :started)
-      new(lead_provider: lead_provider, aggregator: aggregator, calculator: calculator).call(event_type: event_type)
+    def call(lead_provider:,
+             contract:,
+             aggregator: ::ParticipantEventAggregator,
+             # TODO: Add in aggregator for Uplift as uplift_aggregator: ::ParticipantUpliftAggregator (for example)
+             calculator: ::PaymentCalculator::Ecf::PaymentCalculation,
+             event_type: :started)
+      total_participants = aggregator.call({ lead_provider: lead_provider }, event_type: event_type)
+      uplift_participants = total_participants / 3 # Temporary code to fake the 33% target which will be removed when the aggregation is pulled in.
+      # TODO: uplift_participants = uplift_aggregator.call(leod_provider: event_type:) etc..
+      calculator.call(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, event_type: event_type)
     end
-  end
-
-  def call(event_type:)
-    total_participants = @aggregator.call({ lead_provider: @lead_provider }, event_type: event_type)
-    @calculator.call(lead_provider: @lead_provider, total_participants: total_participants, event_type: event_type)
-  end
-
-private
-
-  def initialize(lead_provider:, aggregator: ::ParticipantEventAggregator, calculator: ::ContractEventPaymentCalculator)
-    @lead_provider = lead_provider
-    @aggregator = aggregator
-    @calculator = calculator
   end
 end

--- a/app/services/calculation_orchestrator.rb
+++ b/app/services/calculation_orchestrator.rb
@@ -9,10 +9,12 @@ class CalculationOrchestrator
              contract:,
              aggregator: ::ParticipantEventAggregator,
              # TODO: Add in aggregator for Uplift as uplift_aggregator: ::ParticipantUpliftAggregator (for example)
+             # This is currently defined in Jira as https://dfedigital.atlassian.net/browse/CPDTP-195
              calculator: ::PaymentCalculator::Ecf::PaymentCalculation,
              event_type: :started)
       total_participants = aggregator.call({ lead_provider: lead_provider }, event_type: event_type)
       uplift_participants = total_participants / 3 # Temporary code to fake the 33% target which will be removed when the aggregation is pulled in.
+      # This is currently defined in Jira as https://dfedigital.atlassian.net/browse/CPDTP-195
       # TODO: uplift_participants = uplift_aggregator.call(leod_provider: event_type:) etc..
       calculator.call(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, event_type: event_type)
     end

--- a/app/services/contract_event_payment_calculator.rb
+++ b/app/services/contract_event_payment_calculator.rb
@@ -4,28 +4,8 @@ require "payment_calculator/ecf/payment_calculation"
 
 class ContractEventPaymentCalculator
   class << self
-    def call(lead_provider:, total_participants:, event_type: :started, payment_calculator: ::PaymentCalculator::Ecf::PaymentCalculation)
-      new(lead_provider: lead_provider, payment_calculator: payment_calculator).call(total_participants: total_participants, event_type: event_type)
+    def call(contract:, total_participants:, uplift_participants:, event_type: :started, payment_calculator: ::PaymentCalculator::Ecf::PaymentCalculation)
+      payment_calculator.call(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, event_type: event_type)
     end
-  end
-
-  # @param [Symbol] event_type
-  # @param [Integer] total_participants
-  # Call the payment_calculator class that performs the actual contracted calculation passing in the total number
-  # of filtered participants and the event type
-  # Instantiate with new(lead_provider: <#lead_provider_instance>) or pass that as the named parameter to the class level
-  # call, e.g.
-  #
-  # ContractEventPaymentCalculator.call(lead_provider: <#lead_provider_instance>, total_participants: 2000, event_type: :started)
-  #
-  def call(total_participants:, event_type:)
-    @payment_calculator.call(lead_provider: @lead_provider, total_participants: total_participants, event_type: event_type)
-  end
-
-private
-
-  def initialize(lead_provider:, payment_calculator: ::PaymentCalculator::Ecf::PaymentCalculation)
-    @lead_provider = lead_provider
-    @payment_calculator = payment_calculator
   end
 end

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -12,8 +12,7 @@ module PaymentCalculator
           include HasDIParameters
         end
 
-        delegate :recruitment_target,
-                 :set_up_fee, :set_up_recruitment_basis, to: :contract
+        delegate :recruitment_target, :set_up_fee, :set_up_recruitment_basis, to: :contract
 
         def service_fee_total(band)
           band.number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant(band)

--- a/lib/payment_calculator/ecf/contract/uplift_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/uplift_payment_calculations.rb
@@ -22,8 +22,8 @@ module PaymentCalculator
           event_type == :started ? uplift_payment_per_participant : 0
         end
 
-        def uplift_payment_for_event(total_participants:, event_type:)
-          total_participants * uplift_payment_per_participant_for_event(event_type: event_type)
+        def uplift_payment_for_event(uplift_participants:, event_type:)
+          uplift_participants * uplift_payment_per_participant_for_event(event_type: event_type)
         end
       end
     end

--- a/lib/payment_calculator/ecf/contract/uplift_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/uplift_payment_calculations.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "has_di_parameters"
+
+module PaymentCalculator
+  module Ecf
+    module Contract
+      module UpliftPaymentCalculations
+        extend ActiveSupport::Concern
+
+        included do
+          include HasDIParameters
+        end
+
+        delegate :uplift_amount, to: :contract
+
+        def uplift_payment_per_participant
+          uplift_amount
+        end
+
+        def uplift_payment_per_participant_for_event(event_type:)
+          event_type == :started ? uplift_payment_per_participant : 0
+        end
+
+        def uplift_payment_for_event(total_participants:, event_type:)
+          total_participants * uplift_payment_per_participant_for_event(event_type: event_type)
+        end
+      end
+    end
+  end
+end

--- a/lib/payment_calculator/ecf/output_payment_retention_event.rb
+++ b/lib/payment_calculator/ecf/output_payment_retention_event.rb
@@ -9,7 +9,7 @@ module PaymentCalculator
 
       def call(total_participants:, event_type:, band:)
         {
-          retained_participants: total_participants,
+          retained_participants: band.number_of_participants_in_this_band(total_participants),
           per_participant: output_payment_per_participant_for_event(event_type: event_type, band: band).round(0),
           subtotal: output_payment_for_event(total_participants: total_participants, event_type: event_type, band: band).round(0),
         }

--- a/lib/payment_calculator/ecf/payment_calculation.rb
+++ b/lib/payment_calculator/ecf/payment_calculation.rb
@@ -2,37 +2,50 @@
 
 require "payment_calculator/ecf/service_fees"
 require "payment_calculator/ecf/output_payment_aggregator"
+require "payment_calculator/ecf/uplift_calculation"
 
 module PaymentCalculator
   module Ecf
     class PaymentCalculation
       class << self
-        def call(lead_provider:, service_fee_calculator: ::PaymentCalculator::Ecf::ServiceFees, output_payment_aggregator: ::PaymentCalculator::Ecf::OutputPaymentAggregator, total_participants: 0, event_type: :started)
-          new(lead_provider: lead_provider, service_fee_calculator: service_fee_calculator, output_payment_aggregator: output_payment_aggregator).call(total_participants: total_participants, event_type: event_type)
+        def call(contract:,
+                 service_fee_calculator: ::PaymentCalculator::Ecf::ServiceFees,
+                 output_payment_aggregator: ::PaymentCalculator::Ecf::OutputPaymentAggregator,
+                 uplift_payment_calculator: ::PaymentCalculator::Ecf::UpliftCalculation,
+                 total_participants: 0,
+                 uplift_participants: 0,
+                 event_type: :started)
+          new(
+            contract: contract,
+            service_fee_calculator: service_fee_calculator,
+            output_payment_aggregator: output_payment_aggregator,
+            uplift_payment_calculator: uplift_payment_calculator,
+          ).call(total_participants: total_participants,
+                 uplift_participants: uplift_participants,
+                 event_type: event_type)
         end
       end
 
-      # @param [Symbol] event_type
-      # @param [Integer] total_participants
-      # This is end number of participants who will be used to make the payment calculation.
-      # All invalid users will have already been filtered out before this number is generated and passed here.
-      def call(total_participants: 0, event_type: :started)
+      def call(total_participants: 0,
+               uplift_participants: 0,
+               event_type: :started)
         {
-          service_fees: @service_fee_calculator.call(contract: contract),
-          output_payments: @output_payment_aggregator.call({ contract: contract }, event_type: event_type, total_participants: total_participants),
+          service_fees: @service_fee_calculator.call({ contract: @contract }),
+          output_payments: @output_payment_aggregator.call({ contract: @contract }, event_type: event_type, total_participants: total_participants),
+          uplift: @uplift_payment_calculator.call({ contract: @contract }, event_type: event_type, uplift_participants: uplift_participants),
         }
       end
 
     private
 
-      def initialize(lead_provider:, service_fee_calculator: ::PaymentCalculator::Ecf::ServiceFees, output_payment_aggregator: ::PaymentCalculator::Ecf::OutputPaymentAggregator)
+      def initialize(contract:,
+                     service_fee_calculator: ::PaymentCalculator::Ecf::ServiceFees,
+                     output_payment_aggregator: ::PaymentCalculator::Ecf::OutputPaymentAggregator,
+                     uplift_payment_calculator: ::PaymentCalculator::Ecf::UpliftCalculation)
+        @contract = contract
         @service_fee_calculator = service_fee_calculator
         @output_payment_aggregator = output_payment_aggregator
-        @lead_provider = lead_provider
-      end
-
-      def contract
-        @lead_provider.call_off_contract
+        @uplift_payment_calculator = uplift_payment_calculator
       end
     end
   end

--- a/lib/payment_calculator/ecf/uplift_calculation.rb
+++ b/lib/payment_calculator/ecf/uplift_calculation.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "initialize_with_config"
+
+module PaymentCalculator
+  module Ecf
+    class UpliftCalculation
+      include Ecf::Contract::UpliftPaymentCalculations
+
+      # @param [Symbol] event_type
+      # @param [Integer] total_participants
+      # This is end number of participants who will be used to make the payment calculation.
+      # All invalid users will have already been filtered out before this number is generated and passed here.
+      def call(total_participants: 0, event_type: :started)
+        return nil unless event_type == :started
+
+        config[:contract] ||= lead_provider.call_off_contract
+        {
+          per_participant: uplift_payment_per_participant,
+          monthly: uplift_payment_for_event(event_type: event_type, total_participants: total_participants),
+        }
+      end
+    end
+  end
+end

--- a/lib/payment_calculator/ecf/uplift_calculation.rb
+++ b/lib/payment_calculator/ecf/uplift_calculation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "initialize_with_config"
+require "payment_calculator/ecf/contract/uplift_payment_calculations"
 
 module PaymentCalculator
   module Ecf
@@ -8,16 +8,15 @@ module PaymentCalculator
       include Ecf::Contract::UpliftPaymentCalculations
 
       # @param [Symbol] event_type
-      # @param [Integer] total_participants
+      # @param [Integer] uplift_participants
       # This is end number of participants who will be used to make the payment calculation.
       # All invalid users will have already been filtered out before this number is generated and passed here.
-      def call(total_participants: 0, event_type: :started)
+      def call(uplift_participants: 0, event_type: :started)
         return nil unless event_type == :started
 
-        config[:contract] ||= lead_provider.call_off_contract
         {
           per_participant: uplift_payment_per_participant,
-          monthly: uplift_payment_for_event(event_type: event_type, total_participants: total_participants),
+          sub_total: uplift_payment_for_event(event_type: event_type, uplift_participants: uplift_participants),
         }
       end
     end

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -20,6 +20,7 @@ namespace :payment_calculation do
     end
 
     total_participants = (ARGV[2] || 2000).to_i
+    uplift_participants = (ARGV[3] || 200).to_i
     per_participant_in_bands = lead_provider.call_off_contract.bands.each_with_index.map { |b, i| "£#{b.per_participant.to_i} per participant in #{band_name_from_index(i)}" }.join(", ")
 
     breakdown = PaymentCalculator::Ecf::PaymentCalculation.call(
@@ -27,6 +28,13 @@ namespace :payment_calculation do
       total_participants: total_participants,
       event_type: :started,
     )
+    uplift_calculation = PaymentCalculator::Ecf::UpliftCalculation.call(
+      lead_provider: lead_provider,
+      total_participants: uplift_participants,
+      event_type: :started,
+    )
+
+    puts "*** breakdown #{JSON.pretty_generate(breakdown)}"
 
     service_fees = breakdown.dig(:service_fees).each_with_object([]) do |hash, bands|
       bands << [

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -31,8 +31,6 @@ namespace :payment_calculation do
       event_type: :started,
     )
 
-    puts "*** breakdown #{JSON.pretty_generate(breakdown)}"
-
     service_fees = breakdown.dig(:service_fees).each_with_object([]) do |hash, bands|
       bands << [
         band_name_from_index(bands.length),
@@ -49,8 +47,8 @@ namespace :payment_calculation do
       ]
     end
 
-    uplift_payment = breakdown[:uplift].each_with_object({}) do |(k, v), h|
-      h[k] = "£#{number_to_delimited(v.to_i)}"
+    uplift_payment = breakdown[:uplift].each_with_object({}) do |(type, value), hash|
+      hash[type] = "£#{number_to_delimited(value.to_i)}"
     end
 
     table = Terminal::Table.new(
@@ -75,8 +73,8 @@ namespace :payment_calculation do
     logger.info table
     logger.info output
   rescue StandardError => e
-    puts e.message
-    puts e.backtrace
+    logger.error e.message
+    logger.error e.backtrace
   ensure
     exit(0)
   end

--- a/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
@@ -15,7 +15,7 @@ describe ::PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations do
     if @combined_results.nil?
       expect(call_off_contract.uplift_payment_per_participant.round(2)).to be_a(BigDecimal)
       expect(call_off_contract.uplift_payment_per_participant_for_event(event_type: event_type)).to be_a(BigDecimal)
-      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, total_participants: 100)).to be_a(BigDecimal)
+      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, uplift_participants: 100)).to be_a(BigDecimal)
     end
   end
 
@@ -28,12 +28,12 @@ describe ::PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations do
 
     %i[started].each do |event_type|
       expect(call_off_contract.uplift_payment_per_participant_for_event(event_type: event_type).round(2)).to eq(100.00)
-      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, total_participants: total_participants).round(2)).to eq(33_000.00)
+      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, uplift_participants: total_participants).round(2)).to eq(33_000.00)
     end
 
     %i[retention_1 retention_2 retention_3 retention_4 completion].each do |event_type|
       expect(call_off_contract.uplift_payment_per_participant_for_event(event_type: event_type).round(2)).to eq(0.00)
-      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, total_participants: total_participants.round(2))).to eq(0.00)
+      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, uplift_participants: total_participants.round(2))).to eq(0.00)
     end
   end
 end

--- a/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "payment_calculator/ecf/contract/uplift_payment_calculations"
+
+class DummyClass
+  include PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations
+end
+
+describe ::PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations do
+  it "returns the expected types for uplift" do
+    contract = double("Contract Double", uplift_amount: BigDecimal(100.00, 2))
+    call_off_contract = DummyClass.new({ contract: contract })
+    event_type = :started
+
+    if @combined_results.nil?
+      expect(call_off_contract.uplift_payment_per_participant.round(2)).to be_a(BigDecimal)
+      expect(call_off_contract.uplift_payment_per_participant_for_event(event_type: event_type)).to be_a(BigDecimal)
+      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, total_participants: 100)).to be_a(BigDecimal)
+    end
+  end
+
+  it "performs calculations of the uplift payments" do
+    contract = double("Contract Double", uplift_amount: 100)
+    call_off_contract = DummyClass.new({ contract: contract })
+    total_participants = 330
+
+    expect(call_off_contract.uplift_payment_per_participant.round(0)).to eq(100.00)
+
+    %i[started].each do |event_type|
+      expect(call_off_contract.uplift_payment_per_participant_for_event(event_type: event_type).round(2)).to eq(100.00)
+      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, total_participants: total_participants).round(2)).to eq(33_000.00)
+    end
+
+    %i[retention_1 retention_2 retention_3 retention_4 completion].each do |event_type|
+      expect(call_off_contract.uplift_payment_per_participant_for_event(event_type: event_type).round(2)).to eq(0.00)
+      expect(call_off_contract.uplift_payment_for_event(event_type: event_type, total_participants: total_participants.round(2))).to eq(0.00)
+    end
+  end
+end

--- a/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
@@ -29,7 +29,7 @@ describe ::PaymentCalculator::Ecf::PaymentCalculation do
 
   it "returns the expected types for all outputs" do
     retained_event_aggregations.each do |key, value|
-      result = described_class.call(lead_provider: contract.lead_provider, event_type: key, total_participants: value)
+      result = described_class.call(contract: contract, event_type: key, total_participants: value)
 
       result.dig(:service_fees).each do |service_fee|
         expect(service_fee[:service_fee_per_participant]).to be_a(BigDecimal)
@@ -38,7 +38,7 @@ describe ::PaymentCalculator::Ecf::PaymentCalculation do
       end
     end
 
-    result = described_class.call(lead_provider: contract.lead_provider, event_type: start_event_name, total_participants: participant_for_event)
+    result = described_class.call(contract: contract, event_type: start_event_name, total_participants: participant_for_event)
 
     result.dig(:output_payments).each do |output_payment|
       expect(output_payment.dig(start_event_name, :retained_participants)).to be_an(Integer)

--- a/spec/lib/payment_calculator/ecf/uplift_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/uplift_calculation_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "payment_calculator/ecf/uplift_calculation"
+
+describe ::PaymentCalculator::Ecf::UpliftCalculation do
+  let(:contract) do
+    FactoryBot.create(:call_off_contract)
+  end
+
+  let(:retained_events) do
+    %i[started retained_1 retained_2 retained_3 retained_4 completed]
+  end
+
+  let(:total_participants_eligible) { 330 }
+
+  let(:params) do
+    {
+      contract: contract,
+    }
+  end
+
+  it "returns the expected types for all outputs" do
+    @combined_results = nil
+    retained_events.each do |key|
+      result = described_class.call(lead_provider: contract.lead_provider, event_type: key, total_participants: total_participants_eligible)
+
+      if @combined_results.nil?
+        expect(result.dig(:per_participant)).to be_a(BigDecimal)
+        expect(result.dig(:monthly)).to be_a(BigDecimal)
+      end
+
+      @combined_results ||= { uplift_payment: result }
+    end
+
+    @combined_results[:uplift_payment].each do |_, value|
+      expect(value[:per_participant]).to be_a(BigDecimal)
+      expect(value[:monthly]).to be_a(BigDecimal)
+    end
+  end
+end

--- a/spec/lib/payment_calculator/ecf/uplift_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/uplift_calculation_spec.rb
@@ -22,19 +22,18 @@ describe ::PaymentCalculator::Ecf::UpliftCalculation do
   it "returns the expected types for all outputs" do
     @combined_results = nil
     retained_events.each do |key|
-      result = described_class.call(lead_provider: contract.lead_provider, event_type: key, total_participants: total_participants_eligible)
+      result = described_class.call(contract: contract, event_type: key, total_participants: total_participants_eligible)
 
       if @combined_results.nil?
         expect(result.dig(:per_participant)).to be_a(BigDecimal)
-        expect(result.dig(:monthly)).to be_a(BigDecimal)
+        expect(result.dig(:sub_total)).to be_a(BigDecimal)
       end
 
       @combined_results ||= { uplift_payment: result }
     end
 
     @combined_results[:uplift_payment].each do |_, value|
-      expect(value[:per_participant]).to be_a(BigDecimal)
-      expect(value[:monthly]).to be_a(BigDecimal)
+      expect(value).to be_a(BigDecimal)
     end
   end
 end

--- a/spec/lib/payment_calculator/ecf/uplift_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/uplift_calculation_spec.rb
@@ -20,20 +20,10 @@ describe ::PaymentCalculator::Ecf::UpliftCalculation do
   end
 
   it "returns the expected types for all outputs" do
-    @combined_results = nil
     retained_events.each do |key|
       result = described_class.call(contract: contract, event_type: key, total_participants: total_participants_eligible)
-
-      if @combined_results.nil?
-        expect(result.dig(:per_participant)).to be_a(BigDecimal)
-        expect(result.dig(:sub_total)).to be_a(BigDecimal)
-      end
-
-      @combined_results ||= { uplift_payment: result }
-    end
-
-    @combined_results[:uplift_payment].each do |_, value|
-      expect(value).to be_a(BigDecimal)
+      expect(result.dig(:per_participant)).to be_a(BigDecimal)
+      expect(result.dig(:sub_total)).to be_a(BigDecimal)
     end
   end
 end

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -34,7 +34,7 @@ module OutputPaymentsSteps
                                       per_participant: @per_participant_value)
 
     @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
-    calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)
+    calculator = PaymentCalculator::Ecf::PaymentCalculation.new(contract: @call_off_contract)
     @result = @retention_table.map do |row|
       calculator.call(event_type: row[:payment_type], total_participants: row[:retained_participants])
     end

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -4,6 +4,7 @@ module ServiceFeeSteps
   class DummyClass
     include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
     include PaymentCalculator::Ecf::Contract::OutputPaymentCalculations
+    include PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations
   end
 
   step "I run the calculation" do
@@ -13,11 +14,11 @@ module ServiceFeeSteps
                       set_up_fee: @set_up_fee,
                       band_a: @band_a,
                       bands: [@band_a],
+                      uplift_amount: 100,
                       set_up_recruitment_basis: 2000)
     @call_off_contract = DummyClass.new({ contract: contract,
                                           bands: [@band_a] })
-    lead_provider = double("Lead Provider", call_off_contract: @call_off_contract)
-    calculator = PaymentCalculator::Ecf::PaymentCalculation.new(lead_provider: lead_provider)
+    calculator = PaymentCalculator::Ecf::PaymentCalculation.new(contract: @call_off_contract)
     @result = calculator.call
   end
 end

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CalculationOrchestrator do
         {
           per_participant: 587.0,
           started: {
-            retained_participants: 10,
+            retained_participants: 0,
             per_participant: 117.0,
             subtotal: 0.0,
           },
@@ -43,12 +43,16 @@ RSpec.describe CalculationOrchestrator do
         {
           per_participant: 580.0,
           started: {
-            retained_participants: 10,
+            retained_participants: 0,
             per_participant: 116.0,
             subtotal: 0.0,
           },
         },
       ],
+      uplift: {
+        sub_total: 300.0,
+        per_participant: 100.0,
+      },
     }
   end
 
@@ -61,7 +65,7 @@ RSpec.describe CalculationOrchestrator do
 
   context ".call" do
     it "returns the total calculation" do
-      expect(described_class.call(lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
+      expect(described_class.call(contract: call_off_contract, lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
     end
   end
 end


### PR DESCRIPTION
### Context

The calculator requires uplift payments to be added into the display and calculation.

### Changes proposed in this pull request

**Calculator**:
- Take the number of approved uplift participants and add in the uplift based on this number.
- Update the calculation orchestrator to call and retrieve this number from the aggregator (Note this is a temporary value based on the expected uplift number since there is a separate ticket to perform the actual aggregation which needs to be added to this.)
- Update the calculator to be the PaymentCalculator::Ecf::PaymentCalculation directly and switch this to take a contract rather than a lead provider, since the contract determines the calculation and the only thing that was done with the lead provider was to look this up.
- Update the PaymentCalculator to take an uplift number for calculation of the new section.
- Create the UpliftCalculation to return the correct amount for the `started` event as a per_participant and subtotal based on the number of uplift participants passed in.
- Update the rake task to call with and display the uplift participant values.
- Update integration tests to show the uplift and fix the number of participants displayed for each band.

**Bug fix**:
Change to the OutputPaymentRetentionEvent to return only the number of participants in this band rather than the total number in each band.

### Guidance to review

Mainly calculation code. 
Ignore the aggregation, since that's going to be added by the next PR.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

You can only view the results by running the rake task:

```rake payment_calculation:breakdown <lead_provider> <total_participants> <uplift_participants>```
