### PR TITLE
Hopefully fix the frustrating "no mentors found" test once and for all

### DIFF
--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -9,7 +9,7 @@ class SchoolPolicy < ApplicationPolicy
     return true if admin_only
 
     if user.induction_coordinator?
-      return user.schools.map(&:id).include?(record.id)
+      return user.schools.include?(record)
     end
 
     false

--- a/app/policies/school_policy.rb
+++ b/app/policies/school_policy.rb
@@ -9,7 +9,7 @@ class SchoolPolicy < ApplicationPolicy
     return true if admin_only
 
     if user.induction_coordinator?
-      return user.schools.include?(record)
+      return user.schools.map(&:id).include?(record.id)
     end
 
     false

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -51,13 +51,12 @@ RSpec.describe "Schools::Participants", type: :request do
     end
 
     context "when there are no mentors" do
-      let(:ect_profile) { create(:participant_profile, :ect) }
+      let!(:ect_profile) { create(:participant_profile, :ect) }
       let(:other_school) { ect_profile.school }
-      let!(:other_school_cohort) { create(:school_cohort, school: other_school, cohort: cohort) }
-      let(:cohort) { ect_profile.cohort }
+      let(:other_cohort) { ect_profile.cohort }
       let(:user) { create(:user, :induction_coordinator, school_ids: [other_school.id]) }
       it "does not show the assign mentor link" do
-        get "/schools/#{other_school.slug}/cohorts/#{cohort.start_year}/participants"
+        get "/schools/#{other_school.slug}/cohorts/#{other_cohort.start_year}/participants"
 
         expect(response.body).to include "No mentors added"
         expect(response.body).not_to include "Assign mentor"

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -51,9 +51,10 @@ RSpec.describe "Schools::Participants", type: :request do
     end
 
     context "when there are no mentors" do
-      let!(:ect_profile) { create(:participant_profile, :ect) }
-      let(:other_school) { ect_profile.school }
-      let(:other_cohort) { ect_profile.cohort }
+      let(:other_school) { create(:school) }
+      let(:other_cohort) { create(:cohort) }
+      let!(:other_school_cohort) { create(:school_cohort, cohort: other_cohort, school: other_school) }
+      let!(:ect_profile) { create(:participant_profile, :ect, school_cohort: other_school_cohort) }
       let(:user) { create(:user, :induction_coordinator, school_ids: [other_school.id]) }
       it "does not show the assign mentor link" do
         get "/schools/#{other_school.slug}/cohorts/#{other_cohort.start_year}/participants"


### PR DESCRIPTION
### Context
Every couple of runs I see rspec fail in continuous integration on a particular test.

### Changes proposed in this pull request
I don't really know what was going on. I think perhaps school cohort with which the ECT profile was creating had some weirdly small chance to interfere with the other one we explicitly created in test. Perhaps when cohort start year was the same between the two, or something similar. But really, this fix is a result of running a lot of tests and trial and errors. 

### Guidance to review
Before the changes, this seemed to fail like once every 100 runs locally, although I think it was a lot more common in CI.
After changes I ran it couple thousand times and it works fine.
