### PR TITLE
Serialise CIP from cohorts as well as from profiles

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -31,7 +31,9 @@ class UserSerializer
   end
 
   attributes :core_induction_programme do |user|
-    case user.core_induction_programme&.name
+    core_induction_programme = user.core_induction_programme || find_school_cohort(user)&.core_induction_programme
+
+    case core_induction_programme&.name
     when "Ambition Institute"
       CIP_TYPES[:ambition]
     when "Education Development Trust"
@@ -46,10 +48,13 @@ class UserSerializer
   end
 
   attributes :induction_programme_choice do |user|
+    find_school_cohort(user)&.induction_programme_choice
+  end
+
+  def self.find_school_cohort(user)
     @school_cohorts ||= SchoolCohort.all.to_a
     if user.participant?
-      school_cohort = @school_cohorts.find { |sc| (sc.school_id == user.school&.id) && (sc.cohort_id == user.cohort&.id) }
-      school_cohort&.induction_programme_choice
+      @school_cohorts.find { |sc| (sc.school_id == user.school&.id) && (sc.cohort_id == user.cohort&.id) }
     end
   end
 end


### PR DESCRIPTION
### Context
E&L wants users CIPs. For private beta users, I think we need to get them from school cohort model. Up till now we were getting it from the profile. This fixes it.

### Changes proposed in this pull request
If user has no CIP on their profile, fetch it from their cohort in the serialiser.

### Guidance to review
I had a passing thought of recording user's CIP when we create them and backfilling them. Thoughts on that?

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
You can't
