### PR TITLE
introduce CpdLeadProvider

### DIFF
--- a/app/models/cpd_lead_provider.rb
+++ b/app/models/cpd_lead_provider.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CpdLeadProvider < ApplicationRecord
+  validates :name, presence: { message: "Enter a name" }
+end

--- a/app/models/cpd_lead_provider.rb
+++ b/app/models/cpd_lead_provider.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 class CpdLeadProvider < ApplicationRecord
+  has_many :lead_providers
+  has_many :npq_lead_providers
+
   validates :name, presence: { message: "Enter a name" }
 end

--- a/app/models/cpd_lead_provider.rb
+++ b/app/models/cpd_lead_provider.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class CpdLeadProvider < ApplicationRecord
-  has_many :lead_providers
-  has_many :npq_lead_providers
+  has_one :lead_provider
+  has_one :npq_lead_provider
 
   validates :name, presence: { message: "Enter a name" }
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LeadProvider < ApplicationRecord
+  belongs_to :cpd_lead_provider, optional: true
+
   has_many :partnerships
   has_many :schools, through: :partnerships
   has_many :lead_provider_profiles

--- a/app/models/npq_lead_provider.rb
+++ b/app/models/npq_lead_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class NpqLeadProvider < ApplicationRecord
+  belongs_to :cpd_lead_provider, optional: true
 end

--- a/db/migrate/20210707115324_create_cpd_lead_providers.rb
+++ b/db/migrate/20210707115324_create_cpd_lead_providers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateCpdLeadProviders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :cpd_lead_providers, id: :uuid do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210707120216_populate_cpd_lead_providers.rb
+++ b/db/migrate/20210707120216_populate_cpd_lead_providers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PopulateCpdLeadProviders < ActiveRecord::Migration[6.1]
+  def up
+    all_provider_names = (LeadProvider.pluck(:name) + NpqLeadProvider.pluck(:name)).uniq
+
+    all_provider_names.each do |name|
+      CpdLeadProvider.create!(name: name)
+    end
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute("TRUNCATE cpd_lead_providers")
+  end
+end

--- a/db/migrate/20210707123715_columns_for_lps_and_cpd_lps.rb
+++ b/db/migrate/20210707123715_columns_for_lps_and_cpd_lps.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ColumnsForLpsAndCpdLps < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_table :lead_providers do |t|
+        t.references :cpd_lead_provider, null: true, foreign_key: true, type: :uuid
+      end
+
+      change_table :npq_lead_providers do |t|
+        t.references :cpd_lead_provider, null: true, foreign_key: true, type: :uuid
+      end
+    end
+  end
+end

--- a/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
+++ b/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PopulateLpAndCpdLpAssocs < ActiveRecord::Migration[6.1]
+  def up
+    LeadProvider.all.each do |lp|
+      lp.update(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+    end
+
+    NpqLeadProvider.all.each do |lp|
+      lp.update(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+    end
+  end
+
+  def down
+    LeadProvider.update_all(cpd_lead_provider: nil)
+    NpqLeadProvider.update_all(cpd_lead_provider: nil)
+  end
+end

--- a/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
+++ b/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
@@ -3,11 +3,11 @@
 class PopulateLpAndCpdLpAssocs < ActiveRecord::Migration[6.1]
   def up
     LeadProvider.all.each do |lp|
-      lp.update(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+      lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
     end
 
     NpqLeadProvider.all.each do |lp|
-      lp.update(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+      lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_120216) do
+ActiveRecord::Schema.define(version: 2021_07_07_123715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -278,6 +278,8 @@ ActiveRecord::Schema.define(version: 2021_07_07_120216) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name", null: false
+    t.uuid "cpd_lead_provider_id"
+    t.index ["cpd_lead_provider_id"], name: "index_lead_providers_on_cpd_lead_provider_id"
   end
 
   create_table "local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -335,6 +337,8 @@ ActiveRecord::Schema.define(version: 2021_07_07_120216) do
     t.text "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "cpd_lead_provider_id"
+    t.index ["cpd_lead_provider_id"], name: "index_npq_lead_providers_on_cpd_lead_provider_id"
   end
 
   create_table "npq_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -634,8 +638,10 @@ ActiveRecord::Schema.define(version: 2021_07_07_120216) do
   add_foreign_key "lead_provider_cips", "lead_providers"
   add_foreign_key "lead_provider_profiles", "lead_providers"
   add_foreign_key "lead_provider_profiles", "users"
+  add_foreign_key "lead_providers", "cpd_lead_providers"
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
+  add_foreign_key "npq_lead_providers", "cpd_lead_providers"
   add_foreign_key "participant_bands", "call_off_contracts"
   add_foreign_key "participant_declarations", "lead_providers"
   add_foreign_key "participant_profiles", "cohorts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_115324) do
+ActiveRecord::Schema.define(version: 2021_07_07_120216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_123715) do
+ActiveRecord::Schema.define(version: 2021_07_07_151757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_06_113050) do
+ActiveRecord::Schema.define(version: 2021_07_07_115324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -106,6 +106,12 @@ ActiveRecord::Schema.define(version: 2021_07_06_113050) do
 
   create_table "core_induction_programmes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "cpd_lead_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/models/cpd_lead_provider_spec.rb
+++ b/spec/models/cpd_lead_provider_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CpdLeadProvider, type: :model do
+  it "can be created" do
+    expect {
+      described_class.create(name: "Test Lead Provider")
+    }.to change { described_class.count }.by(1)
+  end
+
+  describe "associations" do
+    it { is_expected.to have_one(:lead_provider) }
+    it { is_expected.to have_one(:npq_lead_provider) }
+  end
+end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe LeadProvider, type: :model do
   end
 
   describe "associations" do
+    it { is_expected.to belong_to(:cpd_lead_provider).required(false) }
+
     it { is_expected.to have_many(:partnerships) }
     it { is_expected.to have_many(:schools).through(:partnerships) }
     it { is_expected.to have_many(:lead_provider_profiles) }

--- a/spec/models/npq_lead_provider_spec.rb
+++ b/spec/models/npq_lead_provider_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NpqLeadProvider, type: :model do
+  it "can be created" do
+    expect {
+      described_class.create(name: "Test Lead Provider")
+    }.to change { described_class.count }.by(1)
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:cpd_lead_provider).required(false) }
+  end
+end


### PR DESCRIPTION
### Context

- Currently there is `LeadProvider` (which are ECF specific providers) and `NpqLeadProvider` and there is some overlap between the 2 entities
- We want a way of unifying this so a provider is capable of accessing multiple APIs with a single token
- Whilst at the same time keeping the data modelling sane

### Changes proposed in this pull request

- Introduce `CpdLeadProvider` which encompasses all lead providers
- These can then be associated to `LeadProvider` and `NpqLeadProvider`
- Populate `CpdLeadProvider` and the data between the different tables

### Guidance to review

- A future change will follow to make the association between `LeadProvider` + `CpdLeadProvider` or `NpqLeadProvider` + `CpdLeadProvider` mandatory. It is only optional here due to missing data
- Another future change is that api token are currently associated with `LeadProvider` this will need to be associated with `CpdLeadProvider` so one api token is capable of accessing multiple APIs

### Testing

- There are no real user facing changes. and the app should behave as before
- Data associations should be correctly setup between `CpdLeadProvider`, `LeadProvider` and `NpqLeadProvider`

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Can't test in review app as data is removed then reseeded causing the outcome of the data migrations to be no longer observable