### PR TITLE
CPDRP-659: Extend participant API with additional information

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -55,7 +55,7 @@ module Api
                                     .distinct
                                     .includes(
                                       teacher_profile: {
-                                        ecf_profile: %i[cohort school],
+                                        ecf_profile: %i[cohort school ecf_participant_eligibility],
                                         early_career_teacher_profile: :mentor,
                                       },
                                     )

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -54,8 +54,10 @@ module Api
         participants = lead_provider.ecf_participants
                                     .distinct
                                     .includes(
-                                      early_career_teacher_profile: %i[cohort mentor school],
-                                      mentor_profile: %i[cohort school],
+                                      teacher_profile: {
+                                        ecf_profile: %i[cohort school],
+                                        early_career_teacher_profile: :mentor,
+                                      },
                                     )
 
         if updated_since.present?

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -14,7 +14,7 @@ class ParticipantSerializer
     end
 
     def participant_active?(user)
-      user.early_career_teacher_profile&.active? || user.mentor_profile&.active?
+      user.teacher_profile.ecf_profile&.active?
     end
   end
 
@@ -24,28 +24,35 @@ class ParticipantSerializer
   active_participant_attribute :full_name, &:full_name
 
   active_participant_attribute :mentor_id do |user|
-    user.early_career_teacher_profile&.mentor&.id
+    user.teacher_profile.early_career_teacher_profile&.mentor&.id
   end
 
   active_participant_attribute :school_urn do |user|
-    user.early_career_teacher_profile&.school&.urn ||
-      user.mentor_profile&.school&.urn
+    user.teacher_profile.ecf_profile&.school&.urn
   end
 
-  attribute :participant_type do |user|
-    if user.early_career_teacher?
+  active_participant_attribute :participant_type do |user|
+    case user.teacher_profile.ecf_profile.type
+    when ParticipantProfile::ECT.name
       :ect
-    elsif user.mentor?
+    when ParticipantProfile::Mentor.name
       :mentor
     end
   end
 
   active_participant_attribute :cohort do |user|
-    user.early_career_teacher_profile&.cohort&.start_year ||
-      user.mentor_profile.cohort&.start_year
+    user.teacher_profile.ecf_profile.cohort.start_year
   end
 
   attribute :status do |user|
-    user.early_career_teacher_profile&.status || user.mentor_profile&.status || "withdrawn"
+    user.teacher_profile.ecf_profile&.status || "withdrawn"
+  end
+
+  active_participant_attribute :teacher_reference_number do |user|
+    user.teacher_profile.trn
+  end
+
+  active_participant_attribute :teacher_reference_number_validated do |user|
+    user.teacher_profile.trn.present?
   end
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -57,7 +57,7 @@ class ParticipantSerializer
   end
 
   active_participant_attribute :eligible_for_funding do |user|
-    user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible? || nil
+    user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible_status? || nil
   end
 
   active_participant_attribute :pupil_premium_uplift do

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -55,4 +55,16 @@ class ParticipantSerializer
   active_participant_attribute :teacher_reference_number_validated do |user|
     user.teacher_profile.trn.present?
   end
+
+  active_participant_attribute :eligible_for_funding do |user|
+    user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible? || nil
+  end
+
+  active_participant_attribute :pupil_premium_uplift do
+    nil # TODO: CPDRP-534 - Share when we know we have the correct information
+  end
+
+  active_participant_attribute :sparsity_uplift do
+    nil # TODO: CPDRP-534 - Share when we know we have the correct information
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
     resource :notify_callback, only: :create, path: "notify-callback"
 
     namespace :v1 do
-      resources :participants, only: :index, constraints: ->(_request) { FeatureFlag.active?(:participant_data_api) }
+      resources :participants, only: :index
       resources :participant_declarations, only: %i[create], path: "participant-declarations"
       resources :users, only: %i[index create]
       resources :ecf_users, only: %i[index create], path: "ecf-users"

--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -26,22 +26,22 @@ def generate_mentors(lead_provider, school, cohort, logger)
   school_cohort = SchoolCohort.find_or_create_by!(school: school, cohort: cohort)
 
   10.times do
-    mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-    mentor_profile = ParticipantProfile::Mentor.create!(user: mentor, school_cohort: school_cohort)
+    mentor = create_teacher
+    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort)
 
     ect_count = rand(0..3)
     ect_count.times do
-      ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-      ParticipantProfile::ECT.create!(user: ect, school_cohort: school_cohort, mentor_profile: mentor_profile)
+      ect = create_teacher
+      ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile)
     end
     logger.info(" Mentor with user_id #{mentor.id} generated with #{ect_count} ECTs")
   end
   2.times do
-    mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-    mentor_profile = ParticipantProfile::Mentor.create!(user: mentor, school_cohort: school_cohort, status: "withdrawn")
+    mentor = create_teacher
+    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort, status: "withdrawn")
 
-    ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-    ParticipantProfile::ECT.create!(user: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn")
+    ect = create_teacher
+    ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn")
   end
   new_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
   logger.info(" Before: #{existing_mentor_count} mentors, after: #{new_mentor_count}")
@@ -69,4 +69,15 @@ def create_school_and_associations(lead_provider, cohort, index)
   SchoolCohort.find_or_create_by!(school: school, cohort: cohort, induction_programme_choice: "full_induction_programme")
 
   school
+end
+
+def random_trn
+  return if [true, false].sample
+
+  sprintf("%07i", Random.random_number(9_999_999))
+end
+
+def create_teacher
+  mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
+  TeacherProfile.create!(user: mentor, trn: random_trn)
 end

--- a/spec/factories/teacher_profiles.rb
+++ b/spec/factories/teacher_profiles.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :teacher_profile do
     user
 
-    trn { Random.alphanumeric(7) }
+    trn { sprintf("%07i", Random.random_number(9_999_999)) }
   end
 end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
               :status,
               :teacher_reference_number,
               :teacher_reference_number_validated,
+              :eligible_for_funding,
+              :pupil_premium_uplift,
+              :sparsity_uplift,
             ).exactly)
         end
 
@@ -130,7 +133,21 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
         end
 
         it "returns the correct headers" do
-          expect(parsed_response.headers).to match_array(%w[id email full_name mentor_id school_urn participant_type cohort status teacher_reference_number teacher_reference_number_validated])
+          expect(parsed_response.headers).to match_array(
+            %w[id
+               email
+               full_name
+               mentor_id
+               school_urn
+               participant_type
+               cohort
+               status
+               teacher_reference_number
+               teacher_reference_number_validated
+               eligible_for_payment
+               pupil_premium_uplift
+               sparsity_uplift],
+          )
         end
 
         it "returns the correct values" do
@@ -145,6 +162,9 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(mentor_row["teacher_reference_number"]).to eql mentor.teacher_profile.trn
           expect(mentor_row["teacher_reference_number_validated"]).to eql "true"
+          expect(mentor_row["eligible_for_funding"]).to be_empty
+          expect(mentor_row["pupil_premium_uplift"]).to be_empty
+          expect(mentor_row["sparsity_uplift"]).to be_empty
 
           ect = ParticipantProfile::ECT.active.first.user
           ect_row = parsed_response.find { |row| row["id"] == ect.id }
@@ -157,6 +177,9 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(ect_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(ect_row["teacher_reference_number"]).to eql ect.teacher_profile.trn
           expect(ect_row["teacher_reference_number_validated"]).to eql "true"
+          expect(mentor_row["eligible_for_funding"]).to be_empty
+          expect(mentor_row["pupil_premium_uplift"]).to be_empty
+          expect(mentor_row["sparsity_uplift"]).to be_empty
 
           withdrawn_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile.user.id }
           expect(withdrawn_row).not_to be_nil
@@ -168,6 +191,9 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(withdrawn_row["cohort"]).to be_empty
           expect(withdrawn_row["teacher_reference_number"]).to be_empty
           expect(withdrawn_row["teacher_reference_number_validated"]).to be_empty
+          expect(mentor_row["eligible_for_funding"]).to be_empty
+          expect(mentor_row["pupil_premium_uplift"]).to be_empty
+          expect(mentor_row["sparsity_uplift"]).to be_empty
         end
 
         it "ignores pagination parameters" do

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
                status
                teacher_reference_number
                teacher_reference_number_validated
-               eligible_for_payment
+               eligible_for_funding
                pupil_premium_uplift
                sparsity_uplift],
           )

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe ParticipantSerializer do
     let(:mentor_cohort) { mentor.mentor_profile.cohort }
 
     it "outputs correctly formatted serialized Mentors" do
-      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year},\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year},\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null}}}"
       expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
     end
 
     it "outputs correctly formatted serialized ECTs" do
-      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year},\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year},\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null}}}"
       expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
     end
 
@@ -24,12 +24,12 @@ RSpec.describe ParticipantSerializer do
       let(:ect) { create(:participant_profile, :ect, mentor_profile: mentor.mentor_profile, status: "withdrawn").user }
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe ParticipantSerializer do
   describe "serialization" do
     let(:mentor) { create(:participant_profile, :mentor).user }
-    let(:ect) { create(:participant_profile, :ect, mentor_profile: mentor.mentor_profile).user }
+    let(:ect_profile) { create(:participant_profile, :ect, mentor_profile: mentor.mentor_profile) }
+    let(:ect) { ect_profile.user }
     let(:ect_cohort) { ect.early_career_teacher_profile.cohort }
     let(:mentor_cohort) { mentor.mentor_profile.cohort }
 
@@ -31,6 +32,59 @@ RSpec.describe ParticipantSerializer do
       it "outputs correctly formatted serialized ECTs" do
         expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
+      end
+    end
+
+    describe "funding_eligibility" do
+      context "when there is no eligibility record" do
+        it "returns nil" do
+          expect(ect_profile.ecf_participant_eligibility).to be_nil
+
+          result = ParticipantSerializer.new(ect).serializable_hash
+          expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
+        end
+      end
+
+      context "when the eligibility is manual_check" do
+        before do
+          eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
+          eligibility.update!(status: :manual_check)
+        end
+
+        it "returns nil" do
+          expect(ect_profile.ecf_participant_eligibility.status).to eql "manual_check"
+
+          result = ParticipantSerializer.new(ect).serializable_hash
+          expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
+        end
+      end
+
+      context "when the eligibility is matched" do
+        before do
+          eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
+          eligibility.update!(status: :matched)
+        end
+
+        it "returns nil" do
+          expect(ect_profile.ecf_participant_eligibility.status).to eql "matched"
+
+          result = ParticipantSerializer.new(ect).serializable_hash
+          expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
+        end
+      end
+
+      context "when the eligibility is eligible" do
+        before do
+          eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
+          eligibility.update!(status: :eligible)
+        end
+
+        it "returns true" do
+          expect(ect_profile.ecf_participant_eligibility.status).to eql "eligible"
+
+          result = ParticipantSerializer.new(ect).serializable_hash
+          expect(result[:data][:attributes][:eligible_for_funding]).to be true
+        end
       end
     end
   end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe ParticipantSerializer do
     let(:mentor_cohort) { mentor.mentor_profile.cohort }
 
     it "outputs correctly formatted serialized Mentors" do
-      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year},\"status\":\"active\"}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":#{mentor_cohort.start_year},\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true}}}"
       expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
     end
 
     it "outputs correctly formatted serialized ECTs" do
-      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year},\"status\":\"active\"}}}"
+      expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":#{ect_cohort.start_year},\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true}}}"
       expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
     end
 
@@ -24,12 +24,12 @@ RSpec.describe ParticipantSerializer do
       let(:ect) { create(:participant_profile, :ect, mentor_profile: mentor.mentor_profile, status: "withdrawn").user }
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\"}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\"}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -675,6 +675,18 @@
               "active",
               "withdrawn"
             ]
+          },
+          "teacher_reference_number": {
+            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "type": "string",
+            "nullable": true,
+            "example": "1234567"
+          },
+          "teacher_reference_number_validated": {
+            "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
           }
         }
       },
@@ -748,6 +760,18 @@
             "enum": [
               "active"
             ]
+          },
+          "teacher_reference_number": {
+            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "type": "string",
+            "nullable": true,
+            "example": "1234567"
+          },
+          "teacher_reference_number_validated": {
+            "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
           }
         }
       },
@@ -777,7 +801,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,null,false\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn,null,null\n"
       },
       "MultipleEcfParticipantsResponse": {
         "description": "A list of ECF participants",
@@ -802,7 +826,9 @@
                   "school_urn": "106286",
                   "participant_type": "ect",
                   "cohort": "2021",
-                  "status": "active"
+                  "status": "active",
+                  "teacher_reference_number": "0012345",
+                  "teacher_reference_number_validated": true
                 }
               },
               {
@@ -814,7 +840,9 @@
                   "school_urn": "106286",
                   "participant_type": "mentor",
                   "cohort": "2021",
-                  "status": "active"
+                  "status": "active",
+                  "teacher_reference_number": null,
+                  "teacher_reference_number_validated": false
                 }
               },
               {
@@ -827,7 +855,9 @@
                   "school_urn": null,
                   "participant_type": "ect",
                   "cohort": null,
-                  "status": "withdrawn"
+                  "status": "withdrawn",
+                  "teacher_reference_number": null,
+                  "teacher_reference_number_validated": null
                 }
               }
             ]

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -166,7 +166,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "45879f51-b4ce-49c8-975e-6f8653c22ab6",
+            "example": "25234630-d7e1-42bf-9e59-ffd2ffe157b3",
             "description": "The ID of the NPQ application to accept.",
             "schema": {
               "type": "string"
@@ -216,7 +216,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "fd79896a-ac81-4769-8c23-37509de0a004",
+            "example": "22bea91d-e8ac-47b7-93a0-c5b7f80a8d95",
             "description": "The ID of the NPQ application to reject.",
             "schema": {
               "type": "string"
@@ -687,6 +687,24 @@
             "type": "boolean",
             "nullable": true,
             "example": true
+          },
+          "eligible_for_funding": {
+            "description": "Indicates whether this participant is eligible to receive DfE funded induction",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "pupil_premium_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "sparsity_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
           }
         }
       },
@@ -772,6 +790,24 @@
             "type": "boolean",
             "nullable": true,
             "example": true
+          },
+          "eligible_for_funding": {
+            "description": "Indicates whether this participant is eligible to receive DfE funded induction",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "pupil_premium_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "sparsity_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
           }
         }
       },
@@ -801,7 +837,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,null,false\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn,null,null\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\"\n"
       },
       "MultipleEcfParticipantsResponse": {
         "description": "A list of ECF participants",
@@ -828,7 +864,10 @@
                   "cohort": "2021",
                   "status": "active",
                   "teacher_reference_number": "0012345",
-                  "teacher_reference_number_validated": true
+                  "teacher_reference_number_validated": true,
+                  "eligible_for_funding": true,
+                  "pupil_premium_uplift": false,
+                  "sparsity_uplift": true
                 }
               },
               {
@@ -842,7 +881,10 @@
                   "cohort": "2021",
                   "status": "active",
                   "teacher_reference_number": null,
-                  "teacher_reference_number_validated": false
+                  "teacher_reference_number_validated": false,
+                  "eligible_for_funding": null,
+                  "pupil_premium_uplift": null,
+                  "sparsity_uplift": null
                 }
               },
               {
@@ -853,11 +895,14 @@
                   "full_name": null,
                   "mentor_id": null,
                   "school_urn": null,
-                  "participant_type": "ect",
+                  "participant_type": null,
                   "cohort": null,
                   "status": "withdrawn",
                   "teacher_reference_number": null,
-                  "teacher_reference_number_validated": null
+                  "teacher_reference_number_validated": null,
+                  "eligible_for_funding": null,
+                  "pupil_premium_uplift": null,
+                  "sparsity_uplift": null
                 }
               }
             ]

--- a/swagger/v1/component_schemas/EcfParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/EcfParticipantAttributes.yml
@@ -43,3 +43,14 @@ properties:
     enum:
       - active
       - withdrawn
+  teacher_reference_number:
+    description: "The Teacher Reference Number (TRN) for this NPQ participant"
+    type: string
+    nullable: true
+    example: "1234567"
+  teacher_reference_number_validated:
+    description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
+    type: boolean
+    nullable: true
+    example: true
+

--- a/swagger/v1/component_schemas/EcfParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/EcfParticipantAttributes.yml
@@ -53,4 +53,18 @@ properties:
     type: boolean
     nullable: true
     example: true
-
+  eligible_for_funding:
+    description: "Indicates whether this participant is eligible to receive DfE funded induction"
+    type: boolean
+    nullable: true
+    example: true
+  pupil_premium_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
+    type: boolean
+    nullable: true
+    example: true
+  sparsity_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
+    type: boolean
+    nullable: true
+    example: true

--- a/swagger/v1/component_schemas/EcfParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/EcfParticipantCsvRow.yml
@@ -65,3 +65,18 @@ properties:
     type: boolean
     nullable: true
     example: true
+  eligible_for_funding:
+    description: "Indicates whether this participant is eligible to receive DfE funded induction"
+    type: boolean
+    nullable: true
+    example: true
+  pupil_premium_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
+    type: boolean
+    nullable: true
+    example: true
+  sparsity_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
+    type: boolean
+    nullable: true
+    example: true

--- a/swagger/v1/component_schemas/EcfParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/EcfParticipantCsvRow.yml
@@ -55,3 +55,13 @@ properties:
     example: active
     enum:
       - active
+  teacher_reference_number:
+    description: "The Teacher Reference Number (TRN) for this NPQ participant"
+    type: string
+    nullable: true
+    example: "1234567"
+  teacher_reference_number_validated:
+    description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
+    type: boolean
+    nullable: true
+    example: true

--- a/swagger/v1/component_schemas/MultipleEcfParticipantsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleEcfParticipantsCsvResponse.yml
@@ -9,7 +9,7 @@ properties:
     items:
       $ref: "#/components/schemas/EcfParticipantCsvRow"
 example: |
-  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated
-  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true
-  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,null,false
-  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn,null,null
+  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift
+  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true
+  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,"",false,false,false,false
+  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,"","","","",ect,"",withdrawn,"","","","",""

--- a/swagger/v1/component_schemas/MultipleEcfParticipantsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleEcfParticipantsCsvResponse.yml
@@ -9,7 +9,7 @@ properties:
     items:
       $ref: "#/components/schemas/EcfParticipantCsvRow"
 example: |
-  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status
-  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active
-  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active
-  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn
+  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated
+  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true
+  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,null,false
+  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn,null,null

--- a/swagger/v1/component_schemas/MultipleEcfParticipantsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleEcfParticipantsResponse.yml
@@ -20,6 +20,9 @@ properties:
           status: active
           teacher_reference_number: "0012345"
           teacher_reference_number_validated: true
+          eligible_for_funding: true
+          pupil_premium_uplift: false
+          sparsity_uplift: true
       - id: bb36d74a-68a7-47b6-86b6-1fd0d141c590
         type: participant
         attributes:
@@ -31,6 +34,9 @@ properties:
           status: active
           teacher_reference_number: null
           teacher_reference_number_validated: false
+          eligible_for_funding: null
+          pupil_premium_uplift: null
+          sparsity_uplift: null
       - id: eb475531-bf08-48ae-b0ef-c2ff5e5bdef0
         type: participant
         attributes:
@@ -38,8 +44,11 @@ properties:
           full_name: null
           mentor_id: null
           school_urn: null
-          participant_type: ect
+          participant_type: null
           cohort: null
           status: withdrawn
           teacher_reference_number: null
           teacher_reference_number_validated: null
+          eligible_for_funding: null
+          pupil_premium_uplift: null
+          sparsity_uplift: null

--- a/swagger/v1/component_schemas/MultipleEcfParticipantsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleEcfParticipantsResponse.yml
@@ -18,6 +18,8 @@ properties:
           participant_type: ect
           cohort: "2021"
           status: active
+          teacher_reference_number: "0012345"
+          teacher_reference_number_validated: true
       - id: bb36d74a-68a7-47b6-86b6-1fd0d141c590
         type: participant
         attributes:
@@ -27,6 +29,8 @@ properties:
           participant_type: mentor
           cohort: "2021"
           status: active
+          teacher_reference_number: null
+          teacher_reference_number_validated: false
       - id: eb475531-bf08-48ae-b0ef-c2ff5e5bdef0
         type: participant
         attributes:
@@ -37,3 +41,5 @@ properties:
           participant_type: ect
           cohort: null
           status: withdrawn
+          teacher_reference_number: null
+          teacher_reference_number_validated: null


### PR DESCRIPTION
### Context
CPDRP-659
Add the following details to participants API
- TRN
- eligible for funding
- uplift

I will follow this up with a PR to add test data to the sandbox

Still to do:
- [x] Document eligibility and uplift

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
