### PR TITLE
CPDTP-423 Generate unique TRNS for testing and sandbox purposes.

### DIFF
--- a/lib/tasks/trn_generator.rb
+++ b/lib/tasks/trn_generator.rb
@@ -3,12 +3,12 @@
 class TRNGenerator
   class << self
     def next
-      taken.push(available.pop || (raise "TRN available list exhausted"))[-1]
+      available.pop || (raise "TRN available list exhausted")
     end
 
   private
 
-    ALL_TRNS = ("001111".."9999999").to_a.freeze unless defined?(ALL_TRNS)
+    ALL_TRNS = ("0011111".."9999999").to_a.freeze unless defined?(ALL_TRNS)
 
     def available
       @available ||= (ALL_TRNS - taken).shuffle

--- a/lib/tasks/trn_generator.rb
+++ b/lib/tasks/trn_generator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class TRNGenerator
+  class << self
+    def next
+      taken.push(available.pop || (raise "TRN available list exhausted"))[-1]
+    end
+
+  private
+
+    ALL_TRNS = ("001111".."9999999").to_a.freeze unless defined?(ALL_TRNS)
+
+    def available
+      @available ||= (ALL_TRNS - taken).shuffle
+    end
+
+    def taken
+      @taken ||= TeacherProfile.where.not(trn: nil).pluck(:trn)
+    end
+  end
+end

--- a/lib/tasks/trn_generator.rb
+++ b/lib/tasks/trn_generator.rb
@@ -1,21 +1,25 @@
 # frozen_string_literal: true
 
+ALL_TRNS = (1111..9_999_999).freeze unless defined?(ALL_TRNS)
+
 class TRNGenerator
   class << self
     def next
-      available.pop || (raise "TRN available list exhausted")
+      sprintf("%07d", taken.push(available.pop || (raise "TRN available list exhausted"))[-1])
     end
 
   private
 
-    ALL_TRNS = ("0011111".."9999999").to_a.freeze unless defined?(ALL_TRNS)
-
     def available
-      @available ||= (ALL_TRNS - taken).shuffle
+      @available.presence || reseed
+    end
+
+    def reseed
+      @available = (10_000.times.map { rand(ALL_TRNS) }.uniq - taken)
     end
 
     def taken
-      @taken ||= TeacherProfile.where.not(trn: nil).pluck(:trn)
+      @taken ||= TeacherProfile.where.not(trn: nil).pluck(:trn).map(&:to_i)
     end
   end
 end

--- a/spec/lib/tasks/trn_generator_spec.rb
+++ b/spec/lib/tasks/trn_generator_spec.rb
@@ -4,25 +4,26 @@ require "tasks/trn_generator"
 require "rails_helper"
 
 RSpec.describe TRNGenerator, type: :helper do
-  it 'produces a new unassigned value' do
+  it "produces a new unassigned value" do
     expect(::TeacherProfile.pluck(:trn)).not_to include(TRNGenerator.next)
   end
 
   it "generates 100_000 unallocated TRNs in under a second" do
-    benchmark = Benchmark.measure {
+    benchmark = Benchmark.measure do
       100_000.times do
         TRNGenerator.next
       end
-    }
+    end
     expect(benchmark.total).to be < 1
   end
 
   it "moves the new TRN to unavailable" do
-    before_counts=[TRNGenerator.send(:available).count, TRNGenerator.send(:taken).count]
-    TRNGenerator.next
-    TRNGenerator.next
-    after_counts=[TRNGenerator.send(:available).count, TRNGenerator.send(:taken).count]
-    expect(after_counts[0]-before_counts[0]).to eq -2
-    expect(after_counts[1]-before_counts[1]).to eq 2
+    number_of_trns_to_generate = 100
+    before_count = TRNGenerator.send(:available).count
+    number_of_trns_to_generate.times do
+      TRNGenerator.next
+    end
+    after_count = TRNGenerator.send(:available).count
+    expect(before_count - after_count).to eq number_of_trns_to_generate
   end
 end

--- a/spec/lib/tasks/trn_generator_spec_spec.rb
+++ b/spec/lib/tasks/trn_generator_spec_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "tasks/trn_generator"
+require "rails_helper"
+
+RSpec.describe TRNGenerator, type: :helper do
+  it 'produces a new unassigned value' do
+    expect(::TeacherProfile.pluck(:trn)).not_to include(TRNGenerator.next)
+  end
+
+  it "generates 100_000 unallocated TRNs in under a second" do
+    benchmark = Benchmark.measure {
+      100_000.times do
+        TRNGenerator.next
+      end
+    }
+    expect(benchmark.total).to be < 1
+  end
+
+  it "moves the new TRN to unavailable" do
+    before_counts=[TRNGenerator.send(:available).count, TRNGenerator.send(:taken).count]
+    TRNGenerator.next
+    TRNGenerator.next
+    after_counts=[TRNGenerator.send(:available).count, TRNGenerator.send(:taken).count]
+    expect(after_counts[0]-before_counts[0]).to eq -2
+    expect(after_counts[1]-before_counts[1]).to eq 2
+  end
+end


### PR DESCRIPTION
### Context

Existing TRN generation code just did a sample without a comparison which meant that scaling it up was more likely to result in collisions.
This class generates unique and unassigned TRNs without having too much impact on the database.

### Changes proposed in this pull request

Create a generator which caches all possibly TRNs and removes the ones already assigned.
Add an enumerator which will return the next unassigned TRN or raise an error if all of the available ones are exhausted.

### Guidance to review

All initial population of the huge array happens during start-up.
A shuffled version of this and the read of the database to determine which ones are actually is use happens the first time that #next is called. 
Once this happens, the available is treated as a stack and the next available value is popped off it.
This minimises the chances of a collision when generating 100_000 values and keeps the time spent handling exceptions low.

### Testing

Specific tests have been written to generate a large number of unique TRNs and benchmark the time taken to create them.

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
