### PR TITLE
Rename Z2H heading in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 # Early careers framework
 
-## Z2H
+## Development Setup
+
 ### Prerequisites
 
 - Ruby 2.7.2


### PR DESCRIPTION
### Changes

Put a plain English replacement for Z2H heading in readme

### Context

The readme should be in plain English as much as possible because there will be many people of varying skills and culture who wish to understand this repo and how to use it. It certainly threw me, I assumed it was a mistake.

It seems from the PR comments on PR #773 (take 1 of this) that Z2H is an acronym for Zero-to-Hero, which is a slang way of getting set up quickly.