### PR TITLE
CPDRP-557: Add mentor column to SIT participant listing

### DIFF
--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -24,7 +24,7 @@
           <td class="govuk-table__cell"><%= t(participant.mentor? ? :mentor : :ect, scope: "schools.participants.type") %></td>
           <td class="govuk-table__cell">
             <% if participant.early_career_teacher? %>
-              <%= (mentor = participant.early_career_teacher_profile.mentor).present? ?
+              <%= (mentor = participant.early_career_teacher_profile.mentor) ?
                     mentor.full_name :
                     govuk_link_to("Assign mentor", schools_participant_edit_mentor_path(participant_id: participant.id)) %>
             <% else %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -13,6 +13,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Full name</th>
         <th scope="col" class="govuk-table__header">Type</th>
+        <th scope="col" class="govuk-table__header">Mentor</th>
         <th scope="col" class="govuk-table__header">Status</th>
       </tr>
     </thead>
@@ -21,6 +22,15 @@
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header"><%= govuk_link_to participant.full_name, schools_participant_path(id: participant) %></th>
           <td class="govuk-table__cell"><%= t(participant.mentor? ? :mentor : :ect, scope: "schools.participants.type") %></td>
+          <td class="govuk-table__cell">
+            <% if participant.early_career_teacher? %>
+              <%= (mentor = participant.early_career_teacher_profile.mentor).present? ?
+                    mentor.full_name :
+                    govuk_link_to("Assign mentor", schools_participant_edit_mentor_path(participant_id: participant.id)) %>
+            <% else %>
+              - <span class="govuk-visually-hidden">Not applicable</span>
+            <% end %>
+          </td>
           <td class="govuk-table__cell">
             <%= render GovukComponent::Tag.new(text: "Pending", colour: "grey") %>
           </td>

--- a/spec/cypress/app_commands/scenarios/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/school_participants.rb
@@ -24,4 +24,4 @@ FactoryBot.create(:user, :mentor, full_name: "Unrelated user", email: "unrelated
 ect_1 = FactoryBot.create(:user, :early_career_teacher, full_name: "Joe Bloggs")
 ect_1.early_career_teacher_profile.update!(school: school, mentor_profile: mentor.mentor_profile)
 ect_2 = FactoryBot.create(:user, :early_career_teacher, full_name: "Dan Smith", email: "dan-smith@example.com")
-ect_2.early_career_teacher_profile.update!(school: school, mentor_profile: mentor.mentor_profile)
+ect_2.early_career_teacher_profile.update!(school: school)

--- a/spec/cypress/app_commands/scenarios/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/school_participants.rb
@@ -21,7 +21,7 @@ mentor.mentor_profile.update!(school: school)
 
 FactoryBot.create(:user, :mentor, full_name: "Unrelated user", email: "unrelated@example.com")
 
-ect_1 = FactoryBot.create(:user, :early_career_teacher, full_name: "Joe Bloggs")
+ect_1 = FactoryBot.create(:user, :early_career_teacher, full_name: "Joe Bloggs", email: "joe-bloggs@example.com")
 ect_1.early_career_teacher_profile.update!(school: school, mentor_profile: mentor.mentor_profile)
 ect_2 = FactoryBot.create(:user, :early_career_teacher, full_name: "Dan Smith", email: "dan-smith@example.com")
 ect_2.early_career_teacher_profile.update!(school: school)

--- a/spec/cypress/integration/schools/ManageParticipants.feature
+++ b/spec/cypress/integration/schools/ManageParticipants.feature
@@ -39,7 +39,6 @@ Feature: School leaders should be able to manage participants
     When I navigate to "2021 school participants" page with id "111111-hogwarts-academy"
     Then "page body" should not contain "Assign mentor"
 
-
   Scenario: Updating details of a participant
     When I click on "link" containing "Dan Smith"
     Then I should be on "2021 school participant" page

--- a/spec/cypress/integration/schools/ManageParticipants.feature
+++ b/spec/cypress/integration/schools/ManageParticipants.feature
@@ -14,7 +14,7 @@ Feature: School leaders should be able to manage participants
     And the page should be accessible
     And percy should be sent snapshot called "Participants index page"
 
-    When I click on "link" containing "Dan Smith"
+    When I click on "link" containing "Joe Bloggs"
     Then I should be on "2021 school participant" page
     And the page should be accessible
     And percy should be sent snapshot called "Participant show page"
@@ -22,7 +22,23 @@ Feature: School leaders should be able to manage participants
     When I click on "link" containing "Abdul Mentor"
     Then I should be on "2021 school participant" page
     And "page body" should contain "Abdul Mentor"
-    And "page body" should not contain "Dan Smith"
+    And "page body" should not contain "Joe Bloggs"
+
+  Scenario: Assigning a mentor
+    When I click on "link" containing "Assign mentor"
+    Then I should be on "2021 school edit ect mentor" page
+    And the page should be accessible
+    And percy should be sent snapshot
+
+    When I click on "Abdul Mentor" label
+    And I click the submit button
+    Then I should be on "2021 school participant" page
+    And "page body" should contain "The mentor for this participant has been updated"
+    And "page body" should contain "Abdul Mentor"
+
+    When I navigate to "2021 school participants" page with id "111111-hogwarts-academy"
+    Then "page body" should not contain "Assign mentor"
+
 
   Scenario: Updating details of a participant
     When I click on "link" containing "Dan Smith"

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -100,6 +100,8 @@ const pagePaths = {
     "/schools/:school_slug/cohorts/2021/participants/:participant_id/email-used",
   "2021 school choose etc mentor":
     "/schools/:id/cohorts/2021/participants/add/choose-mentor",
+  "2021 school edit ect mentor":
+    "/schools/:school_slug/cohorts/2021/participants/:participant_id/edit-mentor",
   "2021 school participant confirm":
     "/schools/:id/cohorts/2021/participants/add/confirm",
   "lead providers report schools start": "/lead-providers/report-schools/start",


### PR DESCRIPTION
### Context
CPDRP-557
Add a column to the SIT participant listing page. This displays the mentor for ECTs, and an "assign" link when one has not been assigned

### Changes proposed in this pull request

### Guidance to review

### Testing
Just a link to existing pages, so just added a cypress test

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Sign in as school-leader@example.com