### PR TITLE
Added foreign key to mentor_profile_id on participant_profiles

### DIFF
--- a/db/migrate/20210705094926_add_mentor_fk_to_participant_profiles.rb
+++ b/db/migrate/20210705094926_add_mentor_fk_to_participant_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMentorFkToParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :participant_profiles, :participant_profiles, column: :mentor_profile_id, validate: false
+  end
+end

--- a/db/migrate/20210705095448_validate_mentor_fk_to_participant_profiles.rb
+++ b/db/migrate/20210705095448_validate_mentor_fk_to_participant_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateMentorFkToParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :participant_profiles, :participant_profiles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_000430) do
+ActiveRecord::Schema.define(version: 2021_07_05_095448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -630,6 +630,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_000430) do
   add_foreign_key "participant_declarations", "lead_providers"
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
+  add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
   add_foreign_key "participant_profiles", "schools"
   add_foreign_key "participant_profiles", "users"
   add_foreign_key "participation_records", "early_career_teacher_profiles"


### PR DESCRIPTION
WE have currently migrated all the data into a new ParticipantProfile model from legacy EarlyCareerTeacherProfile and MentorProfile. The new model is kept in sync with the legacy ones via after_save hook, so we can be certain the data in new model is now fully consistent.

This PR enforces consistency by adding a missing self-referencing FK key to the new model.