### PR TITLE
/api/v1/users now returns all users

### DIFF
--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -7,7 +7,7 @@ module Api
       include ApiPagination
 
       def index
-        render json: UserSerializer.new(paginate(users)).serializable_hash.to_json
+        render json: ECFUserSerializer.new(paginate(users)).serializable_hash.to_json
       end
 
       def create

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -51,7 +51,7 @@ module Api
       end
 
       def users
-        users = User.is_ecf_participant
+        users = User.all
 
         if updated_since.present?
           users = users.changed_since(updated_since)

--- a/app/serializers/ecf_user_serializer.rb
+++ b/app/serializers/ecf_user_serializer.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class ECFUserSerializer
+  include JSONAPI::Serializer
+
+  set_type :user
+
+  USER_TYPES = {
+    early_career_teacher: "early_career_teacher",
+    mentor: "mentor",
+    other: "other",
+  }.freeze
+
+  CIP_TYPES = {
+    ambition: "ambition",
+    edt: "edt",
+    teach_first: "teach_first",
+    ucl: "ucl",
+    none: "none",
+  }.freeze
+
+  set_id :id
+  attributes :email, :full_name
+
+  attributes :user_type do |user|
+    if user.early_career_teacher?
+      USER_TYPES[:early_career_teacher]
+    elsif user.mentor?
+      USER_TYPES[:mentor]
+    else
+      USER_TYPES[:other]
+    end
+  end
+
+  attributes :core_induction_programme do |user|
+    core_induction_programme = user.core_induction_programme || find_school_cohort(user)&.core_induction_programme
+
+    case core_induction_programme&.name
+    when "Ambition Institute"
+      CIP_TYPES[:ambition]
+    when "Education Development Trust"
+      CIP_TYPES[:edt]
+    when "Teach First"
+      CIP_TYPES[:teach_first]
+    when "UCL Institute of Education"
+      CIP_TYPES[:ucl]
+    else
+      CIP_TYPES[:none]
+    end
+  end
+
+  attributes :induction_programme_choice do |user|
+    find_school_cohort(user)&.induction_programme_choice
+  end
+
+  # TODO: CPDRP-508 use the actual users registration completed value as part of participant validation journey
+  attributes :registration_completed do
+    false
+  end
+
+  def self.find_school_cohort(user)
+    if user.participant?
+      user.participant_profiles.ecf.active.first&.school_cohort
+    end
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -3,62 +3,6 @@
 class UserSerializer
   include JSONAPI::Serializer
 
-  USER_TYPES = {
-    early_career_teacher: "early_career_teacher",
-    mentor: "mentor",
-    other: "other",
-  }.freeze
-
-  CIP_TYPES = {
-    ambition: "ambition",
-    edt: "edt",
-    teach_first: "teach_first",
-    ucl: "ucl",
-    none: "none",
-  }.freeze
-
   set_id :id
   attributes :email, :full_name
-
-  attributes :user_type do |user|
-    if user.early_career_teacher?
-      USER_TYPES[:early_career_teacher]
-    elsif user.mentor?
-      USER_TYPES[:mentor]
-    else
-      USER_TYPES[:other]
-    end
-  end
-
-  attributes :core_induction_programme do |user|
-    core_induction_programme = user.core_induction_programme || find_school_cohort(user)&.core_induction_programme
-
-    case core_induction_programme&.name
-    when "Ambition Institute"
-      CIP_TYPES[:ambition]
-    when "Education Development Trust"
-      CIP_TYPES[:edt]
-    when "Teach First"
-      CIP_TYPES[:teach_first]
-    when "UCL Institute of Education"
-      CIP_TYPES[:ucl]
-    else
-      CIP_TYPES[:none]
-    end
-  end
-
-  attributes :induction_programme_choice do |user|
-    find_school_cohort(user)&.induction_programme_choice
-  end
-
-  # TODO: CPDRP-508 use the actual users registration completed value as part of participant validation journey
-  attributes :registration_completed do
-    false
-  end
-
-  def self.find_school_cohort(user)
-    if user.participant?
-      user.participant_profiles.ecf.active.first&.school_cohort
-    end
-  end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "API Users", type: :request do
 
       it "returns all users" do
         get "/api/v1/users"
-        expect(parsed_response["data"].size).to eql(3)
+        expect(parsed_response["data"].size).to eql(User.count)
       end
 
       it "returns correct type" do
@@ -46,46 +46,28 @@ RSpec.describe "API Users", type: :request do
 
       it "has correct attributes" do
         get "/api/v1/users"
-        expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name, :user_type, :core_induction_programme, :induction_programme_choice, :registration_completed).exactly
-      end
-
-      it "returns correct user types" do
-        get "/api/v1/users"
-
-        mentors = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "mentor" }
-        ects = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "early_career_teacher" }
-        others = parsed_response["data"].count { |hash| hash["attributes"]["user_type"] == "other" }
-
-        expect(mentors).to eql(1)
-        expect(ects).to eql(2)
-        expect(others).to eql(0)
-      end
-
-      it "returns correct CIPs" do
-        get "/api/v1/users"
-        expect(parsed_response["data"][0]["attributes"]["core_induction_programme"]).to eql("teach_first")
-        expect(parsed_response["data"][2]["attributes"]["core_induction_programme"]).to eql("teach_first")
+        expect(parsed_response["data"][0]).to have_jsonapi_attributes(:email, :full_name).exactly
       end
 
       it "returns the right number of users per page" do
-        get "/api/v1/users", params: { page: { per_page: 2, page: 1 } }
-        expect(parsed_response["data"].size).to eql(2)
+        get "/api/v1/users", params: { page: { per_page: 3, page: 1 } }
+        expect(parsed_response["data"].size).to eql(3)
       end
 
       it "returns different users for first page" do
-        get "/api/v1/users", params: { page: { per_page: 2, page: 1 } }
-        expect(parsed_response["data"].size).to eql(2)
+        get "/api/v1/users", params: { page: { per_page: 3, page: 1 } }
+        expect(parsed_response["data"].size).to eql(3)
       end
 
       it "returns different users for second page" do
-        get "/api/v1/users", params: { page: { per_page: 2, page: 2 } }
+        get "/api/v1/users", params: { page: { per_page: 3, page: 2 } }
         expect(parsed_response["data"].size).to eql(1)
       end
 
       it "returns users changed since a particular time, if given a changed_since parameter" do
         User.order(:created_at).first.update!(updated_at: 2.days.ago)
         get "/api/v1/users", params: { filter: { updated_since: 1.day.ago.iso8601 } }
-        expect(parsed_response["data"].size).to eql(2)
+        expect(parsed_response["data"].size).to eql(3)
       end
 
       context "when filtering by email" do


### PR DESCRIPTION
### Context

- `/api/v1/users` used to return ECF specific users and this has been duplicated to `/api/v1/ecf-users`
- This endpoint is therefore free to deal with the concept of all users in CPD
- The use case for this change is so NPQ is able to query for existing users in the system based on email address

### Changes proposed in this pull request

- `/api/v1/users` now returns all users
- this is no longer scoped to ECF specific users
- serialization is now generalised removing all ECF specific attributes

### Guidance to review

- Besides NPQ no other client that I am aware of is using this endpoint and therefore safe to change. Is this the case?
- There should be no changes to the endpoint `/api/v1/ecf-users`

### Testing

- See testing on review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Create or use an existing token with private api access
- Create or use an existing non ECF user
- Search for them 
```sh
curl -H "Content-Type: application/vnd.api+json" -H "Authorization: Bearer TOKEN" "https://ecf-review-pr-761.london.cloudapps.digital/api/v1/users?filter[email]=user@example.com"
```
- Should return the user based off their email
- JSON should no longer return an ECF specific properties