### PR TITLE
Change production db to high availability

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -5,7 +5,7 @@ app_environment = "production"
 # Gov.UK PaaS
 paas_api_url = "https://api.london.cloud.service.gov.uk"
 paas_space_name = "early-careers-framework-prod"
-paas_postgres_service_plan = "small-11"
+paas_postgres_service_plan = "small-ha-11"
 paas_app_start_timeout = "180"
 paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"


### PR DESCRIPTION
Do not merge until the upgrade has taken place.
To check this, target the production space and run `cf service ecf-postgres-production`. The plan should be `small-ha-11`
