### PR TITLE
Expand valid NPQ profile headteacher statuses

### DIFF
--- a/app/models/npq_profile.rb
+++ b/app/models/npq_profile.rb
@@ -7,6 +7,7 @@ class NpqProfile < ApplicationRecord
 
   enum headteacher_status: {
     no: "no",
+    yes_when_course_starts: "yes_when_course_starts",
     yes_in_first_two_years: "yes_in_first_two_years",
     yes_over_two_years: "yes_over_two_years",
   }

--- a/spec/models/npq_profile_spec.rb
+++ b/spec/models/npq_profile_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe NpqProfile, type: :model do
+  it {
+    is_expected.to define_enum_for(:headteacher_status).with_values(
+      no: "no",
+      yes_when_course_starts: "yes_when_course_starts",
+      yes_in_first_two_years: "yes_in_first_two_years",
+      yes_over_two_years: "yes_over_two_years",
+    ).backed_by_column_of_type(:text)
+  }
+end


### PR DESCRIPTION
We're adding an additional option on the registration that we'd like ECF to ingest. This PR adds another headship status to `ECFProfile`.

Registration page:

![image (4)](https://user-images.githubusercontent.com/31316/124086364-e2a69300-da48-11eb-9574-5b3154d9e933.png)
