### PR TITLE
Add sandbox google analytics

### DIFF
--- a/app/helpers/google_analytics_helper.rb
+++ b/app/helpers/google_analytics_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module GoogleAnalyticsHelper
+  def get_gtm_id
+    if Rails.env.production?
+      "G-PHZ5TT3VPD"
+    elsif Rails.env.sandbox?
+      "G-3HQPHNKLH6"
+    else
+      "G-LR5YHTJD65"
+    end
+  end
+end

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -37,7 +37,7 @@
     })(window,document,'script','dataLayer','GTM-N58Z5PG');</script>
     <!-- End Google Tag Manager -->
 
-    <% gtm_id = Rails.env.production? ? "G-PHZ5TT3VPD" : "G-LR5YHTJD65" %>
+    <% gtm_id = get_gtm_id %>
 
     <% if cookies[:cookie_consent_1] == "on" %>
       <script async src="https://www.googletagmanager.com/gtag/js?id=<%= gtm_id %>"></script>


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/CPDTP-406

We want to have a separate GA space for sandbox, so we can easily track which pages ths sandbox users are visiting. We don't want to throw it into the shared mix with review apps, etc., because it is accessed by real users (LPs for example).

### Changes proposed in this pull request

Extract gtm_id computation into a helper
Add sandbox value to it.

### How can I view this in a review app?
You can't. Once it is merged I will deploy to staging, sandbox and production and make sure the gtm_id values match our expectations. 
