### PR TITLE
Change current withdrawn status to reflect actual intent.

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -21,7 +21,7 @@ module Admin
     def remove; end
 
     def destroy
-      @participant_profile.withdrawn!
+      @participant_profile.permanently_inactive!
       render :destroy_success
     end
 

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -3,6 +3,7 @@
 class ParticipantProfile < ApplicationRecord
   has_paper_trail
   belongs_to :teacher_profile, touch: true
+  has_many :profile_declarations
 
   # TODO: Back-fill, so that every profile has a schedule. Add touch: true afterwards
   belongs_to :schedule, optional: true, class_name: "Finance::Schedule"
@@ -13,7 +14,7 @@ class ParticipantProfile < ApplicationRecord
 
   enum status: {
     active: "active",
-    withdrawn: "withdrawn",
+    permanently_inactive: "permanently_inactive",
   }
 
   scope :mentors, -> { where(type: Mentor.name) }

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -46,6 +46,6 @@ class ParticipantSerializer
   end
 
   attribute :status do |user|
-    user.early_career_teacher_profile&.status || user.mentor_profile&.status || "withdrawn"
+    user.early_career_teacher_profile&.status || user.mentor_profile&.status || "permanently_inactive"
   end
 end

--- a/app/services/admin/change_induction_service.rb
+++ b/app/services/admin/change_induction_service.rb
@@ -50,7 +50,7 @@ module Admin
     def withdraw_participants_if_required(new_provision)
       return if %i[core_induction_programme full_induction_programme].include? new_provision
 
-      school_cohort.active_ecf_participant_profiles.each(&:withdrawn!)
+      school_cohort.active_ecf_participant_profiles.each(&:permanently_inactive!)
     end
   end
 end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -18,4 +18,13 @@ namespace :data do
       )
     end
   end
+
+  namespace :participant_profile_status do
+    desc "Updates the participant profiles with the new permanently_inactive status change"
+    task permanently_inactive: :environment do
+      ParticipantProfile.where(status: "withdrawn").in_batches do |participant_profile|
+        participant_profile.update!(status: "permanently_inactive")
+      end
+    end
+  end
 end

--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -38,10 +38,10 @@ def generate_mentors(lead_provider, school, cohort, logger)
   end
   2.times do
     mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-    mentor_profile = ParticipantProfile::Mentor.create!(user: mentor, school_cohort: school_cohort, status: "withdrawn")
+    mentor_profile = ParticipantProfile::Mentor.create!(user: mentor, school_cohort: school_cohort, status: "permanently_inactive")
 
     ect = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-    ParticipantProfile::ECT.create!(user: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn")
+    ParticipantProfile::ECT.create!(user: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "permanently_inactive")
   end
   new_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
   logger.info(" Before: #{existing_mentor_count} mentors, after: #{new_mentor_count}")

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -67,8 +67,8 @@ FactoryBot.define do
       pupil_premium_uplift
     end
 
-    trait :withdrawn do
-      status { :withdrawn }
+    trait :permanently_inactive do
+      status { :permanently_inactive }
     end
   end
 end

--- a/spec/forms/participant_mentor_form_spec.rb
+++ b/spec/forms/participant_mentor_form_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe ParticipantMentorForm, type: :model do
 
     subject { described_class.new(school_id: school.id, cohort_id: school_cohort.cohort_id) }
 
-    it "does not include withdrawn mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort, status: "withdrawn").user
+    it "does not include permanently_inactive mentors" do
+      permanently_inactive = create(:participant_profile, :mentor, :permanently_inactive, school_cohort: school_cohort).user
 
-      expect(subject.available_mentors).not_to include(withdrawn_mentor)
+      expect(subject.available_mentors).not_to include(permanently_inactive)
     end
 
     it "includes active mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort).user
+      permanently_inactive_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort).user
 
-      expect(subject.available_mentors).to include(withdrawn_mentor)
+      expect(subject.available_mentors).to include(permanently_inactive_mentor)
     end
   end
 end

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -38,16 +38,16 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
   end
 
   describe "mentor_options" do
-    it "does not include withdrawn mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort, status: "withdrawn").user
+    it "does not include permanently_inactive mentors" do
+      permanently_inactive_mentor = create(:participant_profile, :mentor, :permanently_inactive, school_cohort: school_cohort).user
 
-      expect(subject.mentor_options).not_to include(withdrawn_mentor)
+      expect(subject.mentor_options).not_to include(permanently_inactive_mentor)
     end
 
     it "includes active mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort).user
+      permanently_inactive_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort).user
 
-      expect(subject.mentor_options).to include(withdrawn_mentor)
+      expect(subject.mentor_options).to include(permanently_inactive_mentor)
     end
   end
 
@@ -71,9 +71,9 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         expect(subject).to be_email_already_taken
       end
 
-      context "when the ECT is withdrawn" do
+      context "when the ECT is permanently_inactive" do
         let!(:ect_profile) do
-          create(:participant_profile, :withdrawn, :ect, user: create(:user, email: "ray.clemence@example.com"))
+          create(:participant_profile, :permanently_inactive, :ect, user: create(:user, email: "ray.clemence@example.com"))
         end
 
         it "returns false" do
@@ -91,9 +91,9 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         expect(subject).to be_email_already_taken
       end
 
-      context "when the mentor is withdrawn" do
+      context "when the mentor is permanently_inactive" do
         let!(:mentor_profile) do
-          create(:participant_profile, :withdrawn, :mentor, user: create(:user, email: "ray.clemence@example.com"))
+          create(:participant_profile, :permanently_inactive, :mentor, user: create(:user, email: "ray.clemence@example.com"))
         end
 
         it "returns false" do

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe LeadProvider, type: :model do
         expect(lead_provider.ecf_participant_profiles).to include participant_profile
       end
 
-      it "should include withdrawn participants" do
-        participant_profile = create(:participant_profile, :ect, status: "withdrawn", school_cohort: school_cohort)
+      it "should include permanently_inactive participants" do
+        participant_profile = create(:participant_profile, :ect, :permanently_inactive, school_cohort: school_cohort)
         expect(lead_provider.ecf_participant_profiles).to include participant_profile
       end
 
@@ -76,8 +76,8 @@ RSpec.describe LeadProvider, type: :model do
         expect(lead_provider.active_ecf_participant_profiles).to include participant_profile
       end
 
-      it "should not include withdrawn participants" do
-        participant_profile = create(:participant_profile, :ect, school_cohort: school_cohort, status: "withdrawn")
+      it "should not include permanently_inactive participants" do
+        participant_profile = create(:participant_profile, :ect, :permanently_inactive, school_cohort: school_cohort)
         expect(lead_provider.active_ecf_participant_profiles).not_to include participant_profile
       end
 

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ParticipantProfile, type: :model do
   it {
     is_expected.to define_enum_for(:status).with_values(
       active: "active",
-      withdrawn: "withdrawn",
+      permanently_inactive: "permanently_inactive",
     ).backed_by_column_of_type(:text)
   }
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -471,9 +471,9 @@ RSpec.describe School, type: :model do
       expect(school.participants_for(cohort)).to include(ect_profile.user, mentor_profile.user)
     end
 
-    it "does not include withdrawn participants" do
-      ect = create(:early_career_teacher_profile, status: "withdrawn", school_cohort: school_cohort).user
-      mentor = create(:mentor_profile, status: "withdrawn", school_cohort: school_cohort).user
+    it "does not include permanently_inactive participants" do
+      ect = create(:early_career_teacher_profile, :permanently_inactive, school_cohort: school_cohort).user
+      mentor = create(:mentor_profile, :permanently_inactive, school_cohort: school_cohort).user
 
       expect(school.participants_for(cohort)).not_to include(ect, mentor)
     end
@@ -502,8 +502,8 @@ RSpec.describe School, type: :model do
       expect(school.early_career_teacher_profiles_for(cohort)).to include ect_profile
     end
 
-    it "does not include withdrawn ECTs" do
-      ect_profile = create(:early_career_teacher_profile, status: "withdrawn", school_cohort: school_cohort)
+    it "does not include permanently_inactive ECTs" do
+      ect_profile = create(:early_career_teacher_profile, :permanently_inactive, school_cohort: school_cohort)
 
       expect(school.early_career_teacher_profiles_for(cohort)).not_to include ect_profile
     end
@@ -536,8 +536,8 @@ RSpec.describe School, type: :model do
       expect(school.mentor_profiles_for(cohort)).to include mentor_profile
     end
 
-    it "does not include withdrawn mentors" do
-      mentor_profile = create(:mentor_profile, status: "withdrawn", school_cohort: school_cohort)
+    it "does not include permanently_inactive mentors" do
+      mentor_profile = create(:mentor_profile, :permanently_inactive, school_cohort: school_cohort)
 
       expect(school.mentor_profiles_for(cohort)).not_to include mentor_profile
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe User, type: :model do
       end
 
       it "returns nil when there is no active profile" do
-        user = create(:participant_profile, :ect, status: "withdrawn").user
+        user = create(:participant_profile, :ect, :permanently_inactive).user
         expect(user.early_career_teacher_profile).to be_nil
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe User, type: :model do
       end
 
       it "returns nil when there is no active profile" do
-        user = create(:participant_profile, :mentor, status: :withdrawn).user
+        user = create(:participant_profile, :mentor, status: :permanently_inactive).user
 
         expect(user.mentor_profile).to be_nil
       end
@@ -144,8 +144,8 @@ RSpec.describe User, type: :model do
       expect(user.early_career_teacher?).to be false
     end
 
-    it "is false when the ect profile is withdrawn" do
-      user = create(:participant_profile, :ect, status: "withdrawn").user
+    it "is false when the ect profile is permanently_inactive" do
+      user = create(:participant_profile, :ect, :permanently_inactive).user
       expect(user.early_career_teacher?).to be false
     end
   end
@@ -163,8 +163,8 @@ RSpec.describe User, type: :model do
       expect(user.mentor?).to be false
     end
 
-    it "is false when the mentor profile is withdrawn" do
-      user = create(:mentor_profile, status: "withdrawn").user
+    it "is false when the mentor profile is permanently_inactive" do
+      user = create(:mentor_profile, :permanently_inactive).user
       expect(user.mentor?).to be false
     end
   end

--- a/spec/policies/participant_policy_spec.rb
+++ b/spec/policies/participant_policy_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe ParticipantPolicy, type: :policy do
 
           it { is_expected.to permit_action(:show) }
 
-          context "when the participant is withdrawn" do
-            let(:profile) { create(:participant_profile, profile_type, status: :withdrawn) }
+          context "when the participant is permanently_inactive" do
+            let(:profile) { create(:participant_profile, profile_type, status: :permanently_inactive) }
 
             it { is_expected.to forbid_action(:show) }
           end

--- a/spec/requests/admin/participants_spec.rb
+++ b/spec/requests/admin/participants_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin::Participants", type: :request do
   let!(:mentor_profile) { create :participant_profile, :mentor, school_cohort: school_cohort }
   let!(:ect_profile) { create :participant_profile, :ect, school_cohort: school_cohort, mentor_profile: mentor_profile }
   let!(:npq_profile) { create(:participant_profile, :npq, school: school) }
-  let!(:withdrawn_ect_profile) { create(:participant_profile, :ect, status: "withdrawn", school_cohort: school_cohort) }
+  let!(:permanently_inactive_ect_profile) { create(:participant_profile, :ect, :permanently_inactive, school_cohort: school_cohort) }
 
   before do
     sign_in admin_user
@@ -28,7 +28,7 @@ RSpec.describe "Admin::Participants", type: :request do
       expect(assigns(:participant_profiles)).to include ect_profile
       expect(assigns(:participant_profiles)).to include mentor_profile
       expect(assigns(:participant_profiles)).to include npq_profile
-      expect(assigns(:participant_profiles)).not_to include withdrawn_ect_profile
+      expect(assigns(:participant_profiles)).not_to include permanently_inactive_ect_profile
     end
   end
 
@@ -57,9 +57,9 @@ RSpec.describe "Admin::Participants", type: :request do
   end
 
   describe "DELETE /admin/participants/:id" do
-    it "marks the participant as withdrawn" do
+    it "marks the participant as be_permanently_inactive" do
       delete "/admin/participants/#{ect_profile.id}"
-      expect(ect_profile.reload.withdrawn?).to be true
+      expect(ect_profile.reload.permanently_inactive?).to be true
     end
 
     it "does not withdraw NPQ participants" do

--- a/spec/requests/admin/schools/participants_spec.rb
+++ b/spec/requests/admin/schools/participants_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
   let!(:mentor_profile) { create :participant_profile, :mentor, school_cohort: school_cohort }
   let!(:npq_profile) { create(:participant_profile, :npq, school: school) }
   let!(:unrelated_profile) { create :participant_profile }
-  let!(:withdrawn_profile) { create :participant_profile, :withdrawn, :mentor, school_cohort: school_cohort }
+  let!(:permanently_inactive_mentor_profile) { create :participant_profile, :permanently_inactive, :mentor, school_cohort: school_cohort }
 
   before do
     sign_in admin_user
@@ -32,7 +32,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
       expect(assigns(:participant_profiles)).to include ect_profile
       expect(assigns(:participant_profiles)).not_to include npq_profile
       expect(assigns(:participant_profiles)).not_to include unrelated_profile
-      expect(assigns(:participant_profiles)).not_to include withdrawn_profile
+      expect(assigns(:participant_profiles)).not_to include permanently_inactive_mentor_profile
     end
   end
 end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
     before :each do
       mentor_profile = create(:mentor_profile, school: partnership.school, cohort: partnership.cohort)
       create_list :early_career_teacher_profile, 2, mentor_profile: mentor_profile, school_cohort: school_cohort
-      ect_teacher_profile_with_one_active_and_one_withdrawn_profile = ParticipantProfile::ECT.first.teacher_profile
+      ect_teacher_profile_with_one_active_and_one_permanently_inactive_profile = ParticipantProfile::ECT.first.teacher_profile
       create(:participant_profile,
-             :withdrawn,
+             :permanently_inactive,
              :ect,
-             teacher_profile: ect_teacher_profile_with_one_active_and_one_withdrawn_profile,
+             teacher_profile: ect_teacher_profile_with_one_active_and_one_permanently_inactive_profile,
              school_cohort: school_cohort)
     end
-    let!(:withdrawn_ect_profile) { create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort) }
+    let!(:permanently_inactive_ect_profile) { create(:participant_profile, :permanently_inactive, :ect, school_cohort: school_cohort) }
 
     context "when authorized" do
       before do
@@ -61,7 +61,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           get "/api/v1/participants"
           mentors = 0
           ects = 0
-          withdrawn = 0
+          permanently_inactive = 0
 
           parsed_response["data"].each do |user|
             user_type = user["attributes"]["participant_type"]
@@ -70,14 +70,14 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
               mentors += 1
             elsif user_type == "ect"
               ects += 1
-            elsif user_type.nil? && status == "withdrawn"
-              withdrawn += 1
+            elsif user_type.nil? && status == "permanently_inactive"
+              permanently_inactive += 1
             end
           end
 
           expect(mentors).to eql(1)
           expect(ects).to eql(2)
-          expect(withdrawn).to eql(1)
+          expect(permanently_inactive).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -143,14 +143,14 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(ect_row["participant_type"]).to eql "ect"
           expect(ect_row["cohort"]).to eql partnership.cohort.start_year.to_s
 
-          withdrawn_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile.user.id }
-          expect(withdrawn_row).not_to be_nil
-          expect(withdrawn_row["email"]).to be_empty
-          expect(withdrawn_row["full_name"]).to be_empty
-          expect(withdrawn_row["mentor_id"]).to be_empty
-          expect(withdrawn_row["school_urn"]).to be_empty
-          expect(withdrawn_row["participant_type"]).to be_empty
-          expect(withdrawn_row["cohort"]).to be_empty
+          permanently_inactive_row = parsed_response.find { |row| row["id"] == permanently_inactive_ect_profile.user.id }
+          expect(permanently_inactive_row).not_to be_nil
+          expect(permanently_inactive_row["email"]).to be_empty
+          expect(permanently_inactive_row["full_name"]).to be_empty
+          expect(permanently_inactive_row["mentor_id"]).to be_empty
+          expect(permanently_inactive_row["school_urn"]).to be_empty
+          expect(permanently_inactive_row["participant_type"]).to be_empty
+          expect(permanently_inactive_row["cohort"]).to be_empty
         end
 
         it "ignores pagination parameters" do

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Schools::Participants", type: :request do
   let!(:mentor_user) { create(:participant_profile, :mentor, school_cohort: school_cohort).user }
   let!(:mentor_user_2) { create(:participant_profile, :mentor, school_cohort: school_cohort).user }
   let!(:ect_user) { create(:participant_profile, :ect, mentor_profile: mentor_user.mentor_profile, school_cohort: school_cohort).user }
-  let!(:withdrawn_ect) { create(:participant_profile, :ect, status: "withdrawn", school_cohort: school_cohort).user }
+  let!(:permanently_inactive_ect) { create(:participant_profile, :ect, :permanently_inactive, school_cohort: school_cohort).user }
   let!(:unrelated_mentor) { create(:participant_profile, :mentor, school_cohort: another_cohort).user }
   let!(:unrelated_ect) { create(:participant_profile, :ect, school_cohort: another_cohort).user }
 
@@ -44,10 +44,10 @@ RSpec.describe "Schools::Participants", type: :request do
       expect(response.body).not_to include(CGI.escapeHTML(unrelated_ect.full_name))
     end
 
-    it "does not list withdrawn participants" do
+    it "does not list permanently_inactive participants" do
       get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants"
 
-      expect(response.body).not_to include(CGI.escapeHTML(withdrawn_ect.full_name))
+      expect(response.body).not_to include(CGI.escapeHTML(permanently_inactive_ect.full_name))
     end
 
     context "when there are no mentors" do

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe ParticipantSerializer do
       expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
     end
 
-    context "when the participant is withdrawn" do
-      let(:mentor) { create(:participant_profile, :mentor, status: "withdrawn").user }
-      let(:ect) { create(:participant_profile, :ect, mentor_profile: mentor.mentor_profile, status: "withdrawn").user }
+    context "when the participant is permanently_inactive" do
+      let(:mentor) { create(:participant_profile, :mentor, :permanently_inactive).user }
+      let(:ect) { create(:participant_profile, :ect, :permanently_inactive, mentor_profile: mentor.mentor_profile).user }
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\"}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"permanently_inactive\"}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\"}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"permanently_inactive\"}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end

--- a/spec/services/admin/change_induction_choice_service_spec.rb
+++ b/spec/services/admin/change_induction_choice_service_spec.rb
@@ -141,12 +141,12 @@ RSpec.describe Admin::ChangeInductionService do
         let(:school) { create(:school_cohort, induction_programme_choice: "core_induction_programme", cohort: cohort).school }
         it "withdraws all participants when changing to NoECTs" do
           service.change_induction_provision(:no_early_career_teachers)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_permanently_inactive
         end
 
         it "withdraws all participants when changing to DIY" do
           service.change_induction_provision(:design_our_own)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_permanently_inactive
         end
 
         it "does not change participants when changing to FIP" do
@@ -160,12 +160,12 @@ RSpec.describe Admin::ChangeInductionService do
         let(:school) { create(:school_cohort, induction_programme_choice: "full_induction_programme", cohort: cohort).school }
         it "withdraws all participants when changing to NoECTs" do
           service.change_induction_provision(:no_early_career_teachers)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_permanently_inactive
         end
 
         it "withdraws all participants when changing to DIY" do
           service.change_induction_provision(:design_our_own)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_permanently_inactive
         end
 
         it "does not change participants when changing to CIP" do

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -513,10 +513,10 @@ RSpec.describe InviteSchools do
       expect_send_participants_email(induction_coordinator)
     end
 
-    it "sends emails to tutors who have withdrawn all of their participants" do
+    it "sends emails to tutors who have all of their participants permanently inactive" do
       induction_coordinator = create(:user, :induction_coordinator)
       school_cohort = create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme")
-      create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort)
+      create(:participant_profile, :permanently_inactive, :ect, school_cohort: school_cohort)
 
       InviteSchools.new.send_induction_coordinator_add_participants_email
       expect_send_participants_email(induction_coordinator)

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -672,7 +672,7 @@
             "example": "active",
             "enum": [
               "active",
-              "withdrawn"
+              "permanently_inactive"
             ]
           }
         }
@@ -776,7 +776,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,permanently_inactive\n"
       },
       "MultipleEcfParticipantsResponse": {
         "description": "A list of ECF participants",
@@ -826,7 +826,7 @@
                   "school_urn": null,
                   "participant_type": "ect",
                   "cohort": null,
-                  "status": "withdrawn"
+                  "status": "permanently_inactive"
                 }
               }
             ]

--- a/swagger/v1/component_schemas/EcfParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/EcfParticipantAttributes.yml
@@ -42,4 +42,4 @@ properties:
     example: active
     enum:
       - active
-      - withdrawn
+      - permanently_inactive

--- a/swagger/v1/component_schemas/MultipleEcfParticipantsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleEcfParticipantsCsvResponse.yml
@@ -12,4 +12,4 @@ example: |
   id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status
   db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active
   bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active
-  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,withdrawn
+  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,null,null,null,null,ect,null,permanently_inactive

--- a/swagger/v1/component_schemas/MultipleEcfParticipantsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleEcfParticipantsResponse.yml
@@ -36,4 +36,4 @@ properties:
           school_urn: null
           participant_type: ect
           cohort: null
-          status: withdrawn
+          status: permanently_inactive


### PR DESCRIPTION
### Context

In preparation for the new "withdrawn" API request, this changes the existing "withdrawn" status to "permanently_inactive"

### Changes proposed in this pull request

Status change and rake task for data migration

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
