### PR TITLE
Simply feature flag test to prevent random failures

### DIFF
--- a/spec/factories/ecf_participant_validation_data.rb
+++ b/spec/factories/ecf_participant_validation_data.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ecf_participant_validation_data, class: ECFParticipantValidationData do
-    participant_profile factory: :participant_profile, traits: [:ecf]
+    association :participant_profile, :ecf
     full_name { Faker::Name.name }
     trn { sprintf("%07i", Random.random_number(9_999_999)) }
     date_of_birth { Faker::Date.birthday }

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe FeatureFlag do
   end
 
   def random_record
-    # TODO: WHY ARE SOME FACTORIES BROKEN?
-    create FactoryBot.factories.map(&:name).without(:participant_band, :pupil_premium, :declarable, :profile_declaration, :participant_declaration, :npq_participant_declaration).sample
+    create %i[user school].sample
   end
 end


### PR DESCRIPTION
I don't think we really lose anything by simplifying these, do we?