### PR TITLE
change npq applications api use course identifers

### DIFF
--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -13,12 +13,10 @@ class NPQApplicationSerializer
              :headteacher_status,
              :eligible_for_funding,
              :funding_choice,
-             :course_id,
-             :course_name
+             :course_identifier
 
   attribute(:participant_id, &:user_id)
   attribute(:teacher_reference_number_validated, &:teacher_reference_number_verified)
-  attribute(:course_id, &:npq_course_id)
 
   attribute(:full_name) do |object|
     object.user.full_name
@@ -32,7 +30,7 @@ class NPQApplicationSerializer
     true
   end
 
-  attribute(:course_name) do |object|
-    object.npq_course.name
+  attribute(:course_identifier) do |object|
+    object.npq_course.identifier
   end
 end

--- a/db/migrate/20210716120023_add_identifier_to_npq_course.rb
+++ b/db/migrate/20210716120023_add_identifier_to_npq_course.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIdentifierToNPQCourse < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_courses, :identifier, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_085835) do
+ActiveRecord::Schema.define(version: 2021_07_16_120023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -333,6 +333,7 @@ ActiveRecord::Schema.define(version: 2021_07_15_085835) do
     t.text "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "identifier"
   end
 
   create_table "npq_lead_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -39,12 +39,12 @@ PrivacyPolicy.find_or_initialize_by(major_version: 1, minor_version: 0)
 end
 
 [
-  { name: "NPQ Leading Teaching (NPQLT)", id: "15c52ed8-06b5-426e-81a2-c2664978a0dc" },
-  { name: "NPQ Leading Behaviour and Culture (NPQLBC)", id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" },
-  { name: "NPQ Leading Teacher Development (NPQLTD)", id: "29fee78b-30ce-4b93-ba21-80be2fde286f" },
-  { name: "NPQ for Senior Leadership (NPQSL)", id: "a42736ad-3d0b-401d-aebe-354ef4c193ec" },
-  { name: "NPQ for Headship (NPQH)", id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768" },
-  { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
+  { name: "NPQ Leading Teaching (NPQLT)", id: "15c52ed8-06b5-426e-81a2-c2664978a0dc", identifier: "npq-leading-teaching" },
+  { name: "NPQ Leading Behaviour and Culture (NPQLBC)", id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5", identifier: "npq-leading-behaviour-culture" },
+  { name: "NPQ Leading Teacher Development (NPQLTD)", id: "29fee78b-30ce-4b93-ba21-80be2fde286f", identifier: "npq-leading-teaching-development" },
+  { name: "NPQ for Senior Leadership (NPQSL)", id: "a42736ad-3d0b-401d-aebe-354ef4c193ec", identifier: "npq-senior-leadership" },
+  { name: "NPQ for Headship (NPQH)", id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768", identifier: "npq-headship" },
+  { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a", identifier: "npq-executive-leadership" },
 ].each do |hash|
   NPQCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
 end

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -87,8 +87,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                            headteacher_status
                            eligible_for_funding
                            funding_choice
-                           course_id
-                           course_name
+                           course_identifier
                          ],
                          properties: {
                            id: { type: :string },
@@ -108,8 +107,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                              type: :string,
                              enum: %w[school trust self another],
                            },
-                           course_id: { type: :string },
-                           course_name: { type: :string },
+                           course_identifier: { type: :string },
                          },
                        },
                      },

--- a/spec/factories/npq_courses.rb
+++ b/spec/factories/npq_courses.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :npq_course do
     sequence(:name) { |n| "NPQ Course #{n}" }
+    sequence(:identifier) { |n| "npq-course-#{n}" }
   end
 end

--- a/spec/factories/npq_validation_data.rb
+++ b/spec/factories/npq_validation_data.rb
@@ -8,5 +8,7 @@ FactoryBot.define do
 
     headteacher_status { NPQValidationData.headteacher_statuses.keys.sample }
     funding_choice { NPQValidationData.funding_choices.keys.sample }
+    school_urn { rand(100_000..999_999).to_s }
+    teacher_reference_number { rand(1_000_000..9_999_999).to_s }
   end
 end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -59,8 +59,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
           expect(parsed_response["data"][0]["attributes"]["eligible_for_funding"]).to eql(profile.eligible_for_funding)
 
-          expect(parsed_response["data"][0]["attributes"]["course_id"]).to eql(profile.npq_course_id)
-          expect(parsed_response["data"][0]["attributes"]["course_name"]).to eql(profile.npq_course.name)
+          expect(parsed_response["data"][0]["attributes"]["course_identifier"]).to eql(profile.npq_course.identifier)
         end
 
         it "can return paginated data" do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -134,8 +134,7 @@
                               "headteacher_status",
                               "eligible_for_funding",
                               "funding_choice",
-                              "course_id",
-                              "course_name"
+                              "course_identifier"
                             ],
                             "properties": {
                               "id": {
@@ -183,10 +182,7 @@
                                   "another"
                                 ]
                               },
-                              "course_id": {
-                                "type": "string"
-                              },
-                              "course_name": {
+                              "course_identifier": {
                                 "type": "string"
                               }
                             }


### PR DESCRIPTION
### Context

- We better improve data communication with provider and when providers callback with declaration use identifiers for NPQ courses instead of uuids

### Changes proposed in this pull request

- Add human and machine readable identifiers for NPQ courses
- Use this in the NPQ applications API
- Providers can then use this identifier later as part of the declarations API to identify courses

### Guidance to review

- There will be a small break in the continuity of service for api users when the identifier data is missing in the sandbox environment. This will be updated by hand shortly afterwards which seems acceptable in my books 

### Testing

- See review app instructions

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Add identifiers to courses
- Create some NPQ applications
- Hit the end endpoint
- Should get some responses with the newly added course identifiers