### PR TITLE
Participant validation journey - Fix whitespace at validation time for form

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -105,6 +105,10 @@ module Participants
     end
 
     def teacher_details
+      @trn = trn&.squish
+      @name = name&.squish
+      @national_insurance_number = national_insurance_number&.squish
+
       if trn.blank?
         errors.add(:trn, :blank)
       elsif trn.length < 5

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
       end
     end
 
+    context "when trn has leading/trailing whiitespace" do
+      it "strips whitespace and validates" do
+        form.trn = "   1234567  \t\n"
+        expect(form.valid?(:tell_us_your_details)).to be true
+      end
+    end
+
     context "when name is not supplied" do
       it "returns false" do
         form.name = nil
@@ -152,6 +159,13 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
         form.national_insurance_number = "A 12 VV"
         expect(form.valid?(:tell_us_your_details)).to be false
         expect(form.errors).to include :national_insurance_number
+      end
+    end
+
+    context "when national_insurance_number has leading/trailing whiitespace" do
+      it "strips whitespace and validates" do
+        form.national_insurance_number = "   AB123456C  \t\n"
+        expect(form.valid?(:tell_us_your_details)).to be true
       end
     end
   end


### PR DESCRIPTION
### Context
Fixes whitespace at the point of validation for the entered participant details.

### Changes proposed in this pull request
Squish whitespace before validating the form.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
