### PR TITLE
CPDRP-743: Allow an existing mentor to become a induction coordinator

### DIFF
--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -19,7 +19,7 @@ class NominateInductionTutorForm
   end
 
   def email_already_taken?
-    ParticipantProfile.ecf.joins(:user).where(user: { email: email }).any?
+    ParticipantProfile.active.ects.joins(:user).where(user: { email: email }).any?
   end
 
   def name_different?

--- a/spec/forms/nominate_induction_tutor_form_spec.rb
+++ b/spec/forms/nominate_induction_tutor_form_spec.rb
@@ -13,20 +13,18 @@ RSpec.describe NominateInductionTutorForm, type: :model do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
     it { is_expected.to validate_presence_of(:email).with_message("Enter an email") }
 
-    it "validates that the email address is not in use by a mentor" do
-      create(:user, :mentor, email: email)
-      form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
-      expect(form).not_to be_valid
-      expect(form.errors[:email].first).to eq("This email address is already in use")
-      expect(form.email_already_taken?).to be_truthy
-    end
-
     it "validates that the email address is not in use by an ECT" do
       create(:user, :early_career_teacher, email: email)
       form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
       expect(form).not_to be_valid
       expect(form.errors[:email].first).to eq("This email address is already in use")
       expect(form.email_already_taken?).to be_truthy
+    end
+
+    it "allows the email to be in use by a mentor" do
+      create(:user, :mentor, email: email)
+      form = NominateInductionTutorForm.new(token: token, full_name: name, email: email)
+      expect(form).to be_valid
     end
 
     it "allows the email to be in use by an induction tutor" do

--- a/spec/requests/nominations/nominate_induction_coordinator_spec.rb
+++ b/spec/requests/nominations/nominate_induction_coordinator_spec.rb
@@ -183,16 +183,17 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
     context "when a Mentor user already exists with the provided email" do
       let!(:existing_user) { create(:user, :mentor, email: email) }
 
-      it "redirects to the email-used page" do
+      it "adds an induction tutor profile to the existing user" do
         expect {
           post "/nominations", params: { nominate_induction_tutor_form: {
             full_name: name,
             email: email,
             token: token,
           } }
-        }.not_to(change { User.count })
+        }.not_to change { User.count }
 
-        expect(response).to redirect_to("/nominations/email-used")
+        expect(existing_user.induction_coordinator_profile).not_to be_nil
+        expect(existing_user.schools).to match_array [nomination_email.school]
       end
     end
 
@@ -209,6 +210,7 @@ RSpec.describe "Nominating an induction coordinator", type: :request do
           } }
         }.not_to change { User.count }
 
+        expect(existing_user.induction_coordinator_profile).not_to be_nil
         expect(existing_user.schools).to match_array [nomination_email.school]
       end
     end


### PR DESCRIPTION
### Context
CPDRP-743
We allow induction coordinators to add themselves as mentors, this
change is to allow existing mentors to be nominated (by school) or
assigned (by admin) as an induction coordinator

### Changes proposed in this pull request
relax constraint on users who can gain an induction_coordinator_profile to include mentors

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
