### PR TITLE
Prevent induction coordinator from adding themselves as a mentor at multiple schools

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -65,7 +65,7 @@ module Schools
     end
 
     def can_add_self?
-      school_cohort.active_ecf_participants.exclude? current_user
+      !current_user.mentor?
     end
 
     def mentor_options

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
       it "sets the participant_type to mentor as well as full name and email to match current_user details" do
         expect { subject.type = "self" }
           .to change { subject.participant_type }.to(:mentor)
-          .and change { subject.full_name }.to(user.full_name)
-          .and change { subject.email }.to(user.email)
+                                                 .and change { subject.full_name }.to(user.full_name)
+                                                                                  .and change { subject.email }.to(user.email)
       end
     end
   end
@@ -110,6 +110,34 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
 
       it "returns false" do
         expect(subject).not_to be_email_already_taken
+      end
+    end
+  end
+
+  describe "can_add_self?" do
+    context "when the user is not a mentor" do
+      it "returns true" do
+        expect(subject.can_add_self?).to be true
+      end
+    end
+
+    context "when the user is a mentor at another school" do
+      before do
+        create(:participant_profile, :mentor, user: user)
+      end
+
+      it "returns false" do
+        expect(subject.can_add_self?).to be false
+      end
+    end
+
+    context "when the user is a mentor at this school" do
+      before do
+        create(:participant_profile, :mentor, user: user, school_cohort: school_cohort)
+      end
+
+      it "returns false" do
+        expect(subject.can_add_self?).to be false
       end
     end
   end

--- a/spec/requests/schools/add_participants_spec.rb
+++ b/spec/requests/schools/add_participants_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe "Schools::AddParticipant", type: :request do
                       full_name: Faker::Name.name,
                       email: Faker::Internet.email,
                       mentor_id: "later",
-                      school_cohort_id: school_cohort.id)
+                      school_cohort_id: school_cohort.id,
+                      current_user_id: user.id)
           get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/add/#{step.to_s.dasherize}"
         end
 
@@ -72,7 +73,8 @@ RSpec.describe "Schools::AddParticipant", type: :request do
                     full_name: Faker::Name.name,
                     email: email,
                     mentor_id: "later",
-                    school_cohort_id: school_cohort.id)
+                    school_cohort_id: school_cohort.id,
+                    current_user_id: user.id)
         get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/add/email-taken"
       end
 


### PR DESCRIPTION
Change the check to ensure the induction coordinator is not a mentor at
all before allowing them to add themselves at a school
