### PR TITLE
Delete flapping randomized feature flag tests

### DIFF
--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -31,25 +31,6 @@ RSpec.describe FeatureFlag do
         expect(described_class.active?(feature_name, for: double)).to be true
       end
     end
-
-    context "with object given via for: keyword" do
-      let(:object) { random_record }
-      let(:other_object) { random_record }
-
-      before { described_class.activate(feature_name, for: object) }
-
-      it "enables the feature for given object" do
-        expect(described_class.active?(feature_name, for: object)).to be true
-      end
-
-      it "does not enable the feature for other objects" do
-        expect(described_class.active?(feature_name, for: other_object)).to be false
-      end
-
-      it "does not enable the feature globally" do
-        expect(described_class.active?(feature_name)).to be false
-      end
-    end
   end
 
   describe ".deactivate" do
@@ -69,14 +50,6 @@ RSpec.describe FeatureFlag do
           change { feature.reload.active }.from(true).to(false),
         )
       end
-
-      it "does not deactivate object based flags" do
-        object = random_record
-        described_class.activate(feature_name, for: object)
-
-        expect { described_class.deactivate(feature_name) }
-          .not_to change { described_class.active?(feature_name, for: object) }
-      end
     end
 
     context "with for: :all" do
@@ -95,39 +68,6 @@ RSpec.describe FeatureFlag do
           change { feature.reload.active }.from(true).to(false),
         )
       end
-
-      it "does deactivate all object based flags" do
-        object = random_record
-        described_class.activate(feature_name, for: object)
-
-        expect { described_class.deactivate(feature_name, for: :all) }
-          .to change { described_class.active?(feature_name, for: object) }.to false
-      end
     end
-
-    context "with object passed via for: keyword" do
-      let(:object) { random_record }
-      let(:other_object) { random_record }
-
-      before do
-        described_class.activate(feature_name, for: object)
-        described_class.activate(feature_name, for: other_object)
-      end
-
-      it "does deactivate the feature for given object" do
-        expect { described_class.deactivate(feature_name, for: object) }
-          .to change { described_class.active?(feature_name, for: object) }.to false
-      end
-
-      it "does not deactivate the feature for other objects" do
-        expect { described_class.deactivate(feature_name, for: object) }
-          .not_to change { described_class.active?(feature_name, for: other_object) }
-      end
-    end
-  end
-
-  def random_record
-    # TODO: WHY ARE SOME FACTORIES BROKEN?
-    create FactoryBot.factories.map(&:name).without(:participant_band, :pupil_premium, :declarable, :profile_declaration, :participant_declaration, :npq_participant_declaration).sample
   end
 end


### PR DESCRIPTION
### Changes proposed in this pull request

Delete flapping randomized feature flag tests

### Context

Tests should be repeatable. For reasons that are not explained in the history these tests use a randomized set of factories, as a result this test file is randomly failing causing a drag on other development. This should never have been allowed into the main branch.

In order to restore sanity to development this patch deletes the offending randomization and the tests that depend on it. I shall leave it to the author of these tests to re-do the coverage in a more stable way.