### PR TITLE
CPDRP-508-DQT API returns a boolean not a string value

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -167,9 +167,9 @@ module Participants
 
     def store_eligibility_data!(dqt_data)
       participant_profile.create_ecf_participant_eligibility!(qts: dqt_data[:qts],
-                                                              active_flags: dqt_data[:active_alert] != "No",
-                                                              previous_participation: false,
-                                                              previous_induction: false)
+                                                              active_flags: dqt_data[:active_alert],
+                                                              previous_participation: nil,
+                                                              previous_induction: nil)
     end
 
     def participant_profile

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -45,7 +45,7 @@ module ParticipantValidationSteps
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
       .with(@participant_data)
-      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: "No" })
+      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
     click_on "Continue"
   end
 
@@ -57,7 +57,7 @@ module ParticipantValidationSteps
             full_name: "Sally Participant",
             date_of_birth: @participant_data[:date_of_birth],
             nino: @participant_data[:nino])
-      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: "No" })
+      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
     click_on "Continue"
   end
 


### PR DESCRIPTION
### Context
From participant validation testing - [Jira](https://dfedigital.atlassian.net/browse/CPDRP-508?focusedCommentId=32255)
Fix issue where test API actually returns a boolean not a string "No" value

### Changes proposed in this pull request
Expect a boolean instead of a string value for the `:active_alert` flag value returned from DQT API.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
