### PR TITLE
Stable API tokens in seeds for development

### DIFF
--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -15,6 +15,11 @@ class ApiToken < ApplicationRecord
     find_by(hashed_token: hashed_token)
   end
 
+  def self.create_with_known_token!(token, **options)
+    hashed_token = Devise.token_generator.digest(ApiToken, :hashed_token, token)
+    find_or_create_by!(hashed_token: hashed_token, **options)
+  end
+
   def owner
     raise NotImplementedError
   end

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -7,29 +7,19 @@ edt_cip = CoreInductionProgramme.find_or_create_by!(name: "Education Development
 teach_first_cip = CoreInductionProgramme.find_or_create_by!(name: "Teach First")
 ucl_cip = CoreInductionProgramme.find_or_create_by!(name: "UCL Institute of Education")
 
-ambition = LeadProvider.find_or_create_by!(name: "Ambition Institute")
-ambition.update!(cohorts: [cohort_2021]) unless ambition.cohorts.any?
-LeadProviderCip.find_or_create_by!(lead_provider: ambition, cohort: cohort_2021, core_induction_programme: ambition_cip)
-
-bpn = LeadProvider.find_or_create_by!(name: "Best Practice Network")
-bpn.update!(cohorts: [cohort_2021]) unless bpn.cohorts.any?
-LeadProviderCip.find_or_create_by!(lead_provider: bpn, cohort: cohort_2021, core_induction_programme: ucl_cip)
-
-capita = LeadProvider.find_or_create_by!(name: "Capita")
-capita.update!(cohorts: [cohort_2021]) unless capita.cohorts.any?
-LeadProviderCip.find_or_create_by!(lead_provider: capita, cohort: cohort_2021, core_induction_programme: ambition_cip)
-
-edt = LeadProvider.find_or_create_by!(name: "Education Development Trust")
-edt.update!(cohorts: [cohort_2021]) unless edt.cohorts.any?
-LeadProviderCip.find_or_create_by!(lead_provider: edt, cohort: cohort_2021, core_induction_programme: edt_cip)
-
-teach_first = LeadProvider.find_or_create_by!(name: "Teach First")
-teach_first.update!(cohorts: [cohort_2021]) unless teach_first.cohorts.any?
-LeadProviderCip.find_or_create_by!(lead_provider: teach_first, cohort: cohort_2021, core_induction_programme: teach_first_cip)
-
-ucl = LeadProvider.find_or_create_by!(name: "UCL Institute of Education")
-ucl.update!(cohorts: [cohort_2021]) unless ucl.cohorts.any?
-LeadProviderCip.find_or_create_by!(lead_provider: ucl, cohort: cohort_2021, core_induction_programme: ucl_cip)
+[
+  { provider_name: "Ambition Institute", cip: ambition_cip, token: "ambition-token" },
+  { provider_name: "Best Practice Network", cip: ucl_cip, token: "best-practice-token" },
+  { provider_name: "Capita", cip: ambition_cip, token: "capita-token" },
+  { provider_name: "Education Development Trust", cip: edt_cip, token: "edt-token" },
+  { provider_name: "Teach First", cip: teach_first_cip, token: "teach-first-token" },
+  { provider_name: "UCL Institute of Education", cip: ucl_cip, token: "ucl-token" },
+].each do |seed|
+  provider = LeadProvider.find_or_create_by!(name: seed[:provider_name])
+  provider.update!(cohorts: [cohort_2021]) unless provider.cohorts.any?
+  LeadProviderCip.find_or_create_by!(lead_provider: provider, cohort: cohort_2021, core_induction_programme: seed[:cip])
+  LeadProviderApiToken.create_with_known_token!(seed[:token], lead_provider: provider)
+end
 
 PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)
   .tap { |pp| pp.html = Rails.root.join("db/seeds/privacy_policy_1.0.html").read }
@@ -58,13 +48,4 @@ end
   { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
 ].each do |hash|
   NpqCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
-end
-
-if Rails.env.development?
-  LeadProviderApiToken.create_with_known_token!("_488ase4rzqrLo6p3Kzy", lead_provider: ambition)
-  LeadProviderApiToken.create_with_known_token!("KCC_Frtiy79M3zLNMhic", lead_provider: bpn)
-  LeadProviderApiToken.create_with_known_token!("bBvWZ5dr6wmbUNqidnY-", lead_provider: capita)
-  LeadProviderApiToken.create_with_known_token!("kDyukqzjhuPw7j3kgLT2", lead_provider: edt)
-  LeadProviderApiToken.create_with_known_token!("usQncFvBGym5UoGcbsMs", lead_provider: teach_first)
-  LeadProviderApiToken.create_with_known_token!("RCxkriTrzw4yhnn8zjyy", lead_provider: ucl)
 end

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -18,7 +18,9 @@ ucl_cip = CoreInductionProgramme.find_or_create_by!(name: "UCL Institute of Educ
   provider = LeadProvider.find_or_create_by!(name: seed[:provider_name])
   provider.update!(cohorts: [cohort_2021]) unless provider.cohorts.any?
   LeadProviderCip.find_or_create_by!(lead_provider: provider, cohort: cohort_2021, core_induction_programme: seed[:cip])
-  LeadProviderApiToken.create_with_known_token!(seed[:token], lead_provider: provider)
+  if Rails.env.development?
+    LeadProviderApiToken.create_with_known_token!(seed[:token], lead_provider: provider)
+  end
 end
 
 PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -59,3 +59,12 @@ end
 ].each do |hash|
   NpqCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
 end
+
+if Rails.env.development?
+  LeadProviderApiToken.create_with_known_token!("_488ase4rzqrLo6p3Kzy", lead_provider: ambition)
+  LeadProviderApiToken.create_with_known_token!("KCC_Frtiy79M3zLNMhic", lead_provider: bpn)
+  LeadProviderApiToken.create_with_known_token!("bBvWZ5dr6wmbUNqidnY-", lead_provider: capita)
+  LeadProviderApiToken.create_with_known_token!("kDyukqzjhuPw7j3kgLT2", lead_provider: edt)
+  LeadProviderApiToken.create_with_known_token!("usQncFvBGym5UoGcbsMs", lead_provider: teach_first)
+  LeadProviderApiToken.create_with_known_token!("RCxkriTrzw4yhnn8zjyy", lead_provider: ucl)
+end

--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -13,7 +13,7 @@ cohort_2021 = Cohort.find_or_create_by!(start_year: "2021")
 
 providers_names = ["Capita", "Teach First", "UCL", "Best Practice Network", "Ambition", "Education Development Trust"]
 
-def generate_provider_token(lead_provider, school, cohort, logger)
+def generate_participants(lead_provider, school, cohort, logger)
   existing_user_uuids = User.participants_for_lead_provider(lead_provider).map(&:id)
 
   unless existing_user_uuids.any?
@@ -55,5 +55,5 @@ end
 providers_names.each_with_index do |provider_name, i|
   lead_provider = LeadProvider.find_or_create_by!(name: provider_name)
   school = create_school_and_associations(lead_provider, cohort_2021, i)
-  generate_provider_token(lead_provider, school, cohort_2021, logger)
+  generate_participants(lead_provider, school, cohort_2021, logger)
 end

--- a/db/seeds/sandbox_data.rb
+++ b/db/seeds/sandbox_data.rb
@@ -14,7 +14,6 @@ cohort_2021 = Cohort.find_or_create_by!(start_year: "2021")
 providers_names = ["Capita", "Teach First", "UCL", "Best Practice Network", "Ambition", "Education Development Trust"]
 
 def generate_provider_token(lead_provider, school, cohort, logger)
-  token = LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider)
   existing_user_uuids = User.participants_for_lead_provider(lead_provider).map(&:id)
 
   unless existing_user_uuids.any?
@@ -28,7 +27,7 @@ def generate_provider_token(lead_provider, school, cohort, logger)
     end
   end
   output_uuids = user_uuids || existing_user_uuids
-  logger.info "Token for #{lead_provider.name} is #{token}, user uuids: #{output_uuids.join(',')}"
+  logger.info "#{lead_provider.name} user uuids: #{output_uuids.join(',')}"
 end
 
 def create_school_and_associations(lead_provider, cohort, index)


### PR DESCRIPTION
### Changes proposed in this pull request

* Stable API tokens in seeds for development
* Remove output from sandbox seeds file, the providers already have their sandbox tokens so this is no longer needed.

### Context

Currently working on https://dfedigital.atlassian.net/browse/CPDTP-232 "Seed API sandbox environment with mentor data"

I wanted to remove the token generation from the sandbox seeds as that has already served its one-time purpose of making tokens for providers to test with and it was getting in the way of the current task.

We have been using that output for local development testing, so in order to continue to facilitate that use of the tokens I've moved it to a more permanent home in the initial_seeds file and made them stable for convenience.

### Guidance to review

Are we happy with well known tokens in the code? I *think* it's a good trade-off of convenience here as it will save a lot of passing around tokens.

### Testing

`bundle exec db:reset`

Try one of the new tokens locally.