### PR TITLE
CPDTP-382 Updated usage copy for ECF and NPQ declarations.

### DIFF
--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -103,7 +103,7 @@ Invalid declarations will be excluded from the payment calculation. They will be
 </p>
 
 <p class="govuk-body-m">
-In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations.The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
+In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations. The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
 </p>
 
 <p class="govuk-body-m">
@@ -178,5 +178,3 @@ Where declarations have been submitted in error, there will be a support process
 
 <h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
 <p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
-
-

--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -2,8 +2,10 @@
 
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="#continuing-the-ecf-registration-process" class="govuk-link">Continuing the ECF registration process</a></li>
-  <li><a href="#declaring-that-an-ecf-participant-has-started-their-induction" class="govuk-link">Declaring that an ECF
-    participant has started their induction</a></li>
+  <li><a href="#make-a-declaration" class="govuk-link">Making a declaration for an ECF participant</a></li>
+  <li><a href="#declaring-that-an-ecf-participant-has-started-their-course" class="govuk-link">Declaring that an ECF participant has started their course</a></li>
+  <li><a href="#declaring-that-an-ecf-participant-has-retained-their-course" class="govuk-link">Declaring that an ECF participant has reached a retained milestone</a></li>
+  <li><a href="#declaring-that-an-ecf-participant-has-completed-their-course" class="govuk-link">Declaring that an ECF participant has completed their course</a></li>
 </ul>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
@@ -46,15 +48,83 @@
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#get-api-v1-participants" class="govuk-link">retrieve multiple participants</a> endpoint.</p>
 
-<h2 id="declaring-that-an-ecf-participant-has-started-their-induction" class="govuk-heading-l">Declaring that an ECF participant has started their induction</h2>
+<h2 id="make-a-declaration" class="govuk-heading-l">Making a declaration for an ECF participant</h2>
+
+<h3 class="govuk-heading-m">
+  What is a declaration?
+</h3>
+<p class="govuk-body-m">
+  A declaration is a message in JSON format sent to the participant-declarations API.
+</p>
+
+<p class="govuk-body-m">
+  This will allow providers’ own software systems to integrate with our DfE service - these declarations will not need to be made manually by provider data teams.
+</p>
+
+<p class="govuk-body-m">
+A participant on the ECF programme is defined as either an Early Careers Teacher (ECT) or a mentor.
+</p>
+
+<p class="govuk-body-m">
+For a participant on a course, a declaration is the formal communication from a lead provider to the department that a training event for a specific participant has happened and can be evidenced on the providers’ platform.
+</p>
+
+<p class="govuk-body-m">
+  For example, participant Joe Bloggs who started their induction/course on a lead provider platform requires the lead provider to submit a <code>started</code> declaration for Joe Bloggs to the department.
+</p>
+
+
+<h3 class="govuk-heading-m">
+Declaration submission?
+</h3>
+
+<p class="govuk-body-m">
+Declarations provide contractual MI reporting requirements for lead providers.
+</p>
+
+<p class="govuk-body-m">
+They are the sole means for triggering a milestone payment to a lead provider for a participant.
+</p>
+
+<p class="govuk-body-m">
+They are submitted in line with the contractual milestones set-out by the DfE.
+</p>
+
+<p class="govuk-body-m">
+The participant-declarations API will accept the declarations required to trigger payments.
+</p>
+
+<p class="govuk-body-m">
+The validations process means declarations make sense in relation to the relevant milestone dates and the declarations previously submitted for the participant (available to test link maybe)
+</p>
+
+<p class="govuk-body-m">
+Invalid declarations will be excluded from the payment calculation. They will be rejected with a specific reason with most rejections being asynchronous initially.
+</p>
+
+<p class="govuk-body-m">
+In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations.The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
+</p>
+
+<p class="govuk-body-m">
+Only declarations that occured between the appropriate milestone points (inline with contractual milestones) but were retrospectively identified are eligible for backdating.
+</p>
+
+<p class="govuk-body-m">
+Where declarations have been submitted in error, there will be a support process in place (TBD).
+</p>
+
+<h2 id="declaring-that-an-ecf-participant-has-started-their-course" class="govuk-heading-l">Declaring that an ECF participant has started their course</h2>
+
 <p class="govuk-body-m">This scenario begins after it has been confirmed that an ECF participant is ready to begin their induction training.</p>
+
 
 <h3 class="govuk-heading-m">1. Provider confirms an ECF participant has started</h3>
 <p class="govuk-body-m">Confirm an ECF participant has started their induction training before Milestone 1.</p>
 
-<p class="govuk-body-m"><pre><code>POST /api/v1/participant_declarations</code></pre></p>
+<p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
 
-<p class="govuk-body-m">With a <a href="/lead-providers/guidance/reference#participantdeclaration-object" class="govuk-link">request body containing an ECF participant declaration</a>.</p>
+<p class="govuk-body-m">With a <a href="/lead-providers/guidance/reference#ecfparticipantstarteddeclaration-object" class="govuk-link">request body containing an ECF participant declaration</a>.</p>
 
 <p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">participant declaration recorded</a>.</p>
 
@@ -62,3 +132,51 @@
 
 <h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
 <p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
+
+<h2 id="declaring-that-an-ecf-participant-has-retained-their-course" class="govuk-heading-l">Declaring that an ECF participant has been retained</h2>
+
+<p class="govuk-body-m">This scenario begins after it has been confirmed that an ECF participant has completed enough of their course to meet a milestone.</p>
+<h3 class="govuk-heading-m">1. Provider confirms an ECF participant has been retained</h3>
+<p class="govuk-body-m">
+1. Confirm an ECF participant has been retained by the appropriate number of months for this retained event on their ECF course.
+</p>
+
+<p class="govuk-body-m">
+  An explicit retained-x declaration is required to trigger output payments - this happens when a participant has reached a particular milestone in line with contractual reporting requirements.
+</p>
+
+<p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
+
+<p class="govuk-body-m">With a <a href="/lead-providers/guidance/reference#ecfparticipantretaineddeclaration-object" class="govuk-link">request body containing an ECF participant retained declaration</a>.</p>
+
+<p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">participant declaration recorded</a>.</p>
+
+<p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">confirm ECF participant declarations</a> endpoint.</p>
+
+<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
+<p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
+
+
+<h2 id="declaring-that-an-ecf-participant-has-completed-their-course" class="govuk-heading-l">Declaring that an ECF participant has completed their course</h2>
+<p class="govuk-body-m">This scenario begins after it has been confirmed that an ECF participant has completed their course.</p>
+<h3 class="govuk-heading-m">1. Provider confirms an ECF participant has completed their course.</h3>
+
+<p class="govuk-body-m">
+  Confirm an ECF participant has completed their ECF course.
+</p>
+<p class="govuk-body-m">
+  An explicit completed declaration is required to trigger output payments - this happens when a participant has reached their final milestone and completed their ECF course.
+</p>
+
+<p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
+
+<p class="govuk-body-m">With a <a href="/lead-providers/guidance/reference#ecfparticipantstarteddeclaration-object" class="govuk-link">request body containing an ECF participant completed declaration</a>.</p>
+
+<p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">participant declaration recorded</a>.</p>
+
+<p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">confirm ECF participant declarations</a> endpoint.</p>
+
+<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
+<p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
+
+

--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -2,7 +2,6 @@
 
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="#continuing-the-ecf-registration-process" class="govuk-link">Continuing the ECF registration process</a></li>
-  <li><a href="#make-a-declaration" class="govuk-link">Making a declaration for an ECF participant</a></li>
   <li><a href="#declaring-that-an-ecf-participant-has-started-their-course" class="govuk-link">Declaring that an ECF participant has started their course</a></li>
   <li><a href="#declaring-that-an-ecf-participant-has-retained-their-course" class="govuk-link">Declaring that an ECF participant has reached a retained milestone</a></li>
   <li><a href="#declaring-that-an-ecf-participant-has-completed-their-course" class="govuk-link">Declaring that an ECF participant has completed their course</a></li>
@@ -28,7 +27,7 @@
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#get-api-v1-participants" class="govuk-link">retrieve multiple ECF participants</a> endpoint.</p>
 
 <h3 class="govuk-heading-m">2. ECF Participant enters registration details on register for early career framework service</h3>
-<p class="govuk-body-m">Participant is invited to continue their registration by validating their TRN and contact details.</p>
+<p class="govuk-body-m">A participant is invited to continue their registration by validating their TRN and contact details.</p>
 
 <p class="govuk-body-m">When the participant has completed this step the ECF participant record will show;</p>
 
@@ -48,76 +47,9 @@
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#get-api-v1-participants" class="govuk-link">retrieve multiple participants</a> endpoint.</p>
 
-<h2 id="make-a-declaration" class="govuk-heading-l">Making a declaration for an ECF participant</h2>
-
-<h3 class="govuk-heading-m">
-  What is a declaration?
-</h3>
-<p class="govuk-body-m">
-  A declaration is a message in JSON format sent to the participant-declarations API.
-</p>
-
-<p class="govuk-body-m">
-  This will allow providers’ own software systems to integrate with our DfE service - these declarations will not need to be made manually by provider data teams.
-</p>
-
-<p class="govuk-body-m">
-A participant on the ECF programme is defined as either an Early Careers Teacher (ECT) or a mentor.
-</p>
-
-<p class="govuk-body-m">
-For a participant on a course, a declaration is the formal communication from a lead provider to the department that a training event for a specific participant has happened and can be evidenced on the providers’ platform.
-</p>
-
-<p class="govuk-body-m">
-  For example, participant Joe Bloggs who started their induction/course on a lead provider platform requires the lead provider to submit a <code>started</code> declaration for Joe Bloggs to the department.
-</p>
-
-
-<h3 class="govuk-heading-m">
-Declaration submission?
-</h3>
-
-<p class="govuk-body-m">
-Declarations provide contractual MI reporting requirements for lead providers.
-</p>
-
-<p class="govuk-body-m">
-They are the sole means for triggering a milestone payment to a lead provider for a participant.
-</p>
-
-<p class="govuk-body-m">
-They are submitted in line with the contractual milestones set-out by the DfE.
-</p>
-
-<p class="govuk-body-m">
-The participant-declarations API will accept the declarations required to trigger payments.
-</p>
-
-<p class="govuk-body-m">
-The validations process means declarations make sense in relation to the relevant milestone dates and the declarations previously submitted for the participant (available to test link maybe)
-</p>
-
-<p class="govuk-body-m">
-Invalid declarations will be excluded from the payment calculation. They will be rejected with a specific reason with most rejections being asynchronous initially.
-</p>
-
-<p class="govuk-body-m">
-In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations. The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
-</p>
-
-<p class="govuk-body-m">
-Only declarations that occured between the appropriate milestone points (inline with contractual milestones) but were retrospectively identified are eligible for backdating.
-</p>
-
-<p class="govuk-body-m">
-Where declarations have been submitted in error, there will be a support process in place (TBD).
-</p>
-
 <h2 id="declaring-that-an-ecf-participant-has-started-their-course" class="govuk-heading-l">Declaring that an ECF participant has started their course</h2>
 
 <p class="govuk-body-m">This scenario begins after it has been confirmed that an ECF participant is ready to begin their induction training.</p>
-
 
 <h3 class="govuk-heading-m">1. Provider confirms an ECF participant has started</h3>
 <p class="govuk-body-m">Confirm an ECF participant has started their induction training before Milestone 1.</p>
@@ -130,8 +62,8 @@ Where declarations have been submitted in error, there will be a support process
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">confirm ECF participant declarations</a> endpoint.</p>
 
-<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
-<p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
+<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration ID</h3>
+<p class="govuk-body-m">Store the returned ECF participant declaration ID for future management tasks.</p>
 
 <h2 id="declaring-that-an-ecf-participant-has-retained-their-course" class="govuk-heading-l">Declaring that an ECF participant has been retained</h2>
 
@@ -142,7 +74,7 @@ Where declarations have been submitted in error, there will be a support process
 </p>
 
 <p class="govuk-body-m">
-  An explicit retained-x declaration is required to trigger output payments - this happens when a participant has reached a particular milestone in line with contractual reporting requirements.
+  An explicit <code>retained-x</code> declaration is required to trigger output payments. You should declare this when a participant has reached a particular milestone in line with contractual reporting requirements.
 </p>
 
 <p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
@@ -153,8 +85,8 @@ Where declarations have been submitted in error, there will be a support process
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">confirm ECF participant declarations</a> endpoint.</p>
 
-<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
-<p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
+<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration ID</h3>
+<p class="govuk-body-m">Store the returned ECF participant declaration ID for future management tasks.</p>
 
 
 <h2 id="declaring-that-an-ecf-participant-has-completed-their-course" class="govuk-heading-l">Declaring that an ECF participant has completed their course</h2>
@@ -165,7 +97,7 @@ Where declarations have been submitted in error, there will be a support process
   Confirm an ECF participant has completed their ECF course.
 </p>
 <p class="govuk-body-m">
-  An explicit completed declaration is required to trigger output payments - this happens when a participant has reached their final milestone and completed their ECF course.
+  An explicit <code>completed</code> declaration is required to trigger output payments. You should declare this when a participant has reached their final milestone and completed their ECF course.
 </p>
 
 <p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
@@ -176,5 +108,5 @@ Where declarations have been submitted in error, there will be a support process
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">confirm ECF participant declarations</a> endpoint.</p>
 
-<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration id</h3>
-<p class="govuk-body-m">Store the returned ECF participant declaration id for future management tasks.</p>
+<h3 class="govuk-heading-m">2. Provider records the ECF participant declaration ID</h3>
+<p class="govuk-body-m">Store the returned ECF participant declaration ID for future management tasks.</p>

--- a/app/views/lead_providers/guidance/index.html.erb
+++ b/app/views/lead_providers/guidance/index.html.erb
@@ -8,7 +8,7 @@
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="./reference#get-api-v1-participants" class="govuk-link">Retrieving a list of ECF participants</a></li>
   <li><a href="./reference#get-api-v1-participants-csv" class="govuk-link">Retrieving a CSV file of ECF participants</a></li>
-  <li><a href="./reference#post-api-v1-participant-declarations" class="govuk-link">Declaring an ECF participant has started</a></li>
+  <li><a href="./reference#post-api-v1-participant-declarations" class="govuk-link">Declaring the progress of an ECF or NPQ participant against milestone</a></li>
   <li><a href="./reference#get-api-v1-npq-applications" class="govuk-link">Retrieving a list of NPQ applications</a></li>
   <li><a href="./reference#get-api-v1-npq-applications-csv" class="govuk-link">Retrieving a CSV file of NPQ applications</a></li>
 </ul>

--- a/app/views/lead_providers/guidance/index.html.erb
+++ b/app/views/lead_providers/guidance/index.html.erb
@@ -1,7 +1,7 @@
 <p class="govuk-body-m">This is API documentation for the Department for Education (DfE)’s new Manage teacher continuing professional development service.</p>
 
 <h2 class="govuk-heading-l">What this API is for</h2>
-<p class="govuk-body-m">Once a participant has been added by a school induction tutor, the participant record will become available over the API.</p>
+<p class="govuk-body-m">Once a participant has been added by a school induction tutor, the participant record will become available via the API.</p>
 
 <p class="govuk-body-m">Providers can then use the API for:</p>
 
@@ -18,7 +18,7 @@
 <h3 class="govuk-heading-m">Authentication and authorisation</h3>
 <p class="govuk-body-m">Requests to the API must be accompanied by an authentication token.</p>
 
-<p class="govuk-body-m">Each token is associated with a single provider. It will grant access to participants for courses offered by that provider. You can get a token by writing to <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-link">continuing-professional-development@digital.education.gov.uk</a>.</p>
+<p class="govuk-body-m">Each token is associated with a single provider. It will grant access to participants for courses offered by that provider. You can get a token by writing to <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-link">continuing-professional-development@digital.education.gov.uk</a></p>
 
 <p class="govuk-body-m">For instructions on how to authenticate see the <%= govuk_link_to "API reference", "./reference#authentication" %>.</p>
 
@@ -27,7 +27,7 @@
 
 <p class="govuk-body-m">When the API changes in a way that is backwards-incompatible, a new version number of the API will be published.</p>
 
-<p class="govuk-body-m">When a new version, for example <code>/api/v2</code>, is published, both the previous <strong>v1</strong> and the current <strong>v2</strong> versions will be supported.</p>
+<p class="govuk-body-m">When a new version, for example <code>/api/v2</code>, is published, both the previous <strong>v1</strong> and the current <strong>v2</strong> versions will be available.</p>
 
 <p class="govuk-body-m">We, however, only support one version back, so if the <strong>v3</strong> is published, the <strong>v1</strong> will be discontinued.</p>
 

--- a/app/views/lead_providers/guidance/npq_usage.html.erb
+++ b/app/views/lead_providers/guidance/npq_usage.html.erb
@@ -7,7 +7,6 @@
   <li><a href="#reject-npq-application" class="govuk-link">Rejecting an NPQ application</a></li>
   <li><a href="#handling-deferrals" class="govuk-link">Handling deferrals</a></li>
   <li><a href="#handling-changes-circumstances" class="govuk-link">Handling applications with changes in circumstances</a></li>
-  <li><a href="#make-a-declaration" class="govuk-link">Making a declaration for an NPQ participant</a></li>
   <li><a href="#declaring-that-an-npq-participant-has-started-their-course" class="govuk-link">Declaring that an NPQ participant has started their course</a></li>
   <li><a href="#declaring-that-an-npq-participant-has-been-retained" class="govuk-link">Declaring that an NPQ participant has reached a retained milestone</a></li>
   <li><a href="#declaring-that-an-npq-participant-has-completed-their-course" class="govuk-link">Declaring that an NPQ participant has completed their course</a></li>
@@ -65,7 +64,7 @@
 </p>
 
 <p class="govuk-body-m">
-  Accepting or rejecting a participant is separate and distinct from a “started declaration”, which will be collected as part of the tracking and payment process. More <a href="#declaring-that-an-npq-participant-has-started-their-induction" class="govuk-link">information about declarations</a> can be found further down this page. We will only be able to make payments for participants who are in an “application accepted” state.
+  Accepting or rejecting a participant is separate and distinct from a “started declaration”, which will be collected as part of the tracking and payment process. More <a href="#declaring-that-an-npq-participant-has-started-their-course" class="govuk-link">information about declarations</a> can be found further down this page. We will only be able to make payments for participants who are in an “application accepted” state.
 </p>
 
 <p class="govuk-body-m">
@@ -164,73 +163,6 @@
   If there is a mistake in the application for example where a participant registers for a one NPQ programme but wishes to change to another programme after registration. The provider should reject that participant and ask them to re-register on the NPQ registration service and enter the correct details. Once the new application is available you can then accept.
 </p>
 
-<h2 id="make-a-declaration" class="govuk-heading-l">Making a declaration for an NPQ participant</h2>
-
-<h3 class="govuk-heading-m">
-  What is a declaration?
-</h3>
-
-<p class="govuk-body-m">
-  A declaration is a message in JSON format sent to the participant-declarations API.
-</p>
-
-<p class="govuk-body-m">
-  This will allow providers’ own software systems to integrate with our DfE service - these declarations will not need to be made manually by provider data teams.
-</p>
-
-<p class="govuk-body-m">
-  A participant refers to a late career teacher undertaking a given NPQ course on a given provider learning platform.
-</p>
-
-<p class="govuk-body-m">
-  For a participant on a course, a declaration is the formal communication from a lead provider to the department that a training event for a specific participant has happened and can be evidenced on the providers’ platform.
-</p>
-
-<p class="govuk-body-m">
-  For example, participant Joe Bloggs who started their induction/course on a lead provider platform requires the lead provider to submit a <code>started</code> declaration for Joe Bloggs to the department.
-</p>
-
-<h3 class="govuk-heading-m">
-  Declaration submission?
-</h3>
-
-<p class="govuk-body-m">
-  Declarations provide contractual MI reporting requirements for lead providers.
-</p>
-
-<p class="govuk-body-m">
-  They are the sole means for triggering a milestone payment to a lead provider for a participant.
-</p>
-
-<p class="govuk-body-m">
-  They are submitted in line with the contractual milestones set-out by the DfE.
-</p>
-
-<p class="govuk-body-m">
-  The participant-declarations API will accept the declarations required to trigger payments.
-</p>
-
-<p class="govuk-body-m">
-  The validations process means declarations make sense in relation to the relevant milestone dates and the declarations previously submitted for the participant (available to test link maybe)
-</p>
-
-<p class="govuk-body-m">
-  Invalid declarations will be excluded from the payment calculation. They will be rejected with a specific reason with most rejections being asynchronous initially.
-</p>
-
-<p class="govuk-body-m">
-  In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations. The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
-</p>
-
-<p class="govuk-body-m">
-  Only declarations that occured between the appropriate milestone points (inline with contractual milestones) but were retrospectively identified are eligible for backdating.
-</p>
-
-<p class="govuk-body-m">
-  Where declarations have been submitted in error, there will be a support process in place (TBD).
-</p>
-
-
 <h2 id="declaring-that-an-npq-participant-has-started-their-course" class="govuk-heading-l">
   Declaring that an NPQ participant has started their induction
 </h2>
@@ -260,8 +192,8 @@
   endpoint.
 </p>
 
-<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration id</h3>
-<p class="govuk-body-m">Store the returned NPQ participant declaration id for future management tasks.</p>
+<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration ID</h3>
+<p class="govuk-body-m">Store the returned NPQ participant declaration ID for future management tasks.</p>
 
 <h2 id="declaring-that-an-npq-participant-has-been-retained" class="govuk-heading-l">
   Declaring that an NPQ participant has reached a retained milestone
@@ -276,7 +208,7 @@
 </p>
 
 <p class="govuk-body-m">
-An explicit retained-x declaration is required to trigger output payments once a participant has reached a particular milestone - these are in line with contractual reporting requirements.
+  An explicit <code>retained-x</code> declaration is required to trigger output payments once a participant has reached a particular milestone. You should declare this when a participant has reached a particular milestone in line with contractual reporting requirements.
 </p>
 
 <p class="govuk-body-m">
@@ -299,14 +231,14 @@ An explicit retained-x declaration is required to trigger output payments once a
   endpoint.
 </p>
 
-<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration id</h3>
-<p class="govuk-body-m">Store the returned NPQ participant declaration id for future management tasks.</p>
+<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration ID</h3>
+<p class="govuk-body-m">Store the returned NPQ participant declaration ID for future management tasks.</p>
 
 <h2 id="declaring-that-an-npq-participant-has-completed-their-course" class="govuk-heading-l">
   Declaring that an NPQ participant has completed their course
 </h2>
 <p class="govuk-body-m">
-  This scenario begins after it has been confirmed that an NPQ participant has completed their course
+  This scenario begins after it has been confirmed that an NPQ participant has completed their course.
 </p>
 
 <h3 class="govuk-heading-m">1. Provider confirms an NPQ participant has completed their course.</h3>
@@ -315,7 +247,7 @@ An explicit retained-x declaration is required to trigger output payments once a
 </p>
 
 <p class="govuk-body-m">
-  An explicit completed declaration is required to trigger output payments - this happens once a participant has reached their final milestone and finished their NPQ course.
+  An explicit <code>completed</code> declaration is required to trigger output payments. You should declare this once a participant has reached their final milestone and finished their NPQ course.
 </p>
 
 <p class="govuk-body-m">
@@ -338,5 +270,5 @@ An explicit retained-x declaration is required to trigger output payments once a
   endpoint.
 </p>
 
-<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration id</h3>
-<p class="govuk-body-m">Store the returned NPQ participant declaration id for future management tasks.</p>
+<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration ID</h3>
+<p class="govuk-body-m">Store the returned NPQ participant declaration ID for future management tasks.</p>

--- a/app/views/lead_providers/guidance/npq_usage.html.erb
+++ b/app/views/lead_providers/guidance/npq_usage.html.erb
@@ -219,7 +219,7 @@
 </p>
 
 <p class="govuk-body-m">
-  In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations.The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
+  In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations. The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
 </p>
 
 <p class="govuk-body-m">

--- a/app/views/lead_providers/guidance/npq_usage.html.erb
+++ b/app/views/lead_providers/guidance/npq_usage.html.erb
@@ -3,15 +3,14 @@
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="#continuing-the-npq-registration-process" class="govuk-link">Continuing the NPQ registration process</a></li>
   <li><a href="#about-accept-reject-npq-application" class="govuk-link">About accepting or rejecting an NPQ application</a></li>
-  <li><a href="#accept-npq-application" class="govuk-link">Accept an NPQ application</a></li>
-  <li><a href="#reject-npq-application" class="govuk-link">Reject an NPQ application</a></li>
+  <li><a href="#accept-npq-application" class="govuk-link">Accepting an NPQ application</a></li>
+  <li><a href="#reject-npq-application" class="govuk-link">Rejecting an NPQ application</a></li>
   <li><a href="#handling-deferrals" class="govuk-link">Handling deferrals</a></li>
   <li><a href="#handling-changes-circumstances" class="govuk-link">Handling applications with changes in circumstances</a></li>
-  <li>
-    <a href="#declaring-that-an-npq-participant-has-started-their-induction" class="govuk-link">
-      Declaring that an NPQ participant has started their induction
-    </a>
-  </li>
+  <li><a href="#make-a-declaration" class="govuk-link">Making a declaration for an NPQ participant</a></li>
+  <li><a href="#declaring-that-an-npq-participant-has-started-their-course" class="govuk-link">Declaring that an NPQ participant has started their course</a></li>
+  <li><a href="#declaring-that-an-npq-participant-has-been-retained" class="govuk-link">Declaring that an NPQ participant has reached a retained milestone</a></li>
+  <li><a href="#declaring-that-an-npq-participant-has-completed-their-course" class="govuk-link">Declaring that an NPQ participant has completed their course</a></li>
 </ul>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6">
@@ -165,34 +164,95 @@
   If there is a mistake in the application for example where a participant registers for a one NPQ programme but wishes to change to another programme after registration. The provider should reject that participant and ask them to re-register on the NPQ registration service and enter the correct details. Once the new application is available you can then accept.
 </p>
 
-<h2 id="declaring-that-an-npq-participant-has-started-their-induction" class="govuk-heading-l">
+<h2 id="make-a-declaration" class="govuk-heading-l">Making a declaration for an NPQ participant</h2>
+
+<h3 class="govuk-heading-m">
+  What is a declaration?
+</h3>
+
+<p class="govuk-body-m">
+  A declaration is a message in JSON format sent to the participant-declarations API.
+</p>
+
+<p class="govuk-body-m">
+  This will allow providers’ own software systems to integrate with our DfE service - these declarations will not need to be made manually by provider data teams.
+</p>
+
+<p class="govuk-body-m">
+  A participant refers to a late career teacher undertaking a given NPQ course on a given provider learning platform.
+</p>
+
+<p class="govuk-body-m">
+  For a participant on a course, a declaration is the formal communication from a lead provider to the department that a training event for a specific participant has happened and can be evidenced on the providers’ platform.
+</p>
+
+<p class="govuk-body-m">
+  For example, participant Joe Bloggs who started their induction/course on a lead provider platform requires the lead provider to submit a <code>started</code> declaration for Joe Bloggs to the department.
+</p>
+
+<h3 class="govuk-heading-m">
+  Declaration submission?
+</h3>
+
+<p class="govuk-body-m">
+  Declarations provide contractual MI reporting requirements for lead providers.
+</p>
+
+<p class="govuk-body-m">
+  They are the sole means for triggering a milestone payment to a lead provider for a participant.
+</p>
+
+<p class="govuk-body-m">
+  They are submitted in line with the contractual milestones set-out by the DfE.
+</p>
+
+<p class="govuk-body-m">
+  The participant-declarations API will accept the declarations required to trigger payments.
+</p>
+
+<p class="govuk-body-m">
+  The validations process means declarations make sense in relation to the relevant milestone dates and the declarations previously submitted for the participant (available to test link maybe)
+</p>
+
+<p class="govuk-body-m">
+  Invalid declarations will be excluded from the payment calculation. They will be rejected with a specific reason with most rejections being asynchronous initially.
+</p>
+
+<p class="govuk-body-m">
+  In exceptional circumstances where declarations cannot be evidenced on time and thus cannot be submitted on time; the API will accept backdated declarations.The late declaration will need to be backdated appropriately to fall within the relevant milestone period.
+</p>
+
+<p class="govuk-body-m">
+  Only declarations that occured between the appropriate milestone points (inline with contractual milestones) but were retrospectively identified are eligible for backdating.
+</p>
+
+<p class="govuk-body-m">
+  Where declarations have been submitted in error, there will be a support process in place (TBD).
+</p>
+
+
+<h2 id="declaring-that-an-npq-participant-has-started-their-course" class="govuk-heading-l">
   Declaring that an NPQ participant has started their induction
 </h2>
-
 <p class="govuk-body-m">
   This scenario begins after it has been confirmed that an NPQ participant is ready to begin their induction training.
 </p>
 
 <h3 class="govuk-heading-m">1. Provider confirms an NPQ participant has started</h3>
-
 <p class="govuk-body-m">Confirm an NPQ participant has started their induction training before Milestone 1.</p>
-
 <p class="govuk-body-m">
   <code>POST /api/v1/participant-declarations</code>
 </p>
-
 <p class="govuk-body-m">With a request body containing an
   <a href="/lead-providers/guidance/reference#npqparticipantstarteddeclaration-object" class="govuk-link">
     NPQ participant declaration
   </a>.
 </p>
-
 <p class="govuk-body-m">This returns
   <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">
     participant declaration recorded
   </a>.
 </p>
-
 <p class="govuk-body-m">See
   <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">
     confirm NPQ participant declarations
@@ -201,5 +261,82 @@
 </p>
 
 <h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration id</h3>
+<p class="govuk-body-m">Store the returned NPQ participant declaration id for future management tasks.</p>
 
+<h2 id="declaring-that-an-npq-participant-has-been-retained" class="govuk-heading-l">
+  Declaring that an NPQ participant has reached a retained milestone
+</h2>
+<p class="govuk-body-m">
+  This scenario begins after it has been confirmed that an NPQ participant has completed enough of their course to reach a milestone
+</p>
+
+<h3 class="govuk-heading-m">1. Provider confirms an NPQ participant has been retained</h3>
+<p class="govuk-body-m">
+  Confirm an NPQ participant has been retained by the appropriate number of months for this retained event on their NPQ course.
+</p>
+
+<p class="govuk-body-m">
+An explicit retained-x declaration is required to trigger output payments once a participant has reached a particular milestone - these are in line with contractual reporting requirements.
+</p>
+
+<p class="govuk-body-m">
+  <code>POST /api/v1/participant-declarations</code>
+</p>
+<p class="govuk-body-m">With a request body containing an
+  <a href="/lead-providers/guidance/reference#npqparticipantretaineddeclaration-object" class="govuk-link">
+    NPQ participant declaration
+  </a>.
+</p>
+<p class="govuk-body-m">This returns
+  <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">
+    participant declaration recorded
+  </a>.
+</p>
+<p class="govuk-body-m">See
+  <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">
+    confirm NPQ participant declarations
+  </a>
+  endpoint.
+</p>
+
+<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration id</h3>
+<p class="govuk-body-m">Store the returned NPQ participant declaration id for future management tasks.</p>
+
+<h2 id="declaring-that-an-npq-participant-has-completed-their-course" class="govuk-heading-l">
+  Declaring that an NPQ participant has completed their course
+</h2>
+<p class="govuk-body-m">
+  This scenario begins after it has been confirmed that an NPQ participant has completed their course
+</p>
+
+<h3 class="govuk-heading-m">1. Provider confirms an NPQ participant has completed their course.</h3>
+<p class="govuk-body-m">
+  Confirm an NPQ participant has completed their NPQ course.
+</p>
+
+<p class="govuk-body-m">
+  An explicit completed declaration is required to trigger output payments - this happens once a participant has reached their final milestone and finished their NPQ course.
+</p>
+
+<p class="govuk-body-m">
+  <code>POST /api/v1/participant-declarations</code>
+</p>
+<p class="govuk-body-m">With a request body containing an
+  <a href="/lead-providers/guidance/reference#npqparticipantstarteddeclaration-object" class="govuk-link">
+    NPQ participant declaration
+  </a>.
+</p>
+<p class="govuk-body-m">This returns
+  <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">
+    participant declaration recorded
+  </a>.
+</p>
+<p class="govuk-body-m">See
+  <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">
+    confirm NPQ participant declarations
+  </a>
+  endpoint.
+</p>
+
+<h3 class="govuk-heading-m">2. Provider records the NPQ participant declaration id</h3>
 <p class="govuk-body-m">Store the returned NPQ participant declaration id for future management tasks.</p>

--- a/spec/requests/lead_providers/ecf_usage_spec.rb
+++ b/spec/requests/lead_providers/ecf_usage_spec.rb
@@ -16,10 +16,22 @@ RSpec.describe "ECF usage guide", type: :request do
       expect(response.body).to include("Continuing the ECF registration process")
     end
 
-    it "should explain how to declare that an ECF participant has started their induction" do
+    it "should explain how to declare that an ECF participant has started their course" do
       get lead_providers_guidance_ecf_usage_path
 
-      expect(response.body).to include("Declaring that an ECF participant has started their induction")
+      expect(response.body).to include("Declaring that an ECF participant has started their course")
+    end
+
+    it "should explain how to declare that an ECF participant has been retained" do
+      get lead_providers_guidance_ecf_usage_path
+
+      expect(response.body).to include("Declaring that an ECF participant has been retained")
+    end
+
+    it "should explain how to declare that an ECF participant has completed their course" do
+      get lead_providers_guidance_ecf_usage_path
+
+      expect(response.body).to include("Declaring that an ECF participant has completed their course")
     end
   end
 end

--- a/spec/requests/lead_providers/npq_usage_spec.rb
+++ b/spec/requests/lead_providers/npq_usage_spec.rb
@@ -16,16 +16,24 @@ RSpec.describe "NPQ usage guide", type: :request do
       expect(response.body).to include("Continuing the NPQ registration process")
     end
 
-    it "should explain how to perform the NPQ participant declaration process" do
-      expect(response.body).to include("Declaring that an NPQ participant has started their induction")
-    end
-
     it "should explain how to accept an NPQ application" do
       expect(response.body).to include("Accept an NPQ application")
     end
 
     it "should explain how to reject an NPQ application" do
       expect(response.body).to include("Reject an NPQ application")
+    end
+
+    it "should explain how to perform the NPQ participant started declaration process" do
+      expect(response.body).to include("Declaring that an NPQ participant has started their course")
+    end
+
+    it "should explain how to perform the NPQ participant retained declaration process" do
+      expect(response.body).to include("Declaring that an NPQ participant has reached a retained milestone")
+    end
+
+    it "should explain how to perform the NPQ participant completed declaration process" do
+      expect(response.body).to include("Declaring that an NPQ participant has completed their course")
     end
   end
 end


### PR DESCRIPTION
### Context

Declarations have been updated for NPQ and ECF declarations. This brings the application up-to-date with the copy which has been updated to describe the usage of the API endpoint that corresponds to each declaration type.

### Changes proposed in this pull request

Update documentation and tests

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
