### PR TITLE
Update the rake task for payment calcuation with new cpd_lead_provider

### DIFF
--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -8,20 +8,21 @@ require "terminal-table"
 include ActiveSupport::NumberHelper
 
 namespace :payment_calculation do
-  desc "run payment calculator for a given lead provider"
+  desc "run payment calculator for a given ECF lead provider"
   task breakdown: :environment do
-    lead_provider = begin
-                      LeadProvider.find(ARGV[1])
-                    rescue StandardError
-                      LeadProvider.find_by(name: ARGV[1])
+    cpd_lead_provider = begin
+                      CpdLeadProvider.find(ARGV[1])
+                        rescue StandardError
+                          CpdLeadProvider.find_by(name: ARGV[1])
                     end
-    raise "Unknown lead provider: #{ARGV[1]}" if lead_provider.nil?
+    raise "Unknown lead provider: #{ARGV[1]}" if cpd_lead_provider.nil?
+    raise "Not an ECF lead provider #{ARGV[1]}" if cpd_lead_provider.lead_provider.nil?
 
-    total_participants = (ARGV[2] || ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_for_lead_provider })).to_i
-    uplift_participants = (ARGV[3] || ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_uplift_for_lead_provider })).to_i
-    total_ects = (ARGV[2].present? ? ARGV[2].to_i / 2 : ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_ects_for_lead_provider }))
-    total_mentors = (ARGV[2].present? ? ARGV[2].to_i - ARGV[2].to_i / 2 : ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_mentors_for_lead_provider }))
-    Tasks::PaymentBreakdown.new(contract: lead_provider.call_off_contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors).to_table
+    total_participants = (ARGV[2] || ParticipantEventAggregator.call({ cpd_lead_provider: cpd_lead_provider, started: :count_active_for_lead_provider })).to_i
+    uplift_participants = (ARGV[3] || ParticipantEventAggregator.call({ cpd_lead_provider: cpd_lead_provider, started: :count_active_uplift_for_lead_provider })).to_i
+    total_ects = (ARGV[2].present? ? ARGV[2].to_i / 2 : ParticipantEventAggregator.call({ cpd_lead_provider: cpd_lead_provider, started: :count_active_ects_for_lead_provider }))
+    total_mentors = (ARGV[2].present? ? ARGV[2].to_i - ARGV[2].to_i / 2 : ParticipantEventAggregator.call({ cpd_lead_provider: cpd_lead_provider, started: :count_active_mentors_for_lead_provider }))
+    Tasks::PaymentBreakdown.new(contract: cpd_lead_provider.lead_provider.call_off_contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors).to_table
   rescue StandardError => e
     puts e.message
     puts e.backtrace
@@ -29,7 +30,7 @@ namespace :payment_calculation do
     exit
   end
 
-  desc "generate csv payment calculations for all lead providers"
+  desc "generate csv payment calculations for all ECF lead providers"
   task csv: :environment do
     filename = (ARGV[1] || "output.csv")
     lead_providers = LeadProvider.all
@@ -37,10 +38,10 @@ namespace :payment_calculation do
       csv << Tasks::PaymentBreakdown.new(contract: lead_providers.first.call_off_contract, total_participants: 0, uplift_participants: 0).csv_headings
       lead_providers.each do |lead_provider|
         contract = lead_provider.call_off_contract
-        total_participants = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_for_lead_provider }).to_i
-        uplift_participants = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_uplift_for_lead_provider }).to_i
-        total_ects = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_ects_for_lead_provider })
-        total_mentors = ParticipantEventAggregator.call({ lead_provider: lead_provider, started: :count_active_mentors_for_lead_provider })
+        total_participants = ParticipantEventAggregator.call({ cpd_lead_provider: lead_provider.cpd_lead_provider, started: :count_active_for_lead_provider }).to_i
+        uplift_participants = ParticipantEventAggregator.call({ cpd_lead_provider: lead_provider.cpd_lead_provider, started: :count_active_uplift_for_lead_provider }).to_i
+        total_ects = ParticipantEventAggregator.call({ cpd_lead_provider: lead_provider.cpd_lead_provider, started: :count_active_ects_for_lead_provider })
+        total_mentors = ParticipantEventAggregator.call({ cpd_lead_provider: lead_provider.cpd_lead_provider, started: :count_active_mentors_for_lead_provider })
         csv << Tasks::PaymentBreakdown.new(contract: contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors).csv_body
       end
     end


### PR DESCRIPTION
### Context

The Rake task for payment breakdown was still using the old `lead_provider` -> aggregation + `lead_provider` -> calculator (contract) links. Since this has been updated to move the aggregation to the parent `cpd_lead_provider`, this rake task also needs to have the appropriate aggregator to `cpd_lead_provider` changes made.

### Changes proposed in this pull request

The ECF Payment Calculation Rake task needs the `CpdLeadProvider` for aggregation and
the original `LeadProvider` for the ECF `call_off_contract`.
This updates the breakdown and csv generation to support the new format.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
