### PR TITLE
Fix declaration date validation for current time

### DIFF
--- a/app/validators/future_date_validator.rb
+++ b/app/validators/future_date_validator.rb
@@ -2,6 +2,6 @@
 
 class FutureDateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, I18n.t(:future_declaration_date)) if Time.zone.parse(value) > Time.zone.today
+    record.errors.add(attribute, I18n.t(:future_declaration_date)) if Time.zone.parse(value) > Time.zone.now
   end
 end

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -54,4 +54,11 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
       expect { described_class.call(params) }.to_not raise_error
     end
   end
+
+  context "when declaration date is today" do
+    it "does not raise ParameterMissing error" do
+      params = ect_params.merge({ declaration_date: Time.zone.now.rfc3339(9) })
+      expect { described_class.call(params) }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
### Context
Current valudation compares the date to the beginning of the day (I think). This causes failures when a provider sends us declaration from, say, 1h ago. We should compare it to current time. 
