### PR TITLE
CPDRP-321: Change 'Logout' to 'Sign out' in nav

### DIFF
--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -83,7 +83,7 @@
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item">
-                <%= link_to "Logout", destroy_user_session_path, class: "govuk-header__link" %>
+                <%= link_to "Sign out", destroy_user_session_path, class: "govuk-header__link" %>
               </li>
             </ul>
           </nav>

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -24,7 +24,7 @@ Cypress.Commands.add("login", (...traits) => {
 });
 
 Cypress.Commands.add("logout", () => {
-  cy.get("#navigation").contains("Logout").click();
+  cy.get("#navigation").contains("Sign out").click();
 
   cy.location("pathname").should("eq", "/users/signed-out");
 });


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-321)
Change link text in nav bar from "Logout" to "Sign out"

### Changes proposed in this pull request
Change link text in nav bar from "Logout" to "Sign out"

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
![image](https://user-images.githubusercontent.com/333931/122960614-7908f380-d37b-11eb-9844-08f3d677c018.png)
