### PR TITLE
Fix rspec test output warning

### DIFF
--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
     it "does not raise ParameterMissing error" do
       params = ect_params.merge({ declaration_date: (Time.zone.now - 100.years).rfc3339(9) })
       params[:raw_event] = generate_raw_event(params)
-      expect { described_class.call(params) }.to_not raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(params) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
### Context

Fix for the output warning in the rspec test:

```
......WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally 
any othererror would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, 
`NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. 
Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. 
This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`.
Called from 
/Users/plisovin/Development/early-careers-framework/spec/services/record_declarations/started/early_career_teacher_spec.rb:93:in
 `block (3 levels) in <top (required)>'.
```

