### PR TITLE
CPDTP-259 Eliminate the nil check from validate_provider!

### DIFF
--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -86,8 +86,7 @@ module RecordDeclarations
     end
 
     def validate_provider!
-      # TODO: Remove the nil? check and fix the test setup so that they build the school cohort, partnership and give us back the actual lead_provider.
-      raise ActionController::ParameterMissing, I18n.t(:invalid_participant) unless actual_lead_provider.nil? || lead_provider_from_token == actual_lead_provider
+      raise ActionController::ParameterMissing, I18n.t(:invalid_participant) unless lead_provider_from_token == actual_lead_provider
     end
   end
 end

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -5,6 +5,13 @@ require "swagger_helper"
 RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_spec.json" do
   let(:early_career_teacher_profile) { create(:early_career_teacher_profile) }
   let(:cohort) { early_career_teacher_profile.cohort }
+  let!(:school_cohort) { create(:school_cohort, school: early_career_teacher_profile.school, cohort: early_career_teacher_profile.cohort) }
+  let!(:ect_partnership) do
+    create(:partnership,
+           school: early_career_teacher_profile.school,
+           lead_provider: cpd_lead_provider.lead_provider,
+           cohort: early_career_teacher_profile.cohort)
+  end
   let(:user) { early_career_teacher_profile.user }
   let(:lead_provider) { create(:lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
@@ -32,24 +39,6 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
                 schema: {
                   "$ref": "#/components/schemas/ParticipantDeclaration",
                 }
-
-      response 200, "Successful" do
-        let(:fresh_user) { create(:user, :early_career_teacher) }
-        let(:params) do
-          {
-            "data": {
-              "type": "participant-declaration",
-              "attributes": {
-                "participant_id" => fresh_user.id,
-                "declaration_type" => "started",
-                "declaration_date" => "2021-05-31T15:50:00Z",
-                "course_identifier" => "ecf-induction",
-              },
-            },
-          }
-        end
-        run_test!
-      end
 
       response 200, "Successful" do
         let(:attributes) do

--- a/spec/services/record_declarations/ecf/mentor_spec.rb
+++ b/spec/services/record_declarations/ecf/mentor_spec.rb
@@ -28,13 +28,19 @@ RSpec.describe RecordDeclarations::ECF::Mentor do
     ect_params.merge({ user_id: induction_coordinator_profile.user_id })
   end
   let(:delivery_partner) { create(:delivery_partner) }
-  let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-  let!(:partnership) do
+  let!(:ect_school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
+  let!(:mentor_school_cohort) { create(:school_cohort, school: mentor_profile.school, cohort: mentor_profile.cohort) }
+  let!(:ect_partnership) do
     create(:partnership,
            school: ect_profile.school,
            lead_provider: cpd_lead_provider.lead_provider,
-           cohort: ect_profile.cohort,
-           delivery_partner: delivery_partner)
+           cohort: ect_profile.cohort)
+  end
+  let!(:mentor_partnership) do
+    create(:partnership,
+           school: mentor_profile.school,
+           lead_provider: cpd_lead_provider.lead_provider,
+           cohort: mentor_profile.cohort)
   end
 
   def generate_raw_event(params)

--- a/spec/services/record_participant_declaration_service_spec.rb
+++ b/spec/services/record_participant_declaration_service_spec.rb
@@ -45,14 +45,18 @@ RSpec.describe RecordParticipantDeclaration do
     let(:induction_coordinator_params) do
       ect_params.merge({ user_id: induction_coordinator_profile.user_id })
     end
-    let(:delivery_partner) { create(:delivery_partner) }
     let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-    let!(:partnership) do
+    let!(:ect_partnership) do
       create(:partnership,
              school: ect_profile.school,
              lead_provider: cpd_lead_provider.lead_provider,
-             cohort: ect_profile.cohort,
-             delivery_partner: delivery_partner)
+             cohort: ect_profile.cohort)
+    end
+    let!(:mentor_partnership) do
+      create(:partnership,
+             school: mentor_profile.school,
+             lead_provider: cpd_lead_provider.lead_provider,
+             cohort: mentor_profile.cohort)
     end
 
     def generate_raw_event(params)


### PR DESCRIPTION
### Context

The old code allowed a lead_provider to be nil if a declaration were submitted before the lead_provider was associated with the user profile. This was erroneous and this patch fixes it and updates the tests to require a partnership. It also eliminates an extra 200 test from the API specification, since those tests are included in the request and as the swagger spec is mainly to generate a schema and documentation, they aren't as useful to have them in there.

### Changes proposed in this pull request

- Remove the nil check for the lead_provider associated with the ECF from the declaration
- Remove the extra 200 check from the swagger documentation tests
- Fix the tests to make them work and generate the correct actual_lead_provider for the other parameters specified

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
