### PR TITLE
different feature flag for NPQ applications api

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,6 +17,7 @@ class FeatureFlag
 
   # Short-lived feature flags
   TEMPORARY_FEATURE_FLAGS = %i[
+    npq_applications_api
     participant_data_api
     induction_tutor_manage_participants
     admin_participants

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index create]
       resources :dqt_records, only: :show, path: "dqt-records"
       resources :participant_validation, only: :show, path: "participant-validation"
-      resources :npq_applications, only: :index, path: "npq-applications", constraints: ->(_request) { FeatureFlag.active?(:participant_data_api) }
+      resources :npq_applications, only: :index, path: "npq-applications", constraints: ->(_request) { FeatureFlag.active?(:npq_applications_api) }
 
       jsonapi_resources :npq_profiles, only: [:create]
 

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_flags: { participant_data_api: "active" } do
+describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_flags: { npq_applications_api: "active" } do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "csv"
 
-RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { participant_data_api: "active" } do
+RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { npq_applications_api: "active" } do
   describe "GET /api/v1/npq-applications" do
     let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
     let(:npq_lead_provider) { create(:npq_lead_provider) }


### PR DESCRIPTION
### Context

- At the moment NPQ applications api endpoint shares the same feature flag as the participant data
- We want to split these so the features can be toggled independently

### Changes proposed in this pull request

- Use different feature flag for NPQ applications api endpoint

### Guidance to review

- none

### Testing

- Toggle feature flag on `npq_applications_api`
- Should be able to hit the endpoint
- Toggle feature flag off `npq_applications_api`
- Should no longer be able to hit api endpoint

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Not sure how feature flag are set in the review apps