### PR TITLE
Update participant validation service

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -1,21 +1,44 @@
 # frozen_string_literal: true
 
 class ParticipantValidationService
-  def validate(trn:, nino:, full_name:, dob:)
-    dqt_record = dqt_client.api.dqt_record.show(params: { teacher_reference_number: trn, national_insurance_number: nino })
-    return false if dqt_record.nil?
-    return false unless identity_matches?(trn, nino, full_name, dob, dqt_record)
+  attr_reader :trn, :nino, :full_name, :date_of_birth
 
-    eligible?(dqt_record)
+  def self.validate(trn:, full_name:, date_of_birth:, nino: nil)
+    ParticipantValidationService.new(trn: trn, full_name: full_name, date_of_birth: date_of_birth, nino: nino).validate
+  end
+
+  def initialize(trn:, full_name:, date_of_birth:, nino: nil)
+    @trn = trn
+    @full_name = full_name
+    @date_of_birth = date_of_birth
+    @nino = nino
+  end
+
+  def validate
+    validated_record = matching_record(trn: trn, nino: nino, full_name: full_name, dob: date_of_birth)
+    return if validated_record.nil?
+
+    {
+      trn: validated_record[:teacher_reference_number],
+      qts: validated_record[:qts_date].present? && validated_record[:qts_date] != "null",
+      active_alert: validated_record[:active_alert],
+    }
   end
 
 private
+
+  def dqt_record(trn, nino)
+    dqt_client.api.dqt_record.show(params: { teacher_reference_number: trn, national_insurance_number: nino })
+  end
 
   def dqt_client
     @dqt_client ||= Dqt::Client.new
   end
 
-  def identity_matches?(trn, nino, full_name, dob, dqt_record)
+  def matching_record(trn:, nino:, full_name:, dob:)
+    dqt_record = dqt_record(trn, nino)
+    return if dqt_record.nil?
+
     matches = 0
     trn_matches = trn == dqt_record[:teacher_reference_number]
     matches += 1 if trn_matches
@@ -26,18 +49,12 @@ private
     nino_matches = nino == dqt_record[:national_insurance_number]
     matches += 1 if nino_matches
 
-    return true if matches >= 3
+    return dqt_record if matches >= 3
 
     # If a participant mistypes their TRN and enters someone else's, we should search by NINO instead
     # The API first matches by (mandatory) TRN, then by NINO if it finds no results. This works around that.
     if trn_matches && trn != "0"
-      validate(trn: "0", nino: nino, full_name: full_name, dob: dob)
-    else
-      false
+      matching_record(trn: "0", nino: nino, full_name: full_name, dob: dob)
     end
-  end
-
-  def eligible?(dqt_record)
-    dqt_record[:qts_date].present? && !dqt_record[:active_alert]
   end
 end


### PR DESCRIPTION
### Context
To get ready for automated validation against DQT, we need to return more information when checking participants.

### Changes proposed in this pull request
Change the participant validation service to return correct TRN, QTS status, and active flag status of a participant

