### PR TITLE
Touch User whenever a change is made that is relevant to the participants API

### DIFF
--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -9,7 +9,7 @@ class Partnership < ApplicationRecord
     mistake: "mistake",
   }
 
-  belongs_to :school
+  belongs_to :school, touch: true
   belongs_to :lead_provider
   belongs_to :cohort
   belongs_to :delivery_partner

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -34,6 +34,11 @@ class School < ApplicationRecord
 
   has_many :additional_school_emails
 
+  after_commit do
+    ecf_participant_profiles.touch_all
+    ecf_participants.touch_all
+  end
+
   scope :with_local_authority, lambda { |local_authority|
     joins(%i[school_local_authorities local_authorities])
       .where(school_local_authorities: { end_year: nil }, local_authorities: local_authority)

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -27,6 +27,11 @@ class SchoolCohort < ApplicationRecord
 
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
 
+  after_commit do
+    ecf_participant_profiles.touch_all
+    ecf_participants.touch_all
+  end
+
   def training_provider_status
     school.partnerships&.active&.exists?(cohort: cohort) ? "Done" : "To do"
   end

--- a/spec/components/admin/participants/table_spec.rb
+++ b/spec/components/admin/participants/table_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe Admin::Participants::Table, type: :view_component do
   let!(:participant_profiles) { create_list :participant_profile, rand(11..15) }
   let(:page) { rand 1..2 }
 
-  component { described_class.new profiles: ParticipantProfile.all, page: page }
+  component { described_class.new profiles: ParticipantProfile.all.order(:id), page: page }
   request_path "/admin/participants"
 
   stub_component Admin::Participants::TableRow
 
   it "renders table row for each participant profile on this page" do
-    expected_profiles = participant_profiles.each_slice(10).to_a[page - 1]
+    expected_profiles = participant_profiles.sort_by(&:id).each_slice(10).to_a[page - 1]
 
     expected_profiles.each do |profile|
       expect(rendered).to have_rendered(Admin::Participants::TableRow).with(profile: profile)

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe ParticipantProfile, type: :model do
     ).backed_by_column_of_type(:text)
   }
 
+  it "updates the updated_at on the users" do
+    freeze_time
+    user = create(:user, :mentor, updated_at: 2.weeks.ago)
+
+    user.mentor_profile.touch
+    expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
+  end
+
   describe described_class::Mentor do
     it { is_expected.to belong_to(:school_cohort) }
     it { is_expected.to have_one(:cohort).through(:school_cohort) }

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe Partnership, type: :model do
     it { is_expected.to have_many(:partnership_notification_emails) }
   end
 
+  it "updates the updated_at on participant profiles and users" do
+    freeze_time
+    school_cohort = create(:school_cohort)
+    partnership = create(:partnership, school: school_cohort.school)
+    profile = create(:participant_profile, :ect, school_cohort: school_cohort, updated_at: 2.weeks.ago)
+    user = profile.user
+    user.update!(updated_at: 2.weeks.ago)
+
+    partnership.touch
+    expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
+    expect(profile.reload.updated_at).to be_within(1.second).of Time.zone.now
+  end
+
   describe "#challenged?" do
     it "returns true when the partnership has been challenged" do
       partnership = build(:partnership, challenged_at: Time.zone.now, challenge_reason: "mistake")

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe SchoolCohort, type: :model do
     it { is_expected.to belong_to(:school) }
   end
 
+  it "updates the updated_at on participant profiles and users" do
+    freeze_time
+    school_cohort = create(:school_cohort)
+    profile = create(:participant_profile, :ect, school_cohort: school_cohort, updated_at: 2.weeks.ago)
+    user = profile.user
+    user.update!(updated_at: 2.weeks.ago)
+
+    school_cohort.touch
+    expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
+    expect(profile.reload.updated_at).to be_within(1.second).of Time.zone.now
+  end
+
   it {
     is_expected.to define_enum_for(:induction_programme_choice).with_values(
       full_induction_programme: "full_induction_programme",

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:additional_school_emails) }
   end
 
+  it "updates the updated_at on participant profiles and users" do
+    freeze_time
+    school_cohort = create(:school_cohort)
+    profile = create(:participant_profile, :ect, school_cohort: school_cohort, updated_at: 2.weeks.ago)
+    user = profile.user
+    user.update!(updated_at: 2.weeks.ago)
+
+    school_cohort.school.touch
+    expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
+    expect(profile.reload.updated_at).to be_within(1.second).of Time.zone.now
+  end
+
   describe "eligibility" do
     let!(:open_school) { create(:school, school_status_code: 1) }
     let!(:closed_school) { create(:school, school_status_code: 2) }


### PR DESCRIPTION
Currently for example, when a school forms a partnership and their participants become visible to an LP, that will not be reflected in the updated_since parameter for the participants API endpoint