### PR TITLE
remove colour codes from debug logs

### DIFF
--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -97,6 +97,9 @@ Rails.application.configure do
   logger.formatter = config.log_formatter
   config.logger = ActiveSupport::TaggedLogging.new(logger)
 
+  # Remove colour codes from debug logging
+  config.colorize_logging = false
+
   # Use Lograge for cleaner logging
   config.lograge.enabled = true
   config.lograge.base_controller_class = ["ActionController::API", "ActionController::Base"]


### PR DESCRIPTION
e.g. `[1m[36mTRANSACTION (1.2ms)[0m  [1m[31mROLLBACK[0m`
