### PR TITLE
CPDRP-616: Allow admins to change CIP materials

### DIFF
--- a/app/components/admin/schools/cohorts/cip_info.html.erb
+++ b/app/components/admin/schools/cohorts/cip_info.html.erb
@@ -20,6 +20,14 @@
     <dd class="govuk-summary-list__value">
       <%= school_cohort.core_induction_programme&.name %>
     </dd>
-    <dd class="govuk-summary-list__actions"></dd>
+    <dd class="govuk-summary-list__actions">
+      <% if FeatureFlag.active?(:admin_change_materials) %>
+        <%= govuk_link_to "Change",
+                          admin_school_change_training_materials_path(id: school_cohort.cohort.start_year),
+                          "data-test": "change-materials"
+        %>
+        <span class="govuk-visually-hidden"> training materials</span>
+      <% end %>
+    </dd>
   </div>
 </dl>

--- a/app/controllers/admin/schools/cohorts/change_training_materials_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_training_materials_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Admin
+  module Schools
+    module Cohorts
+      class ChangeTrainingMaterialsController < ::Admin::BaseController
+        skip_after_action :verify_authorized
+        skip_after_action :verify_policy_scoped
+        before_action :set_school_and_cohort
+        before_action :set_form, only: %i[confirm update]
+
+        def show
+          @core_induction_programme_choice_form = CoreInductionProgrammeChoiceForm.new
+        end
+
+        def confirm
+          render :show unless @core_induction_programme_choice_form.valid?
+        end
+
+        def update
+          update_training_materials
+          set_success_message heading: "Training materials have been changed"
+          redirect_to admin_school_cohorts_path
+        end
+
+      private
+
+        def update_training_materials
+          service = ChangeInductionService.new(school: @school, cohort: @cohort)
+          new_materials = @core_induction_programme_choice_form.core_induction_programme
+          service.change_cip_materials(new_materials)
+        end
+
+        def set_school_and_cohort
+          @cohort = ::Cohort.find_by(start_year: params[:id])
+          @school = ::School.friendly.find(params[:school_id])
+        end
+
+        def set_form
+          @core_induction_programme_choice_form = CoreInductionProgrammeChoiceForm.new(
+            params.require(:core_induction_programme_choice_form).permit(:core_induction_programme_id),
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/forms/core_induction_programme_choice_form.rb
+++ b/app/forms/core_induction_programme_choice_form.rb
@@ -12,4 +12,8 @@ class CoreInductionProgrammeChoiceForm
       .pluck(:id, :name)
       .map { |attrs| OpenStruct.new(attrs) }
   end
+
+  def core_induction_programme
+    CoreInductionProgramme.find(core_induction_programme_id)
+  end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,6 +25,7 @@ class FeatureFlag
     year_2020_data_entry
     admin_change_programme
     admin_challenge_partnership
+    admin_change_materials
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/views/admin/schools/cohorts/change_training_materials/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/change_training_materials/confirm.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-xl">
+      You are choosing to change course to: <%= @core_induction_programme_choice_form.core_induction_programme.name %>
+    </h1>
+    <%= form_for @core_induction_programme_choice_form, url: admin_school_change_training_materials_path, method: :put do |f| %>
+      <%= f.hidden_field :core_induction_programme_id %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/schools/cohorts/change_training_materials/show.html.erb
+++ b/app/views/admin/schools/cohorts/change_training_materials/show.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= form_for @core_induction_programme_choice_form, url: confirm_admin_school_change_training_materials_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons :core_induction_programme_id,
+                                           CoreInductionProgramme.all,
+                                           :id,
+                                           :name,
+                                           legend: { text: "Change course for #{@school.name} #{@cohort.academic_year}", tag: "h1", size: "xl" } %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,9 @@ Rails.application.routes.draw do
           resource :challenge_partnership, only: %i[new create], path: "challenge-partnership", controller: "schools/cohorts/challenge_partnership" do
             post :confirm
           end
+          resource :change_training_materials, only: %i[show update], path: "change-training-materials", controller: "schools/cohorts/change_training_materials" do
+            post :confirm
+          end
         end
       end
       resources :participants, controller: "schools/participants", only: :index

--- a/spec/features/admin/schools/changing_training_materials_spec.rb
+++ b/spec/features/admin/schools/changing_training_materials_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
+  scenario "Admin changes training materials" do
+    given_there_is_a_cip_school_in_2021
+    and_there_is_another_core_induction_programme
+    and_i_am_signed_in_as_an_admin
+    and_feature_flag_is_active :admin_change_materials
+    when_i_visit the_school_cohorts_page
+    and_i_click_the_change_materials_link
+    then_i_should_be_on the_change_materials_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named("Admin change materials page")
+
+    when_i_select_ambition
+    and_i_click_the_submit_button
+    then_i_should_be_on the_confirm_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named("Admin confirm change materials page")
+
+    when_i_click_the_submit_button
+    then_i_should_be_on the_school_cohorts_page
+    and_there_should_be_a_success_banner
+  end
+
+private
+
+  def given_there_is_a_cip_school_in_2021
+    school = create(:school, name: "Test school")
+    cohort = create(:cohort, start_year: 2021)
+    chosen_cip = create(:core_induction_programme, name: "Chosen CIP")
+    @school_cohort = create(:school_cohort,
+                            school: school,
+                            cohort: cohort,
+                            induction_programme_choice: "core_induction_programme",
+                            core_induction_programme: chosen_cip)
+  end
+
+  def and_there_is_another_core_induction_programme
+    @other_cip = create(:core_induction_programme, name: "Other CIP")
+  end
+
+  def the_school_cohorts_page
+    admin_school_cohorts_path(school_id: @school_cohort.school.slug)
+  end
+
+  def and_i_click_the_change_materials_link
+    find("[data-test=change-materials]").click
+  end
+
+  def the_change_materials_page
+    admin_school_change_training_materials_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
+  end
+
+  def when_i_select_ambition
+    choose option: @other_cip.id, allow_label_click: true
+  end
+
+  def the_confirm_page
+    confirm_admin_school_change_training_materials_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
+  end
+end

--- a/spec/requests/admin/schools/cohorts/change_training_materials_spec.rb
+++ b/spec/requests/admin/schools/cohorts/change_training_materials_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Schools::Cohorts::ChangeTrainingMaterials", type: :request do
+  let(:school_cohort) { create(:school_cohort) }
+  let(:school) { school_cohort.school }
+  let(:cohort) { school_cohort.cohort }
+
+  before do
+    sign_in create(:user, :admin)
+  end
+
+  describe "GET /admin/schools/:school_slug/cohorts/:id/change-training-materials" do
+    it "renders the new template" do
+      get "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-training-materials"
+      expect(response).to render_template "admin/schools/cohorts/change_training_materials/show"
+    end
+  end
+
+  describe "POST /admin/schools/:school_slug/cohorts/:id/change-training-materials/confirm" do
+    it "shows an error message if no reason is selected" do
+      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-training-materials/confirm", params: {
+        core_induction_programme_choice_form: {
+          core_induction_programme_id: "",
+        },
+      }
+
+      expect(response).to render_template "admin/schools/cohorts/change_training_materials/show"
+      expect(response.body).to include "Select the training materials you want to use"
+    end
+
+    it "shows a confirmation message" do
+      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-training-materials/confirm", params: {
+        core_induction_programme_choice_form: {
+          core_induction_programme_id: create(:core_induction_programme).id,
+        },
+      }
+
+      expect(response).to render_template "admin/schools/cohorts/change_training_materials/confirm"
+    end
+  end
+
+  describe "POST /admin/schools/:school_slug/cohorts/:id/change-training-materials" do
+    let(:core_induction_programme) { create(:core_induction_programme) }
+    it "calls change_cip_materials with the correct arguments" do
+      expect(Admin::ChangeInductionService).to receive(:new).with(school: school, cohort: cohort).and_call_original
+      expect_any_instance_of(Admin::ChangeInductionService).to receive(:change_cip_materials).with(core_induction_programme)
+
+      put "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-training-materials", params: {
+        core_induction_programme_choice_form: {
+          core_induction_programme_id: core_induction_programme.id,
+        },
+      }
+    end
+
+    it "redirects to the cohorts page and shows a success message" do
+      put "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-training-materials", params: {
+        core_induction_programme_choice_form: {
+          core_induction_programme_id: core_induction_programme.id,
+        },
+      }
+
+      expect(response).to redirect_to "/admin/schools/#{school.slug}/cohorts"
+      follow_redirect!
+      expect(response.body).to include "Training materials have been changed"
+    end
+  end
+end


### PR DESCRIPTION
### Context
CPDRP-616
PR 3/3
This completes the set of admin managing schools' provision functionality. Allow changing the CIP

Feature flagged until review

### Testing
Request and feature specs

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
admin@example.com