### PR TITLE
Disable XSS filtering header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,9 @@ module EarlyCareerFramework
 
     config.exceptions_app = routes
     config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
-
+    config.action_dispatch.default_headers = {
+      "X-XSS-Protection" => "0",
+    }
     config.active_job.queue_adapter = :delayed_job
 
     config.middleware.use Rack::Deflater


### PR DESCRIPTION
This was reported by the pentest. In new browsers it has been superseded by CSP policies that disable inline JS.

Dependent on https://github.com/DFE-Digital/early-careers-framework/pull/590