### PR TITLE
CPDRP-556 Remove whitespace before validation on User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   has_one :early_career_teacher_profile, class_name: "ParticipantProfile::ECT"
   has_one :mentor_profile, class_name: "ParticipantProfile::Mentor"
 
+  before_validation :strip_whitespace
   validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, notify_email: true
 
@@ -113,4 +114,11 @@ class User < ApplicationRecord
   scope :in_school, lambda { |school_id|
     includes_school.where(early_career_teacher_profile: { school_id: school_id }).or(User.where(mentor_profile: { school_id: school_id }))
   }
+
+private
+
+  def strip_whitespace
+    full_name&.strip!
+    email&.strip!
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_one(:early_career_teacher_profile) }
   end
 
+  describe "before_validation" do
+    let(:user) { build(:user, full_name: "\t  Gordon Banks \n", email: " \tgordo@example.com \n ") }
+
+    it "strips whitespace from :full_name" do
+      user.valid?
+      expect(user.full_name).to eq "Gordon Banks"
+    end
+
+    it "strips whitespace from :email" do
+      user.valid?
+      expect(user.email).to eq "gordo@example.com"
+    end
+  end
+
   describe "validations" do
     subject { FactoryBot.create(:user) }
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-556)
Remove whitespace around `full_name` attribute. Also noticed it would be helpful to do this for `email` to prevent validation kicking in if there was just leading/trailing whitespace when a user entered the email.

### Changes proposed in this pull request
Add `before_validation` hook to `User` to strip leading and trailing whitespace from `full_name` and `email`

There are 1146 users with trailing whitespace and 22 with leading whitespace in production. We can easily identify and clean those up from the console once this is deployed with something like this:

```ruby
User.where("full_name like '% ' or full_name like ' %'").each(&:save)
```

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
