### PR TITLE
Change back link on sign in page

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,8 +1,5 @@
 <% content_for :title, "Sign in" %>
-<% content_for :before_content, govuk_back_link(
-  text: "Back",
-  href: root_path)
-%>
+<% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This fixes the journey for users coming from /participants/start-registration


 - https://ecf-review-pr-844.london.cloudapps.digital/participants/start-registration
 - Continue
 - Click back link
 - Should be on https://ecf-review-pr-844.london.cloudapps.digital/participants/start-registration not https://ecf-review-pr-844.london.cloudapps.digital/