### PR TITLE
Replace strip with squish

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,7 +113,7 @@ class User < ApplicationRecord
 private
 
   def strip_whitespace
-    full_name&.strip!
-    email&.strip!
+    full_name&.squish!
+    email&.squish!
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "before_validation" do
-    let(:user) { build(:user, full_name: "\t  Gordon Banks \n", email: " \tgordo@example.com \n ") }
+    let(:user) { build(:user, full_name: "\t  Gordon \tBanks \n", email: " \tgordo@example.com \n ") }
 
     it "strips whitespace from :full_name" do
       user.valid?


### PR DESCRIPTION
### Context
There are 120 users in the service with embedded tabs in their name. We currently strip leading/trailing whitespace from the user's name and email, if we use `squish!` instead of `strip!` then it will also handle these too.

### Changes proposed in this pull request
Change `strip!` to `squish!` in the `before_validation` callback for the `User` model

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
