### PR TITLE
Squish whitespace in user entered data

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -27,10 +27,10 @@ module Participants
         have_you_changed_your_name_choice: have_you_changed_your_name_choice,
         updated_record_choice: updated_record_choice,
         name_not_updated_choice: name_not_updated_choice,
-        trn: trn,
-        name: name,
+        trn: trn&.squish,
+        name: name&.squish,
         date_of_birth: date_of_birth,
-        national_insurance_number: national_insurance_number,
+        national_insurance_number: national_insurance_number&.squish,
         validation_attempts: validation_attempts.to_i, # coerce nil to 0
       }
     end

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -173,6 +173,21 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
       form = described_class.new(values)
       expect(form.attributes).to match(values)
     end
+
+    context "when participant details have extraneous whitespace" do
+      it "squishes the whitespace" do
+        values = {
+          trn: "   1231222  \t",
+          name: "    Shiela\n\t Smith    \n",
+          national_insurance_number: "    AW  23  44 44  A\t\n ",
+        }
+        form = described_class.new(values)
+        attributes = form.attributes
+        expect(attributes[:trn]).to eq "1231222"
+        expect(attributes[:name]).to eq "Shiela Smith"
+        expect(attributes[:national_insurance_number]).to eq "AW 23 44 44 A"
+      end
+    end
   end
 
   describe "#trn_choices" do


### PR DESCRIPTION
### Context
From participant validation testing - [Jira](https://dfedigital.atlassian.net/browse/CPDRP-508?focusedCommentId=32248)
Fix issue where user could enter data with spurious trailing/leading whitespace and fail validation.

### Changes proposed in this pull request
Squish the participant details so that leading trailing and multiple embedded whitespace are removed.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
