### PR TITLE
Allow admin users to impersonate induction coordinators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rails", "~> 6.1.3", ">= 6.1.3.2"
 # User management and rbac
 gem "devise", ">= 4.7.3"
 gem "paper_trail"
+gem "pretender"
 gem "pundit"
 
 # Error and performance monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,8 @@ GEM
     percy-capybara (5.0.0)
       capybara (>= 3)
     pg (1.2.3)
+    pretender (0.3.4)
+      actionpack (>= 4.2)
     protobuf-cucumber (3.10.8)
       activesupport (>= 3.2)
       middleware
@@ -596,6 +598,7 @@ DEPENDENCIES
   paper_trail
   percy-capybara
   pg (>= 0.18, < 2.0)
+  pretender
   pry-byebug
   puma (~> 5.3, >= 5.3.1)
   pundit

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -12,6 +12,6 @@ class Admin::BaseController < ApplicationController
 private
 
   def ensure_admin
-    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.admin?
+    raise Pundit::NotAuthorizedError, "Forbidden" unless true_user.admin?
   end
 end

--- a/app/controllers/admin/impersonates_controller.rb
+++ b/app/controllers/admin/impersonates_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Admin
+  class ImpersonatesController < Admin::BaseController
+    skip_after_action :verify_policy_scoped
+
+    before_action :load_user, only: [:create]
+    before_action :check_self_impersonation, only: [:create]
+    before_action :check_admin_user_impersonation, only: [:create]
+    before_action { authorize @user, policy_class: ImpersonationPolicy }
+
+    def create
+      impersonate_user(@user)
+
+      redirect_to after_sign_in_path_for(@user)
+    end
+
+    def destroy
+      stop_impersonating_user
+      redirect_to after_sign_in_path_for(current_user)
+    end
+
+  private
+
+    def load_user
+      @user = User.find(params[:impersonated_user_id])
+    end
+
+    def check_self_impersonation
+      if params[:impersonated_user_id] == current_user.id.to_s
+        flash[:warning] = "You cannot impersonate yourself"
+        redirect_to(after_sign_in_path_for(current_user))
+      end
+    end
+
+    def check_admin_user_impersonation
+      if @user.admin?
+        flash[:warning] = "You cannot impersonate another admin user"
+        redirect_to(after_sign_in_path_for(current_user))
+      end
+    end
+
+    def pundit_user
+      true_user
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+  impersonates :user
+
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :previous_url_for_cookies_page, except: :check
   before_action :check_privacy_policy_accepted, except: :check
@@ -22,8 +24,8 @@ private
     end
   end
 
-  def after_sign_in_path_for(user)
-    stored_location_for(user) || helpers.profile_dashboard_path(user)
+  def after_sign_in_path_for(_user)
+    stored_location_for(current_user) || helpers.profile_dashboard_path(current_user)
   end
 
   def after_sign_out_path_for(_user)
@@ -46,6 +48,9 @@ protected
 
   def check_privacy_policy_accepted
     return if current_user.blank?
+
+    # Impersonators should not accept policies
+    return if current_user != true_user
 
     policy = PrivacyPolicy.current
     return if policy.nil?

--- a/app/policies/impersonation_policy.rb
+++ b/app/policies/impersonation_policy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ImpersonationPolicy < ApplicationPolicy
+  def create?
+    admin_only && !self_impersonation && !admin_impersonation
+  end
+
+  def destroy?
+    admin_only && !self_impersonation && !admin_impersonation
+  end
+
+  class Scope < Scope
+    def resolve
+      return scope.all if user.admin?
+
+      scope.none
+    end
+  end
+
+private
+
+  def self_impersonation
+    @record&.id == user.id
+  end
+
+  def admin_impersonation
+    @record&.admin?
+  end
+end

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -3,6 +3,17 @@
 <h1 class="govuk-heading-xl"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
 <h2 class="govuk-heading-l">Overview</h2>
+
+<% if @induction_coordinator && ImpersonationPolicy.new(current_user, @induction_coordinator).create? %>
+  <%= govuk_button_to('Impersonate induction tutor',
+                      admin_impersonate_path,
+                      params: {
+                        impersonated_user_id: @induction_coordinator.id,
+                      },
+                      method: :post,
+                      "data-test": "impersonate-button")  %>
+<% end %>
+
 <table class="govuk-table">
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -124,6 +124,22 @@
       </div>
     </div>
 
+    <% if current_user != true_user %>
+      <div class="govuk-width-container">
+    <%= render GovukComponent::NotificationBanner.new(title: 'Important', classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-5', html_attributes: { data: { test: "notification-banner"} }) do |banner| %>
+          <p class="govuk-notification-banner__heading">
+            You are impersonating <%= link_to current_user.full_name %> (<%= current_user.email %>)
+          </p>
+
+          <%= govuk_button_to('Stop impersonating',
+              admin_impersonate_path,
+              method: :delete,
+              class: 'govuk-!-margin-bottom-1',
+              "data-test": "stop-impersonating-button") %>
+        <% end %>
+      </div>
+    <% end %>
+
     <%= yield %>
 
     <footer class="govuk-footer " role="contentinfo">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
         end
       end
     end
+    resource :impersonate, only: %i[create destroy]
 
     namespace :gias do
       resources :home, only: :index, path: "/"

--- a/spec/cypress/integration/admin/SchoolManagment.feature
+++ b/spec/cypress/integration/admin/SchoolManagment.feature
@@ -12,6 +12,7 @@ Feature: Admin user managing schools
     And "page body" should contain "Include this school"
     And "page body" should contain "Sarah Smith"
     And "page body" should contain "Test local authority"
+    And "page body" should contain "Impersonate induction tutor"
     And the page should be accessible
 
   Scenario: Viewing a school's cohorts
@@ -44,3 +45,12 @@ Feature: Admin user managing schools
     Then "page body" should contain "123456"
     And "page body" should contain "Include this school"
     And the table should have 1 row
+  
+  Scenario: Impersonating an induction tutor
+    When I click on "link" containing "Include this school"
+    Then I should be on "admin school overview" page
+    When I click on "impersonate button"
+    Then "notification banner" should contain "You are impersonating Sarah Smith"
+    And "notification banner" should contain "Stop impersonating"
+    When I click on "stop impersonating button"
+    Then I should be on "admin schools" page

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -37,6 +37,8 @@ const buttons = {
   "back button": '.govuk-button:contains("Back")',
   "create supplier user button": '.govuk-button:contains("Add a new user")',
   "search button": "[data-test=search-button]",
+  "impersonate button": "[data-test=impersonate-button]",
+  "stop impersonating button": "[data-test=stop-impersonating-button]",
   "remove button": ".govuk-button[value=Remove]",
 };
 

--- a/spec/policies/impersonation_policy_spec.rb
+++ b/spec/policies/impersonation_policy_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ImpersonationPolicy, type: :policy do
+  subject { described_class.new(acting_user, user_under_test) }
+
+  let(:user_under_test) { create(:user) }
+
+  context "being an admin" do
+    let(:acting_user) { create(:user, :admin) }
+
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:destroy) }
+
+    context "and attempting to impersonate its own record" do
+      subject { described_class.new(acting_user, acting_user) }
+
+      it "does not allow deletion" do
+        expect(subject.create?).to eq false
+      end
+    end
+
+    context "and attempting to impersonate another admin" do
+      let(:another_admin) { create(:user, :admin) }
+      subject { described_class.new(acting_user, another_admin) }
+
+      it "does not allow deletion" do
+        expect(subject.create?).to eq false
+      end
+    end
+  end
+
+  context "not being an admin" do
+    let(:acting_user) { create(:user) }
+
+    it { is_expected.to forbid_action(:create) }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+end

--- a/spec/requests/admin/impersonates_spec.rb
+++ b/spec/requests/admin/impersonates_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Participants", type: :request do
+  let(:admin_user) { create(:user, :admin) }
+  let(:other_admin_user) { create(:user, :admin) }
+  let(:cohort) { create(:cohort) }
+  let!(:user) { create(:user, :induction_coordinator) }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "POST /admin/impersonate" do
+    it "sets impersonation session" do
+      when_i_impersonate(user)
+      expect(session[:impersonated_user_id]).to eql(user.id.to_s)
+    end
+
+    it "redirects to impersonated user start page" do
+      when_i_impersonate(user)
+      expect(response).to redirect_to(advisory_schools_choose_programme_path(user.school))
+    end
+
+    it "errors if you impersonate yourself" do
+      when_i_impersonate(admin_user)
+      expect(response).to redirect_to "/admin/schools"
+      expect(flash[:warning]).to eql("You cannot impersonate yourself")
+    end
+
+    it "errors if you impersonate an admin" do
+      when_i_impersonate(other_admin_user)
+      expect(response).to redirect_to "/admin/schools"
+      expect(flash[:warning]).to eql("You cannot impersonate another admin user")
+    end
+  end
+
+  describe "DELETE /admin/impersonate" do
+    before do
+      when_i_impersonate(user)
+    end
+
+    it "clears impersonation session" do
+      when_i_stop_impersonating(user)
+      expect(session[:impersonated_user_id]).to be_blank
+    end
+
+    it "redirects to support user start page" do
+      when_i_stop_impersonating(user)
+      expect(response).to redirect_to("/admin/schools")
+    end
+  end
+
+private
+
+  def when_i_impersonate(user)
+    post "/admin/impersonate", params: {
+      impersonated_user_id: user&.id,
+    }
+  end
+
+  def when_i_stop_impersonating(user)
+    delete "/admin/impersonate", params: {
+      impersonated_user_id: user&.id,
+    }
+  end
+end


### PR DESCRIPTION
### Context

- Allow admin users to impersonate induction coordinators
- I haven't placed any limitations on the impersonation side as to the type of user it can impersonate. That is, it will accept any user ID that is not the impersonator or another admin user. It should just work.
- The dependent gem is relatively straight forward but is well maintained and tested with devise.

<img width="1312" alt="Screenshot 2021-07-20 at 12 03 40" src="https://user-images.githubusercontent.com/31316/126313597-008d9264-8407-4667-813e-3bb5d6ce9bda.png">
<img width="1312" alt="Screenshot 2021-07-20 at 12 03 44" src="https://user-images.githubusercontent.com/31316/126313606-37abe312-6b94-445a-a659-056c719bff46.png">
