### PR TITLE
LeadProviderApiToken now hangs off CpdLeadProvider

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -6,12 +6,16 @@ module Api
       include ApiTokenAuthenticatable
 
       def create
-        params = HashWithIndifferentAccess.new({ raw_event: request.raw_post, lead_provider: current_user }).merge(permitted_params)
+        params = HashWithIndifferentAccess.new({ raw_event: request.raw_post, lead_provider: lead_provider }).merge(permitted_params)
         validate_params!(params)
         render json: RecordParticipantDeclaration.call(params)
       end
 
     private
+
+      def lead_provider
+        current_user.lead_provider
+      end
 
       def validate_params!(params)
         raise ActionController::ParameterMissing, missing_params(params) unless missing_params(params).empty?

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -8,8 +8,6 @@ module Api
       include ApiTokenAuthenticatable
       include Pagy::Backend
 
-      before_action :ensure_lead_provider
-
       def index
         respond_to do |format|
           format.json do
@@ -25,8 +23,8 @@ module Api
 
     private
 
-      def ensure_lead_provider
-        head :forbidden unless current_user.class == LeadProvider
+      def access_scope
+        LeadProviderApiToken.all
       end
 
       def to_csv(hash)
@@ -48,8 +46,12 @@ module Api
         params.dig(:filter, :updated_since)
       end
 
+      def lead_provider
+        current_user.lead_provider
+      end
+
       def participants
-        participants = User.participants_for_lead_provider(current_user)
+        participants = User.participants_for_lead_provider(lead_provider)
                            .includes(
                              early_career_teacher_profile: %i[cohort mentor school],
                              mentor_profile: %i[cohort school],

--- a/app/models/lead_provider_api_token.rb
+++ b/app/models/lead_provider_api_token.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class LeadProviderApiToken < ApiToken
-  belongs_to :lead_provider
+  belongs_to :lead_provider, optional: true
+  belongs_to :cpd_lead_provider, optional: true
 
   def owner
-    lead_provider
+    cpd_lead_provider
   end
 end

--- a/db/migrate/20210708091337_add_cpd_lead_provider_to_tokens.rb
+++ b/db/migrate/20210708091337_add_cpd_lead_provider_to_tokens.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCpdLeadProviderToTokens < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :api_tokens, :cpd_lead_provider, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20210708091338_move_lp_tokens.rb
+++ b/db/migrate/20210708091338_move_lp_tokens.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MoveLpTokens < ActiveRecord::Migration[6.1]
+  def change
+    LeadProviderApiToken.all.each do |token|
+      token.update!(cpd_lead_provider: token.lead_provider.cpd_lead_provider)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,6 +71,8 @@ ActiveRecord::Schema.define(version: 2021_07_08_091751) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "type", default: "ApiToken"
     t.boolean "private_api_access", default: false
+    t.uuid "cpd_lead_provider_id"
+    t.index ["cpd_lead_provider_id"], name: "index_api_tokens_on_cpd_lead_provider_id"
     t.index ["hashed_token"], name: "index_api_tokens_on_hashed_token", unique: true
     t.index ["lead_provider_id"], name: "index_api_tokens_on_lead_provider_id"
   end
@@ -624,6 +626,7 @@ ActiveRecord::Schema.define(version: 2021_07_08_091751) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "additional_school_emails", "schools"
   add_foreign_key "admin_profiles", "users"
+  add_foreign_key "api_tokens", "cpd_lead_providers"
   add_foreign_key "api_tokens", "lead_providers", on_delete: :cascade
   add_foreign_key "call_off_contracts", "lead_providers"
   add_foreign_key "cohorts_lead_providers", "cohorts"

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -8,19 +8,16 @@ teach_first_cip = CoreInductionProgramme.find_or_create_by!(name: "Teach First")
 ucl_cip = CoreInductionProgramme.find_or_create_by!(name: "UCL Institute of Education")
 
 [
-  { provider_name: "Ambition Institute", cip: ambition_cip, token: "ambition-token" },
-  { provider_name: "Best Practice Network", cip: ucl_cip, token: "best-practice-token" },
-  { provider_name: "Capita", cip: ambition_cip, token: "capita-token" },
-  { provider_name: "Education Development Trust", cip: edt_cip, token: "edt-token" },
-  { provider_name: "Teach First", cip: teach_first_cip, token: "teach-first-token" },
-  { provider_name: "UCL Institute of Education", cip: ucl_cip, token: "ucl-token" },
+  { provider_name: "Ambition Institute", cip: ambition_cip },
+  { provider_name: "Best Practice Network", cip: ucl_cip },
+  { provider_name: "Capita", cip: ambition_cip },
+  { provider_name: "Education Development Trust", cip: edt_cip },
+  { provider_name: "Teach First", cip: teach_first_cip },
+  { provider_name: "UCL Institute of Education", cip: ucl_cip },
 ].each do |seed|
   provider = LeadProvider.find_or_create_by!(name: seed[:provider_name])
   provider.update!(cohorts: [cohort_2021]) unless provider.cohorts.any?
   LeadProviderCip.find_or_create_by!(lead_provider: provider, cohort: cohort_2021, core_induction_programme: seed[:cip])
-  if Rails.env.development?
-    LeadProviderApiToken.create_with_known_token!(seed[:token], lead_provider: provider)
-  end
 end
 
 PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)
@@ -50,4 +47,32 @@ end
   { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
 ].each do |hash|
   NPQCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
+end
+
+all_provider_names = (LeadProvider.pluck(:name) + NPQLeadProvider.pluck(:name)).uniq
+
+all_provider_names.each do |name|
+  CpdLeadProvider.find_or_create_by!(name: name)
+end
+
+LeadProvider.all.each do |lp|
+  lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+end
+
+NPQLeadProvider.all.each do |lp|
+  lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+end
+
+if Rails.env.development?
+  [
+    { name: "Ambition Institute", token: "ambition-token" },
+    { name: "Best Practice Network", token: "best-practice-token" },
+    { name: "Capita", token: "capita-token" },
+    { name: "Education Development Trust", token: "edt-token" },
+    { name: "Teach First", token: "teach-first-token" },
+    { name: "UCL Institute of Education", token: "ucl-token" },
+  ].each do |hash|
+    cpd_lead_provider = CpdLeadProvider.find_by(name: hash[:name])
+    LeadProviderApiToken.create_with_known_token!(hash[:token], cpd_lead_provider: cpd_lead_provider)
+  end
 end

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
   let(:early_career_teacher_profile) { create(:early_career_teacher_profile) }
   let(:cohort) { early_career_teacher_profile.cohort }
   let(:user) { early_career_teacher_profile.user }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
   let(:lead_provider) { create(:lead_provider) }
-  let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider) }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
   let(:bearer_token) { "Bearer #{token}" }
   let(:Authorization) { bearer_token }
 

--- a/spec/docs/participants_spec.rb
+++ b/spec/docs/participants_spec.rb
@@ -3,7 +3,9 @@
 require "swagger_helper"
 
 describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_flags: { participant_data_api: "active" } do
-  let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: create(:lead_provider)) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
+  let(:lead_provider) { create(:lead_provider) }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
   let(:bearer_token) { "Bearer #{token}" }
   let(:Authorization) { bearer_token }
 

--- a/spec/factories/cpd_lead_provider.rb
+++ b/spec/factories/cpd_lead_provider.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :cpd_lead_provider do
+    name  { "Lead Provider" }
+    lead_provider
+  end
+end

--- a/spec/requests/api/v1/particpants_spec.rb
+++ b/spec/requests/api/v1/particpants_spec.rb
@@ -5,9 +5,10 @@ require "csv"
 
 RSpec.describe "Participants API", type: :request, with_feature_flags: { participant_data_api: "active" } do
   describe "GET /api/v1/participants" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
     let(:lead_provider) { create(:lead_provider) }
     let(:partnership) { create(:partnership, lead_provider: lead_provider) }
-    let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider) }
+    let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
 
     before :each do

--- a/spec/requests/api/v1/provider_events_spec.rb
+++ b/spec/requests/api/v1/provider_events_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe "Participant Declarations", type: :request do
   describe "participant-declarations" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
     let(:lead_provider) { create(:lead_provider) }
-    let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: lead_provider) }
+    let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
     let(:payload) { create(:early_career_teacher_profile) }
     let(:delivery_partner) { create(:delivery_partner) }


### PR DESCRIPTION
### Context

- ECF and NPQ have different and overlapping providers
- We want providers to be able to access our apis with a single api token

### Changes proposed in this pull request

- Make existing `LeadProviderApiToken` be associated with `CpdLeadProvider` which contains all providers we deal with
- Existing api endpoints continue to work by associating with `LeadProvider` thru `CpdLeadProvider`
- Updated seeds to ensure seed setup continues to work

### Guidance to review

- Once this is deployed we can remove `LeadProviderApiToken#lead_provider`
- We will also be able to mark `belongs_to` associations are required since all data migrations should be complete
- This should also allows to introduce NPQ related api endpoints that can now be accessed by providers via the updated tokening system

### Testing

- Should be able to access existing api endpoints with existing tokens

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- I don't believe this can be tested in the review app due to the way the database is reset after migrations therefore the outcomes of data change migrations are not observable
- Having said that one can check the update of the process did work with a primitive of...
```
(LeadProvider.all.pluck(:name) + NPQLeadProvider.all.pluck(:name)).uniq.count == CpdLeadProvider.count
```