### PR TITLE
Quick fix part 2 - Extra test for area with rescue handling

### DIFF
--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -29,6 +29,11 @@ module ParticipantValidationSteps
     }
   end
 
+  def and_i_am_signed_in_as_an_ect_participant_with_a_trn_already_set
+    and_i_am_signed_in_as_an_ect_participant
+    @user.teacher_profile.update!(trn: "9876543")
+  end
+
   def then_i_should_see_the_do_you_know_your_trn_page
     expect(page).to have_selector("h1", text: "Do you know your teacher reference number")
     expect(page).to have_field("Yes, I know my TRN", visible: :all)
@@ -62,8 +67,6 @@ module ParticipantValidationSteps
       .with(@participant_data)
       .and_return(nil)
     click_on "Continue"
-    # expect(@user.reload.teacher_profile.trn).to be_nil
-    # expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_nil
   end
 
   def then_i_should_see_the_have_you_changed_your_name_page
@@ -139,22 +142,31 @@ module ParticipantValidationSteps
     expect(page).to have_text("Amazing Delivery Team")
   end
 
-  def then_i_should_see_the_checking_details_page_for_matched_user
+  def then_i_should_see_the_checking_details_page
     expect(page).to have_selector("h1", text: "We’re checking your details")
     expect(page).to have_text("Big Provider Ltd")
     expect(page).to have_text("Amazing Delivery Team")
+  end
+
+  def then_i_should_see_the_checking_details_page_for_matched_user
+    then_i_should_see_the_checking_details_page
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_matched_status
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
   end
 
   def then_i_should_see_the_checking_details_page_for_invalid_user
-    expect(page).to have_selector("h1", text: "We’re checking your details")
-    expect(page).to have_text("Big Provider Ltd")
-    expect(page).to have_text("Amazing Delivery Team")
+    then_i_should_see_the_checking_details_page
     expect(@user.reload.teacher_profile.trn).to be_nil
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_nil
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
+  end
+
+  def then_i_should_see_the_checking_details_page_for_existing_trn_user
+    then_i_should_see_the_checking_details_page
+    expect(@user.reload.teacher_profile.trn).to eq "9876543"
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_api_failure
   end
 
   def then_i_should_see_the_find_your_trn_page

--- a/spec/features/participants/unhappy_validation_journeys_for_ect_fip_spec.rb
+++ b/spec/features/participants/unhappy_validation_journeys_for_ect_fip_spec.rb
@@ -57,6 +57,27 @@ RSpec.feature "Unhappy ECT participant validation journeys for FIP induction", t
     and_percy_should_be_sent_a_snapshot_named "Participant Validation: Checking details - Partnered FIP"
   end
 
+  scenario "Participant already has a different TRN set" do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_an_ect_participant_with_a_trn_already_set
+    then_i_should_see_the_do_you_know_your_trn_page
+
+    when_i_select "Yes, I know my TRN"
+    and_i_click "Continue"
+    then_i_should_see_the_have_you_changed_your_name_page
+
+    when_i_select "No, I have the same name"
+    and_i_click "Continue"
+    then_i_should_see_the_tell_us_your_details_page
+
+    when_i_enter_the_participants_details
+    and_i_click "Continue"
+    then_i_should_see_the_confirm_details_page
+
+    when_i_click_continue_to_proceed_with_validation
+    then_i_should_see_the_checking_details_page_for_existing_trn_user
+  end
+
   scenario "Participant does not know their TRN" do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_ect_participant


### PR DESCRIPTION
### Context
A typo fixed in #827 highlighted an area that was missed by the existing tests, this adds an additional test to cover that area.

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
