### PR TITLE
CPDTP-226 add in strong migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ gem "daemons"
 gem "delayed_cron_job"
 gem "delayed_job_active_record"
 
+# Strong migration checker for database migrations
+gem "strong_migrations"
+
 # Acts as State Machine for participant states
 gem "aasm"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,6 +462,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strong_migrations (0.7.7)
+      activerecord (>= 5)
     terminal-table (3.0.1)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
@@ -577,6 +579,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  strong_migrations
   terminal-table
   tzinfo-data
   view_component

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20_210_622_170_835
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Mark existing migrations as safe
-StrongMigrations.start_after = 20_210_622_170_835
+StrongMigrations.start_after = 2021_06_22_17_08_35 # rubocop:disable Style/NumericLiterals
 
 # Set timeouts for migrations
 # If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user


### PR DESCRIPTION
### Context

As part of a previous PR review it was suggested that we add in the `strong_migrations' gem to ensure that any future migrations are checked for any dangerous activity and any preferred alternative solutions are used instead. This gem enables warnings and proposes changes to ensure that the database integrity is preserved.

### Changes proposed in this pull request

Add in and initialise the `strong_migrations` gem.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
