### PR TITLE
CPDTP-227 Update Matt's initial PR to support v0.3 declaration specs.

### DIFF
--- a/app/presenters/api_docs/schema_example.rb
+++ b/app/presenters/api_docs/schema_example.rb
@@ -31,7 +31,7 @@ module ApiDocs
         example_data[property_key] = generate_example_value_for_property(property)
       end
 
-      example_data
+      example_data.presence || schema_data.example || {}
     end
 
     def generate_example_value_for_property(property)

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -253,6 +253,7 @@
           },
           "declaration_type": {
             "description": "The event declaration type",
+            "type": "string",
             "enum": [
               "retained-1",
               "retained-2",
@@ -268,6 +269,8 @@
             "example": "2021-05-31T02:21:32.000Z"
           },
           "course_type": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
             "enum": [
               "ecf-induction",
               "ecf-mentor"
@@ -275,6 +278,8 @@
             "example": "ecf-induction"
           },
           "evidence_held": {
+            "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
+            "type": "string",
             "enum": [
               "training-event-attended",
               "self-study-material-completed"
@@ -309,6 +314,7 @@
           },
           "declaration_type": {
             "description": "The event declaration type",
+            "type": "string",
             "enum": [
               "started",
               "completed"
@@ -322,6 +328,8 @@
             "example": "2021-05-31T02:21:32.000Z"
           },
           "course_type": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
             "enum": [
               "ecf-induction",
               "ecf-mentor"
@@ -411,6 +419,7 @@
           },
           "declaration_type": {
             "description": "The event declaration type",
+            "type": "string",
             "enum": [
               "retained-1",
               "retained-2",
@@ -426,6 +435,8 @@
             "example": "2021-05-31T02:21:32.000Z"
           },
           "course_type": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
             "enum": [
               "npq-leading-teaching",
               "npq-leading-teaching-development",
@@ -437,6 +448,8 @@
             "example": "npq-headship"
           },
           "evidence_held": {
+            "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
+            "type": "string",
             "enum": [
               "training-event-attended",
               "self-study-material-completed"
@@ -471,6 +484,7 @@
           },
           "declaration_type": {
             "description": "The event declaration type",
+            "type": "string",
             "enum": [
               "started",
               "completed"
@@ -484,6 +498,8 @@
             "example": "2021-05-31T02:21:32.000Z"
           },
           "course_type": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
             "enum": [
               "npq-leading-teaching",
               "npq-leading-teaching-development",
@@ -674,7 +690,13 @@
           {
             "$ref": "#/components/schemas/NPQParticipantRetainedDeclaration"
           }
-        ]
+        ],
+        "example": {
+          "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "declaration_type": "started",
+          "declaration_date": "2021-05-31T02:21:32.000Z",
+          "course_type": "ecf-mentor"
+        }
       },
       "ParticipantDeclarationRecordedResponse": {
         "description": "The participant declaration has been recorded successfully",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -235,9 +235,111 @@
             "example": [
               "participant_id",
               "declaration_date",
-              "declaration_type"
+              "declaration_type",
+              "course_type"
             ]
           }
+        }
+      },
+      "ECFParticipantRetainedDeclaration": {
+        "description": "An ECF retained participant declaration",
+        "type": "object",
+        "properties": {
+          "participant_id": {
+            "description": "The unique id of the participant",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "enum": [
+              "retained-1",
+              "retained-2",
+              "retained-3",
+              "retained-4"
+            ],
+            "example": "retained-1"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_type": {
+            "enum": [
+              "ecf-induction",
+              "ecf-mentor"
+            ],
+            "example": "ecf-induction"
+          },
+          "evidence_held": {
+            "enum": [
+              "training-event-attended",
+              "self-study-material-completed"
+            ],
+            "example": "training-event-attended"
+          }
+        },
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_type",
+          "evidence_held"
+        ],
+        "example": {
+          "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "declaration_type": "retained-1",
+          "declaration_date": "2021-05-31T02:21:32.000Z",
+          "course_type": "ecf-induction",
+          "evidence_held": "training-event-attended"
+        }
+      },
+      "ECFParticipantStartedDeclaration": {
+        "description": "An ECF started and completed participant declaration",
+        "type": "object",
+        "properties": {
+          "participant_id": {
+            "description": "The unique id of the participant",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "enum": [
+              "started",
+              "completed"
+            ],
+            "example": "started"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_type": {
+            "enum": [
+              "ecf-induction",
+              "ecf-mentor"
+            ],
+            "example": "ecf-induction"
+          }
+        },
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_type"
+        ],
+        "example": {
+          "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "declaration_type": "started",
+          "declaration_date": "2021-05-31T02:21:32.000Z",
+          "course_type": "ecf-mentor"
         }
       },
       "MultipleParticipantCsvResponse": {
@@ -295,6 +397,115 @@
               }
             ]
           }
+        }
+      },
+      "NPQParticipantRetainedDeclaration": {
+        "description": "An ECF retained participant declaration",
+        "type": "object",
+        "properties": {
+          "participant_id": {
+            "description": "The unique id of the participant",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "enum": [
+              "retained-1",
+              "retained-2",
+              "retained-3",
+              "retained-4"
+            ],
+            "example": "retained-1"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_type": {
+            "enum": [
+              "npq-leading-teaching",
+              "npq-leading-teaching-development",
+              "npq-leading-behaviour-culture",
+              "npq-headship",
+              "npq-senior-leadership",
+              "npq-executive-leadership"
+            ],
+            "example": "npq-headship"
+          },
+          "evidence_held": {
+            "enum": [
+              "training-event-attended",
+              "self-study-material-completed"
+            ],
+            "example": "training-event-attended"
+          }
+        },
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_type",
+          "evidence_held"
+        ],
+        "example": {
+          "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "declaration_type": "retained-1",
+          "declaration_date": "2021-05-31T02:21:32.000Z",
+          "course_type": "npq-headship",
+          "evidence_held": "training-event-attended"
+        }
+      },
+      "NPQParticipantStartedDeclaration": {
+        "description": "An NPQ participant declaration",
+        "type": "object",
+        "properties": {
+          "participant_id": {
+            "description": "The unique id of the participant",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "enum": [
+              "started",
+              "completed"
+            ],
+            "example": "started"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_type": {
+            "enum": [
+              "npq-leading-teaching",
+              "npq-leading-teaching-development",
+              "npq-leading-behaviour-culture",
+              "npq-headship",
+              "npq-senior-leadership",
+              "npq-executive-leadership"
+            ],
+            "example": "npq-headship"
+          }
+        },
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_type"
+        ],
+        "example": {
+          "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+          "declaration_type": "started",
+          "declaration_date": "2021-05-31T02:21:32.000Z",
+          "course_type": "npq-leading-teaching"
         }
       },
       "Pagination": {
@@ -450,42 +661,20 @@
       "ParticipantDeclaration": {
         "description": "A participant declaration",
         "type": "object",
-        "properties": {
-          "participant_id": {
-            "description": "The unique id of the participant",
-            "type": "string",
-            "format": "uuid",
-            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ECFParticipantStartedDeclaration"
           },
-          "declaration_type": {
-            "description": "The event declaration type",
-            "enum": [
-              "started",
-              "retained_1",
-              "retained_2",
-              "retained_3",
-              "retained_4",
-              "completed"
-            ],
-            "example": "started"
+          {
+            "$ref": "#/components/schemas/ECFParticipantRetainedDeclaration"
           },
-          "declaration_date": {
-            "description": "The event declaration date",
-            "type": "string",
-            "format": "date-time",
-            "example": "2021-05-31T02:21:32.000Z"
+          {
+            "$ref": "#/components/schemas/NPQParticipantStartedDeclaration"
+          },
+          {
+            "$ref": "#/components/schemas/NPQParticipantRetainedDeclaration"
           }
-        },
-        "required": [
-          "participant_id",
-          "declaration_type",
-          "declaration_date"
-        ],
-        "example": {
-          "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
-          "declaration_type": "started",
-          "declaration_date": "2021-05-31T02:21:32.000Z"
-        }
+        ]
       },
       "ParticipantDeclarationRecordedResponse": {
         "description": "The participant declaration has been recorded successfully",

--- a/swagger/v1/component_schemas/BadOrMissingParametersResponse.yml
+++ b/swagger/v1/component_schemas/BadOrMissingParametersResponse.yml
@@ -14,3 +14,4 @@ properties:
       - "participant_id"
       - "declaration_date"
       - "declaration_type"
+      - "course_type"

--- a/swagger/v1/component_schemas/ECFParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/ECFParticipantRetainedDeclaration.yml
@@ -8,6 +8,7 @@ properties:
     example: db3a7848-7308-4879-942a-c4a70ced400a
   declaration_type:
     description: "The event declaration type"
+    type: string
     enum:
       - retained-1
       - retained-2
@@ -20,11 +21,15 @@ properties:
     format: date-time
     example: 2021-05-31T02:21:32Z
   course_type:
+    description: "The type of course the participant is enrolled in"
+    type: string
     enum:
       - ecf-induction
       - ecf-mentor
     example: ecf-induction
   evidence_held:
+    description: "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period"
+    type: string
     enum:
       - training-event-attended
       - self-study-material-completed

--- a/swagger/v1/component_schemas/ECFParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/ECFParticipantRetainedDeclaration.yml
@@ -1,0 +1,43 @@
+description: "An ECF retained participant declaration"
+type: object
+properties:
+  participant_id:
+    description: "The unique id of the participant"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type:
+    description: "The event declaration type"
+    enum:
+      - retained-1
+      - retained-2
+      - retained-3
+      - retained-4
+    example: retained-1
+  declaration_date:
+    description: "The event declaration date"
+    type: string
+    format: date-time
+    example: 2021-05-31T02:21:32Z
+  course_type:
+    enum:
+      - ecf-induction
+      - ecf-mentor
+    example: ecf-induction
+  evidence_held:
+    enum:
+      - training-event-attended
+      - self-study-material-completed
+    example: training-event-attended
+required:
+  - participant_id
+  - declaration_type
+  - declaration_date
+  - course_type
+  - evidence_held
+example:
+  participant_id: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type: retained-1
+  declaration_date: 2021-05-31T02:21:32Z
+  course_type: ecf-induction
+  evidence_held: training-event-attended

--- a/swagger/v1/component_schemas/ECFParticipantStartedDeclaration.yml
+++ b/swagger/v1/component_schemas/ECFParticipantStartedDeclaration.yml
@@ -1,0 +1,34 @@
+description: "An ECF started and completed participant declaration"
+type: object
+properties:
+  participant_id:
+    description: "The unique id of the participant"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type:
+    description: "The event declaration type"
+    enum:
+      - started
+      - completed
+    example: started
+  declaration_date:
+    description: "The event declaration date"
+    type: string
+    format: date-time
+    example: 2021-05-31T02:21:32Z
+  course_type:
+    enum:
+      - ecf-induction
+      - ecf-mentor
+    example: ecf-induction
+required:
+  - participant_id
+  - declaration_type
+  - declaration_date
+  - course_type
+example:
+  participant_id: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type: started
+  declaration_date: 2021-05-31T02:21:32Z
+  course_type: ecf-mentor

--- a/swagger/v1/component_schemas/ECFParticipantStartedDeclaration.yml
+++ b/swagger/v1/component_schemas/ECFParticipantStartedDeclaration.yml
@@ -8,6 +8,7 @@ properties:
     example: db3a7848-7308-4879-942a-c4a70ced400a
   declaration_type:
     description: "The event declaration type"
+    type: string
     enum:
       - started
       - completed
@@ -18,6 +19,8 @@ properties:
     format: date-time
     example: 2021-05-31T02:21:32Z
   course_type:
+    description: "The type of course the participant is enrolled in"
+    type: string
     enum:
       - ecf-induction
       - ecf-mentor

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -1,0 +1,47 @@
+description: "An ECF retained participant declaration"
+type: object
+properties:
+  participant_id:
+    description: "The unique id of the participant"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type:
+    description: "The event declaration type"
+    enum:
+      - retained-1
+      - retained-2
+      - retained-3
+      - retained-4
+    example: retained-1
+  declaration_date:
+    description: "The event declaration date"
+    type: string
+    format: date-time
+    example: 2021-05-31T02:21:32Z
+  course_type:
+    enum:
+      - npq-leading-teaching
+      - npq-leading-teaching-development
+      - npq-leading-behaviour-culture
+      - npq-headship
+      - npq-senior-leadership
+      - npq-executive-leadership
+    example: npq-headship
+  evidence_held:
+    enum:
+      - training-event-attended
+      - self-study-material-completed
+    example: training-event-attended
+required:
+  - participant_id
+  - declaration_type
+  - declaration_date
+  - course_type
+  - evidence_held
+example:
+  participant_id: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type: retained-1
+  declaration_date: 2021-05-31T02:21:32Z
+  course_type: npq-headship
+  evidence_held: training-event-attended

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -8,6 +8,7 @@ properties:
     example: db3a7848-7308-4879-942a-c4a70ced400a
   declaration_type:
     description: "The event declaration type"
+    type: string
     enum:
       - retained-1
       - retained-2
@@ -20,6 +21,8 @@ properties:
     format: date-time
     example: 2021-05-31T02:21:32Z
   course_type:
+    description: "The type of course the participant is enrolled in"
+    type: string
     enum:
       - npq-leading-teaching
       - npq-leading-teaching-development
@@ -29,6 +32,8 @@ properties:
       - npq-executive-leadership
     example: npq-headship
   evidence_held:
+    description: "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period"
+    type: string
     enum:
       - training-event-attended
       - self-study-material-completed

--- a/swagger/v1/component_schemas/NPQParticipantStartedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantStartedDeclaration.yml
@@ -8,6 +8,7 @@ properties:
     example: db3a7848-7308-4879-942a-c4a70ced400a
   declaration_type:
     description: "The event declaration type"
+    type: string
     enum:
       - started
       - completed
@@ -18,6 +19,8 @@ properties:
     format: date-time
     example: 2021-05-31T02:21:32Z
   course_type:
+    description: "The type of course the participant is enrolled in"
+    type: string
     enum:
       - npq-leading-teaching
       - npq-leading-teaching-development

--- a/swagger/v1/component_schemas/NPQParticipantStartedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantStartedDeclaration.yml
@@ -1,0 +1,38 @@
+description: "An NPQ participant declaration"
+type: object
+properties:
+  participant_id:
+    description: "The unique id of the participant"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type:
+    description: "The event declaration type"
+    enum:
+      - started
+      - completed
+    example: started
+  declaration_date:
+    description: "The event declaration date"
+    type: string
+    format: date-time
+    example: 2021-05-31T02:21:32Z
+  course_type:
+    enum:
+      - npq-leading-teaching
+      - npq-leading-teaching-development
+      - npq-leading-behaviour-culture
+      - npq-headship
+      - npq-senior-leadership
+      - npq-executive-leadership
+    example: npq-headship
+required:
+  - participant_id
+  - declaration_type
+  - declaration_date
+  - course_type
+example:
+  participant_id: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type: started
+  declaration_date: 2021-05-31T02:21:32Z
+  course_type: npq-leading-teaching

--- a/swagger/v1/component_schemas/ParticipantDeclaration.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclaration.yml
@@ -5,3 +5,8 @@ oneOf:
   - $ref: "#/components/schemas/ECFParticipantRetainedDeclaration"
   - $ref: "#/components/schemas/NPQParticipantStartedDeclaration"
   - $ref: "#/components/schemas/NPQParticipantRetainedDeclaration"
+example:
+  participant_id: db3a7848-7308-4879-942a-c4a70ced400a
+  declaration_type: started
+  declaration_date: 2021-05-31T02:21:32Z
+  course_type: ecf-mentor

--- a/swagger/v1/component_schemas/ParticipantDeclaration.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclaration.yml
@@ -1,32 +1,7 @@
 description: "A participant declaration"
 type: object
-properties:
-  participant_id:
-    description: "The unique id of the participant"
-    type: string
-    format: uuid
-    example: db3a7848-7308-4879-942a-c4a70ced400a
-  declaration_type:
-    description: "The event declaration type"
-    type: string
-    enum:
-      - started
-      - retained_1
-      - retained_2
-      - retained_3
-      - retained_4
-      - completed
-    example: started
-  declaration_date:
-    description: "The event declaration date"
-    type: string
-    format: date-time
-    example: 2021-05-31T02:21:32Z
-required:
-  - participant_id
-  - declaration_type
-  - declaration_date
-example:
-  participant_id: db3a7848-7308-4879-942a-c4a70ced400a
-  declaration_type: started
-  declaration_date: 2021-05-31T02:21:32Z
+oneOf:
+  - $ref: "#/components/schemas/ECFParticipantStartedDeclaration"
+  - $ref: "#/components/schemas/ECFParticipantRetainedDeclaration"
+  - $ref: "#/components/schemas/NPQParticipantStartedDeclaration"
+  - $ref: "#/components/schemas/NPQParticipantRetainedDeclaration"


### PR DESCRIPTION
### Context

A decision was made to have "course_type" for ecf and npq provider declarations and also "evidence_held" for "retained-1..retained-4" declarations.

### Changes proposed in this pull request

Update to have 4 schemas to compare the declaration against:
 - course types for ecf
 - course types for npq
 - extra required field for evidence_held for each of the ecf "retained" declarations.
 - extra required field for evidence_held for each of the npq "retained" declarations.

Note that due to the schema requirement for "oneOf" this couldn't just be two with nested attributes, since that isn't a supported structure.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
