### PR TITLE
CPDTP-417_Change induction to course on NPQ usage guide

### DIFF
--- a/app/views/lead_providers/guidance/npq_usage.html.erb
+++ b/app/views/lead_providers/guidance/npq_usage.html.erb
@@ -164,7 +164,7 @@
 </p>
 
 <h2 id="declaring-that-an-npq-participant-has-started-their-course" class="govuk-heading-l">
-  Declaring that an NPQ participant has started their induction
+  Declaring that an NPQ participant has started their course
 </h2>
 <p class="govuk-body-m">
   This scenario begins after it has been confirmed that an NPQ participant is ready to begin their induction training.


### PR DESCRIPTION
### Context

The NPQ usage guide incorrectly uses the term "induction" when it means course on the description line.

### Changes proposed in this pull request

Fix to the text

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
