### PR TITLE
Add CIP changes to participant validation journey

### DIFF
--- a/app/views/participants/validations/complete_cip.html.erb
+++ b/app/views/participants/validations/complete_cip.html.erb
@@ -4,11 +4,13 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_panel title: title, body: nil, classes: "govuk-!-margin-bottom-8" %>
     <h2 class="govuk-heading-m">What happens next</h2>
-    <p class="govuk-body">We may need to contact you for more information to complete your registration.</p>
     <% if @participant_profile.ect? %>
-      <p class="govuk-body">Your training materials will be available in August. We’ll email you with a link to access them.</p>
+      <p class="govuk-body">Your training materials will be available by the end of August. We’ll email you with a link to access them.</p>
     <% else %>
       <p class="govuk-body">If you need access to training materials, we’ll email you a link in the next 48 hours.</p>
+    <% end %>
+    <% if current_user.induction_coordinator? %>
+      <%= govuk_link_to "Manage induction for your school", induction_coordinator_dashboard_path(current_user) %>
     <% end %>
   </div>
 </div>

--- a/app/views/participants/validations/manual_details_check_cip.html.erb
+++ b/app/views/participants/validations/manual_details_check_cip.html.erb
@@ -6,6 +6,13 @@
     <%= govuk_panel title: title, body: nil, classes: "govuk-!-margin-bottom-8" %>
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk-body">We may need to contact you for more information to complete your registration.</p>
-    <p class="govuk-body">Your training materials will be available in August. We’ll email you with a link to access them.</p>
+    <% if @participant_profile.ect? %>
+      <p class="govuk-body">Your training materials will be available by the end of August. We’ll email you with a link to access them.</p>
+    <% else %>
+      <p class="govuk-body">If you need access to training materials, we’ll email you a link in the next 48 hours.</p>
+    <% end %>
+    <% if current_user.induction_coordinator? %>
+      <%= govuk_link_to "Manage induction for your school", induction_coordinator_dashboard_path(current_user) %>
+    <% end %>
   </div>
 </div>

--- a/spec/features/participants/happy_validation_journeys_for_ect_cip_spec.rb
+++ b/spec/features/participants/happy_validation_journeys_for_ect_cip_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./participant_validation_steps"
+
+RSpec.feature "ECT participant validation journey for CIP induction", type: :feature, js: true, with_feature_flags: { participant_validation: "active" } do
+  include ParticipantValidationSteps
+
+  scenario "Participant validates their details" do
+    given_there_is_a_school_that_has_chosen_cip_for_2021
+    and_i_am_signed_in_as_an_ect_participant
+    then_i_should_see_the_do_you_know_your_trn_page
+
+    when_i_select "Yes, I know my TRN"
+    and_i_click "Continue"
+    then_i_should_see_the_have_you_changed_your_name_page
+
+    when_i_select "No, I have the same name"
+    and_i_click "Continue"
+    then_i_should_see_the_tell_us_your_details_page
+
+    when_i_enter_the_participants_details
+    and_i_click "Continue"
+    then_i_should_see_the_confirm_details_page
+
+    when_i_click_continue_to_proceed_with_validation
+    then_i_should_see_the_checking_details_page_for_matched_cip_ect_participant
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: Complete ECT CIP"
+  end
+end

--- a/spec/features/participants/happy_validation_journeys_for_mentor_cip_spec.rb
+++ b/spec/features/participants/happy_validation_journeys_for_mentor_cip_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./participant_validation_steps"
+
+RSpec.feature "Mentor participant validation journey for CIP induction", type: :feature, js: true, with_feature_flags: { participant_validation: "active" } do
+  include ParticipantValidationSteps
+
+  scenario "Participant validates their details" do
+    given_there_is_a_school_that_has_chosen_cip_for_2021
+    and_i_am_signed_in_as_a_mentor_participant
+    then_i_should_see_the_do_you_know_your_trn_page
+
+    when_i_select "Yes, I know my TRN"
+    and_i_click "Continue"
+    then_i_should_see_the_have_you_changed_your_name_page
+
+    when_i_select "No, I have the same name"
+    and_i_click "Continue"
+    then_i_should_see_the_tell_us_your_details_page
+
+    when_i_enter_the_participants_details
+    and_i_click "Continue"
+    then_i_should_see_the_confirm_details_page
+
+    when_i_click_continue_to_proceed_with_validation
+    then_i_should_see_the_checking_details_page_for_matched_cip_mentor_participant
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Participant Validation: Complete mentor CIP"
+  end
+end


### PR DESCRIPTION
### Context
Rounds out the participant validation journey with changes for CIP

### Changes proposed in this pull request
Changes to the "complete" and "manual checking" end of validation pages.
Specs to cover CIP ect and mentor journey

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
