### PR TITLE
Renamed NPQProfile to NPQValidationData

### DIFF
--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-class NPQProfile < ApplicationRecord
+class NPQValidationData < ApplicationRecord
+  # TODO: Rename table
+  self.table_name = "npq_profiles"
+
+  has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id
   belongs_to :user
   belongs_to :npq_lead_provider
   belongs_to :npq_course

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -2,4 +2,6 @@
 
 class ParticipantProfile::NPQ < ParticipantProfile
   belongs_to :school, optional: true
+
+  has_one :validation_data, class_name: "NPQValidationData", foreign_key: :id, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,14 +9,16 @@ class User < ApplicationRecord
   has_one :lead_provider_profile, dependent: :destroy
   has_one :lead_provider, through: :lead_provider_profile
   has_one :admin_profile, dependent: :destroy
-  has_many :npq_profiles, dependent: :destroy
 
   has_one :participant_profile, dependent: :destroy
-  # TODO: Legacy association, to be removed
+  # TODO: Legacy associations, to be removed
   has_one :early_career_teacher_profile, class_name: "ParticipantProfile::ECT"
   has_one :mentor_profile, class_name: "ParticipantProfile::Mentor"
+  has_many :npq_profiles, class_name: "ParticipantProfile::NPQ", dependent: :destroy
+  # end: TODO
 
   before_validation :strip_whitespace
+
   validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, notify_email: true
 

--- a/app/resources/api/v1/npq_profile_resource.rb
+++ b/app/resources/api/v1/npq_profile_resource.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class NPQProfileResource < JSONAPI::Resource
+      model_name "NPQValidationData"
+
       attributes :date_of_birth,
                  :teacher_reference_number,
                  :teacher_reference_number_verified,

--- a/spec/factories/npq_validation_data.rb
+++ b/spec/factories/npq_validation_data.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :npq_profile do
+  factory :npq_validation_data do
     user
     npq_course
     npq_lead_provider

--- a/spec/models/npq_validation_data_spec.rb
+++ b/spec/models/npq_validation_data_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NPQProfile, type: :model do
+RSpec.describe NPQValidationData, type: :model do
   it {
     is_expected.to define_enum_for(:headteacher_status).with_values(
       no: "no",

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -57,23 +57,26 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
       end
 
       it "creates the npq_profile" do
-        expect {
-          post "/api/v1/npq-profiles", params: json
-        }.to change(NPQProfile, :count).by(1)
+        expect { post "/api/v1/npq-profiles", params: json }
+          .to change(ParticipantProfile::NPQ, :count).by(1)
+          .and change(NPQValidationData, :count).by(1)
 
-        profile = NPQProfile.order(created_at: :desc).first
+        profile = ParticipantProfile::NPQ.order(created_at: :desc).first
 
         expect(profile.user).to eql(user)
-        expect(profile.npq_lead_provider).to eql(npq_lead_provider)
-        expect(profile.date_of_birth).to eql(Date.new(1990, 12, 13))
-        expect(profile.teacher_reference_number).to eql("1234567")
-        expect(profile.teacher_reference_number_verified).to be_truthy
-        expect(profile.active_alert).to be_truthy
-        expect(profile.school_urn).to eql("123456")
-        expect(profile.headteacher_status).to eql("no")
-        expect(profile.npq_course).to eql(npq_course)
-        expect(profile.eligible_for_funding).to eql(true)
-        expect(profile.funding_choice).to eql("school")
+
+        validation_data = profile.validation_data
+
+        expect(validation_data.npq_lead_provider).to eql(npq_lead_provider)
+        expect(validation_data.date_of_birth).to eql(Date.new(1990, 12, 13))
+        expect(validation_data.teacher_reference_number).to eql("1234567")
+        expect(validation_data.teacher_reference_number_verified).to be_truthy
+        expect(validation_data.active_alert).to be_truthy
+        expect(validation_data.school_urn).to eql("123456")
+        expect(validation_data.headteacher_status).to eql("no")
+        expect(validation_data.npq_course).to eql(npq_course)
+        expect(validation_data.eligible_for_funding).to eql(true)
+        expect(validation_data.funding_choice).to eql("school")
       end
 
       it "returns a 201" do
@@ -94,9 +97,9 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
       it "response has correct attributes" do
         post "/api/v1/npq-profiles", params: json
 
-        profile = NPQProfile.order(created_at: :desc).first
+        validation_data = NPQValidationData.order(created_at: :desc).first
 
-        expect(parsed_response["data"]["id"]).to eql(profile.id)
+        expect(parsed_response["data"]["id"]).to eql(validation_data.id)
         expect(parsed_response["data"]).to have_jsonapi_attributes(
           :teacher_reference_number,
           :headteacher_status,


### PR DESCRIPTION
Unlike previous MentorProfile and EarlyCareerTeacherProfile, NPQProfile contains a lot of data that is specific only to NPQ participants. Additionally, it is already exposed via API which is being used by `npq_register`.

Because of this, I have renamed the `NPQProfile` model to `NPQValidationData` and associated it with the `ParticipantProfile::NPQ` model. To avoid any API changes, I have kept the logic which automatically creates ParticpantProfile::NPQ when NPQValidationData is created via API (which we can tackle later on).