### PR TITLE
NPQ API to accept/reject an application

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -20,6 +20,22 @@ module Api
         end
       end
 
+      def reject
+        profile = npq_lead_provider.npq_profiles.includes(:user, :npq_course).find(params[:id])
+
+        profile.update!(status: "rejected")
+
+        render json: NPQApplicationSerializer.new(profile).serializable_hash
+      end
+
+      def accept
+        profile = npq_lead_provider.npq_profiles.includes(:user, :npq_course).find(params[:id])
+
+        profile.update!(status: "accepted")
+
+        render json: NPQApplicationSerializer.new(profile).serializable_hash
+      end
+
     private
 
       def npq_lead_provider

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -23,17 +23,21 @@ module Api
       def reject
         profile = npq_lead_provider.npq_profiles.includes(:user, :npq_course).find(params[:id])
 
-        profile.update!(status: "rejected")
-
-        render json: NPQApplicationSerializer.new(profile).serializable_hash
+        if profile.update(status: "rejected")
+          render json: NPQApplicationSerializer.new(profile).serializable_hash
+        else
+          render json: { errors: Api::ErrorFactory.new(error: profile.errors).call }, status: :bad_request
+        end
       end
 
       def accept
         profile = npq_lead_provider.npq_profiles.includes(:user, :npq_course).find(params[:id])
 
-        profile.update!(status: "accepted")
-
-        render json: NPQApplicationSerializer.new(profile).serializable_hash
+        if profile.update(status: "accepted")
+          render json: NPQApplicationSerializer.new(profile).serializable_hash
+        else
+          render json: { errors: Api::ErrorFactory.new(error: profile.errors).call }, status: :bad_request
+        end
       end
 
     private

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -23,10 +23,10 @@ module Api
       def reject
         profile = npq_lead_provider.npq_profiles.includes(:user, :npq_course).find(params[:id])
 
-        if profile.update(status: "rejected")
+        if profile.update(lead_provider_approval_status: "rejected")
           render json: NPQApplicationSerializer.new(profile).serializable_hash
         else
-          render json: { errors: Api::ErrorFactory.new(error: profile.errors).call }, status: :bad_request
+          render json: { errors: Api::ErrorFactory.new(model: profile).call }, status: :bad_request
         end
       end
 
@@ -35,10 +35,10 @@ module Api
         other_profiles = NPQValidationData.where(profile: (profile.user.npq_profiles - [profile.profile]))
 
         ActiveRecord::Base.transaction do
-          if profile.update(status: "accepted") && other_profiles.update(status: "rejected")
+          if profile.update(lead_provider_approval_status: "accepted") && other_profiles.update(lead_provider_approval_status: "rejected")
             render json: NPQApplicationSerializer.new(profile).serializable_hash
           else
-            render json: { errors: Api::ErrorFactory.new(error: profile.errors).call }, status: :bad_request
+            render json: { errors: Api::ErrorFactory.new(model: profile).call }, status: :bad_request
           end
         end
       end

--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -29,6 +29,21 @@ class NPQValidationData < ApplicationRecord
     rejected: "rejected",
   }
 
+  validate :validate_rejected_status_cannot_change
+  validate :validate_accepted_status_cannot_change
+
+  def validate_rejected_status_cannot_change
+    if status_changed?(from: "rejected")
+      errors.add(:status, :invalid, message: "Once rejected an application cannot change state")
+    end
+  end
+
+  def validate_accepted_status_cannot_change
+    if status_changed?(from: "accepted")
+      errors.add(:status, :invalid, message: "Once accepted an application cannot change state")
+    end
+  end
+
   after_save :update_participant_profile
 
 private

--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -23,6 +23,12 @@ class NPQValidationData < ApplicationRecord
     another: "another",
   }
 
+  enum status: {
+    pending: "pending",
+    accepted: "accepted",
+    rejected: "rejected",
+  }
+
   after_save :update_participant_profile
 
 private

--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -23,7 +23,7 @@ class NPQValidationData < ApplicationRecord
     another: "another",
   }
 
-  enum status: {
+  enum lead_provider_approval_status: {
     pending: "pending",
     accepted: "accepted",
     rejected: "rejected",
@@ -33,14 +33,14 @@ class NPQValidationData < ApplicationRecord
   validate :validate_accepted_status_cannot_change
 
   def validate_rejected_status_cannot_change
-    if status_changed?(from: "rejected")
-      errors.add(:status, :invalid, message: "Once rejected an application cannot change state")
+    if lead_provider_approval_status_changed?(from: "rejected")
+      errors.add(:lead_provider_approval_status, :invalid, message: "Once rejected an application cannot change state")
     end
   end
 
   def validate_accepted_status_cannot_change
-    if status_changed?(from: "accepted")
-      errors.add(:status, :invalid, message: "Once accepted an application cannot change state")
+    if lead_provider_approval_status_changed?(from: "accepted")
+      errors.add(:lead_provider_approval_status, :invalid, message: "Once accepted an application cannot change state")
     end
   end
 

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -53,7 +53,7 @@ private
       record.eligible_for_funding,
       record.funding_choice,
       record.npq_course.identifier,
-      record.status,
+      record.lead_provider_approval_status,
     ]
   end
 end

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -35,6 +35,7 @@ private
       eligible_for_funding
       funding_choice
       course_identifier
+      status
     ]
   end
 
@@ -52,6 +53,7 @@ private
       record.eligible_for_funding,
       record.funding_choice,
       record.npq_course.identifier,
+      record.status,
     ]
   end
 end

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -16,7 +16,8 @@ class NPQApplicationSerializer
              :headteacher_status,
              :eligible_for_funding,
              :funding_choice,
-             :course_identifier
+             :course_identifier,
+             :status
 
   attribute(:participant_id, &:user_id)
   attribute(:teacher_reference_number_validated, &:teacher_reference_number_verified)

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -37,4 +37,6 @@ class NPQApplicationSerializer
   attribute(:course_identifier) do |object|
     object.npq_course.identifier
   end
+
+  attribute(:status, &:lead_provider_approval_status)
 end

--- a/app/services/api/error_factory.rb
+++ b/app/services/api/error_factory.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Api
+  class ErrorFactory
+    attr_reader :error
+
+    def initialize(error:)
+      @error = error
+    end
+
+    def call
+      error.errors.map do |e|
+        {
+          title: "#{e.attribute.to_s.humanize} is #{e.type.to_s.humanize.downcase}",
+          detail: e.message,
+        }
+      end
+    end
+  end
+end

--- a/app/services/api/error_factory.rb
+++ b/app/services/api/error_factory.rb
@@ -2,16 +2,16 @@
 
 module Api
   class ErrorFactory
-    attr_reader :error
+    attr_reader :model
 
-    def initialize(error:)
-      @error = error
+    def initialize(model:)
+      @model = model
     end
 
     def call
-      error.errors.map do |e|
+      model.errors.map do |e|
         {
-          title: "#{e.attribute.to_s.humanize} is #{e.type.to_s.humanize.downcase}",
+          title: "#{model.class.human_attribute_name(e.attribute)} is #{e.type.to_s.humanize.downcase}",
           detail: e.message,
         }
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,9 @@ en:
             choice:
               blank: "Choose whether to replace or update the tutor"
   activerecord:
+    attributes:
+      npq_validation_data:
+        lead_provider_approval_status: Status
     errors:
       models:
         user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,12 @@ Rails.application.routes.draw do
       resources :ecf_users, only: %i[index create], path: "ecf-users"
       resources :dqt_records, only: :show, path: "dqt-records"
       resources :participant_validation, only: :show, path: "participant-validation"
-      resources :npq_applications, only: :index, path: "npq-applications"
+      resources :npq_applications, only: :index, path: "npq-applications" do
+        member do
+          post :accept
+          post :reject
+        end
+      end
 
       jsonapi_resources :npq_profiles, only: [:create]
 

--- a/db/migrate/20210802145839_add_status_to_npq_validation_data.rb
+++ b/db/migrate/20210802145839_add_status_to_npq_validation_data.rb
@@ -2,6 +2,6 @@
 
 class AddStatusToNPQValidationData < ActiveRecord::Migration[6.1]
   def change
-    add_column :npq_profiles, :status, :text, null: false, default: "pending"
+    add_column :npq_profiles, :lead_provider_approval_status, :text, null: false, default: "pending"
   end
 end

--- a/db/migrate/20210802145839_add_status_to_npq_validation_data.rb
+++ b/db/migrate/20210802145839_add_status_to_npq_validation_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToNPQValidationData < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_profiles, :status, :text, null: false, default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -376,6 +376,7 @@ ActiveRecord::Schema.define(version: 2021_08_04_105833) do
     t.boolean "eligible_for_funding", default: false, null: false
     t.text "funding_choice"
     t.text "nino"
+    t.text "status", default: "pending", null: false
     t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
     t.index ["user_id"], name: "index_npq_profiles_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -376,7 +376,7 @@ ActiveRecord::Schema.define(version: 2021_08_04_105833) do
     t.boolean "eligible_for_funding", default: false, null: false
     t.text "funding_choice"
     t.text "nino"
-    t.text "status", default: "pending", null: false
+    t.text "lead_provider_approval_status", default: "pending", null: false
     t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
     t.index ["user_id"], name: "index_npq_profiles_on_user_id"

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -7,6 +7,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
   let(:Authorization) { "Bearer #{token}" }
+  let(:npq_application) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider) }
 
   path "/api/v1/npq-applications" do
     get "Retrieve multiple NPQ applications" do
@@ -39,6 +40,10 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                 description: "Pagination options to navigate through the list of NPQ applications."
 
       response "200", "A list of NPQ applications" do
+        before do
+          npq_application
+        end
+
         schema({ "$ref": "#/components/schemas/MultipleNpqApplicationsResponse" }, content_type: "application/vnd.api+json")
 
         run_test!
@@ -80,6 +85,70 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
 
       response "401", "Unauthorized" do
         let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" }, content_type: "application/vnd.api+json")
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/npq-applications/{id}/accept" do
+    post "Accept an NPQ application" do
+      operationId :npq_applications_accept
+      tags "NPQ applications"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: SecureRandom.uuid,
+                description: "The ID of the NPQ application to accept."
+
+      response "200", "The NPQ application being accepted" do
+        let(:id) { npq_application.id }
+
+        schema({ "$ref": "#/components/schemas/NpqApplicationResponse" }, content_type: "application/vnd.api+json")
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+        let(:id) { npq_application.id }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" }, content_type: "application/vnd.api+json")
+
+        run_test!
+      end
+    end
+  end
+
+  path "/api/v1/npq-applications/{id}/reject" do
+    post "Reject an NPQ application" do
+      operationId :npq_applications_reject
+      tags "NPQ applications"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: SecureRandom.uuid,
+                description: "The ID of the NPQ application to reject."
+
+      response "200", "The NPQ application being rejected" do
+        let(:id) { npq_application.id }
+
+        schema({ "$ref": "#/components/schemas/NpqApplicationResponse" }, content_type: "application/vnd.api+json")
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+        let(:id) { npq_application.id }
 
         schema({ "$ref": "#/components/schemas/UnauthorisedResponse" }, content_type: "application/vnd.api+json")
 

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe LeadProviderApiSpecification do
       paths = %w[
         /api/v1/npq-applications
         /api/v1/npq-applications.csv
+        /api/v1/npq-applications/{id}/accept
+        /api/v1/npq-applications/{id}/reject
         /api/v1/participant-declarations
         /api/v1/participants
         /api/v1/participants.csv

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(row["eligible_for_funding"]).to eql(profile.eligible_for_funding.to_s)
           expect(row["funding_choice"]).to eql(profile.funding_choice)
           expect(row["course_identifier"]).to eql(profile.npq_course.identifier)
-          expect(row["status"]).to eql(profile.status)
+          expect(row["status"]).to eql(profile.lead_provider_approval_status)
         end
       end
     end
@@ -173,9 +173,9 @@ RSpec.describe "NPQ Applications API", type: :request do
       default_headers[:Authorization] = bearer_token
     end
 
-    it "update status to rejected" do
+    it "update lead_provider_approval_status to rejected" do
       expect { post "/api/v1/npq-applications/#{npq_profile.id}/reject" }
-        .to change { npq_profile.reload.status }.from("pending").to("rejected")
+        .to change { npq_profile.reload.lead_provider_approval_status }.from("pending").to("rejected")
     end
 
     it "responds with 200 and representation of the resource" do
@@ -187,7 +187,7 @@ RSpec.describe "NPQ Applications API", type: :request do
     end
 
     context "application has been accepted" do
-      let(:npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, status: "accepted") }
+      let(:npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, lead_provider_approval_status: "accepted") }
 
       it "return 400 bad request " do
         post "/api/v1/npq-applications/#{npq_profile.id}/reject"
@@ -217,7 +217,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
     it "update status to accepted" do
       expect { post "/api/v1/npq-applications/#{npq_profile.id}/accept" }
-        .to change { npq_profile.reload.status }.from("pending").to("accepted")
+        .to change { npq_profile.reload.lead_provider_approval_status }.from("pending").to("accepted")
     end
 
     it "responds with 200 and representation of the resource" do
@@ -234,12 +234,12 @@ RSpec.describe "NPQ Applications API", type: :request do
       it "rejects all other NPQs" do
         post "/api/v1/npq-applications/#{npq_profile.id}/accept"
 
-        expect(other_npq_profile.reload.status).to eql("rejected")
+        expect(other_npq_profile.reload.lead_provider_approval_status).to eql("rejected")
       end
     end
 
     context "application has been rejected" do
-      let(:npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, status: "rejected") }
+      let(:npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, lead_provider_approval_status: "rejected") }
 
       it "return 400 bad request " do
         post "/api/v1/npq-applications/#{npq_profile.id}/accept"

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -4,12 +4,13 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe "NPQ Applications API", type: :request do
+  let(:npq_lead_provider) { create(:npq_lead_provider) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+  let(:bearer_token) { "Bearer #{token}" }
+
   describe "GET /api/v1/npq-applications" do
-    let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
-    let(:npq_lead_provider) { create(:npq_lead_provider) }
     let(:other_npq_lead_provider) { create(:npq_lead_provider) }
-    let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
-    let(:bearer_token) { "Bearer #{token}" }
 
     before :each do
       create_list :npq_validation_data, 3, npq_lead_provider: npq_lead_provider, school_urn: "123456"
@@ -48,18 +49,14 @@ RSpec.describe "NPQ Applications API", type: :request do
           user = User.find(parsed_response["data"][0]["attributes"]["participant_id"])
 
           expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
-
           expect(parsed_response["data"][0]["attributes"]["email"]).to eql(user.email)
           expect(parsed_response["data"][0]["attributes"]["email_validated"]).to eql(true)
-
           expect(parsed_response["data"][0]["attributes"]["school_urn"]).to eql(profile.school_urn)
-
           expect(parsed_response["data"][0]["attributes"]["teacher_reference_number"]).to eql(profile.teacher_reference_number)
           expect(parsed_response["data"][0]["attributes"]["teacher_reference_number_validated"]).to eql(profile.teacher_reference_number_verified)
-
           expect(parsed_response["data"][0]["attributes"]["eligible_for_funding"]).to eql(profile.eligible_for_funding)
-
           expect(parsed_response["data"][0]["attributes"]["course_identifier"]).to eql(profile.npq_course.identifier)
+          expect(parsed_response["data"][0]["attributes"]["status"]).to eql("pending")
         end
 
         it "can return paginated data" do
@@ -165,6 +162,50 @@ RSpec.describe "NPQ Applications API", type: :request do
         get "/api/v1/npq-applications"
         expect(response.status).to eq 403
       end
+    end
+  end
+
+  describe "POST /api/v1/npq-applications/:id/reject" do
+    let(:npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider) }
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    before do
+      default_headers[:Authorization] = bearer_token
+    end
+
+    it "update status to rejected" do
+      expect { post "/api/v1/npq-applications/#{npq_profile.id}/reject" }
+        .to change { npq_profile.reload.status }.from("pending").to("rejected")
+    end
+
+    it "responds with 200 and representation of the resource" do
+      post "/api/v1/npq-applications/#{npq_profile.id}/reject"
+
+      expect(response).to be_successful
+
+      expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
+    end
+  end
+
+  describe "POST /api/v1/npq-applications/:id/accept" do
+    let(:npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider) }
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    before do
+      default_headers[:Authorization] = bearer_token
+    end
+
+    it "update status to accepted" do
+      expect { post "/api/v1/npq-applications/#{npq_profile.id}/accept" }
+        .to change { npq_profile.reload.status }.from("pending").to("accepted")
+    end
+
+    it "responds with 200 and representation of the resource" do
+      post "/api/v1/npq-applications/#{npq_profile.id}/accept"
+
+      expect(response).to be_successful
+
+      expect(parsed_response.dig("data", "attributes", "status")).to eql("accepted")
     end
   end
 end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "NPQ Applications API", type: :request do
               eligible_for_funding
               funding_choice
               course_identifier
+              status
             ],
           )
         end
@@ -129,6 +130,7 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(row["eligible_for_funding"]).to eql(profile.eligible_for_funding.to_s)
           expect(row["funding_choice"]).to eql(profile.funding_choice)
           expect(row["course_identifier"]).to eql(profile.npq_course.identifier)
+          expect(row["status"]).to eql(profile.status)
         end
       end
     end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -230,11 +230,18 @@ RSpec.describe "NPQ Applications API", type: :request do
 
     context "when participant has applied for multiple NPQs" do
       let!(:other_npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, user: user) }
+      let!(:other_accepted_npq_profile) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, user: user, lead_provider_approval_status: "accepted") }
 
-      it "rejects all other NPQs" do
+      it "rejects all pending NPQs" do
         post "/api/v1/npq-applications/#{npq_profile.id}/accept"
 
         expect(other_npq_profile.reload.lead_provider_approval_status).to eql("rejected")
+      end
+
+      it "does not reject non-pending NPQs" do
+        post "/api/v1/npq-applications/#{npq_profile.id}/accept"
+
+        expect(other_accepted_npq_profile.reload.lead_provider_approval_status).to eql("accepted")
       end
     end
 

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(validation_data.npq_course).to eql(npq_course)
         expect(validation_data.eligible_for_funding).to eql(true)
         expect(validation_data.funding_choice).to eql("school")
-        expect(validation_data.status).to eql("pending")
+        expect(validation_data.lead_provider_approval_status).to eql("pending")
       end
 
       it "returns a 201" do

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(validation_data.npq_course).to eql(npq_course)
         expect(validation_data.eligible_for_funding).to eql(true)
         expect(validation_data.funding_choice).to eql("school")
+        expect(validation_data.status).to eql("pending")
       end
 
       it "returns a 201" do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -848,7 +848,7 @@
             }
           }
         },
-        "example": "id,type,participant_id,full_name,email,email_validated,email_validated,teacher_reference_number,teacher_reference_number_validated,school_urn,headteacher_status,eligible_for_funding,funding_choice,course_identifier\ndb3a7848-7308-4879-942a-c4a70ced400a,npq-application,7a8fef46-3c43-42c0-b3d5-1ba5904ba562,Isabelle MacDonald,isabelle.macdonald2@some-school.example.com,true,1234567,true,106286,no,true,trust,npq-leading-teaching\n"
+        "example": "id,type,participant_id,full_name,email,email_validated,email_validated,teacher_reference_number,teacher_reference_number_validated,school_urn,headteacher_status,eligible_for_funding,funding_choice,course_identifier,status\ndb3a7848-7308-4879-942a-c4a70ced400a,npq-application,7a8fef46-3c43-42c0-b3d5-1ba5904ba562,Isabelle MacDonald,isabelle.macdonald2@some-school.example.com,true,1234567,true,106286,no,true,trust,npq-leading-teaching,pending\n"
       },
       "MultipleNpqApplicationsResponse": {
         "description": "A list of NPQ applications",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -867,7 +867,6 @@
                 "id": "db3a7848-7308-4879-942a-c4a70ced400a",
                 "type": "participant",
                 "attributes": {
-                  "id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
                   "participant_id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
                   "full_name": "Isabelle MacDonald",
                   "email": "isabelle.macdonald2@some-school.example.com",
@@ -1281,7 +1280,6 @@
                 "id": "db3a7848-7308-4879-942a-c4a70ced400a",
                 "type": "npq_application",
                 "attributes": {
-                  "id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
                   "participant_id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
                   "full_name": "Isabelle MacDonald",
                   "email": "isabelle.macdonald2@some-school.example.com",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -147,6 +147,106 @@
         }
       }
     },
+    "/api/v1/npq-applications/{id}/accept": {
+      "post": {
+        "summary": "Accept an NPQ application",
+        "operationId": "npq_applications_accept",
+        "tags": [
+          "NPQ applications"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "07ba7a11-1cde-40bd-a5a8-489d895c96dc",
+            "description": "The ID of the NPQ application to accept.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The NPQ application being accepted",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NpqApplicationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/npq-applications/{id}/reject": {
+      "post": {
+        "summary": "Reject an NPQ application",
+        "operationId": "npq_applications_reject",
+        "tags": [
+          "NPQ applications"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "ac2a111b-b6d0-4b66-93ee-3ca9c97c3c7f",
+            "description": "The ID of the NPQ application to reject.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The NPQ application being rejected",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NpqApplicationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participant-declarations": {
       "post": {
         "summary": "Declare a participant has reached a milestone",
@@ -903,7 +1003,7 @@
         }
       },
       "NpqApplication": {
-        "description": "The details of an NPQ Applications",
+        "description": "The details of an NPQ Application",
         "type": "object",
         "required": [
           "id",
@@ -942,11 +1042,9 @@
           "teacher_reference_number",
           "teacher_reference_number_validated",
           "school_urn",
-          "headteacher_status",
           "eligible_for_funding",
-          "funding_choice",
-          "course_id",
-          "course_name"
+          "course_identifier",
+          "status"
         ],
         "properties": {
           "id": {
@@ -1028,6 +1126,16 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership"
+            ]
+          },
+          "status": {
+            "description": "The current state of the NPQ application",
+            "type": "string",
+            "example": "pending",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected"
             ]
           }
         }
@@ -1140,6 +1248,54 @@
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership"
+            ]
+          },
+          "status": {
+            "description": "The current state of the NPQ application",
+            "type": "string",
+            "example": "pending",
+            "enum": [
+              "pending",
+              "accepted",
+              "rejected"
+            ]
+          }
+        }
+      },
+      "NpqApplicationResponse": {
+        "description": "An NPQ application",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/NpqApplication"
+              }
+            ],
+            "example": [
+              {
+                "id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                "type": "npq_application",
+                "attributes": {
+                  "id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
+                  "participant_id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
+                  "full_name": "Isabelle MacDonald",
+                  "email": "isabelle.macdonald2@some-school.example.com",
+                  "email_validated": true,
+                  "teacher_reference_number": "1234567",
+                  "teacher_reference_number_validated": true,
+                  "school_urn": "106286",
+                  "headteacher_status": "no",
+                  "eligible_for_funding": true,
+                  "funding_choice": "trust",
+                  "course_identifier": "npq-leading-teaching",
+                  "status": "pending"
+                }
+              }
             ]
           }
         }

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1269,32 +1269,7 @@
         ],
         "properties": {
           "data": {
-            "type": "object",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/NpqApplication"
-              }
-            ],
-            "example": [
-              {
-                "id": "db3a7848-7308-4879-942a-c4a70ced400a",
-                "type": "npq_application",
-                "attributes": {
-                  "participant_id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
-                  "full_name": "Isabelle MacDonald",
-                  "email": "isabelle.macdonald2@some-school.example.com",
-                  "email_validated": true,
-                  "teacher_reference_number": "1234567",
-                  "teacher_reference_number_validated": true,
-                  "school_urn": "106286",
-                  "headteacher_status": "no",
-                  "eligible_for_funding": true,
-                  "funding_choice": "trust",
-                  "course_identifier": "npq-leading-teaching",
-                  "status": "pending"
-                }
-              }
-            ]
+            "$ref": "#/components/schemas/NpqApplication"
           }
         }
       },

--- a/swagger/v1/component_schemas/MultipleNpqApplicationsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleNpqApplicationsCsvResponse.yml
@@ -9,5 +9,5 @@ properties:
     items:
       $ref: "#/components/schemas/NpqApplicationCsvRow"
 example: |
-  id,type,participant_id,full_name,email,email_validated,email_validated,teacher_reference_number,teacher_reference_number_validated,school_urn,headteacher_status,eligible_for_funding,funding_choice,course_identifier
-  db3a7848-7308-4879-942a-c4a70ced400a,npq-application,7a8fef46-3c43-42c0-b3d5-1ba5904ba562,Isabelle MacDonald,isabelle.macdonald2@some-school.example.com,true,1234567,true,106286,no,true,trust,npq-leading-teaching
+  id,type,participant_id,full_name,email,email_validated,email_validated,teacher_reference_number,teacher_reference_number_validated,school_urn,headteacher_status,eligible_for_funding,funding_choice,course_identifier,status
+  db3a7848-7308-4879-942a-c4a70ced400a,npq-application,7a8fef46-3c43-42c0-b3d5-1ba5904ba562,Isabelle MacDonald,isabelle.macdonald2@some-school.example.com,true,1234567,true,106286,no,true,trust,npq-leading-teaching,pending

--- a/swagger/v1/component_schemas/MultipleNpqApplicationsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleNpqApplicationsResponse.yml
@@ -11,7 +11,6 @@ properties:
       - id: db3a7848-7308-4879-942a-c4a70ced400a
         type: participant
         attributes:
-          id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
           participant_id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
           full_name: "Isabelle MacDonald"
           email: "isabelle.macdonald2@some-school.example.com"

--- a/swagger/v1/component_schemas/NpqApplication.yml
+++ b/swagger/v1/component_schemas/NpqApplication.yml
@@ -1,4 +1,4 @@
-description: "The details of an NPQ Applications"
+description: "The details of an NPQ Application"
 type: object
 required:
   - id

--- a/swagger/v1/component_schemas/NpqApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NpqApplicationAttributes.yml
@@ -9,11 +9,9 @@ required:
   - teacher_reference_number
   - teacher_reference_number_validated
   - school_urn
-  - headteacher_status
   - eligible_for_funding
-  - funding_choice
-  - course_id
-  - course_name
+  - course_identifier
+  - status
 properties:
   id:
     type: string
@@ -81,3 +79,11 @@ properties:
       - npq-senior-leadership
       - npq-headship
       - npq-executive-leadership
+  status:
+    description: "The current state of the NPQ application"
+    type: string
+    example: pending
+    enum:
+      - pending
+      - accepted
+      - rejected

--- a/swagger/v1/component_schemas/NpqApplicationCsvRow.yml
+++ b/swagger/v1/component_schemas/NpqApplicationCsvRow.yml
@@ -89,3 +89,11 @@ properties:
       - npq-senior-leadership
       - npq-headship
       - npq-executive-leadership
+  status:
+    description: "The current state of the NPQ application"
+    type: string
+    example: pending
+    enum:
+      - pending
+      - accepted
+      - rejected

--- a/swagger/v1/component_schemas/NpqApplicationResponse.yml
+++ b/swagger/v1/component_schemas/NpqApplicationResponse.yml
@@ -11,7 +11,6 @@ properties:
       - id: db3a7848-7308-4879-942a-c4a70ced400a
         type: npq_application
         attributes:
-          id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
           participant_id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
           full_name: "Isabelle MacDonald"
           email: "isabelle.macdonald2@some-school.example.com"

--- a/swagger/v1/component_schemas/NpqApplicationResponse.yml
+++ b/swagger/v1/component_schemas/NpqApplicationResponse.yml
@@ -1,0 +1,26 @@
+description: "An NPQ application"
+type: object
+required:
+  - data
+properties:
+  data:
+    type: object
+    oneOf:
+      - $ref: "#/components/schemas/NpqApplication"
+    example:
+      - id: db3a7848-7308-4879-942a-c4a70ced400a
+        type: npq_application
+        attributes:
+          id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
+          participant_id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
+          full_name: "Isabelle MacDonald"
+          email: "isabelle.macdonald2@some-school.example.com"
+          email_validated: true
+          teacher_reference_number: "1234567"
+          teacher_reference_number_validated: true
+          school_urn: "106286"
+          headteacher_status: "no"
+          eligible_for_funding: true
+          funding_choice: "trust"
+          course_identifier: npq-leading-teaching
+          status: pending

--- a/swagger/v1/component_schemas/NpqApplicationResponse.yml
+++ b/swagger/v1/component_schemas/NpqApplicationResponse.yml
@@ -4,22 +4,4 @@ required:
   - data
 properties:
   data:
-    type: object
-    oneOf:
-      - $ref: "#/components/schemas/NpqApplication"
-    example:
-      - id: db3a7848-7308-4879-942a-c4a70ced400a
-        type: npq_application
-        attributes:
-          participant_id: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
-          full_name: "Isabelle MacDonald"
-          email: "isabelle.macdonald2@some-school.example.com"
-          email_validated: true
-          teacher_reference_number: "1234567"
-          teacher_reference_number_validated: true
-          school_urn: "106286"
-          headteacher_status: "no"
-          eligible_for_funding: true
-          funding_choice: "trust"
-          course_identifier: npq-leading-teaching
-          status: pending
+    $ref: "#/components/schemas/NpqApplication"


### PR DESCRIPTION
### Context

- As part of the end of the NPQ lifecycle before we hit track and pay we need for providers to acknowledge NPQ applications

### Changes proposed in this pull request

- NPQ applications start out in a starting state of `pending`
- Providers can then hit one of two endpoints to `accept` or `reject`
- This will then change the `status` to `accepted` or `rejected` respectively
- Once an application has been accepted or rejected it cannot change state
- The first provider to accept an application will cause all other NPQ applications on the user to become rejected
- Swagger docs have been added for these endpoints
- Also included some other swagger doc changes related to NPQ application that were not correctly documented

### Guidance to review

- Do we only allow this once? Can a provider accept then reject an application?

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
