### PR TITLE
Dupe ECF users api

### DIFF
--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ECFUsersController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include ApiPagination
+
+      def index
+        render json: UserSerializer.new(paginate(users)).serializable_hash.to_json
+      end
+
+      def create
+        user = User.find_by(email: params[:data][:attributes][:email])
+
+        if user.present?
+          user.errors.add(:email, :taken)
+
+          hash = {
+            errors: [{
+              status: "409",
+              title: user.errors.full_messages.join(", "),
+            }],
+          }
+
+          render json: hash, status: :conflict and return
+        end
+
+        user = User.create!(
+          email: params[:data][:attributes][:email],
+          full_name: params[:data][:attributes][:full_name],
+        )
+
+        hash = UserSerializer.new(user).serializable_hash
+
+        render json: hash, status: :created
+      end
+
+    private
+
+      def access_scope
+        ApiToken.where(private_api_access: true)
+      end
+
+      def updated_since
+        params.dig(:filter, :updated_since)
+      end
+
+      def email
+        params.dig(:filter, :email)
+      end
+
+      def users
+        users = User.is_ecf_participant
+
+        if updated_since.present?
+          users = users.changed_since(updated_since)
+        end
+
+        if email.present?
+          users = users.where(email: email)
+        end
+
+        users
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
       resources :participants, only: :index, constraints: ->(_request) { FeatureFlag.active?(:participant_data_api) }
       resources :participant_declarations, only: %i[create], path: "participant-declarations"
       resources :users, only: %i[index create]
+      resources :ecf_users, only: %i[index create], path: "ecf-users"
       resources :dqt_records, only: :show, path: "dqt-records"
       resources :participant_validation, only: :show, path: "participant-validation"
       resources :npq_applications, only: :index, path: "npq-applications"

--- a/spec/requests/api/v1/ecf_users_spec.rb
+++ b/spec/requests/api/v1/ecf_users_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API Users", type: :request do
+  let(:parsed_response) { JSON.parse(response.body) }
+  let(:token) { EngageAndLearnApiToken.create_with_random_token! }
+  let(:bearer_token) { "Bearer #{token}" }
+
+  describe "#index" do
+    before :each do
+      # Heads up, for some reason the stored CIP IDs don't match
+      cip = create(:core_induction_programme, name: "Teach First")
+      school = create(:school)
+      school_cohort = create(:school_cohort, school: school)
+      mentor_profile = create(:mentor_profile, school_cohort: school_cohort, core_induction_programme: cip)
+      create(:participant_profile, participant_type: :npq, school: school)
+      create(:participant_profile, participant_type: :npq, school: school, user: mentor_profile.user)
+      create_list(:early_career_teacher_profile, 2, school_cohort: school_cohort, core_induction_programme: cip)
+    end
+
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+      end
+
+      it "returns correct jsonapi content type header" do
+        get "/api/v1/ecf-users"
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns all users" do
+        get "/api/v1/ecf-users"
+        expect(parsed_response["data"].size).to eql(3)
+      end
+
+      it "returns correct type" do
+        get "/api/v1/ecf-users"
+        expect(parsed_response["data"][0]).to have_type("user")
+      end
+
+      it "returns IDs" do
+        get "/api/v1/ecf-users"
+        expect(parsed_response["data"][0]["id"]).to be_in(User.pluck(:id))
+      end
+
+      it "has correct attributes" do
+        get "/api/v1/ecf-users"
+        expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name, :user_type, :core_induction_programme, :induction_programme_choice, :registration_completed).exactly
+      end
+
+      it "returns correct user types" do
+        get "/api/v1/ecf-users"
+
+        mentors = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "mentor" }
+        ects = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "early_career_teacher" }
+        others = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "other" }
+
+        expect(mentors).to eql(1)
+        expect(ects).to eql(2)
+        expect(others).to eql(0)
+      end
+
+      it "returns correct CIPs" do
+        get "/api/v1/ecf-users"
+        expect(parsed_response["data"][0]["attributes"]["core_induction_programme"]).to eql("teach_first")
+        expect(parsed_response["data"][2]["attributes"]["core_induction_programme"]).to eql("teach_first")
+      end
+
+      it "returns the right number of users per page" do
+        get "/api/v1/ecf-users", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
+      end
+
+      it "returns different users for first page" do
+        get "/api/v1/ecf-users", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
+      end
+
+      it "returns different users for second page" do
+        get "/api/v1/ecf-users", params: { page: { per_page: 2, page: 2 } }
+        expect(parsed_response["data"].size).to eql(1)
+      end
+
+      it "returns users changed since a particular time, if given a changed_since parameter" do
+        User.order(:created_at).first.update!(updated_at: 2.days.ago)
+        get "/api/v1/ecf-users", params: { filter: { updated_since: 1.day.ago.iso8601 } }
+        expect(parsed_response["data"].size).to eql(2)
+      end
+
+      context "when filtering by email" do
+        it "returns users that match" do
+          email = User.is_ecf_participant.sample.email
+          get "/api/v1/ecf-users", params: { filter: { email: email } }
+          expect(parsed_response["data"].size).to eql(1)
+          expect(parsed_response.dig("data", 0, "attributes", "email")).to eql(email)
+        end
+
+        it "returns no users if no matches" do
+          email = "dontexist@example.com"
+          get "/api/v1/ecf-users", params: { filter: { email: email } }
+          expect(parsed_response["data"].size).to eql(0)
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v1/ecf-users"
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when using a lead provider token" do
+      let(:token) { LeadProviderApiToken.create_with_random_token!(lead_provider: create(:lead_provider)) }
+
+      it "returns 403 for invalid bearer token" do
+        default_headers[:Authorization] = bearer_token
+        get "/api/v1/ecf-users"
+        expect(response.status).to eq 403
+      end
+    end
+  end
+
+  describe "#create" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+        default_headers["Content-Type"] = "application/vnd.api+json"
+      end
+
+      let(:json) do
+        {
+          data: {
+            type: "user",
+            attributes: {
+              full_name: "John Doe",
+              email: "john.doe@example.com",
+            },
+          },
+        }.to_json
+      end
+
+      it "returns a 201" do
+        post "/api/v1/ecf-users.json", params: json
+        expect(response).to be_created
+      end
+
+      it "returns correct jsonapi content type header" do
+        post "/api/v1/ecf-users.json", params: json
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "creates a user record" do
+        expect {
+          post "/api/v1/ecf-users", params: json
+        }.to change(User, :count).by(1)
+
+        user = User.order(:created_at).last
+
+        expect(user.full_name).to eql("John Doe")
+        expect(user.email).to eql("john.doe@example.com")
+      end
+
+      it "returns the created user resource" do
+        post "/api/v1/ecf-users.json", params: json
+
+        user = User.order(:created_at).last
+
+        expect(parsed_response["data"]["type"]).to eql("user")
+        expect(parsed_response["data"]["id"]).to eql(user.id)
+        expect(parsed_response["data"]["attributes"]["full_name"]).to eql("John Doe")
+        expect(parsed_response["data"]["attributes"]["email"]).to eql("john.doe@example.com")
+      end
+
+      context "when user with email address already exists" do
+        before do
+          User.create!(email: "john.doe@example.com", full_name: "John Doeeeeee")
+        end
+
+        it "returns a 409" do
+          post "/api/v1/ecf-users.json", params: json
+          expect(response.code).to eql("409")
+        end
+
+        it "does not create another record" do
+          expect {
+            post "/api/v1/ecf-users", params: json
+          }.not_to change(User, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/finance/lead_providers_controller_spec.rb
+++ b/spec/requests/finance/lead_providers_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Lead Providers for Finance users", type: :request do
       get "/finance/lead-providers"
 
       expect(response).to render_template("finance/lead_providers/index")
-      assigns(:lead_providers).should eq(lead_providers)
+      expect(assigns(:lead_providers)).to eq(lead_providers)
     end
   end
 end


### PR DESCRIPTION
### Context

- `/api/v1/users` endpoint at the moment contains ECF specific implementation
- NPQ at the moment requires a generic endpoint regarding users without any scoping to any subset of users

### Changes proposed in this pull request

- Duplicate the `/api/v1/users` endpoint at `/api/v1/ecf-users`
- Once deployed ECF can be pointed to `/api/v1/ecf-users`
- This will free then free up `/api/v1/users` where all ECF specific implementation can be removed to make it generic


### Guidance to review

- I feel long-term we want to deprecate the `/api/v1/ecf-users` endpoints. And opt for filtering to return users only ECF is concerned about. And use https://jsonapi.org/format/#fetching-relationships for fetching desired associations 

### Testing

```sh
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer PRIVATE_TOKEN" "http://localhost:3001/api/v1/ecf-users"
```
- should return some users just like before

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Same concept as testing locally