### PR TITLE
Fixed race condition in teacher profile shadowing

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -63,8 +63,10 @@ class ParticipantProfile < ApplicationRecord
   end
 
   def sync_teacher_profile
-    self.teacher_profile = user.teacher_profile || user.build_teacher_profile
-    teacher_profile.school = school
-    teacher_profile.save!
+    profile = user.teacher_profile || user.build_teacher_profile
+    profile.school = school
+    profile.save!
+
+    self.teacher_profile = profile
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,9 +11,10 @@ class User < ApplicationRecord
   has_one :lead_provider, through: :lead_provider_profile
   has_one :admin_profile, dependent: :destroy
   has_one :finance_profile, dependent: :destroy
-  has_one :teacher_profile, dependent: :destroy
 
   has_many :participant_profiles, dependent: :destroy
+  has_one :teacher_profile, dependent: :destroy
+
   # TODO: Legacy associations, to be removed
   has_one :early_career_teacher_profile, -> { active }, class_name: "ParticipantProfile::ECT"
   has_one :mentor_profile, -> { active }, class_name: "ParticipantProfile::Mentor"


### PR DESCRIPTION
### Context

Oops! There's a bug in TeacheProfile shadowing code causing new teacher profiles not being associated with newly created participant profiles: `self.techer_profile = <new_instance_of_record>` does not set the foregin_key value and, for some reason `self.teacher_profile.save` did not update the foreign key... 