### PR TITLE
Fix n+1 query on ecf-users endpoint

### DIFF
--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -52,6 +52,9 @@ module Api
 
       def users
         users = User.where(id: ParticipantProfile::ECF.joins(:teacher_profile).select("teacher_profiles.user_id"))
+                    .includes(teacher_profile: {
+                      ecf_profile: %i[school_cohort core_induction_programme],
+                    })
 
         if updated_since.present?
           users = users.changed_since(updated_since)

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -4,6 +4,8 @@ class ParticipantProfile::ECF < ParticipantProfile
   self.ignored_columns = %i[school_id]
 
   belongs_to :school_cohort
+  belongs_to :core_induction_programme, optional: true
+
   has_one :school, through: :school_cohort
   has_one :cohort, through: :school_cohort
 end

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -7,8 +7,6 @@ class ParticipantProfile < ApplicationRecord
     belongs_to :mentor_profile, class_name: "Mentor", optional: true
     has_one :mentor, through: :mentor_profile, source: :user
 
-    belongs_to :core_induction_programme, optional: true
-
     def ect?
       true
     end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -12,8 +12,6 @@ class ParticipantProfile < ApplicationRecord
              dependent: :nullify
     has_many :mentees, through: :mentee_profiles, source: :user
 
-    belongs_to :core_induction_programme, optional: true
-
     def mentor?
       true
     end

--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -9,6 +9,7 @@ class TeacherProfile < ApplicationRecord
   # TODO: Legacy associations, to be removed
   has_one :early_career_teacher_profile, -> { active }, class_name: "ParticipantProfile::ECT"
   has_one :mentor_profile, -> { active }, class_name: "ParticipantProfile::Mentor"
+  has_one :ecf_profile, -> { active }, class_name: "ParticipantProfile::ECF"
 
   has_many :npq_profiles, class_name: "ParticipantProfile::NPQ"
   # end: TODO

--- a/app/serializers/ecf_user_serializer.rb
+++ b/app/serializers/ecf_user_serializer.rb
@@ -26,9 +26,10 @@ class ECFUserSerializer
   attributes :email, :full_name
 
   attributes :user_type do |user|
-    if user.early_career_teacher?
+    case user.teacher_profile.ecf_profile&.type
+    when ParticipantProfile::ECT.name
       USER_TYPES[:early_career_teacher]
-    elsif user.mentor?
+    when ParticipantProfile::Mentor.name
       USER_TYPES[:mentor]
     else
       USER_TYPES[:other]
@@ -36,7 +37,7 @@ class ECFUserSerializer
   end
 
   attributes :core_induction_programme do |user|
-    core_induction_programme = user.core_induction_programme || find_school_cohort(user)&.core_induction_programme
+    core_induction_programme = find_core_induction_programme(user)
 
     case core_induction_programme&.name
     when "Ambition Institute"
@@ -62,8 +63,11 @@ class ECFUserSerializer
   end
 
   def self.find_school_cohort(user)
-    if user.participant?
-      user.participant_profiles.ecf.active.first&.school_cohort
-    end
+    user.teacher_profile.ecf_profile&.school_cohort
+  end
+
+  def self.find_core_induction_programme(user)
+    user.teacher_profile.ecf_profile&.core_induction_programme ||
+      find_school_cohort(user)&.core_induction_programme
   end
 end

--- a/spec/requests/api/v1/ecf_users_spec.rb
+++ b/spec/requests/api/v1/ecf_users_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "API Users", type: :request do
       school_cohort = create(:school_cohort, school: school)
       mentor_profile = create(:mentor_profile, school_cohort: school_cohort, core_induction_programme: cip)
       create(:participant_profile, participant_type: :npq, school: school)
-      create(:participant_profile, participant_type: :npq, school: school, user: mentor_profile.user)
+      create(:participant_profile, participant_type: :npq, school: school, teacher_profile: mentor_profile.teacher_profile)
       create_list(:early_career_teacher_profile, 2, school_cohort: school_cohort, core_induction_programme: cip)
     end
 


### PR DESCRIPTION
Preload associations to prevent around 200 additional queries per request

I've also fixed a slightly flaky test 

