### PR TITLE
Fix LP association migration

### DIFF
--- a/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
+++ b/db/migrate/20210707151757_populate_lp_and_cpd_lp_assocs.rb
@@ -15,11 +15,11 @@ end
 class PopulateLpAndCpdLpAssocs < ActiveRecord::Migration[6.1]
   def up
     MigrationLeadProvider2.all.each do |lp|
-      lp.update!(cpd_lead_provider: MigrationCpdLeadProvider2.find_by(name: lp.name))
+      lp.update!(cpd_lead_provider_id: MigrationCpdLeadProvider2.find_by(name: lp.name)&.id)
     end
 
     MigrationNPQLeadProvider2.all.each do |lp|
-      lp.update!(cpd_lead_provider: MigrationCpdLeadProvider2.find_by(name: lp.name))
+      lp.update!(cpd_lead_provider_id: MigrationCpdLeadProvider2.find_by(name: lp.name)&.id)
     end
   end
 


### PR DESCRIPTION
This would otherwise break because there's no association on the temporary model to translate it to the _id column.