### PR TITLE
CPDTP-324 Change rake task for payment breakdown to generate csv output

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -10,6 +10,8 @@ class ParticipantDeclaration < ApplicationRecord
   scope :for_declaration, ->(declaration_type) { where(declaration_type: declaration_type) }
   scope :started, -> { for_declaration("started").order(declaration_date: "desc").unique_id }
   scope :uplift, -> { joins(:profile_declaration).merge(ProfileDeclaration.uplift) }
+  scope :ect, -> { joins(:profile_declaration).merge(ProfileDeclaration.ect_profiles) }
+  scope :mentor, -> { joins(:profile_declaration).merge(ProfileDeclaration.mentor_profiles) }
   scope :unique_id, -> { select(:user_id).distinct }
   scope :active_for_lead_provider, ->(lead_provider) { started.for_lead_provider(lead_provider).unique_id }
 
@@ -18,6 +20,8 @@ class ParticipantDeclaration < ApplicationRecord
   scope :submitted_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
 
   # Declaration aggregation scopes
+  scope :count_active_ects_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).ect.count }
+  scope :count_active_mentors_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).mentor.count }
   scope :count_active_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).count }
   scope :count_active_uplift_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).uplift.count }
 end

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -2,6 +2,7 @@
 
 require "payment_calculator/ecf/payment_calculation"
 require "payment_calculator/ecf/uplift_calculation"
+require "tasks/payment_breakdown"
 require "terminal-table"
 
 include ActiveSupport::NumberHelper
@@ -9,11 +10,6 @@ include ActiveSupport::NumberHelper
 namespace :payment_calculation do
   desc "run payment calculator for a given lead provider"
   task breakdown: :environment do
-    logger = Logger.new($stdout)
-    logger.formatter = proc do |_severity, _datetime, _progname, msg|
-      "#{msg}\n"
-    end
-
     lead_provider = begin
                       LeadProvider.find(ARGV[1])
                     rescue StandardError
@@ -21,65 +17,37 @@ namespace :payment_calculation do
                     end
     raise "Unknown lead provider: #{ARGV[1]}" if lead_provider.nil?
 
-    total_participants = (ARGV[2] || ParticipantEventAggregator.call({ lead_provider: lead_provider })).to_i
-    uplift_participants = (ARGV[3] || ParticipantUpliftAggregator.call({ lead_provider: lead_provider })).to_i
-    per_participant_in_bands = lead_provider.call_off_contract.bands.each_with_index.map { |b, i| "£#{b.per_participant.to_i} per participant in #{band_name_from_index(i)}" }.join(", ")
-
-    breakdown = PaymentCalculator::Ecf::PaymentCalculation.call(
-      contract: lead_provider.call_off_contract,
-      total_participants: total_participants,
-      uplift_participants: uplift_participants,
-      event_type: :started,
-    )
-
-    service_fees = breakdown.dig(:service_fees).each_with_object([]) do |hash, bands|
-      bands << [
-        band_name_from_index(bands.length),
-        "£#{number_to_delimited(hash[:service_fee_per_participant].to_i)}",
-        "£#{number_to_delimited(hash[:service_fee_monthly].to_i)}",
-      ]
-    end
-
-    output_payments = breakdown.dig(:output_payments).each_with_object([]) do |hash, bands|
-      bands << [
-        band_name_from_index(bands.length),
-        "£#{number_to_delimited(hash.dig(:started, :per_participant).to_i)}",
-        "£#{number_to_delimited(hash.dig(:started, :subtotal).to_i)}",
-      ]
-    end
-
-    uplift_payment = breakdown[:uplift].each_with_object({}) do |(type, value), hash|
-      hash[type] = "£#{number_to_delimited(value.to_i)}"
-    end
-
-    table = Terminal::Table.new(
-      title: "Started Event Payments",
-      headings: ["", "Service fee\nPer Participant", "Service fee\nThis month"],
-      rows: service_fees,
-    )
-    table.style = { alignment: :center }
-    table.add_separator
-    table.add_row ["", "Output price", "Output price"]
-    table.add_row ["", "Per Participant", "Sub-total"]
-    table.add_separator
-    output_payments.each { |row| table.add_row(row) }
-    table.add_separator
-    table.add_row ["", "Per participant", "Total Uplift"]
-    table.add_separator
-    table.add_row(["Uplift", uplift_payment[:per_participant], uplift_payment[:sub_total]])
-
-    output = <<~RESULT
-      Based on #{number_to_delimited(total_participants.to_i)} participants and #{per_participant_in_bands}
-    RESULT
-    logger.info table
-    logger.info output
+    total_participants = (ARGV[2] || ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_for_lead_provider })).to_i
+    uplift_participants = (ARGV[3] || ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_uplift_for_lead_provider })).to_i
+    total_ects = (ARGV[2].present? ? ARGV[2].to_i / 2 : ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_ects_for_lead_provider }))
+    total_mentors = (ARGV[2].present? ? ARGV[2].to_i - ARGV[2].to_i / 2 : ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_mentors_for_lead_provider }))
+    Tasks::PaymentBreakdown.new(contract: lead_provider.call_off_contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors).to_table
   rescue StandardError => e
-    logger.error e.message
+    puts e.message
+    puts e.backtrace
   ensure
     exit
   end
-end
 
-def band_name_from_index(index)
-  "Band #{('A'..'Z').to_a[index]}"
+  desc "generate csv payment calculations for all lead providers"
+  task csv: :environment do
+    filename = (ARGV[1] || "output.csv")
+    lead_providers = LeadProvider.all
+    CSV.open(filename, "wb") do |csv|
+      csv << Tasks::PaymentBreakdown.new(contract: lead_providers.first.call_off_contract, total_participants: 0, uplift_participants: 0).csv_headings
+      lead_providers.each do |lead_provider|
+        contract = lead_provider.call_off_contract
+        total_participants = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_for_lead_provider }).to_i
+        uplift_participants = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_uplift_for_lead_provider }).to_i
+        total_ects = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_ects_for_lead_provider })
+        total_mentors = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_mentors_for_lead_provider })
+        csv << Tasks::PaymentBreakdown.new(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors).csv_body
+      end
+    end
+  rescue StandardError => e
+    puts e.message
+    puts e.backtrace
+  ensure
+    exit
+  end
 end

--- a/lib/tasks/payment_breakdown.rb
+++ b/lib/tasks/payment_breakdown.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+module Tasks
+  class PaymentBreakdown
+    attr_accessor :total_participants, :uplift_participants, :contract, :total_ects, :total_mentors, :service_fee_calculator, :output_calculator, :uplift_calculator
+    delegate :bands, :recruitment_target, to: :contract
+
+    class << self
+      def call(contract:, total_participants:, uplift_participants:, total_ects: 0, total_mentors: 0)
+        new(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors)
+      end
+    end
+
+    def initialize(contract:, total_participants:, uplift_participants:, total_ects: 0, total_mentors: 0)
+      @contract = contract
+      @total_participants = total_participants
+      @uplift_participants = uplift_participants
+      @total_ects = total_ects
+      @total_mentors = total_mentors
+      @logger = set_up_logger
+      @service_fee_calculator = PaymentCalculator::Ecf::ServiceFeesForBand.new({ contract: contract })
+      @output_calculator = PaymentCalculator::Ecf::OutputPaymentAggregator.new({ contract: contract })
+      @uplift_calculator = PaymentCalculator::Ecf::UpliftCalculation.new({ contract: contract })
+    end
+
+    def set_up_logger
+      Logger.new($stdout).tap do |logger|
+        logger.formatter = proc do |_severity, _datetime, _progname, msg|
+          "#{msg}\n"
+        end
+      end
+    end
+
+    def service_fee_per_participant(band)
+      service_fee_calculator.send(:service_fee_per_participant, band)
+    end
+
+    def service_fee_monthly(band)
+      service_fee_calculator.send(:service_fee_monthly, band)
+    end
+
+    def output_payment_per_participant(band)
+      output_calculator.send(:output_payment_per_participant_for_event, { band: band, event_type: :started })
+    end
+
+    def output_payment_total(band)
+      output_calculator.send(:output_payment_for_event, { band: band, event_type: :started, total_participants: total_participants })
+    end
+
+    # Output helper methods
+    def index_to_heading(number)
+      ("a".."c").to_a[number]
+    end
+
+    def lead_provider_name
+      @contract.lead_provider.name
+    end
+
+    def as_financial(&blk)
+      "£#{number_to_delimited(number_to_rounded(blk.call, precision: 2))}"
+    end
+
+    # Table generator methods
+    def to_table
+      @logger.info headings_table
+      @logger.info service_fee_table
+      @logger.info output_payment_table
+      @logger.info other_fees_table
+    end
+
+    def headings_table
+      Terminal::Table.new do |t|
+        t.title = "Payment breakdown"
+        t.rows = [
+          ["Provider", lead_provider_name],
+          %w[Milestone Started],
+          ["Recruitment target", recruitment_target],
+          ["Current ECTs", total_ects],
+          ["Current mentors", total_mentors],
+          ["Current participants", total_participants],
+        ]
+      end
+    end
+
+    def service_fee_table
+      Terminal::Table.new do |t|
+        t.title = "Service fee"
+        t.headings = ["Band", "Number of Participants", "Payment amount per person", "Payment amount monthly"]
+        t.rows = (0..2).map do |row|
+          band = contract.bands[row]
+          [
+            index_to_heading(row).upcase,
+            band.number_of_participants_in_this_band(recruitment_target),
+            as_financial { service_fee_per_participant(band) },
+            as_financial { service_fee_monthly(band) },
+          ]
+        end
+        t.style = { alignment: :left }
+      end
+    end
+
+    def output_payment_table
+      Terminal::Table.new do |t|
+        t.title = "Output fee"
+        t.headings = ["Band", "Number of Participants", "Payment amount per person", "Payment amount for period"]
+        t.rows = (0..2).map do |row|
+          band = contract.bands[row]
+          [
+            ("A".."C").to_a[row],
+            band.number_of_participants_in_this_band(total_participants),
+            as_financial { output_payment_per_participant(band) },
+            as_financial { output_payment_total(band) },
+          ]
+        end
+        t.style = { alignment: :left }
+      end
+    end
+
+    def other_fees_table
+      Terminal::Table.new do |t|
+        t.title = "Other fees"
+        t.headings = ["Fee", "Number of Participants", "Payment amount per person", "Payment amount for period"]
+        t.rows = [
+          [
+            "Uplift fee",
+            uplift_participants,
+            uplift_calculator.uplift_payment_per_participant,
+            uplift_calculator.uplift_payment_for_event(uplift_participants: uplift_participants, event_type: :started),
+          ],
+        ]
+        t.style = { alignment: :left }
+      end
+    end
+
+    # CSV generator methods
+    def csv_headings
+      summary_headings + service_fee_headings + output_payment_headings + other_fees_headings
+    end
+
+    def csv_body
+      summary_values + service_fee_values + output_payment_values + other_fees_values
+    end
+
+    def summary_headings
+      %w[provider milestone target participants ects mentors band_a band_b band_c]
+    end
+
+    def summary_values
+      [lead_provider_name, "started", recruitment_target, total_participants, total_ects, total_mentors, bands[0].number_of_participants_in_this_band(total_participants), bands[1].number_of_participants_in_this_band(total_participants), bands[2].number_of_participants_in_this_band(total_participants)]
+    end
+
+    def service_fee_headings
+      (0..2).map { |row|
+        ["band_#{index_to_heading(row)}_per_participant_service_fee", "band_#{index_to_heading(row)}_service_fee_amount"]
+      }.flatten
+    end
+
+    def service_fee_values
+      contract.bands.map { |band|
+        [service_fee_per_participant(band), service_fee_monthly(band)]
+      }.flatten
+    end
+
+    def output_payment_headings
+      (0..2).map { |row|
+        ["band_#{index_to_heading(row)}_per_participant_output_payment", "band_#{index_to_heading(row)}_output_amount"]
+      }.flatten
+    end
+
+    def output_payment_values
+      contract.bands.map { |band|
+        [output_payment_per_participant(band), output_payment_total(band)]
+      }.flatten
+    end
+
+    def other_fees_headings
+      %w[uplift_participants uplift_fee_per_participant uplift_fee_for_period]
+    end
+
+    def other_fees_values
+      [uplift_participants, uplift_calculator.uplift_payment_per_participant, uplift_calculator.uplift_payment_for_event(uplift_participants: uplift_participants, event_type: :started)]
+    end
+  end
+end


### PR DESCRIPTION
### Context

We were asked if our current rake task could be made to generate a csv file as a demonstrator. This updates the output and adds in the CSV headings and body to do so.

### Changes proposed in this pull request

Change structure of Rake task to make it easier to maintain, by creating a small class which will perform calls into the calculator for those portions of the calculations that we need. Note that this may actually drive how the calculator works in the future, so is probably a good thing even if it's just used in the rake task.
Add in aggregation scopes for ECTs and mentors.
Change the large single table into smaller tables which are more like the proposed layout for Payment Breakdown in any case.
Add in CSV generation. This is almost certainly going to be temporary code, but does actually interrogate the database and pulls back real numbers.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
