### PR TITLE
Make school tables responsive using NHS responsive table component

### DIFF
--- a/app/components/lead_providers/your_schools/table.html.erb
+++ b/app/components/lead_providers/your_schools/table.html.erb
@@ -1,16 +1,18 @@
-<table data-test="schools-table" class="govuk-table lead-provider-your-schools-table">
-  <thead>
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">School</th>
-      <th scope="col" class="govuk-table__header">URN</th>
-      <th scope="col" class="govuk-table__header">Delivery partner</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric">ECTs</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Mentors</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <%= render LeadProviders::YourSchools::TableRow.with_collection(partnerships) %>
-  </tbody>
-</table>
+<div class="nhsuk-table-container">
+  <table data-test="schools-table" class="govuk-table nhsuk-table-responsive lead-provider-your-schools-table">
+    <thead  class="nhsuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">School</th>
+        <th scope="col" class="govuk-table__header">URN</th>
+        <th scope="col" class="govuk-table__header">Delivery partner</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">ECTs</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">Mentors</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body nhsuk-table__body">
+      <%= render LeadProviders::YourSchools::TableRow.with_collection(partnerships) %>
+    </tbody>
+  </table>
+</div>
 
 <%= govuk_paginate partnerships %>

--- a/app/components/lead_providers/your_schools/table.rb
+++ b/app/components/lead_providers/your_schools/table.rb
@@ -6,7 +6,7 @@ module LeadProviders
       include PaginationHelper
 
       def initialize(partnerships:, page:)
-        @partnerships = partnerships.page(page).per(20)
+        @partnerships = partnerships.page(page).per(10)
       end
 
     private

--- a/app/components/lead_providers/your_schools/table_row.html.erb
+++ b/app/components/lead_providers/your_schools/table_row.html.erb
@@ -1,12 +1,25 @@
-<tr class="govuk-table__row">
-  <td class="govuk-table__cell" >
+<tr class="govuk-table__row nhsuk-table__row">
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">School</span>
     <div class="school-name-with-tag">
       <%= govuk_link_to school.name, lead_providers_partnership_path(partnership) %>
       <%= govuk_tag text: "Reported error", colour: "red" if partnership.challenged? %>
     </div>
   </td>
-  <td class="govuk-table__cell"><%= school.urn %></td>
-  <td class="govuk-table__cell"><%= partnership.delivery_partner.name %></td>
-  <td class="govuk-table__cell govuk-table__cell--numeric"><%= school.early_career_teacher_profiles_for(cohort.start_year).count %></td>
-  <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">URN</span>
+    <%= school.urn %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Delivery partner</span>
+    <%= partnership.delivery_partner.name %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell govuk-table__cell--numeric">
+    <span class="nhsuk-table-responsive__heading">ECTs</span>
+    <%= school.early_career_teacher_profiles_for(cohort.start_year).count %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell govuk-table__cell--numeric">
+    <span class="nhsuk-table-responsive__heading">Mentors</span>
+    0
+  </td>
 </tr>

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -15,7 +15,7 @@ module Admin
         .ransack(induction_coordinators_email_or_urn_or_name_cont: @query).result
         .order(:name)
         .page(params[:page])
-        .per(20)
+        .per(10)
     end
 
     def show

--- a/app/views/admin/schools/index.html.erb
+++ b/app/views/admin/schools/index.html.erb
@@ -16,26 +16,43 @@
   <% end %>
 </div>
 
-<table class="govuk-table">
-  <thead>
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">School</th>
-      <th scope="col" class="govuk-table__header">URN</th>
-      <th scope="col" class="govuk-table__header">Local Authority</th>
-      <th scope="col" class="govuk-table__header">Group/network</th>
-      <th scope="col" class="govuk-table__header">Induction tutor</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @schools.each do |school| %>
+<div class="nhsuk-table-container">
+  <table class="govuk-table nhsuk-table-responsive">
+    <thead class="nhsuk-table__head">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= govuk_link_to school.name, admin_school_path(school) %></td>
-        <td class="govuk-table__cell"><%= school.urn %></td>
-        <td class="govuk-table__cell"><%= school.local_authority&.name %></td>
-        <td class="govuk-table__cell">- <span class='govuk-visually-hidden'>No group or network</span></td>
-        <td class="govuk-table__cell"><%= school.induction_coordinators.first&.email || "- <span class='govuk-visually-hidden'>No induction tutor</span>".html_safe %></td>
+        <th scope="col" class="govuk-table__header">School</th>
+        <th scope="col" class="govuk-table__header">URN</th>
+        <th scope="col" class="govuk-table__header">Local Authority</th>
+        <th scope="col" class="govuk-table__header">Group/network</th>
+        <th scope="col" class="govuk-table__header">Induction tutor</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody class="govuk-table__body nhsuk-table__body">
+      <% @schools.each do |school| %>
+        <tr class="govuk-table__row nhsuk-table__row">
+          <td class="govuk-table__cell nhsuk-table__cell">
+            <span class="nhsuk-table-responsive__heading">School</span>
+            <%= govuk_link_to school.name, admin_school_path(school) %>
+          </td>
+          <td class="govuk-table__cell nhsuk-table__cell">
+            <span class="nhsuk-table-responsive__heading">URN</span>
+            <%= school.urn %>
+          </td>
+          <td class="govuk-table__cell nhsuk-table__cell">
+            <span class="nhsuk-table-responsive__heading">Local Authority</span>
+            <%= school.local_authority&.name %>
+          </td>
+          <td class="govuk-table__cell nhsuk-table__cell">
+            <span class="nhsuk-table-responsive__heading">Group/network</span>
+            - <span class='govuk-visually-hidden'>No group or network</span>
+          </td>
+          <td class="govuk-table__cell nhsuk-table__cell">
+            <span class="nhsuk-table-responsive__heading">Induction tutor</span>
+            <%= school.induction_coordinators.first&.email || "- <span class='govuk-visually-hidden'>No induction tutor</span>".html_safe %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
 <%= govuk_paginate @schools %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -27,6 +27,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "school_search";
 @import "admin/schools";
 @import "aside";
+@import "vendor/nhs_tables";
 
 .govuk-tag {
   white-space: nowrap;

--- a/app/webpacker/styles/vendor/_nhs_tables.scss
+++ b/app/webpacker/styles/vendor/_nhs_tables.scss
@@ -1,0 +1,170 @@
+// Taken from https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/components/tables/_tables.scss
+
+/* ==========================================================================
+   COMPONENTS / #TABLE
+   ========================================================================== */
+
+/**
+ * Table container is used to ensure the table does not break the container.
+ *
+ * 1. Margin is removed so there isn't double spacing.
+ */
+
+.nhsuk-table-container {
+  // @include nhsuk-responsive-margin(7, 'bottom');
+  @include govuk-responsive-margin(8, "bottom");
+
+  display: block;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  overflow-x: auto;
+  width: 100%;
+
+  .nhsuk-table {
+    margin: 0; /* [1] */
+  }
+}
+
+/* Table row hover
+========================================================================== */
+
+/**
+ * Table row hover is used to aid readability for users.
+ */
+
+.nhsuk-table__row {
+  &:hover {
+    // background-color: $color_nhsuk-grey-5;
+  }
+}
+
+/* Table panel with tab heading
+========================================================================== */
+
+/**
+ * 1. Margin is removed so there isn't double spacing.
+ */
+
+// .nhsuk-table__panel-with-heading-tab {
+//   @include panel-with-label(
+//     $color_nhsuk-white,
+//     $nhsuk-text-color,
+//     $color_nhsuk-grey-4
+//   );
+
+//   .nhsuk-table-container,
+//   .nhsuk-table {
+//     margin: 0; /* [1] */
+//   }
+// }
+
+// .nhsuk-table__heading-tab {
+//   @include heading-label($color_nhsuk-blue, $color_nhsuk-white);
+// }
+
+/* Responsive table
+========================================================================== */
+
+/**
+ * 1. Hiding the thead on mobile
+ * 2. Displaying the thead on desktop
+ * 3. Removing default screen reader behaviour
+ * 4. Assigning role of table-row on desktop to give default screen reader behaviour
+ * 5. Using justify content to space out elements in the row on mobile
+ * 6. Assigning a minimum width in case of black cell
+ * 7. Aligning content to the right on mobile
+ * 8. Aligning mobile header to left to split it from the data
+ * 9. Hiding mobile specific header from desktop view
+ * 10. Adding a display block value due to IE 11 not having full flex support
+ */
+
+.nhsuk-table-responsive {
+  margin-bottom: 0;
+  width: 100%;
+
+  thead {
+    // @include visually-hidden; /* [1] */
+
+    // @include mq($from: desktop) {
+    //   @include visually-shown(table-header-group); /* [2] */
+    // }
+
+    @include govuk-media-query($until: desktop) {
+      @include govuk-visually-hidden;
+    }
+  }
+
+  .nhsuk-table__body {
+    .nhsuk-table-responsive__heading {
+      // font-weight: $nhsuk-font-bold;
+      font-weight: bold;
+      // padding-right: nhsuk-spacing(3);
+      padding-right: govuk-spacing(3);
+      text-align: left; /* [8] */
+
+      // @include mq($from: desktop) {
+      @include govuk-media-query($from: desktop) {
+        display: none; /* [9] */
+      }
+    }
+
+    .nhsuk-table__row {
+      display: block; /* [3] */
+      // margin-bottom: nhsuk-spacing(4);
+      margin-bottom: govuk-spacing(4);
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      // @include mq($from: desktop) {
+      @include govuk-media-query($from: desktop) {
+        display: table-row; /* [4] */
+      }
+
+      th {
+        text-align: right;
+        // @include mq($from: desktop) {
+        @include govuk-media-query($from: desktop) {
+          text-align: left;
+        }
+      }
+
+      td {
+        display: block; // For browsers that don't support flexbox
+        display: flex;
+        justify-content: space-between; /* [5] */
+        min-width: 1px; /* [6] */
+        @media all and (-ms-high-contrast: none) { /* [10] */
+          display: block;
+        }
+
+        // @include mq($from: desktop) {
+        @include govuk-media-query($from: desktop) {
+          display: table-cell;
+        }
+
+        // @include mq($until: desktop) {
+        @include govuk-media-query($until: desktop) {
+          padding-right: 0;
+          text-align: right; /* [7] */
+          &:last-child {
+            border-bottom: 3px solid $govuk-border-colour;
+          }
+        }
+      }
+    }
+  }
+}
+
+/* Numeric tables
+========================================================================== */
+
+/**
+ * Right aligns table cells for numeric tables.
+ */
+
+.nhsuk-table__header--numeric,
+.nhsuk-table__cell--numeric {
+  text-align: right;
+}

--- a/spec/components/lead_providers/your_schools/table_spec.rb
+++ b/spec/components/lead_providers/your_schools/table_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LeadProviders::YourSchools::Table, type: :view_component do
   stub_component LeadProviders::YourSchools::TableRow
 
   it "renders table row for each school" do
-    expected_partnerships = partnerships.each_slice(20).to_a[page - 1]
+    expected_partnerships = partnerships.each_slice(10).to_a[page - 1]
 
     expected_partnerships.each do |partnership|
       expect(rendered).to have_rendered(LeadProviders::YourSchools::TableRow).with(partnership: partnership)

--- a/spec/cypress/app_commands/scenarios/admin/schools.rb
+++ b/spec/cypress/app_commands/scenarios/admin/schools.rb
@@ -18,5 +18,5 @@ FactoryBot.create(:school_cohort, cohort: cohort_2022, school: school_with_cohor
 
 Faker::UniqueGenerator.clear
 Faker::Config.random = Random.new(42)
-FactoryBot.create_list(:school, 10)
+FactoryBot.create_list(:school, 7)
 Faker::Config.random = nil

--- a/spec/cypress/integration/admin/SchoolManagment.feature
+++ b/spec/cypress/integration/admin/SchoolManagment.feature
@@ -27,7 +27,7 @@ Feature: Admin user managing schools
     And percy should be sent snapshot
 
   Scenario: Viewing a list of schools
-    Then the table should have 12 rows
+    Then the table should have 9 rows
     And "page body" should contain "Enter the school’s name, URN or tutor email"
     And the page should be accessible
     And percy should be sent snapshot


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDRP-452

### Changes proposed in this pull request

the nhs responsive table is real nice so i added it to our codebase (after switching all the helpers to `govuk-` ones)

It didn't seem to actually add any styling which is ideal - the NHS design system seems to just style all `table` elements. That's why the elements have both `govuk-` and `nhsuk-` classes :)

### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

