### PR TITLE
Change page width and heading style

### DIFF
--- a/app/views/schools/core_programme/materials/edit.html.erb
+++ b/app/views/schools/core_programme/materials/edit.html.erb
@@ -2,11 +2,19 @@
 
 <% content_for :before_content, govuk_back_link( text: "Back", href: { action: :info }) %>
 
-<span class="govuk-caption-l"><%= @cohort.start_year %> cohort</span>
-<h1 class="govuk-heading-l">Which training materials do you want this cohort to use?</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @cohort.start_year %> cohort</span>
+    <h1 class="govuk-heading-xl">Which training materials do you want this cohort to use?</h1>
 
-<%= form_for @form, url: { action: :update }, method: :put do |f| %>
-  <%= f.govuk_error_summary %>
-  <%= f.govuk_collection_radio_buttons :core_induction_programme_id, CoreInductionProgramme.all, :id, :name, legend: { text: false} %>
-  <%= f.govuk_submit "Continue" %>
-<% end %>
+    <%= form_for @form, url: { action: :update }, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons :core_induction_programme_id,
+                                           CoreInductionProgramme.all,
+                                           :id,
+                                           :name,
+                                           legend: { text: false} %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-324)
Fix page width and heading style on choose CIP training materials page

### Changes proposed in this pull request
Add elements to make page width `govuk-grid-column-three-quarters`
Change style of `h1` heading to `govuk-heading-xl`

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
![image](https://user-images.githubusercontent.com/333931/123062839-cda48100-d404-11eb-805e-c0793b5077e8.png)
