### PR TITLE
Check first name only for api/v1/participant-validation

### DIFF
--- a/app/controllers/api/v1/participant_validation_controller.rb
+++ b/app/controllers/api/v1/participant_validation_controller.rb
@@ -11,6 +11,7 @@ module Api
           full_name: params[:full_name],
           date_of_birth: Date.iso8601(params[:date_of_birth]),
           nino: params[:nino],
+          config: { check_first_name_only: true },
         )
 
         if record.present?

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -51,7 +51,7 @@ private
     matches += 1 if trn_matches
 
     name_matches = if check_first_name_only?
-                     full_name.split(" ").first.to_s == dqt_record[:full_name].split(" ").first.to_s
+                     full_name.split(" ").first == dqt_record[:full_name].split(" ").first
                    else
                      full_name == dqt_record[:full_name]
                    end

--- a/spec/requests/api/v1/participant_validation_spec.rb
+++ b/spec/requests/api/v1/participant_validation_spec.rb
@@ -24,7 +24,13 @@ RSpec.describe "participant validation api endpoint", type: :request do
       before do
         default_headers[:Authorization] = bearer_token
 
-        allow(ParticipantValidationService).to receive(:validate).and_return(service_response)
+        allow(ParticipantValidationService).to receive(:validate).with(
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+          config: { check_first_name_only: true },
+        ).and_return(service_response)
       end
 
       it "returns correct jsonapi content type header" do


### PR DESCRIPTION
### Context

- Policy has given the go ahead to auto validate TRNs based on first name and not the whole name

### Changes proposed in this pull request

- `ParticipantValidationService` can now be passed a config hash to check first name only
- This feature is disabled by default and will check the whole name by default
- The api endpoint `api/v1/participant-validation` checks first name now

### Guidance to review

- none

### Testing

- See how to test in a review app below

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Use existing `NPQRegistrationApiToken` or create a new one
- See data extract spreadsheet for test data
```
curl -H "Authorization: Bearer TOKEN" https://ecf-review-pr-791.london.cloudapps.digital/api/v1/participant-validation/TRN?full_name=FULL_NAME_WITH_WONRG_LAST_NAME&date_of_birth=DOB&nino=
```
- Should return record regardless of last names