### PR TITLE
Add induction tutor email to school search

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -12,7 +12,7 @@ module Admin
 
       @schools = policy_scope(School)
         .includes(:induction_coordinators, :local_authority)
-        .yield_self(&method(:search_query))
+        .ransack(induction_coordinators_email_or_urn_or_name_cont: @query).result
         .order(:name)
         .page(params[:page])
         .per(20)
@@ -27,20 +27,6 @@ module Admin
 
     def load_school
       @school = School.eligible.friendly.find(params[:id])
-    end
-
-    def search_query(relation)
-      if @query.present?
-        search_value = "%#{@query}%"
-
-        relation
-          .left_joins(:induction_coordinators)
-          .where(School.arel_table[:name].matches(search_value)
-            .or(School.arel_table[:urn].matches(search_value))
-            .or(User.arel_table[:email].matches(search_value)))
-      else
-        relation
-      end
     end
   end
 end

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -9,10 +9,11 @@ module Admin
 
     def index
       @query = params[:query]
+
       @schools = policy_scope(School)
         .includes(:induction_coordinators, :local_authority)
+        .yield_self(&method(:search_query))
         .order(:name)
-        .ransack(name_or_urn_cont: @query).result
         .page(params[:page])
         .per(20)
     end
@@ -26,6 +27,20 @@ module Admin
 
     def load_school
       @school = School.eligible.friendly.find(params[:id])
+    end
+
+    def search_query(relation)
+      if @query.present?
+        search_value = "%#{@query}%"
+
+        relation
+          .left_joins(:induction_coordinators)
+          .where(School.arel_table[:name].matches(search_value)
+            .or(School.arel_table[:urn].matches(search_value))
+            .or(User.arel_table[:email].matches(search_value)))
+      else
+        relation
+      end
     end
   end
 end

--- a/app/views/admin/schools/index.html.erb
+++ b/app/views/admin/schools/index.html.erb
@@ -7,6 +7,7 @@
               :query,
               value: @query,
               label: { text: "Search schools", size: "s" },
+              hint: { text: "Enter the school’s name, URN or tutor email" },
             )
         %>
       </div>

--- a/spec/cypress/integration/admin/SchoolManagment.feature
+++ b/spec/cypress/integration/admin/SchoolManagment.feature
@@ -28,6 +28,7 @@ Feature: Admin user managing schools
 
   Scenario: Viewing a list of schools
     Then the table should have 12 rows
+    And "page body" should contain "Enter the school’s name, URN or tutor email"
     And the page should be accessible
     And percy should be sent snapshot
 

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -31,20 +31,14 @@ RSpec.describe "Admin::Schools", type: :request do
       it "filters the list of schools by name" do
         get "/admin/schools", params: { query: "include" }
         expect(assigns(:schools)).to match_array [included_school]
-        # expect(response.body).to include(included_school.urn)
-        # expect(response.body).not_to include(excluded_school.urn)
       end
 
       it "filters the list of schools by urn" do
         get "/admin/schools", params: { query: "901" }
         expect(assigns(:schools)).to match_array [included_school]
-        # expect(response.body).to include(included_school.urn)
-        # expect(response.body).not_to include(excluded_school.urn)
       end
 
       it "filters the list by induction tutor email" do
-        # included_school = create(:school, name: "Include Me")
-        # excluded_school = create(:school, name: "Exclude Me")
         create(:user, :induction_coordinator, email: "mary@schools.org", schools: [included_school])
 
         get "/admin/schools", params: { query: "mary" }

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -24,22 +24,32 @@ RSpec.describe "Admin::Schools", type: :request do
       expect(response.body).not_to include(ineligible_school.urn)
     end
 
-    it "filters the list of schools by name" do
-      included_school = create(:school, name: "Include Me")
-      excluded_school = create(:school, name: "Exclude Me")
+    context "filtering the school list" do
+      let!(:included_school) { create(:school, name: "Include Me", urn: "090120") }
+      let!(:excluded_school) { create(:school, name: "Exclude Me", urn: "333333") }
 
-      get "/admin/schools", params: { query: "include" }
-      expect(response.body).to include(included_school.urn)
-      expect(response.body).not_to include(excluded_school.urn)
-    end
+      it "filters the list of schools by name" do
+        get "/admin/schools", params: { query: "include" }
+        expect(assigns(:schools)).to match_array [included_school]
+        # expect(response.body).to include(included_school.urn)
+        # expect(response.body).not_to include(excluded_school.urn)
+      end
 
-    it "filters the list of schools by urn" do
-      included_school = create(:school, name: "Include Me")
-      excluded_school = create(:school, name: "Exclude Me")
+      it "filters the list of schools by urn" do
+        get "/admin/schools", params: { query: "901" }
+        expect(assigns(:schools)).to match_array [included_school]
+        # expect(response.body).to include(included_school.urn)
+        # expect(response.body).not_to include(excluded_school.urn)
+      end
 
-      get "/admin/schools", params: { query: included_school.urn }
-      expect(response.body).to include(included_school.urn)
-      expect(response.body).not_to include(excluded_school.urn)
+      it "filters the list by induction tutor email" do
+        # included_school = create(:school, name: "Include Me")
+        # excluded_school = create(:school, name: "Exclude Me")
+        create(:user, :induction_coordinator, email: "mary@schools.org", schools: [included_school])
+
+        get "/admin/schools", params: { query: "mary" }
+        expect(assigns(:schools)).to match_array [included_school]
+      end
     end
   end
 


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-501)
Enable admins to search search for schools by induction tutor email

### Changes proposed in this pull request
Change the school search to additionally search against induction tutor email
Add hint text to search box to indicate what criteria should be supplied.

### Guidance to review
As an admin user, on the `/admin/schools` page the search function will also match against induction tutor email address and return schools that have a matching induction tutor (in addition to matching against school name and urn).

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
