### PR TITLE
CPDTP-195 Aggregate number of participants eligible for uplift payment

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -8,9 +8,14 @@ class ParticipantDeclaration < ApplicationRecord
   scope :active_for_lead_provider, ->(lead_provider) { active.for_lead_provider(lead_provider) }
   scope :count_active_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).count }
   scope :count_active_for_lead_provider_between, ->(lead_provider, start_date, end_date) { declared_as_between(start_date, end_date).count_active_for_lead_provider(lead_provider) }
+  scope :count_active_uplift_for_lead_provider, ->(lead_provider) { active_uplift_for_lead_provider(lead_provider).count }
 
   scope :unique_early_career_teacher_profile_id, -> { select(:early_career_teacher_profile_id).distinct }
   scope :active, -> { where(declaration_type: "started").order(declaration_date: "desc").unique_early_career_teacher_profile_id }
   scope :declared_as_between, ->(start_date, end_date) { where(declaration_date: start_date..end_date) }
   scope :submitted_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
+  scope :active_uplift_for_lead_provider, lambda { |lead_provider|
+    active_for_lead_provider(lead_provider).joins(:early_career_teacher_profile)
+      .where("early_career_teacher_profiles.sparsity_uplift OR early_career_teacher_profiles.pupil_premium_uplift")
+  }
 end

--- a/app/services/calculation_orchestrator.rb
+++ b/app/services/calculation_orchestrator.rb
@@ -8,14 +8,11 @@ class CalculationOrchestrator
     def call(lead_provider:,
              contract:,
              aggregator: ::ParticipantEventAggregator,
-             # TODO: Add in aggregator for Uplift as uplift_aggregator: ::ParticipantUpliftAggregator (for example)
-             # This is currently defined in Jira as https://dfedigital.atlassian.net/browse/CPDTP-195
+             uplift_aggregator: ::ParticipantUpliftAggregator,
              calculator: ::PaymentCalculator::Ecf::PaymentCalculation,
              event_type: :started)
       total_participants = aggregator.call({ lead_provider: lead_provider }, event_type: event_type)
-      uplift_participants = total_participants / 3 # Temporary code to fake the 33% target which will be removed when the aggregation is pulled in.
-      # This is currently defined in Jira as https://dfedigital.atlassian.net/browse/CPDTP-195
-      # TODO: uplift_participants = uplift_aggregator.call(leod_provider: event_type:) etc..
+      uplift_participants = uplift_aggregator.call({ lead_provider: lead_provider }, event_type: event_type)
       calculator.call(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, event_type: event_type)
     end
   end

--- a/app/services/participant_uplift_aggregator.rb
+++ b/app/services/participant_uplift_aggregator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "has_di_parameters"
+
+class ParticipantUpliftAggregator
+  include HasDIParameters
+
+  def call(event_type: :started)
+    recorder.send(params[event_type], lead_provider)
+  end
+
+private
+
+  def default_params
+    {
+      recorder: ParticipantDeclaration,
+      started: :count_active_uplift_for_lead_provider,
+    }
+  end
+end

--- a/db/migrate/20210610090328_add_uplift_to_early_career_teacher_profile.rb
+++ b/db/migrate/20210610090328_add_uplift_to_early_career_teacher_profile.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUpliftToEarlyCareerTeacherProfile < ActiveRecord::Migration[6.1]
+  def change
+    change_table(:early_career_teacher_profiles, bulk: true) do |table|
+      table.column :sparsity_uplift, :boolean, null: false, default: false
+      table.column :pupil_premium_uplift, :boolean, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -151,6 +151,8 @@ ActiveRecord::Schema.define(version: 2021_06_16_144524) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "mentor_profile_id"
+    t.boolean "sparsity_uplift", default: false, null: false
+    t.boolean "pupil_premium_uplift", default: false, null: false
     t.index ["cohort_id"], name: "index_early_career_teacher_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_ect_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_early_career_teacher_profiles_on_mentor_profile_id"

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :early_career_teacher_profile do
     user
     school
+
+    trait :sparsity_uplift do
+      sparsity_uplift { true }
+    end
   end
 end

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -8,5 +8,14 @@ FactoryBot.define do
     trait :sparsity_uplift do
       sparsity_uplift { true }
     end
+
+    trait :pupil_premium_uplift do
+      pupil_premium_uplift { true }
+    end
+
+    trait :uplift_flags do
+      sparsity_uplift
+      pupil_premium_uplift
+    end
   end
 end

--- a/spec/factories/participant_declarations.rb
+++ b/spec/factories/participant_declarations.rb
@@ -8,7 +8,26 @@ FactoryBot.define do
     declaration_type { "started" }
 
     trait :sparsity_uplift do
+      with_profile
       association :early_career_teacher_profile, :sparsity_uplift
+    end
+
+    trait :pupil_premium_uplift do
+      with_profile
+      association :early_career_teacher_profile, :pupil_premium_uplift
+    end
+
+    trait :uplift_flags do
+      with_profile
+      association :early_career_teacher_profile, :uplift_flags
+    end
+
+    trait :with_profile do
+      after(:create) do |participant_declaration, evaluator|
+        create(:participant_declaration,
+               early_career_teacher_profile: participant_declaration.early_career_teacher_profile,
+               lead_provider: evaluator.lead_provider)
+      end
     end
   end
 end

--- a/spec/factories/participant_declarations.rb
+++ b/spec/factories/participant_declarations.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     lead_provider
     declaration_date { Time.zone.now - 1.week }
     declaration_type { "started" }
+
+    trait :sparsity_uplift do
+      association :early_career_teacher_profile, :sparsity_uplift
+    end
   end
 end

--- a/spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature
+++ b/spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature
@@ -3,6 +3,6 @@ Feature: ECF contract calculations
 
   Scenario: Uplift payment
     Given An uplift per participant of £100
-    And there are 300 participants who have started that are eligible for the uplift payment
+    And there are 100 sparsity and 200 pupil premium participants who have started that are eligible for the uplift payment
     When I setup the contract with uplift payment
     Then the total uplift payment should be £30,000

--- a/spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature
+++ b/spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature
@@ -3,6 +3,7 @@ Feature: ECF contract calculations
 
   Scenario: Uplift payment
     Given An uplift per participant of £100
-    And there are 100 sparsity and 200 pupil premium participants who have started that are eligible for the uplift payment
+    And there are 100 sparsity participants who have started that are eligible for the uplift payment
+    And there are 200 pupil premium participants who have started that are eligible for the uplift payment
     When I setup the contract with uplift payment
     Then the total uplift payment should be £30,000

--- a/spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature
+++ b/spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature
@@ -1,0 +1,8 @@
+@ecf
+Feature: ECF contract calculations
+
+  Scenario: Uplift payment
+    Given An uplift per participant of £100
+    And there are 300 participants who have started that are eligible for the uplift payment
+    When I setup the contract with uplift payment
+    Then the total uplift payment should be £30,000

--- a/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
@@ -9,8 +9,8 @@ module UpliftPaymentsSteps
     @uplift_amount = value
   end
 
-  step "there are :value participants who have started that are eligible for the uplift payment" do |value|
-    @uplift_eligible_participants = value.to_i
+  step "there are :sparsity sparsity and :pupil_premium pupil premium participants who have started that are eligible for the uplift payment" do |sparsity, pupil_premium|
+    @uplift_eligible_participants = sparsity.to_i + pupil_premium.to_i
   end
 
   step "I setup the contract with uplift payment" do

--- a/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module UpliftPaymentsSteps
+  class DummyClass
+    include PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations
+  end
+
+  step "An uplift per participant of £:decimal_placeholder" do |value|
+    @uplift_amount = value
+  end
+
+  step "there are :value participants who have started that are eligible for the uplift payment" do |value|
+    @uplift_eligible_participants = value.to_i
+  end
+
+  step "I setup the contract with uplift payment" do
+    contract = double("Contract Double", uplift_amount: @uplift_amount)
+    @call_off_contract = DummyClass.new({ contract: contract, bands: [] })
+    calculator = PaymentCalculator::Ecf::PaymentCalculation.new(contract: @call_off_contract)
+    @result = calculator.call(uplift_participants: @uplift_eligible_participants)
+  end
+
+  step "the total uplift payment should be £:decimal_placeholder" do |value|
+    expect(@result.dig(:uplift, :sub_total)).to eq(value)
+  end
+end
+
+RSpec.configure do |config|
+  config.include UpliftPaymentsSteps, ecf: true
+end

--- a/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
@@ -9,8 +9,12 @@ module UpliftPaymentsSteps
     @uplift_amount = value
   end
 
-  step "there are :sparsity sparsity and :pupil_premium pupil premium participants who have started that are eligible for the uplift payment" do |sparsity, pupil_premium|
-    @uplift_eligible_participants = sparsity.to_i + pupil_premium.to_i
+  step "there are :value sparsity participants who have started that are eligible for the uplift payment" do |value|
+    @uplift_eligible_participants = value.to_i
+  end
+
+  step "And there are :value pupil premium participants who have started that are eligible for the uplift payment" do |value|
+    @uplift_eligible_participants += value.to_i
   end
 
   step "I setup the contract with uplift payment" do

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -56,16 +56,46 @@ RSpec.describe CalculationOrchestrator do
     }
   end
 
-  before do
-    10.times do
-      participant_declaration = create(:participant_declaration, :sparsity_uplift, lead_provider: call_off_contract.lead_provider)
-      create(:participant_declaration, early_career_teacher_profile: participant_declaration.early_career_teacher_profile, lead_provider: call_off_contract.lead_provider)
-    end
-  end
-
   context ".call" do
-    it "returns the total calculation" do
-      expect(described_class.call(contract: call_off_contract, lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
+    context "when only sparsity_uplift flag was set" do
+      before do
+        create_list(:participant_declaration, 10, :sparsity_uplift, lead_provider: call_off_contract.lead_provider)
+      end
+
+      it "returns the total calculation" do
+        expect(described_class.call(contract: call_off_contract, lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
+      end
+    end
+
+    context "when only pupil_premium_uplift flag was set" do
+      before do
+        create_list(:participant_declaration, 10, :pupil_premium_uplift, lead_provider: call_off_contract.lead_provider)
+      end
+
+      it "returns the total calculation" do
+        expect(described_class.call(contract: call_off_contract, lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
+      end
+    end
+
+    context "when both sparsity_uplift and pupil_premium_uplift flags were set" do
+      before do
+        create_list(:participant_declaration, 10, :uplift_flags, lead_provider: call_off_contract.lead_provider)
+      end
+
+      it "returns the total calculation" do
+        expect(described_class.call(contract: call_off_contract, lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
+      end
+    end
+
+    context "when no uplift flags were set" do
+      before do
+        create_list(:participant_declaration, 10, lead_provider: call_off_contract.lead_provider)
+        expected_result.tap { |hash| hash[:uplift][:sub_total] = 0.0 }
+      end
+
+      it "returns the total calculation" do
+        expect(described_class.call(contract: call_off_contract, lead_provider: call_off_contract.lead_provider, event_type: :started)).to eq(expected_result)
+      end
     end
   end
 end

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -50,15 +50,15 @@ RSpec.describe CalculationOrchestrator do
         },
       ],
       uplift: {
-        sub_total: 300.0,
         per_participant: 100.0,
+        sub_total: 1000.0,
       },
     }
   end
 
   before do
     10.times do
-      participant_declaration = create(:participant_declaration, lead_provider: call_off_contract.lead_provider)
+      participant_declaration = create(:participant_declaration, :sparsity_uplift, lead_provider: call_off_contract.lead_provider)
       create(:participant_declaration, early_career_teacher_profile: participant_declaration.early_career_teacher_profile, lead_provider: call_off_contract.lead_provider)
     end
   end


### PR DESCRIPTION
### Context

Aggregator to return number of participants eligible for uplift payment

### Changes proposed in this pull request

- New scope for ParticipantDeclaration
- Add new columns `sparsity_uplift` and `pupil_premium_uplift` to profiles
- Update rspec and feature tests

### Guidance to review

### Testing

Run calculation orchestrator i.e.

```
lead_provider = LeadProvider.find_by(name: 'Capita')

CalculationOrchestrator.call(
  lead_provider: lead_provider,
  contract: lead_provider.call_off_contract,
  aggregator: ::ParticipantEventAggregator,
  uplift_aggregator: ::ParticipantUpliftAggregator,
  calculator: ::PaymentCalculator::Ecf::PaymentCalculation,
  event_type: :started
)

```

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
