### PR TITLE
Don't alert on 4xx in production

### DIFF
--- a/terraform/monitoring/config/production/alert.rules.yml
+++ b/terraform/monitoring/config/production/alert.rules.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: RequestsFailuresElevated
         # Condition for alerting
-        expr: (sum(rate(requests{app="ecf-production", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-production"}[5m])) ) > 0.1
+        expr: (sum(rate(requests{app="ecf-production", status_range=~"0xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-production"}[5m])) ) > 0.1
         # Annotation - additional informational labels to store more information
         annotations:
           summary: High rate of failing requests


### PR DESCRIPTION
Retain alerts in dev/stag at lower level to catch issues before live