### PR TITLE
Added Javascript sentry

### DIFF
--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
+    <% if Rails.env.to_s.in? Sentry.configuration.enabled_environments %>
+      <%= tag :meta, name: :release, content: Sentry.configuration.release %>
+      <%= tag :meta, name: :"sentry-dsn", content: Sentry.configuration.dsn.to_s %>
+      <%= tag :meta, name: :"sentry-trace", content: Sentry.get_current_scope&.span&.to_sentry_trace %>
+      <%= javascript_pack_tag('sentry') unless params[:nojs] == "nojs" %>
+    <% end %>
+
     <title><%= (yield(:title) + " - " unless yield(:title).blank?).to_s + "Manage training for early career teachers" %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -16,7 +23,7 @@
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application', defer: true unless params[:nojs] === "nojs" %>
+    <%= javascript_pack_tag 'application', defer: true unless params[:nojs] == "nojs" %>
 
     <script>
       dataLayer = <%= data_layer.to_json.html_safe %>;

--- a/app/webpacker/packs/sentry.js
+++ b/app/webpacker/packs/sentry.js
@@ -1,0 +1,16 @@
+import * as Sentry from "@sentry/browser";
+import { Integrations } from "@sentry/tracing";
+
+const release = document.querySelector('meta[name="release"]').content;
+const dsn = document.querySelector('meta[name="sentry-dsn"]').content;
+
+Sentry.init({
+  dsn,
+  release,
+  integrations: [new Integrations.BrowserTracing()],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 0.1,
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "@rails/webpacker": "^5.3.0",
+    "@sentry/browser": "^6.7.2",
+    "@sentry/tracing": "^6.7.2",
     "accessible-autocomplete": "^2.0.3",
     "axe-core": "^4.2.1",
     "cypress-axe": "^0.12.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,6 +2158,69 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@sentry/browser@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.7.2.tgz#cfbe060de5a9694617f175a6bde469e5e266792e"
+  integrity sha512-Lv0Ne1QcesyGAhVcQDfQa3hDPR/MhPSDTMg3xFi+LxqztchVc4w/ynzR0wCZFb8KIHpTj5SpJHfxpDhXYMtS9g==
+  dependencies:
+    "@sentry/core" "6.7.2"
+    "@sentry/types" "6.7.2"
+    "@sentry/utils" "6.7.2"
+    tslib "^1.9.3"
+
+"@sentry/core@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.7.2.tgz#1d294fac6e62744bce3b9dfbcd90b14e93620480"
+  integrity sha512-NTZqwN5nR94yrXmSfekoPs1mIFuKvf8esdIW/DadwSKWAdLJwQTJY9xK/8PQv+SEzd7wiitPAx+mCw2By1xiNQ==
+  dependencies:
+    "@sentry/hub" "6.7.2"
+    "@sentry/minimal" "6.7.2"
+    "@sentry/types" "6.7.2"
+    "@sentry/utils" "6.7.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.7.2.tgz#31b250e74aa303877620dfa500aa89e4411e2dec"
+  integrity sha512-05qVW6ymChJsXag4+fYCQokW3AcABIgcqrVYZUBf6GMU/Gbz5SJqpV7y1+njwWvnPZydMncP9LaDVpMKbE7UYQ==
+  dependencies:
+    "@sentry/types" "6.7.2"
+    "@sentry/utils" "6.7.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.7.2.tgz#9e6c0c587daea64a9042041694a4ad5d559d16cd"
+  integrity sha512-jkpwFv2GFHoVl5vnK+9/Q+Ea8eVdbJ3hn3/Dqq9MOLFnVK7ED6MhdHKLT79puGSFj+85OuhM5m2Q44mIhyS5mw==
+  dependencies:
+    "@sentry/hub" "6.7.2"
+    "@sentry/types" "6.7.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.7.2.tgz#78a6934837143ae5e200b49bd256bc8a917477bc"
+  integrity sha512-juKlI7FICKONWJFJxDxerj0A+8mNRhmtrdR+OXFqOkqSAy/QXlSFZcA/j//O19k2CfwK1BrvoMcQ/4gnffUOVg==
+  dependencies:
+    "@sentry/hub" "6.7.2"
+    "@sentry/minimal" "6.7.2"
+    "@sentry/types" "6.7.2"
+    "@sentry/utils" "6.7.2"
+    tslib "^1.9.3"
+
+"@sentry/types@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.7.2.tgz#8108272c98ad7784ddf9ddda0b7bdc6880ed6e50"
+  integrity sha512-h21Go/PfstUN+ZV6SbwRSZVg9GXRJWdLfHoO5PSVb3TVEMckuxk8tAE57/u+UZDwX8wu+Xyon2TgsKpiWKxqUg==
+
+"@sentry/utils@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.7.2.tgz#c7f957ebe16de3e701a0c5477ac2dba04e7b4b68"
+  integrity sha512-9COL7aaBbe61Hp5BlArtXZ1o/cxli1NGONLPrVT4fMyeQFmLonhUiy77NdsW19XnvhvaA+2IoV5dg3dnFiF/og==
+  dependencies:
+    "@sentry/types" "6.7.2"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"


### PR DESCRIPTION
https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?selectedIssue=CPDRP-487

The above bug was (most likely) caused by the double form submission, which somehow got around our JS shields. I **guess** this could be caused by some JS error we don't know about, so this PR introduces client-side Sentry error collecting. Let's hope we won't be flooded with errors... 