### PR TITLE
CPDEL-572 Add final content to the IT pages

### DIFF
--- a/app/views/pages/induction_tutor_materials/ambition/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/ambition/_handbooks_and_outlines.html.erb
@@ -1,19 +1,16 @@
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">Ambition Institute's handbooks and training outlines</h1>
 
 <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
-<ul class="govuk-list govuk-list--spaced">
-  <li>
-    <%= govuk_link_to "ECF Programme Handbook (PDF, 107 KB, 10 pages)",
+
+<p>The programme handbook outlines how Ambition Institute’s coaching and mentoring programme works.</p>
+<%= govuk_link_to "ECF Programme Handbook (PDF, 107 KB, 10 pages)",
                       "https://www.early-career-framework.education.gov.uk/ambition/wp-content/uploads/sites/3/2020/08/Ambition-EarlyCareerTeachers_2020_ProgrammeHandbook.pdf" %>
-  </li>
-  <li>
-    <%= govuk_link_to "ECF Lead Handbook (PDF, 102 KB, 12 pages)",
+
+<p>The lead handbook provides an overview of your role and responsibilities.</p>
+<%= govuk_link_to "ECF Lead Handbook (PDF, 102 KB, 12 pages)",
                       "https://www.early-career-framework.education.gov.uk/ambition/wp-content/uploads/sites/3/2020/09/Ambition-EarlyCareerTeachers_2020_LeadHandbook_Guidebook_Edit-1-1.pdf" %>
-  </li>
-</ul>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-3">Training outlines</h2>
-<p class="govuk-!-margin-bottom-3">Here is a placholder of contextual blurb about training outlines. Lorem ipsum
-  dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-  aliqua.
+<p class="govuk-!-margin-bottom-3">
+  These training outlines show what early career teachers will learn in each module during their induction.
 </p>

--- a/app/views/pages/induction_tutor_materials/educational_development_trust/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/educational_development_trust/_handbooks_and_outlines.html.erb
@@ -3,6 +3,7 @@
 </h1>
 
 <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
+<p>These materials outline how Education Development Trust’s coaching and mentoring programme works.</p>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <%= govuk_link_to "Overview of the core induction programme",
@@ -24,6 +25,7 @@
       Individual block overviews
     </span>
   </summary>
+  <p>The block overviews show what early career teachers will learn in each module during their induction.</p>
   <div class="govuk-details__text">
     <ul class="govuk-list govuk-list--spaced">
       <li>
@@ -79,8 +81,8 @@
 </details>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-3">Training outlines</h2>
-<p class="govuk-!-margin-bottom-3">
-  Here is a placholder of contextual blurb about training outlines. Lorem ipsum
-  dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-  aliqua.
+<p>
+  Each block features up to 3 dedicated training sessions where experienced practitioners will share practical
+  applications of what early career teachers are learning.
 </p>
+<p>The materials show what should be covered during these training sessions.</p>

--- a/app/views/pages/induction_tutor_materials/teach_first/year_one_and_two.html.erb
+++ b/app/views/pages/induction_tutor_materials/teach_first/year_one_and_two.html.erb
@@ -6,23 +6,19 @@
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">Teach First's handbooks and training outlines</h1>
 
     <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
-    <ul class="govuk-list govuk-list--spaced">
-      <li>
-        <%= govuk_link_to "ECF Sequence (PDF, 289 KB, 17 pages)",
+    <p>The sequence document provides an overview of how the programme is structured across the 2 years of induction.</p>
+    <%= govuk_link_to "ECF Sequence (PDF, 289 KB, 17 pages)",
                           "https://www.early-career-framework.education.gov.uk/teachfirst/wp-content/uploads/sites/4/2020/09/2.-ECF-Sequence.pdf" %>
-      </li>
-      <li>
-        <%= govuk_link_to "ECF SLT and Induction Lead Implementation Guidance (PDF, 652 KB, 30 pages)",
+    <p>The implementation guidance outlines how Teach First’s coaching and mentoring programme works.</p>
+    <%= govuk_link_to "ECF SLT and Induction Lead Implementation Guidance (PDF, 652 KB, 30 pages)",
                           "https://www.early-career-framework.education.gov.uk/teachfirst/wp-content/uploads/sites/4/2020/10/Early-Career-Framework-Programme-SLT-and-Induction-Lead-Handbook-1.pdf" %>
-      </li>
-    </ul>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-3">Training outlines</h2>
-    <p class="govuk-!-margin-bottom-1">
-      Here is a placholder of contextual blurb about training outlines. Lorem ipsum
-      dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
-      aliqua.
+    <p>
+      Each module features up to 3 dedicated training sessions where experienced practitioners will share practical
+      applications of what early career teachers are learning.
     </p>
+    <p>The materials show what should be covered during these training sessions.</p>
 
     <h3 class="govuk-heading-m govuk-!-margin-top-4">Autumn term</h3>
 

--- a/app/views/pages/induction_tutor_materials/ucl/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/ucl/_handbooks_and_outlines.html.erb
@@ -1,18 +1,17 @@
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">University College London's handbooks and training outlines</h1>
 <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>
-
-<ul class="govuk-list govuk-list--spaced">
-  <li>
-    <%= govuk_link_to "Programme Handbook (PDF, 1002 KB, 74 pages)",
+<p>The programme handbook outlines how UCL Early Career Teacher Consortium’s coaching and mentoring programme works.</p>
+<%= govuk_link_to "Programme Handbook (PDF, 1002 KB, 74 pages)",
                       "https://www.early-career-framework.education.gov.uk/ucl/wp-content/uploads/sites/5/2020/12/Programme-Handbook-Updated.pdf" %>
-  </li>
-  <li>
-    <%= govuk_link_to "Year 2 handbook: practitioner inquiry (PDF, 430 KB, 20 pages)",
+<p>
+  The practitioner inquiry handbook details how early career teachers will carry out detailed investigations into
+  specific aspects of their teaching in the second year of their induction.
+</p>
+<%= govuk_link_to "Year 2 handbook: practitioner inquiry (PDF, 430 KB, 20 pages)",
                       "https://www.early-career-framework.education.gov.uk/ucl/wp-content/uploads/sites/5/2020/09/Year-2-Handbook-Practitioner-Inquiry-1.pdf" %>
-  </li>
-</ul>
 
-<h2 class="govuk-heading-l govuk-!-margin-bottom-3">Module summaries</h2>
+<h2 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-3">Module summaries</h2>
+<p>These materials show what early career teachers will learn in each module during their induction.</p>
 <ul class="govuk-list govuk-list--spaced">
   <li>
     <%=govuk_link_to "Module 1 summary guide (PDF, 193 KB, 7 pages)",
@@ -54,6 +53,8 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-6 govuk-!-margin-bottom-3">Training outlines</h2>
 
-<p class="govuk-!-margin-bottom-1">Here is a placholder of contextual blurb about training outlines. Lorem ipsum
-  dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+<p>
+  Each module features up to 3 dedicated training sessions where experienced
+  practitioners will share practical applications of what early career teachers are learning.
 </p>
+<p>The materials show what should be covered during these training sessions.</p>

--- a/app/views/pages/induction_tutor_materials/ucl/year_two.html.erb
+++ b/app/views/pages/induction_tutor_materials/ucl/year_two.html.erb
@@ -68,7 +68,8 @@
       Second half-term: fulfilling professional responsibilities
     </p>
     <p>
-      There are no training sessions for this term, but something about school visits
+      There are no training sessions for this half-term. Instead we encourage ECTs to do a couple of visits to other
+      schools so they can see teaching in contrasting settings.
     </p>
 
   </div>


### PR DESCRIPTION
### Context
[572](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDEL-572)

### Changes proposed in this pull request
Updating Induction Tutor materials pages

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
In the review app below add the following to the url 
`/induction-tutor-materials/ambition/year-one`
`/induction-tutor-materials/educational-development-trust/year-one`
`/induction-tutor-materials/teach-first/year-one-and-two`
`/induction-tutor-materials/ucl/year-one`

Check the correct content has been added from this [google doc](https://docs.google.com/document/d/1sEqdczmq3-jJLsp41Dl_HNUcRAWnOzrztNF3xxGxN2c/edit) 
