### PR TITLE
CPDTP-304 Allow reset of sandbox data

### DIFF
--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -3,7 +3,7 @@
 namespace :db do
   desc "Remove all database content, then seed it. Only for dev environments."
   task safe_reset: :environment do
-    if Rails.env.development? || Rails.env.deployed_development?
+    if Rails.env.development? || Rails.env.deployed_development? || Rails.env.sandbox?
       connection = ActiveRecord::Base.connection
       tables = connection
                    .execute("SELECT * FROM pg_catalog.pg_tables;")


### PR DESCRIPTION
### Context

There are multiple lead providers with the same name in the sandbox. After discussion we think it'll be expedient to reset the whole database and recreate the tokens rather than manually fixup the data.

### Changes proposed in this pull request

* Allow reset of sandbox data

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?