### PR TITLE
CPDRP-799 feature flags and emails for beta

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -15,6 +15,8 @@ class SchoolMailer < ApplicationMailer
   COORDINATOR_REMINDER_TO_CHOOSE_MATERIALS_EMAIL_TEMPLATE = "43baf25c-6a46-437b-9f30-77c57d68a59e"
   ADD_PARTICIPANTS_EMAIL_TEMPLATE = "721787d0-74bc-42a0-a064-ee0c1cb58edb"
   YEAR2020_INVITE_EMAIL_TEMPLATE = "d4b53e26-4630-43a5-b89e-3c668061a41c"
+  PARTICIPANT_VALIDATION_CIP_AND_FIP_ECT_TEMPLATE = "b73fe1d1-94ac-4e77-ab37-71738c2474dd"
+  PARTICIPANT_VALIDATION_FIP_MENTOR_TEMPLATE = "06ad385b-9a76-4f5c-941a-c5d8cf5f72c7"
 
   def nomination_email(recipient:, school_name:, nomination_url:, expiry_date:)
     template_mail(
@@ -230,6 +232,32 @@ class SchoolMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         start_url: start_url,
+      },
+    )
+  end
+
+  def participant_validation_ect_email(recipient:, school_name:, start_url:)
+    template_mail(
+      PARTICIPANT_VALIDATION_CIP_AND_FIP_ECT_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def participant_validation_fip_mentor_email(recipient:, school_name:, start_url:)
+    template_mail(
+      PARTICIPANT_VALIDATION_FIP_MENTOR_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
       },
     )
   end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -236,7 +236,7 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def participant_validation_ect_email(recipient:, school_name:, start_url:)
+  def participant_validation_ect_email(recipient:, school_name:, start_url:, user_research_url:)
     template_mail(
       PARTICIPANT_VALIDATION_CIP_AND_FIP_ECT_TEMPLATE,
       to: recipient,
@@ -245,6 +245,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         school_name: school_name,
         participant_start: start_url,
+        ur_sign_up_url: user_research_url,
       },
     )
   end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -250,7 +250,7 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def participant_validation_fip_mentor_email(recipient:, school_name:, start_url:)
+  def participant_validation_fip_mentor_email(recipient:, school_name:, start_url:, user_research_url:)
     template_mail(
       PARTICIPANT_VALIDATION_FIP_MENTOR_TEMPLATE,
       to: recipient,
@@ -259,6 +259,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         school_name: school_name,
         participant_start: start_url,
+        ur_sign_up_url: user_research_url,
       },
     )
   end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -235,6 +235,8 @@ class InviteSchools
     user_research_url = participant_validation_research_url
 
     School.where(urn: array_of_urns).find_each do |school|
+      next unless school.school_cohorts.find_by(cohort: Cohort.current)&.full_induction_programme?
+
       FeatureFlag.activate(:participant_validation, for: school)
 
       school.active_ecf_participant_profiles.each do |profile|
@@ -250,6 +252,7 @@ class InviteSchools
             recipient: profile.user.email,
             school_name: school.name,
             start_url: start_url,
+            user_research_url: user_research_url,
           ).deliver_later
         end
       rescue StandardError

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -243,13 +243,13 @@ class InviteSchools
             recipient: profile.user.email,
             school_name: school.name,
             start_url: start_url,
-            user_research_url: user_research_url
+            user_research_url: user_research_url,
           ).deliver_later
         elsif profile.mentor?
           SchoolMailer.participant_validation_fip_mentor_email(
             recipient: profile.user.email,
             school_name: school.name,
-            start_url: start_url
+            start_url: start_url,
           ).deliver_later
         end
       rescue StandardError

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -233,6 +233,7 @@ class InviteSchools
   def feature_flag_and_send_participant_validation_beta_emails(array_of_urns:)
     start_url = participant_validation_start_url
     user_research_url = participant_validation_research_url
+    user_research_mentor_url = participant_validation_mentor_research_url
 
     School.where(urn: array_of_urns).find_each do |school|
       next unless school.school_cohorts.find_by(cohort: Cohort.current)&.full_induction_programme?
@@ -252,7 +253,7 @@ class InviteSchools
             recipient: profile.user.email,
             school_name: school.name,
             start_url: start_url,
-            user_research_url: user_research_url,
+            user_research_url: user_research_mentor_url,
           ).deliver_later
         end
       rescue StandardError
@@ -312,6 +313,15 @@ private
     Rails.application.routes.url_helpers.page_url(
       page: "user-research",
       host: Rails.application.config.domain,
+      **UTMService.email(:participant_validation_research, :participant_validation_research),
+    )
+  end
+
+  def participant_validation_mentor_research_url
+    Rails.application.routes.url_helpers.page_url(
+      page: "user-research",
+      host: Rails.application.config.domain,
+      mentor: true,
       **UTMService.email(:participant_validation_research, :participant_validation_research),
     )
   end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -16,6 +16,8 @@ class UTMService
     choose_materials: "choose-materials",
     add_participants: "add-participants",
     year2020_nqt_invite: "year2020-nqt-invite",
+    participant_validation_beta: "participant-validation-beta",
+    participant_validation_research: "participant-validation-research",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -30,6 +32,8 @@ class UTMService
     choose_materials: "choose-materials",
     add_participants: "add-participants",
     year2020_nqt_invite: "year2020-nqt-invite",
+    participant_validation_beta: "participant-validation-beta",
+    participant_validation_research: "participant-validation-research",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -94,4 +94,42 @@ RSpec.describe SchoolMailer, type: :mailer do
       expect(partnership_notification_email.to).to eq([recipient])
     end
   end
+
+  describe "#participant_validation_ect_email" do
+    let(:recipient) { Faker::Internet.email }
+    let(:school_name) { Faker::Company.name }
+    let(:start_url) { "https://www.example.com/participants/start-registration" }
+
+    let(:participant_validation_ect_email) do
+      SchoolMailer.participant_validation_ect_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: start_url
+      )
+    end
+
+    it "renders the right headers" do
+      expect(participant_validation_ect_email.from).to match_array ["mail@example.com"]
+      expect(participant_validation_ect_email.to).to match_array [recipient]
+    end
+  end
+
+  describe "#participant_validation_fip_mentor_email" do
+    let(:recipient) { Faker::Internet.email }
+    let(:school_name) { Faker::Company.name }
+    let(:start_url) { "https://www.example.com/participants/start-registration" }
+
+    let(:participant_validation_fip_mentor_email) do
+      SchoolMailer.participant_validation_fip_mentor_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: start_url
+      )
+    end
+
+    it "renders the right headers" do
+      expect(participant_validation_fip_mentor_email.from).to match_array ["mail@example.com"]
+      expect(participant_validation_fip_mentor_email.to).to match_array [recipient]
+    end
+  end
 end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -99,12 +99,14 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:recipient) { Faker::Internet.email }
     let(:school_name) { Faker::Company.name }
     let(:start_url) { "https://www.example.com/participants/start-registration" }
+    let(:research_url) { "https://www.example.com/pages/user-research" }
 
     let(:participant_validation_ect_email) do
       SchoolMailer.participant_validation_ect_email(
         recipient: recipient,
         school_name: school_name,
         start_url: start_url,
+        user_research_url: research_url,
       )
     end
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe SchoolMailer, type: :mailer do
       SchoolMailer.participant_validation_ect_email(
         recipient: recipient,
         school_name: school_name,
-        start_url: start_url
+        start_url: start_url,
       )
     end
 
@@ -123,7 +123,7 @@ RSpec.describe SchoolMailer, type: :mailer do
       SchoolMailer.participant_validation_fip_mentor_email(
         recipient: recipient,
         school_name: school_name,
-        start_url: start_url
+        start_url: start_url,
       )
     end
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -120,12 +120,14 @@ RSpec.describe SchoolMailer, type: :mailer do
     let(:recipient) { Faker::Internet.email }
     let(:school_name) { Faker::Company.name }
     let(:start_url) { "https://www.example.com/participants/start-registration" }
+    let(:research_url) { "https://www.example.com/pages/user-research" }
 
     let(:participant_validation_fip_mentor_email) do
       SchoolMailer.participant_validation_fip_mentor_email(
         recipient: recipient,
         school_name: school_name,
         start_url: start_url,
+        user_research_url: research_url,
       )
     end
 

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -615,56 +615,73 @@ RSpec.describe InviteSchools do
   end
 
   describe "#feature_flag_and_send_participant_validation_beta_emails" do
-    let(:schools) { create_list(:school, 2) }
-    let!(:mentor_1) { create(:participant_profile, :mentor, school: schools.first) }
-    let!(:mentor_2) { create(:participant_profile, :mentor, school: schools.second) }
-    let!(:ect_1) { create(:participant_profile, :ect, school: schools.first) }
-    let!(:ect_2) { create(:participant_profile, :ect, school: schools.second) }
-    let(:urns) { schools.map(&:urn) }
+    let(:fip_school_1) { create(:school_cohort, induction_programme_choice: "full_induction_programme").school }
+    let(:fip_school_2) { create(:school_cohort, induction_programme_choice: "full_induction_programme").school }
+    let(:cip_school) { create(:school_cohort).school }
+    let!(:mentor_1) { create(:participant_profile, :mentor, school: fip_school_1) }
+    let!(:mentor_2) { create(:participant_profile, :mentor, school: fip_school_2) }
+    let!(:mentor_3) { create(:participant_profile, :mentor, school: cip_school) }
+    let!(:ect_1) { create(:participant_profile, :ect, school: fip_school_1) }
+    let!(:ect_2) { create(:participant_profile, :ect, school: fip_school_2) }
+    let!(:ect_3) { create(:participant_profile, :ect, school: cip_school) }
+    let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=participant-validation-beta&utm_medium=email&utm_source=participant-validation-beta" }
+    let(:research_url) { "http://www.example.com/pages/user-research?utm_campaign=participant-validation-research&utm_medium=email&utm_source=participant-validation-research" }
+    let(:mentor_research_url) { "http://www.example.com/pages/user-research?mentor=true&utm_campaign=participant-validation-research&utm_medium=email&utm_source=participant-validation-research" }
+    let(:urns) { [fip_school_1, fip_school_2, cip_school].map(&:urn) }
 
-    it "activates the participant validation feature flag for the schools" do
+    it "activates the participant validation feature flag for FIP schools", with_feature_flag: { participant_validation: "inactive" } do
       InviteSchools.new.feature_flag_and_send_participant_validation_beta_emails(array_of_urns: urns)
 
-      schools.each do |school|
+      [fip_school_1, fip_school_2].each do |school|
         expect(FeatureFlag.active?(:participant_validation, for: school)).to be true
       end
     end
 
-    it "emails the early career teachers belonging to the schools" do
-      start_url = "http://www.example.com/participants/start-registration?utm_campaign=participant-validation-beta&utm_medium=email&utm_source=participant-validation-beta"
-      research_url = "http://www.example.com/pages/user-research?utm_campaign=participant-validation-research&utm_medium=email&utm_source=participant-validation-research"
+    it "emails the early career teachers belonging to the FIP schools" do
       InviteSchools.new.feature_flag_and_send_participant_validation_beta_emails(array_of_urns: urns)
       expect(SchoolMailer).to delay_email_delivery_of(:participant_validation_ect_email)
                                   .with(hash_including(
                                           recipient: ect_1.user.email,
-                                          school_name: schools.first.name,
+                                          school_name: fip_school_1.name,
                                           start_url: start_url,
                                           user_research_url: research_url,
                                         ))
       expect(SchoolMailer).to delay_email_delivery_of(:participant_validation_ect_email)
                                   .with(hash_including(
                                           recipient: ect_2.user.email,
-                                          school_name: schools.second.name,
+                                          school_name: fip_school_2.name,
                                           start_url: start_url,
                                           user_research_url: research_url,
                                         ))
     end
 
-    it "emails the mentors belonging to the schools" do
-      start_url = "http://www.example.com/participants/start-registration?utm_campaign=participant-validation-beta&utm_medium=email&utm_source=participant-validation-beta"
+    it "emails the mentors belonging to the FIP schools" do
       InviteSchools.new.feature_flag_and_send_participant_validation_beta_emails(array_of_urns: urns)
       expect(SchoolMailer).to delay_email_delivery_of(:participant_validation_fip_mentor_email)
                                   .with(hash_including(
                                           recipient: mentor_1.user.email,
-                                          school_name: schools.first.name,
+                                          school_name: fip_school_1.name,
                                           start_url: start_url,
+                                          user_research_url: mentor_research_url,
                                         ))
       expect(SchoolMailer).to delay_email_delivery_of(:participant_validation_fip_mentor_email)
                                   .with(hash_including(
                                           recipient: mentor_2.user.email,
-                                          school_name: schools.second.name,
+                                          school_name: fip_school_2.name,
                                           start_url: start_url,
+                                          user_research_url: mentor_research_url,
                                         ))
+    end
+
+    it "does not activate the feature flag for schools not doing FIP" do
+      InviteSchools.new.feature_flag_and_send_participant_validation_beta_emails(array_of_urns: [cip_school.urn])
+      expect(FeatureFlag.active?(:participant_validation, for: cip_school)).to be false
+    end
+
+    it "does not email participants at schools not doing FIP" do
+      InviteSchools.new.feature_flag_and_send_participant_validation_beta_emails(array_of_urns: [cip_school.urn])
+      expect(SchoolMailer).not_to delay_email_delivery_of(:participant_validation_ect_email)
+      expect(SchoolMailer).not_to delay_email_delivery_of(:participant_validation_fip_mentor_email)
     end
   end
 


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-799)
Enable feature flags and email participants for private beta of participant validation

### Changes proposed in this pull request
Mailers for ECTs and Mentors (FIP)
Add method to `InviteSchools` to activate `:participant_validation` feature flag for each school in a list of URNs provided by the caller and send the appropriate email to the school's recipients.
Add UTM campaigns for `participant-validation-beta` and `participant-validation-research`

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
