### PR TITLE
store funding data for npq profiles

### DIFF
--- a/app/models/npq_profile.rb
+++ b/app/models/npq_profile.rb
@@ -10,4 +10,11 @@ class NpqProfile < ApplicationRecord
     yes_in_first_two_years: "yes_in_first_two_years",
     yes_over_two_years: "yes_over_two_years",
   }
+
+  enum funding_choice: {
+    school: "school",
+    trust: "trust",
+    self: "self",
+    another: "another",
+  }
 end

--- a/app/resources/api/v1/npq_profile_resource.rb
+++ b/app/resources/api/v1/npq_profile_resource.rb
@@ -8,7 +8,9 @@ module Api
                  :teacher_reference_number_verified,
                  :active_alert,
                  :school_urn,
-                 :headteacher_status
+                 :headteacher_status,
+                 :eligible_for_funding,
+                 :funding_choice
 
       has_one :user
       has_one :npq_lead_provider

--- a/db/migrate/20210625143352_add_funding_fields_to_npq_profile.rb
+++ b/db/migrate/20210625143352_add_funding_fields_to_npq_profile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddFundingFieldsToNpqProfile < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_table :npq_profiles, bulk: true do |t|
+        t.boolean :eligible_for_funding, null: false, default: false
+        t.text :funding_choice
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_23_120047) do
+ActiveRecord::Schema.define(version: 2021_06_25_143352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -328,6 +328,8 @@ ActiveRecord::Schema.define(version: 2021_06_23_120047) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "active_alert", default: false
+    t.boolean "eligible_for_funding", default: false, null: false
+    t.text "funding_choice"
     t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
     t.index ["user_id"], name: "index_npq_profiles_on_user_id"

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
               date_of_birth: "1990-12-13",
               school_urn: "123456",
               headteacher_status: "no",
+              eligible_for_funding: true,
+              funding_choice: "school",
             },
             relationships: {
               user: {
@@ -70,6 +72,8 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(profile.school_urn).to eql("123456")
         expect(profile.headteacher_status).to eql("no")
         expect(profile.npq_course).to eql(npq_course)
+        expect(profile.eligible_for_funding).to eql(true)
+        expect(profile.funding_choice).to eql("school")
       end
 
       it "returns a 201" do
@@ -98,6 +102,8 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
           :headteacher_status,
           :date_of_birth,
           :school_urn,
+          :eligible_for_funding,
+          :funding_choice,
         )
       end
     end


### PR DESCRIPTION
### Context

- NPQ registration collects funding data as part of the process
- We collect whether we think they are eligible for funding based off their course and school
- If they are not eligible we ask them how they intend to fund their course

### Changes proposed in this pull request

- npq profile api endpoints supports `eligible_for_funding` and `funding_choice` along with migrations to add these fields

### Guidance to review

- Should not affect other api endpoints

### Testing

- Test in review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- note down the token
- create a user with

```
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" -X POST -d '{ "data": { "type": "user", "attributes": { "full_name": "John Doe", "email": "john.doe@example.com" } } }' https://ecf-review-pr-595.london.cloudapps.digital/api/v1/users
```

- note down the id of the newly created user

```
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" -X POST -d '{"data":{"type":"npq_profiles","attributes":{"teacher_reference_number":"1234567","teacher_reference_number_verified":true,"date_of_birth":"1990-12-13","school_urn":"123456","headteacher_status":"no","eligible_for_funding":true,"funding_choice":"school"},"relationships":{"user":{"data":{"type":"users","id":"USER_ID_HERE"}},"npq_lead_provider":{"data":{"type":"npq_lead_providers","id":"NPQ_LEAD_PROVIDER_ID"}},"npq_course":{"data":{"type":"npq_courses","id":"NPQ_COURSE_ID"}}}}}' https://ecf-review-pr-595.london.cloudapps.digital/api/v1/npq-profiles
```