### PR TITLE
Fix typo in participant validation journey

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -135,7 +135,7 @@ module Participants
 
         # store validation data for manual re-check later
         # if different TRN already exists or not eligible
-        store_validation_data! unless eligibiliy_data.eligible_status?
+        store_validation_data! unless eligibility_data.eligible_status?
 
         reset_form_data
         store_form_and_redirect_to_step :complete


### PR DESCRIPTION
### Context
Typo was causing error to be raised and not storing validation data under certain circumstances

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
