### PR TITLE
Track DQT response code in exceptions

### DIFF
--- a/lib/dqt/client.rb
+++ b/lib/dqt/client.rb
@@ -32,7 +32,7 @@ module Dqt
           query: params,
         ),
       )
-      raise ResponseError.new("DQT request failed", response) if [*0..199, *300..599].include? response.code
+      raise ResponseError.new("DQT request failed with code #{response.code}", response) if [*0..199, *300..599].include? response.code
 
       response.body
     end


### PR DESCRIPTION
We're seeing a few failures, track the received status code to better
understand them

