### PR TITLE
CPDTP-348 Create lead provider index page for finance users

### DIFF
--- a/app/controllers/finance/base_controller.rb
+++ b/app/controllers/finance/base_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Finance::BaseController < ApplicationController
+  include Pundit
+
+  before_action :authenticate_user!
+  before_action :ensure_finance
+
+private
+
+  def ensure_finance
+    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.finance?
+  end
+end

--- a/app/controllers/finance/lead_providers_controller.rb
+++ b/app/controllers/finance/lead_providers_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Finance::LeadProvidersController < Finance::BaseController
+  def index
+    @lead_providers = LeadProvider.all
+  end
+end

--- a/app/policies/finance_profile_policy.rb
+++ b/app/policies/finance_profile_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FinanceProfilePolicy < ApplicationPolicy
+  def index?
+    !!user&.finance?
+  end
+
+  class Scope < Scope
+    def resolve
+      return scope.all if user.finance?
+
+      scope.none
+    end
+  end
+end

--- a/app/views/finance/lead_providers/index.html.erb
+++ b/app/views/finance/lead_providers/index.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, "Lead Providers" %>
+
+<h1 class="govuk-heading-l">Lead Providers</h1>
+
+<table class="govuk-table">
+  <tbody class="govuk-table__body">
+    <% @lead_providers.each do |lead_provider| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell" data-test="lead-provider-name"><%= lead_provider.name %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,7 +218,7 @@ Rails.application.routes.draw do
   end
 
   namespace :finance do
-    resources :lead_providers, only: %i[index]
+    resources :lead_providers, only: %i[index], path: "lead-providers"
   end
 
   namespace :schools do

--- a/spec/cypress/app_commands/scenarios/finance_lead_providers.rb
+++ b/spec/cypress/app_commands/scenarios/finance_lead_providers.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+FactoryBot.create_list(:lead_provider, 5)

--- a/spec/cypress/integration/finance/Finance.feature
+++ b/spec/cypress/integration/finance/Finance.feature
@@ -1,0 +1,12 @@
+Feature: Finance user viewing finance data
+  Finance users should be able to view financial data
+
+  Background:
+    Given scenario "finance_lead_providers" has been run
+    And I am logged in as a "finance"
+
+  Scenario: Finance page should list lead provider
+    Then the table should have 5 rows
+    Then "page body" should contain "Lead Provider"
+    Then the page should be accessible
+    And percy should be sent snapshot called "Finance lead providers index page"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "returns the finance path for finance" do
-      expect(helper.profile_dashboard_path(finance_user)).to eq("/finance/lead_providers")
+      expect(helper.profile_dashboard_path(finance_user)).to eq("/finance/lead-providers")
     end
 
     it "returns schools/choose-programme for induction coordinators" do

--- a/spec/policies/finance_profile_policy_spec.rb
+++ b/spec/policies/finance_profile_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FinanceProfilePolicy, type: :policy do
+  subject { described_class.new(user, finance_profile) }
+  let(:finance_profile) { create(:finance_profile) }
+
+  context "being a finance" do
+    let(:user) { create(:user, :finance) }
+
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+  end
+
+  context "not being a finance" do
+    let(:user) { create(:user) }
+
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to forbid_action(:index) }
+  end
+end

--- a/spec/requests/finance/lead_providers_controller_spec.rb
+++ b/spec/requests/finance/lead_providers_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Lead Providers for Finance users", type: :request do
+  let(:finance_user) { create(:user, :finance) }
+  let!(:lead_providers) { create_list(:lead_provider, 5) }
+
+  before do
+    sign_in finance_user
+  end
+
+  describe "GET /finance/lead-providers" do
+    it "renders the index template" do
+      get "/finance/lead-providers"
+
+      expect(response).to render_template("finance/lead_providers/index")
+      assigns(:lead_providers).should eq(lead_providers)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Finance users should be able to land on a page showing list of providers, the follow up work will allow them to click on any of them and get price breakdown

https://dfedigital.atlassian.net/browse/CPDTP-348

### Changes proposed in this pull request

Add index page for lead providers and ability for finance users to display them

![Selection_20210723-01-6a67e6a67e6a67e](https://user-images.githubusercontent.com/19378/126778752-cc4e677d-babe-4569-b008-1096583be70e.png)


### Guidance to review

### Testing

Create finance user
Login to the web app
