### PR TITLE
CPDTP-202 Switch from classic autoloader to zeitwerk

### DIFF
--- a/app/controllers/api/school_search_controller.rb
+++ b/app/controllers/api/school_search_controller.rb
@@ -7,7 +7,7 @@ class Api::SchoolSearchController < Api::ApiController
         .eligible
         .ransack(name_or_urn_cont: params[:search_key]).result
         .limit(10)
-      decorated_schools = schools.map { |school| ::Decorators::SchoolDecorator.new(school) }
+      decorated_schools = schools.map { |school| SchoolDecorator.new(school) }
       render json: SchoolSerializer.render(decorated_schools)
     else
       render json: []

--- a/app/decorators/school_decorator.rb
+++ b/app/decorators/school_decorator.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
-module Decorators
-  class SchoolDecorator
-    attr_reader :school
+class SchoolDecorator
+  attr_reader :school
 
-    delegate :id, :name, :address_line1, :address_line2, :address_line3, :postcode, to: :school
+  delegate :id, :name, :address_line1, :address_line2, :address_line3, :postcode, to: :school
 
-    def initialize(school)
-      @school = school
-    end
+  def initialize(school)
+    @school = school
+  end
 
-    def name_with_address
-      "#{name} (#{full_address_formatted})"
-    end
+  def name_with_address
+    "#{name} (#{full_address_formatted})"
+  end
 
-    def full_address_formatted
-      [address_line1, address_line2, address_line3, postcode].reject(&:blank?).join(", ")
-    end
+  def full_address_formatted
+    [address_line1, address_line2, address_line3, postcode].reject(&:blank?).join(", ")
   end
 end

--- a/app/forms/nomination_request_form.rb
+++ b/app/forms/nomination_request_form.rb
@@ -18,7 +18,7 @@ class NominationRequestForm
 
   def available_schools
     School.currently_open.joins(:school_local_authorities).where(school_local_authorities: { local_authority_id: local_authority_id }).map do |sch|
-      Decorators::SchoolDecorator.new(sch)
+      SchoolDecorator.new(sch)
     end
   end
 

--- a/app/models/concerns/participant_record_state_machine.rb
+++ b/app/models/concerns/participant_record_state_machine.rb
@@ -7,50 +7,48 @@
 #
 # You can generate a state diagram with `bundle exec rake aasm-diagram:generate[participant_profile]`
 # The generated diagram goes into the `tmp/` folder of the repo. See https://github.com/Katee/aasm-diagram
-module Concerns
-  module ParticipantRecordStateMachine
-    extend ActiveSupport::Concern
-    included do
-      include AASM
+module ParticipantRecordStateMachine
+  extend ActiveSupport::Concern
+  included do
+    include AASM
 
-      has_paper_trail versions: {
-        class_name: "ParticipantEvent",
-      }
+    has_paper_trail versions: {
+      class_name: "ParticipantEvent",
+    }
 
-      scope :active, -> { where(state: "active") }
-      scope :changed_between, ->(start_date, end_date) { where(updated_at: start_date..end_date) }
+    scope :active, -> { where(state: "active") }
+    scope :changed_between, ->(start_date, end_date) { where(updated_at: start_date..end_date) }
 
-      aasm column: :state
+    aasm column: :state
 
-      aasm do
-        state :assigned, initial: true
-        state :active, :deferred, :withdrawn, :completed
-        before_all_events :before_all_events
+    aasm do
+      state :assigned, initial: true
+      state :active, :deferred, :withdrawn, :completed
+      before_all_events :before_all_events
 
-        event :join do
-          transitions from: :assigned, to: :active
-        end
+      event :join do
+        transitions from: :assigned, to: :active
+      end
 
-        event :defer do
-          transitions from: :active, to: :deferred
-        end
+      event :defer do
+        transitions from: :active, to: :deferred
+      end
 
-        event :resume do
-          transitions from: :deferred, to: :active
-        end
+      event :resume do
+        transitions from: :deferred, to: :active
+      end
 
-        event :withdraw do
-          transitions from: %i[active deferred], to: :withdrawn
-        end
+      event :withdraw do
+        transitions from: %i[active deferred], to: :withdrawn
+      end
 
-        event :complete do
-          transitions from: :active, to: :completed
-        end
+      event :complete do
+        transitions from: :active, to: :completed
       end
     end
+  end
 
-    def before_all_events
-      self.paper_trail_event = aasm.current_event
-    end
+  def before_all_events
+    self.paper_trail_event = aasm.current_event
   end
 end

--- a/app/models/participation_record.rb
+++ b/app/models/participation_record.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipationRecord < ApplicationRecord
-  include Concerns::ParticipantRecordStateMachine
+  include ParticipantRecordStateMachine
   belongs_to :early_career_teacher_profile, class_name: "ParticipantProfile::ECT"
   belongs_to :lead_provider
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module EarlyCareerFramework
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-    config.autoloader = :classic
+    config.autoloader = :zeitwerk
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,4 +19,5 @@
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular "pupil_premium", "pupil_premiums"
+  inflect.acronym("UTM")
 end

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 class DummyController < Api::ApiController
-  include Api::ApiTokenAuthenticatable
+  include ApiTokenAuthenticatable
 end
 
 describe DummyController, type: :controller do

--- a/spec/decorators/school_decorator_spec.rb
+++ b/spec/decorators/school_decorator_spec.rb
@@ -2,9 +2,9 @@
 
 require "rails_helper"
 
-RSpec.describe Decorators::SchoolDecorator do
+RSpec.describe SchoolDecorator do
   let(:school) { create(:school, name: "Western Armstrong", address_line1: "52634 Gloria Circle", address_line2: "Pagac Extensions", postcode: "SE23 1SA") }
-  let(:school_decorator) { Decorators::SchoolDecorator.new(school) }
+  let(:school_decorator) { SchoolDecorator.new(school) }
 
   describe "#name_with_address" do
     let(:expected_name_with_address) do

--- a/spec/serializers/school_serializer_spec.rb
+++ b/spec/serializers/school_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe SchoolSerializer do
   describe "serialization" do
     let(:school) { create(:school, name: "Western Armstrong", address_line1: "52634 Gloria Circle", address_line2: "Pagac Extensions", postcode: "SE23 1SA") }
-    let(:decorated_school) { ::Decorators::SchoolDecorator.new(school) }
+    let(:decorated_school) { SchoolDecorator.new(school) }
     let(:serialized_school) { SchoolSerializer.render(decorated_school) }
 
     it "outputs correctly formatted serialized school" do


### PR DESCRIPTION
### Context

For historical reasons, we have been using the "classic" autoloader. This PR switches it for :zeitwerk

### Changes proposed in this pull request

- change application autoloader to :zeitwerk
- Removed "Concerns" from namespace
- Added in inflector for UTM
- Removed spurious Api:: from the Dummy Api controller

### Guidance to review

Things should behave as before. Only naming changes have been applied.

### Testing

All existing tests pass. Only changes are to namespaces and automatically found names in code where they were previously incorrect, but still being included.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
