### PR TITLE
Refactor tests around NPQ

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,9 +51,7 @@ class User < ApplicationRecord
     early_career_teacher_profile.present?
   end
 
-  def ect?
-    early_career_teacher?
-  end
+  alias_method :ect?, :early_career_teacher?
 
   def mentor?
     mentor_profile.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,10 @@ class User < ApplicationRecord
     early_career_teacher_profile.present?
   end
 
+  def ect?
+    early_career_teacher?
+  end
+
   def mentor?
     mentor_profile.present?
   end

--- a/spec/components/admin/participants/details_spec.rb
+++ b/spec/components/admin/participants/details_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
   end
 
   context "for unvalidated npq profile" do
-    let(:profile) { create :participant_profile, :npq }
+    let(:profile) { create :participant_profile, :npq_with_validation_data }
 
     it "renders all the required information" do
       expect(rendered).to have_contents(
@@ -51,7 +51,7 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
   end
 
   context "for validated npq profile" do
-    let(:profile) { create :participant_profile, :npq }
+    let(:profile) { create :participant_profile, :npq_with_validation_data }
 
     before do
       allow(profile).to receive(%i[approved? rejected?].sample).and_return true

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -48,10 +48,14 @@ FactoryBot.define do
     trait :npq do
       school
       teacher_profile { association :teacher_profile, school: school }
-
-      validation_data { association :npq_validation_data, user: teacher_profile.user }
-
       participant_type { :npq }
+    end
+
+    trait :npq_with_validation_data do
+      school
+      teacher_profile { association :teacher_profile, school: school }
+      participant_type { :npq }
+      validation_data { association :npq_validation_data, user: teacher_profile.user }
     end
 
     trait :sparsity_uplift do

--- a/spec/services/record_declarations/started/npq_spec.rb
+++ b/spec/services/record_declarations/started/npq_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-require_relative "../../../shared/context/service_record_declaration_params.rb"
-require_relative "../../../shared/context/lead_provider_profiles_and_courses.rb"
+require_relative "../../../shared/context/service_record_declaration_params"
+require_relative "../../../shared/context/lead_provider_profiles_and_courses"
 
 RSpec.describe RecordDeclarations::Started::NPQ do
   include_context "lead provider profiles and courses"

--- a/spec/services/record_participant_declaration_service_spec.rb
+++ b/spec/services/record_participant_declaration_service_spec.rb
@@ -5,85 +5,119 @@ require "rails_helper"
 RSpec.describe RecordParticipantDeclaration do
   let(:ecf_lead_provider) { create(:lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: ecf_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
+  let(:another_cpd_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
   let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
-  let!(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
-  let(:npq_profile) do
-    create(:npq_validation_data,
-           npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
-  end
+
+  let(:user) { create(:user) }
+  let(:teacher_profile) { create(:teacher_profile, user: user) }
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
-  let(:params) do
-    {
-      user_id: npq_profile.user.id,
-      declaration_date: "2021-06-21T08:46:29Z",
-      declaration_type: "started",
-      course_identifier: "npq-leading-teaching",
-      lead_provider_from_token: another_lead_provider,
-    }
-  end
 
   context "when sending event for an npq course" do
-    let(:npq_params) do
-      params.merge({ lead_provider_from_token: cpd_lead_provider })
+    let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
+
+    let(:npq_validation_data) do
+      create(:npq_validation_data,
+             npq_lead_provider: npq_lead_provider,
+             npq_course: npq_course,
+             user: user)
     end
+
+    let(:params) do
+      {
+        user_id: user.id,
+        declaration_date: "2021-06-21T08:46:29Z",
+        declaration_type: "started",
+        course_identifier: "npq-leading-teaching",
+        lead_provider_from_token: cpd_lead_provider,
+      }
+    end
+
+    let!(:npq_participant_profile) { create(:participant_profile, :npq, teacher_profile: teacher_profile, validation_data: npq_validation_data) }
+
     it "creates a participant and profile declaration" do
-      expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+      expect { described_class.call(params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
     end
   end
 
   context "when sending event for an ect course" do
-    let(:ect_profile) { create(:early_career_teacher_profile) }
-    let(:mentor_profile) { create(:mentor_profile) }
-    let(:ect_params) do
-      params.merge({ lead_provider_from_token: cpd_lead_provider })
+    let(:params) do
+      {
+        user_id: user.id,
+        declaration_date: "2021-06-21T08:46:29Z",
+        declaration_type: "started",
+        course_identifier: "ecf-induction",
+        lead_provider_from_token: cpd_lead_provider,
+      }
     end
-    let(:mentor_params) do
-      ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
-    end
-    let(:induction_coordinator_params) do
-      ect_params.merge({ user_id: induction_coordinator_profile.user_id })
-    end
+
     let(:delivery_partner) { create(:delivery_partner) }
-    let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
-    let!(:partnership) do
+
+    let(:school_cohort) { create(:school_cohort, school: profile.school, cohort: profile.cohort) }
+
+    let(:partnership) do
       create(:partnership,
-             school: ect_profile.school,
+             school: profile.school,
              lead_provider: cpd_lead_provider.lead_provider,
-             cohort: ect_profile.cohort,
+             cohort: profile.cohort,
              delivery_partner: delivery_partner)
     end
 
     context "when lead providers don't match" do
+      before do
+        params[:lead_provider_from_token] = another_cpd_lead_provider
+      end
+
       it "raises a ParameterMissing error" do
         expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
       end
     end
 
     context "when valid user is an early_career_teacher" do
+      before do
+        school_cohort
+        partnership
+      end
+
+      let(:profile) { create(:early_career_teacher_profile, teacher_profile: teacher_profile) }
+
       it "creates a participant and profile declaration" do
-        expect { described_class.call(ect_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+        expect { described_class.call(params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
       end
 
       it "fails when course is for mentor" do
-        params = ect_params.merge({ course_identifier: "ecf-mentor" })
+        params.merge!({ course_identifier: "ecf-mentor" })
         expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
       end
     end
 
     context "when valid user is a mentor" do
+      before do
+        school_cohort
+        partnership
+      end
+
+      let(:profile) { create(:mentor_profile, teacher_profile: teacher_profile) }
+
+      let(:mentor_params) do
+        params.merge({ user_id: profile.user.id, course_identifier: "ecf-mentor" })
+      end
+
       it "creates a participant and profile declaration" do
         expect { described_class.call(mentor_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
       end
 
       it "fails when course is for an early_career_teacher" do
         params = mentor_params.merge({ course_identifier: "ecf-induction" })
+
         expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
       end
     end
 
     context "when user is not a participant" do
+      let(:induction_coordinator_params) do
+        params.merge({ user_id: induction_coordinator_profile.user_id })
+      end
+
       it "does not create a declaration record and raises ParameterMissing for an invalid user_id" do
         expect { described_class.call(induction_coordinator_params) }.to raise_error(ActionController::ParameterMissing)
       end

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -20,11 +20,18 @@ RSpec.shared_context "lead provider profiles and courses" do
   end
 
   # NPQ setup
+  let(:npq_user) { create(:user) }
+  let(:npq_teacher_profile) { create(:teacher_profile, user: npq_user) }
+  let(:npq_participant_profile) { create(:participant_profile, :npq, teacher_profile: npq_teacher_profile) }
+
   let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider) }
   let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
-  let!(:npq_profile) do
+
+  let(:npq_profile) do
     create(:npq_validation_data,
            npq_lead_provider: npq_lead_provider,
-           npq_course: npq_course)
+           npq_course: npq_course,
+           profile: npq_participant_profile,
+           user: npq_user)
   end
 end

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -17,9 +17,18 @@ RSpec.shared_context "service record declaration params" do
   let(:mentor_params) do
     ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor" })
   end
+
   let(:npq_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider, user_id: npq_profile.user_id, course_identifier: "npq-leading-teaching", evidence_held: "yes" })
+    {
+      user_id: npq_profile.user_id,
+      declaration_date: "2021-06-21T08:46:29Z",
+      declaration_type: "retained-1",
+      course_identifier: "npq-leading-teaching",
+      lead_provider_from_token: cpd_lead_provider,
+      evidence_held: "yes",
+    }
   end
+
   let(:induction_coordinator_params) do
     ect_params.merge({ user_id: induction_coordinator_profile.user_id })
   end


### PR DESCRIPTION

### Context

- There is a callback `NPQValidationData#update_participant_profile`
- It creates and persists multiple database records
- It needs to be removed so we can have finer grain control of when it happens and the behaviour of it
- However many tests rely on this mechanism for the setup of its test data
- Therefore removing this method cannot be done first time round
- By reducing the dependency of this mechanism in the tests and instead setting up the data correctly this callback can be more easily removed in the next change

### Changes proposed in this pull request

- Removes most of test reliance on `NPQValidationData#update_participant_profile`

### Guidance to review

- There should be no behavioural change
- The tests should continue to work if `NPQValidationData#update_participant_profile` had been deleted

### Testing

- n/a

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- No behavioural changes have been made so app should behave the same 