### PR TITLE
configure DQT in sandbox

### DIFF
--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -58,6 +58,10 @@ Rails.application.configure do
   config.gias_api_user = ENV["GIAS_API_USER"]
   config.gias_api_password = Rails.application.credentials.GIAS_API_PASSWORD
 
+  config.dqt_client_api_key = Rails.application.credentials.DQT_CLIENT_API_KEY
+  config.dqt_client_host = Rails.application.credentials.DQT_CLIENT_HOST
+  config.dqt_client_params = Rails.application.credentials.DQT_CLIENT_PARAMS
+
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {


### PR DESCRIPTION
### Context

- DQT has not been configured correctly in sandbox

### Changes proposed in this pull request

- Pass needed config to dqt client in sandbox

### Guidance to review

- none

### Testing

- n/a

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Not possible