### PR TITLE
[CPDEL-788] Fix error for users with no cohort

### DIFF
--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -53,7 +53,10 @@ module Api
       def users
         users = User.where(id: ParticipantProfile::ECF.joins(:teacher_profile).select("teacher_profiles.user_id"))
                     .includes(teacher_profile: {
-                      ecf_profile: %i[school_cohort core_induction_programme],
+                      ecf_profile: [
+                        :core_induction_programme,
+                        school_cohort: :cohort,
+                      ],
                     })
 
         if updated_since.present?

--- a/app/serializers/ecf_user_serializer.rb
+++ b/app/serializers/ecf_user_serializer.rb
@@ -63,7 +63,7 @@ class ECFUserSerializer
   end
 
   attributes :cohort do |user|
-    user.cohort.start_year
+    find_school_cohort(user)&.cohort&.start_year
   end
 
   def self.find_school_cohort(user)


### PR DESCRIPTION

### Context

https://dfedigital.atlassian.net/browse/CPDEL-649

### Changes proposed in this pull request

The previous method shouldn't be used any more as it uses attributes that aren't
the source of truth. We should look at the school cohort to find the user' cohort.

Also use the find_school_cohort method and amend the includes in the controller to
avoid N+1 lookups to find the cohort related to the school cohort.

The previous implementation was throwing an exception on the users index endpoint, 
which is bad because it prevents some users from being synced with engage and learn.

Unfortunately it is hard to create a test for this as a user can't be created without a cohort
without bypassing validations

### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
