### PR TITLE
CPDRP-637 Change email check to allow NPQ registrants

### DIFF
--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -19,9 +19,7 @@ class NominateInductionTutorForm
   end
 
   def email_already_taken?
-    User.left_outer_joins(:induction_coordinator_profile)
-        .where(induction_coordinator_profile: { id: nil })
-        .exists?(email: email)
+    ParticipantProfile.ecf.joins(:user).where(user: { email: email }).any?
   end
 
   def name_different?

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -18,7 +18,9 @@ class CreateInductionTutor < BaseService
 
         user.induction_coordinator_profile.schools << school
       else
-        user = User.create!(full_name: full_name, email: email)
+        user = User.find_or_create_by!(email: email) do |user|
+          user.full_name = full_name
+        end
         InductionCoordinatorProfile.create!(user: user, schools: [school])
       end
 

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -18,8 +18,8 @@ class CreateInductionTutor < BaseService
 
         user.induction_coordinator_profile.schools << school
       else
-        user = User.find_or_create_by!(email: email) do |user|
-          user.full_name = full_name
+        user = User.find_or_create_by!(email: email) do |induction_tutor|
+          induction_tutor.full_name = full_name
         end
         InductionCoordinatorProfile.create!(user: user, schools: [school])
       end

--- a/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
+++ b/spec/cypress/integration/nominations/NominateInductionCoordinator.feature
@@ -56,7 +56,7 @@ Feature: Nominate induction tutor
     And the page should be accessible
     And percy should be sent snapshot called "Start nominations name different"
 
-    Given user was created with email "different-user-type@example.com"
+    Given user was created as "early_career_teacher" with email "different-user-type@example.com"
     When I click on "link" containing "Change the name"
     And I type "John Wick" into "name input"
     And I type "different-user-type@example.com" into "email input"

--- a/spec/forms/nominate_induction_tutor_form_spec.rb
+++ b/spec/forms/nominate_induction_tutor_form_spec.rb
@@ -13,8 +13,16 @@ RSpec.describe NominateInductionTutorForm, type: :model do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
     it { is_expected.to validate_presence_of(:email).with_message("Enter an email") }
 
-    it "validates that the email address is not in use by a different user type" do
-      create(:user, email: email)
+    it "validates that the email address is not in use by a mentor" do
+      create(:user, :mentor, email: email)
+      form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
+      expect(form).not_to be_valid
+      expect(form.errors[:email].first).to eq("This email address is already in use")
+      expect(form.email_already_taken?).to be_truthy
+    end
+
+    it "validates that the email address is not in use by an ECT" do
+      create(:user, :early_career_teacher, email: email)
       form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
       expect(form).not_to be_valid
       expect(form.errors[:email].first).to eq("This email address is already in use")
@@ -23,6 +31,14 @@ RSpec.describe NominateInductionTutorForm, type: :model do
 
     it "allows the email to be in use by an induction tutor" do
       create(:user, :induction_coordinator, full_name: name, email: email)
+      form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
+      expect(form).to be_valid
+    end
+
+    it "allows the email to be in use by a NPQ registrant" do
+      npq_user = create(:user, full_name: name, email: email)
+      create(:participant_profile, :npq, user: npq_user)
+
       form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
       expect(form).to be_valid
     end

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -164,8 +164,8 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
       end
     end
 
-    context "when a different user type already exists with the provided email" do
-      let!(:existing_user) { create(:user, email: email) }
+    context "when an ECT user already exists with the provided email" do
+      let!(:existing_user) { create(:user, :early_career_teacher, email: email) }
 
       it "redirects to the email-used page" do
         expect {
@@ -177,6 +177,39 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
         }.not_to(change { User.count })
 
         expect(response).to redirect_to("/nominations/email-used")
+      end
+    end
+
+    context "when a Mentor user already exists with the provided email" do
+      let!(:existing_user) { create(:user, :mentor, email: email) }
+
+      it "redirects to the email-used page" do
+        expect {
+          post "/nominations", params: { nominate_induction_tutor_form: {
+            full_name: name,
+            email: email,
+            token: token,
+          } }
+        }.not_to(change { User.count })
+
+        expect(response).to redirect_to("/nominations/email-used")
+      end
+    end
+
+    context "when a NPQ registrant already exists with that email address" do
+      let(:existing_user) { create(:user, email: email) }
+      let!(:npq_profile) { create(:participant_profile, :npq, user: existing_user) }
+
+      it "adds an induction tutor profile to the existing user" do
+        expect {
+          post "/nominations", params: { nominate_induction_tutor_form: {
+            full_name: name,
+            email: email,
+            token: token,
+          } }
+        }.not_to change { User.count }
+
+        expect(existing_user.schools).to match_array [nomination_email.school]
       end
     end
   end


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-637)
When nominating an induction tutor, allow an existing user who is an NPQ registrant
See also #703 

### Changes proposed in this pull request
Change the email in use check to allow NPQ registrants.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
