### PR TITLE
Created shadow ParticipantProfile model

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ParticipantProfile < ApplicationRecord
+  belongs_to :user
+  belongs_to :school
+  belongs_to :cohort
+  belongs_to :core_induction_programme, optional: true
+
+  def ect?
+    false
+  end
+
+  def mentor?
+    false
+  end
+
+  scope :mentors, -> { where(type: Mentor.name) }
+  scope :ects, -> { where(type: ECT.name) }
+
+  scope :sparsity, -> { where(sparsity_uplift: true) }
+  scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
+  scope :uplift, -> { sparsity.or(pupil_premium) }
+
+  class ECT < self
+    belongs_to :mentor_profile, class_name: "Mentor", optional: true
+
+    def ect?
+      true
+    end
+  end
+
+  class Mentor < self
+    self.ignored_columns = %i[mentor_profile_id]
+
+    def mentor?
+      true
+    end
+  end
+end

--- a/db/migrate/20210629103240_create_participant_profiles.rb
+++ b/db/migrate/20210629103240_create_participant_profiles.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :participant_profiles do |t|
+      t.string :type, null: false
+
+      t.references :user, foreign_key: true, index: true, null: false
+      t.references :school, foreign_key: true, index: true, null: false
+      t.references :core_induction_programme, foreign_key: true, index: true, null: true
+      t.references :cohort, foreign_key: true, index: true, null: false
+
+      # No foregin key yet - not all records will be present
+      t.references :mentor_profile, foreign_key: false, index: true, null: true
+
+      t.boolean :sparsity_uplift, default: false, null: false
+      t.boolean :pupil_premium_uplift, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -370,6 +370,24 @@ ActiveRecord::Schema.define(version: 2021_06_30_000110) do
     t.index ["item_type", "item_id"], name: "index_participant_events_on_item_type_and_item_id"
   end
 
+  create_table "participant_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "type", null: false
+    t.uuid "user_id", null: false
+    t.uuid "school_id", null: false
+    t.uuid "core_induction_programme_id"
+    t.uuid "cohort_id", null: false
+    t.uuid "mentor_profile_id"
+    t.boolean "sparsity_uplift", default: false, null: false
+    t.boolean "pupil_premium_uplift", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
+    t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
+    t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"
+    t.index ["school_id"], name: "index_participant_profiles_on_school_id"
+    t.index ["user_id"], name: "index_participant_profiles_on_user_id"
+  end
+
   create_table "participation_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -601,6 +619,10 @@ ActiveRecord::Schema.define(version: 2021_06_30_000110) do
   add_foreign_key "participant_bands", "call_off_contracts"
   add_foreign_key "participant_declarations", "early_career_teacher_profiles"
   add_foreign_key "participant_declarations", "lead_providers"
+  add_foreign_key "participant_profiles", "cohorts"
+  add_foreign_key "participant_profiles", "core_induction_programmes"
+  add_foreign_key "participant_profiles", "schools"
+  add_foreign_key "participant_profiles", "users"
   add_foreign_key "participation_records", "early_career_teacher_profiles"
   add_foreign_key "participation_records", "lead_providers"
   add_foreign_key "partnership_notification_emails", "partnerships"


### PR DESCRIPTION
This PR is the first of series of PRs for refactoring current `EarlyCareerTeacherProfile` and `MentorProfile` into a single STI `ParticipantProfile` model.

### Context

At the moment, everywhere in the code `@participant` is always an instance of `User` and `Participant` simply does not exist. We have ParticipantPolicy, which takes an instance of user, we have ParticipantsController (in school and admin namespaces) which both loads Users using participant-related scopes on User class. We have a lot of code like `@participant.is_mentor? ? @participant.mentor_profile : @participant.early_career_profile` and we're passing an instance of user from method to method and searching for the relevant profiles. This feels like a missed Polymorphism opportunity which we'll bring back here.

### Further steps

This PR simply creates a `ParticipantProfile` model which is to shadow current `EarlyCareerTeacherProfile` and `MentorProfile`. This new model is not being used or referenced anywhere else in the code... for now. Further steps.

2. Once this is deployed, we populate missing records. At this point, shadow ParticipantProfile and legacy profile tables will always be in sync.
3. Once table is populated, we can switch all the profile references to use new `ParticipantProfile` instead of legacy model. At this stage we will preserve as much of original interface as possible. We would also switch the legacy profiles to shadow the new participant profiles.
4. Clean-up: removing unnecessary scopes and simplifying the code wherever we can - the legacy profiles can be now safely removed after validation the data is consistend.
