### PR TITLE
Populate schedules on participant profiles

### DIFF
--- a/app/models/finance/schedule.rb
+++ b/app/models/finance/schedule.rb
@@ -3,4 +3,8 @@
 class Finance::Schedule < ApplicationRecord
   has_many :milestones
   has_many :participant_profiles
+
+  def self.default
+    find_by(name: "ECF September standard 2021")
+  end
 end

--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -55,6 +55,7 @@ private
     teacher_profile.school = profile.school = School.find_by(urn: school_urn)
     teacher_profile.save!
 
+    profile.schedule = Finance::Schedule.default
     profile.teacher_profile = teacher_profile
     profile.user_id = user_id
     profile.save!

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -15,7 +15,7 @@ module EarlyCareerTeachers
           profile.school = school_cohort.school
         end
 
-        ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile }.merge(ect_attributes))
+        ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(ect_attributes))
       end
     end
 

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -19,7 +19,7 @@ module Mentors
           profile.school = school_cohort.school
         end
 
-        ParticipantProfile::Mentor.create!({ teacher_profile: teacher_profile }.merge(mentor_attributes))
+        ParticipantProfile::Mentor.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(mentor_attributes))
       end
     end
 

--- a/db/migrate/20210811124609_add_start_date_to_milestones.rb
+++ b/db/migrate/20210811124609_add_start_date_to_milestones.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStartDateToMilestones < ActiveRecord::Migration[6.1]
+  def change
+    add_column :milestones, :start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_11_065838) do
+ActiveRecord::Schema.define(version: 2021_08_11_124609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -346,6 +346,7 @@ ActiveRecord::Schema.define(version: 2021_08_11_065838) do
     t.uuid "schedule_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "start_date"
     t.index ["schedule_id"], name: "index_milestones_on_schedule_id"
   end
 

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -63,7 +63,10 @@ end
 User.find_or_create_by!(email: "npq-registrant@example.com") do |user|
   user.update!(full_name: "NPQ registrant")
   teacher_profile = user.teacher_profile || user.create_teacher_profile
-  ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile)
+
+  ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
+    profile.update!(schedule: Finance::Schedule.default)
+  end
 end
 
 mentor = User.find_or_create_by!(email: "rp-mentor-ambition@example.com") do |user|
@@ -72,6 +75,7 @@ mentor = User.find_or_create_by!(email: "rp-mentor-ambition@example.com") do |us
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"))
+    profile.update!(schedule: Finance::Schedule.default)
   end
 end
 
@@ -81,6 +85,7 @@ mentor_two = User.find_or_create_by!(email: "rp-mentor-edt@example.com") do |use
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"))
+    profile.update!(schedule: Finance::Schedule.default)
   end
 end
 
@@ -90,6 +95,7 @@ mentor_three = User.find_or_create_by!(email: "rp-mentor-ucl@example.com") do |u
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"))
+    profile.update!(schedule: Finance::Schedule.default)
   end
 end
 
@@ -99,6 +105,7 @@ User.find_or_create_by!(email: "rp-ect-ambition@example.com") do |user|
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"), mentor_profile: mentor.mentor_profile)
+    profile.update!(schedule: Finance::Schedule.default)
   end
 end
 
@@ -108,6 +115,7 @@ User.find_or_create_by!(email: "rp-ect-edt@example.com") do |user|
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), mentor_profile: mentor_two.mentor_profile)
+    profile.update!(schedule: Finance::Schedule.default)
   end
 end
 
@@ -117,6 +125,7 @@ User.find_or_create_by!(email: "rp-ect-ucl@example.com") do |user|
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), mentor_profile: mentor_three.mentor_profile)
+    profile.update!(schedule: Finance::Schedule.default)
   end
 end
 

--- a/db/seeds/schedules.rb
+++ b/db/seeds/schedules.rb
@@ -2,65 +2,17 @@
 
 ecf_september_standard_2021 = Finance::Schedule.find_or_create_by!(name: "ECF September standard 2021")
 [
-  { name: "Output 1 - Participant Start", milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
-  { name: "Output 2 – Retention Point 1", milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-  { name: "Output 3 – Retention Point 2", milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
-  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
 ].each do |hash|
   Finance::Milestone.find_or_create_by!(
     schedule: ecf_september_standard_2021,
     name: hash[:name],
-    milestone_date: hash[:milestone_date],
-    payment_date: hash[:payment_date],
-  )
-end
-
-ecf_september_extended_2021 = Finance::Schedule.find_or_create_by!(name: "ECF September extended 2021")
-[
-  { name: "Output 1 - Participant Start", milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
-  { name: "Output 2 – Retention Point 1", milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 3 – Retention Point 2", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
-  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
-  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
-].each do |hash|
-  Finance::Milestone.find_or_create_by!(
-    schedule: ecf_september_extended_2021,
-    name: hash[:name],
-    milestone_date: hash[:milestone_date],
-    payment_date: hash[:payment_date],
-  )
-end
-
-ecf_january_reduced_2022 = Finance::Schedule.find_or_create_by!(name: "ECF January reduced 2022")
-[
-  { name: "Output 1 - Participant Start", milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-  { name: "Output 2 and 3 – Retention Point 1 and 2", milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
-  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
-].each do |hash|
-  Finance::Milestone.find_or_create_by!(
-    schedule: ecf_january_reduced_2022,
-    name: hash[:name],
-    milestone_date: hash[:milestone_date],
-    payment_date: hash[:payment_date],
-  )
-end
-
-ecf_january_extended_2022 = Finance::Schedule.find_or_create_by!(name: "ECF January extended 2021")
-[
-  { name: "Output 1 - Participant Start", milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-  { name: "Output 2 and 3 – Retention Point 1 and 2", milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 4 – Retention Point 3", milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
-  { name: "Output 5 – Retention Point 4", milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
-  { name: "Output 6 – Participant Completion", milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
-].each do |hash|
-  Finance::Milestone.find_or_create_by!(
-    schedule: ecf_january_extended_2022,
-    name: hash[:name],
+    start_date: hash[:start_date],
     milestone_date: hash[:milestone_date],
     payment_date: hash[:payment_date],
   )

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -213,9 +213,11 @@ end
 user = User.find_or_create_by!(email: "fip-ect@example.com") do |u|
   u.full_name = "FIP ECT"
 end
+
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000103").school_cohorts.find_by(cohort: Cohort.current)
+  ect_profile.schedule = Finance::Schedule.default
 end
 
 # FIP mentor
@@ -225,6 +227,7 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000104").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 
 # FIP mentor already doing an NPQ with the same email
@@ -236,8 +239,9 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
 end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
-ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile)
+ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
 
 # FIP mentor already doing an NPQ with a different email
 user = User.find_or_create_by!(email: "fip-mentor-npq-other-email@example.com") do |u|
@@ -246,7 +250,7 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
   profile.trn = "2369848"
 end
-ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile)
+ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
 
 user = User.find_or_create_by!(email: "fip-mentor2@example.com") do |u|
   u.full_name = "FIP Mentor"
@@ -254,6 +258,7 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 
 # FIP mentor already mentoring at another school with another email
@@ -263,8 +268,9 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
   profile.trn = "1357010"
 end
-ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-  profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
+ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
+  mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 
 user = User.find_or_create_by!(email: "fip-mentor3@example.com") do |u|
@@ -273,6 +279,7 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000106").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 
 # SIT also a mentor
@@ -280,6 +287,7 @@ user = User.find_by(email: "cpd-test+tutor-17@example.com")
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = user.induction_coordinator_profile.schools.first.school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 
 # Extra participant records
@@ -289,6 +297,7 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000107").school_cohorts.find_by(cohort: Cohort.current)
+  ect_profile.schedule = Finance::Schedule.default
 end
 
 user = User.find_or_create_by!(email: "fip-mentor4@example.com") do |u|
@@ -297,6 +306,7 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000108").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 
 user = User.find_or_create_by!(email: "fip-mentor5@example.com") do |u|
@@ -305,5 +315,6 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000109").school_cohorts.find_by(cohort: Cohort.current)
+  mentor_profile.schedule = Finance::Schedule.default
 end
 # TODO: add validation data and eligibility records when merged

--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -27,21 +27,21 @@ def generate_mentors(lead_provider, school, cohort, logger)
 
   10.times do
     mentor = create_teacher
-    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort)
+    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort, schedule: Finance::Schedule.default)
 
     ect_count = rand(0..3)
     ect_count.times do
       ect = create_teacher
-      ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile)
+      ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, schedule: Finance::Schedule.default)
     end
     logger.info(" Mentor with user_id #{mentor.id} generated with #{ect_count} ECTs")
   end
   2.times do
     mentor = create_teacher
-    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort, status: "withdrawn")
+    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort, status: "withdrawn", schedule: Finance::Schedule.default)
 
     ect = create_teacher
-    ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn")
+    ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn", schedule: Finance::Schedule.default)
   end
   new_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
   logger.info(" Before: #{existing_mentor_count} mentors, after: #{new_mentor_count}")


### PR DESCRIPTION
### Context
I think every participant profile should have a schedule. That's because we will want to validate whether the declaration date on the declarations LPs send us matches that schedule.

### Changes proposed in this pull request
Find all places where we create participant profiles, and add a default schedule to them. Yes, NPQ participants will need their own schedule, I think, but I don't know what it is - when we do we will add it to prod and run an update.

When this is merged and deployed, I will create the default schedule on each environment, and run something like 
```
ParticipantProfile.each { |profile| profile.update!(schedule: Finance::Schedule.default) }
```

### Guidance to review
I added `start_date` migration here because I want the milestones I create in production to have the right shape. Or as right as they can have as far as I know. 
