### PR TITLE
populate EcfLeadProvider with LeadProvider data

### DIFF
--- a/app/models/ecf_lead_provider.rb
+++ b/app/models/ecf_lead_provider.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class EcfLeadProvider < ApplicationRecord
+  validates :name, presence: { message: "Enter a name" }
+end

--- a/db/migrate/20210706160845_create_ecf_lead_providers.rb
+++ b/db/migrate/20210706160845_create_ecf_lead_providers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateEcfLeadProviders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ecf_lead_providers, id: :uuid do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210706161422_copy_lead_providers.rb
+++ b/db/migrate/20210706161422_copy_lead_providers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CopyLeadProviders < ActiveRecord::Migration[6.1]
+  def up
+    LeadProvider.all.each do |lp|
+      EcfLeadProvider.create!(lp.attributes)
+    end
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute("TRUNCATE ecf_lead_providers")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_06_113050) do
+ActiveRecord::Schema.define(version: 2021_07_06_161422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -186,6 +186,12 @@ ActiveRecord::Schema.define(version: 2021_07_06_113050) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["local_authority_district_id"], name: "index_district_sparsities_on_local_authority_district_id"
+  end
+
+  create_table "ecf_lead_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "event_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
