### PR TITLE
Payments-spec cleanup patches

### DIFF
--- a/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 require "payment_calculator/ecf/contract/output_payment_calculations"
-class DummyClass
+class ModuleTestHarness
   include PaymentCalculator::Ecf::Contract::OutputPaymentCalculations
 end
 
 describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
   let(:contract) { create(:call_off_contract) }
-  let(:call_off_contract) { DummyClass.new({ contract: contract }) }
+  let(:call_off_contract) { ModuleTestHarness.new({ contract: contract }) }
 
   context "when calculating output payments" do
     let(:band_a) { create(:participant_band, min: 0, max: 100, per_participant: 996, call_off_contract: contract) }

--- a/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
@@ -13,7 +13,7 @@ describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
     let(:band_a) { build_stubbed(:participant_band, min: 0, max: 100, per_participant: 996, call_off_contract: contract) }
 
     it "performs calculations of the output payments" do
-      expect(call_off_contract.output_payment_per_participant(band_a).round(0)).to eq(598.00)
+      expect(call_off_contract.output_payment_per_participant(band_a)).to eq(597.60)
 
       %i[started completion].each do |event_type|
         expect(call_off_contract.output_payment_per_participant_for_event(event_type: event_type, band: band_a).round(0)).to eq(120.00)

--- a/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/output_payment_calculations_spec.rb
@@ -6,11 +6,11 @@ class ModuleTestHarness
 end
 
 describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
-  let(:contract) { create(:call_off_contract) }
+  let(:contract) { build_stubbed(:call_off_contract) }
   let(:call_off_contract) { ModuleTestHarness.new({ contract: contract }) }
 
   context "when calculating output payments" do
-    let(:band_a) { create(:participant_band, min: 0, max: 100, per_participant: 996, call_off_contract: contract) }
+    let(:band_a) { build_stubbed(:participant_band, min: 0, max: 100, per_participant: 996, call_off_contract: contract) }
 
     it "performs calculations of the output payments" do
       expect(call_off_contract.output_payment_per_participant(band_a).round(0)).to eq(598.00)
@@ -26,9 +26,9 @@ describe ::PaymentCalculator::Ecf::Contract::OutputPaymentCalculations do
   end
 
   context "when calculating output payment with total participants in multiple bands" do
-    let(:band_a) { create(:participant_band, min: 0, max: 200, per_participant: 100, call_off_contract: contract) }
-    let(:band_b) { create(:participant_band, min: 201, max: 400, per_participant: 200, call_off_contract: contract) }
-    let(:band_c) { create(:participant_band, min: 401, max: 500, per_participant: 300, call_off_contract: contract) }
+    let(:band_a) { build_stubbed(:participant_band, min: 0, max: 200, per_participant: 100, call_off_contract: contract) }
+    let(:band_b) { build_stubbed(:participant_band, min: 201, max: 400, per_participant: 200, call_off_contract: contract) }
+    let(:band_c) { build_stubbed(:participant_band, min: 401, max: 500, per_participant: 300, call_off_contract: contract) }
 
     it "calculates subtotal based on banding total participants" do
       expect(call_off_contract.output_payment_for_event(event_type: :started, total_participants: 500, band: band_a)).to eq(2400.00)

--- a/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
@@ -2,7 +2,7 @@
 
 require "payment_calculator/ecf/contract/service_fee_calculations"
 
-class DummyClass
+class ModuleTestHarness
   include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
 end
 
@@ -17,7 +17,7 @@ describe ::PaymentCalculator::Ecf::Contract::ServiceFeeCalculations do
                       set_up_fee: 149_651.00,
                       band_a: band_a,
                       set_up_recruitment_basis: 2000)
-    call_off_contract = DummyClass.new({ contract: contract })
+    call_off_contract = ModuleTestHarness.new({ contract: contract })
 
     expect(call_off_contract.service_fee_total(band_a).round(2)).to eq(647_149.00)
     expect(call_off_contract.service_fee_monthly(band_a).round(2)).to eq(22_315.48)

--- a/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/service_fee_calculations_spec.rb
@@ -19,8 +19,10 @@ describe ::PaymentCalculator::Ecf::Contract::ServiceFeeCalculations do
                       set_up_recruitment_basis: 2000)
     call_off_contract = ModuleTestHarness.new({ contract: contract })
 
-    expect(call_off_contract.service_fee_total(band_a).round(2)).to eq(647_149.00)
-    expect(call_off_contract.service_fee_monthly(band_a).round(2)).to eq(22_315.48)
-    expect(call_off_contract.service_fee_per_participant(band_a).round(2)).to eq(323.57)
+    aggregate_failures do
+      expect(call_off_contract.service_fee_total(band_a).round(2)).to eq(647_149.00)
+      expect(call_off_contract.service_fee_monthly(band_a).round(2)).to eq(22_315.48)
+      expect(call_off_contract.service_fee_per_participant(band_a).round(2)).to eq(323.57)
+    end
   end
 end

--- a/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
@@ -2,14 +2,14 @@
 
 require "payment_calculator/ecf/contract/uplift_payment_calculations"
 
-class DummyClass
+class ModuleTestHarness
   include PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations
 end
 
 describe ::PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations do
   it "returns the expected types for uplift" do
     contract = double("Contract Double", uplift_amount: BigDecimal(100.00, 2))
-    call_off_contract = DummyClass.new({ contract: contract })
+    call_off_contract = ModuleTestHarness.new({ contract: contract })
     event_type = :started
 
     if @combined_results.nil?
@@ -21,7 +21,7 @@ describe ::PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations do
 
   it "performs calculations of the uplift payments" do
     contract = double("Contract Double", uplift_amount: 100)
-    call_off_contract = DummyClass.new({ contract: contract })
+    call_off_contract = ModuleTestHarness.new({ contract: contract })
     total_participants = 330
 
     expect(call_off_contract.uplift_payment_per_participant.round(0)).to eq(100.00)

--- a/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
+++ b/spec/lib/payment_calculator/ecf/payment_calculation_spec.rb
@@ -4,7 +4,7 @@ require "payment_calculator/ecf/payment_calculation"
 
 describe ::PaymentCalculator::Ecf::PaymentCalculation do
   let(:contract) do
-    FactoryBot.create(:call_off_contract)
+    FactoryBot.build_stubbed(:call_off_contract)
   end
 
   let(:start_event_name) { "Started" }

--- a/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/call_off_contract_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CallOffContractSteps
-  class DummyClass
+  class ModuleTestHarness
     include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
     include PaymentCalculator::Ecf::Contract::OutputPaymentCalculations
   end
@@ -25,7 +25,7 @@ module CallOffContractSteps
                       set_up_fee: @set_up_fee,
                       band_a: @band_a,
                       set_up_recruitment_basis: 2000)
-    @call_off_contract = DummyClass.new({ contract: contract, per_participant: @per_participant_value })
+    @call_off_contract = ModuleTestHarness.new({ contract: contract, per_participant: @per_participant_value })
   end
 
   step :assert_service_fee_per_participant, "the per-participant service fee should be reduced to £:decimal_placeholder"

--- a/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/output_payments_steps.rb
@@ -5,7 +5,7 @@ require "./app/models/participant_band"
 require "./app/models/call_off_contract"
 
 module OutputPaymentsSteps
-  class DummyClass
+  class ModuleTestHarness
     include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
     include PaymentCalculator::Ecf::Contract::OutputPaymentCalculations
   end
@@ -33,7 +33,7 @@ module OutputPaymentsSteps
                                       max: 2000,
                                       per_participant: @per_participant_value)
 
-    @call_off_contract = DummyClass.new({ contract: contract, bands: [@band_a] })
+    @call_off_contract = ModuleTestHarness.new({ contract: contract, bands: [@band_a] })
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(contract: @call_off_contract)
     @result = @retention_table.map do |row|
       calculator.call(event_type: row[:payment_type], total_participants: row[:retained_participants])

--- a/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/service_fees_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ServiceFeeSteps
-  class DummyClass
+  class ModuleTestHarness
     include PaymentCalculator::Ecf::Contract::ServiceFeeCalculations
     include PaymentCalculator::Ecf::Contract::OutputPaymentCalculations
     include PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations
@@ -16,8 +16,8 @@ module ServiceFeeSteps
                       bands: [@band_a],
                       uplift_amount: 100,
                       set_up_recruitment_basis: 2000)
-    @call_off_contract = DummyClass.new({ contract: contract,
-                                          bands: [@band_a] })
+    @call_off_contract = ModuleTestHarness.new({ contract: contract,
+                                                 bands: [@band_a] })
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(contract: @call_off_contract)
     @result = calculator.call
   end

--- a/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
+++ b/spec/lib/payment_calculator/turnip_steps/ecf/uplift_payment_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module UpliftPaymentsSteps
-  class DummyClass
+  class ModuleTestHarness
     include PaymentCalculator::Ecf::Contract::UpliftPaymentCalculations
   end
 
@@ -19,7 +19,7 @@ module UpliftPaymentsSteps
 
   step "I setup the contract with uplift payment" do
     contract = double("Contract Double", uplift_amount: @uplift_amount)
-    @call_off_contract = DummyClass.new({ contract: contract, bands: [] })
+    @call_off_contract = ModuleTestHarness.new({ contract: contract, bands: [] })
     calculator = PaymentCalculator::Ecf::PaymentCalculation.new(contract: @call_off_contract)
     @result = calculator.call(uplift_participants: @uplift_eligible_participants)
   end


### PR DESCRIPTION
### Context

These commits fell out of the work I'm doing to convert the turnip specs to plain rspec.

https://dfedigital.atlassian.net/browse/CPDTP-302

### Changes proposed in this pull request

* Remove rounding from `output_payment_calculations_spec`
* Use `build_stubbed` in payment specs (much faster)
* Aggregate failures in `service_fee_calculations_spec`
* Refactor tests - rename `DummyClass` to `ModuleTestHarness`

### Guidance to review

Have a look at the individual commits.