### PR TITLE
CPDTP-224 Refactor MentorProfile creation form and add uplift

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -108,26 +108,19 @@ module Schools
     end
 
     def save!
-      if type == :ect
-        EarlyCareerTeachers::Create.call(
-          full_name: full_name,
-          email: email,
-          cohort_id: school_cohort.cohort_id,
-          school_id: school_cohort.school_id,
-          mentor_profile_id: mentor&.mentor_profile&.id,
-        )
-      else
-        ActiveRecord::Base.transaction do
-          # TODO: What if email matches but with different name?
-          user = User.find_or_create_by!(full_name: full_name, email: email)
-
-          MentorProfile.create!(
-            user: user,
-            school_id: school_cohort.school_id,
-            cohort_id: school_cohort.cohort_id,
-          )
-        end
-      end
+      creator = case type
+                when :ect
+                  EarlyCareerTeachers::Create
+                when :mentor
+                  Mentors::Create
+                end
+      creator.constantize.call(
+        full_name: full_name,
+        email: email,
+        cohort_id: school_cohort.cohort_id,
+        school_id: school_cohort.school_id,
+        mentor_profile_id: mentor&.mentor_profile&.id,
+      )
     end
   end
 end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -115,7 +115,7 @@ module Schools
     end
 
     def save!
-      creators[participant_type]&.call(
+      creators[participant_type].call(
         full_name: full_name,
         email: email,
         cohort_id: school_cohort.cohort_id,

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -107,14 +107,15 @@ module Schools
       @current_user ||= User.find_by(id: current_user_id)
     end
 
+    def creators
+      {
+        ect: EarlyCareerTeachers::Create,
+        mentor: Mentors::Create,
+      }
+    end
+
     def save!
-      creator = case type
-                when :ect
-                  EarlyCareerTeachers::Create
-                when :mentor
-                  Mentors::Create
-                end
-      creator.constantize.call(
+      creators[participant_type]&.call(
         full_name: full_name,
         email: email,
         cohort_id: school_cohort.cohort_id,

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -1,33 +1,31 @@
 # frozen_string_literal: true
 
-module EarlyCareerTeachers
+module Mentors
   class Create < BaseService
     include SchoolCohortDelegator
     def call
       ActiveRecord::Base.transaction do
         # TODO: What if email matches but with different name?
         user = User.find_or_create_by!(full_name: full_name, email: email)
-        EarlyCareerTeacherProfile.create!({ user: user }.merge(ect_attributes))
+        MentorProfile.create!({ user: user }.merge(mentor_attributes))
       end
     end
 
   private
 
-    attr_reader :full_name, :email, :cohort_id, :school_id, :mentor_profile_id
+    attr_reader :full_name, :email, :cohort_id, :school_id
 
-    def initialize(full_name:, email:, cohort_id:, school_id:, mentor_profile_id: nil)
+    def initialize(full_name:, email:, cohort_id:, school_id:, **)
       @full_name = full_name
       @email = email
       @cohort_id = cohort_id
       @school_id = school_id
-      @mentor_profile_id = mentor_profile_id
     end
 
-    def ect_attributes
+    def mentor_attributes
       {
         school_id: school_id,
         cohort_id: cohort_id,
-        mentor_profile_id: mentor_profile_id,
         sparsity_uplift: sparsity_uplift?(start_year),
         pupil_premium_uplift: pupil_premium_uplift?(start_year),
       }

--- a/app/services/school_cohort_delegator.rb
+++ b/app/services/school_cohort_delegator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SchoolCohortDelegator
+  def school
+    School.find(school_id)
+  end
+
+  def cohort
+    Cohort.find(cohort_id)
+  end
+
+  delegate :sparsity_uplift?, :pupil_premium_uplift?, to: :school
+  delegate :start_year, to: :cohort
+end

--- a/db/migrate/20210630000100_add_uplift_to_mentor_profile.rb
+++ b/db/migrate/20210630000100_add_uplift_to_mentor_profile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUpliftToMentorProfile < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_table(:mentor_profiles, bulk: true) do |table|
+        table.column :sparsity_uplift, :boolean, null: false, default: false
+        table.column :pupil_premium_uplift, :boolean, null: false, default: false
+      end
+    end
+  end
+end

--- a/db/migrate/20210630000110_backfill_mentor_profile_uplift_data.rb
+++ b/db/migrate/20210630000110_backfill_mentor_profile_uplift_data.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class BackfillMentorProfileUpliftData < ActiveRecord::Migration[6.1]
+  def up
+    MentorProfile.find_each do |profile|
+      profile.sparsity_uplift = profile.school.sparsity_uplift?(2021)
+      profile.pupil_premium_uplift = profile.school.pupil_premium_uplift?(2021)
+      profile.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_25_143352) do
+ActiveRecord::Schema.define(version: 2021_06_30_000100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -269,6 +269,8 @@ ActiveRecord::Schema.define(version: 2021_06_25_143352) do
     t.uuid "cohort_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "sparsity_uplift", default: false, null: false
+    t.boolean "pupil_premium_uplift", default: false, null: false
     t.index ["cohort_id"], name: "index_mentor_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_mentor_profiles_on_core_induction_programme_id"
     t.index ["school_id"], name: "index_mentor_profiles_on_school_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_000100) do
+ActiveRecord::Schema.define(version: 2021_06_30_000110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Mentors::Create do
+  let(:user) { create :user }
+  let(:school) { create :school }
+  let(:pupil_premium_school) { create :school, :pupil_premium_uplift }
+  let(:sparsity_school) { create :school, :sparsity_uplift }
+  let(:uplift_school) { create :school, :sparsity_uplift, :pupil_premium_uplift }
+  let(:cohort) { create :cohort, :current }
+
+  it "creates a Mentor record" do
+    expect { described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id) }.to change { MentorProfile.count }.by(1)
+    expect { described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_id: 'random discardable') }.to change { MentorProfile.count }.by(1)
+  end
+
+  it "has no uplift if the school has not uplift set" do
+    mentor_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id)
+    expect(mentor_profile.pupil_premium_uplift).to be(false)
+    expect(mentor_profile.sparsity_uplift).to be(false)
+  end
+
+  it "has only pupil_premium_uplift set when the school has only pupil_premium_uplift set" do
+    mentor_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: pupil_premium_school.id, cohort_id: cohort.id)
+    expect(mentor_profile.pupil_premium_uplift).to be(true)
+    expect(mentor_profile.sparsity_uplift).to be(false)
+  end
+
+  it "has only sparsity_uplift set when the school has only sparsity_uplift set" do
+    mentor_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: sparsity_school.id, cohort_id: cohort.id)
+    expect(mentor_profile.pupil_premium_uplift).to be(false)
+    expect(mentor_profile.sparsity_uplift).to be(true)
+  end
+
+  it "has both sparsity_uplift and pupil_premium_uplift set when the school has both pupil_premium_uplift and sparsity_uplift set" do
+    mentor_profile = described_class.call(email: user.email, full_name: user.full_name, school_id: uplift_school.id, cohort_id: cohort.id)
+    expect(mentor_profile.pupil_premium_uplift).to be(true)
+    expect(mentor_profile.sparsity_uplift).to be(true)
+  end
+end

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mentors::Create do
 
   it "creates a Mentor record" do
     expect { described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id) }.to change { MentorProfile.count }.by(1)
-    expect { described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_id: 'random discardable') }.to change { MentorProfile.count }.by(1)
+    expect { described_class.call(email: user.email, full_name: user.full_name, school_id: school.id, cohort_id: cohort.id, mentor_id: "random discardable") }.to change { MentorProfile.count }.by(1)
   end
 
   it "has no uplift if the school has not uplift set" do


### PR DESCRIPTION
### Context

As part of the uplift piece for payment, the sparsity uplift and pupil premium uplift flags were added to the `EarlyCareerTeacherProfile`. This adds in the corresponding flags to the `MentorProfile` and carries on the form
refactoring that was done in the earlier piece.

### Changes proposed in this pull request

- Add in the new flags and flag creation to the Form
- Extract MentorProfile Creation into a separate Mentors::Create service and remove duplication from this and EarlyCareerTeachers::Create by pulling the common School/Cohort code into a shared module.
- Add in tests for MentorProfile creation in line with those added for EarlyCareerTeacherProfile creation

### Guidance to review

Functional changes are only that the uplift flags will be populated and are backfilled.
Everything else is a refactor.

### Testing

New tests added to test the population of the MentorProfile table with the appropriate flags set.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

Should have no noticeable change, but the MentorProfile records in the database should be updated with the appropriate sparsity and pupil premium uplift flags.