### PR TITLE
Extend the beta invite task to send a notification to SITs

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -17,6 +17,7 @@ class SchoolMailer < ApplicationMailer
   YEAR2020_INVITE_EMAIL_TEMPLATE = "d4b53e26-4630-43a5-b89e-3c668061a41c"
   PARTICIPANT_VALIDATION_CIP_AND_FIP_ECT_TEMPLATE = "b73fe1d1-94ac-4e77-ab37-71738c2474dd"
   PARTICIPANT_VALIDATION_FIP_MENTOR_TEMPLATE = "06ad385b-9a76-4f5c-941a-c5d8cf5f72c7"
+  PARTICIPANT_VALIDATION_INDUCTION_COORDINATOR_TEMPLATE = "afb54050-7ebd-43af-ad83-7fa6795d1523"
 
   def nomination_email(recipient:, school_name:, nomination_url:, expiry_date:)
     template_mail(
@@ -260,6 +261,19 @@ class SchoolMailer < ApplicationMailer
         school_name: school_name,
         participant_start: start_url,
         ur_sign_up_url: user_research_url,
+      },
+    )
+  end
+
+  def participant_validation_induction_coordinator_email(recipient:, school_name:, start_url:)
+    template_mail(
+      PARTICIPANT_VALIDATION_INDUCTION_COORDINATOR_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        start_url: start_url,
       },
     )
   end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -18,6 +18,7 @@ class UTMService
     year2020_nqt_invite: "year2020-nqt-invite",
     participant_validation_beta: "participant-validation-beta",
     participant_validation_research: "participant-validation-research",
+    participant_validation_sit_notification: "participant-validation-sit-notification",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -136,4 +136,23 @@ RSpec.describe SchoolMailer, type: :mailer do
       expect(participant_validation_fip_mentor_email.to).to match_array [recipient]
     end
   end
+
+  describe "#participant_validation_induction_coordinator_email" do
+    let(:recipient) { Faker::Internet.email }
+    let(:school_name) { Faker::Company.name }
+    let(:start_url) { "https://www.example.com/" }
+
+    let(:participant_validation_fip_mentor_email) do
+      SchoolMailer.participant_validation_induction_coordinator_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: start_url,
+      )
+    end
+
+    it "renders the right headers" do
+      expect(participant_validation_fip_mentor_email.from).to match_array ["mail@example.com"]
+      expect(participant_validation_fip_mentor_email.to).to match_array [recipient]
+    end
+  end
 end


### PR DESCRIPTION
We send a courtesy email to induction coordinators to inform them that we have asked their ECTs and Mentors to enter details
