### PR TITLE
Making ParticipantProfile to shadow legacy profile models

### DIFF
--- a/app/models/early_career_teacher_profile.rb
+++ b/app/models/early_career_teacher_profile.rb
@@ -14,4 +14,19 @@ class EarlyCareerTeacherProfile < ApplicationRecord
   scope :sparsity, -> { where(sparsity_uplift: true) }
   scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
   scope :uplift, -> { sparsity.or(pupil_premium) }
+
+  after_save :save_participant_profile
+  before_destroy :destroy_participant_profile
+
+private
+
+  def save_participant_profile
+    profile = ParticipantProfile::ECT.find_or_initialize_by(id: id)
+    profile.assign_attributes(attributes)
+    profile.save!
+  end
+
+  def destroy_participant_profile
+    ParticipantProfile::ECT.where(id: id).destroy_all
+  end
 end

--- a/app/models/mentor_profile.rb
+++ b/app/models/mentor_profile.rb
@@ -14,4 +14,20 @@ class MentorProfile < ApplicationRecord
   scope :sparsity, -> { where(sparsity_uplift: true) }
   scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
   scope :uplift, -> { sparsity.or(pupil_premium) }
+  # TODO: Add a link to participant_record if we need to
+
+  after_save :save_participant_profile
+  before_destroy :destroy_participant_profile
+
+private
+
+  def save_participant_profile
+    profile = ParticipantProfile::Mentor.find_or_initialize_by(id: id)
+    profile.assign_attributes(attributes)
+    profile.save!
+  end
+
+  def destroy_participant_profile
+    ParticipantProfile::Mentor.where(id: id).destroy_all
+  end
 end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -32,6 +32,8 @@ class ParticipantProfile < ApplicationRecord
   class Mentor < self
     self.ignored_columns = %i[mentor_profile_id]
 
+    has_many :mentee_profiles, class_name: "ParticipantProfile::ECT", foreign_key: :mentor_profile_id, dependent: :nullify
+
     def mentor?
       true
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -630,6 +630,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_000430) do
   add_foreign_key "participant_declarations", "lead_providers"
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
+  add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
   add_foreign_key "participant_profiles", "schools"
   add_foreign_key "participant_profiles", "users"
   add_foreign_key "participation_records", "early_career_teacher_profiles"

--- a/spec/cypress/app_commands/scenarios/no_mentors_for_participants.rb
+++ b/spec/cypress/app_commands/scenarios/no_mentors_for_participants.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 # expects "school_participants" to have been previously run
-#
+
 school = School.find_by(name: "Hogwarts Academy")
+
 if school.present?
   school.mentor_profiles.each do |profile|
     EarlyCareerTeacherProfile.where(mentor_profile: profile).update_all(mentor_profile_id: nil)
     profile.user.destroy!
   end
-  school.reload
 end

--- a/spec/cypress/integration/schools/AddParticipants.feature
+++ b/spec/cypress/integration/schools/AddParticipants.feature
@@ -1,4 +1,4 @@
-Feature: School leaders should be able to manage participants
+Feature: School leaders should be able to add participants
 
   Background:
     Given scenario "school_participants" has been run

--- a/spec/cypress/support/on-rails.js
+++ b/spec/cypress/support/on-rails.js
@@ -14,8 +14,16 @@ Cypress.Commands.add("appCommands", (body) => {
 
 let createdRecords = {};
 export default {
-  getCreatedRecord(factory, index = 0) {
-    return createdRecords[factory] && createdRecords[factory][index];
+  getCreatedRecord(factory, givenIndex = -1) {
+    if (!createdRecords[factory]) {
+      return null;
+    }
+
+    let index = givenIndex;
+    if (index < 0) {
+      index = createdRecords[factory].length + index;
+    }
+    return createdRecords[factory][index];
   },
 };
 

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,15 +2,19 @@
 
 FactoryBot.define do
   factory :cohort do
+    to_create do |instance|
+      if (existing = Cohort.find_by(start_year: instance.start_year))
+        instance.attributes = existing.attributes
+        instance.instance_variable_set("@new_record", false)
+      else
+        instance.save!
+      end
+    end
+
     start_year { Faker::Number.unique.between(from: 2021, to: 2100) }
 
     trait :current do
-      # In order for factory_bot to correctly use seeds in the database you have to jump through a couple of hoops,
-      # Detailed in: https://dev.to/jooeycheng/factorybot-findorcreateby-3h8k
-      to_create do |instance|
-        instance.attributes = Cohort.find_or_create_by!(start_year: 2021).attributes
-        instance.instance_variable_set("@new_record", false)
-      end
+      start_year { 2021 }
     end
   end
 end

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :early_career_teacher_profile do
     user
     school
-    cohort { build(:cohort, :current) }
+    cohort
 
     trait :sparsity_uplift do
       sparsity_uplift { true }

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :mentor_profile do
     user
     school
+    cohort
 
     trait :sparsity_uplift do
       sparsity_uplift { true }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     login_token_valid_until { 1.hour.from_now }
 
     trait :admin do
-      admin_profile { build(:admin_profile) }
+      admin_profile
     end
 
     trait :induction_coordinator do
@@ -29,11 +29,12 @@ FactoryBot.define do
     end
 
     trait :lead_provider do
-      lead_provider_profile { build(:lead_provider_profile) }
+      lead_provider_profile
     end
 
     trait :early_career_teacher do
-      early_career_teacher_profile { build(:early_career_teacher_profile) }
+      early_career_teacher_profile
+
       transient do
         mentor {}
         school {}
@@ -54,7 +55,7 @@ FactoryBot.define do
     end
 
     trait :mentor do
-      mentor_profile { build(:mentor_profile) }
+      mentor_profile
 
       transient do
         school {}

--- a/spec/requests/api/v1/particpants_spec.rb
+++ b/spec/requests/api/v1/particpants_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
     let(:bearer_token) { "Bearer #{token}" }
 
     before :each do
-      mentor = create(:user, :mentor, school: partnership.school, cohort: partnership.cohort)
-      2.times do
-        create(:user, :early_career_teacher, mentor: mentor, school: partnership.school, cohort: partnership.cohort)
-      end
+      mentor_profile = create(:mentor_profile, school: partnership.school, cohort: partnership.cohort)
+      create_list :early_career_teacher_profile, 2, mentor_profile: mentor_profile, school: partnership.school, cohort: partnership.cohort
     end
 
     context "when authorized" do

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -13,12 +13,11 @@ RSpec.describe "API Users", type: :request do
       cip = create(:core_induction_programme, name: "Teach First")
       school = create(:school)
       school_cohort = create(:school_cohort, school: school)
-      mentor = create(:user, :mentor, school: school, cohort: school_cohort.cohort)
-      mentor.mentor_profile.update!(core_induction_programme: cip)
-      2.times do
-        ect = create(:user, :early_career_teacher, school: school, cohort: school_cohort.cohort)
-        ect.early_career_teacher_profile.update!(core_induction_programme: cip)
-      end
+      create(:mentor_profile, school: school, cohort: school_cohort.cohort, core_induction_programme: cip).user
+      create_list :early_career_teacher_profile, 2,
+                  school: school,
+                  cohort: school_cohort.cohort,
+                  core_induction_programme: cip
     end
 
     context "when authorized" do

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -6,15 +6,16 @@ RSpec.describe ParticipantSerializer do
   describe "serialization" do
     let(:mentor) { create(:user, :mentor) }
     let(:ect) { create(:user, :early_career_teacher, mentor: mentor) }
-    let(:cohort) { ect.early_career_teacher_profile.cohort }
+    let(:ect_cohort) { ect.early_career_teacher_profile.cohort }
+    let(:mentor_cohort) { mentor.mentor_profile.cohort }
 
     it "outputs correctly formatted serialized Mentors" do
-      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":null}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year}}}}"
       expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
     end
 
     it "outputs correctly formatted serialized ECTs" do
-      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{cohort.start_year}}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year}}}}"
       expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
     end
   end


### PR DESCRIPTION
Another PR for ParticipantProfile migration / refactor.

This will ensure that any new changes to MentorProfile and EarlyCareerTeacherProfile will be automatically propagated to ParticipantProfile. 

Once merged, we could quickly populate ParticipantProfiles with:

```ruby
MentorProfile.all.find_each do |profile|
  profile.send :save_participant_profile
end
EarlyCareerTeacherProfile.all.find_each do |profile|
  profile.send :save_participant_profile
end
```