### PR TITLE
CPDRP-770 SIT mentor validation

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -13,7 +13,23 @@ module Participants
                                                         cannot_find_details]
 
     def start
-      store_form_and_redirect_to_step :do_you_know_your_trn
+      # check whether the user is a SIT/mentor and offer the choice
+      # to proceed (unless they have already completed)
+      if current_user.induction_coordinator?
+        store_for_and_redirect_to_step :do_you_want_to_add_mentor_information
+      else
+        store_form_and_redirect_to_step :do_you_know_your_trn
+      end
+    end
+
+    def do_you_want_to_add_mentor_information
+      choice = @participant_validation_form.do_you_want_to_add_mentor_information_choice
+      if choice == "yes"
+        store_form_and_redirect_to_step :do_you_know_your_trn
+      else
+        reset_form_data
+        redirect_to induction_coordinator_dashboard_path(current_user)
+      end
     end
 
     def do_you_know_your_trn

--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -15,7 +15,7 @@ module Participants
     attr_reader :date_of_birth
     attr_accessor :validation_attempts
 
-    validate :add_mentor_info, on: :do_you_want_to_add_mentor_information
+    validate :add_mentor_info_choice, on: :do_you_want_to_add_mentor_information
     validate :trn_choice, on: :do_you_know_your_trn
     validate :name_change_choice, on: :have_you_changed_your_name
     validate :confirm_updated_record_choice, on: :confirm_updated_record
@@ -25,7 +25,7 @@ module Participants
     def attributes
       {
         step: step,
-        do_you_want_to_add_mentor_information: do_you_want_to_add_mentor_information_choice,
+        do_you_want_to_add_mentor_information_choice: do_you_want_to_add_mentor_information_choice,
         do_you_know_your_trn_choice: do_you_know_your_trn_choice,
         have_you_changed_your_name_choice: have_you_changed_your_name_choice,
         updated_record_choice: updated_record_choice,

--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -8,12 +8,14 @@ module Participants
     # lifted from https://github.com/dwp/nino-format-validation
     NINO_REGEX = /(^(?!BG)(?!GB)(?!NK)(?!KN)(?!TN)(?!NT)(?!ZZ)[A-Z&&[^DFIQUV]][A-Z&&[^DFIOQUV]][0-9]{6}[A-D]$)/.freeze
     attr_accessor :step
+    attr_accessor :do_you_want_to_add_mentor_information_choice
     attr_accessor :do_you_know_your_trn_choice, :have_you_changed_your_name_choice
     attr_accessor :updated_record_choice, :name_not_updated_choice
     attr_accessor :trn, :name, :national_insurance_number
     attr_reader :date_of_birth
     attr_accessor :validation_attempts
 
+    validate :add_mentor_info, on: :do_you_want_to_add_mentor_information
     validate :trn_choice, on: :do_you_know_your_trn
     validate :name_change_choice, on: :have_you_changed_your_name
     validate :confirm_updated_record_choice, on: :confirm_updated_record
@@ -23,6 +25,7 @@ module Participants
     def attributes
       {
         step: step,
+        do_you_want_to_add_mentor_information: do_you_want_to_add_mentor_information_choice,
         do_you_know_your_trn_choice: do_you_know_your_trn_choice,
         have_you_changed_your_name_choice: have_you_changed_your_name_choice,
         updated_record_choice: updated_record_choice,
@@ -40,6 +43,13 @@ module Participants
       @date_of_birth = ActiveRecord::Type::Date.new.cast(value)
     rescue StandardError
       @date_of_birth_invalid = true
+    end
+
+    def add_mentor_information_choices
+      [
+        OpenStruct.new(id: "yes", name: "Yes, I want to add information now"),
+        OpenStruct.new(id: "no", name: "No, I’ll do it later"),
+      ]
     end
 
     def trn_choices
@@ -87,6 +97,10 @@ module Participants
     end
 
   private
+
+    def add_mentor_info_choice
+      errors.add(:do_you_want_to_add_mentor_information_choice, :blank) unless add_mentor_information_choices.map(&:id).include?(do_you_want_to_add_mentor_information_choice)
+    end
 
     def trn_choice
       errors.add(:do_you_know_your_trn_choice, :blank) unless trn_choices.map(&:id).include?(do_you_know_your_trn_choice)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
     elsif user.finance?
       finance_lead_providers_path
     elsif user.sit_mentor?
-      sit_mentor_redirector(user)
+      sit_mentor_path(user)
     elsif user.induction_coordinator?
       induction_coordinator_dashboard_path(user)
     elsif user.mentor? || user.early_career_teacher?
@@ -43,12 +43,15 @@ module ApplicationHelper
     else
       dashboard_path
     end
+  end
 
 private
 
-  def sit_mentor_redirector(user)
-    profile = user.participant_profiles.active.mentors.first
-    return participants_validation_start_path unless profile&.completed_validation_wizard?
+  def sit_mentor_path(user)
+    if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school)
+      profile = user.participant_profiles.active.mentors.first
+      return participant_start_path(user) unless profile&.completed_validation_wizard?
+    end
 
     induction_coordinator_dashboard_path(user)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,8 @@ module ApplicationHelper
       admin_schools_path
     elsif user.finance?
       finance_lead_providers_path
-    elsif user.sit_mentor?
-      sit_mentor_path(user)
+    elsif user.induction_coordinator_and_mentor?
+      induction_coordinator_mentor_path(user)
     elsif user.induction_coordinator?
       induction_coordinator_dashboard_path(user)
     elsif user.mentor? || user.early_career_teacher?
@@ -47,10 +47,10 @@ module ApplicationHelper
 
 private
 
-  def sit_mentor_path(user)
+  def induction_coordinator_mentor_path(user)
     if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school)
       profile = user.participant_profiles.active.mentors.first
-      return participant_start_path(user) unless profile&.completed_validation_wizard?
+      return participants_validation_start_path unless profile&.completed_validation_wizard?
     end
 
     induction_coordinator_dashboard_path(user)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,10 @@ module ApplicationHelper
       admin_schools_path
     elsif user.finance?
       finance_lead_providers_path
-    elsif user.induction_coordinator?
+    elsif user.sit_mentor?
       sit_mentor_redirector(user)
+    elsif user.induction_coordinator?
+      induction_coordinator_dashboard_path(user)
     elsif user.mentor? || user.early_career_teacher?
       participant_start_path(user)
     else
@@ -45,10 +47,8 @@ module ApplicationHelper
 private
 
   def sit_mentor_redirector(user)
-    if user.mentor?
-      profile = user.participant_profiles.active.mentor.first
-      return participants_validation_start_path unless profile.ecf_participant_validation_data.present? || profile.ecf_participant_eligibility.present?
-    end
+    profile = user.participant_profiles.active.mentors.first
+    return participants_validation_start_path unless profile&.completed_validation_wizard?
 
     induction_coordinator_dashboard_path(user)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
     elsif user.finance?
       finance_lead_providers_path
     elsif user.induction_coordinator?
-      induction_coordinator_dashboard_path(user)
+      sit_mentor_redirector(user)
     elsif user.mentor? || user.early_career_teacher?
       participant_start_path(user)
     else
@@ -26,8 +26,6 @@ module ApplicationHelper
     analytics_data
   end
 
-private
-
   def induction_coordinator_dashboard_path(user)
     return schools_dashboard_index_path if user.schools.count > 1
 
@@ -43,5 +41,15 @@ private
     else
       dashboard_path
     end
+
+private
+
+  def sit_mentor_redirector(user)
+    if user.mentor?
+      profile = user.participant_profiles.active.mentor.first
+      return participants_validation_start_path unless profile.ecf_participant_validation_data.present? || profile.ecf_participant_eligibility.present?
+    end
+
+    induction_coordinator_dashboard_path(user)
   end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -9,4 +9,8 @@ class ParticipantProfile::ECF < ParticipantProfile
   has_one :school, through: :school_cohort
   has_one :cohort, through: :school_cohort
   has_one :ecf_participant_eligibility, foreign_key: :participant_profile_id
+
+  def completed_validation_wizard?
+    ecf_participant_eligibility.present? || ecf_participant_validation_data.present?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
     early_career_teacher? || mentor?
   end
 
-  def sit_mentor?
+  def induction_coordinator_and_mentor?
     induction_coordinator? && mentor?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,10 @@ class User < ApplicationRecord
     early_career_teacher? || mentor?
   end
 
+  def sit_mentor?
+    induction_coordinator? && mentor?
+  end
+
   def core_induction_programme
     return early_career_teacher_profile.core_induction_programme if early_career_teacher?
     return mentor_profile.core_induction_programme if mentor?

--- a/app/views/layouts/school_cohort.html.erb
+++ b/app/views/layouts/school_cohort.html.erb
@@ -1,14 +1,16 @@
 <%= render layout: 'layouts/width_container' do %>
   <%= render SchoolRecruitedTransitionComponent.new(school_cohort: @school_cohort) if @school_cohort %>
-  <% if current_user.sit_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
-    <%= render GovukComponent::NotificationBanner.new(title: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
-      banner.slot(
-        :heading,
-        text: "You need to add information about yourself as a mentor.",
-        link_text: "Update now",
-        link_target: participants_validation_do_you_know_your_trn_path,
-      )
-    end %>
+  <% if FeatureFlag.active?(:participant_validation, for: current_user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school) %>
+    <% if current_user.sit_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
+      <%= render GovukComponent::NotificationBanner.new(title: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
+        banner.slot(
+          :heading,
+          text: "You need to add information about yourself as a mentor.",
+          link_text: "Update now",
+          link_target: participants_validation_do_you_know_your_trn_path,
+        )
+      end %>
+    <% end %>
   <% end %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/school_cohort.html.erb
+++ b/app/views/layouts/school_cohort.html.erb
@@ -1,5 +1,14 @@
 <%= render layout: 'layouts/width_container' do %>
   <%= render SchoolRecruitedTransitionComponent.new(school_cohort: @school_cohort) if @school_cohort %>
-
+  <% if current_user.sit_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
+    <%= render GovukComponent::NotificationBanner.new(title: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
+      banner.slot(
+        :heading,
+        text: "You need to add information about yourself as a mentor.",
+        link_text: "Update now",
+        link_target: participants_validation_do_you_know_your_trn_path,
+      )
+    end %>
+  <% end %>
   <%= yield %>
 <% end %>

--- a/app/views/layouts/school_cohort.html.erb
+++ b/app/views/layouts/school_cohort.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: 'layouts/width_container' do %>
   <%= render SchoolRecruitedTransitionComponent.new(school_cohort: @school_cohort) if @school_cohort %>
   <% if FeatureFlag.active?(:participant_validation, for: current_user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school) %>
-    <% if current_user.sit_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
+    <% if current_user.induction_coordinator_and_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
       <%= render GovukComponent::NotificationBanner.new(title: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
         banner.slot(
           :heading,

--- a/app/views/participants/validations/do_you_want_to_add_mentor_information.html.erb
+++ b/app/views/participants/validations/do_you_want_to_add_mentor_information.html.erb
@@ -11,6 +11,7 @@
       <%= f.govuk_collection_radio_buttons(
         :do_you_want_to_add_mentor_information_choice, @participant_validation_form.add_mentor_information_choices,
         :id, :name,
+        legend: { text: false },
       ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/participants/validations/do_you_want_to_add_mentor_information.html.erb
+++ b/app/views/participants/validations/do_you_want_to_add_mentor_information.html.erb
@@ -1,0 +1,18 @@
+<% title = "Do you want to add information about yourself as a mentor?" %>
+<% content_for :title, title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <p class="govuk-body">We need to check your details on the Teaching Regulation Agency records. This is to make sure you qualify for this programme.</p>
+    <%= form_for @participant_validation_form, url: { action: @participant_validation_form.step }, method: :put do |f| %>
+      <%= f.hidden_field :step, value: @participant_validation_form.step %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_collection_radio_buttons(
+        :do_you_want_to_add_mentor_information_choice, @participant_validation_form.add_mentor_information_choices,
+        :id, :name,
+      ) %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/participants/validations/manual_details_check_fip.html.erb
+++ b/app/views/participants/validations/manual_details_check_fip.html.erb
@@ -5,12 +5,20 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel title: title, body: nil, classes: "govuk-!-margin-bottom-8" %>
     <h2 class="govuk-heading-m">What happens next</h2>
+
     <p class="govuk-body">We may need to contact you for more information to complete your registration.</p>
-    <p class="govuk-body">You will not need to use this service again during your training.</p>
+    <% unless current_user.induction_coordinator? %>
+      <p class="govuk-body">You will not need to use this service again during your training.</p>
+    <% end %>
+
     <% if @partnership.present? %>
       <p class="govuk-body"><%= @school.name %> has chosen <%= @partnership.delivery_partner.name %> and <%= @partnership.lead_provider.name %> to deliver your training programme. These organisations will contact you directly with more information.</p>
     <% else %>
       <p class="govuk-body"><%= @school.name %> has been asked to choose a training provider to deliver your programme. The provider will contact you directly.</p>
+    <% end %>
+
+    <% if current_user.induction_coordinator? %>
+      <%= govuk_link_to "Manage induction for your school", induction_coordinator_dashboard_path(current_user) %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,8 @@ en:
       models:
         participants/participant_validation_form:
           attributes:
+            do_you_want_to_add_mentor_information_choice:
+              blank: Select whether you want to add your mentor information now
             do_you_know_your_trn_choice:
               blank: Select whether you know your teacher reference number
             have_you_changed_your_name_choice:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,6 +251,8 @@ Rails.application.routes.draw do
     authenticated :user, ->(user) { FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school) } do
       scope :validation, as: :validation do
         get "/", to: "validations#start", as: :start
+        get "/do-you-want-to-add-your-mentor-information", to: "validations#do_you_want_to_add_mentor_information", as: :do_you_want_to_add_mentor_information
+        put "/do-you-want-to-add-your-mentor-information", to: "validations#do_you_want_to_add_mentor_information"
         get "/do-you-know-your-teacher-reference-number", to: "validations#do_you_know_your_trn", as: :do_you_know_your_trn
         put "/do-you-know-your-teacher-reference-number", to: "validations#do_you_know_your_trn"
         get "/have-you-changed-your-name", to: "validations#have_you_changed_your_name", as: :have_you_changed_your_name

--- a/spec/features/participants/happy_validation_journeys_for_ect_fip_spec.rb
+++ b/spec/features/participants/happy_validation_journeys_for_ect_fip_spec.rb
@@ -42,6 +42,10 @@ RSpec.feature "ECT participant validation journey for FIP induction", type: :fea
     then_i_should_see_the_checking_details_page_for_matched_user
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named "Participant Validation: Complete Partnered FIP"
+
+    when_i_sign_out
+    and_i_sign_in_again_as_the_same_user
+    then_i_should_see_the_checking_details_page_for_matched_user
   end
 
   scenario "Participant has changed their name and updated TRA" do

--- a/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
+++ b/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./participant_validation_steps"
+
+RSpec.feature "SIT/mentor participant validation journeys for FIP induction", type: :feature, js: true, with_feature_flags: { participant_validation: "active" } do
+  include ParticipantValidationSteps
+
+  scenario "SIT/Mentor Participant validates their details" do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_a_sit_mentor_participant
+    then_i_should_see_the_do_you_want_to_add_your_mentor_information_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: Do you want to add your mentor information"
+    when_i_select "Yes, I want to add information now"
+    and_i_click "Continue"
+    then_i_should_see_the_do_you_know_your_trn_page
+
+    when_i_select "Yes, I know my TRN"
+    and_i_click "Continue"
+    then_i_should_see_the_have_you_changed_your_name_page
+
+    when_i_select "No, I have the same name"
+    and_i_click "Continue"
+    then_i_should_see_the_tell_us_your_details_page
+
+    when_i_enter_the_participants_details
+    and_i_click "Continue"
+    then_i_should_see_the_confirm_details_page
+
+    when_i_click_continue_to_proceed_with_validation
+    then_i_should_see_the_checking_details_page_for_a_sit_mentor
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: SIT/Mentor Complete Partnered FIP"
+
+    when_i_sign_out
+    and_i_sign_in_again_as_the_same_user
+    then_i_should_see_the_manage_your_training_page
+    and_i_should_not_see_a_banner_telling_me_i_need_to_add_my_mentor_information
+  end
+
+  scenario "SIT/Mentor Participant chooses to do it later and then changes their mind" do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_a_sit_mentor_participant
+    then_i_should_see_the_do_you_want_to_add_your_mentor_information_page
+
+    when_i_select "No, I’ll do it later"
+    and_i_click "Continue"
+    then_i_should_see_the_manage_your_training_page
+    and_i_should_see_a_banner_telling_me_i_need_to_add_my_mentor_information
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: SIT/Mentor dashboard banner"
+
+    when_i_click "Update now"
+    then_i_should_see_the_do_you_know_your_trn_page
+
+    when_i_select "Yes, I know my TRN"
+    and_i_click "Continue"
+    then_i_should_see_the_have_you_changed_your_name_page
+
+    when_i_select "No, I have the same name"
+    and_i_click "Continue"
+    then_i_should_see_the_tell_us_your_details_page
+
+    when_i_enter_the_participants_details
+    and_i_click "Continue"
+    then_i_should_see_the_confirm_details_page
+
+    when_i_click_continue_to_proceed_with_validation
+    then_i_should_see_the_checking_details_page_for_a_sit_mentor
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: SIT/Mentor Complete Partnered FIP"
+
+    when_i_click "Manage induction for your school"
+    then_i_should_see_the_manage_your_training_page
+    and_i_should_not_see_a_banner_telling_me_i_need_to_add_my_mentor_information
+  end
+end

--- a/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
+++ b/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
@@ -75,4 +75,11 @@ RSpec.feature "SIT/mentor participant validation journeys for FIP induction", ty
     then_i_should_see_the_manage_your_training_page
     and_i_should_not_see_a_banner_telling_me_i_need_to_add_my_mentor_information
   end
+
+  scenario "SIT/Mentor outside of beta does not see journey", with_feature_flags: { participant_validation: "inactive" } do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_a_sit_mentor_participant
+    then_i_should_see_the_manage_your_training_page
+    and_i_should_not_see_a_banner_telling_me_i_need_to_add_my_mentor_information
+  end
 end

--- a/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
+++ b/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
@@ -74,8 +74,6 @@ RSpec.feature "SIT/mentor participant validation journeys for FIP induction", ty
 
     when_i_click_continue_to_proceed_with_validation
     then_i_should_see_the_checking_details_page_for_a_sit_mentor
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Participant Validation: SIT/Mentor Complete Partnered FIP"
 
     when_i_click "Manage induction for your school"
     then_i_should_see_the_manage_your_training_page

--- a/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
+++ b/spec/features/participants/sit_mentor_fip_validation_journeys_spec.rb
@@ -12,6 +12,12 @@ RSpec.feature "SIT/mentor participant validation journeys for FIP induction", ty
     then_i_should_see_the_do_you_want_to_add_your_mentor_information_page
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named "Participant Validation: Do you want to add your mentor information"
+
+    when_i_click "Continue"
+    then_i_see_an_error_message "Select whether you want to add your mentor information now"
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: Do you want to add your mentor information - error"
+
     when_i_select "Yes, I want to add information now"
     and_i_click "Continue"
     then_i_should_see_the_do_you_know_your_trn_page

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -5,6 +5,31 @@ require "rails_helper"
 RSpec.describe Participants::ParticipantValidationForm, type: :model do
   subject(:form) { described_class.new }
 
+  describe "do_you_want_to_add_mentor_information validations" do
+    context "when a valid choice is made" do
+      it "returns true" do
+        form.do_you_want_to_add_mentor_information_choice = form.add_mentor_information_choices.map(&:id).sample
+        expect(form.valid?(:do_you_want_to_add_mentor_information)).to be true
+        expect(form.errors).to be_empty
+      end
+    end
+
+    context "when no choice has been made" do
+      it "returns false" do
+        expect(form.valid?(:do_you_want_to_add_mentor_information)).to be false
+        expect(form.errors).to include :do_you_want_to_add_mentor_information_choice
+      end
+    end
+
+    context "when an invalid choice has been made" do
+      it "returns false" do
+        form.do_you_know_your_trn_choice = :banana
+        expect(form.valid?(:do_you_want_to_add_mentor_information)).to be false
+        expect(form.errors).to include :do_you_want_to_add_mentor_information_choice
+      end
+    end
+  end
+
   describe "do_you_know_your_trn validations" do
     context "when a valid choice is made" do
       it "returns true" do
@@ -174,6 +199,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
     it "returns a hash of the attribute data" do
       values = {
         step: :my_step,
+        do_you_want_to_add_mentor_information_choice: form.add_mentor_information_choices.map(&:id).sample,
         do_you_know_your_trn_choice: form.trn_choices.map(&:id).sample,
         have_you_changed_your_name_choice: form.name_change_choices.map(&:id).sample,
         updated_record_choice: form.updated_record_choices.map(&:id).sample,

--- a/spec/support/features/interaction_helper.rb
+++ b/spec/support/features/interaction_helper.rb
@@ -32,4 +32,11 @@ module InteractionHelper
   end
 
   alias_method :and_i_visit, :when_i_visit
+
+  def when_i_sign_out
+    click_on "Sign out"
+    expect(page).to have_selector("h1", text: "You are now signed out")
+  end
+
+  alias_method :and_i_sign_out, :when_i_sign_out
 end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -8,8 +8,8 @@ module UserHelper
   end
 
   def sign_in_as(user)
-    token = "test-token"
-    user.update!(login_token: token)
+    token = "test-token-#{Time.zone.now.to_f}"
+    user.update!(login_token: token, login_token_valid_until: 1.hour.from_now)
     visit users_confirm_sign_in_path(login_token: token)
     click_button "Continue"
   end


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-770)
Add changes to participant validation journey for SIT/mentors

### Changes proposed in this pull request
Redirect SIT/mentors to the validation journey if not already completed on sign in.
Add extra step to process for SIT/mentors to ask whether they want to add their mentor information now or not
Add banner to that is shown to SIT/mentors if they have not completed their mentor registration
Changes to end pages for SITs

### Guidance to review
Sign in as a SIT/mentor (`cpd-test+tutor-17@example.com` is a SIT mentor).
You should be shown the "Do you want to add your mentor information" question
Selecting yes, takes you into the participant validation as normal
Selecting no, takes you to the SIT dashboard.
The SIT should see an information banner reminding them to add their mentor information until they complete the validation.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
