### PR TITLE
Set the nonce correctly for percy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       nonce: ${{ steps.generate-nonce.outputs.nonce }}
     steps:
       - id: generate-nonce
-        run: echo "::set-output nonce=$(tr -dc 0-9 </dev/urandom | head -c 18 ; echo '')"
+        run: echo "::set-output name=nonce::$(tr -dc 0-9 </dev/urandom | head -c 18 ; echo '')"
 
   backend-tests:
     name: Run rspec


### PR DESCRIPTION
In an attempt to fix Percy, I broke it completely. Let's see what this attempt at fixing it does...

I got the github actions syntax for setting output variables wrong. This fixes it.