### PR TITLE
Shadowing NPQ profile by ParticipantProfile

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class NpqProfilesController < Api::ApiController
+    class NPQProfilesController < Api::ApiController
       include ApiTokenAuthenticatable
       include JSONAPI::ActsAsResourceController
 

--- a/app/models/npq_course.rb
+++ b/app/models/npq_course.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class NpqCourse < ApplicationRecord
+class NPQCourse < ApplicationRecord
   has_many :npq_profiles
 end

--- a/app/models/npq_lead_provider.rb
+++ b/app/models/npq_lead_provider.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class NpqLeadProvider < ApplicationRecord
+class NPQLeadProvider < ApplicationRecord
   belongs_to :cpd_lead_provider, optional: true
 end

--- a/app/models/npq_profile.rb
+++ b/app/models/npq_profile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NpqProfile < ApplicationRecord
+class NPQProfile < ApplicationRecord
   belongs_to :user
   belongs_to :npq_lead_provider
   belongs_to :npq_course
@@ -18,4 +18,15 @@ class NpqProfile < ApplicationRecord
     self: "self",
     another: "another",
   }
+
+  after_save :update_participant_profile
+
+private
+
+  def update_participant_profile
+    profile = ParticipantProfile::NPQ.find_or_initialize_by(id: id)
+    profile.school = School.find_by(urn: school_urn)
+    profile.user_id = user_id
+    profile.save!
+  end
 end

--- a/app/models/npq_registration_api_token.rb
+++ b/app/models/npq_registration_api_token.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NpqRegistrationApiToken < ApiToken
+class NPQRegistrationApiToken < ApiToken
   attribute :private_api_access, default: true
 
   def owner

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -2,9 +2,6 @@
 
 class ParticipantProfile < ApplicationRecord
   belongs_to :user
-  belongs_to :school
-  belongs_to :cohort
-  belongs_to :core_induction_programme, optional: true
 
   def ect?
     false
@@ -20,27 +17,4 @@ class ParticipantProfile < ApplicationRecord
   scope :sparsity, -> { where(sparsity_uplift: true) }
   scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
   scope :uplift, -> { sparsity.or(pupil_premium) }
-
-  class ECT < self
-    belongs_to :mentor_profile, class_name: "Mentor", optional: true
-    has_one :mentor, through: :mentor_profile, source: :user
-
-    def ect?
-      true
-    end
-  end
-
-  class Mentor < self
-    self.ignored_columns = %i[mentor_profile_id]
-
-    has_many :mentee_profiles,
-             class_name: "ParticipantProfile::ECT",
-             foreign_key: :mentor_profile_id,
-             dependent: :nullify
-    has_many :mentees, through: :mentee_profiles, source: :user
-
-    def mentor?
-      true
-    end
-  end
 end

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ParticipantProfile::ECT < ParticipantProfile
+  belongs_to :mentor_profile, class_name: "Mentor", optional: true
+  has_one :mentor, through: :mentor_profile, source: :user
+
+  belongs_to :cohort
+  belongs_to :school
+  belongs_to :core_induction_programme, optional: true
+
+  def ect?
+    true
+  end
+end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ParticipantProfile::Mentor < ParticipantProfile
+  self.ignored_columns = %i[mentor_profile_id]
+
+  has_many :mentee_profiles,
+           class_name: "ParticipantProfile::ECT",
+           foreign_key: :mentor_profile_id,
+           dependent: :nullify
+  has_many :mentees, through: :mentee_profiles, source: :user
+
+  belongs_to :cohort
+  belongs_to :school
+  belongs_to :core_induction_programme, optional: true
+
+  def mentor?
+    true
+  end
+end

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ParticipantProfile::NPQ < ParticipantProfile
+  belongs_to :school, optional: true
+end

--- a/app/resources/api/v1/npq_course_resource.rb
+++ b/app/resources/api/v1/npq_course_resource.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class NpqCourseResource < JSONAPI::Resource
+    class NPQCourseResource < JSONAPI::Resource
       has_many :npq_profiles
     end
   end

--- a/app/resources/api/v1/npq_lead_provider_resource.rb
+++ b/app/resources/api/v1/npq_lead_provider_resource.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class NpqLeadProviderResource < JSONAPI::Resource
+    class NPQLeadProviderResource < JSONAPI::Resource
       has_many :npq_profiles
     end
   end

--- a/app/resources/api/v1/npq_profile_resource.rb
+++ b/app/resources/api/v1/npq_profile_resource.rb
@@ -2,7 +2,7 @@
 
 module Api
   module V1
-    class NpqProfileResource < JSONAPI::Resource
+    class NPQProfileResource < JSONAPI::Resource
       attributes :date_of_birth,
                  :teacher_reference_number,
                  :teacher_reference_number_verified,

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,5 +19,7 @@
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular "pupil_premium", "pupil_premiums"
-  inflect.acronym("UTM")
+  inflect.acronym "UTM"
+  inflect.acronym "ECT"
+  inflect.acronym "NPQ"
 end

--- a/db/migrate/20210311121031_remove_discard_on_ect.rb
+++ b/db/migrate/20210311121031_remove_discard_on_ect.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveDiscardOnEct < ActiveRecord::Migration[6.1]
+class RemoveDiscardOnECT < ActiveRecord::Migration[6.1]
   def change
     remove_index :early_career_teacher_profiles, :discarded_at
     remove_column :early_career_teacher_profiles, :discarded_at, :datetime

--- a/db/migrate/20210616103630_create_npq_lead_providers.rb
+++ b/db/migrate/20210616103630_create_npq_lead_providers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateNpqLeadProviders < ActiveRecord::Migration[6.1]
+class CreateNPQLeadProviders < ActiveRecord::Migration[6.1]
   def change
     create_table :npq_lead_providers do |t|
       t.text :name, null: false

--- a/db/migrate/20210616103631_create_npq_profiles.rb
+++ b/db/migrate/20210616103631_create_npq_profiles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateNpqProfiles < ActiveRecord::Migration[6.1]
+class CreateNPQProfiles < ActiveRecord::Migration[6.1]
   def change
     create_table :npq_profiles do |t|
       t.references :user

--- a/db/migrate/20210616144524_create_npq_courses.rb
+++ b/db/migrate/20210616144524_create_npq_courses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateNpqCourses < ActiveRecord::Migration[6.1]
+class CreateNPQCourses < ActiveRecord::Migration[6.1]
   def change
     create_table :npq_courses do |t|
       t.text :name, null: false

--- a/db/migrate/20210623082855_add_active_alert_to_npq_profiles.rb
+++ b/db/migrate/20210623082855_add_active_alert_to_npq_profiles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddActiveAlertToNpqProfiles < ActiveRecord::Migration[6.1]
+class AddActiveAlertToNPQProfiles < ActiveRecord::Migration[6.1]
   def change
     add_column :npq_profiles, :active_alert, :boolean, default: false
   end

--- a/db/migrate/20210625143352_add_funding_fields_to_npq_profile.rb
+++ b/db/migrate/20210625143352_add_funding_fields_to_npq_profile.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddFundingFieldsToNpqProfile < ActiveRecord::Migration[6.1]
+class AddFundingFieldsToNPQProfile < ActiveRecord::Migration[6.1]
   def change
     safety_assured do
       change_table :npq_profiles, bulk: true do |t|

--- a/db/migrate/20210706112741_delete_ect_profiles.rb
+++ b/db/migrate/20210706112741_delete_ect_profiles.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeleteEctProfiles < ActiveRecord::Migration[6.1]
+class DeleteECTProfiles < ActiveRecord::Migration[6.1]
   def up
     drop_table :early_career_teacher_profiles
   end

--- a/db/migrate/20210707120216_populate_cpd_lead_providers.rb
+++ b/db/migrate/20210707120216_populate_cpd_lead_providers.rb
@@ -2,7 +2,7 @@
 
 class PopulateCpdLeadProviders < ActiveRecord::Migration[6.1]
   def up
-    all_provider_names = (LeadProvider.pluck(:name) + NpqLeadProvider.pluck(:name)).uniq
+    all_provider_names = (LeadProvider.pluck(:name) + NPQLeadProvider.pluck(:name)).uniq
 
     all_provider_names.each do |name|
       CpdLeadProvider.create!(name: name)

--- a/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
+++ b/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
@@ -6,13 +6,13 @@ class PopulateLpAndCpdLpAssocs < ActiveRecord::Migration[6.1]
       lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
     end
 
-    NpqLeadProvider.all.each do |lp|
+    NPQLeadProvider.all.each do |lp|
       lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
     end
   end
 
   def down
     LeadProvider.update_all(cpd_lead_provider: nil)
-    NpqLeadProvider.update_all(cpd_lead_provider: nil)
+    NPQLeadProvider.update_all(cpd_lead_provider: nil)
   end
 end

--- a/db/migrate/20210708091751_optional_participant_cohort_and_school.rb
+++ b/db/migrate/20210708091751_optional_participant_cohort_and_school.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class OptionalParticipantCohortAndSchool < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :participant_profiles, :cohort_id, true
+    change_column_null :participant_profiles, :school_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_151757) do
+ActiveRecord::Schema.define(version: 2021_07_08_091751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -396,9 +396,9 @@ ActiveRecord::Schema.define(version: 2021_07_07_151757) do
   create_table "participant_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "type", null: false
     t.uuid "user_id", null: false
-    t.uuid "school_id", null: false
+    t.uuid "school_id"
     t.uuid "core_induction_programme_id"
-    t.uuid "cohort_id", null: false
+    t.uuid "cohort_id"
     t.uuid "mentor_profile_id"
     t.boolean "sparsity_uplift", default: false, null: false
     t.boolean "pupil_premium_uplift", default: false, null: false

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -105,7 +105,7 @@ end
 # The tokens below have different unhashed version to avoid worrying about clever cryptographic attacks
 if Rails.env.deployed_development?
   EngageAndLearnApiToken.find_or_create_by!(hashed_token: "dfce9a34c6f982e8adb4b903f8b6064682e6ad1f7858c41ed8a0a7468abc8896")
-  NpqRegistrationApiToken.find_or_create_by!(hashed_token: "1dae3836ed90df4b796eff1f4a4713247ac5bc8a00352ea46eee621d74cd4fcf")
+  NPQRegistrationApiToken.find_or_create_by!(hashed_token: "1dae3836ed90df4b796eff1f4a4713247ac5bc8a00352ea46eee621d74cd4fcf")
   DataStudioApiToken.find_or_create_by!(hashed_token: "c7123fb0e2aecb17e1089e01849d71665983e200e891fe726341a08f176c1d64")
 elsif Rails.env.development?
   EngageAndLearnApiToken.find_or_create_by!(hashed_token: "f4a16cd7fc10918fbc7d869d7a83df36059bb98fac7c82502d797b1f1dd73e86")

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -38,7 +38,7 @@ PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)
   { name: "Teach First", id: "a02ae582-f939-462f-90bc-cebf20fa8473" },
   { name: "UCL Institute of Education", id: "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7" },
 ].each do |hash|
-  NpqLeadProvider.find_or_create_by!(name: hash[:name], id: hash[:id])
+  NPQLeadProvider.find_or_create_by!(name: hash[:name], id: hash[:id])
 end
 
 [
@@ -49,5 +49,5 @@ end
   { name: "NPQ for Headship (NPQH)", id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768" },
   { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
 ].each do |hash|
-  NpqCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
+  NPQCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
 end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -3,8 +3,7 @@
 FactoryBot.define do
   factory :participant_profile do
     user
-    cohort
-    school
+
     type do
       case participant_type
       when :ect then "ParticipantProfile::ECT"
@@ -19,10 +18,16 @@ FactoryBot.define do
     end
 
     trait :ect do
+      cohort
+      school
+
       participant_type { :ect }
     end
 
     trait :mentor do
+      cohort
+      school
+
       participant_type { :mentor }
     end
 

--- a/spec/models/npq_lead_provider_spec.rb
+++ b/spec/models/npq_lead_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NpqLeadProvider, type: :model do
+RSpec.describe NPQLeadProvider, type: :model do
   it "can be created" do
     expect {
       described_class.create(name: "Test Lead Provider")

--- a/spec/models/npq_profile_spec.rb
+++ b/spec/models/npq_profile_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NpqProfile, type: :model do
+RSpec.describe NPQProfile, type: :model do
   it {
     is_expected.to define_enum_for(:headteacher_status).with_values(
       no: "no",

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -4,18 +4,26 @@ require "rails_helper"
 
 RSpec.describe ParticipantProfile, type: :model do
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to belong_to(:school) }
-  it { is_expected.to belong_to(:core_induction_programme).optional }
-  it { is_expected.to belong_to(:cohort) }
 
   describe described_class::Mentor do
+    it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to belong_to(:school) }
     it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:core_induction_programme).optional }
+
     it { is_expected.to have_many(:mentee_profiles) }
     it { is_expected.to have_many(:mentees).through(:mentee_profiles) }
   end
 
   describe described_class::ECT do
+    it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to belong_to(:school) }
     it { is_expected.to belong_to(:mentor_profile).optional }
     it { is_expected.to have_one(:mentor).through(:mentor_profile) }
+    it { is_expected.to belong_to(:core_induction_programme).optional }
+  end
+
+  describe described_class::NPQ do
+    it { is_expected.to belong_to(:school).optional }
   end
 end

--- a/spec/requests/api/v1/data_studio/school_rollout_spec.rb
+++ b/spec/requests/api/v1/data_studio/school_rollout_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "School rollout data endpoint", type: :request do
     end
 
     context "using a private token from different scope" do
-      let(:other_private_token) { NpqRegistrationApiToken.create_with_random_token! }
+      let(:other_private_token) { NPQRegistrationApiToken.create_with_random_token! }
 
       it "returns data successfully" do
         default_headers[:Authorization] = "Bearer #{other_private_token}"

--- a/spec/requests/api/v1/dqt_records_spec.rb
+++ b/spec/requests/api/v1/dqt_records_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "DQT records api endpoint", type: :request do
   describe "#show" do
-    let(:token) { NpqRegistrationApiToken.create_with_random_token! }
+    let(:token) { NPQRegistrationApiToken.create_with_random_token! }
     let(:bearer_token) { "Bearer #{token}" }
     let(:trn) { "1000000" }
     let(:parsed_response) { JSON.parse(response.body) }

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "NPQ profiles api endpoint", type: :request do
-  let(:token) { NpqRegistrationApiToken.create_with_random_token! }
+  let(:token) { NPQRegistrationApiToken.create_with_random_token! }
   let(:bearer_token) { "Bearer #{token}" }
   let(:parsed_response) { JSON.parse(response.body) }
 
@@ -59,9 +59,9 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
       it "creates the npq_profile" do
         expect {
           post "/api/v1/npq-profiles", params: json
-        }.to change(NpqProfile, :count).by(1)
+        }.to change(NPQProfile, :count).by(1)
 
-        profile = NpqProfile.order(created_at: :desc).first
+        profile = NPQProfile.order(created_at: :desc).first
 
         expect(profile.user).to eql(user)
         expect(profile.npq_lead_provider).to eql(npq_lead_provider)
@@ -94,7 +94,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
       it "response has correct attributes" do
         post "/api/v1/npq-profiles", params: json
 
-        profile = NpqProfile.order(created_at: :desc).first
+        profile = NPQProfile.order(created_at: :desc).first
 
         expect(parsed_response["data"]["id"]).to eql(profile.id)
         expect(parsed_response["data"]).to have_jsonapi_attributes(

--- a/spec/requests/api/v1/particpant_validation_spec.rb
+++ b/spec/requests/api/v1/particpant_validation_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "participant validation api endpoint", type: :request do
   describe "#show" do
-    let(:token) { NpqRegistrationApiToken.create_with_random_token! }
+    let(:token) { NPQRegistrationApiToken.create_with_random_token! }
     let(:bearer_token) { "Bearer #{token}" }
     let(:parsed_response) { JSON.parse(response.body) }
     let(:trn) { rand(1_000_000..9_999_999).to_s }


### PR DESCRIPTION
It was decided that NPQs are still partiicpants and it is useful for them to be represented in the ParticipantProfile table as well.

In this PR we oncly create shadowing ParticipantProfile::NPQ model to ensure data consistency when we run the data migration. We'll be switching to MTI once the data is migrated.
