### PR TITLE
CPDRP-199: Add a task to clear S3 buckets

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -11,6 +11,28 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Code
 
+      - name: setup-inputs
+        run: |
+          INPUTS='${{ format('{{"task": "s3:delete_csvs", "env": "{0}"}}', github.event.inputs.environment) }}'
+          echo "INPUTS=${INPUTS}" >> $GITHUB_ENV
+
+      - name: Clear S3 bucket
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: Run task in dev space # Workflow name
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          inputs: ${{ env.INPUTS }}
+
+      - name: Wait for S3 bucket
+        id: wait_for_deploy_app
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        with:
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          checkName: run-task # Job name within workflow
+          timeoutSeconds: 600
+          intervalSeconds: 15
+
       - name: Terraform pin version
         uses: hashicorp/setup-terraform@v1.3.2
         with:

--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :s3 do
+  desc "Delete attachments from S3 bucket"
+  task delete_csvs: :environment do
+    exit(0) unless Rails.env.deployed_development?
+
+    PartnershipCsvUpload.find_each do |partnership_csv_upload|
+      partnership_csv_upload.csv.purge
+    end
+  end
+end

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -11,4 +11,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && /app/bin/delayed_job --pool=mailers --pool=*:2 start && rails db:safe_reset && rails cron:schedule && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate s3:delete_csvs && /app/bin/delayed_job --pool=mailers --pool=*:2 start && rails db:safe_reset && rails cron:schedule && rails s"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,4 +10,4 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && /app/bin/delayed_job --pool=mailers --pool=*:2 start && rails db:safe_reset && rails cron:schedule && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate s3:delete_csvs && /app/bin/delayed_job --pool=mailers --pool=*:2 start && rails db:safe_reset && rails cron:schedule && rails s"


### PR DESCRIPTION
Clear uploaded CSVs from S3 on each deploy & db wipe to dev and review.
Also clear them before tearing down a review app. We cannot delete the
bucket if it is non-empty.

This might not catch 100% of cases, but that's still a lot better than at the moment.
I looked for something we could do in terraform or cloudfoundry to delete the bucket without it being empty, but instead found lots of threads of people choosing not to implement that...
