### PR TITLE
Hardcoded created_at for admin participant cypress test

### DIFF
--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -7,34 +7,40 @@ mentor_1 = FactoryBot.create :participant_profile,
                              :mentor,
                              user: FactoryBot.create(:user, full_name: "Mentor User 1"),
                              school: school,
-                             cohort: cohort
+                             cohort: cohort,
+                             created_at: Date.parse("20/03/2020")
 
 FactoryBot.create :participant_profile,
                   :mentor,
                   user: FactoryBot.create(:user, full_name: "Mentor User 2"),
                   school: school,
-                  cohort: cohort
+                  cohort: cohort,
+                  created_at: Date.parse("06/05/2020")
 
 FactoryBot.create :participant_profile,
                   :ect,
                   user: FactoryBot.create(:user, full_name: "ECT User 1", email: "young_prosacco@crist.net"),
                   mentor_profile: mentor_1,
                   school: school,
-                  cohort: cohort
+                  cohort: cohort,
+                  created_at: Date.parse("01/07/2020")
 
 FactoryBot.create :participant_profile,
                   :ect,
                   user: FactoryBot.create(:user, full_name: "ECT User 2"),
                   mentor_profile: mentor_1,
                   school: school,
-                  cohort: cohort
+                  cohort: cohort,
+                  created_at: Date.parse("25/05/2020")
 
 FactoryBot.create :participant_profile,
                   :mentor,
                   user: FactoryBot.create(:user, full_name: "Unrelated mentor"),
-                  school: FactoryBot.create(:school, name: "Some other school", urn: "222222")
+                  school: FactoryBot.create(:school, name: "Some other school", urn: "222222"),
+                  created_at: Date.parse("10/11/2020")
 
 FactoryBot.create :participant_profile,
                   :ect,
                   user: FactoryBot.create(:user, full_name: "Unrelated ect"),
-                  school: FactoryBot.create(:school, name: "Some other school", urn: "111111")
+                  school: FactoryBot.create(:school, name: "Some other school", urn: "111111"),
+                  created_at: Date.parse("29/12/2020")


### PR DESCRIPTION
`created_at` is displayed on the admin participant page, so it needs to be hardcoded in the test scenario to avoid percy failures.