### PR TITLE
CPDRP-585: Add a status enum to participant profiles

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -3,6 +3,11 @@
 class ParticipantProfile < ApplicationRecord
   belongs_to :user
 
+  enum status: {
+    active: "active",
+    withdrawn: "withdrawn",
+  }
+
   def ect?
     false
   end

--- a/db/migrate/20210708125502_add_status_to_participant_profiles.rb
+++ b/db/migrate/20210708125502_add_status_to_participant_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_profiles, :status, :text, null: false, default: "active"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_08_091751) do
+ActiveRecord::Schema.define(version: 2021_07_08_125502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -404,6 +404,7 @@ ActiveRecord::Schema.define(version: 2021_07_08_091751) do
     t.boolean "pupil_premium_uplift", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "status", default: "active", null: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -4,6 +4,12 @@ require "rails_helper"
 
 RSpec.describe ParticipantProfile, type: :model do
   it { is_expected.to belong_to(:user) }
+  it {
+    is_expected.to define_enum_for(:status).with_values(
+      active: "active",
+      withdrawn: "withdrawn",
+    ).backed_by_column_of_type(:text)
+  }
 
   describe described_class::Mentor do
     it { is_expected.to belong_to(:cohort) }


### PR DESCRIPTION
### Context
CPDRP-585
This is the first in a series of PRs which will allow admins to delete participants, and make that information available to LPs in the API

### Changes proposed in this pull request
Add status enum to participant profiles, defaulting to active

### Testing
Added unit test for enum

