### PR TITLE
able to parse TRA record when qtsAwardDate is null

### DIFF
--- a/lib/dqt/api/v1/dqt_record.rb
+++ b/lib/dqt/api/v1/dqt_record.rb
@@ -19,14 +19,18 @@ module Dqt
           # API returns multiple items but we only ever use the first one. Decided to create a consistent interface here for automated checks rather than spend time creating an abstract interface.
           first_item = response[:data].first
 
-          {
+          hash = {
             teacher_reference_number: first_item[:trn],
             full_name: first_item[:name],
             date_of_birth: Date.parse(first_item[:doB]),
             national_insurance_number: first_item[:niNumber],
-            qts_date: Date.parse(first_item[:qtsAwardDate]),
+            qts_date: nil,
             active_alert: first_item[:activeAlert],
           }
+
+          hash[:qts_date] = Date.parse(first_item[:qtsAwardDate]) if first_item[:qtsAwardDate].present?
+
+          hash
         rescue Dqt::Client::ResponseError => e
           if e.response.code == 404
             nil

--- a/spec/lib/dqt/api/v1/dqt_record_spec.rb
+++ b/spec/lib/dqt/api/v1/dqt_record_spec.rb
@@ -10,6 +10,7 @@ module Dqt
 
         describe "#show" do
           subject(:show) { dqt_record.show(params: params_args) }
+
           let(:trn) { "1234567" }
           let(:nino) { "AA123456C" }
 
@@ -19,6 +20,7 @@ module Dqt
               national_insurance_number: nino,
             }
           end
+
           let(:expected_dqt_record) { build_dqt_record(trn: trn, nino: nino) }
 
           let!(:show_endpoint) do
@@ -33,6 +35,18 @@ module Dqt
 
           it "returns qualified teaching status" do
             expect(show).to eq(expected_dqt_record)
+          end
+
+          context "when qtsAwardDate is nil" do
+            let(:expected_dqt_record) do
+              r = build_dqt_record(trn: trn, nino: nino)
+              r[:qts_date] = nil
+              r
+            end
+
+            it "does not raise an error" do
+              expect { show }.not_to raise_error
+            end
           end
         end
 
@@ -63,28 +77,29 @@ module Dqt
         end
 
         def dqt_body(expected_dqt_record:)
-          <<~JSON
-            {
-              "data": [
-                {
-                  "id": 5,
-                  "trn": "#{expected_dqt_record[:teacher_reference_number]}",
-                  "name": "#{expected_dqt_record[:full_name]}",
-                  "doB": "#{expected_dqt_record[:date_of_birth]}",
-                  "niNumber": "#{expected_dqt_record[:national_insurance_number]}",
-                  "qtsAwardDate": "#{expected_dqt_record[:qts_date].strftime('%Y-%m-%d %H:%M:%S')}",
-                  "ittSubject1Code": "G100",
-                  "ittSubject2Code": "NULL",
-                  "ittSubject3Code": "NULL",
-                  "activeAlert": #{expected_dqt_record[:active_alert]},
-                  "qualificationName": "Professional Graduate Certificate in Education",
-                  "ittStartDate": "2014-08-31T23:00:00",
-                  "teacherStatus": "Assessment Only Route"
-                }
-              ],
-              "message": null
-            }
-          JSON
+          hash = {
+            data: [
+              {
+                "id": 5,
+                "trn": expected_dqt_record[:teacher_reference_number],
+                "name": expected_dqt_record[:full_name],
+                "doB": expected_dqt_record[:date_of_birth],
+                "niNumber": expected_dqt_record[:national_insurance_number],
+                "ittSubject1Code": "G100",
+                "ittSubject2Code": "NULL",
+                "ittSubject3Code": "NULL",
+                "activeAlert": expected_dqt_record[:active_alert],
+                "qualificationName": "Professional Graduate Certificate in Education",
+                "ittStartDate": "2014-08-31T23:00:00",
+                "teacherStatus": "Assessment Only Route",
+              },
+            ],
+            "message": nil,
+          }
+
+          hash[:data][0][:qtsAwardDate] = expected_dqt_record[:qts_date].strftime("%Y-%m-%d %H:%M:%S") if expected_dqt_record[:qts_date].present?
+
+          hash.to_json
         end
       end
     end


### PR DESCRIPTION
### Context

- It seems TRA can return records that do not have a record a `qtsAwardDate` with a value of `null`
- The current implementation does not support this as `Date.parse` cannot parse `nil`

### Changes proposed in this pull request

- For `qtsAwardDate` return `nil` if value is `null`
- This will therefore no longer throw an error as we no longer call `Date.parse(nil)`

### Guidance to review

- The output api slightly differs so ensuring there are no knock-on effects

### Testing

- You'd have to connect to the live instance as the test instance is not available
- Find a user with no qts award date
- calling something like `Dqt::Client.new.api.dqt_record.show(params: { teacher_reference_number: "TRN", national_insurance_number: "" })` should be sufficient to validate

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Not possible this moment in time as the TRA test instance is not currently available