### PR TITLE
Skip magic link auth for certain domains on non-production environments

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,10 +3,29 @@
 class Users::SessionsController < Devise::SessionsController
   include ApplicationHelper
 
-  TEST_USERS = %w[admin@example.com lead-provider@example.com school-leader@example.com early-career-teacher@example.com].freeze
+  TEST_DOMAINS = %w[
+    example.com
+    ambition.org.uk
+    churchofengland.org
+    pracedo.com
+    ucl.ac.uk
+    tribalgroup.com
+    teachfirst.org.uk
+    educationdevelopmenttrust.com
+    capita.com
+    bestpracticenet.co.uk
+    aircury.com
+    setsquaresolutions.com
+    harrisfederation.org.uk
+    harrischaffordhundred.org.uk
+    llse.org.uk
+    realgroup.co.uk
+    teacherdevelopmenttrust.org 
+    uclconsultants.com
+  ].freeze
 
   skip_before_action :check_privacy_policy_accepted
-  before_action :mock_login, only: :create, if: -> { Rails.env.development? || Rails.env.deployed_development? }
+  before_action :mock_login, only: :create, if: -> { Rails.env.development? || Rails.env.deployed_development? || Rails.env.sandbox? }
   before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]
   before_action :ensure_login_token_valid, only: %i[sign_in_with_token redirect_from_magic_link]
 
@@ -60,7 +79,7 @@ private
 
   def mock_login
     email = params.dig(:user, :email)
-    return unless TEST_USERS.include?(email)
+    return unless TEST_DOMAINS.any? { |domain| email.include?(domain) }
 
     user = User.find_by_email(email)
     sign_in(user, scope: :user)

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -67,6 +67,33 @@ RSpec.describe "Users::Sessions", type: :request do
     end
   end
 
+  describe "Mock login" do
+    let(:test_email) { "admin@example.com" }
+
+    before do
+      user.update!(email: test_email)
+      allow(Rails).to receive(:env).and_return ActiveSupport::EnvironmentInquirer.new(environment.to_s)
+    end
+
+    context "using a non-production enviromment" do
+      let(:environment) { :sandbox }
+
+      it "redirects to the dashboard" do
+        post "/users/sign_in", params: { user: { email: test_email } }
+        expect(response).to redirect_to "/dashboard"
+      end
+    end
+
+    context "using a production environment" do
+      let(:environment) { :production }
+
+      it "renders the login_email_sent template" do
+        post "/users/sign_in", params: { user: { email: test_email } }
+        expect(response).to render_template(:login_email_sent)
+      end
+    end
+  end
+
   describe "GET /users/confirm_sign_in" do
     it "renders the redirect_from_magic_link template" do
       get "/users/confirm_sign_in?login_token=#{user.login_token}"


### PR DESCRIPTION
Draft pending confirmation on applicable domains.

- Expand mock login to cover all non-production environments, including sandbox.
- Set whitelist of email domains to apply mock login to

### How can I view this in a review app?

- Can you log in with an email address with an applicable domain without using the magic-link process?