### PR TITLE
service to import NPQ manual validation CSV data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,7 @@ Rails/UnknownEnv:
 
 Naming/VariableNumber:
   EnforcedStyle: snake_case
+
+Rails/Output:
+  Exclude:
+    - "app/services/importers/*"

--- a/README.md
+++ b/README.md
@@ -195,6 +195,20 @@ per participant service fee £398 (40%) >> monthly service fee £27k >> total se
 * "Output payments" are payments made based on the performance of the training provider (i.e. their output).
 * "Payment type" for start/retention_x/completion output payments.
 
+## Runbook
+
+### Updating NPQ applications from manual validation
+
+This procedure is used after a batch from manual validation has been complete. The data also needs to be uploaded to the NPQ application as it uses a different database and there is no syncing procedure in place.
+
+1. Log in to a container instance
+2. Save CSV data to disk via `vi` and remember the path
+3. Start rails console
+4. Instantiate service with `svc = Importers::NPQManualValidation.new(path_to_csv: Rails.root.join("batchX.csv"))`
+5. Call service with `svc.call`
+6. Exit rails console
+7. Delete CSV as no longer needed
+
 ## Monitoring, logging, and alerting
 ### Sentry
 We use [sentry.io](https://sentry.io/) for error tracking and performance monitoring. Ask a team member for access - this is done through digi-tools.

--- a/app/services/importers/npq_manual_validation.rb
+++ b/app/services/importers/npq_manual_validation.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Importers::NPQManualValidation
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:)
+    @path_to_csv = path_to_csv
+  end
+
+  def call
+    check_headers
+
+    rows.each do |row|
+      data = NPQValidationData.find_by(id: row["application_ecf_id"])
+
+      puts "no NPQValidationData found for #{row['application_ecf_id']}" if data.nil?
+      next if data.nil?
+
+      puts "updating trn for NPQValidationData: #{row['application_ecf_id']} with trn: #{row['validated_trn']}"
+
+      data.update!(teacher_reference_number: row["validated_trn"], teacher_reference_number_verified: true)
+    end
+  end
+
+private
+
+  def check_headers
+    unless rows.headers == %w[application_ecf_id validated_trn]
+      raise NameError, "Invalid headers"
+    end
+  end
+
+  def rows
+    @rows ||= CSV.read(path_to_csv, headers: true)
+  end
+end

--- a/spec/lib/importers/npq_manual_validation.rb
+++ b/spec/lib/importers/npq_manual_validation.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Importers::NPQManualValidation do
+  let(:profile) { create(:npq_validation_data) }
+
+  let(:file) { Tempfile.new("test.csv") }
+
+  around do |example|
+    original_stdout = $stdout
+    $stdout = File.open(File::NULL, "w")
+
+    example.run
+
+    $stdout = original_stdout
+  end
+
+  describe "#call" do
+    subject do
+      described_class.new(path_to_csv: file.path)
+    end
+
+    context "with well formed csv" do
+      before do
+        file.write("application_ecf_id,validated_trn")
+        file.write("\n")
+        file.write("123,7654321")
+        file.write("\n")
+        file.write("#{profile.id},7654321")
+        file.rewind
+      end
+
+      it "updates trn" do
+        expect {
+          subject.call
+        }.to change { profile.reload.teacher_reference_number }.to("7654321")
+      end
+
+      it "updates teacher_reference_number_verified to true" do
+        expect {
+          subject.call
+        }.to change { profile.reload.teacher_reference_number_verified }.to(true)
+      end
+    end
+
+    context "with malformed csv" do
+      before do
+        file.write("application_id,trn")
+        file.write("\n")
+        file.rewind
+      end
+
+      it "raises error" do
+        expect {
+          subject.call
+        }.to raise_error(NameError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- The automatic TRN validation at the moment is not great due to missing data
- Therefore there is currently a manual validation process in place involving CSVs
- After the manual validation has been performed the data needs to be re-imported back into the service 

### Changes proposed in this pull request

- Add CSV importer for NPQ applications

### Guidance to review

- Added new folder and therefore namespace for importers
- I suggest we start grouping the importers together at least otherwise the services folder will just become unmanageable 
- `ll app/services | grep -i "importer.rb$" | wc -l` => `4`
- I'm sure there will be other groupings in the future

### Testing

- Start rails console
- Create test NPQManualValidation records with blank or incorrect TRNs
- Create a new CSV with headers `application_ecf_id,validated_trn` 
- Populate CSV with test records and correct TRNs
- `svc = Importers::NPQManualValidation.new(path_to_csv: Rails.root.join("manual-validation.csv"))` 
- `svc.call`
- Records should now have correct TRN and marked as verified

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Probably easier locally but same instructions from testing apply here