### PR TITLE
CPDTP-391 Extract common setup for record declarations test

### DIFF
--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
   describe "post" do
     let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
-    let(:payload) { create(:participant_profile, :ect) }
+
     let(:valid_params) do
       {
-        participant_id: payload.user.id,
+        participant_id: ect_profile.user.id,
         declaration_type: "started",
         declaration_date: (Time.zone.now - 1.week).iso8601,
         course_identifier: "ecf-induction",
@@ -20,7 +20,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
     end
 
     let(:invalid_user_id) do
-      valid_params.merge({ participant_id: payload.id })
+      valid_params.merge({ participant_id: ect_profile.id })
     end
     let(:incorrect_course_identifier) do
       valid_params.merge({ course_identifier: "typoed-course-name" })

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -1,23 +1,15 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
 
 RSpec.describe "participant-declarations endpoint spec", type: :request do
+  include_context "lead provider profiles and courses"
+
   describe "post" do
-    let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
-    let(:lead_provider) { create(:lead_provider) }
     let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
     let(:payload) { create(:participant_profile, :ect) }
-    let(:delivery_partner) { create(:delivery_partner) }
-    let!(:school_cohort) { create(:school_cohort, school: payload.school, cohort: payload.cohort) }
-    let!(:partnership) do
-      create(:partnership,
-             school: payload.school,
-             lead_provider: lead_provider,
-             cohort: payload.cohort,
-             delivery_partner: delivery_partner)
-    end
     let(:valid_params) do
       {
         participant_id: payload.user.id,

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+
 require_relative "../../../shared/context/service_record_declaration_params.rb"
 require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
 

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -1,41 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "../../../shared/context/service_record_declaration_params.rb"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
 
 RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
-  let(:ect_profile) { create(:early_career_teacher_profile) }
-  let(:mentor_profile) { create(:mentor_profile) }
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: ect_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "retained-1",
-      course_identifier: "ecf-induction",
-      lead_provider_from_token: another_lead_provider,
-      evidence_held: "other",
-    }
-  end
-  let(:ect_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
-  end
-  let(:mentor_params) do
-    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
-  end
-  let(:induction_coordinator_params) do
-    ect_params.merge({ user_id: induction_coordinator_profile.user_id })
-  end
-  let(:delivery_partner) { create(:delivery_partner) }
-  let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-  let!(:partnership) do
-    create(:partnership,
-           school: ect_profile.school,
-           lead_provider: cpd_lead_provider.lead_provider,
-           cohort: ect_profile.cohort,
-           delivery_partner: delivery_partner)
-  end
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -1,41 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "../../../shared/context/service_record_declaration_params.rb"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
 
 RSpec.describe RecordDeclarations::Retained::Mentor do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
-  let(:ect_profile) { create(:early_career_teacher_profile) }
-  let(:mentor_profile) { create(:mentor_profile) }
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: ect_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "retained-1",
-      course_identifier: "ecf-induction",
-      lead_provider_from_token: another_lead_provider,
-      evidence_held: "other",
-    }
-  end
-  let(:ect_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
-  end
-  let(:mentor_params) do
-    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
-  end
-  let(:induction_coordinator_params) do
-    ect_params.merge({ user_id: induction_coordinator_profile.user_id })
-  end
-  let(:delivery_partner) { create(:delivery_partner) }
-  let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-  let!(:partnership) do
-    create(:partnership,
-           school: ect_profile.school,
-           lead_provider: cpd_lead_provider.lead_provider,
-           cohort: ect_profile.cohort,
-           delivery_partner: delivery_partner)
-  end
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -1,35 +1,12 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "../../../shared/context/service_record_declaration_params.rb"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
 
 RSpec.describe RecordDeclarations::Retained::NPQ do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
-  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
-  let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
-  let!(:npq_profile) do
-    create(:npq_validation_data,
-           npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
-  end
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: npq_profile.user_id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "retained-1",
-      course_identifier: "npq-leading-teaching",
-      lead_provider_from_token: another_lead_provider,
-      evidence_held: "yes",
-    }
-  end
-
-  let(:npq_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
-  end
-  let(:induction_coordinator_params) do
-    npq_params.merge({ user_id: induction_coordinator_profile.user_id })
-  end
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
 
   context "when sending event for an npq course" do
     it "creates a participant and profile declaration" do

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -2,42 +2,12 @@
 
 require "rails_helper"
 
+require_relative "../../../shared/context/service_record_declaration_params.rb"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
+
 RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: create(:lead_provider)) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown", lead_provider: create(:lead_provider)) }
-  let(:ect_profile) { create(:participant_profile, :ect) }
-  let(:mentor_profile) { create(:participant_profile, :mentor) }
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: ect_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "started",
-      course_identifier: "ecf-induction",
-      lead_provider_from_token: another_lead_provider,
-    }
-  end
-  let(:ect_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
-  end
-  let(:mentor_params) do
-    ect_params.merge({ user_id: mentor_profile.user_id, course_identifier: "ecf-mentor" })
-  end
-  let(:induction_coordinator_params) do
-    ect_params.merge({ user_id: induction_coordinator_profile.user_id })
-  end
-  let(:delivery_partner) { create(:delivery_partner) }
-  let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-  let!(:partnership) do
-    create(:partnership,
-           school: ect_profile.school,
-           lead_provider: cpd_lead_provider.lead_provider,
-           cohort: ect_profile.cohort,
-           delivery_partner: delivery_partner)
-  end
-  let(:invalid_date_params) do
-    ect_params
-  end
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do

--- a/spec/services/record_declarations/started/mentor_spec.rb
+++ b/spec/services/record_declarations/started/mentor_spec.rb
@@ -2,39 +2,12 @@
 
 require "rails_helper"
 
+require_relative "../../../shared/context/service_record_declaration_params.rb"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
+
 RSpec.describe RecordDeclarations::Started::Mentor do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: create(:lead_provider)) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown", lead_provider: create(:lead_provider)) }
-  let(:ect_profile) { create(:participant_profile, :ect) }
-  let(:mentor_profile) { create(:participant_profile, :mentor) }
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: ect_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "started",
-      course_identifier: "ecf-induction",
-      lead_provider_from_token: another_lead_provider,
-    }
-  end
-  let(:ect_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
-  end
-  let(:mentor_params) do
-    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
-  end
-  let(:induction_coordinator_params) do
-    ect_params.merge({ user_id: induction_coordinator_profile.user_id })
-  end
-  let(:delivery_partner) { create(:delivery_partner) }
-  let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-  let!(:partnership) do
-    create(:partnership,
-           school: ect_profile.school,
-           lead_provider: cpd_lead_provider.lead_provider,
-           cohort: ect_profile.cohort,
-           delivery_partner: delivery_partner)
-  end
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do

--- a/spec/services/record_declarations/started/npq_spec.rb
+++ b/spec/services/record_declarations/started/npq_spec.rb
@@ -2,33 +2,12 @@
 
 require "rails_helper"
 
-RSpec.describe RecordDeclarations::Started::NPQ do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
-  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
-  let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
-  let!(:npq_profile) do
-    create(:npq_validation_data,
-           npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
-  end
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: npq_profile.user_id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "started",
-      course_identifier: "npq-leading-teaching",
-      lead_provider_from_token: another_lead_provider,
-    }
-  end
+require_relative "../../../shared/context/service_record_declaration_params.rb"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
 
-  let(:npq_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
-  end
-  let(:induction_coordinator_params) do
-    npq_params.merge({ user_id: induction_coordinator_profile.user_id })
-  end
+RSpec.describe RecordDeclarations::Started::NPQ do
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
 
   context "when sending event for an npq course" do
     it "creates a participant and profile declaration" do

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "lead provider profiles and courses" do
+  # lead providers setup
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
+
+  # ECF setup
   let(:ect_profile) { create(:early_career_teacher_profile) }
   let(:mentor_profile) { create(:mentor_profile) }
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-
-  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
-  let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
-  let!(:npq_profile) do
-    create(:npq_validation_data,
-           npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
-  end
-
   let(:delivery_partner) { create(:delivery_partner) }
   let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
   let!(:partnership) do
@@ -23,5 +17,14 @@ RSpec.shared_context "lead provider profiles and courses" do
            lead_provider: cpd_lead_provider.lead_provider,
            cohort: ect_profile.cohort,
            delivery_partner: delivery_partner)
+  end
+
+  # NPQ setup
+  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
+  let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
+  let!(:npq_profile) do
+    create(:npq_validation_data,
+           npq_lead_provider: npq_lead_provider,
+           npq_course: npq_course)
   end
 end

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "lead provider profiles and courses" do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
+  let(:ect_profile) { create(:early_career_teacher_profile) }
+  let(:mentor_profile) { create(:mentor_profile) }
+  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
+
+  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
+  let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
+  let!(:npq_profile) do
+    create(:npq_validation_data,
+           npq_lead_provider: npq_lead_provider,
+           npq_course: npq_course)
+  end
+
+  let(:delivery_partner) { create(:delivery_partner) }
+  let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
+  let!(:partnership) do
+    create(:partnership,
+           school: ect_profile.school,
+           lead_provider: cpd_lead_provider.lead_provider,
+           cohort: ect_profile.cohort,
+           delivery_partner: delivery_partner)
+  end
+end

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "service record declaration params" do
+  let(:params) do
+    {
+      user_id: ect_profile.user.id,
+      declaration_date: "2021-06-21T08:46:29Z",
+      declaration_type: "retained-1",
+      course_identifier: "ecf-induction",
+      lead_provider_from_token: another_lead_provider,
+      evidence_held: "other",
+    }
+  end
+  let(:ect_params) do
+    params.merge({ lead_provider_from_token: cpd_lead_provider })
+  end
+  let(:mentor_params) do
+    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
+  end
+  let(:npq_params) do
+    params.merge({ lead_provider_from_token: cpd_lead_provider, user_id: npq_profile.user_id, course_identifier: "npq-leading-teaching", evidence_held: "yes" })
+  end
+  let(:induction_coordinator_params) do
+    ect_params.merge({ user_id: induction_coordinator_profile.user_id })
+  end
+end


### PR DESCRIPTION
### Context

Record declaration tests have common setup blocks in them. This is the first step to extract into shared context and use it in other areas for example in request type rspec test. 

