### PR TITLE
TRA API will now send us padded TRNs

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -39,8 +39,10 @@ private
     dqt_record = dqt_record(trn, nino)
     return if dqt_record.nil?
 
+    padded_trn = trn.rjust(7, "0")
+
     matches = 0
-    trn_matches = trn == dqt_record[:teacher_reference_number]
+    trn_matches = padded_trn == dqt_record[:teacher_reference_number]
     matches += 1 if trn_matches
     name_matches = full_name == dqt_record[:full_name]
     matches += 1 if name_matches

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -38,6 +38,37 @@ RSpec.describe ParticipantValidationService do
       end
     end
 
+    context "when trn is less than 7 characters" do
+      let(:trn) { "123456" }
+      let(:padded_trn) { "0123456" }
+
+      let(:dqt_record) do
+        { teacher_reference_number: "0123456", # API sends padded TRNs
+          national_insurance_number: nino,
+          full_name: full_name,
+          date_of_birth: dob,
+          qts_date: qts_date,
+          active_alert: alert }
+      end
+
+      let(:validation_result) do
+        ParticipantValidationService.validate(
+          trn: trn,
+          nino: "WRONG",
+          full_name: full_name,
+          date_of_birth: dob,
+        )
+      end
+
+      before do
+        expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)
+      end
+
+      it "returns record with padded trn when trn is not padded" do
+        expect(validation_result).to eql({ trn: padded_trn, qts: true, active_alert: false })
+      end
+    end
+
     context "when the participant has qts and no active flags" do
       before do
         expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)


### PR DESCRIPTION
### Context

- We have people that failed auto validation. turns out these people were simply missing from the temporary database
- but my understanding was they were in the database but did not have the padded trn. ie the look up failed
- eg user entered `0123456` we look for that but don’t find it because its stored under 123456
- so the temporary api now pads the request to TRA so it always finds the record
- on top of that responses to us will now contain a padded TRN
- therefore any matching we do our end must also be on a padded TRN
- without this change users who have been padding their own TRN will get auto validated. but those entering 6 digit trns will start failing

### Changes proposed in this pull request

- API response will now be padded with leading zeros till 7 character length
- therefore any matching our side will also need to be padded
- service API has therefore changed as we now return padded TRNS
- which mirrors what TRA will now send to us

### Guidance to review

- No integrating parts will be broken as a result of this change

### Testing

- Connect to the test instance api
```ruby
ParticipantValidationService.validate(
  trn: "0000001",
  nino: "WRONG",
  full_name: "FULL NAME FROM EXTRACT",
  date_of_birth: DOB_FROM_EXTRACT,
)
```
- should return test record

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Testing instructions apply here