### PR TITLE
Fix turnip step name

### DIFF
--- a/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
@@ -13,7 +13,7 @@ module UpliftPaymentsSteps
     @uplift_eligible_participants = value.to_i
   end
 
-  step "And there are :value pupil premium participants who have started that are eligible for the uplift payment" do |value|
+  step "there are :value pupil premium participants who have started that are eligible for the uplift payment" do |value|
     @uplift_eligible_participants += value.to_i
   end
 


### PR DESCRIPTION
### Context

We were getting a warning that this test is broken:

> No such step: 'there are 200 pupil premium participants who have started that are eligible for the uplift payment'
> ./spec/lib/payment_calculator/turnip_features/ecf/uplift_payment.feature:7

We previously tried making missing steps into failures but the error message is unhelpful when configured that way. See https://github.com/jnicklas/turnip/pull/240

### Changes proposed in this pull request

* Fix turnip step name