### PR TITLE
CPDRP-622 Prevent NPQ registration from blocking ECT/mentor registration

### DIFF
--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -12,7 +12,7 @@ module Admin
                                             .ecf
                                             .select(:user_id))
                           .order(:full_name)
-                          .includes(participant_profile: %i[cohort school])
+                          .includes(participant_profiles: %i[cohort school])
     end
 
   private

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -81,7 +81,7 @@ module Schools
     end
 
     def email_already_taken?
-      User.exists?(email: email)
+      User.find_by(email: email)&.participant_profiles&.ecf&.any?
     end
 
     def type=(value)

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -9,13 +9,6 @@ class ParticipantProfile < ApplicationRecord
     withdrawn: "withdrawn",
   }
 
-  scope :mentors, -> { where(type: Mentor.name) }
-  scope :ects, -> { where(type: ECT.name) }
-
-  scope :sparsity, -> { where(sparsity_uplift: true) }
-  scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
-  scope :uplift, -> { sparsity.or(pupil_premium) }
-
   attr_reader :participant_type
 
   def ect?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_one :lead_provider, through: :lead_provider_profile
   has_one :admin_profile, dependent: :destroy
 
-  has_one :participant_profile, dependent: :destroy
+  has_many :participant_profiles, dependent: :destroy
   # TODO: Legacy associations, to be removed
   has_one :early_career_teacher_profile, class_name: "ParticipantProfile::ECT"
   has_one :mentor_profile, class_name: "ParticipantProfile::Mentor"
@@ -103,7 +103,7 @@ class User < ApplicationRecord
   }
 
   scope :is_participant, lambda {
-    includes_school.joins(:participant_profile).merge(ParticipantProfile.active)
+    includes_school.joins(:participant_profiles).merge(ParticipantProfile.active)
   }
 
   scope :in_school, lambda { |school_id|

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -27,7 +27,8 @@ private
 
   def user_can_access?(participant)
     return false unless participant.participant?
-    return false if participant.participant_profile.withdrawn?
+    # TODO: is this correct? assumes we're only looking at mentors and ECTs?
+    return false if participant.participant_profiles.ecf.first.withdrawn?
 
     user.schools.include?(participant.school)
   end

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -27,8 +27,8 @@ private
 
   def user_can_access?(participant)
     return false unless participant.participant?
-    # TODO: is this correct? assumes we're only looking at mentors and ECTs?
-    return false if participant.participant_profiles.ecf.first.withdrawn?
+    # Prevent NPQ only participants from being accessed
+    return false unless participant.participant_profiles.ecf.active.any?
 
     user.schools.include?(participant.school)
   end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -5,8 +5,14 @@ module Mentors
     include SchoolCohortDelegator
     def call
       ActiveRecord::Base.transaction do
-        # TODO: What if email matches but with different name?
-        user = User.find_or_create_by!(full_name: full_name, email: email)
+        # NOTE: This will not update the full_name if the user exists, the scenario
+        # I am working on is enabling a NPQ user to be added as a mentor
+        # Not matching on full_name means this works more smoothly for the end user
+        # and they don't get "email already in use" errors if they spell the name
+        # differently
+        user = User.find_or_create_by!(email: email) do |mentor|
+          mentor.full_name = full_name
+        end
         ParticipantProfile::Mentor.create!({ user: user }.merge(mentor_attributes))
       end
     end

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -58,6 +58,11 @@ User.find_or_create_by!(email: "school-leader@example.com") do |user|
   end
 end
 
+User.find_or_create_by!(email: "npq-registrant@example.com") do |user|
+  user.update!(full_name: "NPQ registrant")
+  ParticipantProfile::NPQ.find_or_create_by!(user: user)
+end
+
 mentor = User.find_or_create_by!(email: "rp-mentor-ambition@example.com") do |user|
   user.update!(full_name: "Sally Mentor")
   ParticipantProfile::Mentor.find_or_create_by!(user: user) do |profile|

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -36,4 +36,47 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
       end
     end
   end
+
+  describe "email_already_taken?" do
+    before do
+      subject.email = "ray.clemence@example.com"
+    end
+
+    context "when the email is not already in use" do
+      it "returns true" do
+        expect(subject).not_to be_email_already_taken
+      end
+    end
+
+    context "when the email is in use by an ECT user" do
+      before do
+        create(:user, :early_career_teacher, email: "ray.clemence@example.com")
+      end
+
+      it "returns true" do
+        expect(subject).to be_email_already_taken
+      end
+    end
+
+    context "when the email is in use by a Mentor" do
+      before do
+        create(:user, :mentor, email: "ray.clemence@example.com")
+      end
+
+      it "returns true" do
+        expect(subject).to be_email_already_taken
+      end
+    end
+
+    context "when the email is in use by a NPQ registrant" do
+      before do
+        existing_user = create(:user, email: "ray.clemence@example.com")
+        create(:participant_profile, :npq, user: existing_user)
+      end
+
+      it "returns false" do
+        expect(subject).not_to be_email_already_taken
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "associations" do
+    it { is_expected.to have_many(:participant_profiles) }
     it { is_expected.to have_one(:admin_profile) }
     it { is_expected.to have_one(:induction_coordinator_profile) }
     it { is_expected.to have_many(:schools).through(:induction_coordinator_profile) }

--- a/spec/policies/participant_policy_spec.rb
+++ b/spec/policies/participant_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ParticipantPolicy, type: :policy do
 
       context "being an induction coordinator" do
         context "when from the same school" do
-          let(:acting_user) { create(:user, :induction_coordinator, school_ids: [user_under_test.participant_profile.school_id]) }
+          let(:acting_user) { create(:user, :induction_coordinator, school_ids: [user_under_test.participant_profiles.ecf.first.school_id]) }
           it { is_expected.to permit_action(:show) }
 
           context "when the participant is withdrawn" do


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-622)
If user has registered for NPQ this prevents the same user from being added as a ECT/mentor.

### Changes proposed in this pull request
When checking if the email already exists, only check against users that are already ECTs and Mentors so we can add NPQ registrants.

### Guidance to review

### Testing
A test user has been added with a `ParticipantProfile::NPQ` and email address `npq-registrant@example.com`
Sign-in as the `school-leader@example.com` user and attempt to add a participant with the same email address as the NPQ user and it should succeed.
Attempting to add any existing ECT or Mentor should fail.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
