### PR TITLE
Add code-doc to help avoid further `LeadProvider` naming confusion

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# This is actually EcfLeadProvider in all but name. See https://github.com/DFE-Digital/early-careers-framework/issues/698
 class LeadProvider < ApplicationRecord
   belongs_to :cpd_lead_provider, optional: true
 


### PR DESCRIPTION
### Context

Issue #698

### Changes proposed in this pull request

Add code-doc to help avoid further `LeadProvider` naming confusion

### Guidance to review

:ship: