### PR TITLE
change migrations to use throwaway classes

### DIFF
--- a/db/migrate/20210707120216_populate_cpd_lead_providers.rb
+++ b/db/migrate/20210707120216_populate_cpd_lead_providers.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
+class MigrationLeadProvider < ApplicationRecord
+  self.table_name = "lead_providers"
+end
+
+class MigrationNPQLeadProvider < ApplicationRecord
+  self.table_name = "npq_lead_providers"
+end
+
+class MigrationCpdLeadProvider < ApplicationRecord
+  self.table_name = "cpd_lead_providers"
+end
+
 class PopulateCpdLeadProviders < ActiveRecord::Migration[6.1]
   def up
-    all_provider_names = (LeadProvider.pluck(:name) + NPQLeadProvider.pluck(:name)).uniq
+    all_provider_names = (MigrationLeadProvider.pluck(:name) + MigrationNPQLeadProvider.pluck(:name)).uniq
 
     all_provider_names.each do |name|
-      CpdLeadProvider.create!(name: name)
+      MigrationCpdLeadProvider.create!(name: name)
     end
   end
 

--- a/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
+++ b/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
@@ -1,18 +1,30 @@
 # frozen_string_literal: true
 
+class MigrationLeadProvider2 < ApplicationRecord
+  self.table_name = "lead_providers"
+end
+
+class MigrationNPQLeadProvider2 < ApplicationRecord
+  self.table_name = "npq_lead_providers"
+end
+
+class MigrationCpdLeadProvider2 < ApplicationRecord
+  self.table_name = "cpd_lead_providers"
+end
+
 class PopulateLpAndCpdLpAssocs < ActiveRecord::Migration[6.1]
   def up
-    LeadProvider.all.each do |lp|
-      lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+    MigrationLeadProvider2.all.each do |lp|
+      lp.update!(cpd_lead_provider: MigrationCpdLeadProvider2.find_by(name: lp.name))
     end
 
-    NPQLeadProvider.all.each do |lp|
-      lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
+    MigrationNPQLeadProvider2.all.each do |lp|
+      lp.update!(cpd_lead_provider: MigrationCpdLeadProvider2.find_by(name: lp.name))
     end
   end
 
   def down
-    LeadProvider.update_all(cpd_lead_provider: nil)
-    NPQLeadProvider.update_all(cpd_lead_provider: nil)
+    MigrationLeadProvider2.update_all(cpd_lead_provider: nil)
+    MigrationNPQLeadProvider2.update_all(cpd_lead_provider: nil)
   end
 end


### PR DESCRIPTION
### Context

- Cached classes in migration seem to be causing problems

### Changes proposed in this pull request

- Use throwaway classes in migrations

### Guidance to review

- none

### Testing

- Drop database and recreate empty db
- Run the migrations

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Probably can't