### PR TITLE
CPDTP-195 Add migration to backfill ECT profile uplift data

### DIFF
--- a/db/migrate/20210618160328_backfill_profile_uplift_data.rb
+++ b/db/migrate/20210618160328_backfill_profile_uplift_data.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BackfillProfileUpliftData < ActiveRecord::Migration[6.1]
+  def up
+    EarlyCareerTeacherProfile.find_each do |profile|
+      profile.sparsity_uplift = profile.school.sparsity_uplift?(2021)
+      profile.pupil_premium_uplift = profile.school.pupil_premium_uplift?(2021)
+      profile.save!
+    end
+  end
+end


### PR DESCRIPTION
### Context

Registrations have already been collected in production so we need to backfill the data that was not already captured in the new field.

Part of a bigger story to process uplift information for payments. https://dfedigital.atlassian.net/browse/CPDTP-195

### Changes proposed in this pull request

Add migration to backfill ECT profile uplift data

### Guidance to review


### Testing

```
testing the migration:

bundle exec rails console

# pupil premium setup
s1 = School.with_pupil_premium_uplift(2021).first # from existing seed data
e1 = EarlyCareerTeacherProfile.create!(school: s1, user: User.first, cohort: Cohort.first)
e1.id # make a note of the new id

# sparsity migration setup
l = LocalAuthorityDistrict.create!
d = DistrictSparsity.create!(start_year: 2021, local_authority_district: l)
l.sparse? # returns true
s2 = School.create!(urn:"4321321", name:"sparse migrate test school", address_line1:"x",postcode:"sw1a 1aa")
slad = SchoolLocalAuthorityDistrict.create(school: s2, local_authority_district: l, start_year: 2021)
s2.sparsity_uplift? # now returns true
e2 = EarlyCareerTeacherProfile.create!(school: s2, user: User.first, cohort: Cohort.first)
e2.id # make a note of the new id
e2.school.sparsity_uplift?(2021) # returns true now

exit

bundle exec rails db:migrate

bundle exec rails console

# check pupil premium values:
id1="<GUID from above>"
e1 = EarlyCareerTeacherProfile.find(id1)
e1.pupil_premium_uplift? # should return true

# check sparsity values:
id2="<GUID from above>"
e2 = EarlyCareerTeacherProfile.find(id2)
e2.sparsity_uplift? # should return true
```
