### PR TITLE
CPDRP-536: Add task to send email to federation schools

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -8,6 +8,7 @@ class SchoolMailer < ApplicationMailer
   MINISTERIAL_LETTER_EMAIL_TEMPLATE = "f1310917-aa50-4789-b8c2-8cc5e9b91485"
   BETA_INVITE_EMAIL_TEMPLATE = "0ae827de-3caa-4a93-b464-c434cbbd02c0"
   MAT_INVITE_EMAIL_TEMPLATE = "f856f50e-6f49-441e-8018-f8303367eb5c"
+  FEDERATION_INVITE_EMAIL_TEMPLATE = "9269c50d-b579-425b-b55b-4c93f67074d4"
 
   def nomination_email(recipient:, school_name:, nomination_url:, expiry_date:)
     template_mail(
@@ -127,6 +128,19 @@ class SchoolMailer < ApplicationMailer
   def mat_invite_email(recipient:, school_name:, nomination_url:)
     template_mail(
       MAT_INVITE_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        nomination_url: nomination_url,
+      },
+    )
+  end
+
+  def federation_invite_email(recipient:, school_name:, nomination_url:)
+    template_mail(
+      FEDERATION_INVITE_EMAIL_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -25,4 +25,9 @@ namespace :schools do
   task :invite_mats, [:school_urns] => :environment do |_task, args|
     InviteSchools.new.invite_mats(args.school_urns.split)
   end
+
+  desc "Send nomination links to federation schools"
+  task :invite_federations, [:school_urns] => :environment do |_task, args|
+    InviteSchools.new.invite_federations(args.school_urns.split)
+  end
 end


### PR DESCRIPTION
CPDRP-536
Add some code so we can send an email with a nomination link to federation schools

Much the same at the task to send emails to MATs, except for different email copy
