### PR TITLE
CPDTP-342 Skip mock login for unknown email instead of raising

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -81,7 +81,8 @@ private
     email = params.dig(:user, :email)
     return unless TEST_DOMAINS.any? { |domain| email.include?(domain) }
 
-    user = User.find_by_email(email)
+    user = User.find_by_email(email) || return
+
     sign_in(user, scope: :user)
     redirect_to profile_dashboard_path(user)
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,7 @@ class Users::SessionsController < Devise::SessionsController
     harrischaffordhundred.org.uk
     llse.org.uk
     realgroup.co.uk
-    teacherdevelopmenttrust.org 
+    teacherdevelopmenttrust.org
     uclconsultants.com
   ].freeze
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Users::Sessions", type: :request do
     context "unknown whitelisted email" do
       let(:test_email) { "not-in-the-database@example.com" }
 
-      it "redirects to the dashboard" do
+      it "renders the login_email_sent template" do
         post "/users/sign_in", params: { user: { email: test_email } }
         expect(response).to render_template(:login_email_sent) # falls back to prod behaviour
       end
@@ -116,7 +116,7 @@ RSpec.describe "Users::Sessions", type: :request do
       let(:test_email) { "admin@some.other.example.com" }
 
       context "using a non-production enviromment" do
-        it "redirects to the dashboard" do
+        it "renders the login_email_sent template" do
           post "/users/sign_in", params: { user: { email: test_email } }
           expect(response).to render_template(:login_email_sent) # falls back to prod behaviour
         end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -67,29 +67,59 @@ RSpec.describe "Users::Sessions", type: :request do
     end
   end
 
-  describe "Mock login" do
-    let(:test_email) { "admin@example.com" }
-
+  describe "Valid mock login" do
     before do
       user.update!(email: test_email)
       allow(Rails).to receive(:env).and_return ActiveSupport::EnvironmentInquirer.new(environment.to_s)
     end
 
-    context "using a non-production enviromment" do
-      let(:environment) { :sandbox }
+    context "admin email" do
+      let(:test_email) { "admin@example.com" }
+
+      context "using a non-production enviromment" do
+        let(:environment) { :sandbox }
+
+        it "redirects to the dashboard" do
+          post "/users/sign_in", params: { user: { email: test_email } }
+          expect(response).to redirect_to "/dashboard"
+        end
+      end
+
+      context "using a production environment" do
+        let(:environment) { :production }
+
+        it "renders the login_email_sent template" do
+          post "/users/sign_in", params: { user: { email: test_email } }
+          expect(response).to render_template(:login_email_sent)
+        end
+      end
+    end
+  end
+
+  describe "Invalid mock logins" do
+    let(:environment) { :sandbox }
+
+    before do
+      allow(Rails).to receive(:env).and_return ActiveSupport::EnvironmentInquirer.new(environment.to_s)
+    end
+
+    context "unknown whitelisted email" do
+      let(:test_email) { "not-in-the-database@example.com" }
 
       it "redirects to the dashboard" do
         post "/users/sign_in", params: { user: { email: test_email } }
-        expect(response).to redirect_to "/dashboard"
+        expect(response).to render_template(:login_email_sent) # falls back to prod behaviour
       end
     end
 
-    context "using a production environment" do
-      let(:environment) { :production }
+    context "email domain not in the whitelist" do
+      let(:test_email) { "admin@some.other.example.com" }
 
-      it "renders the login_email_sent template" do
-        post "/users/sign_in", params: { user: { email: test_email } }
-        expect(response).to render_template(:login_email_sent)
+      context "using a non-production enviromment" do
+        it "redirects to the dashboard" do
+          post "/users/sign_in", params: { user: { email: test_email } }
+          expect(response).to render_template(:login_email_sent) # falls back to prod behaviour
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Resolves an exception seen on sandbox environment when entering in an unknown email address with a domain that is in the `TEST_DOMAINS` list into `/users/sign_in`.

https://sentry.io/organizations/dfe-bat/issues/2509940522/

### Changes proposed in this pull request

Skip mock login for unknown email instead of raising

### Guidance to review

:ship: