### PR TITLE
CPDTP-339 Add a new finance user type and give them a default URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,8 @@ module ApplicationHelper
   def profile_dashboard_path(user)
     if user.admin?
       admin_schools_path
+    elsif user.finance?
+      finance_lead_providers_path
     elsif user.induction_coordinator?
       induction_coordinator_dashboard_path(user)
     else

--- a/app/models/finance_profile.rb
+++ b/app/models/finance_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FinanceProfile < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_one :lead_provider_profile, dependent: :destroy
   has_one :lead_provider, through: :lead_provider_profile
   has_one :admin_profile, dependent: :destroy
+  has_one :finance_profile, dependent: :destroy
 
   has_many :participant_profiles, dependent: :destroy
   # TODO: Legacy associations, to be removed
@@ -25,6 +26,10 @@ class User < ApplicationRecord
 
   def admin?
     admin_profile.present?
+  end
+
+  def finance?
+    finance_profile.present?
   end
 
   def supplier_name
@@ -61,6 +66,8 @@ class User < ApplicationRecord
       "DfE admin"
     elsif induction_coordinator?
       "Induction tutor"
+    elsif finance?
+      "DfE Finance"
     elsif lead_provider?
       "Lead provider"
     elsif early_career_teacher?
@@ -86,6 +93,7 @@ class User < ApplicationRecord
   scope :induction_coordinators, -> { joins(:induction_coordinator_profile) }
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }
+  scope :finance_users, -> { joins(:finance_profile) }
 
   scope :changed_since, lambda { |timestamp|
     if timestamp.present?

--- a/app/services/create_finance_user.rb
+++ b/app/services/create_finance_user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateFinanceUser < BaseService
+  def self.call(full_name, email)
+    user = User.new(full_name: full_name, email: email)
+
+    ActiveRecord::Base.transaction do
+      user.save!
+      FinanceProfile.create!(user: user)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,10 @@ Rails.application.routes.draw do
     resources :induction_coordinators, only: %i[index edit update], path: "induction-coordinators"
   end
 
+  namespace :finance do
+    resources :lead_providers, only: %i[index]
+  end
+
   namespace :schools do
     resources :dashboard, controller: :dashboard, only: %i[index show], path: "/", param: :school_id
 

--- a/db/migrate/20210722094019_create_finance_profiles.rb
+++ b/db/migrate/20210722094019_create_finance_profiles.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateFinanceProfiles < ActiveRecord::Migration[6.1]
+  def change
+    create_table :finance_profiles do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_20_171815) do
+ActiveRecord::Schema.define(version: 2021_07_22_094019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -223,6 +223,13 @@ ActiveRecord::Schema.define(version: 2021_07_20_171815) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_features_on_name", unique: true
+  end
+
+  create_table "finance_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_finance_profiles_on_user_id"
   end
 
   create_table "friendly_id_slugs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -622,6 +629,7 @@ ActiveRecord::Schema.define(version: 2021_07_20_171815) do
   add_foreign_key "data_stage_school_links", "data_stage_schools"
   add_foreign_key "district_sparsities", "local_authority_districts"
   add_foreign_key "feature_selected_objects", "features"
+  add_foreign_key "finance_profiles", "users"
   add_foreign_key "induction_coordinator_profiles", "users"
   add_foreign_key "lead_provider_cips", "cohorts"
   add_foreign_key "lead_provider_cips", "core_induction_programmes"

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -7,6 +7,11 @@ User.find_or_create_by!(email: "admin@example.com") do |user|
   AdminProfile.find_or_create_by!(user: user)
 end
 
+User.find_or_create_by!(email: "finance@example.com") do |user|
+  user.update!(full_name: "Finance User")
+  FinanceProfile.find_or_create_by!(user: user)
+end
+
 User.find_or_create_by!(email: "lead-provider@example.com") do |user|
   user.update!(full_name: "LeadProvider User")
   LeadProviderProfile.find_or_create_by!(user: user, lead_provider: LeadProvider.first)

--- a/lib/tasks/create_finance_user.rake
+++ b/lib/tasks/create_finance_user.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+desc "Manage admin users"
+namespace :users do
+  namespace :finance do
+    desc "Create finance user"
+    task :create, %i[full_name email] => :environment do |_task, args|
+      puts "Creating finance user..."
+      CreateFinanceUser.call(args[:full_name], args[:email])
+      puts "User created."
+    end
+  end
+end

--- a/spec/factories/finance_profiles.rb
+++ b/spec/factories/finance_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :finance_profile do
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -63,5 +63,9 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :finance do
+      finance_profile
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   include Devise::Test::ControllerHelpers
 
   let(:admin_user) { create(:user, :admin) }
+  let(:finance_user) { create(:user, :finance) }
   let(:induction_coordinator) { create(:user, :induction_coordinator) }
   let(:school) { induction_coordinator.induction_coordinator_profile.schools.first }
   let!(:cohort) { create(:cohort, :current) }
@@ -13,6 +14,10 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#profile_dashboard_path" do
     it "returns the admin/schools path for admins" do
       expect(helper.profile_dashboard_path(admin_user)).to eq("/admin/schools")
+    end
+
+    it "returns the finance path for finance" do
+      expect(helper.profile_dashboard_path(finance_user)).to eq("/finance/lead_providers")
     end
 
     it "returns schools/choose-programme for induction coordinators" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:participant_profiles) }
     it { is_expected.to have_one(:admin_profile) }
+    it { is_expected.to have_one(:finance_profile) }
     it { is_expected.to have_one(:induction_coordinator_profile) }
     it { is_expected.to have_many(:schools).through(:induction_coordinator_profile) }
     it { is_expected.to have_one(:lead_provider_profile) }
@@ -60,6 +61,20 @@ RSpec.describe User, type: :model do
       user = create(:user)
 
       expect(user.admin?).to be false
+    end
+  end
+
+  describe "#finance?" do
+    it "is expected to be true when the user has a finance profile" do
+      user = create(:user, :finance)
+
+      expect(user.finance?).to be true
+    end
+
+    it "is expected to be false when the user does not have a finance profile" do
+      user = create(:user)
+
+      expect(user.finance?).to be false
     end
   end
 
@@ -260,6 +275,14 @@ RSpec.describe User, type: :model do
 
       it "returns DfE admin" do
         expect(user.user_description).to eq("DfE admin")
+      end
+    end
+
+    context "when the user is a finance user" do
+      subject(:user) { create(:user, :finance) }
+
+      it "returns DfE finance" do
+        expect(user.user_description).to eq("DfE Finance")
       end
     end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -196,6 +196,15 @@ RSpec.describe "Users::Sessions", type: :request do
       end
     end
 
+    context "when user is a finance user" do
+      let(:user) { create(:user, :finance) }
+
+      it "redirects to correct dashboard" do
+        post "/users/sign_in_with_token", params: { login_token: user.login_token }
+        expect(response).to redirect_to(finance_lead_providers_path)
+      end
+    end
+
     context "when the login_token has expired" do
       before { user.update(login_token_valid_until: 2.days.ago) }
 

--- a/spec/services/create_finance_user_spec.rb
+++ b/spec/services/create_finance_user_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe CreateFinanceUser do
+  it "Creates finance user" do
+    email = "bobby.tables@example.com"
+    described_class.call("Bobby Tables", email)
+    user = User.find_by!(email: email)
+    expect(user).to be_finance
+    expect(user).not_to be_admin
+  end
+end


### PR DESCRIPTION
### Context

These users are DfE internal users intended to be able to view payment information.

https://dfedigital.atlassian.net/browse/CPDTP-339

### Changes proposed in this pull request

* Add a new finance user type and give them default URL that they will be redirected to on login
* Add a seed finance user
* Add a rake task for creating finance users (via a service class)

This patch is largely copied from the existing admin user code.

### Guidance to review

* Rather than testing the rake task with all the stdout redirection that involves, the logic for the rake task has been pushed into a service class and that is tested instead.

### Testing

```bash
bundle exec rails users:finance:create["Marge Simpson",marge@example.com]
bundle exec rails console
> User.find_by(email: "marge@example.com").finance?
...
true
```

### How can I view this in a review app?

Sign in to https://ecf-review-pr-738.london.cloudapps.digital/ as `finance@example.com` and see the redirect to https://ecf-review-pr-738.london.cloudapps.digital/finance/lead_providers which 404's as expected until the next PR lands.