### PR TITLE
Only show validated TRNs after ECF validation

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -16,6 +16,17 @@ class ParticipantSerializer
     def participant_active?(user)
       user.teacher_profile.ecf_profile&.active?
     end
+
+    def trn(user)
+      user.teacher_profile.trn || user.teacher_profile.ecf_profile.ecf_participant_validation_data&.trn
+    end
+
+    def validated_trn(user)
+      eligibility_status = user.teacher_profile.ecf_profile.ecf_participant_eligibility&.status
+      if %w[matched eligible].include?(eligibility_status)
+        user.teacher_profile.trn
+      end
+    end
   end
 
   set_id :id
@@ -49,11 +60,11 @@ class ParticipantSerializer
   end
 
   active_participant_attribute :teacher_reference_number do |user|
-    user.teacher_profile.trn
+    trn(user)
   end
 
   active_participant_attribute :teacher_reference_number_validated do |user|
-    user.teacher_profile.trn.present?
+    trn(user).nil? ? nil : validated_trn(user).present?
   end
 
   active_participant_attribute :eligible_for_funding do |user|

--- a/spec/factories/ecf_participant_validation_data.rb
+++ b/spec/factories/ecf_participant_validation_data.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_participant_validation_data, class: ECFParticipantValidationData do
+    participant_profile factory: :participant_profile, traits: [:ecf]
+    full_name { Faker::Name.name }
+    trn { sprintf("%07i", Random.random_number(9_999_999)) }
+    date_of_birth { Faker::Date.birthday }
+  end
+end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["participant_type"]).to eql "mentor"
           expect(mentor_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(mentor_row["teacher_reference_number"]).to eql mentor.teacher_profile.trn
-          expect(mentor_row["teacher_reference_number_validated"]).to eql "true"
+          expect(mentor_row["teacher_reference_number_validated"]).to eql "false"
           expect(mentor_row["eligible_for_funding"]).to be_empty
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty
@@ -176,7 +176,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(ect_row["participant_type"]).to eql "ect"
           expect(ect_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(ect_row["teacher_reference_number"]).to eql ect.teacher_profile.trn
-          expect(ect_row["teacher_reference_number_validated"]).to eql "true"
+          expect(ect_row["teacher_reference_number_validated"]).to eql "false"
           expect(mentor_row["eligible_for_funding"]).to be_empty
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty


### PR DESCRIPTION
There is a chance that something could go wrong at ECF TRN validation
that means a TRN we get from NPQ is not correct. Be conservative in
declaring that the TRN is validated.

Also, share some TRN pre-validation
