### PR TITLE
CPDRP-527 Opt out schools that report partnership as no ECTs

### DIFF
--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -22,6 +22,12 @@ class ChallengePartnershipForm
         },
       )
 
+      if partnership.no_ects?
+        school_cohort = partnership.school.school_cohorts.find_by(cohort: partnership.cohort)
+        school_cohort.update!(induction_programme_choice: :no_early_career_teachers,
+                              opt_out_of_updates: true)
+      end
+
       partnership.lead_provider.users.each do |lead_provider_user|
         LeadProviderMailer.partnership_challenged_email(
           partnership: partnership,

--- a/spec/forms/challenge_partnership_form_spec.rb
+++ b/spec/forms/challenge_partnership_form_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe ChallengePartnershipForm, type: :model do
   end
 
   describe "#challenge!" do
+    let(:school) { create :school }
+    let(:cohort) { create :cohort, :current }
+    let!(:school_cohort) { create :school_cohort, school: school, cohort: cohort }
     let(:lead_provider) { create :lead_provider }
     let!(:lead_provider_profiles) { create_list(:lead_provider_profile, rand(2..3), lead_provider: lead_provider) }
-    let(:partnership) { create :partnership, lead_provider: lead_provider }
+    let(:partnership) { create :partnership, school: school, lead_provider: lead_provider, cohort: cohort }
     let(:reason) { described_class.new.challenge_reason_options.sample.id }
 
     subject { described_class.new(partnership: partnership, challenge_reason: reason) }
@@ -30,6 +33,22 @@ RSpec.describe ChallengePartnershipForm, type: :model do
       lead_provider_profiles.each do |lp_profile|
         expect(LeadProviderMailer).to delay_email_delivery_of(:partnership_challenged_email)
           .with(user: lp_profile.user, partnership: partnership)
+      end
+    end
+
+    context "when the challenge reason is no ECTs this year" do
+      let(:reason) { "no_ects" }
+
+      before do
+        school_cohort.full_induction_programme!
+      end
+
+      it "sets the schools programme choice to reflect no ECTs" do
+        expect { subject.challenge! }.to change { school_cohort.reload.induction_programme_choice }.to "no_early_career_teachers"
+      end
+
+      it "opts the school out of updates" do
+        expect { subject.challenge! }.to change { school_cohort.reload.opt_out_of_updates }.to true
       end
     end
   end


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-527)
If a school challenges a partnership with the reason that they have no ECTs, then set that school's programme choice to `no_early_career_teachers` and opt them out of updates.

### Changes proposed in this pull request
Add logic to update the `SchoolCohort` with the `no_early_career_teachers` programme choice and set `opt_out_of_updates = true` to ensure the school isn't sent unnecessary comms for the cohort.

### Guidance to review

### Testing
Challenging a partnership with the reason "We do not have any early career teachers this year" should result in the programme choice being changed to "No early career teachers for this cohort" (visible in the __Manage your training__ page)

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
![image](https://user-images.githubusercontent.com/333931/124772288-d08a9000-df33-11eb-993a-316d9f311c41.png)
![image](https://user-images.githubusercontent.com/333931/124772608-18111c00-df34-11eb-9729-e147ea9b4a61.png)
