### PR TITLE
Fix issue with slack template for alert manager

### DIFF
--- a/terraform/monitoring/config/slack.tmpl
+++ b/terraform/monitoring/config/slack.tmpl
@@ -69,15 +69,19 @@
 
 {{/* The test to display in the pretext */}}
 {{ define "slack.monzo.pretext" -}}
-    {{ range .Alerts }}
-        {{- if .Annotations.summary }}
-          {{- if eq .CommonLabels.severity "high" -}}
-            <!channel> *{{ .Annotations.summary }}*
-          {{- else -}}
-            *{{ .Annotations.summary }}*
-          {{- end }}
+    {{ if eq .CommonLabels.severity "high" }}
+        {{ range .Alerts }}
+            {{- if .Annotations.summary }}
+              <!channel> *{{ .Annotations.summary }}*
+            {{- end }}
         {{- end }}
-    {{- end }}
+    {{else}}
+        {{ range .Alerts }}
+            {{- if .Annotations.summary }}
+              *{{ .Annotations.summary }}*
+            {{- end }}
+        {{- end }}
+    {{ end }}
 {{- end }}
 
 


### PR DESCRIPTION
.CommonLabels was not defined within the .Alerts range

I really hope this is the last one... Ran a terraform apply locally in develop on this one and it works, so that's good