### PR TITLE
Cypress fixes

### DIFF
--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 school = FactoryBot.create(:school, name: "Test School", slug: "test-school")
-cohort = FactoryBot.create(:cohort, start_year: 2021)
+cohort = Cohort.find_or_create_by!(start_year: 2021)
 
 user_1 = FactoryBot.create(:user, :mentor, full_name: "Mentor User 1")
 user_1.mentor_profile.update!(school: school, cohort: cohort)

--- a/spec/cypress/app_commands/scenarios/admin/suppliers.rb
+++ b/spec/cypress/app_commands/scenarios/admin/suppliers.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 delivery_partner = FactoryBot.create(:delivery_partner, name: "Delivery Partner 1")
-cohort = FactoryBot.create(:cohort, start_year: 2021)
+cohort = Cohort.find_or_create_by!(start_year: 2021)
 lead_provider = FactoryBot.create(:lead_provider, name: "Lead Provider 1", cohorts: [cohort])
 ProviderRelationship.create!(delivery_partner: delivery_partner, lead_provider: lead_provider, cohort: cohort)
 

--- a/spec/cypress/app_commands/scenarios/challenge_partnership.rb
+++ b/spec/cypress/app_commands/scenarios/challenge_partnership.rb
@@ -2,7 +2,7 @@
 
 school = FactoryBot.create(:school, name: "Test school", slug: "111111-test-school")
 delivery_partner = FactoryBot.create(:delivery_partner, name: "Test delivery partner")
-cohort = FactoryBot.create(:cohort, start_year: 2021)
+cohort = Cohort.find_or_create_by!(start_year: 2021)
 user = FactoryBot.create(:user, :induction_coordinator, schools: [school], email: "test-subject@example.com")
 partnership = FactoryBot.create(:partnership, :in_challenge_window, school: school, cohort: cohort, delivery_partner: delivery_partner)
 SchoolCohort.create!(school: school, cohort: cohort, induction_programme_choice: "full_induction_programme")

--- a/spec/cypress/app_commands/scenarios/cip_cohort_with_school.rb
+++ b/spec/cypress/app_commands/scenarios/cip_cohort_with_school.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-cohort = FactoryBot.create(:cohort, start_year: 2021)
+cohort = Cohort.find_or_create_by!(start_year: 2021)
 school = FactoryBot.create(:school, name: "Outstanding school", slug: "111111-outstanding-school")
 FactoryBot.create(:school_cohort, school: school, cohort: cohort, induction_programme_choice: "core_induction_programme")
 FactoryBot.create(:core_induction_programme, name: "Awesome induction course")

--- a/spec/cypress/app_commands/scenarios/confirm_cip.rb
+++ b/spec/cypress/app_commands/scenarios/confirm_cip.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-cohort = FactoryBot.create(:cohort, start_year: 2021)
+cohort = Cohort.find_or_create_by!(start_year: 2021)
 
 unconfirmed_school = FactoryBot.create(:school, name: "Test Town Primary", slug: "test-town-primary")
 FactoryBot.create(:user, :induction_coordinator, email: "confirm-provider@example.com", school_ids: [unconfirmed_school.id])

--- a/spec/cypress/app_commands/scenarios/school_opted_out_but_was_recruited.rb
+++ b/spec/cypress/app_commands/scenarios/school_opted_out_but_was_recruited.rb
@@ -12,7 +12,7 @@ SchoolCohort.create!(school: school,
                      cohort: Cohort.current)
 
 FactoryBot.create(:partnership,
-                  :in_challenge_window,
+                  challenge_deadline: Time.utc(2099, 1, 1),
                   delivery_partner: delivery_partner,
                   lead_provider: lead_provider,
                   school: school,

--- a/spec/cypress/app_commands/scenarios/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/school_participants.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-cohort = FactoryBot.create(:cohort, start_year: 2021)
+cohort = Cohort.find_or_create_by!(start_year: 2021)
 school = FactoryBot.create(:school, name: "Hogwarts Academy", slug: "111111-hogwarts-academy")
 
 FactoryBot.create(:school_cohort, cohort: cohort, school: school, induction_programme_choice: "full_induction_programme")


### PR DESCRIPTION
- Remove random data from visual tests
- Fix duplicate cohort error

I have no idea why the cohort was sometimes a duplicate, everything is supposed to be truncated before every test. 