### PR TITLE
CDPTP-255 Handle record not found for ParticipantEvent by returning the expected 422

### DIFF
--- a/app/services/record_participant_event.rb
+++ b/app/services/record_participant_event.rb
@@ -47,7 +47,7 @@ private
   end
 
   def early_career_teacher_profile
-    User.find(@params[:participant_id])&.early_career_teacher_profile
+    User.find_by(id: @params[:participant_id])&.early_career_teacher_profile
   end
 
   def create_record

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe "Participant Declarations", type: :request do
         expect(response.status).to eq 204
       end
 
-      it "returns 404 when trying to create for an invalid user id" do # Expectes the user uuid. Pass the early_career_teacher_profile_id
+      it "returns 422 when trying to create for an invalid user id" do # Expectes the user uuid. Pass the early_career_teacher_profile_id
         post "/api/v1/participant-declarations", params: invalid_user_id.to_json
-        expect(response.status).to eq 404
+        expect(response.status).to eq 422
       end
 
-      it "returns 404 when trying to create with no id" do
+      it "returns 422 when trying to create with no id" do
         post "/api/v1/participant-declarations", params: missing_user_id.to_json
-        expect(response.status).to eq 404
+        expect(response.status).to eq 422
       end
 
       it "returns 422 when a required parameter is missing" do


### PR DESCRIPTION
### Context

The current API returns a 404 to the caller if either the participant_id is empty or the record is not found.
Design of this requires a 422 with an error body of the participant_id being bad or missing.

### Changes proposed in this pull request

Update RecordParticipantEvent to return 422 with the appropriate error condition set rather than raising an ActiveRecord::RecordNotFound which the top level handler catches.
Update the spec tests to also reflect this behaviour.

### Guidance to review

This is centred around the RecordParticipantEvent returning a nil value for the `find_by()&.early_career_teacher_profile` as opposed to raising an exception. Once this is handled correctly, the expected result is returned.

### Testing

API testing should allow a missing or incorrect participant_id to return the correct status and message in line with the swagger documentation.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

You can issue an api request to the `participant-declarations` endpoint with an invalid participant_id which should return a 422 in line with the swagger documentation.