### PR TITLE
Add milestone date validation

### DIFF
--- a/app/models/finance/schedule.rb
+++ b/app/models/finance/schedule.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Finance::Schedule < ApplicationRecord
-  has_many :milestones
+  has_many :milestones, -> { order(milestone_date: :asc) }
   has_many :participant_profiles
 
   def self.default

--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -55,7 +55,7 @@ private
     teacher_profile.school = profile.school = School.find_by(urn: school_urn)
     teacher_profile.save!
 
-    profile.schedule = Finance::Schedule.default
+    profile.schedule ||= Finance::Schedule.default
     profile.teacher_profile = teacher_profile
     profile.user_id = user_id
     profile.save!

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -12,6 +12,9 @@ class ParticipantProfile < ApplicationRecord
   has_one :ecf_participant_validation_data
   has_many :validation_decisions, class_name: "ProfileValidationDecision"
 
+  has_many :profile_declarations
+  has_many :participant_declarations, through: :profile_declarations
+
   enum status: {
     active: "active",
     withdrawn: "withdrawn",

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -128,11 +128,11 @@ module RecordDeclarations
     end
 
     def validate_milestone!
-      unless milestone.start_date < parsed_date
+      unless milestone.start_date.beginning_of_day < parsed_date
         raise ActionController::ParameterMissing, I18n.t(:declaration_before_milestone_start)
       end
 
-      unless milestone.milestone_date > parsed_date
+      unless parsed_date <= milestone.milestone_date.end_of_day
         raise ActionController::ParameterMissing, I18n.t(:declaration_after_milestone_cutoff)
       end
     end
@@ -142,17 +142,17 @@ module RecordDeclarations
         raise ActionController::ParameterMissing, I18n.t(:schedule_missing)
       end
 
-      declaration_to_milestone_map[declaration_type.to_sym]
+      declaration_to_milestone_map[declaration_type]
     end
 
     def declaration_to_milestone_map
       {
-        "started": schedule.milestones[0],
-        "retained-1": schedule.milestones[1],
-        "retained-2": schedule.milestones[2],
-        "retained-3": schedule.milestones[3],
-        "retained-4": schedule.milestones[4],
-        "completed": schedule.milestones.last,
+        "started" => schedule.milestones[0],
+        "retained-1" => schedule.milestones[1],
+        "retained-2" => schedule.milestones[2],
+        "retained-3" => schedule.milestones[3],
+        "retained-4" => schedule.milestones[4],
+        "completed" => schedule.milestones.last,
       }
     end
   end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -14,6 +14,7 @@ module RecordDeclarations
     validates :declaration_type, presence: { message: I18n.t(:missing_declaration_type) }
     validates :user, presence: { message: I18n.t(:invalid_participant) }
     validates :lead_provider_from_token, presence: { message: I18n.t(:missing_lead_provider) }
+    validates :parsed_date, future_date: true, allow_blank: true
 
     validate :profile_exists
     validate :date_has_the_right_format
@@ -116,7 +117,7 @@ module RecordDeclarations
       return if declaration_date.blank?
 
       errors.add(:declaration_date, I18n.t(:invalid_declaration_date)) unless declaration_date.match(RFC3339_DATE_REGEX)
-      errors.add(:declaration_date, I18n.t(:future_declaration_date)) if parsed_date > Time.zone.now
+      parsed_date
     rescue StandardError
       errors.add(:declaration_date, I18n.t(:invalid_declaration_date))
     end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -139,7 +139,6 @@ module RecordDeclarations
       end
 
       next_milestone = schedule.milestones[existing_declarations.count]
-      parsed_date = self.parsed_date
       unless next_milestone.start_date < parsed_date
         raise ActionController::ParameterMissing, I18n.t(:declaration_before_milestone_start)
       end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -3,7 +3,7 @@
 module RecordDeclarations
   class Base
     include ActiveModel::Model
-    RCF3339_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/i.freeze
+    RFC3339_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/i.freeze
 
     attr_accessor :course_identifier, :user_id, :lead_provider_from_token, :declaration_date, :declaration_type, :evidence_held
 
@@ -115,7 +115,7 @@ module RecordDeclarations
     def date_has_the_right_format
       return if declaration_date.blank?
 
-      errors.add(:declaration_date, I18n.t(:invalid_declaration_date)) unless declaration_date.match(RCF3339_DATE_REGEX)
+      errors.add(:declaration_date, I18n.t(:invalid_declaration_date)) unless declaration_date.match(RFC3339_DATE_REGEX)
       errors.add(:declaration_date, I18n.t(:future_declaration_date)) if parsed_date > Time.zone.now
     rescue StandardError
       errors.add(:declaration_date, I18n.t(:invalid_declaration_date))

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -4,14 +4,6 @@ module RecordDeclarations
   class Base
     include ActiveModel::Model
     RFC3339_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/i.freeze
-    DECLARATION_TO_MILESTONE_MAP = {
-      "started": schedule.milestones[0],
-      "retained-1": schedule.milestones[1],
-      "retained-2": schedule.milestones[2],
-      "retained-3": schedule.milestones[3],
-      "retained-4": schedule.milestones[4],
-      "completed": schedule.milestones.last,
-    }.freeze
 
     attr_accessor :course_identifier, :user_id, :lead_provider_from_token, :declaration_date, :declaration_type, :evidence_held
 
@@ -150,7 +142,18 @@ module RecordDeclarations
         raise ActionController::ParameterMissing, I18n.t(:schedule_missing)
       end
 
-      DECLARATION_TO_MILESTONE_MAP[declaration_type.to_sym]
+      declaration_to_milestone_map[declaration_type.to_sym]
+    end
+
+    def declaration_to_milestone_map
+      {
+        "started": schedule.milestones[0],
+        "retained-1": schedule.milestones[1],
+        "retained-2": schedule.milestones[2],
+        "retained-3": schedule.milestones[3],
+        "retained-4": schedule.milestones[4],
+        "completed": schedule.milestones.last,
+      }
     end
   end
 end

--- a/app/validators/declaration_date_validator.rb
+++ b/app/validators/declaration_date_validator.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class DeclarationDateValidator < ActiveModel::EachValidator
-  RCF3339_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/i.freeze
-
-  def validate_each(record, attribute, value)
-    record.errors.add(attribute, I18n.t(:invalid_declaration_date)) unless value.match(RCF3339_DATE_REGEX)
-  end
-end

--- a/app/validators/future_date_validator.rb
+++ b/app/validators/future_date_validator.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class FutureDateValidator < ActiveModel::EachValidator
-  def validate_each(record, attribute, value)
-    record.errors.add(attribute, I18n.t(:future_declaration_date)) if Time.zone.parse(value) > Time.zone.now
-  end
-end

--- a/app/validators/future_date_validator.rb
+++ b/app/validators/future_date_validator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FutureDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, I18n.t(:future_declaration_date)) if value > Time.zone.now
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,10 @@ en:
   invalid_event: "The property '#/declaration_type' must be a valid declaration type"
   invalid_course: "The property '#/course_identifier' must be an available course to '#/participant_id'"
   invalid_evidence_type: "The property '#/evidence_held' must be an available type to the event type and course type"
+  schedule_missing: "The participant does not have a schedule"
+  too_many_declarations: "The participant has more declarations than milestones"
+  declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
+  declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"
   invalid_data_structure: correct json data structure required. See API docs for reference
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,6 @@ en:
   invalid_course: "The property '#/course_identifier' must be an available course to '#/participant_id'"
   invalid_evidence_type: "The property '#/evidence_held' must be an available type to the event type and course type"
   schedule_missing: "The participant does not have a schedule"
-  too_many_declarations: "The participant has more declarations than milestones"
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
   declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"
   invalid_data_structure: correct json data structure required. See API docs for reference

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :early_career_teacher_profile, class: ParticipantProfile::ECT do
     user
     school_cohort
+    schedule
 
     trait :sparsity_uplift do
       sparsity_uplift { true }

--- a/spec/factories/finance/milestones.rb
+++ b/spec/factories/finance/milestones.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :milestone, class: "Finance::Milestone" do
+    name { "Test milestone" }
+
+    start_date { Time.zone.now - 1.month }
+    milestone_date { Time.zone.now + 1.month }
+    payment_date { Time.zone.now + 2.months }
+  end
+end

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :schedule, class: "Finance::Schedule" do
+    name { "Test schedule" }
+    after(:create) do |schedule|
+      [Date.new(2021, 9, 1), Date.new(2021, 11, 1), Date.new(2022, 2, 1)].each do |start_date|
+        create(
+          :milestone,
+          schedule: schedule,
+          start_date: start_date,
+          milestone_date: start_date + 1.month,
+          payment_date: start_date + 2.months,
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :mentor_profile, class: ParticipantProfile::Mentor do
     user
     school_cohort
+    schedule
 
     trait :sparsity_uplift do
       sparsity_uplift { true }

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       end
     end
 
-    schedule { create(:schedule) }
+    schedule
     teacher_profile
 
     transient do

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
       end
     end
 
+    schedule { create(:schedule) }
     teacher_profile
 
     transient do

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
       {
         participant_id: ect_profile.user.id,
         declaration_type: "started",
-        declaration_date: (ect_profile.schedule.milestones.first.start_date + 1.days).rfc3339,
+        declaration_date: (ect_profile.schedule.milestones.first.start_date + 1.day).rfc3339,
         course_identifier: "ecf-induction",
       }
     end

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -9,25 +9,30 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  let(:retained_params) { params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:retained_ect_params) { ect_params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:milestone_start_date) { ect_profile.schedule.milestones[1].start_date }
+
   before do
-    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+    travel_to milestone_start_date + 2.days
   end
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when valid user is an early_career_teacher" do
     %w[training-event-attended self-study-material-completed other].each do |evidence_held|
       it "creates a participant and profile declaration" do
-        expect { described_class.call(ect_params.merge(evidence_held: evidence_held)) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+        expect { described_class.call(retained_ect_params.merge(evidence_held: evidence_held)) }
+            .to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
       end
     end
 
     it "fails when course is for mentor" do
-      params = ect_params.merge({ course_identifier: "ecf-mentor" })
+      params = retained_ect_params.merge({ course_identifier: "ecf-mentor" })
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
     end
   end
@@ -40,19 +45,19 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
 
   context "when declaration type is invalid" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when evidence held is invalid" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when declaration date is invalid" do
     it "raises a ParameterMissing error" do
-      params = ect_params.merge({ declaration_date: "2021-06-21 08:46:29" })
+      params = retained_ect_params.merge({ declaration_date: "2021-06-21 08:46:29" })
       expected_msg = /The property '#\/declaration_date' must be a valid RCF3339 date/
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing, expected_msg)
     end

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+  end
+
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+  end
+
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -8,25 +8,30 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  let(:retained_params) { params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:retained_mentor_params) { mentor_params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:milestone_start_date) { mentor_profile.schedule.milestones[1].start_date }
+
   before do
-    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+    travel_to milestone_start_date + 2.days
   end
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when valid user is a mentor" do
     %w[training-event-attended self-study-material-completed other].each do |evidence_held|
       it "creates a participant and profile declaration" do
-        expect { described_class.call(mentor_params.merge(evidence_held: evidence_held)) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+        expect { described_class.call(retained_mentor_params.merge(evidence_held: evidence_held)) }
+            .to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
       end
     end
 
     it "fails when course is for an early_career_teacher" do
-      params = mentor_params.merge({ course_identifier: "ecf-induction" })
+      params = retained_mentor_params.merge({ course_identifier: "ecf-induction" })
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
     end
   end
@@ -39,13 +44,13 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
 
   context "when declaration type is invalid" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when evidence held is invalid" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 end

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+  end
+
   context "when sending event for an npq course" do
     it "creates a participant and profile declaration" do
       expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  let(:retained_params) { params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:retained_npq_params) { npq_params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:milestone_start_date) { npq_profile.schedule.milestones[1].start_date }
+
   before do
-    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+    travel_to milestone_start_date + 2.days
   end
 
   context "when sending event for an npq course" do
     it "creates a participant and profile declaration" do
-      expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+      expect { described_class.call(retained_npq_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
     end
   end
 
@@ -26,19 +30,19 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
 
   context "when declaration type is invalid" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(declaration_type: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when declaration type is valid for ECF but not NPQ" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(declaration_type: "retained-3")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(declaration_type: "retained-3")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 
   context "when evidence held is invalid" do
     it "raises a ParameterMissing error" do
-      expect { described_class.call(params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
+      expect { described_class.call(retained_params.merge(evidence_held: "invalid")) }.to raise_error(ActionController::ParameterMissing)
     end
   end
 end

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+  end
+
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
@@ -50,7 +54,7 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
 
   context "when declaration date is in the past" do
     it "does not raise ParameterMissing error" do
-      params = ect_params.merge({ declaration_date: (Time.zone.now - 100.years).rfc3339(9) })
+      params = ect_params.merge({ declaration_date: (Time.zone.now - 1.day).rfc3339(9) })
       expect { described_class.call(params) }.to_not raise_error
     end
   end

--- a/spec/services/record_declarations/started/mentor_spec.rb
+++ b/spec/services/record_declarations/started/mentor_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RecordDeclarations::Started::Mentor do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+  end
+
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)

--- a/spec/services/record_declarations/started/npq_spec.rb
+++ b/spec/services/record_declarations/started/npq_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RecordDeclarations::Started::NPQ do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+  end
+
   context "when sending event for an npq course" do
     it "creates a participant and profile declaration" do
       expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)

--- a/spec/services/record_declarations/started/npq_spec.rb
+++ b/spec/services/record_declarations/started/npq_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RecordDeclarations::Started::NPQ do
   include_context "service record declaration params"
 
   before do
-    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
+    travel_to npq_profile.schedule.milestones.first.start_date + 2.days
   end
 
   context "when sending event for an npq course" do

--- a/spec/services/record_participant_declaration_service_spec.rb
+++ b/spec/services/record_participant_declaration_service_spec.rb
@@ -2,62 +2,27 @@
 
 require "rails_helper"
 
+require_relative "../shared/context/service_record_declaration_params.rb"
+require_relative "../shared/context/lead_provider_profiles_and_courses.rb"
+
 RSpec.describe RecordParticipantDeclaration do
-  let(:ecf_lead_provider) { create(:lead_provider) }
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: ecf_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
-  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
-  let!(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
-  let(:npq_profile) do
-    create(:npq_validation_data,
-           npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
-  end
-  let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: npq_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "started",
-      course_identifier: "npq-leading-teaching",
-      lead_provider_from_token: another_lead_provider,
-    }
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
+
+  before do
+    travel_to ect_profile.schedule.milestones.first.start_date + 2.days
   end
 
   context "when sending event for an npq course" do
-    let(:npq_params) do
-      params.merge({ lead_provider_from_token: cpd_lead_provider })
-    end
     it "creates a participant and profile declaration" do
       expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
     end
   end
 
   context "when sending event for an ect course" do
-    let(:ect_profile) { create(:early_career_teacher_profile) }
-    let(:mentor_profile) { create(:mentor_profile) }
-    let(:ect_params) do
-      params.merge({ lead_provider_from_token: cpd_lead_provider })
-    end
-    let(:mentor_params) do
-      ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
-    end
-    let(:induction_coordinator_params) do
-      ect_params.merge({ user_id: induction_coordinator_profile.user_id })
-    end
-    let(:delivery_partner) { create(:delivery_partner) }
-    let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-    let!(:partnership) do
-      create(:partnership,
-             school: ect_profile.school,
-             lead_provider: cpd_lead_provider.lead_provider,
-             cohort: ect_profile.cohort,
-             delivery_partner: delivery_partner)
-    end
-
     context "when lead providers don't match" do
       it "raises a ParameterMissing error" do
-        expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
+        expect { described_class.call(ect_params.merge(cpd_lead_provider: another_lead_provider)) }.to raise_error(ActionController::ParameterMissing)
       end
     end
 

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -6,8 +6,9 @@ RSpec.shared_context "lead provider profiles and courses" do
   let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
 
   # ECF setup
-  let(:ect_profile) { create(:early_career_teacher_profile) }
-  let(:mentor_profile) { create(:mentor_profile) }
+  let(:ecf_lead_provider) { cpd_lead_provider.lead_provider }
+  let!(:ect_profile) { create(:early_career_teacher_profile) }
+  let!(:mentor_profile) { create(:mentor_profile) }
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:delivery_partner) { create(:delivery_partner) }
   let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -24,8 +24,17 @@ RSpec.shared_context "lead provider profiles and courses" do
   let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
   let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
   let!(:npq_profile) do
-    create(:npq_validation_data,
-           npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
+    validation_data = create(
+      :npq_validation_data,
+      npq_lead_provider: npq_lead_provider,
+      npq_course: npq_course,
+    )
+    create(
+      :participant_profile,
+      :npq,
+      validation_data: validation_data,
+      user: validation_data.user,
+      teacher_profile: validation_data.user.teacher_profile,
+    )
   end
 end

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -21,12 +21,12 @@ RSpec.shared_context "service record declaration params" do
     ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor", declaration_date: mentor_declaration_date.rfc3339 })
   end
 
-  let(:npq_declaration_date) { ect_profile.schedule.milestones.first.start_date + 1.day }
+  let(:npq_declaration_date) { npq_profile.schedule.milestones.first.start_date + 1.day }
   let(:npq_params) do
     params.merge({
       lead_provider_from_token: cpd_lead_provider,
-      user_id: npq_profile.user_id,
-      course_identifier: "npq-leading-teaching",
+      user_id: npq_profile.user.id,
+      course_identifier: npq_profile.validation_data.npq_course.identifier,
       evidence_held: "yes",
       declaration_date: npq_declaration_date.rfc3339,
     })

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -6,7 +6,7 @@ RSpec.shared_context "service record declaration params" do
     {
       user_id: ect_profile.user.id,
       declaration_date: ect_declaration_date.rfc3339,
-      declaration_type: "retained-1",
+      declaration_type: "started",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
       evidence_held: "other",

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "service record declaration params" do
+  let(:ect_declaration_date) { ect_profile.schedule.milestones.first.start_date + 1.day }
   let(:params) do
     {
       user_id: ect_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
+      declaration_date: ect_declaration_date.rfc3339,
       declaration_type: "retained-1",
       course_identifier: "ecf-induction",
       lead_provider_from_token: another_lead_provider,
@@ -14,12 +15,23 @@ RSpec.shared_context "service record declaration params" do
   let(:ect_params) do
     params.merge({ lead_provider_from_token: cpd_lead_provider })
   end
+
+  let(:mentor_declaration_date) { mentor_profile.schedule.milestones.first.start_date + 1.day }
   let(:mentor_params) do
-    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
+    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor", declaration_date: mentor_declaration_date.rfc3339 })
   end
+
+  let(:npq_declaration_date) { ect_profile.schedule.milestones.first.start_date + 1.day }
   let(:npq_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider, user_id: npq_profile.user_id, course_identifier: "npq-leading-teaching", evidence_held: "yes" })
+    params.merge({
+      lead_provider_from_token: cpd_lead_provider,
+      user_id: npq_profile.user_id,
+      course_identifier: "npq-leading-teaching",
+      evidence_held: "yes",
+      declaration_date: npq_declaration_date.rfc3339,
+    })
   end
+
   let(:induction_coordinator_params) do
     ect_params.merge({ user_id: induction_coordinator_profile.user_id })
   end


### PR DESCRIPTION
### Context
We want to check that the declaration has been sent in the correct milestone period.

This does not check that the declaration type (started, retained) matches the milestone. 

### Changes proposed in this pull request
1. Add start dates to milestones
2. Remove non-standard schedules from the seed
3. Make all participant declaration tests aware that they need to send the correct dates on them. 

### Guidance to review
As you can see, if a participant has no schedule, the API call will fail - cause it cannot check the dates. I can temporarily change it to be an early return (so the validation passes), but it really tells me we should populate schedules on participant profiles. 

I need to set up schedules for all test participants so this can be properly tested. 

So I think I will extract the migration part from this PR, add a rake task, deploy everywhere and run a script so all participants are on September schedule. 

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Try sending a declaration for a participant before 1st of September. It should fail. 