### PR TITLE
Reduce alerting noise

### DIFF
--- a/terraform/monitoring/config/development/alert.rules.yml
+++ b/terraform/monitoring/config/development/alert.rules.yml
@@ -1,0 +1,70 @@
+groups:
+  - name: Request-rates
+    rules:
+      - alert: RequestsFailuresElevated
+        # Condition for alerting
+        expr: (sum(rate(requests{app="ecf-dev", status_range=~"0xx|4xx|5xx"}[10m]))) / (sum(rate(requests{app="ecf-dev"}[10m])) ) > 0.2
+        # Annotation - additional informational labels to store more information
+        annotations:
+          summary: High rate of failing requests
+          description: "ecf-dev: The proportion of failed HTTP requests in the past 5 min is above 10% (current value: {{ humanizePercentage $value }})"
+        # Labels - additional labels to be attached to the alert
+        labels:
+          environment: development
+          severity: low
+
+  - name: CPU-usage
+    rules:
+      - alert: AppCPUHigh
+        expr: avg by ( app ) (cpu{app="ecf-dev"}) > 60
+        for: 5m
+        annotations:
+          summary: App CPU usage high
+          description: "App CPU usage at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: development
+          severity: low
+      - alert: WorkerCPUHigh
+        expr: avg by ( app ) (cpu{app="ecf-dev-worker"}) > 75
+        for: 10m
+        annotations:
+          summary: Worker CPU usage high
+          description: "ecf-dev: Worker CPU usage at least 75% for more than 10 minutes (current value: {{ $value }})"
+        labels:
+          environment: development
+          severity: low
+
+  - name: Disk-utilisation
+    rules:
+      - alert: DiskUtilisationHigh
+        expr: avg by ( app ) ( disk_utilization{ app=~"ecf-dev" }) > 60
+        for: 5m
+        annotations:
+          summary: Disk Utilization High
+          description: "ecf-dev: Disk utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: development
+          severity: low
+
+  - name: Memory-utilisation
+    rules:
+      - alert: MemoryUtilizationHigh
+        expr: avg by ( app ) (memory_utilization{app=~"ecf-dev"}) > 75
+        for: 5m
+        annotations:
+          summary: Memory Utilization High
+          description: "ecf-dev: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: development
+          severity: low
+
+  - name: Crashed-apps
+    rules:
+      - alert: AppsCrashed
+        expr: rate(crash{app=~"ecf-dev"}[1m])*60 > 1
+        annotations:
+          summary: Crashed Apps non-zero
+          description: "ecf-dev: At least 1 crashed app (current value: {{ $value }})"
+        labels:
+          environment: development
+          severity: low

--- a/terraform/monitoring/config/production/alert.rules.yml
+++ b/terraform/monitoring/config/production/alert.rules.yml
@@ -3,68 +3,68 @@ groups:
     rules:
       - alert: RequestsFailuresElevated
         # Condition for alerting
-        expr: (sum(rate(requests{app="${app_name}", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="${app_name}"}[5m])) ) > 0.1
+        expr: (sum(rate(requests{app="ecf-production", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-production"}[5m])) ) > 0.1
         # Annotation - additional informational labels to store more information
         annotations:
           summary: High rate of failing requests
-          description: "${app_name}: The proportion of failed HTTP requests in the past 5 min is above 10% (current value: {{ humanizePercentage $value }})"
+          description: "ecf-production: The proportion of failed HTTP requests in the past 5 min is above 10% (current value: {{ humanizePercentage $value }})"
         # Labels - additional labels to be attached to the alert
         labels:
-          environment: ${environment}
+          environment: production
           severity: high
 
   - name: CPU-usage
     rules:
       - alert: AppCPUHigh
-        expr: avg by ( app ) (cpu{app="${app_name}"}) > 60
+        expr: avg by ( app ) (cpu{app="ecf-production"}) > 60
         for: 5m
         annotations:
           summary: App CPU usage high
           description: "App CPU usage at least 60% for more than 5 minutes (current value: {{ $value }})"
         labels:
-          environment: ${environment}
+          environment: production
           severity: high
       - alert: WorkerCPUHigh
-        expr: avg by ( app ) (cpu{app="${app_name}-worker"}) > 75
+        expr: avg by ( app ) (cpu{app="ecf-production-worker"}) > 75
         for: 10m
         annotations:
           summary: Worker CPU usage high
-          description: "${app_name}: Worker CPU usage at least 75% for more than 10 minutes (current value: {{ $value }})"
+          description: "ecf-production: Worker CPU usage at least 75% for more than 10 minutes (current value: {{ $value }})"
         labels:
-          environment: ${environment}
+          environment: production
           severity: high
 
   - name: Disk-utilisation
     rules:
       - alert: DiskUtilisationHigh
-        expr: avg by ( app ) ( disk_utilization{ app=~"${app_name}" }) > 60
+        expr: avg by ( app ) ( disk_utilization{ app=~"ecf-production" }) > 60
         for: 5m
         annotations:
           summary: Disk Utilization High
-          description: "${app_name}: Disk utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+          description: "ecf-production: Disk utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
         labels:
-          environment: ${environment}
+          environment: production
           severity: high
 
   - name: Memory-utilisation
     rules:
       - alert: MemoryUtilizationHigh
-        expr: avg by ( app ) (memory_utilization{app=~"${app_name}"}) > 60
+        expr: avg by ( app ) (memory_utilization{app=~"ecf-production"}) > 60
         for: 5m
         annotations:
           summary: Memory Utilization High
-          description: "${app_name}: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+          description: "ecf-production: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
         labels:
-          environment: ${environment}
+          environment: production
           severity: high
 
   - name: Crashed-apps
     rules:
       - alert: AppsCrashed
-        expr: rate(crash{app=~"${app_name}"}[1m])*60 > 1
+        expr: rate(crash{app=~"ecf-production"}[1m])*60 > 1
         annotations:
           summary: Crashed Apps non-zero
-          description: "${app_name}: At least 1 crashed app (current value: {{ $value }})"
+          description: "ecf-production: At least 1 crashed app (current value: {{ $value }})"
         labels:
-          environment: ${environment}
+          environment: production
           severity: high

--- a/terraform/monitoring/config/slack.tmpl
+++ b/terraform/monitoring/config/slack.tmpl
@@ -1,0 +1,93 @@
+# This builds the silence URL.  We exclude the alertname in the range
+# to avoid the issue of having trailing comma separator (%2C) at the end
+# of the generated URL
+#
+# This file was copied from https://gist.github.com/milesbxf/e2744fc90e9c41b47aa47925f8ff6512
+# Thank you :)
+
+{{ define "__alert_silence_link" -}}
+    {{ .ExternalURL }}/#/silences/new?filter=%7B
+    {{- range .CommonLabels.SortedPairs -}}
+        {{- if ne .Name "alertname" -}}
+            {{- .Name }}%3D"{{- .Value -}}"%2C%20
+        {{- end -}}
+    {{- end -}}
+    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+{{- end }}
+
+
+
+{{ define "__alert_severity_prefix" -}}
+    {{ if ne .Status "firing" -}}
+      :white_check_mark:
+    {{- else if eq .Labels.severity "high" -}}
+      :fire:
+    {{- else if eq .Labels.severity "medium" -}}
+      :warning:
+    {{- else -}}
+      :question:
+    {{- end }}
+{{- end }}
+
+{{ define "__alert_severity_prefix_title" -}}
+    {{ if ne .Status "firing" -}}
+      :white_check_mark:
+    {{- else if eq .CommonLabels.severity "high" -}}
+      :fire:
+    {{- else if eq .CommonLabels.severity "medium" -}}
+      :warning:
+    {{- else if eq .CommonLabels.severity "low" -}}
+      :information_source:
+    {{- else -}}
+      :question:
+    {{- end }}
+{{- end }}
+
+
+{{/* First line of Slack alerts */}}
+{{ define "slack.monzo.title" -}}
+  [{{ .Status | toUpper -}}
+  {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+  ] {{ template "__alert_severity_prefix_title" . }} {{ .CommonLabels.alertname }}
+{{- end }}
+
+
+{{/* Color of Slack attachment (appears as line next to alert )*/}}
+{{ define "slack.monzo.color" -}}
+    {{ if eq .Status "firing" -}}
+        {{ if eq .CommonLabels.severity "medium" -}}
+          warning
+        {{- else if eq .CommonLabels.severity "high" -}}
+          danger
+        {{- else -}}
+          #439FE0
+        {{- end -}}
+    {{ else -}}
+      good
+    {{- end }}
+{{- end }}
+
+{{/* The test to display in the pretext */}}
+{{ define "slack.monzo.pretext" -}}
+    {{ range .Alerts }}
+        {{- if .Annotations.summary }}
+          {{- if eq .CommonLabels.severity "high" -}}
+            <!channel> *{{ .Annotations.summary }}*
+          {{- else -}}
+            *{{ .Annotations.summary }}*
+          {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+
+{{/* The test to display in the alert */}}
+{{ define "slack.monzo.text" -}}
+    {{ if eq .Status "firing" -}}
+        {{ range .Alerts }}
+            {{- if .Annotations.description }}
+                {{ .Annotations.description }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -1,0 +1,70 @@
+groups:
+  - name: Request-rates
+    rules:
+      - alert: RequestsFailuresElevated
+        # Condition for alerting
+        expr: (sum(rate(requests{app="ecf-staging", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1
+        # Annotation - additional informational labels to store more information
+        annotations:
+          summary: High rate of failing requests
+          description: "ecf-staging: The proportion of failed HTTP requests in the past 5 min is above 10% (current value: {{ humanizePercentage $value }})"
+        # Labels - additional labels to be attached to the alert
+        labels:
+          environment: staging
+          severity: medium
+
+  - name: CPU-usage
+    rules:
+      - alert: AppCPUHigh
+        expr: avg by ( app ) (cpu{app="ecf-staging"}) > 60
+        for: 5m
+        annotations:
+          summary: App CPU usage high
+          description: "App CPU usage at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium
+      - alert: WorkerCPUHigh
+        expr: avg by ( app ) (cpu{app="ecf-staging-worker"}) > 75
+        for: 10m
+        annotations:
+          summary: Worker CPU usage high
+          description: "ecf-staging: Worker CPU usage at least 75% for more than 10 minutes (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium
+
+  - name: Disk-utilisation
+    rules:
+      - alert: DiskUtilisationHigh
+        expr: avg by ( app ) ( disk_utilization{ app=~"ecf-staging" }) > 60
+        for: 5m
+        annotations:
+          summary: Disk Utilization High
+          description: "ecf-staging: Disk utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium
+
+  - name: Memory-utilisation
+    rules:
+      - alert: MemoryUtilizationHigh
+        expr: avg by ( app ) (memory_utilization{app=~"ecf-staging"}) > 60
+        for: 5m
+        annotations:
+          summary: Memory Utilization High
+          description: "ecf-staging: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium
+
+  - name: Crashed-apps
+    rules:
+      - alert: AppsCrashed
+        expr: rate(crash{app=~"ecf-staging"}[1m])*60 > 1
+        annotations:
+          summary: Crashed Apps non-zero
+          description: "ecf-staging: At least 1 crashed app (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium

--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -1,17 +1,15 @@
 module "prometheus_all" {
-  source = "git::https://github.com/DFE-Digital/cf-monitoring.git//prometheus_all"
+  source = "git::https://github.com/ethanmills/cf-monitoring.git//prometheus_all"
 
   monitoring_instance_name = var.monitoring_instance_name
   monitoring_org_name = "dfe"
   monitoring_space_name = var.paas_space_name
   paas_exporter_username = var.paas_user
   paas_exporter_password = var.paas_password
-  alert_rules = templatefile("${path.module}/config/alert.rules.yml", {
-    environment = var.environment,
-    app_name = var.app_name
-  })
+  alert_rules = file("${path.module}/config/${var.environment}/alert.rules.yml")
   alertmanager_slack_url = var.alertmanager_slack_url
   alertmanager_slack_channel = "cpd-dev-alerts"
+  alertmanager_slack_template = file("${path.module}/config/")
   grafana_admin_password = var.grafana_admin_password
   grafana_google_client_id = var.google_client_id
   grafana_google_client_secret = var.google_client_secret


### PR DESCRIPTION
- Add separate alert configs per environment
- Relax dev alert criteria
- Reduce severity of alerts in other environments
- Change monitoring stack to fork to allow setting slack template
- Only notify @channel for high severity alerts
