### PR TITLE
CPDRP-323: Change width of Manage your training page content

### DIFF
--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -1,33 +1,39 @@
 <% content_for :title, "Manage training" %>
 
-<span class="govuk-caption-l"><%= @school.name %></span>
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-7">Manage your training</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-7">Manage your training</h1>
 
-<p class="govuk-body-l govuk-!-margin-bottom-5">Check and complete steps for every academic year/cohort</p>
+    <p class="govuk-body-l govuk-!-margin-bottom-5">
+      Check and complete steps for every academic year/cohort
+    </p>
 
-<h2 class="govuk-heading-m govuk-!-margin-bottom-1">Your cohorts</h2>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Your cohorts</h2>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Year</th>
-      <th class="govuk-table__header" scope="col">Programme</th>
-      <th class="govuk-table__header" scope="col">Status</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @school_cohorts.each do |school_cohort| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <%= govuk_link_to school_cohort.cohort.start_year, schools_cohort_path(cohort_id: school_cohort.cohort) %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes]) %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= render AutoTagComponent.new(text: school_cohort.status) unless school_cohort.status.blank? %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Year</th>
+          <th class="govuk-table__header" scope="col">Programme</th>
+          <th class="govuk-table__header" scope="col">Status</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @school_cohorts.each do |school_cohort| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= govuk_link_to school_cohort.cohort.start_year, schools_cohort_path(cohort_id: school_cohort.cohort) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes]) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= render AutoTagComponent.new(text: school_cohort.status) unless school_cohort.status.blank? %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-323)
Width of content should be two thirds not full width.

### Changes proposed in this pull request
Wrap content in `govuk-grid-row` and `govuk-grid-column-two-thirds` containers.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
![image](https://user-images.githubusercontent.com/333931/122965771-7d83db00-d380-11eb-80fe-cc9ee6f8e8f2.png)
