### PR TITLE
CPDTP-251: Add schedules

### DIFF
--- a/app/models/milestone.rb
+++ b/app/models/milestone.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Milestone < ApplicationRecord
+  belongs_to :schedule
+end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -3,6 +3,10 @@
 class ParticipantProfile < ApplicationRecord
   has_paper_trail
   belongs_to :teacher_profile, touch: true
+
+  # TODO: Back-fill, so that every profile has a schedule
+  belongs_to :schedule, optional: true, touch: true
+
   has_one :user, through: :teacher_profile
 
   has_many :validation_decisions, class_name: "ProfileValidationDecision"

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Schedule < ApplicationRecord
+  has_many :milestones
+  has_many :participant_profiles
+end

--- a/db/migrate/20210804103946_create_schedules_and_milestones.rb
+++ b/db/migrate/20210804103946_create_schedules_and_milestones.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateSchedulesAndMilestones < ActiveRecord::Migration[6.1]
+  def change
+    create_table :schedules, id: :uuid do |t|
+      t.text :name, null: false
+
+      t.timestamps
+    end
+
+    create_table :milestones, id: :uuid do |t|
+      t.text :name, null: false
+      t.date :milestone_date, null: false
+      t.date :payment_date, null: false
+      t.references :schedule, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210804105629_add_schedule_to_participant_profile.rb
+++ b/db/migrate/20210804105629_add_schedule_to_participant_profile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddScheduleToParticipantProfile < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :participant_profiles, :schedule, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20210804105817_add_schedule_foreign_key_to_participant_profile.rb
+++ b/db/migrate/20210804105817_add_schedule_foreign_key_to_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScheduleForeignKeyToParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :participant_profiles, :schedules, column: :schedule_id, null: true, validate: false
+  end
+end

--- a/db/migrate/20210804105833_validate_schedule_foreign_key_participant_profile.rb
+++ b/db/migrate/20210804105833_validate_schedule_foreign_key_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateScheduleForeignKeyParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :participant_profiles, :schedules
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_29_105503) do
+ActiveRecord::Schema.define(version: 2021_08_04_105833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -307,6 +307,16 @@ ActiveRecord::Schema.define(version: 2021_07_29_105503) do
     t.index ["code"], name: "index_local_authority_districts_on_code", unique: true
   end
 
+  create_table "milestones", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.date "milestone_date", null: false
+    t.date "payment_date", null: false
+    t.uuid "schedule_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["schedule_id"], name: "index_milestones_on_schedule_id"
+  end
+
   create_table "networks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -410,9 +420,11 @@ ActiveRecord::Schema.define(version: 2021_07_29_105503) do
     t.text "status", default: "active", null: false
     t.uuid "school_cohort_id"
     t.uuid "teacher_profile_id"
+    t.uuid "schedule_id"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"
+    t.index ["schedule_id"], name: "index_participant_profiles_on_schedule_id"
     t.index ["school_cohort_id"], name: "index_participant_profiles_on_school_cohort_id"
     t.index ["school_id"], name: "index_participant_profiles_on_school_id"
     t.index ["teacher_profile_id"], name: "index_participant_profiles_on_teacher_profile_id"
@@ -522,6 +534,12 @@ ActiveRecord::Schema.define(version: 2021_07_29_105503) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["school_id"], name: "index_pupil_premiums_on_school_id"
+  end
+
+  create_table "schedules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "school_cohorts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -660,6 +678,7 @@ ActiveRecord::Schema.define(version: 2021_07_29_105503) do
   add_foreign_key "lead_provider_profiles", "lead_providers"
   add_foreign_key "lead_provider_profiles", "users"
   add_foreign_key "lead_providers", "cpd_lead_providers"
+  add_foreign_key "milestones", "schedules"
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
   add_foreign_key "npq_lead_providers", "cpd_lead_providers"
@@ -667,6 +686,7 @@ ActiveRecord::Schema.define(version: 2021_07_29_105503) do
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
   add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
+  add_foreign_key "participant_profiles", "schedules"
   add_foreign_key "participant_profiles", "school_cohorts"
   add_foreign_key "participant_profiles", "schools"
   add_foreign_key "participant_profiles", "teacher_profiles"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,7 @@
 seed_path = %w[db seeds]
 
 load Rails.root.join(*seed_path, "initial_seed.rb").to_s
+load Rails.root.join(*seed_path, "schedules.rb").to_s
 
 if %w[development deployed_development test sandbox].include?(Rails.env)
   %w[test_data dummy_structures].each do |seed|

--- a/db/seeds/schedules.rb
+++ b/db/seeds/schedules.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+ecf_september_standard_2021 = Schedule.find_or_create_by!(name: "ECF September standard 2021")
+[
+  { name: "Output 1 - Participant Start", milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
+  { name: "Output 2 – Retention Point 1", milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+  { name: "Output 3 – Retention Point 2", milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
+  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
+  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+].each do |hash|
+  Milestone.find_or_create_by!(
+    schedule: ecf_september_standard_2021,
+    name: hash[:name],
+    milestone_date: hash[:milestone_date],
+    payment_date: hash[:payment_date],
+  )
+end
+
+ecf_september_extended_2021 = Schedule.find_or_create_by!(name: "ECF September extended 2021")
+[
+  { name: "Output 1 - Participant Start", milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
+  { name: "Output 2 – Retention Point 1", milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
+  { name: "Output 3 – Retention Point 2", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
+  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
+].each do |hash|
+  Milestone.find_or_create_by!(
+    schedule: ecf_september_extended_2021,
+    name: hash[:name],
+    milestone_date: hash[:milestone_date],
+    payment_date: hash[:payment_date],
+  )
+end
+
+ecf_january_reduced_2022 = Schedule.find_or_create_by!(name: "ECF January reduced 2022")
+[
+  { name: "Output 1 - Participant Start", milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+  { name: "Output 2 and 3 – Retention Point 1 and 2", milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
+  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
+  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+].each do |hash|
+  Milestone.find_or_create_by!(
+    schedule: ecf_january_reduced_2022,
+    name: hash[:name],
+    milestone_date: hash[:milestone_date],
+    payment_date: hash[:payment_date],
+  )
+end
+
+ecf_january_extended_2022 = Schedule.find_or_create_by!(name: "ECF January extended 2021")
+[
+  { name: "Output 1 - Participant Start", milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+  { name: "Output 2 and 3 – Retention Point 1 and 2", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
+  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
+].each do |hash|
+  Milestone.find_or_create_by!(
+    schedule: ecf_january_extended_2022,
+    name: hash[:name],
+    milestone_date: hash[:milestone_date],
+    payment_date: hash[:payment_date],
+  )
+end

--- a/spec/models/milestone_spec.rb
+++ b/spec/models/milestone_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Milestone, type: :model do
+  it { is_expected.to belong_to(:schedule) }
+end

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe ParticipantProfile, type: :model do
   it { is_expected.to belong_to(:teacher_profile) }
+  it { is_expected.to belong_to(:schedule).optional }
   it { is_expected.to have_one(:user).through(:teacher_profile) }
   it {
     is_expected.to define_enum_for(:status).with_values(

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schedule, type: :model do
+  it { is_expected.to have_many(:milestones) }
+  it { is_expected.to have_many(:participant_profiles) }
+end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDTP-251

We want to make sure declarations are made at the correct time. And we want to have a way of representing the time the payments get made.

### Changes proposed in this pull request
Add schedule and milestone model.
Add basic unit tests.
Add schedule seeds for known schedules (https://docs.google.com/presentation/d/1HBVEZabnGuakaAKJ6d5AGJthC7Bl21cex4MN5K8rus4/edit#slide=id.ge582d819d0_0_304)

### Guidance to review
I think all participants profiles will need to be pointing at a schedule. By default probably September standard one. We might need to worry about how exactly we know which schedule they are doing - is it IC's job, or participant's job, or LP's job to tell us. Not sure, not in scope for this ticket, just something to be aware. 

I think all participant declarations will be implicitly made against milestones - they have `declaration_date` on them, and from that we can work out which milestone they belong to (a Milestone with the earliest milestone date that is after the declaration date). I don't think we should store it in the database for time being. perhaps at a future time we will for easier querying, but for now it is just something to be aware of.

### Testing
Unit tests for models

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
You can't. I guess if you are a dev you can ssh into review app and check out the schedules and milestones in Rails console. 
