### PR TITLE
CPDRP-548: Induction tutors change participant details

### DIFF
--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -11,8 +11,15 @@ class ParticipantPolicy < UserPolicy
     return user_can_access?(@record) if user.induction_coordinator?
   end
 
-  alias_method :edit_details?, :show?
-  alias_method :update_details?, :show?
+  def update?
+    show?
+  end
+
+  alias_method :edit_name?, :edit?
+  alias_method :update_name?, :update?
+  alias_method :edit_email?, :edit?
+  alias_method :update_email?, :update?
+  alias_method :update_details?, :update?
   alias_method :edit_mentor?, :show?
   alias_method :update_mentor?, :show?
 

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change participant's email address</h1>
+    <%= form_for @participant, url: schools_participant_update_email_path, method: :put do |f| %>
+      <%= f.govuk_text_field :email, label: { text: "Email address" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change participant's name</h1>
+    <%= form_for @participant, url: schools_participant_update_name_path, method: :put do |f| %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/participants/email_used.html.erb
+++ b/app/views/schools/participants/email_used.html.erb
@@ -1,0 +1,8 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: schools_participant_edit_email_path) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">That email address is already in use</h1>
+    <p class="govuk-body">Check the address entered and try again.</p>
+    <%= govuk_link_to "Try again", schools_participant_edit_email_path, button: true %>
+  </div>
+</div>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -22,6 +22,9 @@
           <%= @participant.full_name %>
         </dd>
         <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to schools_participant_edit_name_path(participant_id: @participant) do %>
+            Change <span class="govuk-visually-hidden">name</span>
+          <% end %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">
@@ -32,6 +35,9 @@
           <%= @participant.email %>
         </dd>
         <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to schools_participant_edit_email_path(participant_id: @participant) do %>
+            Change <span class="govuk-visually-hidden">email</span>
+          <% end %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,7 +212,11 @@ Rails.application.routes.draw do
           resource :programme, only: %i[edit], controller: "choose_programme"
 
           resources :participants, only: %i[index show] do
-            get :edit_details, path: "edit-details"
+            get :edit_name, path: "edit-name"
+            put :update_name, path: "update-name"
+            get :edit_email, path: "edit-email"
+            put :update_email, path: "update-email"
+            get :email_used, path: "email-used"
             get :edit_mentor, path: "edit-mentor"
             put :update_mentor, path: "update-mentor"
 

--- a/spec/cypress/integration/schools/ManageParticipants.feature
+++ b/spec/cypress/integration/schools/ManageParticipants.feature
@@ -23,3 +23,37 @@ Feature: School leaders should be able to manage participants
     Then I should be on "2021 school participant" page
     And "page body" should contain "Abdul Mentor"
     And "page body" should not contain "Dan Smith"
+
+  Scenario: Updating details of a participant
+    When I click on "link" containing "Dan Smith"
+    Then I should be on "2021 school participant" page
+
+    When I click on "link" containing "Change email"
+    Then I should be on "2021 school participant edit email" page
+    And the page should be accessible
+    And percy should be sent snapshot called "induction tutor edit participant email"
+
+    When I type "james.bond.007@secret.gov.uk" into field labelled "Email"
+    And I click the submit button
+    Then I should be on "2021 school participant" page
+    And "page body" should contain "Dan Smith"
+    And "page body" should contain "james.bond.007@secret.gov.uk"
+    And "page body" should contain "The participant's email address has been updated"
+    And "page body" should not contain "dan-smith@example.com"
+
+    When I click on "link" containing "Change name"
+    Then I should be on "2021 school participant edit name" page
+    And the page should be accessible
+    And percy should be sent snapshot called "induction tutor edit participant name"
+
+    When I type "New Name" into field labelled "Full name"
+    And I click the submit button
+    Then I should be on "2021 school participant" page
+    And "page body" should contain "New Name"
+    And "page body" should contain "james.bond.007@secret.gov.uk"
+    And "page body" should contain "The participant's name has been updated"
+    And "page body" should not contain "Dan Smith"
+
+    Given I am on "2021 school participant edit email used" page with school_slug "111111-hogwarts-academy" and participant_id "51223b41-a562-4d94-b50c-0ce59a8bb34d"
+    Then the page should be accessible
+    And percy should be sent snapshot called "induction tutor edit participant email used in same school"

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -92,6 +92,12 @@ const pagePaths = {
     "/schools/:id/cohorts/2021/participants/:id/type",
   "2021 school participant details":
     "/schools/:id/cohorts/2021/participants/:id/details",
+  "2021 school participant edit name":
+    "/schools/:id/cohorts/2021/participants/:id/edit-name",
+  "2021 school participant edit email":
+    "/schools/:id/cohorts/2021/participants/:id/edit-email",
+  "2021 school participant edit email used":
+    "/schools/:school_slug/cohorts/2021/participants/:participant_id/email-used",
   "2021 school choose etc mentor":
     "/schools/:id/cohorts/2021/participants/add/choose-mentor",
   "2021 school participant confirm":


### PR DESCRIPTION
### Context
CPDRP-548
Let induction tutors edit name and email address of participants.
Blocked on content design

### Guidance to review
Ideas for how to make the whole email validation thing less messy appreciated.
Will conflict with Stan's work

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Sign in as school-leader@example.com and edit some details
