### PR TITLE
Correct the number of retained for npqs

### DIFF
--- a/etc/schema/0.3/npq/participant_declarations/retained/create/request_schema.json
+++ b/etc/schema/0.3/npq/participant_declarations/retained/create/request_schema.json
@@ -30,9 +30,7 @@
       "retained": {
         "enum": [
           "retained-1",
-          "retained-2",
-          "retained-3",
-          "retained-4"
+          "retained-2"
         ]
       }
     },

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -12,8 +12,6 @@ properties:
     enum:
       - retained-1
       - retained-2
-      - retained-3
-      - retained-4
     example: retained-1
   declaration_date:
     description: "The event declaration date"


### PR DESCRIPTION
### Context

NPQs only have retained-1 and retained-2, so the schema for swagger and validation needs to reflect this.

### Changes proposed in this pull request

Drop the retained-3 and retained-4 from the schema docs.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
