### PR TITLE
CPDTP-416 Fix reference html to code rather than links

### DIFF
--- a/app/views/lead_providers/guidance/reference.html.erb
+++ b/app/views/lead_providers/guidance/reference.html.erb
@@ -72,7 +72,7 @@
 </p>
 
 <p class="govuk-body">
-  <code>https://ecf-sandbox.london.cloudapps.digital/api/v1</code>>
+  <code>https://ecf-sandbox.london.cloudapps.digital/api/v1</code>
 </p>
 
 <p class="govuk-body">

--- a/app/views/lead_providers/guidance/reference.html.erb
+++ b/app/views/lead_providers/guidance/reference.html.erb
@@ -72,7 +72,7 @@
 </p>
 
 <p class="govuk-body">
-  <%= govuk_link_to 'https://ecf-sandbox.london.cloudapps.digital/api/v1', 'https://ecf-sandbox.london.cloudapps.digital/api/v1' %>
+  <code>https://ecf-sandbox.london.cloudapps.digital/api/v1</code>>
 </p>
 
 <p class="govuk-body">
@@ -81,7 +81,7 @@
 </p>
 
 <p class="govuk-body">
-  <%= govuk_link_to 'https://manage-training-for-early-career-teachers.education.gov.uk/api/v1', 'https://manage-training-for-early-career-teachers.education.gov.uk/api/v1' %>
+  <code>https://manage-training-for-early-career-teachers.education.gov.uk/api/v1</code>
 </p>
 
 <h3 class="govuk-heading-m">Rate limits</h3>


### PR DESCRIPTION
### Context

Found two broken links in the reference documentation which should really be code since they are the API endpoints.

### Changes proposed in this pull request

Update from links to <code> blocks

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

Visit the /lead-providers/guidance/reference#developing page on the app and view the changes under the Environments section on the page