### PR TITLE
Populating the shadow ParticipantProfile table with data from legacy profiles

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -630,7 +630,6 @@ ActiveRecord::Schema.define(version: 2021_07_01_000430) do
   add_foreign_key "participant_declarations", "lead_providers"
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
-  add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
   add_foreign_key "participant_profiles", "schools"
   add_foreign_key "participant_profiles", "users"
   add_foreign_key "participation_records", "early_career_teacher_profiles"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc "Populates ParticipantProfile using data from EarlyCareerTeacherProfile and MentorProfile"
+  task populate_participant_profiles: :environment do
+    MentorProfile.where.not(id: ParticipantProfile.select(:id)).find_in_batches(batch_size: 100) do |batch|
+      ParticipantProfile.insert_all(
+        batch.map do |mentor_profile|
+          {
+            type: "ParticipantProfile::Mentor",
+            **mentor_profile.attributes.transform_keys(&:to_sym),
+          }
+        end,
+      )
+    end
+
+    EarlyCareerTeacherProfile.where.not(id: ParticipantProfile.select(:id)).find_in_batches(batch_size: 100) do |batch|
+      ParticipantProfile.insert_all(
+        batch.map do |ect_profile|
+          {
+            type: "ParticipantProfile::ECT",
+            **ect_profile.attributes.transform_keys(&:to_sym),
+          }
+        end,
+      )
+    end
+  end
+end


### PR DESCRIPTION
Second step of migrating legacy MentorProfile and EarlyCareerTeacherProfile into STI ParticipantProfile model.

Previous step created the model and made it shadow the legacy profile records via after_save hook. This PR, once merged, will populate the ParticipantProfile table with the existing data in legacy profiles.

Once data is fully migrated we can then refactor the code to use new model in place of legacy profiles.