### PR TITLE
delete feature flag for NPQ applications api

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index create]
       resources :dqt_records, only: :show, path: "dqt-records"
       resources :participant_validation, only: :show, path: "participant-validation"
-      resources :npq_applications, only: :index, path: "npq-applications", constraints: ->(_request) { FeatureFlag.active?(:participant_data_api) }
+      resources :npq_applications, only: :index, path: "npq-applications"
 
       jsonapi_resources :npq_profiles, only: [:create]
 

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_flags: { participant_data_api: "active" } do
+describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "csv"
 
-RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { participant_data_api: "active" } do
+RSpec.describe "NPQ Applications API", type: :request do
   describe "GET /api/v1/npq-applications" do
     let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
     let(:npq_lead_provider) { create(:npq_lead_provider) }
@@ -149,16 +149,6 @@ RSpec.describe "NPQ Applications API", type: :request, with_feature_flags: { par
         get "/api/v1/npq-applications"
         expect(response.status).to eq 403
       end
-    end
-  end
-end
-
-RSpec.describe "NPQ Applications API without feature flag", type: :request do
-  describe "GET /api/v1/npq-applications" do
-    it "does not route" do
-      expect {
-        get "/api/v1/npq-applications"
-      }.to raise_error(ActionController::RoutingError)
     end
   end
 end


### PR DESCRIPTION
### Context

- Feature flag for NPQ applications api endpoint is no longer needed

### Changes proposed in this pull request

- Delete feature flag around NPQ applications endpoint

### Guidance to review

- none

### Testing

- Same as review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Disable feature flag `participant_data_api`
- API endpoint should continue to be available