### PR TITLE
CPDRP-585: Show status in participant api

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -4,22 +4,29 @@ class ParticipantSerializer
   include JSONAPI::Serializer
 
   set_id :id
-  attributes :email, :full_name
+  attribute :email do |user|
+    if participant_active?(user)
+      user.email
+    end
+  end
+
+  attribute :full_name
 
   attributes :mentor_id do |user|
-    user&.early_career_teacher_profile&.mentor&.id
+    if participant_active?(user)
+      user.early_career_teacher_profile&.mentor&.id
+    end
   end
 
   attributes :school_urn do |user|
-    if user.early_career_teacher?
-      user.early_career_teacher_profile.school.urn
-    else
-      user.mentor_profile.school.urn
+    if participant_active?(user)
+      user.early_career_teacher_profile&.school&.urn ||
+        user.mentor_profile&.school&.urn
     end
   end
 
   attributes :participant_type do |user|
-    if user.early_career_teacher?
+    if user.early_career_teacher_profile
       :ect
     else
       :mentor
@@ -27,10 +34,17 @@ class ParticipantSerializer
   end
 
   attributes :cohort do |user|
-    if user.early_career_teacher?
-      user.early_career_teacher_profile.cohort&.start_year
-    else
-      user.mentor_profile.cohort&.start_year
+    if participant_active?(user)
+      user.early_career_teacher_profile&.cohort&.start_year ||
+        user.mentor_profile.cohort&.start_year
     end
   end
+
+  attribute :status do |user|
+    user.early_career_teacher_profile&.status || user.mentor_profile&.status
+  end
+end
+
+def participant_active?(user)
+  user.early_career_teacher_profile&.active? || user.mentor_profile&.active?
 end

--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -34,6 +34,13 @@ def generate_mentors(lead_provider, school, cohort, logger)
     end
     logger.info(" Mentor with user_id #{mentor.id} generated with #{ect_count} ECTs")
   end
+  2.times do
+    mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
+    mentor_profile = ParticipantProfile::Mentor.create!(user: mentor, school: school, cohort: cohort, status: "withdrawn")
+
+    ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
+    ParticipantProfile::ECT.create!(user: ect, school: school, cohort: cohort, mentor_profile: mentor_profile, status: "withdrawn")
+  end
   new_mentor_count = lead_provider.participant_profiles.mentors.count
   logger.info(" Before: #{existing_mentor_count} mentors, after: #{new_mentor_count}")
   new_ect_count = lead_provider.participant_profiles.ects.count

--- a/spec/docs/participants_spec.rb
+++ b/spec/docs/participants_spec.rb
@@ -13,7 +13,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_fl
     get "Retrieve multiple participants" do
       operationId :participants
       tags "participant"
-      consumes "application/json"
+      produces "application/vnd.api+json"
       security [bearerAuth: []]
 
       parameter name: :filter,
@@ -60,7 +60,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_fl
     get "Retrieve multiple participants in CSV format" do
       operationId :participants_csv
       tags "participant"
-      consumes "application/json"
+      produces "text/csv"
       security [bearerAuth: []]
 
       parameter name: :filter,

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
 
         it "has correct attributes" do
           get "/api/v1/participants"
-          expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name, :mentor_id, :school_urn, :participant_type, :cohort).exactly
+          expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name, :mentor_id, :school_urn, :participant_type, :cohort, :status).exactly
         end
 
         it "returns correct user types" do
@@ -102,7 +102,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
         end
 
         it "returns the correct headers" do
-          expect(parsed_response.headers).to match_array(%w[id email full_name mentor_id school_urn participant_type cohort])
+          expect(parsed_response.headers).to match_array(%w[id email full_name mentor_id school_urn participant_type cohort status])
         end
 
         it "returns the correct values" do

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -10,13 +10,28 @@ RSpec.describe ParticipantSerializer do
     let(:mentor_cohort) { mentor.mentor_profile.cohort }
 
     it "outputs correctly formatted serialized Mentors" do
-      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year}}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year},\"status\":\"active\"}}}"
       expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
     end
 
     it "outputs correctly formatted serialized ECTs" do
-      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year}}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year},\"status\":\"active\"}}}"
       expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
+    end
+
+    context "when the participant is withdrawn" do
+      let(:mentor) { create(:participant_profile, :mentor, status: "withdrawn").user }
+      let(:ect) { create(:participant_profile, :ect, mentor: mentor, status: "withdrawn").user }
+
+      it "outputs correctly formatted serialized Mentors" do
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":null,\"participant_type\":\"mentor\",\"cohort\":null,\"status\":\"withdrawn\"}}}"
+        expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
+      end
+
+      it "outputs correctly formatted serialized ECTs" do
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":\"#{ect.full_name}\",\"mentor_id\":null,\"school_urn\":null,\"participant_type\":\"ect\",\"cohort\":null,\"status\":\"withdrawn\"}}}"
+        expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
+      end
     end
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -255,7 +255,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active\n"
       },
       "MultipleParticipantResponse": {
         "description": "A list of participants",
@@ -279,7 +279,8 @@
                   "mentor_id": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
                   "school_urn": "106286",
                   "participant_type": "ect",
-                  "cohort": "2021"
+                  "cohort": "2021",
+                  "status": "active"
                 }
               },
               {
@@ -290,7 +291,8 @@
                   "full_name": "Martin jones",
                   "school_urn": "106286",
                   "participant_type": "mentor",
-                  "cohort": "2021"
+                  "cohort": "2021",
+                  "status": "active"
                 }
               }
             ]
@@ -346,7 +348,8 @@
           "full_name",
           "school_urn",
           "participant_type",
-          "cohort"
+          "cohort",
+          "status"
         ],
         "properties": {
           "email": {
@@ -383,6 +386,15 @@
             "description": "Which cohort this participant is associated with",
             "type": "string",
             "example": "2021"
+          },
+          "status": {
+            "description": "The status of the participant",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "withdrawn"
+            ]
           }
         }
       },
@@ -396,7 +408,8 @@
           "full_name",
           "school_urn",
           "participant_type",
-          "cohort"
+          "cohort",
+          "status"
         ],
         "properties": {
           "id": {
@@ -444,6 +457,14 @@
             "description": "Which cohort this participant is associated with",
             "type": "string",
             "example": "2021"
+          },
+          "status": {
+            "description": "The status of the participant",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active"
+            ]
           }
         }
       },

--- a/swagger/v1/component_schemas/MultipleParticipantCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleParticipantCsvResponse.yml
@@ -9,6 +9,6 @@ properties:
     items:
       $ref: "#/components/schemas/ParticipantCsvRow"
 example: |
-  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort
-  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021
-  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021
+  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status
+  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active
+  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active

--- a/swagger/v1/component_schemas/MultipleParticipantResponse.yml
+++ b/swagger/v1/component_schemas/MultipleParticipantResponse.yml
@@ -17,6 +17,7 @@ properties:
           school_urn: "106286"
           participant_type: ect
           cohort: "2021"
+          status: active
       - id: bb36d74a-68a7-47b6-86b6-1fd0d141c590
         type: participant
         attributes:
@@ -25,3 +26,4 @@ properties:
           school_urn: "106286"
           participant_type: mentor
           cohort: "2021"
+          status: active

--- a/swagger/v1/component_schemas/ParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantAttributes.yml
@@ -6,6 +6,7 @@ required:
   - school_urn
   - participant_type
   - cohort
+  - status
 properties:
   email:
     description: "The email registered for this participant"
@@ -35,3 +36,10 @@ properties:
     description: "Which cohort this participant is associated with"
     type: string
     example: "2021"
+  status:
+    description: "The status of the participant"
+    type: string
+    example: active
+    enum:
+      - active
+      - withdrawn

--- a/swagger/v1/component_schemas/ParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/ParticipantCsvRow.yml
@@ -8,6 +8,7 @@ required:
   - school_urn
   - participant_type
   - cohort
+  - status
 properties:
   id:
     description: "The unique identifier of the participant record"
@@ -46,3 +47,9 @@ properties:
     description: "Which cohort this participant is associated with"
     type: string
     example: "2021"
+  status:
+    description: "The status of the participant"
+    type: string
+    example: active
+    enum:
+      - active


### PR DESCRIPTION
### Context
CPDRP-585
Lead providers need to know when a participant is withdrawn/deleted/whatever. We tell them via a status field in the API.
Remove some other fields from withdrawn participants that don't make sense/we shouldn't share (e.g. email)
