### PR TITLE
Change dashboard text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
     elsif user.induction_coordinator?
       induction_coordinator_dashboard_path(user)
     elsif user.mentor? || user.early_career_teacher?
-      participants_validation_start_path
+      participant_start_path(user)
     else
       dashboard_path
     end
@@ -35,5 +35,13 @@ private
     return advisory_schools_choose_programme_path(school_id: school.slug) unless school.chosen_programme?(Cohort.current)
 
     schools_dashboard_path(school_id: school.slug)
+  end
+
+  def participant_start_path(user)
+    if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school)
+      participants_validation_start_path
+    else
+      dashboard_path
+    end
   end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-three-quarters">
     <% if current_user.lead_provider? %>
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: "navigation" %>
@@ -14,8 +14,11 @@
         <p>See which schools have added their early career teachers and mentors.</p>
       </div>
     <% else %>
-      <h1 class="govuk-heading-l">User dashboard</h1>
-      <p class="govuk-body"> You are logged in</p>
+      <h1 class="govuk-heading-xl">You cannot use this service yet</h1>
+      <p class="govuk-body">
+        If your school induction tutor has added your information as an early career teacher (ECT) or mentor, we'll
+        contact you soon.
+      </p>
     <% end %>
   </div>
 </div>

--- a/spec/cypress/integration/aaa-meta/cypress.js
+++ b/spec/cypress/integration/aaa-meta/cypress.js
@@ -9,7 +9,7 @@
 describe("Meta test helper tests", () => {
   it("should have login and logout helper commands", () => {
     cy.login();
-    cy.get("h1").should("contain", "User dashboard");
+    cy.get("h1").should("contain", "You cannot use this service yet");
 
     cy.logout();
     cy.get("h1").should("contain", "You are now signed out");

--- a/spec/cypress/integration/accessibility.js
+++ b/spec/cypress/integration/accessibility.js
@@ -46,7 +46,7 @@ describe("Accessibility", () => {
     cy.percySnapshot("Confirm sign in page");
 
     cy.get('[action="/users/sign_in_with_token"] [name="commit"]').click();
-    cy.get("h1").should("contain", "User dashboard");
+    cy.get("h1").should("contain", "You cannot use this service yet");
     cy.checkA11y();
 
     cy.logout();

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe ApplicationHelper, type: :helper do
   let(:induction_coordinator) { create(:user, :induction_coordinator) }
   let(:school) { induction_coordinator.induction_coordinator_profile.schools.first }
   let!(:cohort) { create(:cohort, :current) }
+  let(:participant_profile) { create(:participant_profile, :ect) }
+  let(:participant_school) { participant_profile.school }
+  let(:lead_provider) { create(:user, :lead_provider) }
 
   describe "#profile_dashboard_path" do
     it "returns the admin/schools path for admins" do
@@ -43,6 +46,24 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "return the schools dashboard path (index)" do
         expect(helper.profile_dashboard_path(induction_coordinator)).to eq("/schools")
       end
+    end
+
+    it "returns dashboard path for participants" do
+      expect(helper.profile_dashboard_path(participant_profile.user)).to eq("/dashboard")
+    end
+
+    context "when the validation feature flag is active for a participant" do
+      before do
+        FeatureFlag.activate(:participant_validation, for: participant_school)
+      end
+
+      it "returns the validation start path" do
+        expect(helper.profile_dashboard_path(participant_profile.user)).to eq("/participants/validation")
+      end
+    end
+
+    it "returns the dashboard path for lead providers" do
+      expect(helper.profile_dashboard_path(lead_provider)).to eq("/dashboard")
     end
   end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -161,10 +161,22 @@ RSpec.describe "Users::Sessions", type: :request do
   describe "POST /users/sign_in_with_token" do
     context "when user is an ECT" do
       let(:user) { create(:participant_profile, :ect).user }
+      let(:school) { user.teacher_profile.early_career_teacher_profile.school }
 
-      it "redirects to participant validation on successful login" do
+      it "redirects to generic dashboard on successful login" do
         post "/users/sign_in_with_token", params: { login_token: user.login_token }
-        expect(response).to redirect_to(participants_validation_start_path)
+        expect(response).to redirect_to(dashboard_path)
+      end
+
+      context "when the validations feature flag is active for the user" do
+        before do
+          FeatureFlag.activate(:participant_validation, for: school)
+        end
+
+        it "redirects to participant validation on successful login" do
+          post "/users/sign_in_with_token", params: { login_token: user.login_token }
+          expect(response).to redirect_to(participants_validation_start_path)
+        end
       end
     end
 


### PR DESCRIPTION
- Direct participants unable to start validation to the generic dashboard
- If a participant signs in before they're able to start validation, show
a more helpful message
