### PR TITLE
add missing LP api paths to test

### DIFF
--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe LeadProviderApiSpecification do
   describe ".as_yaml" do
     it "includes only the expected paths" do
       paths = %w[
+        /api/v1/npq-applications
+        /api/v1/npq-applications.csv
         /api/v1/participant-declarations
         /api/v1/participants
         /api/v1/participants.csv


### PR DESCRIPTION
### Context

- Merge of #680 caused a test failure due to merge ordering

### Changes proposed in this pull request

- Add missing LP api paths to test

### Guidance to review

- None

### Testing

- Test suite should pass

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Not possible