### PR TITLE
Do not count two blank NINos as being a match

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -48,7 +48,7 @@ private
     matches += 1 if name_matches
     dob_matches = dob == dqt_record[:date_of_birth]
     matches += 1 if dob_matches
-    nino_matches = nino.downcase == dqt_record[:national_insurance_number]&.downcase
+    nino_matches = nino.present? && nino.downcase == dqt_record[:national_insurance_number]&.downcase
     matches += 1 if nino_matches
 
     return dqt_record if matches >= 3

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -149,5 +149,16 @@ RSpec.describe ParticipantValidationService do
         expect(validation_result).to eql({ trn: trn, qts: true, active_alert: true })
       end
     end
+
+    context "when the DQT nino is blank" do
+      let(:nino) { "" }
+      before do
+        expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).twice.and_return(dqt_record)
+      end
+
+      it "does not count blank NINos as matching" do
+        expect(ParticipantValidationService.validate(trn: trn, nino: "", full_name: "John Smithe", date_of_birth: dob)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
At present the validation service counts a match a blank NINo from the participant and  a blank from the DQT. This is wrong.
