### PR TITLE
Bugfix: Prevent double scheduling of jobs

### DIFF
--- a/app/services/partnerships/report.rb
+++ b/app/services/partnerships/report.rb
@@ -42,7 +42,7 @@ module Partnerships
         )
 
         if partnership.pending?
-          PartnershipActivationJob.new.delay(run_at: partnership.challenge_deadline).perform(
+          PartnershipActivationJob.set(wait_until: partnership.challenge_deadline).perform_later(
             partnership: partnership,
             report_id: partnership.report_id,
           )

--- a/spec/services/partnerships/report_spec.rb
+++ b/spec/services/partnerships/report_spec.rb
@@ -116,8 +116,9 @@ RSpec.describe Partnerships::Report do
     it "schedules an activation job" do
       result
 
-      expect(an_instance_of(PartnershipActivationJob)).to delay_execution_of(:perform)
-        .with(partnership: result, report_id: result.report_id)
+      expect(PartnershipActivationJob)
+        .to be_enqueued.with(partnership: result, report_id: result.report_id)
+                       .at(Partnerships::Report::CHALLENGE_WINDOW.from_now)
     end
   end
 end


### PR DESCRIPTION
Using a combination of active job and delayed job syntax results in the
job being scheduled twice: once correctly, and once immediately with no
parameters.

Resolves https://sentry.io/organizations/dfe-bat/issues/2445872434/?project=5748989&query=is%3Aunresolved