### PR TITLE
Ensure email does not end with a dot

### DIFF
--- a/app/validators/notify_email_validator.rb
+++ b/app/validators/notify_email_validator.rb
@@ -19,6 +19,7 @@ class NotifyEmailValidator < ActiveModel::EachValidator
     return false if email.include?("..")
 
     hostname = email_match[1]
+    return false unless hostname.last.match(/[a-z0-9]/i)
 
     parts = hostname.split(".")
     return false if hostname.length > 253 || parts.length < 2

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe NotifyEmailValidator do
       '"quoted@domain.com"',
       "lots-of-dots@domain..gov..uk",
       "two-dots..in-local@domain.com",
+      "trailing-dot-in-domain@domain.com.",
       "multiple@domains@domain.com",
       "spaces in local@domain.com",
       "spaces-in-domain@dom ain.com",


### PR DESCRIPTION
Sentry has caught errors caused by people entering emails ending with a
dot
