### PR TITLE
DQT NI number data may be cased incorrectly

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -46,7 +46,7 @@ private
     matches += 1 if name_matches
     dob_matches = dob == dqt_record[:date_of_birth]
     matches += 1 if dob_matches
-    nino_matches = nino == dqt_record[:national_insurance_number]
+    nino_matches = nino.downcase == dqt_record[:national_insurance_number]&.downcase
     matches += 1 if nino_matches
 
     return dqt_record if matches >= 3

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -53,15 +53,21 @@ RSpec.describe ParticipantValidationService do
         ).to eql({ trn: trn, qts: true, active_alert: false })
       end
 
-      it "returns the validated details when nino is wrong" do
+      it "returns the validated details when name is wrong" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: nino, full_name: "John Smithe", date_of_birth: dob),
         ).to eql({ trn: trn, qts: true, active_alert: false })
       end
 
-      it "returns the validated details when name is wrong" do
+      it "returns the validated details when nino is wrong" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: "AA654321A", full_name: full_name, date_of_birth: dob),
+        ).to eql({ trn: trn, qts: true, active_alert: false })
+      end
+
+      it "returns the validated details when name is wrong and nino is cased differently" do
+        expect(
+          ParticipantValidationService.validate(trn: trn, nino: nino.downcase, full_name: "John Smithe", date_of_birth: dob),
         ).to eql({ trn: trn, qts: true, active_alert: false })
       end
     end


### PR DESCRIPTION
### Context

- I have seen NI numbers in prod API return NI numbers that are mixed cased

### Changes proposed in this pull request

- To better out matching this makes NI matching case insensitive

### Guidance to review

- nil guard is present incase api data is not provided

### Testing

- Test on review app
- Test data seems to be upcased correctly so enter downcased data to verify case insensitivity

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- ssh into review app
- fire up rails console
- see csv test data to create a test case
- `ParticipantValidationService.validate(trn: "CORRECT_TRN", full_name: "CORRECT_NAME", date_of_birth: WRONG_DATE, nino: "INCORRECTLY_CASED_NINO")`
- should return correct record