### PR TITLE
CPDTP-371 Create header to more tightly control date validation for the non-production systems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,8 @@ gem "rouge"
 
 gem "ransack"
 
+gem "timecop"
+
 # Payment breackdown
 
 gem "terminal-table"

--- a/Gemfile
+++ b/Gemfile
@@ -101,8 +101,6 @@ gem "rouge"
 
 gem "ransack"
 
-gem "timecop"
-
 # Payment breackdown
 
 gem "terminal-table"
@@ -148,6 +146,7 @@ end
 
 group :development, :deployed_development, :test, :sandbox do
   gem "faker"
+  gem "timecop"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,6 +489,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     thread_safe (0.3.6)
+    timecop (0.9.4)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2020.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -612,6 +612,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   strong_migrations
   terminal-table
+  timecop
   tzinfo-data
   view_component
   wdm (>= 0.1.0)

--- a/app/middlewares/time_traveler.rb
+++ b/app/middlewares/time_traveler.rb
@@ -6,7 +6,7 @@ class TimeTraveler
   end
 
   def call(env)
-    return @app.call(env) unless env.key?("HTTP_X_WITH_SERVER_DATE")
+    return @app.call(env) unless env.key?("HTTP_X_WITH_SERVER_DATE") && %w[development deployed_development sandbox test].include?(Rails.env)
 
     Timecop.travel(Time.zone.parse(env["HTTP_X_WITH_SERVER_DATE"])) do
       @app.call(env)

--- a/app/middlewares/time_traveler.rb
+++ b/app/middlewares/time_traveler.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TimeTraveler
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    return @app.call(env) unless env.key?("HTTP_X_WITH_SERVER_DATE")
+
+    Timecop.travel(Time.zone.parse(env["HTTP_X_WITH_SERVER_DATE"])) do
+      @app.call(env)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,10 @@ module EarlyCareerFramework
       require_dependency(c)
     end
 
+    Dir.glob(Rails.root + "app/middlewares/*.rb").sort.each do |file|
+      require file
+    end
+
     Dir.glob(Rails.root + "app/serializers/**/*_serializer*.rb").each do |c|
       require_dependency(c)
     end

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -5,6 +5,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
+  config.middleware.use TimeTraveler
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
+  config.middleware.use TimeTraveler
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.middleware.use TimeTraveler
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
   # Code is not reloaded between requests.

--- a/spec/middlewares/time_traveler_spec.rb
+++ b/spec/middlewares/time_traveler_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe TimeTraveler do
+  context "when called with a POST request" do
+    let(:app) { proc { [200, {}, %w[Live]] } }
+    let(:middleware) { described_class.new(app) }
+    let(:request) { Rack::MockRequest.new(middleware) }
+    let(:header_date) { "2021-01-02T03:04:05.000Z" }
+    let(:expected_date) { Time.zone.parse(header_date) }
+
+    context "when server date header passed" do
+      it "passes the request through unchanged" do
+        request.get("/", "X_WITH_SERVER_DATE" => header_date) do
+          expect(Time.zone.now).to eq(expected_date)
+        end
+      end
+    end
+  end
+end

--- a/spec/middlewares/time_traveler_spec.rb
+++ b/spec/middlewares/time_traveler_spec.rb
@@ -1,18 +1,40 @@
 # frozen_string_literal: true
 
 describe TimeTraveler do
-  context "when called with a POST request" do
-    let(:app) { proc { [200, {}, %w[Live]] } }
-    let(:middleware) { described_class.new(app) }
-    let(:request) { Rack::MockRequest.new(middleware) }
-    let(:header_date) { "2021-01-02T03:04:05.000Z" }
-    let(:expected_date) { Time.zone.parse(header_date) }
+  let(:app) { proc { [200, {}, Time.zone.now.to_s] } }
+  let(:middleware) { described_class.new(app) }
+  let(:request) { Rack::MockRequest.new(middleware) }
+  let(:header_date) { "2021-01-02T03:04:05.000Z" }
+  let(:expected_date) { Time.zone.parse(header_date) }
+  let(:local_time) { Time.zone.local(2021, 8, 8, 10, 10, 0) }
+  let(:some_other_date) { Timecop.travel(local_time) }
 
-    context "when server date header passed" do
-      it "passes the request through unchanged" do
-        request.get("/", "X_WITH_SERVER_DATE" => header_date) do
-          expect(Time.zone.now).to eq(expected_date)
-        end
+  context "when server date header passed" do
+    it "changes the current date to the date from the header" do
+      response = request.get("/", "HTTP_X_WITH_SERVER_DATE" => header_date)
+      expect(Time.zone.parse(response.body)).to eq(expected_date)
+    end
+  end
+
+  context "when date header not present" do
+    context "with timecop travel" do
+      before do
+        Timecop.freeze(local_time)
+      end
+      after do
+        Timecop.return
+      end
+
+      it "doesn't change the current date and matches current time" do
+        response = request.get("/")
+        expect(Time.zone.parse(response.body)).to eq(local_time)
+      end
+    end
+
+    context "without timecop travel" do
+      it "doesn't match wrong time" do
+        response = request.get("/")
+        expect(Time.zone.parse(response.body)).not_to eq(Time.zone.now - 1.second)
       end
     end
   end


### PR DESCRIPTION
### Context

There is a requirement for lead providers to be able to test declaration date validation in sandbox environment. They should be able to pass a date in the ```header X-With-Server-Date``` and the server will use it as current date. Future ticket will cover validations.

### Changes proposed in this pull request

Middleware to use timecop to set date for the scope of a request

### Guidance to review

### Testing

Set an additional header and check the server side date will be set to that date.

<img width="556" alt="Screenshot 2021-08-06 at 10 27 06" src="https://user-images.githubusercontent.com/77098906/128490027-eb983276-555c-45c3-ba7e-ce647aa13c10.png">


### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
