### PR TITLE
Temporarily disable auditing middleware

### DIFF
--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -8,7 +8,8 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
-  config.middleware.use LeadProviderRequestAuditor
+  # TODO: Enable after more thorough testing
+  # config.middleware.use LeadProviderRequestAuditor
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,8 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
-  config.middleware.use LeadProviderRequestAuditor
+  # TODO: Enable after more thorough testing
+  # config.middleware.use LeadProviderRequestAuditor
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.middleware.use LeadProviderRequestAuditor
+  # TODO: Enable after more thorough testing
+  # config.middleware.use LeadProviderRequestAuditor
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -8,7 +8,8 @@ Rails.application.configure do
   # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
   config.middleware.use TimeTraveler
 
-  config.middleware.use LeadProviderRequestAuditor
+  # TODO: Enable after more thorough testing
+  # config.middleware.use LeadProviderRequestAuditor
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,7 +5,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.middleware.use LeadProviderRequestAuditor
+  # TODO: Enable after more thorough testing
+  # config.middleware.use LeadProviderRequestAuditor
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
### Context
For some reason the middleware causes 400s. I need to dig deeper into it, for now we should disable it. 
