### PR TITLE
CPDTP-183 Enable a11y and percy checks for sandbox landing page

### DIFF
--- a/spec/cypress/integration/Sandbox.feature
+++ b/spec/cypress/integration/Sandbox.feature
@@ -1,0 +1,5 @@
+Feature: Sandbox page
+  Scenario: Visiting the sandbox page
+    Given I am on "sandbox" page
+    Then the page should be accessible
+    And percy should be sent snapshot

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -18,6 +18,7 @@ Given("scenario {string} has been run", (scenario) => cy.appScenario(scenario));
 const pagePaths = {
   cookie: "/cookies",
   start: "/",
+  sandbox: "/sandbox",
   privacy: "/privacy-policy",
   accessibility: "/accessibility-statement",
   dashboard: "/dashboard",


### PR DESCRIPTION
### Context

The sandbox landing page was added a while ago. It is accessed by external parties (lead providers) so it would be good to know if the display changes before we ship to avoid accidental regressions. Also a11y checks because that's always good.

### Changes proposed in this pull request

* Enable a11y and percy checks for sandbox landing page

### Guidance to review

Let's see what percy does...

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?