### PR TITLE
Ignoring user_id on participant profiles

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -27,7 +27,7 @@ class ParticipantProfile < ApplicationRecord
   class_attribute :validation_steps
   self.validation_steps = []
 
-  self.ignored_columns = %w(user_id)
+  self.ignored_columns = %w[user_id]
 
   def ect?
     false

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -27,6 +27,8 @@ class ParticipantProfile < ApplicationRecord
   class_attribute :validation_steps
   self.validation_steps = []
 
+  self.ignored_columns = %w(user_id)
+
   def ect?
     false
   end


### PR DESCRIPTION
The column is unused now