### PR TITLE
add /api/v1/participant-validation endpoint

### DIFF
--- a/app/controllers/api/v1/participant_validation_controller.rb
+++ b/app/controllers/api/v1/participant_validation_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ParticipantValidationController < Api::ApiController
+      include ApiTokenAuthenticatable
+
+      def show
+        record = ParticipantValidationService.validate(
+          trn: params[:id],
+          full_name: params[:full_name],
+          date_of_birth: Date.iso8601(params[:date_of_birth]),
+          nino: params[:nino],
+        )
+
+        if record.present?
+          render json: ParticipantValidationSerializer.new(OpenStruct.new(record)).serializable_hash.to_json
+        else
+          head :not_found
+        end
+      end
+
+    private
+
+      def access_scope
+        ApiToken.where(private_api_access: true)
+      end
+    end
+  end
+end

--- a/app/serializers/participant_validation_serializer.rb
+++ b/app/serializers/participant_validation_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ParticipantValidationSerializer
+  include JSONAPI::Serializer
+
+  set_id :trn
+  attributes :trn, :qts, :active_alert
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
       resources :participant_declarations, only: %i[create], path: "participant-declarations"
       resources :users, only: %i[index create]
       resources :dqt_records, only: :show, path: "dqt-records"
+      resources :participant_validation, only: :show, path: "participant-validation"
 
       jsonapi_resources :npq_profiles, only: [:create]
     end

--- a/spec/requests/api/v1/particpant_validation_spec.rb
+++ b/spec/requests/api/v1/particpant_validation_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "participant validation api endpoint", type: :request do
+  describe "#show" do
+    let(:token) { NpqRegistrationApiToken.create_with_random_token! }
+    let(:bearer_token) { "Bearer #{token}" }
+    let(:parsed_response) { JSON.parse(response.body) }
+    let(:trn) { rand(1_000_000..9_999_999).to_s }
+    let(:full_name) { "John Doe" }
+    let(:date_of_birth) { rand(50.years.ago..20.years.ago).to_date }
+    let(:nino) { "AB123456C" }
+
+    let(:service_response) do
+      {
+        trn: trn,
+        qts: "1999-12-13",
+        active_alert: false,
+      }
+    end
+
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+
+        allow(ParticipantValidationService).to receive(:validate).and_return(service_response)
+      end
+
+      it "returns correct jsonapi content type header" do
+        get "/api/v1/participant-validation/#{trn}?full_name=#{full_name}&date_of_birth=#{date_of_birth}&nino=#{nino}"
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns correct type" do
+        get "/api/v1/participant-validation/#{trn}?full_name=#{full_name}&date_of_birth=#{date_of_birth}&nino=#{nino}"
+        expect(parsed_response["data"]).to have_type("participant_validation")
+      end
+
+      it "has correct attributes" do
+        get "/api/v1/participant-validation/#{trn}?full_name=#{full_name}&date_of_birth=#{date_of_birth}&nino=#{nino}"
+
+        expect(parsed_response["data"]["id"]).to eql(service_response[:trn])
+        expect(parsed_response["data"]).to have_jsonapi_attributes(:trn, :qts, :active_alert).exactly
+      end
+
+      context "when no record is found for given teacher_reference_number" do
+        let(:service_response) { nil }
+
+        it "returns a 404" do
+          get "/api/v1/participant-validation/#{trn}?full_name=#{full_name}&date_of_birth=#{date_of_birth}&nino=#{nino}"
+          expect(response).to be_not_found
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v1/participant-validation/#{trn}?full_name=#{full_name}&date_of_birth=#{date_of_birth}&nino=#{nino}"
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "using valid token but for different scope" do
+      let(:other_token) { ApiToken.create_with_random_token! }
+
+      it "returns 403" do
+        default_headers[:Authorization] = "Bearer #{other_token}"
+        get "/api/v1/participant-validation/#{trn}?full_name=#{full_name}&date_of_birth=#{date_of_birth}&nino=#{nino}"
+        expect(response.status).to eq 403
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- NPQ registration needs to verify TRNs of applicants
- Currently this is done with the `/api/v1/dqt-records` endpoint
- A constraint of the current implementation of this endpoint means the TRNs must match in order for participant to be valid
- With the recent addition of `ParticipantValidationService` we can now wrap this service in an api endpoint
- These means it is now possible to verify participants even if the TRN they entered is incorrect but all other pieces of information are correct

### Changes proposed in this pull request

- added `/api/v1/participant-validation` api endpoint which wraps `ParticipantValidationService`

### Guidance to review

- If everything goes smoothly and nothing else is using `/api/v1/dqt-records`, It can be teared down in a later change

### Testing

- Test in review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- create an api token with `NpqRegistrationApiToken.create_with_random_token!`
- note down the token
- call new endpoint
```
curl -H "Authorization: Bearer UNHASHED_TOKEN" https://ecf-review-pr-636.london.cloudapps.digital/api/v1/participant-validation/VALID_TRN?full_name=CORRECT_NAME&date_of_birth=YYYY-MM-DD&nino=CORRECT_NINO
```
- see csv extract for data points to test against
- should return correct TRN
- change TRN so it is incorrect
- should still return correct TRN assuming all other fields are correct