### PR TITLE
Fix the deprecation warning for rspec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -258,8 +258,8 @@ RSpec.describe User, type: :model do
 
       subject { User.changed_since(nil) }
 
-      it { should include user }
-      it { should include old_user }
+      it { is_expected.to include user }
+      it { is_expected.to include old_user }
     end
 
     context "with a user that was just updated" do
@@ -270,8 +270,8 @@ RSpec.describe User, type: :model do
 
       subject { User.changed_since(10.minutes.ago) }
 
-      it { should include user }
-      it { should_not include old_user }
+      it { is_expected.to include user }
+      it { is_expected.to_not include old_user }
     end
 
     context "with a user that has been updated less than a second after the given timestamp" do
@@ -280,7 +280,7 @@ RSpec.describe User, type: :model do
 
       subject { User.changed_since(timestamp) }
 
-      it { should include user }
+      it { is_expected.to include user }
     end
 
     context "with a user that has been updated exactly at the given timestamp" do
@@ -289,7 +289,7 @@ RSpec.describe User, type: :model do
 
       subject { User.changed_since(timestamp) }
 
-      it { should_not include user }
+      it { is_expected.to_not include user }
     end
   end
 


### PR DESCRIPTION
### Context

There are some older tests using `should` and `should_not` rather than the more modern `expect().to` and `expect().to_not`.
This commit replaces just those tests.

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
