### PR TITLE
CPDRP-575: Add chaser emails

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -10,6 +10,9 @@ class SchoolMailer < ApplicationMailer
   MAT_INVITE_EMAIL_TEMPLATE = "f856f50e-6f49-441e-8018-f8303367eb5c"
   FEDERATION_INVITE_EMAIL_TEMPLATE = "9269c50d-b579-425b-b55b-4c93f67074d4"
   COORDINATOR_SIGN_IN_CHASER_EMAIL_TEMPLATE = "b5c318a4-2171-4ded-809a-af72dd87e7a7"
+  COORDINATOR_REMINDER_TO_CHOOSE_ROUTE_EMAIL_TEMPLATE = "c939c27a-9951-4ac3-817d-56b7bf343fb4"
+  COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE = "e7a60b68-334e-4a25-8adf-55ebc70622f9"
+  COORDINATOR_REMINDER_TO_CHOOSE_MATERIALS_EMAIL_TEMPLATE = "43baf25c-6a46-437b-9f30-77c57d68a59e"
 
   def nomination_email(recipient:, school_name:, nomination_url:, expiry_date:)
     template_mail(
@@ -44,7 +47,6 @@ class SchoolMailer < ApplicationMailer
     recipient:,
     lead_provider_name:,
     delivery_partner_name:,
-    cohort:,
     school_name:,
     nominate_url:,
     challenge_url:,
@@ -56,26 +58,25 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        provider_name: lead_provider_name, # TODO: remove once template updated
         lead_provider_name: lead_provider_name,
         delivery_partner_name: delivery_partner_name,
-        cohort: cohort,
         school_name: school_name,
         nominate_url: nominate_url,
         challenge_url: challenge_url,
         challenge_deadline: challenge_deadline,
-        subject: "Provider confirmed",
+        subject: "FAO: NQT coordinator. Training provider confirmed.",
       },
     )
   end
 
   def coordinator_partnership_notification_email(
     recipient:,
+    name:,
     lead_provider_name:,
     delivery_partner_name:,
     cohort:,
     school_name:,
-    start_url:,
+    sign_in_url:,
     challenge_url:,
     challenge_deadline:
   )
@@ -85,15 +86,15 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        provider_name: lead_provider_name, # TODO: remove once template updated
+        name: name,
         lead_provider_name: lead_provider_name,
         delivery_partner_name: delivery_partner_name,
-        cohort: cohort,
+        cohort: cohort, # TODO: remove once template updated
         school_name: school_name,
-        start_url: start_url,
+        sign_in_url: sign_in_url,
         challenge_url: challenge_url,
         challenge_deadline: challenge_deadline,
-        subject: "Provider confirmed",
+        subject: "Training provider confirmed: add your ECTs and mentors",
       },
     )
   end
@@ -162,6 +163,48 @@ class SchoolMailer < ApplicationMailer
         name: name,
         school_name: school_name,
         start_url: start_url,
+      },
+    )
+  end
+
+  def induction_coordinator_reminder_to_choose_route_email(recipient:, name:, school_name:, sign_in_url:)
+    template_mail(
+      COORDINATOR_REMINDER_TO_CHOOSE_ROUTE_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: name,
+        school_name: school_name,
+        sign_in_url: sign_in_url,
+      },
+    )
+  end
+
+  def induction_coordinator_reminder_to_choose_provider_email(recipient:, name:, school_name:, sign_in_url:)
+    template_mail(
+      COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: name,
+        school_name: school_name,
+        sign_in_url: sign_in_url,
+      },
+    )
+  end
+
+  def induction_coordinator_reminder_to_choose_materials_email(recipient:, name:, school_name:, sign_in_url:)
+    template_mail(
+      COORDINATOR_REMINDER_TO_CHOOSE_MATERIALS_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: name,
+        school_name: school_name,
+        sign_in_url: sign_in_url,
       },
     )
   end

--- a/app/models/nomination_email.rb
+++ b/app/models/nomination_email.rb
@@ -28,7 +28,7 @@ class NominationEmail < ApplicationRecord
     Rails.application.routes.url_helpers.start_nominate_induction_coordinator_url(
       token: token,
       host: Rails.application.config.domain,
-      **UTMService.email(:nominate_tutor),
+      **UTMService.email(:nominate_tutor, :nominate_tutor),
     )
   end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -63,6 +63,10 @@ class School < ApplicationRecord
     left_outer_joins(:school_cohorts).where(school_cohorts: { cohort_id: [cohort.id, nil], opt_out_of_updates: [false, nil] })
   }
 
+  def partnered?(cohort)
+    partnerships.unchallenged.where(cohort: cohort).any?
+  end
+
   def lead_provider(year)
     partnerships.unchallenged.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
   end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -169,7 +169,7 @@ class InviteSchools
     induction_coordinators_not_in_partnership.find_each do |induction_coordinator|
       school_without_provider = induction_coordinator.schools.first do |school|
         school.school_cohorts.first.induction_programme_choice == "full_induction_programme" &&
-          school.partnerships.none? { |partnership| partnership.challenge_reason.nil? }
+          !school.partnered?(Cohort.current)
       end
       SchoolMailer.induction_coordinator_reminder_to_choose_provider_email(
         recipient: induction_coordinator.email,

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -134,6 +134,75 @@ class InviteSchools
     end
   end
 
+  def send_induction_coordinator_choose_route_chasers
+    induction_coordinators_not_chosen_route = User.includes(:induction_coordinator_profile, schools: :school_cohorts)
+                                                  .joins(:induction_coordinator_profile)
+                                                  .left_outer_joins(schools: :school_cohorts)
+                                                  .where(school_cohorts: { id: nil })
+                                                  .where.not(last_sign_in_at: nil)
+    induction_coordinators_not_chosen_route.find_each do |induction_coordinator|
+      school_without_cohort = induction_coordinator.schools
+                                                   .first { |school| school.school_cohorts.none? }
+      SchoolMailer.induction_coordinator_reminder_to_choose_route_email(
+        recipient: induction_coordinator.email,
+        name: induction_coordinator.full_name,
+        school_name: school_without_cohort.name,
+        sign_in_url: choose_route_chaser_sign_in_url,
+      ).deliver_later
+    rescue StandardError
+      logger.info "Error emailing induction coordinator, email: #{induction_coordinator.email} ... skipping"
+    end
+  end
+
+  def send_induction_coordinator_choose_provider_chasers
+    induction_coordinators_not_in_partnership = User.includes(
+      :induction_coordinator_profile,
+      schools: %i[school_cohorts partnerships],
+    ).where(
+      id:
+        School.unpartnered(Cohort.current.start_year)
+              .joins(:school_cohorts, :induction_coordinator_profiles)
+              .where(school_cohorts: { induction_programme_choice: "full_induction_programme" })
+              .pluck(:user_id),
+    )
+
+    induction_coordinators_not_in_partnership.find_each do |induction_coordinator|
+      school_without_provider = induction_coordinator.schools.first do |school|
+        school.school_cohorts.first.induction_programme_choice == "full_induction_programme" &&
+          school.partnerships.none? { |partnership| partnership.challenge_reason.nil? }
+      end
+      SchoolMailer.induction_coordinator_reminder_to_choose_provider_email(
+        recipient: induction_coordinator.email,
+        name: induction_coordinator.full_name,
+        school_name: school_without_provider.name,
+        sign_in_url: choose_provider_chaser_sign_in_url,
+      ).deliver_later
+    rescue StandardError
+      logger.info "Error emailing induction coordinator, email: #{induction_coordinator.email} ... skipping"
+    end
+  end
+
+  def send_induction_coordinator_choose_materials_chasers
+    induction_coordinators_not_chosen_materials = User.includes(:induction_coordinator_profile, schools: :school_cohorts)
+                                                      .joins(:induction_coordinator_profile, schools: :school_cohorts)
+                                                      .where(school_cohorts: {
+                                                        induction_programme_choice: "core_induction_programme",
+                                                        core_induction_programme_id: nil,
+                                                      })
+    induction_coordinators_not_chosen_materials.find_each do |induction_coordinator|
+      school_without_cohort = induction_coordinator.schools
+                                                   .first { |school| school.school_cohorts.any? { |school_cohort| school_cohort.core_induction_programme? && school_cohort.core_induction_programme_id.nil? } }
+      SchoolMailer.induction_coordinator_reminder_to_choose_materials_email(
+        recipient: induction_coordinator.email,
+        name: induction_coordinator.full_name,
+        school_name: school_without_cohort.name,
+        sign_in_url: choose_materials_chaser_sign_in_url,
+      ).deliver_later
+    rescue StandardError
+      logger.info "Error emailing induction coordinator, email: #{induction_coordinator.email} ... skipping"
+    end
+  end
+
 private
 
   def private_beta_start_url
@@ -146,8 +215,27 @@ private
   def sign_in_chaser_start_url
     Rails.application.routes.url_helpers.root_url(
       host: Rails.application.config.domain,
-      **UTMService.email(:sign_in_reminder),
+      **UTMService.email(:sign_in_reminder, :sign_in_reminder),
     )
+  end
+
+  def sign_in_url_with_campaign(campaign)
+    Rails.application.routes.url_helpers.new_user_session_url(
+      host: Rails.application.config.domain,
+      **UTMService.email(campaign, campaign),
+    )
+  end
+
+  def choose_route_chaser_sign_in_url
+    sign_in_url_with_campaign(:choose_route)
+  end
+
+  def choose_provider_chaser_sign_in_url
+    sign_in_url_with_campaign(:choose_provider)
+  end
+
+  def choose_materials_chaser_sign_in_url
+    sign_in_url_with_campaign(:choose_materials)
   end
 
   def find_eligible_school(urn)

--- a/app/services/partnership_notification_service.rb
+++ b/app/services/partnership_notification_service.rb
@@ -9,7 +9,8 @@ class PartnershipNotificationService
           PartnershipNotificationEmail.email_types[:induction_coordinator_email],
         )
 
-        send_notification_email_to_coordinator(notification_email)
+        coordinator_name = partnership.school.induction_coordinators.first.full_name
+        send_notification_email_to_coordinator(notification_email, coordinator_name)
       else
         notification_email = create_notification_email(
           partnership,
@@ -71,7 +72,6 @@ private
       recipient: notification_email.sent_to,
       lead_provider_name: notification_email.lead_provider.name,
       delivery_partner_name: notification_email.delivery_partner.name,
-      cohort: notification_email.partnership.cohort.display_name,
       school_name: notification_email.school.name,
       nominate_url: nomination_email.nomination_url,
       challenge_url: challenge_url(notification_email.token),
@@ -81,16 +81,17 @@ private
     notification_email.update!(notify_id: notify_id)
   end
 
-  def send_notification_email_to_coordinator(notification_email)
+  def send_notification_email_to_coordinator(notification_email, coordinator_name)
     notify_id = SchoolMailer.coordinator_partnership_notification_email(
       recipient: notification_email.sent_to,
+      name: coordinator_name,
       lead_provider_name: notification_email.lead_provider.name,
       delivery_partner_name: notification_email.delivery_partner.name,
       cohort: notification_email.partnership.cohort.display_name,
       school_name: notification_email.school.name,
-      start_url: Rails.application.routes.url_helpers.root_url(
+      sign_in_url: Rails.application.routes.url_helpers.new_user_session_url(
         host: Rails.application.config.domain,
-        **UTMService.email(:partnership_notification),
+        **UTMService.email(:partnership_notification, :partnership_notification),
       ),
       challenge_url: challenge_url(notification_email.token),
       challenge_deadline: notification_email.challenge_deadline.strftime("%d/%m/%Y"),

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -11,11 +11,21 @@ class UTMService
     partnership_notification: "partnership-notification",
     june_private_beta: "june-private-beta",
     sign_in_reminder: "sign-in-reminder",
+    choose_route: "choose-route",
+    choose_provider: "choose-provider",
+    choose_materials: "choose-materials",
   }.freeze
 
+  # Campaigns aren't showing up in GA at the moment, so use specific sources
   SOURCES = {
     service: "cpdservice",
     private_beta: "cpdprivatebeta",
+    partnership_notification: "partnership-notification",
+    nominate_tutor: "nominate-tutor",
+    sign_in_reminder: "sign-in-reminder",
+    choose_route: "choose-route",
+    choose_provider: "choose-provider",
+    choose_materials: "choose-materials",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -43,9 +43,10 @@ RSpec.describe SchoolMailer, type: :mailer do
 
   describe "#coordinator_partnership_notification_email" do
     let(:recipient) { Faker::Internet.email }
+    let(:name) { Faker::Name.name }
     let(:provider_name) { Faker::Company.name }
     let(:school_name) { Faker::Company.name }
-    let(:start_url) { "https://www.example.com" }
+    let(:sign_in_url) { "https://www.example.com/sign-in" }
     let(:challenge_url) { "https://www.example.com?token=abc123" }
     let(:challenge_deadline) { "1/1/1970" }
     let(:cohort) { create(:cohort) }
@@ -53,11 +54,12 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:partnership_notification_email) do
       SchoolMailer.coordinator_partnership_notification_email(
         recipient: recipient,
+        name: name,
         lead_provider_name: provider_name,
         delivery_partner_name: provider_name,
         cohort: cohort,
         school_name: school_name,
-        start_url: start_url,
+        sign_in_url: sign_in_url,
         challenge_url: challenge_url,
         challenge_deadline: challenge_deadline,
       )
@@ -76,14 +78,12 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:nominate_url) { "https://www.example.com?token=def456" }
     let(:challenge_url) { "https://www.example.com?token=abc123" }
     let(:challenge_deadline) { "1/1/1970" }
-    let(:cohort) { create(:cohort) }
 
     let(:partnership_notification_email) do
       SchoolMailer.school_partnership_notification_email(
         recipient: recipient,
         lead_provider_name: provider_name,
         delivery_partner_name: provider_name,
-        cohort: cohort,
         school_name: school_name,
         nominate_url: nominate_url,
         challenge_url: challenge_url,

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -440,4 +440,35 @@ RSpec.describe School, type: :model do
       expect(School.not_opted_out).not_to include opted_out_school
     end
   end
+
+  describe "#partnered" do
+    it "returns true when the school is in a partnership" do
+      partnership = create(:partnership)
+      expect(partnership.school.partnered?(partnership.cohort)).to be true
+    end
+
+    it "returns false when the school is not in a partnership" do
+      school = create(:school)
+      expect(school.partnered?(create(:cohort))).to be false
+    end
+
+    it "returns false when the school is not in a partnership for the specified cohort" do
+      partnership = create(:partnership)
+      expect(partnership.school.partnered?(create(:cohort))).to be false
+    end
+
+    it "returns false when the partnership has been challenged" do
+      partnership = create(:partnership, :challenged)
+      expect(partnership.school.partnered?(partnership.cohort)).to be false
+    end
+
+    it "returns true when the school has a challenged and unchallenged partnership" do
+      cohort = create(:cohort)
+      school = create(:school)
+      create(:partnership, school: school, cohort: cohort)
+      create(:partnership, :challenged, school: school, cohort: cohort)
+
+      expect(school.partnered?(cohort)).to be true
+    end
+  end
 end

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe InviteSchools do
     end
 
     it "does not email induction coordinators who have signed in" do
-      create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      create_signed_in_induction_tutor
       InviteSchools.new.send_induction_coordinator_sign_in_chasers
       expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_sign_in_chaser_email)
     end
@@ -360,7 +360,7 @@ RSpec.describe InviteSchools do
 
   describe "#send_induction_coordinator_choose_route_chasers" do
     it "emails coordinators with a school who has not chosen a route" do
-      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      induction_coordinator = create_signed_in_induction_tutor
       InviteSchools.new.send_induction_coordinator_choose_route_chasers
       expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_route_email)
                                 .with(hash_including(
@@ -378,7 +378,7 @@ RSpec.describe InviteSchools do
     end
 
     it "does not email coordinators who have chosen routes for all their schools" do
-      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      induction_coordinator = create_signed_in_induction_tutor
       create(:school_cohort, school: induction_coordinator.schools.first, cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_route_chasers
       expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_route_email)
@@ -401,7 +401,7 @@ RSpec.describe InviteSchools do
 
   describe "#send_induction_coordinator_choose_provider_chasers" do
     it "emails coordinators with a school who has not chosen a provider" do
-      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      induction_coordinator = create_signed_in_induction_tutor
       create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_provider_chasers
       expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
@@ -414,7 +414,7 @@ RSpec.describe InviteSchools do
     end
 
     it "does not email coordinators who have chosen providers for all their schools" do
-      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      induction_coordinator = create_signed_in_induction_tutor
       create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
       create(:partnership, school: induction_coordinator.schools.first, cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_provider_chasers
@@ -422,7 +422,7 @@ RSpec.describe InviteSchools do
     end
 
     it "does not email coordinators who only have CIP schools" do
-      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      induction_coordinator = create_signed_in_induction_tutor
       create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "core_induction_programme", cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_provider_chasers
       expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
@@ -479,7 +479,7 @@ RSpec.describe InviteSchools do
     end
 
     it "does not email coordinators who only have FIP schools" do
-      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      induction_coordinator = create_signed_in_induction_tutor
       create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_materials_chasers
       expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_materials_email)
@@ -504,5 +504,11 @@ RSpec.describe InviteSchools do
                                         sign_in_url: String,
                                       ))
     end
+  end
+
+private
+
+  def create_signed_in_induction_tutor
+    create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
   end
 end

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe InviteSchools do
   subject(:invite_schools) { described_class.new }
   let(:primary_contact_email) { Faker::Internet.email }
   let(:secondary_contact_email) { Faker::Internet.email }
+  let!(:cohort) { create(:cohort, :current) }
 
   let(:school) do
     create(
@@ -231,10 +232,10 @@ RSpec.describe InviteSchools do
     it "does not send emails to other types of school" do
       InviteSchools.new.send_beta_chasers
       expect(SchoolMailer).not_to delay_email_delivery_of(:beta_invite_email)
-                                .with(hash_including(
-                                        recipient: unexpected_induction_coordinator.email,
-                                        name: unexpected_induction_coordinator.full_name,
-                                      ))
+                                    .with(hash_including(
+                                            recipient: unexpected_induction_coordinator.email,
+                                            name: unexpected_induction_coordinator.full_name,
+                                          ))
     end
   end
 
@@ -335,6 +336,173 @@ RSpec.describe InviteSchools do
           ),
         )
       end
+    end
+  end
+
+  describe "#send_induction_coordinator_sign_in_chasers" do
+    it "emails induction coordinators yet to sign in" do
+      induction_coordinator = create(:user, :induction_coordinator)
+      InviteSchools.new.send_induction_coordinator_sign_in_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_sign_in_chaser_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        start_url: String,
+                                      ))
+    end
+
+    it "does not email induction coordinators who have signed in" do
+      create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      InviteSchools.new.send_induction_coordinator_sign_in_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_sign_in_chaser_email)
+    end
+  end
+
+  describe "#send_induction_coordinator_choose_route_chasers" do
+    it "emails coordinators with a school who has not chosen a route" do
+      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      InviteSchools.new.send_induction_coordinator_choose_route_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_route_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        school_name: induction_coordinator.schools.first.name,
+                                        sign_in_url: String,
+                                      ))
+    end
+
+    it "does not email coordinators who have not signed in" do
+      create(:user, :induction_coordinator)
+      InviteSchools.new.send_induction_coordinator_choose_route_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_route_email)
+    end
+
+    it "does not email coordinators who have chosen routes for all their schools" do
+      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      create(:school_cohort, school: induction_coordinator.schools.first, cohort: cohort)
+      InviteSchools.new.send_induction_coordinator_choose_route_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_route_email)
+    end
+
+    it "uses the name of a school without a route chosen" do
+      cip_schools = create_list(:school_cohort, 10).map(&:school)
+      target_school = create(:school)
+      induction_coordinator = create(:user, :induction_coordinator, school_ids: [target_school.id, *cip_schools.map(&:id)], last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      InviteSchools.new.send_induction_coordinator_choose_route_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_route_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        school_name: target_school.name,
+                                        sign_in_url: String,
+                                      ))
+    end
+  end
+
+  describe "#send_induction_coordinator_choose_provider_chasers" do
+    it "emails coordinators with a school who has not chosen a provider" do
+      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
+      InviteSchools.new.send_induction_coordinator_choose_provider_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        school_name: induction_coordinator.schools.first.name,
+                                        sign_in_url: String,
+                                      ))
+    end
+
+    it "does not email coordinators who have chosen providers for all their schools" do
+      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
+      create(:partnership, school: induction_coordinator.schools.first, cohort: cohort)
+      InviteSchools.new.send_induction_coordinator_choose_provider_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
+    end
+
+    it "does not email coordinators who only have CIP schools" do
+      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "core_induction_programme", cohort: cohort)
+      InviteSchools.new.send_induction_coordinator_choose_provider_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
+    end
+
+    it "uses the name of a school without a provider chosen" do
+      partnered_schools = create_list(
+        :school_cohort,
+        10,
+        induction_programme_choice: "full_induction_programme",
+        cohort: cohort,
+      ).map(&:school)
+      partnered_schools.each { |school| create(:partnership, school: school, cohort: cohort) }
+      target_school = create(:school_cohort, induction_programme_choice: "full_induction_programme", cohort: cohort).school
+      induction_coordinator = create(:user, :induction_coordinator, school_ids: [target_school.id, *partnered_schools.map(&:id)])
+      InviteSchools.new.send_induction_coordinator_choose_provider_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        school_name: target_school.name,
+                                        sign_in_url: String,
+                                      ))
+    end
+  end
+
+  describe "#send_induction_coordinator_choose_materials_chasers" do
+    it "emails coordinators with a school who has not chosen materials" do
+      induction_coordinator = create(:user, :induction_coordinator)
+      create(:school_cohort,
+             school: induction_coordinator.schools.first,
+             induction_programme_choice: "core_induction_programme",
+             cohort: cohort,
+             core_induction_programme: nil)
+      InviteSchools.new.send_induction_coordinator_choose_materials_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_materials_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        school_name: induction_coordinator.schools.first.name,
+                                        sign_in_url: String,
+                                      ))
+    end
+
+    it "does not email coordinators who have chosen materials for all their schools" do
+      induction_coordinator = create(:user, :induction_coordinator)
+      create(:school_cohort,
+             school: induction_coordinator.schools.first,
+             induction_programme_choice: "core_induction_programme",
+             cohort: cohort,
+             core_induction_programme: create(:core_induction_programme))
+      InviteSchools.new.send_induction_coordinator_choose_materials_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_materials_email)
+    end
+
+    it "does not email coordinators who only have FIP schools" do
+      induction_coordinator = create(:user, :induction_coordinator, last_sign_in_at: Time.zone.now, current_sign_in_at: Time.zone.now)
+      create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
+      InviteSchools.new.send_induction_coordinator_choose_materials_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_materials_email)
+    end
+
+    it "uses the name of a school without materials chosen" do
+      chosen_cip_schools = create_list(
+        :school_cohort,
+        10,
+        induction_programme_choice: "core_induction_programme",
+        core_induction_programme: create(:core_induction_programme),
+        cohort: cohort,
+      ).map(&:school)
+      target_school = create(:school_cohort, induction_programme_choice: "core_induction_programme", cohort: cohort).school
+      induction_coordinator = create(:user, :induction_coordinator, school_ids: [target_school.id, *chosen_cip_schools.map(&:id)])
+      InviteSchools.new.send_induction_coordinator_choose_materials_chasers
+      expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_materials_email)
+                                .with(hash_including(
+                                        recipient: induction_coordinator.email,
+                                        name: induction_coordinator.full_name,
+                                        school_name: target_school.name,
+                                        sign_in_url: String,
+                                      ))
     end
   end
 end

--- a/spec/services/partnership_notification_service_spec.rb
+++ b/spec/services/partnership_notification_service_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe PartnershipNotificationService do
           hash_including(
             lead_provider_name: @lead_provider.name,
             delivery_partner_name: @delivery_partner.name,
-            cohort: String,
+            school_name: school.name,
             nominate_url: String,
             challenge_url: String,
+            challenge_deadline: String,
             recipient: contact_email,
           ),
         ).and_call_original
@@ -58,9 +59,7 @@ RSpec.describe PartnershipNotificationService do
     context "when the school has an induction coordinator" do
       let(:contact_email) { Faker::Internet.email }
       let(:school) { create(:school) }
-      before do
-        create(:user, :induction_coordinator, schools: [school], email: contact_email)
-      end
+      let!(:coordinator) { create(:user, :induction_coordinator, schools: [school], email: contact_email) }
 
       before(:all) do
         RSpec::Mocks.configuration.verify_partial_doubles = false
@@ -73,11 +72,13 @@ RSpec.describe PartnershipNotificationService do
       it "emails the induction coordinator" do
         expect(SchoolMailer).to receive(:coordinator_partnership_notification_email).with(
           hash_including(
+            name: coordinator.full_name,
             lead_provider_name: @lead_provider.name,
             delivery_partner_name: @delivery_partner.name,
             cohort: String,
-            start_url: String,
+            sign_in_url: String,
             challenge_url: String,
+            challenge_deadline: String,
             recipient: contact_email,
           ),
         ).and_call_original
@@ -107,11 +108,12 @@ RSpec.describe PartnershipNotificationService do
       it "emails the school primary contact" do
         expect(SchoolMailer).to receive(:school_partnership_notification_email).with(
           hash_including(
+            school_name: school.name,
             lead_provider_name: @lead_provider.name,
             delivery_partner_name: @delivery_partner.name,
-            cohort: String,
             nominate_url: String,
             challenge_url: String,
+            challenge_deadline: String,
             recipient: contact_email,
           ),
         ).and_call_original
@@ -127,10 +129,7 @@ RSpec.describe PartnershipNotificationService do
     context "when the school has an induction coordinator" do
       let(:contact_email) { Faker::Internet.email }
       let(:school) { create(:school) }
-      before do
-        create(:user, :induction_coordinator, schools: [school], email: contact_email)
-      end
-
+      let!(:coordinator) { create(:user, :induction_coordinator, schools: [school], email: contact_email) }
       before(:all) do
         RSpec::Mocks.configuration.verify_partial_doubles = false
       end
@@ -142,11 +141,13 @@ RSpec.describe PartnershipNotificationService do
       it "emails the induction coordinator" do
         expect(SchoolMailer).to receive(:coordinator_partnership_notification_email).with(
           hash_including(
+            name: coordinator.full_name,
             lead_provider_name: @lead_provider.name,
             delivery_partner_name: @delivery_partner.name,
             cohort: String,
-            start_url: String,
+            sign_in_url: String,
             challenge_url: String,
+            challenge_deadline: String,
             recipient: contact_email,
           ),
         ).and_call_original


### PR DESCRIPTION
Add and update a series of targeted mailshots.

I haven't added rake tasks for these because they're going to be scheduled (console, `InviteSchools.new.delay(run_at: sometime, queue: "mailers", priority: 1).send_induction_coordinator_choose_route_chasers`)
