### PR TITLE
Add school cohorts step 1: add the field and shadow it on the models

### DIFF
--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class ParticipantProfile::ECT < ParticipantProfile
+  belongs_to :school_cohort, optional: true
+  belongs_to :school
+  belongs_to :cohort
+
   belongs_to :mentor_profile, class_name: "Mentor", optional: true
   has_one :mentor, through: :mentor_profile, source: :user
 
-  belongs_to :cohort
-  belongs_to :school, optional: false
   belongs_to :core_induction_programme, optional: true
 
   def ect?
@@ -14,5 +16,9 @@ class ParticipantProfile::ECT < ParticipantProfile
 
   def participant_type
     :ect
+  end
+
+  before_save do |profile|
+    profile.school_cohort = SchoolCohort.find_by(school: profile.school, cohort: profile.cohort)
   end
 end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -3,14 +3,16 @@
 class ParticipantProfile::Mentor < ParticipantProfile
   self.ignored_columns = %i[mentor_profile_id]
 
+  belongs_to :school_cohort, optional: true
+  belongs_to :school
+  belongs_to :cohort
+
   has_many :mentee_profiles,
            class_name: "ParticipantProfile::ECT",
            foreign_key: :mentor_profile_id,
            dependent: :nullify
   has_many :mentees, through: :mentee_profiles, source: :user
 
-  belongs_to :cohort
-  belongs_to :school, optional: false
   belongs_to :core_induction_programme, optional: true
 
   def mentor?
@@ -19,5 +21,9 @@ class ParticipantProfile::Mentor < ParticipantProfile
 
   def participant_type
     :mentor
+  end
+
+  before_save do |profile|
+    profile.school_cohort = SchoolCohort.find_by(school: profile.school, cohort: profile.cohort)
   end
 end

--- a/db/migrate/20210715091827_add_school_cohort_to_participant_profile.rb
+++ b/db/migrate/20210715091827_add_school_cohort_to_participant_profile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSchoolCohortToParticipantProfile < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :participant_profiles, :school_cohort, null: true, type: :uuid, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20210715091828_add_foreign_key_school_cohort_participant_profile.rb
+++ b/db/migrate/20210715091828_add_foreign_key_school_cohort_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddForeignKeySchoolCohortParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :participant_profiles, :school_cohorts, column: :school_cohort_id, null: true, validate: false
+  end
+end

--- a/db/migrate/20210715091829_validate_foreign_key_school_cohort_participant_profile.rb
+++ b/db/migrate/20210715091829_validate_foreign_key_school_cohort_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateForeignKeySchoolCohortParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :participant_profiles, :school_cohorts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_085835) do
+ActiveRecord::Schema.define(version: 2021_07_15_091829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -409,9 +409,11 @@ ActiveRecord::Schema.define(version: 2021_07_15_085835) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "status", default: "active", null: false
+    t.uuid "school_cohort_id"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"
+    t.index ["school_cohort_id"], name: "index_participant_profiles_on_school_cohort_id"
     t.index ["school_id"], name: "index_participant_profiles_on_school_id"
     t.index ["user_id"], name: "index_participant_profiles_on_user_id"
   end
@@ -653,6 +655,7 @@ ActiveRecord::Schema.define(version: 2021_07_15_085835) do
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
   add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
+  add_foreign_key "participant_profiles", "school_cohorts"
   add_foreign_key "participant_profiles", "schools"
   add_foreign_key "participant_profiles", "users"
   add_foreign_key "participation_records", "lead_providers"


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDRP-545

### Changes proposed in this pull request

Add optional school_cohort field to participant profiles. Shadow it on ECT and Mentor models. 

I will need to get it deployed, and run a script to populate the school_cohort. Something like `ParticipantProfile.ecf.each { |record| record.save }` should do the trick. And I should do it in every environment. 