### PR TITLE
CDPTP-224 Remove lead_provider from profile_declarations

### DIFF
--- a/app/models/profile_declaration.rb
+++ b/app/models/profile_declaration.rb
@@ -3,5 +3,4 @@
 class ProfileDeclaration < ApplicationRecord
   delegated_type :declarable, types: %w[EarlyCareerTeacherProfile MentorProfile]
   belongs_to :participant_declaration
-  belongs_to :lead_provider
 end

--- a/db/migrate/20210701000300_remove_lead_provider_from_profile_declarations.rb
+++ b/db/migrate/20210701000300_remove_lead_provider_from_profile_declarations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveLeadProviderFromProfileDeclarations < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :profile_declarations, :lead_provider_id, :uuid }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_000200) do
+ActiveRecord::Schema.define(version: 2021_07_01_000300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -463,13 +463,11 @@ ActiveRecord::Schema.define(version: 2021_06_30_000200) do
 
   create_table "profile_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "participant_declaration_id", null: false
-    t.uuid "lead_provider_id", null: false
     t.string "declarable_type", null: false
     t.uuid "declarable_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["declarable_type", "declarable_id"], name: "index_profile_declarations_on_declarable"
-    t.index ["lead_provider_id"], name: "index_profile_declarations_on_lead_provider_id"
     t.index ["participant_declaration_id"], name: "index_profile_declarations_on_participant_declaration_id"
   end
 


### PR DESCRIPTION
### Context

There was a thought to use the lead_provider/declarable_id as an
index, but it's a premature thought for now. With the principle
of YAGNI, we will add it back if and when we need it.

### Changes proposed in this pull request

Remove lead_provider from profile_declarations

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
