### PR TITLE
Remove FQDN from sandbox as it has not been setup

### DIFF
--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -13,4 +13,3 @@ paas_web_app_instances = 1
 paas_web_app_memory = 8192
 paas_worker_app_instances = 1
 paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=*:2 start && bundle exec rake jobs:work"
-govuk_hostnames = ["sandbox-manage-training-for-early-career-teachers"]

--- a/terraform/workspace-variables/sandbox_app_env.yml
+++ b/terraform/workspace-variables/sandbox_app_env.yml
@@ -7,7 +7,4 @@ RAILS_MAX_THREADS: 5
 RAILS_SERVE_STATIC_FILES: true
 SERVICE_TYPE: web
 DATABASE_URL: postgres://postgres@localhost:5432
-DOMAIN: sandbox-manage-teacher-development.education.gov.uk
-GOVUK_WEBSITE_ROOT: sandbox-manage-teacher-development.education.gov.uk
-GOVUK_APP_DOMAIN: sandbox-manage-teacher-development.education.gov.uk
 SEND_EMAILS_TO: cpd-test@digital.education.gov.uk


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
