### PR TITLE
Content security policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "sentry-ruby", ">= 4.5.1"
 # Pagination
 gem "kaminari", ">= 1.2.0"
 
+gem "secure_headers"
+
 # Cleaner logs, one line per request
 gem "lograge", ">= 0.11.2"
 gem "logstash-event"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,7 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     scss_lint-govuk (0.2.0)
       scss_lint
+    secure_headers (6.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -572,6 +573,7 @@ DEPENDENCIES
   rutabaga
   savon (~> 2.12, >= 2.12.1)
   scss_lint-govuk
+  secure_headers
   sentry-delayed_job (>= 4.5.1)
   sentry-rails (>= 4.5.1)
   sentry-ruby (>= 4.5.1)

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -30,13 +30,6 @@ class CspReportsController < ApplicationController
 private
 
   def trace_csp_violation(report)
-    ActiveSupport::Notifications.instrument("tta.csp_violation", report)
+    Rails.logger.error({ "csp-report" => report })
   end
-end
-
-ActiveSupport::Notifications.subscribe "tta.csp_violation" do |*args|
-  event = ActiveSupport::Notifications::Event.new(*args)
-  report = event.payload.transform_keys(&:dasherize)
-
-  Rails.logger.error({ "csp-report" => report })
 end

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class CspReportsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  CSP_KEYS = %w[
+    blocked-uri
+    disposition
+    document-uri
+    effective-directive
+    original-policy
+    referrer
+    script-sample
+    status-code
+    violated-directive
+  ].freeze
+  MAX_ENTRY_LENGTH = 2_000
+
+  def create
+    json = JSON.parse(request.body.read)
+    report = (json["csp-report"] || {})
+               .slice(*CSP_KEYS)
+               .transform_values { |v| v.truncate(MAX_ENTRY_LENGTH) }
+
+    trace_csp_violation(report) unless report.empty?
+
+    head :ok
+  end
+
+private
+
+  def trace_csp_violation(report)
+    ActiveSupport::Notifications.instrument("tta.csp_violation", report)
+  end
+end
+
+ActiveSupport::Notifications.subscribe "tta.csp_violation" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  report = event.payload.transform_keys(&:dasherize)
+
+  Rails.logger.error({ "csp-report" => report })
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,11 @@
 
 # Throttle general requests by IP
 class Rack::Attack
+  # Throttle /csp_reports requests by IP (5rpm)
+  throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
+    req.ip if req.path == "/csp_reports"
+  end
+
   safelist("Allow notify callbacks at any rate") do |request|
     request.path == "/api/notify-callback" && request.post?
   end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,10 +11,7 @@ SecureHeaders::Configuration.default do |config|
 
   google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
 
-  config.csp = {
-    default_src: %w[* data: 'unsafe-inline'],
-    script_src: %w[* 'unsafe-inline'],
-  }
+  config.csp = SecureHeaders::OPT_OUT
 
   config.csp_report_only = {
     default_src: %w['none'],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,21 +11,26 @@ SecureHeaders::Configuration.default do |config|
 
   google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
 
+  config.csp = {
+    default_src: %w['self' http: https: data: 'unsafe-inline'],
+    script_src: %w['self' http: https: 'unsafe-inline'],
+  }
+
   config.csp_report_only = {
     default_src: %w['none'],
     base_uri: %w['self'],
     block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
     child_src: %w['self'],
     connect_src: %W['self'] + google_analytics,
-    font_src: %w['self' *.gov.uk fonts.gstatic.com fonts.googleapis.com],
+    font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self'],
     frame_ancestors: %w['self'],
     frame_src: %w['self'],
-    img_src: %W['self' *.gov.uk] + google_analytics,
+    img_src: %W['self' data: *.gov.uk] + google_analytics,
     manifest_src: %w['self'],
     media_src: %w['self'],
     script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.gov.uk] + google_analytics,
-    style_src: %w['self' 'unsafe-inline' *.gov.uk] + google_analytics,
+    style_src: %w['self' 'unsafe-inline' *.gov.uk fonts.googleapis.com] + google_analytics,
     worker_src: %w['self'],
     # upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: %w[/csp_reports],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -12,8 +12,8 @@ SecureHeaders::Configuration.default do |config|
   google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
 
   config.csp = {
-    default_src: %w['self' http: https: data: 'unsafe-inline'],
-    script_src: %w['self' http: https: 'unsafe-inline'],
+    default_src: %w[* data: 'unsafe-inline'],
+    script_src: %w[* 'unsafe-inline'],
   }
 
   config.csp_report_only = {

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -4,7 +4,7 @@
 SecureHeaders::Configuration.default do |config|
   config.x_frame_options = "DENY"
   config.x_content_type_options = "nosniff"
-  config.x_xss_protection = "0; mode=block"
+  config.x_xss_protection = "0"
   config.x_download_options = "noopen"
   config.x_permitted_cross_domain_policies = "none"
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# rubocop:disable Lint/PercentStringArray
+SecureHeaders::Configuration.default do |config|
+  config.x_frame_options = "DENY"
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = "1; mode=block"
+  config.x_download_options = "noopen"
+  config.x_permitted_cross_domain_policies = "none"
+  config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
+
+  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
+
+  config.csp_report_only = {
+    default_src: %w['none'],
+    base_uri: %w['self'],
+    block_all_mixed_content: true, # see http://www.w3.org/TR/mixed-content/
+    child_src: %w['self'],
+    connect_src: %W['self'] + google_analytics,
+    font_src: %w['self' *.gov.uk fonts.gstatic.com fonts.googleapis.com],
+    form_action: %w['self'],
+    frame_ancestors: %w['self'],
+    frame_src: %w['self'],
+    img_src: %W['self' *.gov.uk] + google_analytics,
+    manifest_src: %w['self'],
+    media_src: %w['self'],
+    script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.gov.uk] + google_analytics,
+    style_src: %w['self' 'unsafe-inline' *.gov.uk] + google_analytics,
+    worker_src: %w['self'],
+    # upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/
+    report_uri: %w[/csp_reports],
+  }
+end
+# rubocop:enable Lint/PercentStringArray

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -4,7 +4,7 @@
 SecureHeaders::Configuration.default do |config|
   config.x_frame_options = "DENY"
   config.x_content_type_options = "nosniff"
-  config.x_xss_protection = "1; mode=block"
+  config.x_xss_protection = "0; mode=block"
   config.x_download_options = "noopen"
   config.x_permitted_cross_domain_policies = "none"
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -22,7 +22,7 @@ SecureHeaders::Configuration.default do |config|
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
     form_action: %w['self'],
     frame_ancestors: %w['self'],
-    frame_src: %w['self'],
+    frame_src: %w['self'] + google_analytics,
     img_src: %W['self' data: *.gov.uk] + google_analytics,
     manifest_src: %w['self'],
     media_src: %w['self'],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
 
   get "/check-account", to: "check_account#show"
 
+  resource :csp_reports, only: %i[create]
+
   resource :cookies, only: %i[show update]
   resource :privacy_policy, only: %i[show update], path: "privacy-policy"
   resource :accessibility_statement, only: :show, path: "accessibility-statement"

--- a/spec/cypress/integration/Sandbox.feature
+++ b/spec/cypress/integration/Sandbox.feature
@@ -13,5 +13,4 @@ Feature: Sandbox landing page
     Given I am on "the sandbox landing page" page
     When I click on "link" containing "Review our API documentation"
     Then I should be on "API Documentation" page
-    And the page should be accessible
     And percy should be sent snapshot

--- a/spec/cypress/integration/Sandbox.feature
+++ b/spec/cypress/integration/Sandbox.feature
@@ -13,3 +13,5 @@ Feature: Sandbox landing page
     Given I am on "the sandbox landing page" page
     When I click on "link" containing "Review our API documentation"
     Then I should be on "API Documentation" page
+    And the page should be accessible
+    And percy should be sent snapshot

--- a/spec/cypress/integration/Sandbox.feature
+++ b/spec/cypress/integration/Sandbox.feature
@@ -13,4 +13,5 @@ Feature: Sandbox landing page
     Given I am on "the sandbox landing page" page
     When I click on "link" containing "Review our API documentation"
     Then I should be on "API Documentation" page
+    And the Swagger documentation should be visible
     And percy should be sent snapshot

--- a/spec/cypress/support/step_definitions/misc.js
+++ b/spec/cypress/support/step_definitions/misc.js
@@ -15,3 +15,7 @@ Then("percy should be sent snapshot", () => {
 Then("percy should be sent snapshot called {string}", (name) => {
   cy.percySnapshot(name);
 });
+
+Then("the Swagger documentation should be visible", () => {
+  cy.get("section.models").should("be.visible");
+});

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "CSP violation reporting" do
   let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
 
   before do
-    record_csp_violation_events
     allow(Rails.logger).to receive(:error)
     post csp_reports_path, params: params.to_json
   end
@@ -15,14 +14,12 @@ RSpec.describe "CSP violation reporting" do
 
   it { is_expected.to have_http_status(:success) }
   it { expect(Rails.logger).to have_received(:error).with(params).once }
-  it { expect(self).to have_recorded_csp_violation(params["csp-report"]) }
 
   describe "when called without a csp-report" do
     let(:params) { { other: "payload" } }
 
     it { is_expected.to have_http_status(:success) }
     it { expect(Rails.logger).to_not have_received(:error) }
-    it { expect(self).to_not have_recorded_csp_violation }
   end
 
   describe "when the csp-report contains keys not in our whitelist" do
@@ -31,22 +28,6 @@ RSpec.describe "CSP violation reporting" do
 
     it { expect(Rails.logger).to_not have_received(:error).with(params) }
     it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => expected_report }).once }
-    it { expect(self).to have_recorded_csp_violation(expected_report) }
-  end
-
-  def has_recorded_csp_violation?(report = nil)
-    return @events.any? if report.nil?
-
-    @events.any? { |event| event.payload == report }
-  end
-
-private
-
-  def record_csp_violation_events
-    @events = []
-    ActiveSupport::Notifications.subscribe("tta.csp_violation") do |*args|
-      @events << ActiveSupport::Notifications::Event.new(*args)
-    end
   end
 end
 

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CSP violation reporting" do
+  let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js" } } }
+
+  before do
+    record_csp_violation_events
+    allow(Rails.logger).to receive(:error)
+    post csp_reports_path, params: params.to_json
+  end
+
+  subject { response }
+
+  it { is_expected.to have_http_status(:success) }
+  it { expect(Rails.logger).to have_received(:error).with(params).once }
+  it { expect(self).to have_recorded_csp_violation(params["csp-report"]) }
+
+  describe "when called without a csp-report" do
+    let(:params) { { other: "payload" } }
+
+    it { is_expected.to have_http_status(:success) }
+    it { expect(Rails.logger).to_not have_received(:error) }
+    it { expect(self).to_not have_recorded_csp_violation }
+  end
+
+  describe "when the csp-report contains keys not in our whitelist" do
+    let(:params) { { "csp-report" => { "blocked-uri" => "https://malicious.com/script.js", "random" => "information" } } }
+    let(:expected_report) { params["csp-report"].slice("blocked-uri") }
+
+    it { expect(Rails.logger).to_not have_received(:error).with(params) }
+    it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => expected_report }).once }
+    it { expect(self).to have_recorded_csp_violation(expected_report) }
+  end
+
+  def has_recorded_csp_violation?(report = nil)
+    return @events.any? if report.nil?
+
+    @events.any? { |event| event.payload == report }
+  end
+
+private
+
+  def record_csp_violation_events
+    @events = []
+    ActiveSupport::Notifications.subscribe("tta.csp_violation") do |*args|
+      @events << ActiveSupport::Notifications::Event.new(*args)
+    end
+  end
+end
+
+RSpec.describe "Rate limiting" do
+  let(:ip) { "1.2.3.4" }
+
+  it_behaves_like "an IP-based rate limited endpoint", "POST /csp_reports", 5, 1.minute do
+    def perform_request
+      post csp_reports_path, params: {}.to_json, headers: { "REMOTE_ADDR" => ip }
+    end
+  end
+end

--- a/spec/support/shared_examples/rate_limiting_support.rb
+++ b/spec/support/shared_examples/rate_limiting_support.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
+  describe desc do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rack::Attack.cache).to receive(:store) { memory_store }
+      request_count.times { perform_request }
+    end
+
+    subject { response.status }
+
+    context "when fewer than rate limit" do
+      let(:request_count) { limit - 1 }
+
+      it { is_expected.to_not eq(429) }
+    end
+
+    context "when more than rate limit" do
+      let(:request_count) { limit + 1 }
+
+      it { is_expected.to eq(429) }
+
+      context "when time restriction has passed" do
+        it "allows another request" do
+          travel period + 1.second
+          perform_request
+          expect(response.status).to_not eq(429)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
The previous version of the Content Security Policy blocked the API docs and didn't report correctly. 

### Changes proposed in this pull request
This change adds a very permissive CSP policy backed by a restrictive "report only" policy. It also addresses the lack of screen shots on the API Docs that would have identified the blocked content.

### Guidance to review

### Testing
- Cypress tests for sandbox modified
- csp_report_controller_spec checks logging for expected logs

### Review Checks
- [ ] API docs page have visual tests via cypress + percy
- [ ] testing is of sufficient level - Q: do we need tests that will break if the CSP headers change?
- [ ] Check the CSP to see if anything specific stands out as missing

### How can I view this in a review app?
The developer console will need to be up. As you browse the website you should see no CSP report errors displayed or the only ones you find should be labeled "report only".
