### PR TITLE
CPDRP-624 Update induction tutor chaser email

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -152,7 +152,7 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def induction_coordinator_sign_in_chaser_email(recipient:, name:, school_name:, start_url:)
+  def induction_coordinator_sign_in_chaser_email(recipient:, name:, school_name:, sign_in_url:)
     template_mail(
       COORDINATOR_SIGN_IN_CHASER_EMAIL_TEMPLATE,
       to: recipient,
@@ -161,7 +161,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         name: name,
         school_name: school_name,
-        start_url: start_url,
+        sign_in_url: sign_in_url,
       },
     )
   end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -121,13 +121,13 @@ class InviteSchools
   end
 
   def send_induction_coordinator_sign_in_chasers
-    induction_coordinators_never_signed_in = User.joins(:induction_coordinator_profile).where(last_sign_in_at: nil)
+    induction_coordinators_never_signed_in = User.joins(:induction_coordinator_profile).where("last_sign_in_at IS NULL and users.created_at < ?", 2.days.ago)
     induction_coordinators_never_signed_in.each do |induction_coordinator|
       SchoolMailer.induction_coordinator_sign_in_chaser_email(
         recipient: induction_coordinator.email,
         name: induction_coordinator.full_name,
         school_name: induction_coordinator.schools.first.name,
-        start_url: sign_in_chaser_start_url,
+        sign_in_url: sign_in_chaser_sign_in_url,
       ).deliver_later
     rescue StandardError
       logger.info "Error emailing induction coordinator, email: #{induction_coordinator.email} ... skipping"
@@ -235,8 +235,8 @@ private
     )
   end
 
-  def sign_in_chaser_start_url
-    Rails.application.routes.url_helpers.root_url(
+  def sign_in_chaser_sign_in_url
+    Rails.application.routes.url_helpers.new_user_session_url(
       host: Rails.application.config.domain,
       **UTMService.email(:sign_in_reminder, :sign_in_reminder),
     )

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -341,9 +341,15 @@ RSpec.describe InviteSchools do
 
   describe "#send_induction_coordinator_sign_in_chasers" do
     it "emails induction coordinators yet to sign in" do
-      induction_coordinator = create(:user, :induction_coordinator)
+      induction_coordinator = create(:user, :induction_coordinator, created_at: 5.days.ago)
       InviteSchools.new.send_induction_coordinator_sign_in_chasers
       expect_sign_in_chaser_email(induction_coordinator)
+    end
+
+    it "does not email induction coordinators who were created within the last 2 days" do
+      induction_coordinator = create(:user, :induction_coordinator, created_at: 1.day.ago)
+      InviteSchools.new.send_induction_coordinator_sign_in_chasers
+      expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_sign_in_chaser_email)
     end
 
     it "does not email induction coordinators who have signed in" do
@@ -612,7 +618,7 @@ private
   end
 
   def expect_sign_in_chaser_email(induction_coordinator)
-    expect_email(:induction_coordinator_sign_in_chaser_email, induction_coordinator, start_url: String)
+    expect_email(:induction_coordinator_sign_in_chaser_email, induction_coordinator, sign_in_url: String)
   end
 
   def expect_email(method, induction_coordinator, **params)


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-624)
Update details for Notify template param and exclude induction tutors that have been recently created from recipients.

### Changes proposed in this pull request
Update template param name to `sign_in_url` instead of `start_url`
Set `sign_in_url` to sign-in page instead of start page
Exclude users who were added in the last 2 days from the recipients query.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
