### PR TITLE
prevent screenshots and video on cypress tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,7 @@ jobs:
           env: port=5017
           project: ./spec
           command-prefix: 'percy exec -- npx'
+          config: 'video=false,screenshotOnRunFailure=false'
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}


### PR DESCRIPTION
This should speed up the test runs. We don't use them anyway

I tried to do this before, but only changed the local setting