### PR TITLE
CPDTP-109 Update output to clean up the display

### DIFF
--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -52,13 +52,14 @@ namespace :payment_calculation do
     end
 
     table = Terminal::Table.new(
-      title: "Breakdown Payments",
-      headings: ["Banding", "Service fee (PP)", "Service fee (monthly)"],
+      title: "Started Event Payments",
+      headings: ["", "Service fee\nPer Participant", "Service fee\nThis month"],
       rows: service_fees,
     )
     table.style = { alignment: :center }
     table.add_separator
-    table.add_row ["Banding", "Output price  (PP)", "Output price  (monthly)"]
+    table.add_row ["", "Output price", "Output price"]
+    table.add_row ["", "Per Participant", "Sub-total"]
     table.add_separator
     output_payments.each { |row| table.add_row(row) }
     table.add_separator
@@ -69,14 +70,8 @@ namespace :payment_calculation do
     output = <<~RESULT
       Based on #{number_to_delimited(total_participants.to_i)} participants and #{per_participant_in_bands}
     RESULT
-
     logger.info table
     logger.info output
-  rescue StandardError => e
-    logger.error e.message
-    logger.error e.backtrace
-  ensure
-    exit(0)
   end
 end
 


### PR DESCRIPTION
- Tweak display output to make it closer to reality
- Remove error log and exit(0) and have it display and return the actual error number

### Context

After reviewing the code with the BA and PM a couple of tweak were made to have the display headings more accurate and clean up the display a bit
Also, comments had been made about whether we needed the error catch and exit(0), so they were removed as superfluous code

### Changes proposed in this pull request

- Change headings and expand acronyms
- Remove `rescue` and `ensure` to let errors display as normal

### Guidance to review

run the `rake payment_calculation:breakdown` with lead_provider, total_participants and uplift participants as parameters
e.g.

`rake payment_calculation:breakdown <lead_provider_id> 2000 400`

to run with the contract applied to the lead_provider in the database, a total participant value of 2000 and 400 participants applicable for uplift.

### Testing

Run the rake task with various parameters and check against the call-off pricing schedule with the appropriate contract details.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

Rake task only
