### PR TITLE
return course_identifier in npq applications csv

### DIFF
--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -34,8 +34,7 @@ private
       headteacher_status
       eligible_for_funding
       funding_choice
-      course_id
-      course_name
+      course_identifier
     ]
   end
 
@@ -52,8 +51,7 @@ private
       record.headteacher_status,
       record.eligible_for_funding,
       record.funding_choice,
-      record.npq_course_id,
-      record.npq_course.name,
+      record.npq_course.identifier,
     ]
   end
 end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -111,10 +111,27 @@ RSpec.describe "NPQ Applications API", type: :request do
               headteacher_status
               eligible_for_funding
               funding_choice
-              course_id
-              course_name
+              course_identifier
             ],
           )
+        end
+
+        it "returns correct data" do
+          profile = npq_lead_provider.npq_profiles[0]
+          row = parsed_response[0]
+
+          expect(row["id"]).to eql(profile.id)
+          expect(row["participant_id"]).to eql(profile.user.id)
+          expect(row["full_name"]).to eql(profile.user.full_name)
+          expect(row["email"]).to eql(profile.user.email)
+          expect(row["email_validated"]).to eql("true")
+          expect(row["teacher_reference_number"]).to eql(profile.teacher_reference_number)
+          expect(row["teacher_reference_number_validated"]).to eql(profile.teacher_reference_number_verified.to_s)
+          expect(row["school_urn"]).to eql(profile.school_urn)
+          expect(row["headteacher_status"]).to eql(profile.headteacher_status)
+          expect(row["eligible_for_funding"]).to eql(profile.eligible_for_funding.to_s)
+          expect(row["funding_choice"]).to eql(profile.funding_choice)
+          expect(row["course_identifier"]).to eql(profile.npq_course.identifier)
         end
       end
     end


### PR DESCRIPTION
### Context

- We improve data communication with providers and when providers callback with declaration use identifiers for NPQ courses instead of uuids
- This change was applied to the JSON endpoint but the CSV one was forgotten

### Changes proposed in this pull request

- In the NPQ application csv api endpoint we return course identifiers instead of course uuids and names

### Guidance to review

- Related to https://github.com/DFE-Digital/early-careers-framework/pull/710 however this applies the same change to the CSV api endpoint

### Testing

- See review app instructions

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Add identifiers to courses
- Create some NPQ applications
- Hit the end CSV api endpoint
- Should get some responses with the newly added course identifiers