### PR TITLE
CDPTP-195 Set payment uplift flags on new EarlyCareerTeacherProfile records

### DIFF
--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -11,4 +11,16 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   has_one :mentor, through: :mentor_profile, source: :user
   has_one :participation_record, dependent: :destroy
   has_many :participant_declarations
+
+  # Would like to move the following once we have a refactor on the multistep, which currently leaves either this
+  # approach, or changing the form.save! as options. This was chosen to make it obvious that it's separate from the
+  # R&P code, since it's only required for uplift payment.
+  # This is only required the first time a profile is created, since it shouldn't change even if the underlying
+  # school uplift payment scope changes.
+  before_save :set_uplift_payment_flags, if: :new_record?
+
+  def set_uplift_payment_flags
+    self.sparsity_uplift = school.sparsity_uplift?(cohort.start_year)
+    self.pupil_premium_uplift = school.pupil_premium_uplift?(cohort.start_year)
+  end
 end

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -12,6 +12,10 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   has_one :participation_record, dependent: :destroy
   has_many :participant_declarations
 
+  scope :sparsity, -> { where(sparsity_uplift: true) }
+  scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
+  scope :uplift, -> { sparsity.or(pupil_premium) }
+
   # Would like to move the following once we have a refactor on the multistep, which currently leaves either this
   # approach, or changing the form.save! as options. This was chosen to make it obvious that it's separate from the
   # R&P code, since it's only required for uplift payment.
@@ -20,7 +24,7 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   before_save :set_uplift_payment_flags, if: :new_record?
 
   def set_uplift_payment_flags
-    self.sparsity_uplift = school.sparsity_uplift?(cohort.start_year)
-    self.pupil_premium_uplift = school.pupil_premium_uplift?(cohort.start_year)
+    self.sparsity_uplift ||= school.sparsity_uplift?(cohort.start_year)
+    self.pupil_premium_uplift ||= school.pupil_premium_uplift?(cohort.start_year)
   end
 end

--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -15,16 +15,4 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   scope :sparsity, -> { where(sparsity_uplift: true) }
   scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
   scope :uplift, -> { sparsity.or(pupil_premium) }
-
-  # Would like to move the following once we have a refactor on the multistep, which currently leaves either this
-  # approach, or changing the form.save! as options. This was chosen to make it obvious that it's separate from the
-  # R&P code, since it's only required for uplift payment.
-  # This is only required the first time a profile is created, since it shouldn't change even if the underlying
-  # school uplift payment scope changes.
-  before_save :set_uplift_payment_flags, if: :new_record?
-
-  def set_uplift_payment_flags
-    self.sparsity_uplift ||= school.sparsity_uplift?(cohort.start_year)
-    self.pupil_premium_uplift ||= school.pupil_premium_uplift?(cohort.start_year)
-  end
 end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -4,18 +4,19 @@ class ParticipantDeclaration < ApplicationRecord
   belongs_to :lead_provider
   belongs_to :early_career_teacher_profile
 
+  # Helper scopes
   scope :for_lead_provider, ->(lead_provider) { where(lead_provider: lead_provider) }
-  scope :active_for_lead_provider, ->(lead_provider) { active.for_lead_provider(lead_provider) }
-  scope :count_active_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).count }
-  scope :count_active_for_lead_provider_between, ->(lead_provider, start_date, end_date) { declared_as_between(start_date, end_date).count_active_for_lead_provider(lead_provider) }
-  scope :count_active_uplift_for_lead_provider, ->(lead_provider) { active_uplift_for_lead_provider(lead_provider).count }
-
+  scope :for_declaration, ->(declaration_type) { where(declaration_type: declaration_type) }
+  scope :started, -> { for_declaration("started").order(declaration_date: "desc").unique_early_career_teacher_profile_id }
+  scope :uplift, -> { joins(:early_career_teacher_profile).merge(EarlyCareerTeacherProfile.uplift) }
   scope :unique_early_career_teacher_profile_id, -> { select(:early_career_teacher_profile_id).distinct }
-  scope :active, -> { where(declaration_type: "started").order(declaration_date: "desc").unique_early_career_teacher_profile_id }
+  scope :active_for_lead_provider, ->(lead_provider) { started.for_lead_provider(lead_provider).unique_early_career_teacher_profile_id }
+
+  # Time dependent Range scopes
   scope :declared_as_between, ->(start_date, end_date) { where(declaration_date: start_date..end_date) }
   scope :submitted_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
-  scope :active_uplift_for_lead_provider, lambda { |lead_provider|
-    active_for_lead_provider(lead_provider).joins(:early_career_teacher_profile)
-      .where("early_career_teacher_profiles.sparsity_uplift OR early_career_teacher_profiles.pupil_premium_uplift")
-  }
+
+  # Declaration aggregation scopes
+  scope :count_active_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).count }
+  scope :count_active_uplift_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).uplift.count }
 end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module EarlyCareerTeachers
+  class Create < BaseService
+    def call
+      ActiveRecord::Base.transaction do
+        # TODO: What if email matches but with different name?
+        user = User.find_or_create_by!(full_name: full_name, email: email)
+        EarlyCareerTeacherProfile.create!({ user: user }.merge(ect_attributes))
+      end
+    end
+
+  private
+
+    attr_reader :full_name, :email, :cohort_id, :school_id, :mentor_profile_id
+
+    def initialize(full_name:, email:, cohort_id:, school_id:, mentor_profile_id: nil)
+      @full_name = full_name
+      @email = email
+      @cohort_id = cohort_id
+      @school_id = school_id
+      @mentor_profile_id = mentor_profile_id
+    end
+
+    def school
+      School.find(school_id)
+    end
+
+    def cohort
+      Cohort.find(cohort_id)
+    end
+
+    delegate :sparsity_uplift?, :pupil_premium_uplift?, to: :school
+    delegate :start_year, to: :cohort
+
+    def ect_attributes
+      {
+        school_id: school_id,
+        cohort_id: cohort_id,
+        mentor_profile_id: mentor_profile_id,
+        sparsity_uplift: sparsity_uplift?(start_year),
+        pupil_premium_uplift: pupil_premium_uplift?(start_year),
+      }
+    end
+  end
+end

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe EarlyCareerTeachers::Create do
   let(:mentor_profile) { create :mentor_profile }
 
   it "creates an Early Career Teacher Profile record" do
-    before_count = EarlyCareerTeacherProfile.count
+    expect { described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id) }.to change { EarlyCareerTeacherProfile.count }.by(1)
+  end
+
+  it "sets the correct mentor profile" do
     early_career_teacher_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id)
-    after_count = EarlyCareerTeacherProfile.count
-    expect(after_count).to eq(before_count + 1)
+    expect(early_career_teacher_profile.mentor_profile).to eq(mentor_profile)
+  end
+
+  it "has no uplift if the school has not uplift set" do
+    early_career_teacher_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id)
     expect(early_career_teacher_profile.pupil_premium_uplift).to be(false)
     expect(early_career_teacher_profile.sparsity_uplift).to be(false)
   end

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe EarlyCareerTeachers::Create do
+  let(:user) { create :user }
+  let(:school) { create :school }
+  let(:pupil_premium_school) { create :school, :pupil_premium_uplift }
+  let(:sparsity_school) { create :school, :sparsity_uplift }
+  let(:uplift_school) { create :school, :sparsity_uplift, :pupil_premium_uplift }
+  let(:cohort) { create :cohort, :current }
+  let(:mentor_profile) { create :mentor_profile }
+
+  it "creates an Early Career Teacher Profile record" do
+    before_count = EarlyCareerTeacherProfile.count
+    early_career_teacher_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id)
+    after_count = EarlyCareerTeacherProfile.count
+    expect(after_count).to eq(before_count + 1)
+    expect(early_career_teacher_profile.pupil_premium_uplift).to be(false)
+    expect(early_career_teacher_profile.sparsity_uplift).to be(false)
+  end
+
+  it "has only pupil_premium_uplift set when the school has only pupil_premium_uplift set" do
+    early_career_teacher_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: pupil_premium_school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id)
+    expect(early_career_teacher_profile.pupil_premium_uplift).to be(true)
+    expect(early_career_teacher_profile.sparsity_uplift).to be(false)
+  end
+
+  it "has only sparsity_uplift set when the school has only sparsity_uplift set" do
+    early_career_teacher_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: sparsity_school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id)
+    expect(early_career_teacher_profile.pupil_premium_uplift).to be(false)
+    expect(early_career_teacher_profile.sparsity_uplift).to be(true)
+  end
+
+  it "has both sparsity_uplift and pupil_premium_uplift set when the school has both pupil_premium_uplift and sparsity_uplift set" do
+    early_career_teacher_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: uplift_school.id, cohort_id: cohort.id, mentor_profile_id: mentor_profile.id)
+    expect(early_career_teacher_profile.pupil_premium_uplift).to be(true)
+    expect(early_career_teacher_profile.sparsity_uplift).to be(true)
+  end
+end


### PR DESCRIPTION
### Context

Track and Pay require flags against the Early Career Teacher Profiles to ensure that we are picking up the participants
to whom uplift is required. The decision about the flags boils down to the fact that we don't care if the underlying information changes, we just care if it was applicable at the point of the registration.

This is to ensure that when a new registration happens, we set those flags against the early career teacher.

### Changes proposed in this pull request

Add code to pick up the current uplift flags from sparsity and pupil premium and set them in the early career teacher profile.

### Guidance to review

Would rather have this in a service or other separated section, but there's been some work on building a multistep form that I don't want to refactor at the moment to make this more separated, so it's a callback for now.

### Testing

New early_career_teacher_profile records will have the appropriate flags set.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

No visible changes.