### PR TITLE
CPDTP-195 Make cohort mandatory for Early Career Teachers

### DIFF
--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -6,7 +6,7 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   belongs_to :user
   belongs_to :school
   belongs_to :core_induction_programme, optional: true
-  belongs_to :cohort, optional: true
+  belongs_to :cohort
   belongs_to :mentor_profile, optional: true
   has_one :mentor, through: :mentor_profile, source: :user
   has_one :participation_record, dependent: :destroy

--- a/db/migrate/20210621160955_change_early_career_teacher_profile_to_make_cohorts_required.rb
+++ b/db/migrate/20210621160955_change_early_career_teacher_profile_to_make_cohorts_required.rb
@@ -2,6 +2,6 @@
 
 class ChangeEarlyCareerTeacherProfileToMakeCohortsRequired < ActiveRecord::Migration[6.1]
   def change
-    change_column_null :early_career_teacher_profiles, :cohort_id, false, Cohort.current.id
+    add_check_constraint :early_career_teacher_profiles, "cohort_id IS NOT NULL", name: "early_career_teacher_profiles_cohort_id_null", validate: false
   end
 end

--- a/db/migrate/20210621160955_change_early_career_teacher_profile_to_make_cohorts_required.rb
+++ b/db/migrate/20210621160955_change_early_career_teacher_profile_to_make_cohorts_required.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeEarlyCareerTeacherProfileToMakeCohortsRequired < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :early_career_teacher_profiles, :cohort_id, false, Cohort.current.id
+  end
+end

--- a/db/migrate/20210623120047_run_validation_on_early_career_teacher_profile_and_switch_cohorts_column.rb
+++ b/db/migrate/20210623120047_run_validation_on_early_career_teacher_profile_and_switch_cohorts_column.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RunValidationOnEarlyCareerTeacherProfileAndSwitchCohortsColumn < ActiveRecord::Migration[6.1]
+  def change
+    validate_check_constraint :early_career_teacher_profiles, name: "early_career_teacher_profiles_cohort_id_null"
+    safety_assured { change_column_null :early_career_teacher_profiles, :cohort_id, false }
+    remove_check_constraint :early_career_teacher_profiles, name: "early_career_teacher_profiles_cohort_id_null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_23_082855) do
+ActiveRecord::Schema.define(version: 2021_06_23_120047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -147,7 +147,7 @@ ActiveRecord::Schema.define(version: 2021_06_23_082855) do
     t.uuid "user_id", null: false
     t.uuid "school_id", null: false
     t.uuid "core_induction_programme_id"
-    t.uuid "cohort_id"
+    t.uuid "cohort_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "mentor_profile_id"

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -4,6 +4,7 @@ require "swagger_helper"
 
 RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_spec.json" do
   let(:early_career_teacher_profile) { create(:early_career_teacher_profile) }
+  let(:cohort) { early_career_teacher_profile.cohort }
   let(:user) { early_career_teacher_profile.user }
   let(:lead_provider) { create(:lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider) }

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -5,7 +5,12 @@ FactoryBot.define do
     start_year { Faker::Number.unique.between(from: 2021, to: 2100) }
 
     trait :current do
-      start_year { 2021 }
+      # In order for factory_bot to correctly use seeds in the database you have to jump through a couple of hoops,
+      # Detailed in: https://dev.to/jooeycheng/factorybot-findorcreateby-3h8k
+      to_create do |instance|
+        instance.attributes = Cohort.find_or_create_by!(start_year: 2021).attributes
+        instance.instance_variable_set("@new_record", false)
+      end
     end
   end
 end

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :early_career_teacher_profile do
     user
     school
+    cohort { build(:cohort, :current) }
 
     trait :sparsity_uplift do
       sparsity_uplift { true }

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Schools::Participants", type: :request do
   let(:user) { create(:user, :induction_coordinator) }
   let(:school) { user.induction_coordinator_profile.schools.first }
-  let(:cohort) { create(:cohort, start_year: 2021) }
+  let(:cohort) { create(:cohort) }
   let!(:school_cohort) { create(:school_cohort, school: school, cohort: cohort) }
   let!(:mentor_user) do
     user = create(:user, :mentor)

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ParticipantSerializer do
   describe "serialization" do
     let(:mentor) { create(:user, :mentor) }
     let(:ect) { create(:user, :early_career_teacher, mentor: mentor) }
+    let(:cohort) { ect.early_career_teacher_profile.cohort }
 
     it "outputs correctly formatted serialized Mentors" do
       expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":null}}}"
@@ -13,7 +14,7 @@ RSpec.describe ParticipantSerializer do
     end
 
     it "outputs correctly formatted serialized ECTs" do
-      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":null}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{cohort.start_year}}}}"
       expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
     end
   end


### PR DESCRIPTION
### Context

Cohort was not a mandatory attribute for Early Career Teachers (ECT), but really should be.

### Changes proposed in this pull request

- Make cohort required in the database and set a default value for existing records that are currently null.
- Change factories to add cohorts to ECTs.
- Make a :current trait that uses the existing seeded value when this year is used in a factory.
  - See https://dev.to/jooeycheng/factorybot-findorcreateby-3h8k for details

### Guidance to review

Is defaulting the cohort value to 'current', the best and only option? 
Are the assumptions sound?

### Testing

All existing tests and features should still pass.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

It's fundamentally a refactor to make something concrete that has been previously assumed. 