### PR TITLE
CPDRP-616: admin challenge partnership

### DIFF
--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -22,7 +22,12 @@
     <dd class="govuk-summary-list__value">
       <%= school_cohort.lead_provider&.name %>
     </dd>
-    <dd class="govuk-summary-list__actions"></dd>
+    <dd class="govuk-summary-list__actions">
+      <% if school_cohort.lead_provider.present? %>
+        <%= govuk_link_to "Change", new_admin_school_challenge_partnership_path(id: school_cohort.cohort.start_year) %>
+        <span class="govuk-visually-hidden"> partnership</span>
+      <% end %>
+    </dd>
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -23,9 +23,11 @@
       <%= school_cohort.lead_provider&.name %>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <% if school_cohort.lead_provider.present? %>
-        <%= govuk_link_to "Change", new_admin_school_challenge_partnership_path(id: school_cohort.cohort.start_year) %>
-        <span class="govuk-visually-hidden"> partnership</span>
+      <% if FeatureFlag.active?(:admin_challenge_partnership) %>
+        <% if school_cohort.lead_provider.present? %>
+          <%= govuk_link_to "Change", new_admin_school_challenge_partnership_path(id: school_cohort.cohort.start_year) %>
+          <span class="govuk-visually-hidden"> partnership</span>
+        <% end %>
       <% end %>
     </dd>
   </div>

--- a/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
+++ b/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Admin
+  module Schools
+    module Cohorts
+      class ChallengePartnershipController < ::Admin::BaseController
+        skip_after_action :verify_policy_scoped
+        before_action :set_challenge_partnership_form, only: %i[confirm create]
+
+        def new
+          school = School.friendly.find params[:school_id]
+          cohort = ::Cohort.find_by(start_year: params[:id])
+          partnership = Partnership.find_by(school: school, cohort: cohort)
+          authorize partnership, :update?
+          @challenge_partnership_form = ChallengePartnershipForm.new(
+            school_name: school.name,
+            lead_provider_name: partnership.lead_provider.name,
+            delivery_partner_name: partnership.delivery_partner.name,
+            partnership_id: partnership.id,
+          )
+        end
+
+        def confirm
+          authorize @challenge_partnership_form.partnership, :update?
+          render :new unless @challenge_partnership_form.valid?
+        end
+
+        def create
+          authorize @challenge_partnership_form.partnership, :update?
+          @challenge_partnership_form.challenge!
+          set_success_message heading: "Induction programme has been changed"
+          redirect_to admin_school_cohorts_path
+        end
+
+      private
+
+        def set_challenge_partnership_form
+          @challenge_partnership_form = ChallengePartnershipForm.new(
+            params.require(:challenge_partnership_form).permit(:partnership_id, :challenge_reason, :lead_provider_name),
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
+++ b/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
@@ -14,8 +14,6 @@ module Admin
           authorize partnership, :update?
           @challenge_partnership_form = ChallengePartnershipForm.new(
             school_name: school.name,
-            lead_provider_name: partnership.lead_provider.name,
-            delivery_partner_name: partnership.delivery_partner.name,
             partnership_id: partnership.id,
           )
         end
@@ -36,7 +34,7 @@ module Admin
 
         def set_challenge_partnership_form
           @challenge_partnership_form = ChallengePartnershipForm.new(
-            params.require(:challenge_partnership_form).permit(:partnership_id, :challenge_reason, :lead_provider_name),
+            params.require(:challenge_partnership_form).permit(:partnership_id, :challenge_reason),
           )
         end
       end

--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -26,7 +26,7 @@ private
 
   def authorize_partnership
     @token = params[:token] || params.dig(:challenge_partnership_form, :token)
-    partnership_id = params[:partnership] || params.dig(:challenge_partnership_form, :partnership)
+    partnership_id = params[:partnership] || params.dig(:challenge_partnership_form, :partnership_id)
     if @token.present?
       notification_email = PartnershipNotificationEmail.find_by(token: @token)
       raise ActionController::RoutingError, "Not Found" if notification_email.blank?

--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -48,8 +48,6 @@ private
 
     @challenge_partnership_form = ChallengePartnershipForm.new(
       school_name: @school_name,
-      lead_provider_name: @partnership.lead_provider.name,
-      delivery_partner_name: @partnership.delivery_partner.name,
       token: @token,
       partnership_id: @partnership.id,
     )

--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -51,7 +51,7 @@ private
       lead_provider_name: @partnership.lead_provider.name,
       delivery_partner_name: @partnership.delivery_partner.name,
       token: @token,
-      partnership: @partnership,
+      partnership_id: @partnership.id,
     )
 
     @challenge_partnership_form.assign_attributes(form_params)

--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -16,8 +16,6 @@ class ChallengePartnershipForm
     Partnerships::Challenge.call(partnership, challenge_reason)
   end
 
-private
-
   def partnership
     Partnership.find(partnership_id)
   end

--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -3,7 +3,7 @@
 class ChallengePartnershipForm
   include ActiveModel::Model
 
-  attr_accessor :challenge_reason, :token, :school_name, :lead_provider_name, :delivery_partner_name, :partnership_id
+  attr_accessor :challenge_reason, :token, :school_name, :partnership_id
   validates :challenge_reason, presence: { message: "Select a reason why you think this confirmation is incorrect" }
 
   def challenge_reason_options
@@ -17,6 +17,14 @@ class ChallengePartnershipForm
   end
 
   def partnership
-    Partnership.find(partnership_id)
+    @partnership ||= Partnership.find(partnership_id)
+  end
+
+  def lead_provider_name
+    @lead_provider_name ||= partnership.lead_provider.name
+  end
+
+  def delivery_partner_name
+    @delivery_partner_name ||= partnership.delivery_partner.name
   end
 end

--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -3,7 +3,7 @@
 class ChallengePartnershipForm
   include ActiveModel::Model
 
-  attr_accessor :challenge_reason, :token, :school_name, :lead_provider_name, :delivery_partner_name, :partnership
+  attr_accessor :challenge_reason, :token, :school_name, :lead_provider_name, :delivery_partner_name, :partnership_id
   validates :challenge_reason, presence: { message: "Select a reason why you think this confirmation is incorrect" }
 
   def challenge_reason_options
@@ -14,5 +14,11 @@ class ChallengePartnershipForm
 
   def challenge!
     Partnerships::Challenge.call(partnership, challenge_reason)
+  end
+
+private
+
+  def partnership
+    Partnership.find(partnership_id)
   end
 end

--- a/app/policies/partnership_policy.rb
+++ b/app/policies/partnership_policy.rb
@@ -2,6 +2,7 @@
 
 class PartnershipPolicy < ApplicationPolicy
   def update?
+    return true if admin?
     return false unless user&.induction_coordinator?
 
     user.schools.include?(record.school)

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,6 +24,7 @@ class FeatureFlag
     participant_validation
     year_2020_data_entry
     admin_change_programme
+    admin_challenge_partnership
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-xl">
+      You are choosing to change course report and remove: <%= @challenge_partnership_form.lead_provider_name %>
+    </h1>
+    <%= form_for @challenge_partnership_form, url: admin_school_challenge_partnership_path do |f| %>
+      <%= f.hidden_field :partnership_id %>
+      <%= f.hidden_field :challenge_reason %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, "Report provider error" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Report that <%= @challenge_partnership_form.school_name %> has been signed up incorrectly</h1>
+
+    <%= form_for @challenge_partnership_form, url: confirm_admin_school_challenge_partnership_path do |f| %>
+      <%= f.hidden_field :partnership_id %>
+      <%= f.hidden_field :lead_provider_name %>
+      <%= f.govuk_collection_radio_buttons(
+            :challenge_reason,
+            @challenge_partnership_form.challenge_reason_options,
+            :id,
+            :name,
+            legend: { text: "Tell us why", size: "m" }) %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
@@ -6,7 +6,6 @@
 
     <%= form_for @challenge_partnership_form, url: confirm_admin_school_challenge_partnership_path do |f| %>
       <%= f.hidden_field :partnership_id %>
-      <%= f.hidden_field :lead_provider_name %>
       <%= f.govuk_collection_radio_buttons(
             :challenge_reason,
             @challenge_partnership_form.challenge_reason_options,

--- a/app/views/challenge_partnerships/show.html.erb
+++ b/app/views/challenge_partnerships/show.html.erb
@@ -9,7 +9,7 @@
 
     <%= form_for @challenge_partnership_form, url: challenge_partnership_path do |f| %>
       <%= f.hidden_field :token %>
-      <%= f.hidden_field :partnership, value: @challenge_partnership_form.partnership.id %>
+      <%= f.hidden_field :partnership_id %>
       <%= f.govuk_collection_radio_buttons(
             :challenge_reason,
             @challenge_partnership_form.challenge_reason_options,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,10 @@ Rails.application.routes.draw do
       resources :cohorts, controller: "schools/cohorts", only: :index do
         member do
           resource :change_programme, only: %i[show update], path: "change-programme", controller: "schools/cohorts/change_programme" do
-            post "confirm", action: :confirm
+            post :confirm
+          end
+          resource :challenge_partnership, only: %i[new create], path: "challenge-partnership", controller: "schools/cohorts/challenge_partnership" do
+            post :confirm
           end
         end
       end

--- a/spec/cypress/integration/ChallengePartnership.feature
+++ b/spec/cypress/integration/ChallengePartnership.feature
@@ -38,7 +38,6 @@ Feature: Reporting an error with a partnership
     When I navigate to "2021 school partnerships" page with id "111111-test-school"
     Then "page body" should contain "Signing up with a training provider"
 
-    @focus
   Scenario: A logged in induction tutor for CIP school challenges partnership
     Given I am logged in as existing user with email "test-subject2@example.com"
     And I am on "2021 school cohorts" page with id "111113-test-school-3"

--- a/spec/features/admin/schools/challenging_partnerships_spec.rb
+++ b/spec/features/admin/schools/challenging_partnerships_spec.rb
@@ -28,9 +28,9 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
 private
 
   def given_there_is_a_partnered_school
-    @partnership = create(:partnership)
-    @school = @partnership.school
-    @cohort = @partnership.cohort
+    @school = create(:school, name: "Test School")
+    @cohort = create(:cohort, start_year: 2021)
+    @partnership = create(:partnership, school: @school, cohort: @cohort)
     create(:school_cohort, cohort: @cohort, school: @school, induction_programme_choice: "full_induction_programme")
   end
 

--- a/spec/features/admin/schools/challenging_partnerships_spec.rb
+++ b/spec/features/admin/schools/challenging_partnerships_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
+  scenario "Admin challenges school partnership" do
+    given_there_is_a_partnered_school
+    and_i_am_signed_in_as_an_admin
+    when_i_visit the_school_cohorts_page
+    and_i_click_the_link_containing "Change"
+
+    then_i_should_be_on the_challenge_partnership_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named("Admin challenge partnership page")
+
+    when_i_select_mistake
+    and_i_click_the_submit_button
+    then_i_should_be_on the_confirm_page
+    and_the_page_should_contain_lead_provider_name
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named("Admin confirm challenge partnership page")
+
+    when_i_click_the_submit_button
+    then_i_should_be_on the_school_cohorts_page
+    and_there_should_be_a_success_banner
+  end
+
+private
+
+  def given_there_is_a_partnered_school
+    @partnership = create(:partnership)
+    @school = @partnership.school
+    @cohort = @partnership.cohort
+    create(:school_cohort, cohort: @cohort, school: @school, induction_programme_choice: "full_induction_programme")
+  end
+
+  def the_school_cohorts_page
+    admin_school_cohorts_path(school_id: @school.slug)
+  end
+
+  def the_challenge_partnership_page
+    new_admin_school_challenge_partnership_path(school_id: @school.slug, id: @cohort.start_year)
+  end
+
+  def when_i_select_mistake
+    choose option: "mistake", allow_label_click: true
+  end
+
+  def the_confirm_page
+    confirm_admin_school_challenge_partnership_path(school_id: @school.slug, id: @cohort.start_year)
+  end
+
+  def and_the_page_should_contain_lead_provider_name
+    expect(page).to have_content @partnership.lead_provider.name
+  end
+end

--- a/spec/features/admin/schools/challenging_partnerships_spec.rb
+++ b/spec/features/admin/schools/challenging_partnerships_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
   scenario "Admin challenges school partnership" do
     given_there_is_a_partnered_school
+    and_feature_flag_is_active :admin_challenge_partnership
     and_i_am_signed_in_as_an_admin
     when_i_visit the_school_cohorts_page
     and_i_click_the_link_containing "Change"

--- a/spec/features/admin/schools/changing_provision_spec.rb
+++ b/spec/features/admin/schools/changing_provision_spec.rb
@@ -27,8 +27,9 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
 private
 
   def given_there_is_a_fip_school_in_2021
+    school = create(:school, name: "Test school")
     cohort = create(:cohort, start_year: 2021)
-    @school_cohort = create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme")
+    @school_cohort = create(:school_cohort, school: school, cohort: cohort, induction_programme_choice: "full_induction_programme")
   end
 
   def and_feature_flag_is_active(flag)

--- a/spec/features/admin/schools/changing_provision_spec.rb
+++ b/spec/features/admin/schools/changing_provision_spec.rb
@@ -32,10 +32,6 @@ private
     @school_cohort = create(:school_cohort, school: school, cohort: cohort, induction_programme_choice: "full_induction_programme")
   end
 
-  def and_feature_flag_is_active(flag)
-    FeatureFlag.activate(flag)
-  end
-
   def the_school_cohorts_page
     admin_school_cohorts_path(school_id: @school_cohort.school.slug)
   end

--- a/spec/features/admin/schools/changing_provision_spec.rb
+++ b/spec/features/admin/schools/changing_provision_spec.rb
@@ -7,20 +7,20 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
     given_there_is_a_fip_school_in_2021
     and_i_am_signed_in_as_an_admin
     and_feature_flag_is_active :admin_change_programme
-    when_i_visit_the_school_cohorts_page
-    and_i_click_the_change_link
-    then_i_should_be_on_the_change_programme_page
+    when_i_visit the_school_cohorts_page
+    and_i_click_the_link_containing "Change"
+    then_i_should_be_on the_change_programme_page
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named("Admin choose programme page")
 
     when_i_select_cip
     and_i_click_the_submit_button
-    then_i_should_be_on_the_confirm_page
+    then_i_should_be_on the_confirm_page
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named("Admin confirm programme page")
 
     when_i_click_the_submit_button
-    then_i_should_be_on_the_school_cohorts_page
+    then_i_should_be_on the_school_cohorts_page
     and_there_should_be_a_success_banner
   end
 
@@ -31,47 +31,23 @@ private
     @school_cohort = create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme")
   end
 
-  def and_i_am_signed_in_as_an_admin
-    create(:user, :admin, login_token: "test-token")
-    visit "/users/confirm_sign_in?login_token=test-token"
-    click_button "Continue"
-  end
-
   def and_feature_flag_is_active(flag)
     FeatureFlag.activate(flag)
   end
 
-  def when_i_visit_the_school_cohorts_page
-    visit admin_school_cohorts_path(school_id: @school_cohort.school.slug)
+  def the_school_cohorts_page
+    admin_school_cohorts_path(school_id: @school_cohort.school.slug)
   end
 
-  def and_i_click_the_change_link
-    click_link("Change")
-  end
-
-  def then_i_should_be_on_the_change_programme_page
-    expect(page).to have_current_path admin_school_change_programme_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
+  def the_change_programme_page
+    admin_school_change_programme_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
   end
 
   def when_i_select_cip
     choose option: "core_induction_programme", allow_label_click: true
   end
 
-  def and_i_click_the_submit_button
-    click_button "Continue"
-  end
-
-  alias_method :when_i_click_the_submit_button, :and_i_click_the_submit_button
-
-  def then_i_should_be_on_the_confirm_page
-    expect(page).to have_current_path confirm_admin_school_change_programme_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
-  end
-
-  def then_i_should_be_on_the_school_cohorts_page
-    expect(page).to have_current_path admin_school_cohorts_path(school_id: @school_cohort.school.slug)
-  end
-
-  def and_there_should_be_a_success_banner
-    expect(page).to have_selector ".govuk-notification-banner--success"
+  def the_confirm_page
+    confirm_admin_school_change_programme_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
   end
 end

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -20,6 +20,9 @@ Capybara.javascript_driver = :chrome_headless
 
 RSpec.configure do |config|
   config.include AxeAndPercyHelper, type: :feature
+  config.include InteractionHelper, type: :feature
+  config.include PageAssertionsHelper, type: :feature
+  config.include UserHelper, type: :feature
 
   # need this for percy and axe
   config.before(:each, type: :feature) do

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -20,6 +20,7 @@ Capybara.javascript_driver = :chrome_headless
 
 RSpec.configure do |config|
   config.include AxeAndPercyHelper, type: :feature
+  config.include FeatureFlagHelper, type: :feature
   config.include InteractionHelper, type: :feature
   config.include PageAssertionsHelper, type: :feature
   config.include UserHelper, type: :feature

--- a/spec/forms/challenge_partnership_form_spec.rb
+++ b/spec/forms/challenge_partnership_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ChallengePartnershipForm, type: :model do
     let(:partnership) { create :partnership }
     let(:reason) { described_class.new.challenge_reason_options.sample.id }
 
-    subject { described_class.new(partnership: partnership, challenge_reason: reason) }
+    subject { described_class.new(partnership_id: partnership.id, challenge_reason: reason) }
 
     it "calls Partnerships::Challenge" do
       expect(Partnerships::Challenge).to receive(:call).with(partnership, reason)

--- a/spec/forms/challenge_partnership_form_spec.rb
+++ b/spec/forms/challenge_partnership_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ChallengePartnershipForm, type: :model do
   describe "validations" do
     it do
       is_expected.to validate_presence_of(:challenge_reason)
-        .with_message("Select a reason why you think this confirmation is incorrect")
+                       .with_message("Select a reason why you think this confirmation is incorrect")
     end
   end
 
@@ -17,6 +17,38 @@ RSpec.describe ChallengePartnershipForm, type: :model do
     it "calls Partnerships::Challenge" do
       expect(Partnerships::Challenge).to receive(:call).with(partnership, reason)
       subject.challenge!
+    end
+  end
+
+  describe "#partnership" do
+    let!(:correct_partnership) { create(:partnership) }
+    let!(:incorrect_partnership) { create(:partnership) }
+    subject { described_class.new(partnership_id: correct_partnership.id) }
+
+    it "returns the correct partnership" do
+      expect(subject.partnership).to eql correct_partnership
+    end
+  end
+
+  describe "#lead_provider_name" do
+    let!(:partnership) { create(:partnership) }
+    let!(:incorrect_lead_provider) { create(:lead_provider, name: "wrong name") }
+    let(:correct_name) { partnership.lead_provider.name }
+    subject { described_class.new(partnership_id: partnership.id) }
+
+    it "returns the correct lead provider name" do
+      expect(subject.lead_provider_name).to eql correct_name
+    end
+  end
+
+  describe "#delivery_partner_name" do
+    let!(:partnership) { create(:partnership) }
+    let!(:incorrect_lead_provider) { create(:delivery_partner, name: "wrong name") }
+    let(:correct_name) { partnership.delivery_partner.name }
+    subject { described_class.new(partnership_id: partnership.id) }
+
+    it "returns the correct delivery partner name" do
+      expect(subject.delivery_partner_name).to eql correct_name
     end
   end
 end

--- a/spec/policies/partnership_policy_spec.rb
+++ b/spec/policies/partnership_policy_spec.rb
@@ -22,4 +22,10 @@ RSpec.describe PartnershipPolicy, type: :policy do
 
     it { is_expected.not_to permit_actions(%i[create show edit update]) }
   end
+
+  context "being an admin" do
+    let(:user) { create(:user, :admin) }
+
+    it { is_expected.to permit_action(:update) }
+  end
 end

--- a/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
+++ b/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
+  let(:partnership) { create(:partnership) }
+  let(:school) { partnership.school }
+  let(:cohort) { partnership.cohort }
+
+  before do
+    sign_in create(:user, :admin)
+  end
+
+  describe "GET /admin/schools/:school_slug/cohorts/:id/challenge-partnership/new" do
+    it "renders the new template" do
+      get "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership/new"
+      expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
+    end
+  end
+
+  describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership/confirm" do
+    it "shows an error message if no reason is selected" do
+      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership/confirm", params: {
+        challenge_partnership_form: {
+          partnership_id: partnership.id,
+          lead_provider_name: partnership.lead_provider.name,
+          challenge_reason: "",
+        },
+      }
+
+      expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
+      expect(response.body).to include "Select a reason why you think this confirmation is incorrect"
+    end
+
+    it "shows a confirmation message" do
+      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership/confirm", params: {
+        challenge_partnership_form: {
+          partnership_id: partnership.id,
+          lead_provider_name: partnership.lead_provider.name,
+          challenge_reason: "mistake",
+        },
+      }
+
+      expect(response).to render_template "admin/schools/cohorts/challenge_partnership/confirm"
+    end
+  end
+
+  describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership" do
+    it "call Partnerships::Challenge with the correct arguments" do
+      expect(Partnerships::Challenge).to receive(:call).with(partnership, "mistake")
+
+      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership", params: {
+        challenge_partnership_form: {
+          partnership_id: partnership.id,
+          challenge_reason: "mistake",
+        },
+      }
+    end
+
+    it "redirects to the cohorts page and shows a success message" do
+      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership", params: {
+        challenge_partnership_form: {
+          partnership_id: partnership.id,
+          challenge_reason: "mistake",
+        },
+      }
+
+      expect(response).to redirect_to "/admin/schools/#{school.slug}/cohorts"
+      follow_redirect!
+      expect(response.body).to include "Induction programme has been changed"
+    end
+  end
+end

--- a/spec/services/admin/change_induction_choice_service_spec.rb
+++ b/spec/services/admin/change_induction_choice_service_spec.rb
@@ -213,14 +213,6 @@ RSpec.describe Admin::ChangeInductionService do
     end
   end
 
-  describe "#challenge_partnership" do
-    let(:school) { create(:school_cohort, induction_programme_choice: "full_induction_programme", cohort: cohort).school }
-    let!(:partnership) { create(:partnership, cohort: cohort, school: school) }
-
-    it "should record the reason for challenging the partnership"
-    it "should email the lead provider"
-  end
-
 private
 
   def expect_to_set_to(new_value)

--- a/spec/services/partnerships/challenge_spec.rb
+++ b/spec/services/partnerships/challenge_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe Partnerships::Challenge do
       expect { subject.call }.to change { partnership.reload.challenged? }.to true
     end
 
+    it "sets the correct challenge reason" do
+      expect { subject.call }.to change { partnership.reload.challenge_reason }.to reason
+      created_event = partnership.event_logs.order(created_at: :desc).first
+      expect(created_event.event).to eql "challenged"
+      expect(created_event.data["reason"]).to eql reason
+    end
+
     it "stores :challenged event in the partnership event log" do
       expect { subject.call }.to change { partnership.event_logs.map(&:event) }.by %w[challenged]
     end

--- a/spec/support/features/feature_flag_helper.rb
+++ b/spec/support/features/feature_flag_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module FeatureFlagHelper
+  def and_feature_flag_is_active(flag)
+    FeatureFlag.activate(flag)
+  end
+end

--- a/spec/support/features/interaction_helper.rb
+++ b/spec/support/features/interaction_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module InteractionHelper
+  include Capybara::DSL
+
+  alias_method :when_i_click_the_link_containing, :click_link
+  alias_method :and_i_click_the_link_containing, :click_link
+
+  def when_i_click_the_submit_button
+    click_button class: "govuk-button", name: "commit"
+  end
+
+  alias_method :and_i_click_the_submit_button, :when_i_click_the_submit_button
+
+  def then_i_should_be_on(path)
+    expect(page).to have_current_path path
+  end
+
+  alias_method :and_i_should_be_on, :then_i_should_be_on
+
+  def when_i_visit(path)
+    visit path
+  end
+
+  alias_method :and_i_visit, :when_i_visit
+end

--- a/spec/support/features/page_assertions_helper.rb
+++ b/spec/support/features/page_assertions_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageAssertionsHelper
+  include Capybara::DSL
+
+  def then_there_should_be_a_success_banner
+    expect(page).to have_selector ".govuk-notification-banner--success"
+  end
+
+  alias_method :and_there_should_be_a_success_banner, :then_there_should_be_a_success_banner
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module UserHelper
+  def given_i_am_logged_in_as_an_admin
+    create(:user, :admin, login_token: "test-token")
+    visit "/users/confirm_sign_in?login_token=test-token"
+    click_button "Continue"
+  end
+
+  alias_method :and_i_am_signed_in_as_an_admin, :given_i_am_logged_in_as_an_admin
+end


### PR DESCRIPTION
### Context
CPDRP-616 PR 2/3 
Give admins the ability to challenge a partnership on behalf of a school. There is no time limit on this at the moment, so we will need to revisit this once the declarations start coming in

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
