### PR TITLE
Fix production compilation and performance webpacker settings

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -81,14 +81,14 @@ test:
 production: &production
   <<: *default
 
-sandbox: &production
-  <<: *default
-
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+sandbox: &production
+  <<: *default
 
 deployed_development:
   <<: *production


### PR DESCRIPTION
### Context

A change was introduced in bea7a4ad827179dfcd63d8811fb3a10fe2c60956 to add the new sandbox environment to webpacker. It pushed two config settings into the sandbox environment instead of the production environment.

### Changes proposed in this pull request

This PR pushes the values back into the scope of production which is then inherited by the other non-test environments.