### PR TITLE
Scope API tokens for access to participants API

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -24,7 +24,7 @@ module Api
     private
 
       def access_scope
-        LeadProviderApiToken.all
+        LeadProviderApiToken.joins(cpd_lead_provider: [:lead_provider])
       end
 
       def to_csv(hash)

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -157,5 +157,17 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
         expect(response.status).to eq 403
       end
     end
+
+    context "when using LeadProviderApiToken with only NPQ access" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider, lead_provider: nil) }
+      let(:npq_lead_provider) { create(:npq_lead_provider) }
+      let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+
+      it "returns 403" do
+        default_headers[:Authorization] = bearer_token
+        get "/api/v1/participants"
+        expect(response.status).to eq 403
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- This fix is in response to https://sentry.io/organizations/dfe-bat/issues/2519946117/?environment=sandbox&project=5748989&query=is%3Aunresolved
- This prevents API tokens not associated to an ECF provider such as NPQ only lead providers from accessing the participants API

### Changes proposed in this pull request

- Scope API token to only those with an (ECF) `LeadProvider` to be able to access the participants API

### Guidance to review

- Existing API access should not be broken and there should be continuity of service

### Testing

- Create or use an existing `CpdLeadProvder` that has a `NPQLeadProvider` but not an (ECF) `LeadProvider`
- This will mimic a NPQ only lead provider
- Create a `LeadProviderApiToken` associated to this `CpdLeadProvider`
- Attempt to access the participants api endpoint
- Should receive a 403 and not an unexpected error

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Probably easier locally, but the same instructions for local testing should apply here