### PR TITLE
T&P: Split audit from logic in participant declarations

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -6,7 +6,7 @@ module Api
       include ApiTokenAuthenticatable
 
       def create
-        params = HashWithIndifferentAccess.new({ raw_event: request.raw_post, lead_provider_from_token: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
+        params = HashWithIndifferentAccess.new({ lead_provider_from_token: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
         validate_params!(params)
         render json: RecordParticipantDeclaration.call(convert_params_for_declaration(params))
       end

--- a/app/middlewares/lead_provider_request_auditor.rb
+++ b/app/middlewares/lead_provider_request_auditor.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class LeadProviderRequestAuditor
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    store_request_details(env)
+    @app.call(env)
+  end
+
+private
+
+  def store_request_details(env)
+    path = env["PATH_INFO"]
+    if audited_paths.any? { |pattern| pattern.match?(path) }
+      request = Rack::Request.new(env)
+      body = request.body.read.squish
+      ApiRequestAudit.create!(path: path, body: body)
+    end
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
+
+  def audited_paths
+    [/\/api\/v1\/participant-declarations/]
+  end
+end

--- a/app/models/api_request_audit.rb
+++ b/app/models/api_request_audit.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApiRequestAudit < ApplicationRecord
+end

--- a/app/models/participant_declaration_attempt.rb
+++ b/app/models/participant_declaration_attempt.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ParticipantDeclarationAttempt < ApplicationRecord
+  belongs_to :cpd_lead_provider
+  belongs_to :user
+end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -54,8 +54,10 @@ module RecordDeclarations
         raise ActionController::ParameterMissing, errors.map(&:message)
       end
 
-      declaration = create_record!
+      create_declaration_attempt!
       validate_provider!
+      declaration = create_record!
+
       { id: declaration.id }
     end
 
@@ -69,6 +71,17 @@ module RecordDeclarations
 
     def user
       @user ||= User.find_by(id: user_id)
+    end
+
+    def create_declaration_attempt!
+      ParticipantDeclarationAttempt.create!(
+        course_identifier: course_identifier,
+        declaration_date: declaration_date,
+        declaration_type: declaration_type,
+        cpd_lead_provider: lead_provider_from_token,
+        user: user,
+        evidence_held: evidence_held,
+      )
     end
 
     def create_record!

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -4,7 +4,7 @@ module RecordDeclarations
   class Base
     include ActiveModel::Model
 
-    attr_accessor :course_identifier, :user_id, :raw_event, :lead_provider_from_token, :declaration_date, :declaration_type, :evidence_held
+    attr_accessor :course_identifier, :user_id, :lead_provider_from_token, :declaration_date, :declaration_type, :evidence_held
 
     validates :course_identifier, inclusion: { in: :valid_courses_for_user, message: I18n.t(:invalid_identifier) }, allow_blank: true
     validates :declaration_type, inclusion: { in: :valid_declaration_types, message: I18n.t(:invalid_declaration_type) }
@@ -80,7 +80,6 @@ module RecordDeclarations
           cpd_lead_provider: lead_provider_from_token,
           user: user,
           evidence_held: evidence_held,
-          raw_event: raw_event,
         ).tap do |participant_declaration|
           ProfileDeclaration.create!(
             participant_declaration: participant_declaration,

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,7 @@ module EarlyCareerFramework
 
     config.active_job.queue_adapter = :delayed_job
 
+    config.middleware.use LeadProviderRequestAuditor
     config.middleware.use Rack::Deflater
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,6 @@ module EarlyCareerFramework
 
     config.active_job.queue_adapter = :delayed_job
 
-    config.middleware.use LeadProviderRequestAuditor
     config.middleware.use Rack::Deflater
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
+  config.middleware.use LeadProviderRequestAuditor
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
+  config.middleware.use LeadProviderRequestAuditor
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.middleware.use LeadProviderRequestAuditor
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
+  config.middleware.use LeadProviderRequestAuditor
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,6 +5,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.middleware.use LeadProviderRequestAuditor
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/db/migrate/20210810124951_create_api_request_audits.rb
+++ b/db/migrate/20210810124951_create_api_request_audits.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateApiRequestAudits < ActiveRecord::Migration[6.1]
+  def change
+    create_table :api_request_audits do |t|
+      t.string :path, null: true
+      t.jsonb :body, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210810124952_remove_raw_event_from_declarations.rb
+++ b/db/migrate/20210810124952_remove_raw_event_from_declarations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRawEventFromDeclarations < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :participant_declarations, :raw_event, type: :jsonb }
+  end
+end

--- a/db/migrate/20210811065838_create_participant_declaration_attempts.rb
+++ b/db/migrate/20210811065838_create_participant_declaration_attempts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateParticipantDeclarationAttempts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :participant_declaration_attempts do |t|
+      t.string :declaration_type
+      t.datetime :declaration_date
+      t.uuid :user_id
+      t.string :course_identifier
+      t.string :evidence_held
+      t.uuid :cpd_lead_provider_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_04_161507) do
+ActiveRecord::Schema.define(version: 2021_08_10_124952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -61,6 +61,13 @@ ActiveRecord::Schema.define(version: 2021_08_04_161507) do
     t.datetime "discarded_at"
     t.index ["discarded_at"], name: "index_admin_profiles_on_discarded_at"
     t.index ["user_id"], name: "index_admin_profiles_on_user_id"
+  end
+
+  create_table "api_request_audits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "path"
+    t.jsonb "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "api_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -420,7 +427,6 @@ ActiveRecord::Schema.define(version: 2021_08_04_161507) do
   create_table "participant_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "declaration_type"
     t.datetime "declaration_date"
-    t.jsonb "raw_event"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_10_124952) do
+ActiveRecord::Schema.define(version: 2021_08_11_065838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -422,6 +422,17 @@ ActiveRecord::Schema.define(version: 2021_08_10_124952) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["call_off_contract_id"], name: "index_participant_bands_on_call_off_contract_id"
+  end
+
+  create_table "participant_declaration_attempts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "declaration_type"
+    t.datetime "declaration_date"
+    t.uuid "user_id"
+    t.string "course_identifier"
+    t.string "evidence_held"
+    t.uuid "cpd_lead_provider_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "participant_declarations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
           caller_attributes = attributes.merge(
             user_id: attributes["participant_id"],
             lead_provider_from_token: cpd_lead_provider,
-            raw_event: params.to_json,
           ).except("participant_id")
           RecordParticipantDeclaration.call(HashWithIndifferentAccess.new(caller_attributes))
         end

--- a/spec/middlewares/lead_provider_request_auditor_spec.rb
+++ b/spec/middlewares/lead_provider_request_auditor_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe LeadProviderRequestAuditor do
+  let(:app) { proc { [200, {}, Time.zone.now.to_s] } }
+  let(:middleware) { described_class.new(app) }
+  let(:request) { Rack::MockRequest.new(middleware) }
+
+  context "when sending a request to an audited path" do
+    it "saves the request details" do
+      expect { request.post("/api/v1/participant-declarations.json") }.to change(ApiRequestAudit, :count).by(1)
+    end
+  end
+
+  context "when sending a request to non-audited path" do
+    it "changes the current date to the date from the header" do
+      expect { request.get("/") }.not_to change(ApiRequestAudit, :count)
+    end
+  end
+end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -62,12 +62,29 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         default_headers[:CONTENT_TYPE] = "application/json"
       end
 
-      it "create declaration record and return id when successful" do
-        expect {
-          post "/api/v1/participant-declarations", params: build_params(valid_params)
-        }.to change(ParticipantDeclaration, :count).by(1)
+      it "create declaration record and declaration attempt and return id when successful" do
+        expect { post "/api/v1/participant-declarations", params: build_params(valid_params) }
+            .to(change(ParticipantDeclaration, :count).by(1))
+            .and(change(ParticipantDeclarationAttempt, :count).by(1))
         expect(response.status).to eq 200
         expect(parsed_response["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)
+      end
+
+      context "when lead provider has no access to the user" do
+        before do
+          partnership.update!(lead_provider: create(:lead_provider))
+        end
+
+        it "create declaration attempt" do
+          expect { post "/api/v1/participant-declarations", params: build_params(valid_params) }
+              .to change(ParticipantDeclarationAttempt, :count).by(1)
+        end
+
+        it "does not create declaration" do
+          expect { post "/api/v1/participant-declarations", params: build_params(valid_params) }
+              .not_to change(ParticipantDeclaration, :count)
+          expect(response.status).to eq 422
+        end
       end
 
       it "returns 422 when trying to create for an invalid user id" do # Expects the user uuid. Pass the early_career_teacher_profile_id

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"retained-1\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"ecf-induction\"}",
       user_id: ect_profile.user.id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "retained-1",
@@ -38,10 +37,6 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
            delivery_partner: delivery_partner)
   end
 
-  def generate_raw_event(params)
-    params.except(:raw_event, :cpd_lead_provider).to_json
-  end
-
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
@@ -57,7 +52,6 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
 
     it "fails when course is for mentor" do
       params = ect_params.merge({ course_identifier: "ecf-mentor" })
-      params[:raw_event] = generate_raw_event(params)
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
     end
   end

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"retained-1\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"ecf-induction\"}",
       user_id: ect_profile.user.id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "retained-1",
@@ -38,10 +37,6 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
            delivery_partner: delivery_partner)
   end
 
-  def generate_raw_event(params)
-    params.except(:raw_event, :cpd_lead_provider).to_json
-  end
-
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
@@ -57,7 +52,6 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
 
     it "fails when course is for an early_career_teacher" do
       params = mentor_params.merge({ course_identifier: "ecf-induction" })
-      params[:raw_event] = generate_raw_event(params)
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
     end
   end

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"retained-1\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"npq-leading-teaching\"}",
       user_id: npq_profile.user_id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "retained-1",

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"started\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"ecf-induction\"}",
       user_id: ect_profile.user.id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "started",
@@ -37,10 +36,6 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
            delivery_partner: delivery_partner)
   end
 
-  def generate_raw_event(params)
-    params.except(:raw_event, :cpd_lead_provider).to_json
-  end
-
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
@@ -54,7 +49,6 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
 
     it "fails when course is for mentor" do
       params = ect_params.merge({ course_identifier: "ecf-mentor" })
-      params[:raw_event] = generate_raw_event(params)
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
     end
   end

--- a/spec/services/record_declarations/started/mentor_spec.rb
+++ b/spec/services/record_declarations/started/mentor_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RecordDeclarations::Started::Mentor do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"started\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"ecf-induction\"}",
       user_id: ect_profile.user.id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "started",
@@ -37,10 +36,6 @@ RSpec.describe RecordDeclarations::Started::Mentor do
            delivery_partner: delivery_partner)
   end
 
-  def generate_raw_event(params)
-    params.except(:raw_event, :cpd_lead_provider).to_json
-  end
-
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
@@ -54,7 +49,6 @@ RSpec.describe RecordDeclarations::Started::Mentor do
 
     it "fails when course is for an early_career_teacher" do
       params = mentor_params.merge({ course_identifier: "ecf-induction" })
-      params[:raw_event] = generate_raw_event(params)
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
     end
   end

--- a/spec/services/record_declarations/started/npq_spec.rb
+++ b/spec/services/record_declarations/started/npq_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe RecordDeclarations::Started::NPQ do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"started\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"npq-leading-teaching\"}",
       user_id: npq_profile.user_id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "started",

--- a/spec/services/record_participant_declaration_service_spec.rb
+++ b/spec/services/record_participant_declaration_service_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe RecordParticipantDeclaration do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:params) do
     {
-      raw_event: "{\"participant_id\":\"37b300a8-4e99-49f1-ae16-0235672b6708\",\"declaration_type\":\"started\",\"declaration_date\":\"2021-06-21T08:57:31Z\",\"course_identifier\":\"npq-leading-teaching\"}",
       user_id: npq_profile.user.id,
       declaration_date: "2021-06-21T08:46:29Z",
       declaration_type: "started",
@@ -56,10 +55,6 @@ RSpec.describe RecordParticipantDeclaration do
              delivery_partner: delivery_partner)
     end
 
-    def generate_raw_event(params)
-      params.except(:raw_event, :cpd_lead_provider).to_json
-    end
-
     context "when lead providers don't match" do
       it "raises a ParameterMissing error" do
         expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
@@ -73,7 +68,6 @@ RSpec.describe RecordParticipantDeclaration do
 
       it "fails when course is for mentor" do
         params = ect_params.merge({ course_identifier: "ecf-mentor" })
-        params[:raw_event] = generate_raw_event(params)
         expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
       end
     end
@@ -85,7 +79,6 @@ RSpec.describe RecordParticipantDeclaration do
 
       it "fails when course is for an early_career_teacher" do
         params = mentor_params.merge({ course_identifier: "ecf-induction" })
-        params[:raw_event] = generate_raw_event(params)
         expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
       end
     end


### PR DESCRIPTION
### Context

We want to know what LPs are doing with our api, especially if they don't really use it right. 

https://dfedigital.atlassian.net/browse/CPDTP-383 says that "all declarations that pass schema validations should be stored".

We were storing raw event details on the declarations. I don't think that's the right place to store them. Truth be told, I am not sure we want to store them in our app at all (maybe logit is more appropriate), but to preserve a way of storing the raw requests we are sent I added a middleware that audits our api.

### Changes proposed in this pull request
1. Move `raw_event` into its own model, store it via the api before any validation or authentication.
2. Add `ParticipantDeclarationAttempt` model - which should store things that pass schema validation but not business logic validation.

### Testing
Added unit tests for the middleware.
Added request spec to show the case when attempt is recorded but declaration is not. 

### How can I view this in a review app?
Try making a declaration against a participant that is not in your lead provider scope.
Then ssh into the app - the attempt should be saved, but the declaration should not. 
