### PR TITLE
Issue#336 Stop the cohorts_validation using break from within a validation proc

### DIFF
--- a/app/forms/delivery_partner_form.rb
+++ b/app/forms/delivery_partner_form.rb
@@ -75,10 +75,18 @@ class DeliveryPartnerForm
     end
   end
 
+  def current_lead_provider_ids
+    lead_provider_ids&.filter(&:present?)
+  end
+
+  def chosen_provider_relationships_lead_provider_ids
+    chosen_provider_relationships.pluck(:lead_provider_id)
+  end
+
 private
 
   def lead_providers_validation
-    unless lead_provider_ids&.filter(&:present?)&.any?
+    unless current_lead_provider_ids&.any?
       errors.add(:lead_provider_ids, :blank, message: "Choose at least one")
     end
   end
@@ -86,10 +94,8 @@ private
   def cohorts_validation
     # Ensure all selected lead providers have at least one selected cohort
     # This is indicated by the presence of a provider relationship for that lead provider
-    lead_provider_ids&.filter(&:present?)&.any? do |lead_provider_id|
-      unless chosen_provider_relationships.pluck(:lead_provider_id).include?(lead_provider_id)
-        errors.add(:provider_relationship_hashes, :blank, message: "Choose at least one cohort for every lead provider")
-      end
+    if (current_lead_provider_ids - chosen_provider_relationships_lead_provider_ids).any?
+      errors.add(:provider_relationship_hashes, :blank, message: "Choose at least one cohort for every lead provider")
     end
   end
 end

--- a/app/forms/delivery_partner_form.rb
+++ b/app/forms/delivery_partner_form.rb
@@ -86,10 +86,9 @@ private
   def cohorts_validation
     # Ensure all selected lead providers have at least one selected cohort
     # This is indicated by the presence of a provider relationship for that lead provider
-    lead_provider_ids&.filter(&:present?)&.each do |lead_provider_id|
+    lead_provider_ids&.filter(&:present?)&.any? do |lead_provider_id|
       unless chosen_provider_relationships.pluck(:lead_provider_id).include?(lead_provider_id)
         errors.add(:provider_relationship_hashes, :blank, message: "Choose at least one cohort for every lead provider")
-        break
       end
     end
   end


### PR DESCRIPTION
### Context

Fixes issue #336
Breaks the coverage tests since a break inside a proc is an illegal instruction.

### Changes proposed in this pull request

- Switching each to any? and dropping the break will stop after the first error is added, which was the intent.

errors.add returns the errors object, which is truthy, so will stop the loop and only add it once.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
