### PR TITLE
2020 Invite email: Add invite email for 2020 Cohort

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -14,6 +14,7 @@ class SchoolMailer < ApplicationMailer
   COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE = "e7a60b68-334e-4a25-8adf-55ebc70622f9"
   COORDINATOR_REMINDER_TO_CHOOSE_MATERIALS_EMAIL_TEMPLATE = "43baf25c-6a46-437b-9f30-77c57d68a59e"
   ADD_PARTICIPANTS_EMAIL_TEMPLATE = "721787d0-74bc-42a0-a064-ee0c1cb58edb"
+  YEAR2020_INVITE_EMAIL_TEMPLATE = "d4b53e26-4630-43a5-b89e-3c668061a41c"
 
   def nomination_email(recipient:, school_name:, nomination_url:, expiry_date:)
     template_mail(
@@ -217,6 +218,18 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         name: name,
         sign_in_url: sign_in_url,
+      },
+    )
+  end
+
+  def year2020_invite_email(recipient:, start_url:)
+    template_mail(
+      YEAR2020_INVITE_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        start_url: start_url,
       },
     )
   end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -224,7 +224,7 @@ class InviteSchools
   def send_year2020_invite_email
     return unless FeatureFlag.active?(:year_2020_data_entry)
 
-    School.currently_open.each do |school|
+    School.eligible.each do |school|
       recipient = school.contact_email
       SchoolMailer.year2020_invite_email(recipient: recipient, start_url: year2020_start_url(school)).deliver_later if recipient.present?
     end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -221,12 +221,29 @@ class InviteSchools
     end
   end
 
+  def send_year2020_invite_email
+    return unless FeatureFlag.active?(:year_2020_data_entry)
+
+    School.currently_open.each do |school|
+      recipient = school.contact_email
+      SchoolMailer.year2020_invite_email(recipient: recipient, start_url: year2020_start_url(school)).deliver_later if recipient.present?
+    end
+  end
+
 private
 
   def private_beta_start_url
     Rails.application.routes.url_helpers.root_url(
       host: Rails.application.config.domain,
       **UTMService.email(:june_private_beta, :private_beta),
+    )
+  end
+
+  def year2020_start_url(school)
+    Rails.application.routes.url_helpers.start_schools_year_2020_url(
+      host: Rails.application.config.domain,
+      **UTMService.email(:year2020_nqt_invite, :year2020_nqt_invite),
+      school_id: school.friendly_id,
     )
   end
 

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -15,6 +15,7 @@ class UTMService
     choose_provider: "choose-provider",
     choose_materials: "choose-materials",
     add_participants: "add-participants",
+    year2020_nqt_invite: "year2020-nqt-invite",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -28,6 +29,7 @@ class UTMService
     choose_provider: "choose-provider",
     choose_materials: "choose-materials",
     add_participants: "add-participants",
+    year2020_nqt_invite: "year2020-nqt-invite",
   }.freeze
 
   def self.email(campaign, source = :service)


### PR DESCRIPTION
### Context

We will want to send schools an email about 2020 cohort. This should include a link - when they click it, they should go to the start of our flow.

### Changes proposed in this pull request
Add a new email to school mailer, and another method to the service inviting schools.
Add some tests.

We want to send the email to:
> State-funded English schools. In essence, the exact same schools who are eligible for FIP.

(from slack message)

### How can I view this in a review app?
You can't.