### PR TITLE
CPDTP-329 Add in model validations for participant_declarations

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -5,6 +5,9 @@ class ParticipantDeclaration < ApplicationRecord
   belongs_to :cpd_lead_provider
   belongs_to :user
 
+  validates :course_identifier, inclusion: { in: :valid_courses }
+  validates :course_identifier, :user, :cpd_lead_provider, :declaration_date, :declaration_type, presence: true
+
   # Helper scopes
   scope :for_lead_provider, ->(cpd_lead_provider) { where(cpd_lead_provider: cpd_lead_provider) }
   scope :for_declaration, ->(declaration_type) { where(declaration_type: declaration_type) }

--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration::ECF < ParticipantDeclaration
+  def valid_courses
+    %w[ecf-induction ecf-mentor]
+  end
 end

--- a/app/models/participant_declaration/npq.rb
+++ b/app/models/participant_declaration/npq.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration::NPQ < ParticipantDeclaration
+  def valid_courses
+    NPQCourse.all.map(&:identifier)
+  end
 end

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -46,7 +46,7 @@ end
   { name: "NPQ for Headship (NPQH)", id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768", identifier: "npq-headship" },
   { name: "NPQ for Executive Leadership (NPQEL)", id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a", identifier: "npq-executive-leadership" },
 ].each do |hash|
-  NPQCourse.find_or_create_by!(name: hash[:name], id: hash[:id])
+  NPQCourse.find_or_create_by!(name: hash[:name], id: hash[:id], identifier: hash[:identifier])
 end
 
 all_provider_names = (LeadProvider.pluck(:name) + NPQLeadProvider.pluck(:name)).uniq

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -7,45 +7,39 @@ FactoryBot.define do
     declaration_date { Time.zone.now - 1.week }
     declaration_type { "started" }
 
+    factory :ect_participant_declaration do
+      type { "ParticipantDeclaration::ECF" }
+      course_identifier { "ecf-induction" }
+      profile_type { :early_career_teacher_profile }
+      with_profile_type
+    end
+
+    factory :mentor_participant_declaration do
+      type { "ParticipantDeclaration::ECF" }
+      course_identifier { "ecf-mentor" }
+      profile_type { :mentor_profile }
+      with_profile_type
+    end
+
+    factory :npq_participant_declaration do
+      course_identifier { NPQCourse.all.map(&:identifier).sample }
+    end
+
     trait :sparsity_uplift do
-      with_random_profile
       uplift { :sparsity_uplift }
     end
 
     trait :pupil_premium_uplift do
-      with_random_profile
       uplift { :pupil_premium_uplift }
     end
 
     trait :uplift_flags do
-      with_random_profile
       uplift { :uplift_flags }
-    end
-
-    trait :only_mentor_profile do
-      with_profile_type
-      profile_type { :mentor_profile }
-    end
-
-    trait :only_ect_profile do
-      with_profile_type
-      profile_type { :early_career_teacher_profile }
     end
 
     transient do
       uplift { :sparsity_uplift }
       profile_type { :early_career_teacher_profile }
-    end
-
-    trait :with_random_profile do
-      after(:create) do |participant_declaration, evaluator|
-        create(:profile_declaration,
-               participant_declaration: participant_declaration,
-               participant_profile: create(
-                 %i[early_career_teacher_profile mentor_profile].sample,
-                 evaluator.uplift,
-               ))
-      end
     end
 
     trait :with_profile_type do

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -16,11 +16,14 @@ RSpec.describe ParticipantDeclaration, type: :model do
         create(:participant_declaration,
                :with_profile_type,
                cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider,
-               profile_type: profile_type)
+               profile_type: profile_type,
+               course_identifier: course_identifier)
       end
 
       context "for mentor was created" do
         let(:profile_type) { :mentor_profile }
+        let(:course_identifier) { "ecf-mentor" }
+        let(:course) { :ecf_mentor }
 
         it "includes declaration with mentor profile" do
           expect(ParticipantDeclaration.uplift).to include(profile_declaration)
@@ -29,6 +32,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
 
       context "for early career teacher was created" do
         let(:profile_type) { :early_career_teacher_profile }
+        let(:course_identifier) { "ecf-induction" }
 
         it "includes declaration with mentor profile" do
           expect(ParticipantDeclaration.uplift).to include(profile_declaration)

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ParticipantDeclaration, type: :model do
       context "for mentor was created" do
         let(:profile_type) { :mentor_profile }
         let(:course_identifier) { "ecf-mentor" }
-        let(:course) { :ecf_mentor }
 
         it "includes declaration with mentor profile" do
           expect(ParticipantDeclaration.uplift).to include(profile_declaration)

--- a/spec/models/profile_declaration_spec.rb
+++ b/spec/models/profile_declaration_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe ProfileDeclaration, type: :model do
 
     describe "ect_profiles" do
       let!(:ect_declaration) do
-        create(:participant_declaration,
-               :with_profile_type,
+        create(:ect_participant_declaration,
                cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
@@ -20,10 +19,8 @@ RSpec.describe ProfileDeclaration, type: :model do
 
     describe "mentor_profiles" do
       let!(:mentor_declaration) do
-        create(:participant_declaration,
-               :with_profile_type,
-               cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider,
-               profile_type: :mentor_profile)
+        create(:mentor_participant_declaration,
+               cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "includes declaration with mentor profile" do

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(response.body).to eq({ bad_or_missing_parameters: ["The property '#/course_identifier' must be an available course to '#/participant_id'"] }.to_json)
       end
 
+      it "returns 422 when there are multiple errors" do
+        post "/api/v1/participant-declarations", params: build_params("")
+        expect(response.status).to eq 422
+        expect(response.body).to eq({ bad_or_missing_parameters: %w[participant_id declaration_date declaration_type course_identifier] }.to_json)
+      end
+
       it "returns 400 when the data block is incorrect" do
         post "/api/v1/participant-declarations", params: {}.to_json
         expect(response.status).to eq 400

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe CalculationOrchestrator do
       let(:with_uplift) { :sparsity_uplift }
 
       before do
-        create_list(:participant_declaration, 10, with_uplift, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 5, with_uplift, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:mentor_participant_declaration, 5, with_uplift, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       context "when only sparsity_uplift flag was set" do
@@ -89,7 +90,8 @@ RSpec.describe CalculationOrchestrator do
 
     context "when no uplift flags were set" do
       before do
-        create_list(:participant_declaration, 10, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 5, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, uplift: false)
+        create_list(:mentor_participant_declaration, 5, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, uplift: false)
         expected_result.tap { |hash| hash[:uplift][:sub_total] = 0.0 }
       end
 
@@ -100,7 +102,7 @@ RSpec.describe CalculationOrchestrator do
 
     context "when only mentor profile declaration records available" do
       before do
-        create_list(:participant_declaration, 10, :only_mentor_profile, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:mentor_participant_declaration, 10, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "returns the total calculation" do
@@ -110,7 +112,7 @@ RSpec.describe CalculationOrchestrator do
 
     context "when only ect profile declaration records available" do
       before do
-        create_list(:participant_declaration, 10, :only_ect_profile, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 10, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "returns the total calculation" do
@@ -120,8 +122,7 @@ RSpec.describe CalculationOrchestrator do
 
     context "when both mentor profile and ect profile declaration records available" do
       before do
-        create_list(:participant_declaration, 5, :only_ect_profile, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
-        create_list(:participant_declaration, 5, :only_ect_profile, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 10, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "returns the total calculation" do

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -128,6 +128,6 @@ RSpec.describe FeatureFlag do
 
   def random_record
     # TODO: WHY ARE SOME FACTORIES BROKEN?
-    create FactoryBot.factories.map(&:name).without(:participant_band, :pupil_premium, :declarable, :profile_declaration).sample
+    create FactoryBot.factories.map(&:name).without(:participant_band, :pupil_premium, :declarable, :profile_declaration, :participant_declaration, :npq_participant_declaration).sample
   end
 end

--- a/spec/services/participant_event_aggregator_service_spec.rb
+++ b/spec/services/participant_event_aggregator_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe ParticipantEventAggregator do
   context "event declarations" do
     before do
       10.times do
-        participant_declaration = create(:participant_declaration, cpd_lead_provider: cpd_lead_provider)
-        create(:participant_declaration, user: participant_declaration.user, cpd_lead_provider: cpd_lead_provider)
+        participant_declaration = create(:ect_participant_declaration, cpd_lead_provider: cpd_lead_provider)
+        create(:ect_participant_declaration, user: participant_declaration.user, cpd_lead_provider: cpd_lead_provider)
       end
     end
 


### PR DESCRIPTION
### Context

Now that this is using STI we can put in proper course type validations for NPQ and ECF courses.

### Changes proposed in this pull request

Inclusion validations to make sure that the correct course identifier is used for each declaration type. For NPQ it reads from the NPQCourse identifiers held in the database, so that if more courses are added, we can validate against those without having to make code changes too.
Presence validation to ensure that the required fields are passed to the model.

Factories and tests updated to ensure that correct course_identifiers are linked to the correct profile types.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
