### PR TITLE
Do not explicitly specify percy nonce to allow test re-runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,19 @@ on:
       - '**'
 
 jobs:
+  create-nonce:
+    name: Create nonce
+    runs-on: ubuntu-20.04
+    outputs:
+      nonce: ${{ steps.generate-nonce.outputs.nonce }}
+    steps:
+      - id: generate-nonce
+        run: echo "::set-output nonce=$(tr -dc 0-9 </dev/urandom | head -c 18 ; echo '')"
+
   backend-tests:
     name: Run rspec
-
     runs-on: ubuntu-20.04
+    needs: create-nonce
 
     env:
       RAILS_ENV: test
@@ -18,6 +27,7 @@ jobs:
       DB_HOSTNAME: 127.0.0.1
       DB_PORT: 5432
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      PERCY_PARALLEL_NONCE: ${{ needs.create-nonce.outputs.nonce }}
       PERCY_PARALLEL_TOTAL: 2
 
     services:
@@ -105,8 +115,8 @@ jobs:
 
   e2e-tests:
     name: Run Cypress
-
     runs-on: ubuntu-20.04
+    needs: create-nonce
 
     env:
       RAILS_ENV: test
@@ -176,4 +186,5 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}
+          PERCY_PARALLEL_NONCE: ${{ needs.create-nonce.outputs.nonce }}
           PERCY_PARALLEL_TOTAL: 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       DB_HOSTNAME: 127.0.0.1
       DB_PORT: 5432
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-      PERCY_PARALLEL_NONCE: ${{ github.run_number }}
       PERCY_PARALLEL_TOTAL: 2
 
     services:
@@ -177,5 +176,4 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}
-          PERCY_PARALLEL_NONCE: ${{ github.run_number }}
           PERCY_PARALLEL_TOTAL: 2


### PR DESCRIPTION
Per documentation https://docs.percy.io/docs/parallel-test-suites#advanced-details the nonce should be
automatically provided by github actions. Fixing it to the run number
prevents re-running a failed test run
