### PR TITLE
CPDRP-578: Fix change induction coordinator logic

### DIFF
--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe CreateInductionTutor do
           expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be true
           expect(User.exists?(existing_user.id)).to be true
           expect(existing_user.schools).to contain_exactly(other_school)
+          expect(School.exists?(school.id)).to be true
         end
 
         context "when the induction coordinator is also a mentor" do
@@ -70,6 +71,7 @@ RSpec.describe CreateInductionTutor do
             expect(User.exists?(existing_user.id)).to be true
             expect(ParticipantProfile::Mentor.exists?(mentor_profile.id)).to be true
             expect(existing_user.schools).to contain_exactly(other_school)
+            expect(School.exists?(school.id)).to be true
           end
         end
       end

--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -26,11 +26,8 @@ RSpec.describe CreateInductionTutor do
     end
 
     context "when an induction coordinator for the school exists" do
-      let!(:existing_profile) { create(:induction_coordinator_profile, schools: [school]) }
-
-      before do
-        existing_profile
-      end
+      let!(:existing_user) { create(:user) }
+      let!(:existing_profile) { create(:induction_coordinator_profile, schools: [school], user: existing_user) }
 
       it "removes the existing induction coordinator" do
         expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
@@ -39,6 +36,58 @@ RSpec.describe CreateInductionTutor do
 
         user = User.find_by(email: email)
         expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
+        expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be false
+        expect(User.exists?(existing_user.id)).to be false
+      end
+
+      context "when the induction coordinator has other schools" do
+        let!(:other_school) { create(:school) }
+        let!(:existing_profile) { create(:induction_coordinator_profile, schools: [school, other_school], user: existing_user) }
+
+        it "removes the school from the existing induction coordinator" do
+          expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
+
+          CreateInductionTutor.call(school: school, email: email, full_name: name)
+
+          user = User.find_by(email: email)
+          expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
+          expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be true
+          expect(User.exists?(existing_user.id)).to be true
+          expect(existing_user.schools).to contain_exactly(other_school)
+        end
+
+        context "when the induction coordinator is also a mentor" do
+          let!(:mentor_profile) { create(:mentor_profile, user: existing_profile.user, school: school) }
+
+          it "removes the school from the existing induction coordinator" do
+            expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
+
+            CreateInductionTutor.call(school: school, email: email, full_name: name)
+
+            user = User.find_by(email: email)
+            expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
+            expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be true
+            expect(User.exists?(existing_user.id)).to be true
+            expect(ParticipantProfile::Mentor.exists?(mentor_profile.id)).to be true
+            expect(existing_user.schools).to contain_exactly(other_school)
+          end
+        end
+      end
+
+      context "when the induction coordinator is also a mentor" do
+        let!(:mentor_profile) { create(:mentor_profile, user: existing_profile.user, school: school) }
+
+        it "retains the user but deletes the induction coordinator profile" do
+          expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
+
+          CreateInductionTutor.call(school: school, email: email, full_name: name)
+
+          user = User.find_by(email: email)
+          expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
+          expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be false
+          expect(User.exists?(existing_user.id)).to be true
+          expect(ParticipantProfile::Mentor.exists?(mentor_profile.id)).to be true
+        end
       end
     end
 


### PR DESCRIPTION
CPDRP-578

Previously, changing induction coordinator would not work if that user
was also a mentor. If they managed more than one school, changing any of
 those schools would delete the user altogether. This change:
 - Makes it possible to change induction coordinator but leave the
 mentor unchanged
 - Makes it possible to change induction coordinator for a school
 without removing the old coordinator from any other schools

# Testing
## Change induction tutor but leave mentor
- Sign in as school-leader@example.com
- Add yourself as a mentor
- Sign in as admin@example.com
- Change induction tutor for school with urn 999999
- ensure school-leader@example.com still shows in list of participants for school
## Change induction tutor with multiple schools
- sign in as admin@example.com
- add school-leader@example.com as induction tutor to another school
- Change induction tutor for school urn 999999
- Sign in as school-leader@example.com
- Ensure you see the school added in step 2
