### PR TITLE
Populating missing ParticipantProfile::NPQ records

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc "Populates all missing ParticipantProfiles::NPQ to match NPQProfile table"
+  task populate_npq_profiles: :environment do
+    NPQProfile.where.not(id: ParticipantProfile::NPQ.select(:id)).find_each do |profile|
+      profile.send(:update_participant_profile)
+    end
+  end
+end

--- a/spec/cypress/support/axe.js
+++ b/spec/cypress/support/axe.js
@@ -6,7 +6,7 @@ Cypress.Commands.overwrite("injectAxe", () => {
   // https://github.com/component-driven/cypress-axe/issues/6#issuecomment-726986454
   cy.window({ log: false }).then((win) => {
     // eslint-disable-next-line global-require
-    const axe = require("axe-core/axe.js");
+    const axe = require("axe-core/axe");
     const script = win.document.createElement("script");
     script.innerHTML = axe.source;
     win.document.head.appendChild(script);

--- a/spec/factories/npq_profiles.rb
+++ b/spec/factories/npq_profiles.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :npq_profile do
+    user
+    npq_course
+    npq_lead_provider
+
+    headteacher_status { NPQProfile.headteacher_statuses.keys.sample }
+    funding_choice { NPQProfile.funding_choices.keys.sample }
+  end
+end


### PR DESCRIPTION
ParticipantProfile::NPQ is now shadowing the NPQProfile. This PR introduced a rake task to migrate the create the remaining ParticipantProfile::NPQ.