### PR TITLE
NPQ Profile can be created with NI number

### DIFF
--- a/app/resources/api/v1/npq_profile_resource.rb
+++ b/app/resources/api/v1/npq_profile_resource.rb
@@ -14,6 +14,8 @@ module Api
                  :eligible_for_funding,
                  :funding_choice
 
+      attribute :national_insurance_number, delegate: :nino
+
       has_one :user
       has_one :npq_lead_provider
       has_one :npq_course

--- a/db/migrate/20210715085835_add_ni_number_to_npq_profiles.rb
+++ b/db/migrate/20210715085835_add_ni_number_to_npq_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNiNumberToNPQProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_profiles, :nino, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_08_125502) do
+ActiveRecord::Schema.define(version: 2021_07_15_085835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -357,6 +357,7 @@ ActiveRecord::Schema.define(version: 2021_07_08_125502) do
     t.boolean "active_alert", default: false
     t.boolean "eligible_for_funding", default: false, null: false
     t.text "funding_choice"
+    t.text "nino"
     t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
     t.index ["user_id"], name: "index_npq_profiles_on_user_id"

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
               teacher_reference_number_verified: true,
               active_alert: true,
               date_of_birth: "1990-12-13",
+              national_insurance_number: "AB123456C",
               school_urn: "123456",
               headteacher_status: "no",
               eligible_for_funding: true,
@@ -69,6 +70,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
 
         expect(validation_data.npq_lead_provider).to eql(npq_lead_provider)
         expect(validation_data.date_of_birth).to eql(Date.new(1990, 12, 13))
+        expect(validation_data.nino).to eql("AB123456C")
         expect(validation_data.teacher_reference_number).to eql("1234567")
         expect(validation_data.teacher_reference_number_verified).to be_truthy
         expect(validation_data.active_alert).to be_truthy


### PR DESCRIPTION
### Context

- For NPQ in order to better validate TRNs we need to store NI numbers against the application until they can be validated 

### Changes proposed in this pull request

- Allow NPQ endpoint to store NI number against the registration

### Guidance to review

- none

### Testing

- Test in review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Create or use existing npq api token
- Ensure user exists
- Create profile with NI number
```sh
curl -X POST -H "Authorization: Bearer TOKEN" -H "Content-Type: application/vnd.api+json" "https://ecf-review-pr-699.london.cloudapps.digital/api/v1/npq-profiles" -d '{"data":{"type":"npq_profiles","attributes":{"teacher_reference_number":"1234567","teacher_reference_number_verified":true,"date_of_birth":"1990-12-13","school_urn":"123456","headteacher_status":"no", "national_insurance_number":"AA111111A"},"relationships":{"user":{"data":{"type":"users","id":"USER_ID"}},"npq_lead_provider":{"data":{"type":"npq_lead_providers","id":"PROVIDER_ID"}},"npq_course":{"data":{"type":"npq_courses","id":"COURSE_ID"}}}}}'
```
- NI number should be set