### PR TITLE
Fix validation for event type

### DIFF
--- a/app/services/record_declarations/retained.rb
+++ b/app/services/record_declarations/retained.rb
@@ -5,7 +5,8 @@ module RecordDeclarations
     extend ActiveSupport::Concern
 
     included do
-      validates :evidence_held, presence: { message: "The property '#/evidence_held' must be present" }
+      validates :evidence_held, presence: { message: I18n.t(:missing_evidence_held) }
+      validates :evidence_held, inclusion: { in: :valid_evidence_types, message: I18n.t(:invalid_evidence_type) }, allow_blank: true
     end
   end
 end

--- a/app/services/record_declarations/retained/early_career_teacher.rb
+++ b/app/services/record_declarations/retained/early_career_teacher.rb
@@ -7,7 +7,7 @@ module RecordDeclarations
       include Retained
 
       def valid_evidence_types
-        %w[training-event-attended self-study-material-completed]
+        %w[training-event-attended self-study-material-completed other]
       end
     end
   end

--- a/app/services/record_declarations/retained/early_career_teacher.rb
+++ b/app/services/record_declarations/retained/early_career_teacher.rb
@@ -5,6 +5,10 @@ module RecordDeclarations
     class EarlyCareerTeacher < ::RecordDeclarations::Base
       include RecordDeclarations::EarlyCareerTeacher
       include Retained
+
+      def valid_evidence_types
+        %w[training-event-attended self-study-material-completed]
+      end
     end
   end
 end

--- a/app/services/record_declarations/retained/mentor.rb
+++ b/app/services/record_declarations/retained/mentor.rb
@@ -5,6 +5,10 @@ module RecordDeclarations
     class Mentor < ::RecordDeclarations::Base
       include RecordDeclarations::Mentor
       include Retained
+
+      def valid_evidence_types
+        %w[training-event-attended]
+      end
     end
   end
 end

--- a/app/services/record_declarations/retained/mentor.rb
+++ b/app/services/record_declarations/retained/mentor.rb
@@ -7,7 +7,7 @@ module RecordDeclarations
       include Retained
 
       def valid_evidence_types
-        %w[training-event-attended]
+        %w[training-event-attended self-study-material-completed other]
       end
     end
   end

--- a/app/services/record_declarations/retained/npq.rb
+++ b/app/services/record_declarations/retained/npq.rb
@@ -5,6 +5,10 @@ module RecordDeclarations
     class NPQ < ::RecordDeclarations::Base
       include RecordDeclarations::NPQ
       include Retained
+
+      def valid_evidence_types
+        %w[training-event-attended]
+      end
     end
   end
 end

--- a/app/services/record_declarations/retained/npq.rb
+++ b/app/services/record_declarations/retained/npq.rb
@@ -7,7 +7,7 @@ module RecordDeclarations
       include Retained
 
       def valid_evidence_types
-        %w[training-event-attended]
+        %w[training-event-attended other]
       end
     end
   end

--- a/app/services/record_declarations/retained/npq.rb
+++ b/app/services/record_declarations/retained/npq.rb
@@ -7,7 +7,7 @@ module RecordDeclarations
       include Retained
 
       def valid_evidence_types
-        %w[training-event-attended other]
+        %w[yes]
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,9 +45,11 @@ en:
   missing_course_identifier: "The property '#/course_identifier' must be present"
   missing_declaration_date: "The property '#/declaration_date' must be present"
   missing_declaration_type: "The property '#/declaration_type' must be present"
+  missing_evidence_held: "The property '#/evidence_held' must be present"
   missing_lead_provider: "The lead provider must be present"
   invalid_event: "The property '#/declaration_type' must be a valid declaration type"
   invalid_course: "The property '#/course_identifier' must be an available course to '#/participant_id'"
+  invalid_evidence_type: "The property '#/evidence_held' must be an available type to the event type and course type"
   invalid_data_structure: correct json data structure required. See API docs for reference
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults

--- a/etc/schema/0.3/npq/participant_declarations/retained/create/request.json
+++ b/etc/schema/0.3/npq/participant_declarations/retained/create/request.json
@@ -6,7 +6,7 @@
       "declaration_date": "2015-02-14T02:21:34",
       "participant_id": "0cdc3c2f-20e3-4721-97f1-485b397ae7e9",
       "course_type": "leading-teaching",
-      "evidence_held": "training-event-attended"
+      "evidence_held": "yes"
     }
   }
 }

--- a/etc/schema/0.3/npq/participant_declarations/retained/create/request_schema.json
+++ b/etc/schema/0.3/npq/participant_declarations/retained/create/request_schema.json
@@ -36,8 +36,7 @@
     },
     "evidence_type": {
       "enum": [
-        "training-event-attended",
-        "self-study-material-completed"
+        "training-event-attended"
       ]
     },
     "npq": {

--- a/etc/schema/0.3/npq/participant_declarations/retained/create/request_schema.json
+++ b/etc/schema/0.3/npq/participant_declarations/retained/create/request_schema.json
@@ -36,7 +36,7 @@
     },
     "evidence_type": {
       "enum": [
-        "training-event-attended"
+        "yes"
       ]
     },
     "npq": {

--- a/etc/schema/0.3/npq/participant_declarations/started/create/request_schema.json
+++ b/etc/schema/0.3/npq/participant_declarations/started/create/request_schema.json
@@ -34,12 +34,6 @@
         ]
       }
     },
-    "evidence_type": {
-      "enum": [
-        "training-event-attended",
-        "self-study-material-completed"
-      ]
-    },
     "npq": {
       "courses": {
         "enum": [

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: %w[training-event-attended self-study-material-completed].sample,
+      evidence_held: %w[training-event-attended self-study-material-completed other].sample,
     }
   end
   let(:ect_params) do

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: %w[training-event-attended self-study-material-completed other].sample,
+      evidence_held: "other",
     }
   end
   let(:ect_params) do
@@ -49,8 +49,10 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
   end
 
   context "when valid user is an early_career_teacher" do
-    it "creates a participant and profile declaration" do
-      expect { described_class.call(ect_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+    %w[training-event-attended self-study-material-completed other].each do |evidence_held|
+      it "creates a participant and profile declaration" do
+        expect { described_class.call(ect_params.merge(evidence_held: evidence_held)) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+      end
     end
 
     it "fails when course is for mentor" do

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: "Test evidence",
+      evidence_held: %w[training-event-attended self-study-material-completed].sample,
     }
   end
   let(:ect_params) do
@@ -69,6 +69,12 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
   context "when declaration type is invalid" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
+
+  context "when evidence held is invalid" do
+    it "raises a ParameterMissing error" do
+      expect { described_class.call(params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 end

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: "Test evidence",
+      evidence_held: "training-event-attended",
     }
   end
   let(:ect_params) do
@@ -69,6 +69,12 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
   context "when declaration type is invalid" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
+
+  context "when evidence held is invalid" do
+    it "raises a ParameterMissing error" do
+      expect { described_class.call(params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 end

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: "training-event-attended",
+      evidence_held: %w[training-event-attended self-study-material-completed other].sample,
     }
   end
   let(:ect_params) do

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: %w[training-event-attended self-study-material-completed other].sample,
+      evidence_held: "other",
     }
   end
   let(:ect_params) do
@@ -49,8 +49,10 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
   end
 
   context "when valid user is a mentor" do
-    it "creates a participant and profile declaration" do
-      expect { described_class.call(mentor_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+    %w[training-event-attended self-study-material-completed other].each do |evidence_held|
+      it "creates a participant and profile declaration" do
+        expect { described_class.call(mentor_params.merge(evidence_held: evidence_held)) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+      end
     end
 
     it "fails when course is for an early_career_teacher" do

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
       declaration_type: "retained-1",
       course_identifier: "npq-leading-teaching",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: "training-event-attended",
+      evidence_held: %w[training-event-attended other].sample,
     }
   end
 

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
       declaration_type: "retained-1",
       course_identifier: "npq-leading-teaching",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: %w[training-event-attended other].sample,
+      evidence_held: "yes",
     }
   end
 

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
       declaration_type: "retained-1",
       course_identifier: "npq-leading-teaching",
       lead_provider_from_token: another_lead_provider,
-      evidence_held: "Test evidence",
+      evidence_held: "training-event-attended",
     }
   end
 
@@ -53,6 +53,12 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
   context "when declaration type is valid for ECF but not NPQ" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params.merge(declaration_type: "retained-3")) }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
+
+  context "when evidence held is invalid" do
+    it "raises a ParameterMissing error" do
+      expect { described_class.call(params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -800,9 +800,7 @@
             "type": "string",
             "enum": [
               "retained-1",
-              "retained-2",
-              "retained-3",
-              "retained-4"
+              "retained-2"
             ],
             "example": "retained-1"
           },
@@ -829,10 +827,9 @@
             "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
             "type": "string",
             "enum": [
-              "training-event-attended",
-              "self-study-material-completed"
+              "yes"
             ],
-            "example": "training-event-attended"
+            "example": "yes"
           }
         },
         "required": [
@@ -847,7 +844,7 @@
           "declaration_type": "retained-1",
           "declaration_date": "2021-05-31T02:21:32.000Z",
           "course_identifier": "npq-headship",
-          "evidence_held": "training-event-attended"
+          "evidence_held": "yes"
         }
       },
       "NPQParticipantStartedDeclaration": {

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -33,9 +33,8 @@ properties:
     description: "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period"
     type: string
     enum:
-      - training-event-attended
-      - self-study-material-completed
-    example: training-event-attended
+      - "yes"
+    example: "yes"
 required:
   - participant_id
   - declaration_type
@@ -47,4 +46,4 @@ example:
   declaration_type: retained-1
   declaration_date: 2021-05-31T02:21:32Z
   course_identifier: npq-headship
-  evidence_held: training-event-attended
+  evidence_held: "yes"


### PR DESCRIPTION
### Context
We missed that when we switched from json schema validator into rails validations.

### Changes proposed in this pull request
Add validations for evidence type. Add tests to show how they work.

### Guidance to review
I also changed the schemas. One was the npq retained event, because we need it to match our actual validation.

The other was for ecf started event. I think we don't want or need them on that event.

### Testing
Unit tests for the validations.

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Try submitting a retained event with invalid evidence held, it should fail. Before it succeeded.
