### PR TITLE
2020 Multiple participants: Add adding, removing and updating participants

### DIFF
--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -32,7 +32,11 @@ module Schools
       render :select_cip and return unless @year_2020_form.valid? :choose_cip
 
       store_year_2020_session
-      redirect_to action: :new_teacher
+      if @year_2020_form.get_participants.count.positive?
+        redirect_to action: :check
+      else
+        redirect_to action: :new_teacher
+      end
     end
 
     def new_teacher; end

--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -40,6 +40,35 @@ module Schools
     def create_teacher
       render :new_teacher and return unless @year_2020_form.valid? :create_teacher
 
+      @year_2020_form.store_new_participant
+      store_year_2020_session
+      redirect_to action: :check
+    end
+
+    def remove_teacher
+      participant = @year_2020_form.get_participant(participant_index)
+      redirect_to action: :check unless participant
+
+      @year_2020_form.email = participant[:email]
+      @year_2020_form.full_name = participant[:full_name]
+    end
+
+    def delete_teacher
+      @year_2020_form.remove_participant(participant_index)
+      store_year_2020_session
+      redirect_to action: :check
+    end
+
+    def edit_teacher
+      participant = @year_2020_form.get_participant(participant_index)
+      redirect_to action: :check unless participant
+
+      @year_2020_form.email = participant[:email]
+      @year_2020_form.full_name = participant[:full_name]
+    end
+
+    def update_teacher
+      @year_2020_form.update_participant(participant_index)
       store_year_2020_session
       redirect_to action: :check
     end
@@ -74,6 +103,10 @@ module Schools
 
     def store_year_2020_session
       session[SESSION_KEY] = @year_2020_form.serializable_hash
+    end
+
+    def participant_index
+      params[:index].to_i
     end
   end
 end

--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -68,6 +68,8 @@ module Schools
     end
 
     def update_teacher
+      render :edit_teacher and return unless @year_2020_form.valid? :update_teacher
+
       @year_2020_form.update_participant(participant_index)
       store_year_2020_session
       redirect_to action: :check

--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -95,12 +95,14 @@ module Schools
         school_cohort.core_induction_programme = core_induction_programme
         school_cohort.save!
 
-        EarlyCareerTeachers::Create.call(
-          full_name: full_name,
-          email: email,
-          school_cohort: school_cohort,
-          mentor_profile_id: nil,
-        )
+        get_participants.each do |participant|
+          EarlyCareerTeachers::Create.call(
+            full_name: participant[:full_name],
+            email: participant[:email],
+            school_cohort: school_cohort,
+            mentor_profile_id: nil,
+          )
+        end
       end
     end
   end

--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -10,12 +10,12 @@ module Schools
     validates :induction_programme_choice, presence: true, on: :choose_induction_programme
     validates :core_induction_programme_id, presence: true, on: :choose_cip
 
-    validates :full_name, presence: true, on: :create_teacher
+    validates :full_name, presence: true, on: %i[create_teacher update_teacher]
     # TODO: unique emails
     validates :email,
               presence: true,
               notify_email: { allow_blank: true },
-              on: :create_teacher
+              on: %i[create_teacher update_teacher]
 
     def attributes
       { school_id: nil, induction_programme_choice: nil, core_induction_programme_id: nil, participants: nil }

--- a/app/views/schools/year2020/check.html.erb
+++ b/app/views/schools/year2020/check.html.erb
@@ -9,11 +9,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Confirm details for <%= @year_2020_form.school.name %></h1>
 
+    <h2 class="govuk-heading-m">DfE accredited material choice</h2>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          DfE accredited material choice
-        </dt>
         <dd class="govuk-summary-list__value">
           <%= @year_2020_form.core_induction_programme.name %>
         </dd>
@@ -26,23 +24,32 @@
       </div>
     </dl>
 
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Details
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <div><%= @year_2020_form.full_name %></div>
-          <div><%= @year_2020_form.email %></div>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
-          <%= govuk_link_to({ action: :new_teacher }, button: false) do %>
-            Change <span class="govuk-visually-hidden">personal details</span>
-          <% end %>
-        </dd>
-      </div>
+    <h2 class="govuk-heading-m">Teachers</h2>
+    <dl class="govuk-summary-list">
+      <% @year_2020_form.get_participants.each do |participant| %>
+        <div class="govuk-summary-list__row">
+          <dd class="govuk-summary-list__value">
+            <div><%= participant[:full_name] %></div>
+            <div><%= participant[:email] %></div>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
+            <%= govuk_link_to({ action: :remove_teacher, index: participant[:index] }, button: false, class: "govuk-!-margin-right-5") do %>
+              Delete
+            <% end %>
+            <%= govuk_link_to({ action: :edit_teacher, index: participant[:index] }, button: false) do %>
+              Change <span class="govuk-visually-hidden">personal details</span>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
     </dl>
+
+    <p>
+      <%= govuk_link_to({ action: :new_teacher }, button: false) do %>
+        Add another teacher
+      <% end %>
+    </p>
 
     <%= form_for @year_2020_form, url: { action: :confirm }, method: :post do |f| %>
       <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/year2020/edit_teacher.html.erb
+++ b/app/views/schools/year2020/edit_teacher.html.erb
@@ -1,0 +1,22 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :select_cip })
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Update teacher</h1>
+    <p class="govuk-body">
+      To give your teachers access to your schools chosen materials we will need their full name and email address.
+    </p>
+
+    <%= form_for @year_2020_form, url: { action: :update_teacher, index: params[:index] }, method: :put do |f| %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_email_field :email,
+                              label: { text: "Email address" },
+                              hint: { text: "You can use their personal or work email address" }
+      %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/year2020/remove_teacher.html.erb
+++ b/app/views/schools/year2020/remove_teacher.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_content, govuk_back_link(
+  text: "Back",
+  href: { action: :select_cip })
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Are you sure you want to delete <%= @year_2020_form.full_name %></h1>
+    <p class="govuk-hint">
+      You won't be able to undo this action and will have to input their details again
+    </p>
+
+    <%= form_for @year_2020_form, url: { action: :delete_teacher, index: params[:index] }, method: :put do |f| %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Confirm",  class: "govuk-button--warning" %>
+
+        <%# govuk_link_to issue: https://github.com/DFE-Digital/govuk-components/issues/193 %>
+        <%= govuk_link_to({ action: :check }, button: false) do %>
+          Cancel
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,10 @@ Rails.application.routes.draw do
         put "choose-core-induction-programme", action: :choose_cip
         get "add-teacher", action: :new_teacher
         put "add-teacher", action: :create_teacher
+        get "remove-teacher", action: :remove_teacher
+        put "remove-teacher", action: :delete_teacher
+        get "edit-teacher", action: :edit_teacher
+        put "edit-teacher", action: :update_teacher
         get "check-your-answers", action: :check
         post "check-your-answers", action: :confirm
         get "success", action: :success

--- a/spec/cypress/integration/schools/Year2020.feature
+++ b/spec/cypress/integration/schools/Year2020.feature
@@ -34,6 +34,37 @@ Feature: School leaders should be able to add participants
     And the page should be accessible
     And percy should be sent snapshot called "Year 2020 check your answers page"
 
+    When I click on "link" containing "Add another teacher"
+    Then I should be on "2020 add teacher" page
+
+    When I type "Dummy User" into field labelled "Full name"
+    And I type "dummy@secret.gov.uk" into field labelled "Email"
+    And I click the submit button
+    Then I should be on "2020 check your answers" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 check your answers page with two teachers"
+
+    When I click on "link" containing "Change personal details"
+    Then I should be on "2020 edit teacher" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 edit teacher"
+
+    When I type "James Bond 2" into field labelled "Full name"
+    And I click the submit button
+    Then I should be on "2020 check your answers" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 check your answers page with two teachers edited"
+
+    When I click on "link" containing "Delete"
+    Then I should be on "2020 remove teacher" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 remove teacher"
+
+    When I click the submit button
+    Then I should be on "2020 check your answers" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Year 2020 check your answers page with a deleted teacher"
+
     When I click the submit button
     And the page should be accessible
     And percy should be sent snapshot called "Year 2020 ect participant added"

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -152,6 +152,8 @@ const pagePaths = {
   "2020 cip choice":
     "/schools/:school_id/year-2020/choose-core-induction-programme",
   "2020 add teacher": "/schools/:school_id/year-2020/add-teacher",
+  "2020 edit teacher": "/schools/:school_id/year-2020/edit-teacher",
+  "2020 remove teacher": "/schools/:school_id/year-2020/remove-teacher",
   "2020 check your answers": "/schools/:school_id/year-2020/check-your-answers",
   "2020 success": "/schools/:school_id/year-2020/success",
 };

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -14,16 +14,27 @@ RSpec.describe Schools::Year2020Form, type: :model do
 
   describe "save!" do
     it "creates a school cohort and user when given all details" do
-      subject.full_name = "Test User"
-      subject.email = "ray.clemence@example.com"
       subject.core_induction_programme_id = core_induction_programme.id
-      subject.school_id = school.id
+      add_new_participant(subject)
 
       subject.save!
       school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
 
       expect(school_cohort).not_to be_nil
       expect(school_cohort.ecf_participants.count).to eq(1)
+    end
+
+    it "works with multiple participants" do
+      subject.core_induction_programme_id = core_induction_programme.id
+      add_new_participant(subject)
+      add_new_participant(subject)
+      add_new_participant(subject)
+
+      subject.save!
+      school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+
+      expect(school_cohort).not_to be_nil
+      expect(school_cohort.ecf_participants.count).to eq(3)
     end
   end
 
@@ -51,7 +62,6 @@ RSpec.describe Schools::Year2020Form, type: :model do
   describe "opt_out!" do
     before do
       subject.induction_programme_choice = %w[no_early_career_teachers design_our_own].sample
-      subject.school_id = school.id
     end
 
     context "when no school cohort for 2020 exists" do
@@ -73,5 +83,75 @@ RSpec.describe Schools::Year2020Form, type: :model do
         expect(school_cohort.induction_programme_choice).to eq(subject.induction_programme_choice)
       end
     end
+  end
+
+  describe "store_new_participant" do
+    it "adds participant with email and full_name from the form to its participants" do
+      subject.full_name = "Joe Bloggs"
+      subject.email = "joe@example.com"
+
+      subject.store_new_participant
+
+      form_participant = subject.get_participant(1)
+      expect(form_participant[:full_name]).to eq("Joe Bloggs")
+      expect(form_participant[:email]).to eq("joe@example.com")
+    end
+  end
+
+  describe "remove_participant" do
+    it "removes participant with particular index" do
+      subject.store_new_participant
+      subject.remove_participant(1)
+      expect(subject.get_participant(1)).to be_nil
+    end
+
+    it "removes participant with particular index" do
+      subject.store_new_participant
+      subject.store_new_participant
+      subject.store_new_participant
+      subject.remove_participant(1)
+      expect(subject.get_participant(1)).to be_nil
+      expect(subject.get_participant(2)).not_to be_nil
+      expect(subject.get_participant(3)).not_to be_nil
+    end
+  end
+
+  describe "new_participant_index" do
+    it "returns 1 when no participants" do
+      expect(subject.new_participant_index).to eq(1)
+    end
+
+    it "returns 1 more than max of participant indexes" do
+      subject.store_new_participant
+      subject.store_new_participant
+      subject.store_new_participant
+
+      expect(subject.new_participant_index).to eq(4)
+    end
+
+    it "returns 1 more than max of participant indexes even with gaps in the middle" do
+      subject.store_new_participant
+      subject.store_new_participant
+      subject.remove_participant(1)
+      subject.store_new_participant
+
+      expect(subject.new_participant_index).to eq(4)
+    end
+
+    it "reuses removed index if it was the max index" do
+      subject.store_new_participant
+      subject.store_new_participant
+      subject.remove_participant(2)
+
+      expect(subject.new_participant_index).to eq(2)
+    end
+  end
+
+private
+
+  def add_new_participant(form, name: Faker::Name.name, email: Faker::Internet.email)
+    form.full_name = name
+    form.email = email
+    form.store_new_participant
   end
 end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDEL-727

### Changes proposed in this pull request

Add `participants` field to the 2020 form. That's where the data for all participants is stored.
Add pages and routes for edit/update, and remove/delete teachers.

### Guidance to review

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Go to `/schools/999999-example-school/year-2020/start` and play around :) 