### PR TITLE
NPQ applications api

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Api
+  module V1
+    class NPQApplicationsController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include ApiPagination
+
+      def index
+        respond_to do |format|
+          format.json do
+            render json: NpqApplicationSerializer.new(paginate(scope)).serializable_hash
+          end
+
+          format.csv do
+            render body: NpqApplicationCsvSerializer.new(scope).call
+          end
+        end
+      end
+
+    private
+
+      def npq_lead_provider
+        current_api_token.cpd_lead_provider.npq_lead_provider
+      end
+
+      def scope
+        npq_lead_provider.npq_profiles.includes(:user, :npq_course)
+      end
+
+      def access_scope
+        LeadProviderApiToken.all
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -11,11 +11,11 @@ module Api
       def index
         respond_to do |format|
           format.json do
-            render json: NPQApplicationSerializer.new(paginate(scope)).serializable_hash
+            render json: NPQApplicationSerializer.new(paginate(query_scope)).serializable_hash
           end
 
           format.csv do
-            render body: NPQApplicationCsvSerializer.new(scope).call
+            render body: NPQApplicationCsvSerializer.new(query_scope).call
           end
         end
       end
@@ -26,10 +26,10 @@ module Api
         current_api_token.cpd_lead_provider.npq_lead_provider
       end
 
-      def scope
-        s = npq_lead_provider.npq_profiles.includes(:user, :npq_course)
-        s = s.where("updated_at > ?", Time.iso8601(updated_since_filter)) if updated_since_filter.present?
-        s
+      def query_scope
+        scope = npq_lead_provider.npq_profiles.includes(:user, :npq_course)
+        scope = scope.where("updated_at > ?", Time.iso8601(updated_since_filter)) if updated_since_filter.present?
+        scope
       end
 
       def filter

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -11,11 +11,11 @@ module Api
       def index
         respond_to do |format|
           format.json do
-            render json: NpqApplicationSerializer.new(paginate(scope)).serializable_hash
+            render json: NPQApplicationSerializer.new(paginate(scope)).serializable_hash
           end
 
           format.csv do
-            render body: NpqApplicationCsvSerializer.new(scope).call
+            render body: NPQApplicationCsvSerializer.new(scope).call
           end
         end
       end

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -41,7 +41,7 @@ module Api
       end
 
       def access_scope
-        LeadProviderApiToken.all
+        LeadProviderApiToken.joins(cpd_lead_provider: [:npq_lead_provider])
       end
     end
   end

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -27,7 +27,17 @@ module Api
       end
 
       def scope
-        npq_lead_provider.npq_profiles.includes(:user, :npq_course)
+        s = npq_lead_provider.npq_profiles.includes(:user, :npq_course)
+        s = s.where("updated_at > ?", Time.iso8601(updated_since_filter)) if updated_since_filter.present?
+        s
+      end
+
+      def filter
+        params[:filter] ||= {}
+      end
+
+      def updated_since_filter
+        filter[:updated_since]
       end
 
       def access_scope

--- a/app/controllers/concerns/api_pagination.rb
+++ b/app/controllers/concerns/api_pagination.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ApiPagination
+  extend ActiveSupport::Concern
+  include Pagy::Backend
+
+  included do
+  end
+
+private
+
+  def paginate(scope)
+    _pagy, paginated_records = pagy(scope, items: per_page, page: page)
+
+    paginated_records
+  end
+
+  def per_page
+    params[:page] ||= {}
+
+    [(params.dig(:page, :per_page) || default_per_page).to_i, max_per_page].min
+  end
+
+  def default_per_page
+    100
+  end
+
+  def max_per_page
+    100
+  end
+
+  def page
+    params[:page] ||= {}
+    (params.dig(:page, :page) || 1).to_i
+  end
+end

--- a/app/controllers/concerns/api_pagination.rb
+++ b/app/controllers/concerns/api_pagination.rb
@@ -4,9 +4,6 @@ module ApiPagination
   extend ActiveSupport::Concern
   include Pagy::Backend
 
-  included do
-  end
-
 private
 
   def paginate(scope)

--- a/app/controllers/concerns/api_token_authenticatable.rb
+++ b/app/controllers/concerns/api_token_authenticatable.rb
@@ -26,6 +26,10 @@ module ApiTokenAuthenticatable
 
 private
 
+  def current_api_token
+    @current_api_token
+  end
+
   def check_access_scope
     head :forbidden unless access_scope.include?(@current_api_token)
   end

--- a/app/models/npq_lead_provider.rb
+++ b/app/models/npq_lead_provider.rb
@@ -3,5 +3,5 @@
 class NPQLeadProvider < ApplicationRecord
   belongs_to :cpd_lead_provider, optional: true
 
-  has_many :npq_profiles
+  has_many :npq_profiles, class_name: "NPQValidationData"
 end

--- a/app/models/npq_lead_provider.rb
+++ b/app/models/npq_lead_provider.rb
@@ -2,4 +2,6 @@
 
 class NPQLeadProvider < ApplicationRecord
   belongs_to :cpd_lead_provider, optional: true
+
+  has_many :npq_profiles
 end

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -5,7 +5,23 @@ require "csv"
 class NPQApplicationCsvSerializer
   attr_reader :scope
 
-  def self.headers
+  def initialize(scope)
+    @scope = scope
+  end
+
+  def call
+    CSV.generate do |csv|
+      csv << csv_headers
+
+      scope.each do |record|
+        csv << to_row(record)
+      end
+    end
+  end
+
+private
+
+  def csv_headers
     %w[
       id
       participant_id
@@ -22,22 +38,6 @@ class NPQApplicationCsvSerializer
       course_name
     ]
   end
-
-  def initialize(scope)
-    @scope = scope
-  end
-
-  def call
-    CSV.generate do |csv|
-      csv << self.class.headers
-
-      scope.each do |record|
-        csv << to_row(record)
-      end
-    end
-  end
-
-private
 
   def to_row(record)
     [

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -2,7 +2,7 @@
 
 require "csv"
 
-class NpqApplicationCsvSerializer
+class NPQApplicationCsvSerializer
   attr_reader :scope
 
   def self.headers

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class NpqApplicationCsvSerializer
+  attr_reader :scope
+
+  def self.headers
+    %w[
+      id
+      participant_id
+      full_name
+      email
+      email_validated
+      teacher_reference_number
+      teacher_reference_number_validated
+      school_urn
+      headteacher_status
+      eligible_for_funding
+      funding_choice
+      course_id
+      course_name
+    ]
+  end
+
+  def initialize(scope)
+    @scope = scope
+  end
+
+  def call
+    CSV.generate do |csv|
+      csv << self.class.headers
+
+      scope.each do |record|
+        csv << to_row(record)
+      end
+    end
+  end
+
+private
+
+  def to_row(record)
+    [
+      record.id,
+      record.user_id,
+      record.user.full_name,
+      record.user.email,
+      true,
+      record.teacher_reference_number,
+      record.teacher_reference_number_verified,
+      record.school_urn,
+      record.headteacher_status,
+      record.eligible_for_funding,
+      record.funding_choice,
+      record.npq_course_id,
+      record.npq_course.name,
+    ]
+  end
+end

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class NpqApplicationSerializer
+  include JSONAPI::Serializer
+
+  attributes :id,
+             :participant_id,
+             :full_name,
+             :email,
+             :email_validated,
+             :teacher_reference_number,
+             :teacher_reference_number_validated,
+             :school_urn,
+             :headteacher_status,
+             :eligible_for_funding,
+             :funding_choice,
+             :course_id,
+             :course_name
+
+  attribute(:participant_id) do |object|
+    object.user_id
+  end
+
+  attribute(:full_name) do |object|
+    object.user.full_name
+  end
+
+  attribute(:email) do |object|
+    object.user.email
+  end
+
+  attribute(:email_validated) do |object|
+    true
+  end
+
+  attribute(:teacher_reference_number_validated) do |object|
+    object.teacher_reference_number_verified
+  end
+
+  attribute(:course_id) do |object|
+    object.npq_course_id
+  end
+
+  attribute(:course_name) do |object|
+    object.npq_course.name
+  end
+end

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -3,8 +3,7 @@
 class NpqApplicationSerializer
   include JSONAPI::Serializer
 
-  attributes :id,
-             :participant_id,
+  attributes :participant_id,
              :full_name,
              :email,
              :email_validated,

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -16,9 +16,9 @@ class NpqApplicationSerializer
              :course_id,
              :course_name
 
-  attribute(:participant_id) do |object|
-    object.user_id
-  end
+  attribute(:participant_id, &:user_id)
+  attribute(:teacher_reference_number_validated, &:teacher_reference_number_verified)
+  attribute(:course_id, &:npq_course_id)
 
   attribute(:full_name) do |object|
     object.user.full_name
@@ -28,16 +28,8 @@ class NpqApplicationSerializer
     object.user.email
   end
 
-  attribute(:email_validated) do |object|
+  attribute(:email_validated) do
     true
-  end
-
-  attribute(:teacher_reference_number_validated) do |object|
-    object.teacher_reference_number_verified
-  end
-
-  attribute(:course_id) do |object|
-    object.npq_course_id
   end
 
   attribute(:course_name) do |object|

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NpqApplicationSerializer
+class NPQApplicationSerializer
   include JSONAPI::Serializer
 
   attributes :participant_id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index create]
       resources :dqt_records, only: :show, path: "dqt-records"
       resources :participant_validation, only: :show, path: "participant-validation"
+      resources :npq_applications, only: :index, path: "npq-applications", constraints: ->(_request) { FeatureFlag.active?(:participant_data_api) }
 
       jsonapi_resources :npq_profiles, only: [:create]
 

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_flags: { participant_data_api: "active" } do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
+  let(:npq_lead_provider) { create(:npq_lead_provider) }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+  let(:Authorization) { "Bearer #{token}" }
+
+  path "/api/v1/npq-applications" do
+    get "Returns all NPQ applications for current lead provider" do
+      operationId :api_v1_npq_applications_index
+      tags "npq_applications"
+      produces "application/vnd.api+json"
+      security [bearerAuth: []]
+
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  type: :object,
+                  description: "This schema is used to search within collections to return more specific results.",
+                  example: { updated_since: "2020-11-13T11:21:55Z" },
+                  properties: {
+                    updated_since: {
+                      description: "Return participants that have been updated since the specified timestamp (ISO 8601 format)",
+                      type: :string,
+                      example: "2021-05-13T11:21:55Z",
+                    },
+                  },
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine NPQ applications to return.",
+                example: { updated_since: "2020-11-13T11:21:55Z" }
+
+      parameter name: :page,
+                in: :query,
+                schema: {
+                  type: :object,
+                  description: "This schema used to paginate through a collection.",
+                  properties: {
+                    page: {
+                      type: :integer,
+                      description: "The page number to paginate to in the collection. If no value is specified it defaults to the first page.",
+                      example: 3,
+                    },
+                    per_page: {
+                      type: :integer,
+                      description: "The number items to display on a page. Defaults to 100. Maximum is 500, if the value is greater that the maximum allowed it will fallback to 100.",
+                      example: 10,
+                    },
+                  },
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                example: { page: 1, per_page: 5 },
+                description: "Pagination options to navigate through the collection."
+
+      response "200", "Collection of NPQ applications." do
+        schema type: :object,
+               required: %w[data],
+               properties: {
+                 data: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     required: %w[id type attributes],
+                     properties: {
+                       id: { type: :string },
+                       type: { type: :string },
+                       attributes: {
+                         type: :object,
+                         required: %w[
+                           id
+                           participant_id
+                           full_name
+                           email
+                           email_validated
+                           teacher_reference_number
+                           teacher_reference_number_validated
+                           school_urn
+                           headteacher_status
+                           eligible_for_funding
+                           funding_choice
+                           course_id
+                           course_name
+                         ],
+                         properties: {
+                           id: { type: :string },
+                           participant_id: { type: :string },
+                           full_name: { type: :string },
+                           email: { type: :string },
+                           email_validated: { type: :boolean },
+                           teacher_reference_number: { type: :string },
+                           teacher_reference_number_validated: { type: :boolean },
+                           school_urn: { type: :string },
+                           headteacher_status: {
+                             type: :string,
+                             enum: %w[no yes_when_course_starts yes_in_first_two_years yes_over_two_years],
+                           },
+                           eligible_for_funding: { type: :boolean },
+                           funding_choice: {
+                             type: :string,
+                             enum: %w[school trust self another],
+                           },
+                           course_id: { type: :string },
+                           course_name: { type: :string },
+                         },
+                       },
+                     },
+                   },
+                 },
+               }
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/npq-applications.csv" do
+    get "Returns all NPQ applications for the current lead provider" do
+      operationId :api_v1_npq_applications_index_csv
+      tags "npq_applications"
+      produces "text/csv"
+      security [bearerAuth: []]
+
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  type: :object,
+                  example: "",
+                  description: "This schema is used to search within collections to return more specific results.",
+                  properties: {
+                    updated_since: {
+                      description: "Return participants that have been updated since the specified timestamp (ISO 8601 format)",
+                      type: :string,
+                      example: "2021-05-13T11:21:55Z",
+                    },
+                  },
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine NPQ applications to return.",
+                example: { updated_since: "2020-11-13T11:21:55Z" }
+
+      response "200", "Collection of participants." do
+        schema type: :string
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/factories/npq_validation_data.rb
+++ b/spec/factories/npq_validation_data.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     npq_course
     npq_lead_provider
 
-    headteacher_status { NPQProfile.headteacher_statuses.keys.sample }
-    funding_choice { NPQProfile.funding_choices.keys.sample }
+    headteacher_status { NPQValidationData.headteacher_statuses.keys.sample }
+    funding_choice { NPQValidationData.funding_choices.keys.sample }
   end
 end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -128,6 +128,19 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
       end
     end
 
+    context "when token belongs to provider that does not handle NPQs" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
+      let(:lead_provider) { create(:lead_provider) }
+      let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+      let(:bearer_token) { "Bearer #{token}" }
+
+      it "returns 403" do
+        default_headers[:Authorization] = bearer_token
+        get "/api/v1/npq-applications"
+        expect(response.status).to eq 403
+      end
+    end
+
     context "when using a engage and learn token" do
       let(:token) { EngageAndLearnApiToken.create_with_random_token! }
 

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { participant_data_api: "active" } do
+  describe "GET /api/v1/npq-applications" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
+    let(:npq_lead_provider) { create(:npq_lead_provider) }
+    let(:other_npq_lead_provider) { create(:npq_lead_provider) }
+    let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+    let(:bearer_token) { "Bearer #{token}" }
+
+    before :each do
+      create_list :npq_profile, 3, npq_lead_provider: npq_lead_provider
+      create_list :npq_profile, 2, npq_lead_provider: other_npq_lead_provider
+    end
+
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+      end
+
+      describe "JSON API" do
+        let(:parsed_response) { JSON.parse(response.body) }
+
+        it "returns correct jsonapi content type header" do
+          get "/api/v1/npq-applications"
+          expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+        end
+
+        it "returns scoped profiles" do
+          get "/api/v1/npq-applications"
+          expect(parsed_response["data"].size).to eql(3)
+        end
+
+        it "returns correct type" do
+          get "/api/v1/npq-applications"
+          expect(parsed_response["data"][0]).to have_type("npq_application")
+        end
+
+        it "returns correct data" do
+          get "/api/v1/npq-applications"
+
+          expect(parsed_response["data"][0]["id"]).to be_in(NPQProfile.pluck(:id))
+
+          profile = NPQProfile.find(parsed_response["data"][0]["id"])
+          user = User.find(parsed_response["data"][0]["attributes"]["participant_id"])
+
+          expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
+
+          expect(parsed_response["data"][0]["attributes"]["email"]).to eql(user.email)
+          expect(parsed_response["data"][0]["attributes"]["email_validated"]).to eql(true)
+
+          expect(parsed_response["data"][0]["attributes"]["school_urn"]).to eql(profile.school_urn)
+
+          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number"]).to eql(profile.teacher_reference_number)
+          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number_validated"]).to eql(profile.teacher_reference_number_verified)
+
+          expect(parsed_response["data"][0]["attributes"]["eligible_for_funding"]).to eql(profile.eligible_for_funding)
+
+          expect(parsed_response["data"][0]["attributes"]["course_id"]).to eql(profile.npq_course_id)
+          expect(parsed_response["data"][0]["attributes"]["course_name"]).to eql(profile.npq_course.name)
+        end
+
+        it "can return paginated data" do
+          get "/api/v1/npq-applications", params: { page: { per_page: 2, page: 1 } }
+          expect(parsed_response["data"].size).to eql(2)
+
+          get "/api/v1/npq-applications", params: { page: { per_page: 2, page: 2 } }
+          expect(JSON.parse(response.body)["data"].size).to eql(1)
+        end
+      end
+
+      describe "CSV API" do
+        let(:parsed_response) { CSV.parse(response.body, headers: true) }
+
+        before do
+          get "/api/v1/npq-applications.csv"
+        end
+
+        it "returns the correct CSV content type header" do
+          expect(response.headers["Content-Type"]).to eql("text/csv")
+        end
+
+        it "returns scoped profiles" do
+          expect(parsed_response.length).to eql(NPQProfile.where(npq_lead_provider: npq_lead_provider).count)
+        end
+
+        it "returns the correct headers" do
+          expect(parsed_response.headers).to match_array(
+            %w[
+              id
+              participant_id
+              full_name
+              email
+              email_validated
+              teacher_reference_number
+              teacher_reference_number_validated
+              school_urn
+              headteacher_status
+              eligible_for_funding
+              funding_choice
+              course_id
+              course_name
+            ],
+          )
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v1/npq-applications"
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when using a engage and learn token" do
+      let(:token) { EngageAndLearnApiToken.create_with_random_token! }
+
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = bearer_token
+        get "/api/v1/npq-applications"
+        expect(response.status).to eq 403
+      end
+    end
+  end
+end
+
+RSpec.describe "NPQ Applications API without feature flag", type: :request do
+  describe "GET /api/v1/npq-applications" do
+    it "does not route" do
+      expect {
+        get "/api/v1/npq-applications"
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
           get "/api/v1/npq-applications", params: { page: { per_page: 2, page: 2 } }
           expect(JSON.parse(response.body)["data"].size).to eql(1)
         end
+
+        context "filtering" do
+          before do
+            create_list :npq_profile, 2, npq_lead_provider: npq_lead_provider, updated_at: 10.days.ago
+          end
+
+          it "returns content updated after specified timestamp" do
+            get "/api/v1/npq-applications", params: { filter: { updated_since: 2.days.ago.iso8601 } }
+            expect(parsed_response["data"].size).to eql(3)
+          end
+        end
       end
 
       describe "CSV API" do

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
     let(:bearer_token) { "Bearer #{token}" }
 
     before :each do
-      create_list :npq_profile, 3, npq_lead_provider: npq_lead_provider
-      create_list :npq_profile, 2, npq_lead_provider: other_npq_lead_provider
+      create_list :npq_validation_data, 3, npq_lead_provider: npq_lead_provider
+      create_list :npq_validation_data, 2, npq_lead_provider: other_npq_lead_provider
     end
 
     context "when authorized" do
@@ -42,9 +42,9 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
         it "returns correct data" do
           get "/api/v1/npq-applications"
 
-          expect(parsed_response["data"][0]["id"]).to be_in(NPQProfile.pluck(:id))
+          expect(parsed_response["data"][0]["id"]).to be_in(NPQValidationData.pluck(:id))
 
-          profile = NPQProfile.find(parsed_response["data"][0]["id"])
+          profile = NPQValidationData.find(parsed_response["data"][0]["id"])
           user = User.find(parsed_response["data"][0]["attributes"]["participant_id"])
 
           expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
@@ -73,7 +73,7 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
 
         context "filtering" do
           before do
-            create_list :npq_profile, 2, npq_lead_provider: npq_lead_provider, updated_at: 10.days.ago
+            create_list :npq_validation_data, 2, npq_lead_provider: npq_lead_provider, updated_at: 10.days.ago
           end
 
           it "returns content updated after specified timestamp" do
@@ -95,7 +95,7 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
         end
 
         it "returns scoped profiles" do
-          expect(parsed_response.length).to eql(NPQProfile.where(npq_lead_provider: npq_lead_provider).count)
+          expect(parsed_response.length).to eql(NPQValidationData.where(npq_lead_provider: npq_lead_provider).count)
         end
 
         it "returns the correct headers" do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -45,6 +45,243 @@
     }
   ],
   "paths": {
+    "/api/v1/npq-applications": {
+      "get": {
+        "summary": "Returns all NPQ applications for current lead provider",
+        "operationId": "api_v1_npq_applications_index",
+        "tags": [
+          "npq_applications"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "description": "This schema is used to search within collections to return more specific results.",
+              "example": {
+                "updated_since": "2020-11-13T11:21:55Z"
+              },
+              "properties": {
+                "updated_since": {
+                  "description": "Return participants that have been updated since the specified timestamp (ISO 8601 format)",
+                  "type": "string",
+                  "example": "2021-05-13T11:21:55Z"
+                }
+              }
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine NPQ applications to return.",
+            "example": {
+              "updated_since": "2020-11-13T11:21:55Z"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "description": "This schema used to paginate through a collection.",
+              "properties": {
+                "page": {
+                  "type": "integer",
+                  "description": "The page number to paginate to in the collection. If no value is specified it defaults to the first page.",
+                  "example": 3
+                },
+                "per_page": {
+                  "type": "integer",
+                  "description": "The number items to display on a page. Defaults to 100. Maximum is 500, if the value is greater that the maximum allowed it will fallback to 100.",
+                  "example": 10
+                }
+              }
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": {
+              "page": 1,
+              "per_page": 5
+            },
+            "description": "Pagination options to navigate through the collection."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Collection of NPQ applications.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "type",
+                          "attributes"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "required": [
+                              "id",
+                              "participant_id",
+                              "full_name",
+                              "email",
+                              "email_validated",
+                              "teacher_reference_number",
+                              "teacher_reference_number_validated",
+                              "school_urn",
+                              "headteacher_status",
+                              "eligible_for_funding",
+                              "funding_choice",
+                              "course_id",
+                              "course_name"
+                            ],
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "participant_id": {
+                                "type": "string"
+                              },
+                              "full_name": {
+                                "type": "string"
+                              },
+                              "email": {
+                                "type": "string"
+                              },
+                              "email_validated": {
+                                "type": "boolean"
+                              },
+                              "teacher_reference_number": {
+                                "type": "string"
+                              },
+                              "teacher_reference_number_validated": {
+                                "type": "boolean"
+                              },
+                              "school_urn": {
+                                "type": "string"
+                              },
+                              "headteacher_status": {
+                                "type": "string",
+                                "enum": [
+                                  "no",
+                                  "yes_when_course_starts",
+                                  "yes_in_first_two_years",
+                                  "yes_over_two_years"
+                                ]
+                              },
+                              "eligible_for_funding": {
+                                "type": "boolean"
+                              },
+                              "funding_choice": {
+                                "type": "string",
+                                "enum": [
+                                  "school",
+                                  "trust",
+                                  "self",
+                                  "another"
+                                ]
+                              },
+                              "course_id": {
+                                "type": "string"
+                              },
+                              "course_name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/npq-applications.csv": {
+      "get": {
+        "summary": "Returns all NPQ applications for the current lead provider",
+        "operationId": "api_v1_npq_applications_index_csv",
+        "tags": [
+          "npq_applications"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "object",
+              "example": "",
+              "description": "This schema is used to search within collections to return more specific results.",
+              "properties": {
+                "updated_since": {
+                  "description": "Return participants that have been updated since the specified timestamp (ISO 8601 format)",
+                  "type": "string",
+                  "example": "2021-05-13T11:21:55Z"
+                }
+              }
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine NPQ applications to return.",
+            "example": {
+              "updated_since": "2020-11-13T11:21:55Z"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Collection of participants.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
     "/api/v1/participant-declarations": {
       "post": {
         "summary": "Create participant declarations",


### PR DESCRIPTION
### Context

- Providers need to be able to fetch NPQ applications from us

### Changes proposed in this pull request

- Add `/api/v1/npq-applications` endpoint
- Can fetch json and csv responses
- Added swagger docs for this new endpoints so providers can see how to use it

### Guidance to review

- JSON endpoint accepts pagination and the CSV endpoint does not. This is by design to mirror the participants endpoint for consistency
- I've implemented the filter `updated_since` to also mirror the partcipants endpoint for consistency
- I have opted to not use `JSONAPI::Resources` although powerful it seems to lack flexibility and extensibility
- This feature is behind a feature flag so it can be made available in sandbox whilst disabled in production

### Testing

- Test in review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Create or use an existing `LeadProviderApiToken`
- Ensure there exists some data to fetch from the api
```rb
NPQValidationData.create!(npq_course: NPQCourse.all.sample, npq_lead_provider: NPQLeadProvider.all.sample, date_of_birth: 50.year
s.ago, teacher_reference_number: rand(1_000_000..9_999_999).to_s, school_urn: rand(100_000..999_999), headteacher_status: "no", funding_choice: "s
chool", user: User.all.sample)
```
- Make json api call
```sh
curl -H "Authorization: Bearer TOKEN" https://ecf-review-pr-680.london.cloudapps.digital/api/v1/npq-applications
```
- Make CSV api call
```sh
curl -H "Authorization: Bearer TOKEN" https://ecf-review-pr-680.london.cloudapps.digital/api/v1/npq-applications.csv
```
- Test data contains only applications for the current lead provider based off the api token 
- Test pagination
- Test filtering
- Check the docs https://ecf-review-pr-680.london.cloudapps.digital/api-docs