### PR TITLE
/api/v1/users endpoint now supports email filter

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -46,11 +46,19 @@ module Api
         params.dig(:filter, :updated_since)
       end
 
+      def email
+        params.dig(:filter, :email)
+      end
+
       def users
         users = User.includes_school
 
         if updated_since.present?
           users = users.changed_since(updated_since)
+        end
+
+        if email.present?
+          users = users.where(email: email)
         end
 
         users

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe "API Users", type: :request do
         get "/api/v1/users", params: { filter: { updated_since: 1.day.ago.iso8601 } }
         expect(parsed_response["data"].size).to eql(2)
       end
+
+      context "when filtering by email" do
+        it "returns users that match" do
+          email = User.all.sample.email
+          get "/api/v1/users", params: { filter: { email: email } }
+          expect(parsed_response["data"].size).to eql(1)
+          expect(parsed_response.dig("data", 0, "attributes", "email")).to eql(email)
+        end
+
+        it "returns no users if no matches" do
+          email = "dontexist@example.com"
+          get "/api/v1/users", params: { filter: { email: email } }
+          expect(parsed_response["data"].size).to eql(0)
+        end
+      end
     end
 
     context "when unauthorized" do


### PR DESCRIPTION
### Context

- ECF does not allow users to have duplicate emails (for obvious reasons)
- NPQ registration can create user accounts, however it is possible for a user to already exist in ECF with this same email address
- NPQ registration should check if such an account exist and use that if it exists otherwise create the account

### Changes proposed in this pull request

- Allow the endpoint `/api/v1/users` to support filtering by email

### Guidance to review

- Should not negatively impact the existing endpoint for other integrations

### Testing

- Test in review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- note down the token
- create a new user via command line or find an existing user and note down the email

```
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" "https://ecf-review-pr-584.london.cloudapps.digital/api/v1/users?filter[email]=EMAIL"
```

- should return the found user