### PR TITLE
CPDTP-204 Don't output mentor ids in sandbox seed output

### DIFF
--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -21,7 +21,6 @@ def generate_provider_token(lead_provider, school, cohort, logger)
     user_uuids = 10.times.each_with_object([]) do |_i, uuids|
       mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
       mentor_profile = MentorProfile.create!(user: mentor, school: school, cohort: cohort)
-      uuids << mentor.id
 
       ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
       EarlyCareerTeacherProfile.create!(user: ect, school: school, cohort: cohort, mentor_profile: mentor_profile)


### PR DESCRIPTION
### Context

You can't currently submit a declaration against mentor user ids so this was a pit of failure... into which I fell.

### Changes proposed in this pull request

* Don't output mentor ids in sandbox seed output.

### Guidance to review

:ship:

### Testing

* rails db:reset
* See new output with less ids
* Optionally submit one of the ids to the declaration endpoint, but note there's another bug blocking this being fixed in #596