### PR TITLE
Cpdrp 701 readd withdrawn participants

### DIFF
--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -7,6 +7,7 @@ module Admin
 
     def index
       @participant_profiles = policy_scope(ParticipantProfile::ECF, policy_scope_class: ParticipantProfilePolicy::Scope)
+        .active
         .where(school_cohort_id: SchoolCohort.where(school: school).select(:id))
         .includes(:user)
         .order("users.full_name")

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -52,10 +52,11 @@ module Api
 
       def participants
         participants = lead_provider.ecf_participants
-                           .includes(
-                             early_career_teacher_profile: %i[cohort mentor school],
-                             mentor_profile: %i[cohort school],
-                           )
+                                    .distinct
+                                    .includes(
+                                      early_career_teacher_profile: %i[cohort mentor school],
+                                      mentor_profile: %i[cohort school],
+                                    )
 
         if updated_since.present?
           participants = participants.changed_since(updated_since)

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -79,7 +79,12 @@ module Schools
     end
 
     def email_already_taken?
-      User.find_by(email: email)&.participant_profiles&.ecf&.any?
+      User.find_by(email: email)
+        &.teacher_profile
+        &.participant_profiles
+        &.active
+        &.ecf
+        &.any?
     end
 
     def type=(value)

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -11,7 +11,11 @@ module EarlyCareerTeachers
         end
         user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active&.any?
 
-        ParticipantProfile::ECT.create!({ user: user }.merge(ect_attributes))
+        teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
+          profile.school = school_cohort.school
+        end
+
+        ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile }.merge(ect_attributes))
       end
     end
 

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -5,8 +5,12 @@ module EarlyCareerTeachers
     include SchoolCohortDelegator
     def call
       ActiveRecord::Base.transaction do
-        # TODO: What if email matches but with different name?
-        user = User.find_or_create_by!(full_name: full_name, email: email)
+        # Retain the original name if the user already exists
+        user = User.find_or_create_by!(email: email) do |ect|
+          ect.full_name = full_name
+        end
+        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active&.any?
+
         ParticipantProfile::ECT.create!({ user: user }.merge(ect_attributes))
       end
     end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -201,13 +201,13 @@ class InviteSchools
   def send_induction_coordinator_add_participants_email
     induction_coordinators_chosen_route = User.distinct
                                               .joins(:induction_coordinator_profile, schools: :school_cohorts)
-                                              .left_outer_joins(schools: :ecf_participant_profiles)
+                                              .left_outer_joins(schools: :active_ecf_participant_profiles)
                                               .where(
                                                 school_cohorts: {
                                                   induction_programme_choice: %w[core_induction_programme full_induction_programme],
                                                   opt_out_of_updates: false,
                                                 },
-                                                ecf_participant_profiles: { id: nil },
+                                                active_ecf_participant_profiles: { id: nil },
                                               )
 
     induction_coordinators_chosen_route.find_each do |induction_coordinator|

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -3,19 +3,23 @@
 module Mentors
   class Create < BaseService
     include SchoolCohortDelegator
+
     def call
       ActiveRecord::Base.transaction do
-        # NOTE: This will not update the full_name if the user exists, the scenario
-        # I am working on is enabling a NPQ user to be added as a mentor
+        # NOTE: This will not update the full_name if the user has an active participant profile,
+        # the scenario I am working on is enabling a NPQ user to be added as a mentor
         # Not matching on full_name means this works more smoothly for the end user
-        # and they don't get "email already in use" errors if they spell the name
-        # differently
+        # and they don't get "email already in use" errors if they spell the name differently
         user = User.find_or_create_by!(email: email) do |mentor|
           mentor.full_name = full_name
         end
         user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active&.any?
 
-        ParticipantProfile::Mentor.create!({ user: user }.merge(mentor_attributes))
+        teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
+          profile.school = school_cohort.school
+        end
+
+        ParticipantProfile::Mentor.create!({ teacher_profile: teacher_profile }.merge(mentor_attributes))
       end
     end
 

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -13,6 +13,8 @@ module Mentors
         user = User.find_or_create_by!(email: email) do |mentor|
           mentor.full_name = full_name
         end
+        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active&.any?
+
         ParticipantProfile::Mentor.create!({ user: user }.merge(mentor_attributes))
       end
     end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -66,5 +66,9 @@ FactoryBot.define do
       sparsity_uplift
       pupil_premium_uplift
     end
+
+    trait :withdrawn do
+      status { :withdrawn }
+    end
   end
 end

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
       it "sets the participant_type to mentor as well as full name and email to match current_user details" do
         expect { subject.type = "self" }
           .to change { subject.participant_type }.to(:mentor)
-          .and change { subject.full_name }.to(user.full_name)
-          .and change { subject.email }.to(user.email)
+                                                 .and change { subject.full_name }.to(user.full_name)
+                                                                                  .and change { subject.email }.to(user.email)
       end
     end
   end
@@ -63,22 +63,42 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when the email is in use by an ECT user" do
-      before do
+      let!(:ect_profile) do
         create(:participant_profile, :ect, user: create(:user, email: "ray.clemence@example.com"))
       end
 
       it "returns true" do
         expect(subject).to be_email_already_taken
       end
+
+      context "when the ECT is withdrawn" do
+        let!(:ect_profile) do
+          create(:participant_profile, :withdrawn, :ect, user: create(:user, email: "ray.clemence@example.com"))
+        end
+
+        it "returns false" do
+          expect(subject).not_to be_email_already_taken
+        end
+      end
     end
 
     context "when the email is in use by a Mentor" do
-      before do
+      let!(:mentor_profile) do
         create(:participant_profile, :mentor, user: create(:user, email: "ray.clemence@example.com"))
       end
 
       it "returns true" do
         expect(subject).to be_email_already_taken
+      end
+
+      context "when the mentor is withdrawn" do
+        let!(:mentor_profile) do
+          create(:participant_profile, :withdrawn, :mentor, user: create(:user, email: "ray.clemence@example.com"))
+        end
+
+        it "returns false" do
+          expect(subject).not_to be_email_already_taken
+        end
       end
     end
 

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
       it "sets the participant_type to mentor as well as full name and email to match current_user details" do
         expect { subject.type = "self" }
           .to change { subject.participant_type }.to(:mentor)
-                                                 .and change { subject.full_name }.to(user.full_name)
-                                                                                  .and change { subject.email }.to(user.email)
+          .and change { subject.full_name }.to(user.full_name)
+          .and change { subject.email }.to(user.email)
       end
     end
   end

--- a/spec/requests/admin/schools/participants_spec.rb
+++ b/spec/requests/admin/schools/participants_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
   let!(:mentor_profile) { create :participant_profile, :mentor, school_cohort: school_cohort }
   let!(:npq_profile) { create(:participant_profile, :npq, school: school) }
   let!(:unrelated_profile) { create :participant_profile }
+  let!(:withdrawn_profile) { create :participant_profile, :withdrawn, :mentor, school_cohort: school_cohort }
 
   before do
     sign_in admin_user
@@ -23,7 +24,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
       expect(response).to render_template("admin/schools/participants/index")
     end
 
-    it "only displays school's participants" do
+    it "only displays school's active participants" do
       get "/admin/schools/#{school.slug}/participants"
 
       expect(response.body).not_to include("No participants found for this school.")
@@ -31,6 +32,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
       expect(assigns(:participant_profiles)).to include ect_profile
       expect(assigns(:participant_profiles)).not_to include npq_profile
       expect(assigns(:participant_profiles)).not_to include unrelated_profile
+      expect(assigns(:participant_profiles)).not_to include withdrawn_profile
     end
   end
 end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -15,8 +15,12 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
     before :each do
       mentor_profile = create(:mentor_profile, school: partnership.school, cohort: partnership.cohort)
       create_list :early_career_teacher_profile, 2, mentor_profile: mentor_profile, school_cohort: school_cohort
-      ect_teacher_profile = ParticipantProfile::ECT.first.teacher_profile
-      create(:participant_profile, :withdrawn, :ect, teacher_profile: ect_teacher_profile, school_cohort: school_cohort)
+      ect_teacher_profile_with_one_active_and_one_withdrawn_profile = ParticipantProfile::ECT.first.teacher_profile
+      create(:participant_profile,
+             :withdrawn,
+             :ect,
+             teacher_profile: ect_teacher_profile_with_one_active_and_one_withdrawn_profile,
+             school_cohort: school_cohort)
     end
     let!(:withdrawn_ect_profile) { create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort) }
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
     let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
     let(:lead_provider) { create(:lead_provider) }
     let(:partnership) { create(:partnership, lead_provider: lead_provider) }
+    let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: partnership.cohort, induction_programme_choice: "full_induction_programme") }
     let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
 
     before :each do
       mentor_profile = create(:mentor_profile, school: partnership.school, cohort: partnership.cohort)
-      create_list :early_career_teacher_profile, 2, mentor_profile: mentor_profile, school: partnership.school, cohort: partnership.cohort
+      create_list :early_career_teacher_profile, 2, mentor_profile: mentor_profile, school_cohort: school_cohort
+      ect_teacher_profile = ParticipantProfile::ECT.first.teacher_profile
+      create(:participant_profile, :withdrawn, :ect, teacher_profile: ect_teacher_profile, school_cohort: school_cohort)
     end
+    let!(:withdrawn_ect_profile) { create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort) }
 
     context "when authorized" do
       before do
@@ -31,7 +35,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
 
         it "returns all users" do
           get "/api/v1/participants"
-          expect(parsed_response["data"].size).to eql(3)
+          expect(parsed_response["data"].size).to eql(4)
         end
 
         it "returns correct type" do
@@ -53,18 +57,23 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           get "/api/v1/participants"
           mentors = 0
           ects = 0
+          withdrawn = 0
 
           parsed_response["data"].each do |user|
             user_type = user["attributes"]["participant_type"]
+            status = user["attributes"]["status"]
             if user_type == "mentor"
               mentors += 1
             elsif user_type == "ect"
               ects += 1
+            elsif user_type.nil? && status == "withdrawn"
+              withdrawn += 1
             end
           end
 
           expect(mentors).to eql(1)
           expect(ects).to eql(2)
+          expect(withdrawn).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -75,15 +84,19 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
         it "returns different users for each page" do
           get "/api/v1/participants", params: { page: { per_page: 2, page: 1 } }
           expect(parsed_response["data"].size).to eql(2)
+          first_page_id = parsed_response["data"].first["id"]
 
           get "/api/v1/participants", params: { page: { per_page: 2, page: 2 } }
-          expect(JSON.parse(response.body)["data"].size).to eql(1)
+          second_parsed_response = JSON.parse(response.body)
+          second_page_ids = second_parsed_response["data"].map { |item| item["id"] }
+          expect(second_parsed_response["data"].size).to eql(2)
+          expect(second_page_ids).not_to include first_page_id
         end
 
         it "returns users changed since a particular time, if given a updated_since parameter" do
           User.first.update!(updated_at: 2.days.ago)
           get "/api/v1/participants", params: { filter: { updated_since: 1.day.ago.iso8601 } }
-          expect(parsed_response["data"].size).to eql(2)
+          expect(parsed_response["data"].size).to eql(3)
         end
       end
 
@@ -98,7 +111,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
         end
 
         it "returns all users" do
-          expect(parsed_response.length).to eql 3
+          expect(parsed_response.length).to eql 4
         end
 
         it "returns the correct headers" do
@@ -116,7 +129,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["participant_type"]).to eql "mentor"
           expect(mentor_row["cohort"]).to eql partnership.cohort.start_year.to_s
 
-          ect = ParticipantProfile::ECT.first.user
+          ect = ParticipantProfile::ECT.active.first.user
           ect_row = parsed_response.find { |row| row["id"] == ect.id }
           expect(ect_row).not_to be_nil
           expect(ect_row["email"]).to eql ect.email
@@ -125,17 +138,26 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(ect_row["school_urn"]).to eql partnership.school.urn
           expect(ect_row["participant_type"]).to eql "ect"
           expect(ect_row["cohort"]).to eql partnership.cohort.start_year.to_s
+
+          withdrawn_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile.user.id }
+          expect(withdrawn_row).not_to be_nil
+          expect(withdrawn_row["email"]).to be_empty
+          expect(withdrawn_row["full_name"]).to be_empty
+          expect(withdrawn_row["mentor_id"]).to be_empty
+          expect(withdrawn_row["school_urn"]).to be_empty
+          expect(withdrawn_row["participant_type"]).to be_empty
+          expect(withdrawn_row["cohort"]).to be_empty
         end
 
         it "ignores pagination parameters" do
           get "/api/v1/participants.csv", params: { page: { per_page: 2, page: 1 } }
-          expect(parsed_response.length).to eql 3
+          expect(parsed_response.length).to eql 4
         end
 
         it "respects the updated_since parameter" do
           User.first.update!(updated_at: 2.days.ago)
           get "/api/v1/participants.csv", params: { filter: { updated_since: 1.day.ago.iso8601 } }
-          expect(parsed_response.length).to eql(2)
+          expect(parsed_response.length).to eql(3)
         end
       end
     end

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -19,6 +19,32 @@ RSpec.describe EarlyCareerTeachers::Create do
     }.to change { ParticipantProfile::ECT.count }.by(1)
   end
 
+  it "updates the users name" do
+    expect {
+      described_class.call(
+        email: user.email,
+        full_name: Faker::Name.name,
+        school_cohort: school_cohort,
+      )
+    }.to change { user.reload.full_name }
+  end
+
+  context "when the user has an active participant profile" do
+    before do
+      create(:participant_profile, teacher_profile: create(:teacher_profile, user: user))
+    end
+
+    it "does not update the users name" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: Faker::Name.name,
+          school_cohort: school_cohort,
+        )
+      }.not_to change { user.reload.full_name }
+    end
+  end
+
   it "sets the correct mentor profile" do
     participant_profile = described_class.call(email: user.email, full_name: user.full_name, school_cohort: school_cohort, mentor_profile_id: mentor_profile.id)
     expect(participant_profile.mentor_profile).to eq(mentor_profile)

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe EarlyCareerTeachers::Create do
-  let(:user) { create :user }
+  let!(:user) { create :user }
   let(:school_cohort) { create :school_cohort }
   let(:pupil_premium_school) { create :school, :pupil_premium_uplift }
   let(:sparsity_school) { create :school, :sparsity_uplift }
   let(:uplift_school) { create :school, :sparsity_uplift, :pupil_premium_uplift }
-  let(:mentor_profile) { create :mentor_profile }
+  let!(:mentor_profile) { create :participant_profile, :mentor }
+  let!(:npq_participant) { create(:participant_profile, :npq).teacher_profile.user }
 
   it "creates an Early Career Teacher Profile record" do
     expect {
@@ -17,6 +18,32 @@ RSpec.describe EarlyCareerTeachers::Create do
         mentor_profile_id: mentor_profile.id,
       )
     }.to change { ParticipantProfile::ECT.count }.by(1)
+     .and not_change { User.count }
+     .and change { TeacherProfile.count }.by(1)
+  end
+
+  it "uses the existing teacher profile record" do
+    expect {
+      described_class.call(
+        email: npq_participant.email,
+        full_name: npq_participant.full_name,
+        school_cohort: school_cohort,
+      )
+    }.to change { ParticipantProfile::ECT.count }.by(1)
+     .and not_change { User.count }
+     .and not_change { TeacherProfile.count }
+  end
+
+  it "creates a new user and teacher profile" do
+    expect {
+      described_class.call(
+        email: Faker::Internet.email,
+        full_name: Faker::Name.name,
+        school_cohort: school_cohort,
+      )
+    }.to change { ParticipantProfile::ECT.count }.by(1)
+    .and change { User.count }.by(1)
+    .and change { TeacherProfile.count }.by(1)
   end
 
   it "updates the users name" do

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -513,6 +513,15 @@ RSpec.describe InviteSchools do
       expect_send_participants_email(induction_coordinator)
     end
 
+    it "sends emails to tutors who have withdrawn all of their participants" do
+      induction_coordinator = create(:user, :induction_coordinator)
+      school_cohort = create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme")
+      create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort)
+
+      InviteSchools.new.send_induction_coordinator_add_participants_email
+      expect_send_participants_email(induction_coordinator)
+    end
+
     it "does not send emails to tutors who have not chosen routes for their schools" do
       create(:user, :induction_coordinator)
 

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Mentors::Create do
-  let(:user) { create :user }
+  let!(:user) { create :user }
   let(:school_cohort) { create :school_cohort }
   let(:pupil_premium_school) { create :school, :pupil_premium_uplift }
   let(:sparsity_school) { create :school, :sparsity_uplift }
   let(:uplift_school) { create :school, :sparsity_uplift, :pupil_premium_uplift }
+  let!(:npq_participant) { create(:participant_profile, :npq).teacher_profile.user }
 
   it "creates a Mentor record" do
     expect {
@@ -15,7 +16,23 @@ RSpec.describe Mentors::Create do
         school_cohort: school_cohort,
       )
     }.to change { ParticipantProfile::Mentor.count }.by(1)
+     .and not_change { User.count }
+  end
 
+  it "uses the existing teacher profile record" do
+    expect {
+      described_class.call(
+        email: npq_participant.email,
+        full_name: npq_participant.full_name,
+        school_cohort: school_cohort,
+        mentor_id: "random discardable",
+      )
+    }.to change { ParticipantProfile::Mentor.count }.by(1)
+     .and not_change { User.count }
+     .and not_change { TeacherProfile.count }
+  end
+
+  it "ignores mentor id" do
     expect {
       described_class.call(
         email: user.email,
@@ -24,6 +41,18 @@ RSpec.describe Mentors::Create do
         mentor_id: "random discardable",
       )
     }.to change { ParticipantProfile::Mentor.count }.by(1)
+  end
+
+  it "creates a new user and teacher profile" do
+    expect {
+      described_class.call(
+        email: Faker::Internet.email,
+        full_name: Faker::Name.name,
+        school_cohort: school_cohort,
+      )
+    }.to change { ParticipantProfile::Mentor.count }.by(1)
+     .and change { User.count }.by(1)
+     .and change { TeacherProfile.count }.by(1)
   end
 
   it "updates the users name" do

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -26,6 +26,32 @@ RSpec.describe Mentors::Create do
     }.to change { ParticipantProfile::Mentor.count }.by(1)
   end
 
+  it "updates the users name" do
+    expect {
+      described_class.call(
+        email: user.email,
+        full_name: Faker::Name.name,
+        school_cohort: school_cohort,
+      )
+    }.to change { user.reload.full_name }
+  end
+
+  context "when the user has an active participant profile" do
+    before do
+      create(:participant_profile, teacher_profile: create(:teacher_profile, user: user))
+    end
+
+    it "does not update the users name" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: Faker::Name.name,
+          school_cohort: school_cohort,
+        )
+      }.not_to change { user.reload.full_name }
+    end
+  end
+
   it "has no uplift if the school has not uplift set" do
     mentor_profile = described_class.call(email: user.email, full_name: user.full_name, school_cohort: school_cohort)
     expect(mentor_profile.pupil_premium_uplift).to be(false)


### PR DESCRIPTION
### Context
CPDRP-701
Once participant profiles have been marked as withdrawn, we should allow new profiles to be created for those users

### Changes proposed in this pull request
- Ensure withdrawn profiles are displayed correctly in the participants API
- Ensure withdrawn participants are not displayed to admins
- Allow withdrawn participants to be readded by SITs
- Update email chaser logic to account for withdrawn participants

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
- sign in as school-leader@example.com and add a participant
- sign in as admin@example.com and remove the particiapant
- sign back in as school-leader and add the same details again

Ensure they are displayed to the school tutor and the admin correctly