### PR TITLE
CDPTP-390 Fix sandbox data seed with new ecf_participant_profiles

### DIFF
--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -21,8 +21,8 @@ namespace :lead_provider do
 end
 
 def generate_mentors(lead_provider, school, cohort, logger)
-  existing_mentor_count = lead_provider.participant_profiles.mentors.count
-  existing_ect_count = lead_provider.participant_profiles.ects.count
+  existing_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
+  existing_ect_count = lead_provider.ecf_participant_profiles.ects.count
   school_cohort = SchoolCohort.find_or_create_by!(school: school, cohort: cohort)
 
   10.times do
@@ -43,9 +43,9 @@ def generate_mentors(lead_provider, school, cohort, logger)
     ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
     ParticipantProfile::ECT.create!(user: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn")
   end
-  new_mentor_count = lead_provider.participant_profiles.mentors.count
+  new_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
   logger.info(" Before: #{existing_mentor_count} mentors, after: #{new_mentor_count}")
-  new_ect_count = lead_provider.participant_profiles.ects.count
+  new_ect_count = lead_provider.ecf_participant_profiles.ects.count
   logger.info(" Before: #{existing_ect_count} ECTs, after: #{new_ect_count}")
 end
 


### PR DESCRIPTION
### Context

Wasn't updated when the participant_profiles to ecf_participant_profiles change was made.


### Changes proposed in this pull request

Switch from participant_profiles in the rake task to ecf_participant_profiles to ensure that seeding works.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
