### PR TITLE
Spin up a very basic version of multipage flow for 2020

### DIFF
--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Schools
+  class Year2020Controller < ApplicationController
+    include Pundit
+
+    before_action :authenticate_user!
+    before_action :ensure_school_user
+    before_action :set_paper_trail_whodunnit
+    after_action :verify_authorized
+
+    layout "school_cohort"
+
+    include Multistep::Controller
+
+    skip_after_action :verify_authorized
+    before_action :set_school_cohort
+
+    form Year2020Form, as: :year_2020_form
+    result as: :participant_profile
+
+    abandon_journey_path do
+      schools_dashboard_path
+    end
+
+    setup_form do |form|
+      form.school_cohort_id = @school_cohort.id
+      form.current_user_id = current_user.id
+    end
+
+  private
+
+    def email_used_in_the_same_school?
+      User.find_by(email: year_2020_form.email).school == year_2020_form.school_cohort.school
+    end
+
+    helper_method :email_used_in_the_same_school?
+
+    def ensure_school_user
+      raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.induction_coordinator?
+
+      authorize(active_school, :show?) if active_school.present?
+    end
+
+    def active_school
+      return if params[:school_id].blank?
+
+      School.friendly.find(params[:school_id])
+    end
+
+    def active_cohort
+      Cohort.find_or_create_by!(start_year: 2020) # QQQQ Add
+    end
+
+    def set_school_cohort
+      @school = active_school
+      @cohort = active_cohort
+
+      @school_cohort = SchoolCohort.find_or_create_by!(
+        cohort: @cohort,
+        school: @school,
+        induction_programme_choice: "core_induction_programme",
+      )
+    end
+  end
+end

--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -24,8 +24,7 @@ module Schools
     end
 
     setup_form do |form|
-      form.school_cohort_id = @school_cohort.id
-      form.current_user_id = current_user.id
+      form.school_id = @school.id
     end
 
   private
@@ -49,18 +48,12 @@ module Schools
     end
 
     def active_cohort
-      Cohort.find_or_create_by!(start_year: 2020) # QQQQ Add
+      Cohort.find_by(start_year: 2020)
     end
 
     def set_school_cohort
       @school = active_school
       @cohort = active_cohort
-
-      @school_cohort = SchoolCohort.find_or_create_by!(
-        cohort: @cohort,
-        school: @school,
-        induction_programme_choice: "core_induction_programme",
-      )
     end
   end
 end

--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Schools
+  class Year2020Form
+    include ActiveModel::Model
+    include Multistep::Form
+
+    attribute :school_cohort_id
+    attribute :current_user_id
+    attribute :participant_type
+
+    step :start do
+      next_step do
+        :select_cip
+      end
+    end
+    # QQQQ let users quit forever in this step
+
+    step :select_cip do
+      attribute :core_induction_programme_id
+
+      validates :core_induction_programme_id, presence: true
+
+      next_step do
+        :details
+      end
+    end
+
+    step :details do
+      attribute :full_name
+      attribute :email
+
+      validates :full_name, presence: true
+
+      validates :email,
+                presence: true,
+                notify_email: { allow_blank: true }
+
+      next_step do
+        if email_already_taken?
+          :email_taken
+        else
+          :confirm
+        end
+      end
+    end
+
+    step :email_taken
+
+    step :confirm
+
+    def email_already_taken?
+      User.exists?(email: email)
+    end
+
+    def school_cohort
+      @school_cohort ||= SchoolCohort.find_by(id: school_cohort_id)
+    end
+
+    def current_user
+      @current_user ||= User.find_by(id: current_user_id)
+    end
+
+    def save!
+      EarlyCareerTeachers::Create.call(
+        full_name: full_name,
+        email: email,
+        cohort_id: school_cohort.cohort_id,
+        school_id: school_cohort.school_id,
+        mentor_profile_id: nil,
+      )
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -20,6 +20,7 @@ class FeatureFlag
     participant_data_api
     induction_tutor_manage_participants
     admin_participants
+    year_2020_data_entry
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/views/schools/year2020/complete.html.erb
+++ b/app/views/schools/year2020/complete.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Teacher or mentor added" %>
+
+<% if participant_profile.user == current_user %>
+  <%= govuk_panel title: "You have been added to the #{@cohort.display_name} cohort", body: nil, classes: "govuk-!-margin-bottom-8" %>
+
+  <h2 class="govuk-heading-m">What happens next</h2>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>we will contact you if we need anymore details and update you on your status</li>
+  </ul>
+
+<% else %>
+  <%= govuk_panel title: "You have added #{participant_profile.user.full_name} to the #{@cohort.display_name} cohort", body: nil, classes: "govuk-!-margin-bottom-8" %>
+
+  <h2 class="govuk-heading-m">What happens next</h2>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>we will verify their Qualified Teacher Status (QTS) and eligibility for induction</li>
+    <li>we will alert you if there are any issues or if we need any further information</li>
+    <li>you can also view your early career teachers (ECTs) and mentors to see their status (pending, approved or rejected)</li>
+  </ul>
+<% end %>
+
+<div class="govuk-button-group">
+  <%= govuk_link_to "Go to your dashboard", schools_dashboard_path %>
+</div>

--- a/app/views/schools/year2020/confirm.html.erb
+++ b/app/views/schools/year2020/confirm.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, "Confirm these details" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Confirm these details</h1>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Details
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <div><%= year_2020_form.full_name %></div>
+          <div><%= year_2020_form.email %></div>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
+          <%= govuk_link_to({ action: :show, step: "details" }, button: false) do %>
+            Change <span class="govuk-visually-hidden">personal details</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+
+<!--    QQQQ Add another participant, display more participants -->
+
+    <%= form_for year_2020_form, url: { action: :complete }, method: :post do |f| %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/details.html.erb
+++ b/app/views/schools/year2020/details.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Enter details to confirm" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @school.name %>, <%= @cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Add a participant</h1>
+
+    <%= form_for year_2020_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_email_field :email,
+                              label: { text: "Email address" },
+                              hint: { text: "You can use their personal or work email address" }
+      %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/email_taken.html.erb
+++ b/app/views/schools/year2020/email_taken.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, "Email used" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if email_used_in_the_same_school? %>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-7">This email has already been added</h1>
+
+      <p class="govuk-body">This email address has already been used to add an early career teacher or mentor.</p>
+    <% else %>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-7">This email is being used by someone at another school</h1>
+
+      <p class="govuk-body govuk-!-margin-bottom-7">Contact them directly to check whether they need to be transferred to your school.</p>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/select_cip.erb
+++ b/app/views/schools/year2020/select_cip.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Add early career teacher - choose CIP" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @school.name %>, <%= @cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Which training materials do you want this cohort to use?</h1>
+
+    <%= form_for year_2020_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons :core_induction_programme_id,
+                                           CoreInductionProgramme.all,
+                                           :id,
+                                           :name,
+                                           legend: { text: false} %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/start.erb
+++ b/app/views/schools/year2020/start.erb
@@ -1,0 +1,14 @@
+<% content_for :title, "Add early career teacher" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @school.name %>, <%= @cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Hello world!</h1>
+
+    <%= form_for year_2020_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,12 @@ Rails.application.routes.draw do
         get :success
       end
 
+      resources :year_2020, path: "year-2020", only: [] do
+        collection do
+          multistep_form :add, Schools::Year2020Form, controller: :year2020
+        end
+      end
+
       resources :cohorts, only: :show, param: :cohort_id do
         member do
           resources :partnerships, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,7 +227,7 @@ Rails.application.routes.draw do
         get :success
       end
 
-      resources :year_2020, path: "year-2020", only: [] do
+      resources :year_2020, path: "year-2020", only: [], constraints: ->(_request) { FeatureFlag.active?(:year_2020_data_entry) } do
         collection do
           multistep_form :add, Schools::Year2020Form, controller: :year2020
         end

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+Cohort.find_or_create_by!(start_year: 2020)
 cohort_2021 = Cohort.find_or_create_by!(start_year: 2021)
 
 ambition_cip = CoreInductionProgramme.find_or_create_by!(name: "Ambition Institute")

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when the email is not already in use" do
-      it "returns true" do
+      it "returns false" do
         expect(subject).not_to be_email_already_taken
       end
     end

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::Year2020Form, type: :model do
+  let!(:school) { create :school }
+  let!(:cohort) { create :cohort, start_year: 2020 }
+  let!(:core_induction_programme) { create :core_induction_programme }
+
+  subject { described_class.new(school_id: school.id) }
+
+  it { is_expected.to validate_presence_of(:full_name).on(:details) }
+  it { is_expected.to validate_presence_of(:email).on(:details) }
+
+  describe "email_already_taken?" do
+    before do
+      subject.email = "ray.clemence@example.com"
+    end
+
+    context "when the email is not already in use" do
+      it "returns false" do
+        expect(subject).not_to be_email_already_taken
+      end
+    end
+
+    context "when the email is in use by an ECT user" do
+      it "returns true" do
+        create(:user, :early_career_teacher, email: "ray.clemence@example.com")
+        expect(subject).to be_email_already_taken
+      end
+    end
+
+    context "when the email is in use by a Mentor" do
+      it "returns true" do
+        create(:user, :mentor, email: "ray.clemence@example.com")
+        expect(subject).to be_email_already_taken
+      end
+    end
+
+    context "when the email is in use by a NPQ registrant" do
+      it "returns false" do
+        existing_user = create(:user, email: "ray.clemence@example.com")
+        create(:participant_profile, :npq, user: existing_user)
+        expect(subject).not_to be_email_already_taken
+      end
+    end
+  end
+
+  describe "save!" do
+    it "creates a school cohort and user when given all details" do
+      subject.full_name = "Test User"
+      subject.email = "ray.clemence@example.com"
+      subject.core_induction_programme_id = core_induction_programme.id
+      subject.school_id = school.id
+
+      subject.save!
+      school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+
+      expect(school_cohort).not_to be_nil
+      expect(school_cohort.ecf_participants.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### Context

More of an exploratory experience - figuring out how far we can push the multistep form, what we can save, what screens make sense, etc. I would not merge it, the PR is mostly for the review app. 

### How can I view this in a review app?
Sign in as `school-leader@example.com`.
Go to `/schools/999999-example-school/year-2020/add` in the url.

Known things to address:
1. 'Opt out' somewhere, perhaps the first page.
2. Multiple participants.
3. Multiple schools.
3. Saving data correctly.
4. Hide behind a feature flag?
4. Tests.