### PR TITLE
Switch the sandbox_data seeding to use the new structure

### DIFF
--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -25,12 +25,12 @@ def generate_mentors(lead_provider, school, cohort, logger)
   existing_ect_count = User.early_career_teachers_for_lead_provider(lead_provider).count
   10.times do
     mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-    mentor_profile = MentorProfile.create!(user: mentor, school: school, cohort: cohort)
+    mentor_profile = ParticipantProfile::Mentor.create!(user: mentor, school: school, cohort: cohort)
 
     ect_count = rand(0..3)
     ect_count.times do
       ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-      EarlyCareerTeacherProfile.create!(user: ect, school: school, cohort: cohort, mentor_profile: mentor_profile)
+      ParticipantProfile::ECT.create!(user: ect, school: school, cohort: cohort, mentor_profile: mentor_profile)
     end
     logger.info(" Mentor with user_id #{mentor.id} generated with #{ect_count} ECTs")
   end


### PR DESCRIPTION
### Context

We've recently had a change to the shape of the ParticipantProfiles. This rake task was still pointing to the old way.

### Changes proposed in this pull request

Switch EarlyCareerTeacherProfile and MentorProfile for the newer ParticipantProfile::ECT and ParticipantProfile::Mentor

### Guidance to review

### Testing

Self-contained rake task that generates pseudo random participant data for each lead provider.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
