### PR TITLE
Add active_alert to NPQ profile

### DIFF
--- a/app/resources/api/v1/npq_profile_resource.rb
+++ b/app/resources/api/v1/npq_profile_resource.rb
@@ -6,6 +6,7 @@ module Api
       attributes :date_of_birth,
                  :teacher_reference_number,
                  :teacher_reference_number_verified,
+                 :active_alert,
                  :school_urn,
                  :headteacher_status
 

--- a/db/migrate/20210623082855_add_active_alert_to_npq_profiles.rb
+++ b/db/migrate/20210623082855_add_active_alert_to_npq_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddActiveAlertToNpqProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_profiles, :active_alert, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_16_144524) do
+ActiveRecord::Schema.define(version: 2021_06_23_082855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -325,6 +325,7 @@ ActiveRecord::Schema.define(version: 2021_06_16_144524) do
     t.text "headteacher_status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "active_alert", default: false
     t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
     t.index ["user_id"], name: "index_npq_profiles_on_user_id"

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
             attributes: {
               teacher_reference_number: "1234567",
               teacher_reference_number_verified: true,
+              active_alert: true,
               date_of_birth: "1990-12-13",
               school_urn: "123456",
               headteacher_status: "no",
@@ -65,6 +66,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(profile.date_of_birth).to eql(Date.new(1990, 12, 13))
         expect(profile.teacher_reference_number).to eql("1234567")
         expect(profile.teacher_reference_number_verified).to be_truthy
+        expect(profile.active_alert).to be_truthy
         expect(profile.school_urn).to eql("123456")
         expect(profile.headteacher_status).to eql("no")
         expect(profile.npq_course).to eql(npq_course)


### PR DESCRIPTION
### Context

The NPQ profile and respective API should accept an `active_alert` for each participant. Right now we'll just store it, but it might play into the manual validation process for NPQ participants. 