### PR TITLE
CPDRP-508 Add missing line to checking details page

### DIFF
--- a/app/views/participants/validations/manual_details_check_fip.html.erb
+++ b/app/views/participants/validations/manual_details_check_fip.html.erb
@@ -5,6 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel title: title, body: nil, classes: "govuk-!-margin-bottom-8" %>
     <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk-body">We may need to contact you for more information to complete your registration.</p>
     <p class="govuk-body">You will not need to use this service again during your training.</p>
     <% if @partnership.present? %>
       <p class="govuk-body"><%= @school.name %> has chosen <%= @partnership.delivery_partner.name %> and <%= @partnership.lead_provider.name %> to deliver your training programme. These organisations will contact you directly with more information.</p>

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -144,6 +144,7 @@ module ParticipantValidationSteps
 
   def then_i_should_see_the_checking_details_page
     expect(page).to have_selector("h1", text: "We’re checking your details")
+    expect(page).to have_text("We may need to contact you for more information to complete your registration.")
     expect(page).to have_text("Big Provider Ltd")
     expect(page).to have_text("Amazing Delivery Team")
   end


### PR DESCRIPTION
### Context
From participant validation testing - [Jira](https://dfedigital.atlassian.net/browse/CPDRP-508?focusedCommentId=32247)
The "We’re checking your details" page was missing a sentence.

### Changes proposed in this pull request
Add missing content to page

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
