### PR TITLE
CPDRP-319: change width of privacy policy area

### DIFF
--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Privacy policy" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <% if !@policy.acceptance_required?(current_user) %>
       <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
       <h1 class="govuk-heading-xl">How we look after your personal data</h1>


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-319)
Change width of column for privacy policy text

### Changes proposed in this pull request
Changes the style on the privacy policy page to use `govuk-grid-column-three-quarters` class instead of `govuk-grid-column-two-thirds`.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
![image](https://user-images.githubusercontent.com/333931/122945604-97b5bd00-d370-11eb-8954-58985dc90db6.png)
