### PR TITLE
Enable capybara so we can write rspec feature tests

### DIFF
--- a/spec/components/lead_providers/partnerships/challenged_banner_spec.rb
+++ b/spec/components/lead_providers/partnerships/challenged_banner_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe LeadProviders::Partnerships::ChallengedBanner, type: :view_compon
   it "renders expected notification banner" do
     banner = rendered.css(".govuk-notification-banner")
 
-    expect(banner)
-      .to have_selector(".govuk-notification-banner__header", text: "Important")
-      .and have_content(t(".header"))
-      .and have_content(t(".content", reason: t(partnership.challenge_reason, scope: "partnerships.challenge_reasons")))
+    expect(banner).to have_selector(".govuk-notification-banner__header", text: "Important")
+    expect(banner).to have_content(t(".header"))
+    expect(banner).to have_content(t(".content", reason: t(partnership.challenge_reason, scope: "partnerships.challenge_reasons")))
   end
 end

--- a/spec/features/start_journey_spec.rb
+++ b/spec/features/start_journey_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Start user journey", type: :feature, rutabaga: false do
+  scenario "Root URL should be the home page" do
+    when_i_visit_the_home_page
+    then_i_should_see_the_service_name
+    and_i_should_see_a_start_button
+  end
+
+private
+
+  def when_i_visit_the_home_page
+    visit "/"
+  end
+
+  def then_i_should_see_the_service_name
+    expect(page).to have_selector("h1", text: "Manage training for early career teachers")
+  end
+
+  def and_i_should_see_a_start_button
+    expect(page).to have_selector("a.govuk-button--start", text: "Start now")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,9 @@
 require "simplecov"
 SimpleCov.start
 
+require "capybara"
+require "capybara/rspec"
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"


### PR DESCRIPTION
### Context
Enable writing feature specs in RSpec (task from dev retro).  I've added an example feature spec with the work-around to prevent rutabaga from trying to load `.feature` file
Once the rutabaga feature tests for the payments calculator are refactored and removed, we can remove the `rutabaga: false` param.

### Changes proposed in this pull request
Add `require` for capybara dependencies.
Add example feature test.
Fix spec that was using `.and` which isn't supported with Capybara::RSpecMatchers.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
