### PR TITLE
CPDTP-204 Return `id` of newly created declaration in API

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -7,15 +7,14 @@ module Api
 
       def create
         params = HashWithIndifferentAccess.new({ raw_event: request.raw_post, lead_provider: current_user }).merge(permitted_params)
-        return head(RecordParticipantEvent.call(params)) if check_config(params)
-
-        raise ActionController::ParameterMissing, missing_params(params)
+        validate_params!(params)
+        head(RecordParticipantEvent.call(params))
       end
 
     private
 
-      def check_config(params)
-        missing_params(params).empty?
+      def validate_params!(params)
+        raise ActionController::ParameterMissing, missing_params(params) unless missing_params(params).empty?
       end
 
       def missing_params(params)

--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -8,7 +8,7 @@ module Api
       def create
         params = HashWithIndifferentAccess.new({ raw_event: request.raw_post, lead_provider: current_user }).merge(permitted_params)
         validate_params!(params)
-        head(RecordParticipantEvent.call(params))
+        render json: RecordParticipantEvent.call(params)
       end
 
     private

--- a/app/services/record_participant_event.rb
+++ b/app/services/record_participant_event.rb
@@ -18,11 +18,9 @@ class RecordParticipantEvent
   def call
     validate_schema!
     add_ect_profile_params!
-    return :unprocessable_entity unless create_record
-
+    declaration = create_record!
     validate_provider!
-
-    :no_content
+    { id: declaration.id }
   end
 
 private
@@ -50,8 +48,8 @@ private
     User.find_by(id: @params[:participant_id])&.early_career_teacher_profile
   end
 
-  def create_record
-    ParticipantDeclaration.create(@params.slice(*required_params))
+  def create_record!
+    ParticipantDeclaration.create!(@params.slice(*required_params))
   end
 
   def lead_provider

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
         },
       }, description: "The event declaration date"
 
-      response 204, "Successful" do
+      response 200, "Successful" do
         let(:fresh_user) { create(:user, :early_career_teacher) }
         let(:params) do
           {
@@ -75,7 +75,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
         run_test!
       end
 
-      response 204, "Successful" do
+      response 200, "Successful" do
         let(:params) do
           {
             "participant_id" => user.id,
@@ -87,6 +87,8 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
         before do
           RecordParticipantEvent.call(HashWithIndifferentAccess.new({ lead_provider: lead_provider, raw_event: params.to_json }).merge(params))
         end
+
+        schema "$ref": "#/components/schemas/id"
 
         run_test!
       end

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Participant Declarations", type: :request do
           post "/api/v1/participant-declarations", params: params.to_json
         }.to change(ParticipantDeclaration, :count).by(1)
         expect(response.status).to eq 200
-        expect(parsed_response["id"]).to eq(ParticipantDeclaration.last.id)
+        expect(parsed_response["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)
       end
 
       it "returns 422 when trying to create for an invalid user id" do # Expectes the user uuid. Pass the early_career_teacher_profile_id

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -37,14 +37,19 @@ RSpec.describe "Participant Declarations", type: :request do
     let(:parsed_response) { JSON.parse(response.body) }
 
     context "when authorized" do
+      let(:parsed_response) { JSON.parse(response.body) }
+
       before do
         default_headers[:Authorization] = bearer_token
         default_headers[:CONTENT_TYPE] = "application/json"
       end
 
-      it "returns 204 status when successful" do
-        post "/api/v1/participant-declarations", params: params.to_json
-        expect(response.status).to eq 204
+      it "create declaration record and return id when successful" do
+        expect {
+          post "/api/v1/participant-declarations", params: params.to_json
+        }.to change(ParticipantDeclaration, :count).by(1)
+        expect(response.status).to eq 200
+        expect(parsed_response["id"]).to eq(ParticipantDeclaration.last.id)
       end
 
       it "returns 422 when trying to create for an invalid user id" do # Expectes the user uuid. Pass the early_career_teacher_profile_id

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -34,6 +34,14 @@ RSpec.configure do |config|
               },
             },
           },
+          id: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+              },
+            },
+          },
         },
       },
       security: [

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -26,6 +26,14 @@
             "minItems": 1
           }
         }
+      },
+      "id": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
       }
     }
   },
@@ -93,8 +101,15 @@
 
         ],
         "responses": {
-          "204": {
-            "description": "Successful"
+          "200": {
+            "description": "Successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/id"
+                }
+              }
+            }
           },
           "422": {
             "description": "Bad or Missing parameter",


### PR DESCRIPTION
### Context

This patch allows providers to (at a later time) reference declarations they have created by returning to them the id of the newly created declaration record.

This may be needed to allow them to "void" declarations when they realise there has been a mistake (to be confirmed).

Currently based on branch for #596

### Changes proposed in this pull request

* Refactor params validation
* Return id of newly created declaration in API

### Guidance to review

Have a look at the updated swagger, and try it out.

Here is a successful request with `id` returned:

![successful request with `id` returned](https://user-images.githubusercontent.com/19378/123644048-ed7ce000-d81c-11eb-8a4f-48f82b3b72de.png)

### Testing

* run db:reset to get seed ids (watch out for just-merged #597 that isn't in this branch yet)
* use swagger to post real declarations
* see declaration id now in returned json
 
### How can I view this in a review app?

https://ecf-review-pr-601.london.cloudapps.digital/api-docs/index.html

### Pre-merge todo list

- [x] #596 merged
- [x] Change base branch