### PR TITLE
Fix API URLs on API usage guide

### DIFF
--- a/app/views/lead_providers/guidance/reference.html.erb
+++ b/app/views/lead_providers/guidance/reference.html.erb
@@ -72,7 +72,7 @@
 </p>
 
 <p class="govuk-body">
-  <%= govuk_link_to 'https://ecf-sandbox.london.cloudapps.digital/api-docs/reference', 'https://ecf-sandbox.london.cloudapps.digital/api-docs/reference' %>
+  <%= govuk_link_to 'https://ecf-sandbox.london.cloudapps.digital/api/v1', 'https://ecf-sandbox.london.cloudapps.digital/api/v1' %>
 </p>
 
 <p class="govuk-body">
@@ -81,7 +81,7 @@
 </p>
 
 <p class="govuk-body">
-  <%= govuk_link_to 'https://manage-training-for-early-career-teachers.education.gov.uk/api-docs/reference', 'https://manage-training-for-early-career-teachers.education.gov.uk/api-docs/reference' %>
+  <%= govuk_link_to 'https://manage-training-for-early-career-teachers.education.gov.uk/api/v1', 'https://manage-training-for-early-career-teachers.education.gov.uk/api/v1' %>
 </p>
 
 <h3 class="govuk-heading-m">Rate limits</h3>


### PR DESCRIPTION
### Context

These links are currently 404ing. They should be the API paths for each environment.
