### PR TITLE
2020 cohort: Add the first actual version of the flow.

### DIFF
--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -17,7 +17,7 @@ module Schools
     def choose_induction_programme
       render :select_induction_programme and return unless @year_2020_form.valid? :choose_induction_programme
 
-      session[SESSION_KEY] = @year_2020_form.serializable_hash
+      store_year_2020_session
       if @year_2020_form.opt_out?
         @year_2020_form.opt_out!
         redirect_to action: :no_accredited_materials
@@ -31,7 +31,7 @@ module Schools
     def choose_cip
       render :select_cip and return unless @year_2020_form.valid? :choose_cip
 
-      session[SESSION_KEY] = @year_2020_form.serializable_hash
+      store_year_2020_session
       redirect_to action: :new_teacher
     end
 
@@ -40,7 +40,7 @@ module Schools
     def create_teacher
       render :new_teacher and return unless @year_2020_form.valid? :create_teacher
 
-      session[SESSION_KEY] = @year_2020_form.serializable_hash
+      store_year_2020_session
       redirect_to action: :check
     end
 
@@ -70,6 +70,10 @@ module Schools
 
     def get_year_2020_session
       session[SESSION_KEY] || {}
+    end
+
+    def store_year_2020_session
+      session[SESSION_KEY] = @year_2020_form.serializable_hash
     end
   end
 end

--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Schools
+  class Year2020Controller < ApplicationController
+    before_action :load_year_2020_form
+    SESSION_KEY = :schools_year2020_form
+
+    def start
+      unless params[:continue]
+        session.delete(SESSION_KEY)
+        load_year_2020_form
+      end
+    end
+
+    def select_induction_programme; end
+
+    def choose_induction_programme
+      render :select_induction_programme and return unless @year_2020_form.valid? :choose_induction_programme
+
+      session[SESSION_KEY] = @year_2020_form.serializable_hash
+      if @year_2020_form.opt_out?
+        @year_2020_form.opt_out!
+        redirect_to action: :no_accredited_materials
+      else
+        redirect_to action: :select_cip
+      end
+    end
+
+    def select_cip; end
+
+    def choose_cip
+      render :select_cip and return unless @year_2020_form.valid? :choose_cip
+
+      session[SESSION_KEY] = @year_2020_form.serializable_hash
+      redirect_to action: :new_teacher
+    end
+
+    def new_teacher; end
+
+    def create_teacher
+      render :new_teacher and return unless @year_2020_form.valid? :create_teacher
+
+      session[SESSION_KEY] = @year_2020_form.serializable_hash
+      redirect_to action: :check
+    end
+
+    def check; end
+
+    def confirm
+      @year_2020_form.save!
+      redirect_to action: :success
+    end
+
+    def success; end
+
+    def no_accredited_materials; end
+
+  private
+
+    def load_year_2020_form
+      @year_2020_form = Year2020Form.new(get_year_2020_session.merge(school_id: params[:school_id]))
+      @year_2020_form.assign_attributes(year_2020_params)
+    end
+
+    def year_2020_params
+      return {} unless params.key?(:schools_year2020_form)
+
+      params.require(:schools_year2020_form).permit(:induction_programme_choice, :core_induction_programme_id, :full_name, :email)
+    end
+
+    def get_year_2020_session
+      session[SESSION_KEY] || {}
+    end
+  end
+end

--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Schools
+  class Year2020Form
+    include ActiveModel::Model
+    include ActiveModel::Serialization
+
+    attr_accessor :school_id, :induction_programme_choice, :core_induction_programme_id, :full_name, :email
+
+    validates :induction_programme_choice, presence: true, on: :choose_induction_programme
+    validates :core_induction_programme_id, presence: true, on: :choose_cip
+
+    validates :full_name, presence: true, on: :create_teacher
+    validates :email,
+              presence: true,
+              notify_email: { allow_blank: true },
+              on: :create_teacher
+
+    def attributes
+      { school_id: nil, induction_programme_choice: nil, core_induction_programme_id: nil, full_name: nil, email: nil }
+    end
+
+    def induction_programme_options
+      [
+        OpenStruct.new(id: "core_induction_programme", name: "Use DfE accredited materials"),
+        OpenStruct.new(id: "no_programme", name: "Do not participate in the programme"),
+      ]
+    end
+
+    def school
+      School.friendly.find(school_id) || School.find_by(urn: school_id)
+    end
+
+    def cohort
+      Cohort.find_by(start_year: 2020)
+    end
+
+    def opt_out?
+      induction_programme_choice == "no_programme"
+    end
+
+    def opt_out!
+      school_cohort = SchoolCohort.find_or_initialize_by(school: school, cohort: cohort)
+      school_cohort.induction_programme_choice = "no_early_career_teachers"
+      school_cohort.save!
+    end
+
+    def save!
+      ActiveRecord::Base.transaction do
+        school_cohort = SchoolCohort.find_or_initialize_by(school: school, cohort: cohort)
+        school_cohort.induction_programme_choice = "core_induction_programme"
+        school_cohort.core_induction_programme = CoreInductionProgramme.find(core_induction_programme_id)
+        school_cohort.save!
+
+        EarlyCareerTeachers::Create.call(
+          full_name: full_name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+        )
+      end
+    end
+  end
+end

--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -22,8 +22,9 @@ module Schools
 
     def induction_programme_options
       [
-        OpenStruct.new(id: "core_induction_programme", name: "Use DfE accredited materials"),
-        OpenStruct.new(id: "no_programme", name: "Do not participate in the programme"),
+        OpenStruct.new(id: "core_induction_programme", name: "Yes"),
+        OpenStruct.new(id: "design_our_own", name: "No, we will support our NQTs another way"),
+        OpenStruct.new(id: "no_early_career_teachers", name: "No, we don't have any NQTs"),
       ]
     end
 
@@ -31,17 +32,21 @@ module Schools
       School.friendly.find(school_id) || School.find_by(urn: school_id)
     end
 
+    def core_induction_programme
+      CoreInductionProgramme.find(core_induction_programme_id)
+    end
+
     def cohort
       Cohort.find_by(start_year: 2020)
     end
 
     def opt_out?
-      induction_programme_choice == "no_programme"
+      induction_programme_choice == "design_our_own" || induction_programme_choice == "no_early_career_teachers"
     end
 
     def opt_out!
       school_cohort = SchoolCohort.find_or_initialize_by(school: school, cohort: cohort)
-      school_cohort.induction_programme_choice = "no_early_career_teachers"
+      school_cohort.induction_programme_choice = induction_programme_choice
       school_cohort.save!
     end
 
@@ -49,7 +54,7 @@ module Schools
       ActiveRecord::Base.transaction do
         school_cohort = SchoolCohort.find_or_initialize_by(school: school, cohort: cohort)
         school_cohort.induction_programme_choice = "core_induction_programme"
-        school_cohort.core_induction_programme = CoreInductionProgramme.find(core_induction_programme_id)
+        school_cohort.core_induction_programme = core_induction_programme
         school_cohort.save!
 
         EarlyCareerTeachers::Create.call(

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     induction_tutor_manage_participants
     admin_participants
     admin_delete_participants
+    year_2020_data_entry
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/views/schools/year2020/check.html.erb
+++ b/app/views/schools/year2020/check.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, "Confirm these details" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Confirm these details</h1>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Details
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <div><%= @year_2020_form.full_name %></div>
+          <div><%= @year_2020_form.email %></div>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
+          <%= govuk_link_to({ action: :new_teacher }, button: false) do %>
+            Change <span class="govuk-visually-hidden">personal details</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+
+    <%= form_for @year_2020_form, url: { action: :confirm }, method: :post do |f| %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/check.html.erb
+++ b/app/views/schools/year2020/check.html.erb
@@ -1,8 +1,30 @@
 <% content_for :title, "Confirm these details" %>
 
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :new_teacher })
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Confirm these details</h1>
+    <h1 class="govuk-heading-l">Confirm details for <%= @year_2020_form.school.name %></h1>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          DfE accredited material choice
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @year_2020_form.core_induction_programme.name %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
+          <%= govuk_link_to({ action: :select_cip }, button: false) do %>
+            Change <span class="govuk-visually-hidden">material choice</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">

--- a/app/views/schools/year2020/new_teacher.html.erb
+++ b/app/views/schools/year2020/new_teacher.html.erb
@@ -1,7 +1,14 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :select_cip })
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
-    <h1 class="govuk-heading-xl">Add a participant</h1>
+    <h1 class="govuk-heading-xl">Add teachers</h1>
+    <p class="govuk-body">
+      To give your teachers access to your schools chosen materials we will need their full name and email address.
+    </p>
 
     <%= form_for @year_2020_form, url: { action: :create_teacher }, method: :put do |f| %>
       <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>

--- a/app/views/schools/year2020/new_teacher.html.erb
+++ b/app/views/schools/year2020/new_teacher.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Add a participant</h1>
+
+    <%= form_for @year_2020_form, url: { action: :create_teacher }, method: :put do |f| %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_email_field :email,
+                              label: { text: "Email address" },
+                              hint: { text: "You can use their personal or work email address" }
+      %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/no_accredited_materials.html.erb
+++ b/app/views/schools/year2020/no_accredited_materials.html.erb
@@ -1,3 +1,8 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :select_induction_programme })
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>

--- a/app/views/schools/year2020/no_accredited_materials.html.erb
+++ b/app/views/schools/year2020/no_accredited_materials.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">You have chosen not to participate</h1>
+  </div>
+</div>

--- a/app/views/schools/year2020/select_cip.erb
+++ b/app/views/schools/year2020/select_cip.erb
@@ -1,7 +1,15 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :select_induction_programme })
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
-    <h1 class="govuk-heading-xl">Which training materials do you want this cohort to use?</h1>
+    <h1 class="govuk-heading-xl">Which study materials would you like to use?</h1>
+    <p class="govuk-body">
+      You don't necessarily need to choose the material that you chose before. If you are undecided you can read the
+      <%= govuk_link_to "guidance about different materials", "/pages/core-materials-info" %>.
+    </p>
 
     <%= form_for @year_2020_form, url: { action: :choose_cip }, method: :put do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/schools/year2020/select_cip.erb
+++ b/app/views/schools/year2020/select_cip.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Which training materials do you want this cohort to use?</h1>
+
+    <%= form_for @year_2020_form, url: { action: :choose_cip }, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons :core_induction_programme_id,
+                                           CoreInductionProgramme.all,
+                                           :id,
+                                           :name,
+                                           legend: { text: false} %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/select_induction_programme.erb
+++ b/app/views/schools/year2020/select_induction_programme.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Hello world!</h1>
+
+    <%= form_for @year_2020_form, url: { action: :choose_induction_programme }, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons :induction_programme_choice,
+                                           @year_2020_form.induction_programme_options,
+                                           :id,
+                                           :name,
+                                           legend: { text: false} %>
+      <%= f.govuk_submit "Continue" %>    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/select_induction_programme.erb
+++ b/app/views/schools/year2020/select_induction_programme.erb
@@ -1,7 +1,11 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :start })
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
-    <h1 class="govuk-heading-xl">Hello world!</h1>
+    <h1 class="govuk-heading-xl">Would you like to use DfE accredited materials to support last year's NQTs?</h1>
 
     <%= form_for @year_2020_form, url: { action: :choose_induction_programme }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
@@ -10,6 +14,7 @@
                                            :id,
                                            :name,
                                            legend: { text: false} %>
-      <%= f.govuk_submit "Continue" %>    <% end %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/schools/year2020/start.erb
+++ b/app/views/schools/year2020/start.erb
@@ -1,8 +1,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
-    <h1 class="govuk-heading-xl">Hello world!</h1>
+    <h1 class="govuk-heading-xl">Access materials for last year's NQTs</h1>
 
-    <%= govuk_link_to "Continue", choose_induction_programme_schools_year_2020_path, button: true %>
+    <%= govuk_start_now_button text: "Start now", href: choose_induction_programme_schools_year_2020_path %>
+
+    <h2 class="govuk-heading-m">Before you start</h2>
+    <p class="govuk-body">
+      You should already know what DfE accredited materials you want to use. If you don't know you can
+      <%= govuk_link_to "review this guidance", "/pages/core-materials-info" %>.
+    </p>
   </div>
 </div>

--- a/app/views/schools/year2020/start.erb
+++ b/app/views/schools/year2020/start.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <span class="govuk-caption-l"><%= @year_2020_form.school.name %>, <%= @year_2020_form.cohort.display_name %> cohort</span>
+    <h1 class="govuk-heading-xl">Hello world!</h1>
+
+    <%= govuk_link_to "Continue", choose_induction_programme_schools_year_2020_path, button: true %>
+  </div>
+</div>

--- a/app/views/schools/year2020/success.html.erb
+++ b/app/views/schools/year2020/success.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "Teacher added" %>
+
+<%= govuk_panel title: "2020 cohort information saved", body: nil, classes: "govuk-!-margin-bottom-8" %>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<div class="govuk-button-group">
+  <%= govuk_link_to "Go to your dashboard", schools_dashboard_path %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,6 +235,22 @@ Rails.application.routes.draw do
         get :success
       end
 
+      resource :year_2020, path: "year-2020", controller: "year2020", only: [], constraints: ->(_request) { FeatureFlag.active?(:year_2020_data_entry) } do
+        get "start", action: :start
+
+        get "choose-induction-programme", action: :select_induction_programme
+        put "choose-induction-programme", action: :choose_induction_programme
+        get "choose-core-induction-programme", action: :select_cip
+        put "choose-core-induction-programme", action: :choose_cip
+        get "add-teacher", action: :new_teacher
+        put "add-teacher", action: :create_teacher
+        get "check-your-answers", action: :check
+        post "check-your-answers", action: :confirm
+        get "success", action: :success
+
+        get "no-accredited-materials", action: :no_accredited_materials
+      end
+
       resources :cohorts, only: :show, param: :cohort_id do
         member do
           resources :partnerships, only: :index

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+Cohort.find_or_create_by!(start_year: 2020)
 cohort_2021 = Cohort.find_or_create_by!(start_year: 2021)
 
 ambition_cip = CoreInductionProgramme.find_or_create_by!(name: "Ambition Institute")

--- a/spec/cypress/integration/schools/Year2020.feature
+++ b/spec/cypress/integration/schools/Year2020.feature
@@ -10,7 +10,7 @@ Feature: School leaders should be able to add participants
     And percy should be sent snapshot called "Year 2020 start page"
 
   Scenario: Should be able to add a new 2020 ECT participant
-    When I click on "link" containing "Continue"
+    When I click on "link" containing "Start now"
     Then I should be on "2020 programme choice" page
     And the page should be accessible
     And percy should be sent snapshot called "Year 2020 Programme Choice page"

--- a/spec/cypress/integration/schools/Year2020.feature
+++ b/spec/cypress/integration/schools/Year2020.feature
@@ -1,0 +1,39 @@
+Feature: School leaders should be able to add participants
+
+  Background:
+    Given school was created with name "Test School" and slug "test-school"
+    And cohort was created with start_year "2020"
+    And core_induction_programme was created with name "Awesome induction course"
+    And feature year_2020_data_entry is active
+    And I am on "/schools/test-school/year-2020/start" path
+    Then the page should be accessible
+    And percy should be sent snapshot called "Year 2020 start page"
+
+  Scenario: Should be able to add a new 2020 ECT participant
+    When I click on "link" containing "Continue"
+    Then I should be on "2020 programme choice" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 Programme Choice page"
+
+    When I set "programme choice radio" to "core_induction_programme"
+    And I click the submit button
+    Then I should be on "2020 cip choice" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 CIP Choice page"
+
+    When I click on "label" containing "Awesome induction course"
+    And I click the submit button
+    Then I should be on "2020 add teacher" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 add teacher page"
+
+    When I type "James Bond" into field labelled "Full name"
+    And I type "james.bond.007@secret.gov.uk" into field labelled "Email"
+    And I click the submit button
+    Then I should be on "2020 check your answers" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 check your answers page"
+
+    When I click the submit button
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 ect participant added"

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -12,6 +12,9 @@ const inputs = {
   "replace induction tutor": "input[value=replace].govuk-radios__input",
   "update induction tutor": "input[value=update].govuk-radios__input",
   "new participant type radio": '[name="schools_add_participant_form[type]"]',
+  "programme choice radio":
+    '[name="schools_year2020_form[induction_programme_choice]"]',
+  "cip radio": '[name="schools_year2020_form[induction_programme_choice]"]',
   "nominate induction tutor radio button":
     "input[value=yes].govuk-radios__input",
   "opt out of updates radio button": "input[value=no].govuk-radios__input",

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -146,7 +146,18 @@ const pagePaths = {
   "NPQ usage guide": "/lead-providers/guidance/npq-usage",
   "API release notes": "/lead-providers/guidance/release-notes",
   "API guidance support": "/lead-providers/guidance/help",
+  "2020 programme choice":
+    "/schools/:school_id/year-2020/choose-induction-programme",
+  "2020 cip choice":
+    "/schools/:school_id/year-2020/choose-core-induction-programme",
+  "2020 add teacher": "/schools/:school_id/year-2020/add-teacher",
+  "2020 check your answers": "/schools/:school_id/year-2020/check-your-answers",
+  "2020 success": "/schools/:school_id/year-2020/success",
 };
+
+Given("I am on {string} path", (path) => {
+  cy.visit(path);
+});
 
 Given("I am on {string} page", (page) => {
   const path = pagePaths[page];

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when the email is not already in use" do
-      it "returns true" do
+      it "returns false" do
         expect(subject).not_to be_email_already_taken
       end
     end

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::Year2020Form, type: :model do
+  let!(:school) { create :school }
+  let!(:cohort) { create :cohort, start_year: 2020 }
+  let!(:core_induction_programme) { create :core_induction_programme }
+
+  subject { described_class.new(school_id: school.id) }
+
+  it { is_expected.to validate_presence_of(:induction_programme_choice).on(:choose_induction_programme) }
+  it { is_expected.to validate_presence_of(:core_induction_programme_id).on(:choose_cip) }
+  it { is_expected.to validate_presence_of(:full_name).on(:create_teacher) }
+  it { is_expected.to validate_presence_of(:email).on(:create_teacher) }
+
+  describe "save!" do
+    it "creates a school cohort and user when given all details" do
+      subject.full_name = "Test User"
+      subject.email = "ray.clemence@example.com"
+      subject.core_induction_programme_id = core_induction_programme.id
+      subject.school_id = school.id
+
+      subject.save!
+      school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+
+      expect(school_cohort).not_to be_nil
+      expect(school_cohort.ecf_participants.count).to eq(1)
+    end
+  end
+
+  describe "opt_out?" do
+    it "returns true when induction programme choice is 'no_programme'" do
+      subject.induction_programme_choice = "no_programme"
+      expect(subject.opt_out?).to be_truthy
+    end
+
+    it "returns false when induction programme choice is 'core_induction_programme'" do
+      subject.induction_programme_choice = "core_induction_programme"
+      expect(subject.opt_out?).to be_falsey
+    end
+
+    it "returns false when induction programme choice is nil" do
+      expect(subject.opt_out?).to be_falsey
+    end
+  end
+
+  describe "opt_out!" do
+    context "when no school cohort for 2020 exists" do
+      before do
+        subject.core_induction_programme_id = core_induction_programme.id
+        subject.school_id = school.id
+      end
+
+      it "creates the school cohort, and sets programme choice to 'no_early_career_teachers'" do
+        subject.opt_out!
+        school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+        expect(school_cohort.no_early_career_teachers?).to be_truthy
+      end
+    end
+
+    context "school cohort for 2020 exists" do
+      before do
+        subject.core_induction_programme_id = core_induction_programme.id
+        subject.school_id = school.id
+        SchoolCohort.create!(school: school, cohort: cohort, induction_programme_choice: "core_induction_programme")
+      end
+
+      it "creates the school cohort, and sets programme choice to 'no_early_career_teachers'" do
+        subject.opt_out!
+        school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+        expect(school_cohort.no_early_career_teachers?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -28,8 +28,13 @@ RSpec.describe Schools::Year2020Form, type: :model do
   end
 
   describe "opt_out?" do
-    it "returns true when induction programme choice is 'no_programme'" do
-      subject.induction_programme_choice = "no_programme"
+    it "returns true when induction programme choice is 'no_early_career_teachers'" do
+      subject.induction_programme_choice = "no_early_career_teachers"
+      expect(subject.opt_out?).to be_truthy
+    end
+
+    it "returns true when induction programme choice is 'design_our_own'" do
+      subject.induction_programme_choice = "design_our_own"
       expect(subject.opt_out?).to be_truthy
     end
 

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -49,30 +49,28 @@ RSpec.describe Schools::Year2020Form, type: :model do
   end
 
   describe "opt_out!" do
-    context "when no school cohort for 2020 exists" do
-      before do
-        subject.core_induction_programme_id = core_induction_programme.id
-        subject.school_id = school.id
-      end
+    before do
+      subject.induction_programme_choice = %w[no_early_career_teachers design_our_own].sample
+      subject.school_id = school.id
+    end
 
-      it "creates the school cohort, and sets programme choice to 'no_early_career_teachers'" do
+    context "when no school cohort for 2020 exists" do
+      it "creates school cohort, and sets programme choice to induction_programme_choice value" do
         subject.opt_out!
         school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
-        expect(school_cohort.no_early_career_teachers?).to be_truthy
+        expect(school_cohort.induction_programme_choice).to eq(subject.induction_programme_choice)
       end
     end
 
     context "school cohort for 2020 exists" do
       before do
-        subject.core_induction_programme_id = core_induction_programme.id
-        subject.school_id = school.id
         SchoolCohort.create!(school: school, cohort: cohort, induction_programme_choice: "core_induction_programme")
       end
 
       it "creates the school cohort, and sets programme choice to 'no_early_career_teachers'" do
         subject.opt_out!
         school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
-        expect(school_cohort.no_early_career_teachers?).to be_truthy
+        expect(school_cohort.induction_programme_choice).to eq(subject.induction_programme_choice)
       end
     end
   end

--- a/spec/requests/schools/year2020_spec.rb
+++ b/spec/requests/schools/year2020_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Schools::AddParticipant", type: :request do
+  let!(:school) { create :school }
+  let!(:cohort) { create :cohort, start_year: 2020 }
+  let!(:core_induction_programme) { create :core_induction_programme }
+
+  subject { response }
+
+  before do
+    FeatureFlag.activate(:year_2020_data_entry)
+  end
+
+  describe "GET /schools/:school_id/year-2020/start" do
+    before do
+      get "/schools/#{school.slug}/year-2020/start"
+    end
+
+    it { is_expected.to render_template("schools/year2020/start") }
+  end
+
+  describe "GET /schools/:school_id/year-2020/choose-induction-programme" do
+    before do
+      get "/schools/#{school.slug}/year-2020/choose-induction-programme"
+    end
+
+    it { is_expected.to render_template("schools/year2020/select_induction_programme") }
+  end
+
+  describe "PUT /schools/:school_id/year-2020/choose-induction-programme" do
+    it "renders the select_induction_programme if programme choice is missing" do
+      put "/schools/#{school.slug}/year-2020/choose-induction-programme"
+      expect(response).to render_template("schools/year2020/select_induction_programme")
+    end
+
+    it "redirects to cip choice page when programme choice is CIP" do
+      put "/schools/#{school.slug}/year-2020/choose-induction-programme", params: {
+        schools_year2020_form: { induction_programme_choice: "core_induction_programme" },
+      }
+      expect(response).to redirect_to "/schools/#{school.slug}/year-2020/choose-core-induction-programme"
+    end
+
+    it "redirects to no programme page when school opts out" do
+      put "/schools/#{school.slug}/year-2020/choose-induction-programme", params: {
+        schools_year2020_form: { induction_programme_choice: "no_programme" },
+      }
+      expect(response).to redirect_to "/schools/#{school.slug}/year-2020/no-accredited-materials"
+    end
+  end
+
+  describe "GET /schools/:school_id/year-2020/no-accredited-materials" do
+    before do
+      get "/schools/#{school.slug}/year-2020/no-accredited-materials"
+    end
+
+    it { is_expected.to render_template("schools/year2020/no_accredited_materials") }
+  end
+
+  describe "GET /schools/:school_id/year-2020/choose-core-induction-programme" do
+    before do
+      get "/schools/#{school.slug}/year-2020/choose-core-induction-programme"
+    end
+
+    it { is_expected.to render_template("schools/year2020/select_cip") }
+  end
+
+  describe "PUT /schools/:school_id/year-2020/choose-core-induction-programme" do
+    it "renders the select_induction_programme if cip choice is missing" do
+      put "/schools/#{school.slug}/year-2020/choose-core-induction-programme"
+      expect(response).to render_template("schools/year2020/select_cip")
+    end
+
+    it "redirects to new teacher page when programme choice is valid" do
+      put "/schools/#{school.slug}/year-2020/choose-core-induction-programme", params: {
+        schools_year2020_form: { core_induction_programme_id: core_induction_programme.id },
+      }
+      expect(response).to redirect_to "/schools/#{school.slug}/year-2020/add-teacher"
+    end
+  end
+
+  describe "GET /schools/:school_id/year-2020/add-teacher" do
+    before do
+      get "/schools/#{school.slug}/year-2020/add-teacher"
+    end
+
+    it { is_expected.to render_template("schools/year2020/new_teacher") }
+  end
+
+  describe "PUT /schools/:school_id/year-2020/add-teacher" do
+    it "renders the select_induction_programme if teacher details are missing" do
+      put "/schools/#{school.slug}/year-2020/add-teacher"
+      expect(response).to render_template("schools/year2020/new_teacher")
+    end
+
+    it "redirects to check page when teacher details are valid" do
+      put "/schools/#{school.slug}/year-2020/add-teacher", params: {
+        schools_year2020_form: { full_name: "Joe Bloggs", email: "joe@example.com" },
+      }
+      expect(response).to redirect_to "/schools/#{school.slug}/year-2020/check-your-answers"
+    end
+  end
+
+  describe "GET /schools/:school_id/year-2020/check-your-answers" do
+    before do
+      get "/schools/#{school.slug}/year-2020/check-your-answers"
+    end
+
+    it { is_expected.to render_template("schools/year2020/check") }
+  end
+
+  describe "POST /schools/:school_id/year-2020/check-your-answers" do
+    before do
+      set_session(:schools_year2020_form,
+                  full_name: "Joe Bloggs",
+                  email: "joe@example.com",
+                  school_id: school.friendly_id,
+                  induction_programme_choice: "core_induction_programme",
+                  core_induction_programme_id: core_induction_programme.id)
+    end
+
+    it "redirects to success page" do
+      post "/schools/#{school.slug}/year-2020/check-your-answers"
+      expect(response).to redirect_to "/schools/#{school.slug}/year-2020/success"
+    end
+
+    it "saves the data" do
+      post "/schools/#{school.slug}/year-2020/check-your-answers"
+      school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+
+      expect(school_cohort).not_to be_nil
+      expect(school_cohort.ecf_participants.count).to eq(1)
+      expect(school_cohort.ecf_participants.first.full_name).to eq("Joe Bloggs")
+      expect(school_cohort.ecf_participants.first.email).to eq("joe@example.com")
+    end
+  end
+
+  describe "GET /schools/:school_id/year-2020/success" do
+    before do
+      get "/schools/#{school.slug}/year-2020/success"
+    end
+
+    it { is_expected.to render_template("schools/year2020/success") }
+  end
+end

--- a/spec/requests/schools/year2020_spec.rb
+++ b/spec/requests/schools/year2020_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Schools::AddParticipant", type: :request do
 
     it "redirects to no programme page when school opts out" do
       put "/schools/#{school.slug}/year-2020/choose-induction-programme", params: {
-        schools_year2020_form: { induction_programme_choice: "no_programme" },
+        schools_year2020_form: { induction_programme_choice: "design_our_own" },
       }
       expect(response).to redirect_to "/schools/#{school.slug}/year-2020/no-accredited-materials"
     end

--- a/spec/requests/schools/year2020_spec.rb
+++ b/spec/requests/schools/year2020_spec.rb
@@ -104,6 +104,12 @@ RSpec.describe "Schools::AddParticipant", type: :request do
 
   describe "GET /schools/:school_id/year-2020/check-your-answers" do
     before do
+      set_session(:schools_year2020_form,
+                  full_name: "Joe Bloggs",
+                  email: "joe@example.com",
+                  school_id: school.friendly_id,
+                  induction_programme_choice: "core_induction_programme",
+                  core_induction_programme_id: core_induction_programme.id)
       get "/schools/#{school.slug}/year-2020/check-your-answers"
     end
 


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDEL-726

### Changes proposed in this pull request

Add a form, a controller and a bunch of views for 2020 data input. Hide them behind a new feature flag.

### Guidance to review

Multiple participants will come in a later PR. Entry points into the flow (almost certainly emails) will come in a later PR.

This replaces https://github.com/DFE-Digital/early-careers-framework/pull/729. You might notice it is not using the multipage form. That's because there are a bunch of edge cases that I know of already (such as opting out) and things we will do for the first time (managing multiple participants), which I think the multipage form is not really geared towards handling.

And I think for speed of iterative improvement it will be better to use a more flexible approach (arbitrary controller actions) - with an ambition to refactor it to use our multipage form when we know for sure what exactly we need to add to it to fit all our requirements. 

### Testing
rspec for the form, request spec for the controller, percy for accessibility and visual tests

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
1. Go to `/schools/999999-example-school/year-2020/start` in the review app.