### PR TITLE
Cpdtp 423 create tool to generate valid data for lead providers to test against

### DIFF
--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -1,83 +1,17 @@
 # frozen_string_literal: true
 
-namespace :lead_provider do
-  desc "create seed mentors for API testing"
-  task seed_mentors: :environment do
+require "tasks/valid_test_data_generator"
+
+namespace :lead_providers do
+  desc "create seed schools and participants for API testing"
+  task seed_schools_and_participants: :environment do
     logger = Logger.new($stdout)
     logger.formatter = proc do |_severity, _datetime, _progname, msg|
       "#{msg}\n"
     end
 
-    providers_names = ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Ambition Institute", "Education Development Trust"]
-    cohort_2021 = Cohort.find_by!(start_year: "2021")
-
-    providers_names.each_with_index do |provider_name, index|
-      logger.info("Generating seed mentors for '#{provider_name}'...")
-      lead_provider = LeadProvider.find_by!(name: provider_name)
-      school = create_school_and_associations(lead_provider, cohort_2021, index)
-      generate_mentors(lead_provider, school, cohort_2021, logger)
+    ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Ambition Institute", "Education Development Trust"].each do |provider|
+      ValidTestDataGenerator::LeadProviderPopulator.call(name: provider, total_schools: 100, participants_per_school: 100)
     end
   end
-end
-
-def generate_mentors(lead_provider, school, cohort, logger)
-  existing_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
-  existing_ect_count = lead_provider.ecf_participant_profiles.ects.count
-  school_cohort = SchoolCohort.find_or_create_by!(school: school, cohort: cohort)
-
-  10.times do
-    mentor = create_teacher
-    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort, schedule: Finance::Schedule.default)
-
-    ect_count = rand(0..3)
-    ect_count.times do
-      ect = create_teacher
-      ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, schedule: Finance::Schedule.default)
-    end
-    logger.info(" Mentor with user_id #{mentor.id} generated with #{ect_count} ECTs")
-  end
-  2.times do
-    mentor = create_teacher
-    mentor_profile = ParticipantProfile::Mentor.create!(teacher_profile: mentor, school_cohort: school_cohort, status: "withdrawn", schedule: Finance::Schedule.default)
-
-    ect = create_teacher
-    ParticipantProfile::ECT.create!(teacher_profile: ect, school_cohort: school_cohort, mentor_profile: mentor_profile, status: "withdrawn", schedule: Finance::Schedule.default)
-  end
-  new_mentor_count = lead_provider.ecf_participant_profiles.mentors.count
-  logger.info(" Before: #{existing_mentor_count} mentors, after: #{new_mentor_count}")
-  new_ect_count = lead_provider.ecf_participant_profiles.ects.count
-  logger.info(" Before: #{existing_ect_count} ECTs, after: #{new_ect_count}")
-end
-
-def create_school_and_associations(lead_provider, cohort, index)
-  school = School.find_or_create_by!(
-    urn: sprintf("%06d", (10_000 + index)),
-  ) do |s|
-    s.name = Faker::Company.name
-    s.address_line1 = Faker::Address.street_address
-    s.postcode = Faker::Address.postcode
-  end
-
-  Partnership.find_or_create_by!(
-    school: school,
-    lead_provider: lead_provider,
-    cohort: cohort,
-  ) do |partnership|
-    partnership.delivery_partner = DeliveryPartner.create!(name: Faker::Company.name)
-  end
-
-  SchoolCohort.find_or_create_by!(school: school, cohort: cohort, induction_programme_choice: "full_induction_programme")
-
-  school
-end
-
-def random_trn
-  return if [true, false].sample
-
-  sprintf("%07i", Random.random_number(9_999_999))
-end
-
-def create_teacher
-  mentor = User.create!(full_name: Faker::Name.name, email: Faker::Internet.email)
-  TeacherProfile.create!(user: mentor, trn: random_trn)
 end

--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -11,7 +11,7 @@ namespace :lead_providers do
     end
 
     ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Ambition Institute", "Education Development Trust"].each do |provider|
-      ValidTestDataGenerator::LeadProviderPopulator.call(name: provider, total_schools: 100, participants_per_school: 100)
+      ValidTestDataGenerator::LeadProviderPopulater.call(name: provider, total_schools: 100, participants_per_school: 100)
     end
   end
 end

--- a/lib/tasks/school_urn_generator.rb
+++ b/lib/tasks/school_urn_generator.rb
@@ -5,10 +5,20 @@ ALL_URNS = (1..999_999).freeze unless defined?(ALL_URNS)
 class SchoolURNGenerator
   class << self
     def next
-      sprintf("%06d", taken.push(available.pop || (raise "URN available list exhausted"))[-1])
+      next_urn=next_from_available_stack
+      add_to_taken_stack(next_urn)
+      sprintf("%06d", next_urn)
     end
 
-  private
+    private
+
+    def add_to_taken_stack(next_urn)
+      taken.push(next_urn)
+    end
+
+    def next_from_available_stack
+      available.pop || (raise "URN available list exhausted")
+    end
 
     def available
       @available.presence || reseed

--- a/lib/tasks/school_urn_generator.rb
+++ b/lib/tasks/school_urn_generator.rb
@@ -5,12 +5,12 @@ ALL_URNS = (1..999_999).freeze unless defined?(ALL_URNS)
 class SchoolURNGenerator
   class << self
     def next
-      next_urn=next_from_available_stack
+      next_urn = next_from_available_stack
       add_to_taken_stack(next_urn)
       sprintf("%06d", next_urn)
     end
 
-    private
+  private
 
     def add_to_taken_stack(next_urn)
       taken.push(next_urn)

--- a/lib/tasks/school_urn_generator.rb
+++ b/lib/tasks/school_urn_generator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+ALL_URNS = (1..999_999).freeze unless defined?(ALL_URNS)
+
+class SchoolURNGenerator
+  class << self
+    def next
+      sprintf("%06d", taken.push(available.pop || (raise "URN available list exhausted"))[-1])
+    end
+
+  private
+
+    def available
+      @available.presence || reseed
+    end
+
+    def reseed
+      @available = (1_000.times.map { rand(ALL_URNS) }.uniq - taken)
+    end
+
+    def taken
+      @taken ||= School.where.not(urn: nil).pluck(:urn).map(&:to_i)
+    end
+  end
+end

--- a/lib/tasks/trn_generator.rb
+++ b/lib/tasks/trn_generator.rb
@@ -5,10 +5,19 @@ ALL_TRNS = (1111..9_999_999).freeze unless defined?(ALL_TRNS)
 class TRNGenerator
   class << self
     def next
-      sprintf("%07d", taken.push(available.pop || (raise "TRN available list exhausted"))[-1])
+      next_trn=next_from_available_stack
+      add_to_taken_stack(next_trn)
+      sprintf("%07d", next_trn)
     end
 
   private
+    def add_to_taken_stack(next_trn)
+      taken.push(next_trn)
+    end
+
+    def next_from_available_stack
+      available.pop || (raise "TRN available list exhausted")
+    end
 
     def available
       @available.presence || reseed

--- a/lib/tasks/trn_generator.rb
+++ b/lib/tasks/trn_generator.rb
@@ -5,12 +5,13 @@ ALL_TRNS = (1111..9_999_999).freeze unless defined?(ALL_TRNS)
 class TRNGenerator
   class << self
     def next
-      next_trn=next_from_available_stack
+      next_trn = next_from_available_stack
       add_to_taken_stack(next_trn)
       sprintf("%07d", next_trn)
     end
 
   private
+
     def add_to_taken_stack(next_trn)
       taken.push(next_trn)
     end

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "tasks/school_urn_generator"
+require "tasks/trn_generator"
+
+module ValidTestDataGenerator
+  class LeadProviderPopulator
+    class << self
+      def call(name:, total_schools: 10, participants_per_school: 100)
+        new(name: name).call(total_schools: total_schools, participants_per_school: participants_per_school)
+      end
+    end
+
+    def call(total_schools: 10, participants_per_school: 100)
+      generate_new_schools(count: total_schools - lead_provider.schools.count) if lead_provider.schools.count < total_schools
+      lead_provider.schools.order("created_at desc").limit(total_schools).each do |school|
+        find_or_create_participants(school: school, number_of_participants: participants_per_school)
+      end
+    end
+
+  private
+
+    attr_reader :lead_provider
+
+    def initialize(name:)
+      @lead_provider = ::LeadProvider.find_or_create_by!(name: name)
+    end
+
+    def generate_new_schools(count:)
+      count.times { create_fip_school_with_cohort(urn: SchoolURNGenerator.next) }
+    end
+
+    def find_or_create_participants(school:, number_of_participants:)
+      generate_new_participants(school: school, count: number_of_participants - school.ecf_participants.count) if school.ecf_participants.count < number_of_participants
+      school.ecf_participants.order("created_at desc").limit(number_of_participants).to_a
+    end
+
+    def generate_new_participants(school:, count:)
+      ((count + 1) / 2).times do
+        status = (%w[active] * 6 + %w[withdrawn]).sample
+        mentor = create_participant(school_cohort: school_cohort(school: school), profile_klass: ParticipantProfile::Mentor, status: status)
+        create_participant(school_cohort: school_cohort(school: school), profile_klass: ParticipantProfile::ECT, mentor_profile: mentor, status: status)
+      end
+    end
+
+    def create_participant(school_cohort:, profile_klass: ParticipantProfile::ECT, mentor_profile: nil, status: "active")
+      name = Faker::Name.name
+      user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
+      teacher_profile = TeacherProfile.create!(user: user, trn: random_or_nil_trn)
+      if profile_klass == ParticipantProfile::ECT
+        ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status)
+      else
+        ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status)
+      end
+    end
+
+    def school_cohort(school:)
+      SchoolCohort.find_or_create_by!(school: school, cohort: Cohort.current, induction_programme_choice: "full_induction_programme")
+    end
+
+    def create_fip_school_with_cohort(urn:)
+      school = School.find_or_create_by!(urn: urn) do |s|
+        s.name = Faker::Company.name
+        s.address_line1 = Faker::Address.street_address
+        s.postcode = Faker::Address.postcode
+        s.sparsity_uplift = ([true] * 11 + [false] * 89).sample
+        s.pupil_premium = ([true] * 11 + [false] * 39).sample
+      end
+      school_cohort(school: school)
+      attach_partnership_to_school(school: school)
+    end
+
+    def attach_partnership_to_school(school:)
+      Partnership.find_or_create_by!(
+        school: school,
+        lead_provider: lead_provider,
+        cohort: Cohort.current,
+      ) do |partnership|
+        partnership.delivery_partner = DeliveryPartner.create!(name: Faker::Company.name)
+        ProviderRelationship.find_or_create_by!(
+          lead_provider: lead_provider,
+          cohort: Cohort.current,
+          delivery_partner: partnership.delivery_partner,
+        )
+      end
+    end
+
+    def random_or_nil_trn
+      [true, false].sample ? nil : TRNGenerator.next
+    end
+  end
+end

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -32,20 +32,20 @@ module ValidTestDataGenerator
       count.times { create_fip_school_with_cohort(urn: SchoolURNGenerator.next) }
     end
 
-    def find_or_create_participants(school:, number_of_participants:, sparsity_uplift:, pupil_premium_uplift: )
+    def find_or_create_participants(school:, number_of_participants:, sparsity_uplift:, pupil_premium_uplift:)
       generate_new_participants(school: school, count: number_of_participants - school.ecf_participants.count, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift) if school.ecf_participants.count < number_of_participants
     end
 
     def generate_new_participants(school:, count:, sparsity_uplift:, pupil_premium_uplift:)
-      while count > 0
-        status = weighted_choice(selection: %w[active withdrawn], odds: [6,1])
-        profile_type = weighted_choice(selection: %i[mentor ect], odds: [9,1])
-        count-=1
-        if profile_type==:mentor
+      while count.positive?
+        status = weighted_choice(selection: %w[active withdrawn], odds: [6, 1])
+        profile_type = weighted_choice(selection: %i[mentor ect], odds: [9, 1])
+        count -= 1
+        if profile_type == :mentor
           mentor = create_participant(school_cohort: school_cohort(school: school), profile_type: :mentor, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
           rand(0..3).times do
             create_participant(school_cohort: school_cohort(school: school), profile_type: :ect, mentor_profile: mentor, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
-            count-=1
+            count -= 1
           end
         else
           create_participant(school_cohort: school_cohort(school: school), profile_type: :ect, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
@@ -98,9 +98,9 @@ module ValidTestDataGenerator
     end
 
     def weighted_choice(selection:, odds:)
-      selection.each_with_index.map do |item, index|
+      selection.each_with_index.map { |item, index|
         [item] * odds[index]
-      end.flatten.sample
+      }.flatten.sample
     end
   end
 end

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -4,7 +4,7 @@ require "tasks/school_urn_generator"
 require "tasks/trn_generator"
 
 module ValidTestDataGenerator
-  class LeadProviderPopulator
+  class LeadProviderPopulater
     class << self
       def call(name:, total_schools: 10, participants_per_school: 100)
         new(name: name).call(total_schools: total_schools, participants_per_school: participants_per_school)
@@ -57,10 +57,11 @@ module ValidTestDataGenerator
       name = Faker::Name.name
       user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
       teacher_profile = TeacherProfile.create!(user: user, trn: random_or_nil_trn)
+      schedule = Finance::Schedule.default
       if profile_type == :ect
-        ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+        ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift, schedule: schedule)
       else
-        ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+        ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift, schedule: schedule)
       end
     end
 

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -14,7 +14,9 @@ module ValidTestDataGenerator
     def call(total_schools: 10, participants_per_school: 100)
       generate_new_schools(count: total_schools - lead_provider.schools.count) if lead_provider.schools.count < total_schools
       lead_provider.schools.order("created_at desc").limit(total_schools).each do |school|
-        find_or_create_participants(school: school, number_of_participants: participants_per_school)
+        sparsity_uplift = weighted_choice(selection: [true, false], odds: [11, 89])
+        pupil_premium_uplift = weighted_choice(selection: [true, false], odds: [11, 39])
+        find_or_create_participants(school: school, number_of_participants: participants_per_school, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
       end
     end
 
@@ -30,27 +32,35 @@ module ValidTestDataGenerator
       count.times { create_fip_school_with_cohort(urn: SchoolURNGenerator.next) }
     end
 
-    def find_or_create_participants(school:, number_of_participants:)
-      generate_new_participants(school: school, count: number_of_participants - school.ecf_participants.count) if school.ecf_participants.count < number_of_participants
-      school.ecf_participants.order("created_at desc").limit(number_of_participants).to_a
+    def find_or_create_participants(school:, number_of_participants:, sparsity_uplift:, pupil_premium_uplift: )
+      generate_new_participants(school: school, count: number_of_participants - school.ecf_participants.count, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift) if school.ecf_participants.count < number_of_participants
     end
 
-    def generate_new_participants(school:, count:)
-      ((count + 1) / 2).times do
-        status = (%w[active] * 6 + %w[withdrawn]).sample
-        mentor = create_participant(school_cohort: school_cohort(school: school), profile_klass: ParticipantProfile::Mentor, status: status)
-        create_participant(school_cohort: school_cohort(school: school), profile_klass: ParticipantProfile::ECT, mentor_profile: mentor, status: status)
+    def generate_new_participants(school:, count:, sparsity_uplift:, pupil_premium_uplift:)
+      while count > 0
+        status = weighted_choice(selection: %w[active withdrawn], odds: [6,1])
+        profile_type = weighted_choice(selection: %i[mentor ect], odds: [9,1])
+        count-=1
+        if profile_type==:mentor
+          mentor = create_participant(school_cohort: school_cohort(school: school), profile_type: :mentor, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+          rand(0..3).times do
+            create_participant(school_cohort: school_cohort(school: school), profile_type: :ect, mentor_profile: mentor, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+            count-=1
+          end
+        else
+          create_participant(school_cohort: school_cohort(school: school), profile_type: :ect, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+        end
       end
     end
 
-    def create_participant(school_cohort:, profile_klass: ParticipantProfile::ECT, mentor_profile: nil, status: "active")
+    def create_participant(school_cohort:, profile_type: :ect, mentor_profile: nil, status: "active", sparsity_uplift: false, pupil_premium_uplift: false)
       name = Faker::Name.name
       user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
       teacher_profile = TeacherProfile.create!(user: user, trn: random_or_nil_trn)
-      if profile_klass == ParticipantProfile::ECT
-        ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status)
+      if profile_type == :ect
+        ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
       else
-        ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status)
+        ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
       end
     end
 
@@ -63,8 +73,6 @@ module ValidTestDataGenerator
         s.name = Faker::Company.name
         s.address_line1 = Faker::Address.street_address
         s.postcode = Faker::Address.postcode
-        s.sparsity_uplift = ([true] * 11 + [false] * 89).sample
-        s.pupil_premium = ([true] * 11 + [false] * 39).sample
       end
       school_cohort(school: school)
       attach_partnership_to_school(school: school)
@@ -87,6 +95,12 @@ module ValidTestDataGenerator
 
     def random_or_nil_trn
       [true, false].sample ? nil : TRNGenerator.next
+    end
+
+    def weighted_choice(selection:, odds:)
+      selection.each_with_index.map do |item, index|
+        [item] * odds[index]
+      end.flatten.sample
     end
   end
 end

--- a/spec/lib/tasks/school_urn_generator_spec.rb
+++ b/spec/lib/tasks/school_urn_generator_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "tasks/school_urn_generator"
+require "rails_helper"
+
+RSpec.describe SchoolURNGenerator do
+  it "produces a new unassigned value" do
+    expect(::School.pluck(:urn)).not_to include(SchoolURNGenerator.next)
+  end
+
+  it "generates 10_000 unallocated TRNs in under a second" do
+    benchmark = Benchmark.measure do
+      10_000.times do
+        SchoolURNGenerator.next
+      end
+    end
+    expect(benchmark.total).to be < 1
+  end
+
+  it "moves the new URN to unavailable" do
+    number_of_urns_to_generate = 100
+    before_count = SchoolURNGenerator.send(:available).count
+    number_of_urns_to_generate.times do
+      SchoolURNGenerator.next
+    end
+    after_count = SchoolURNGenerator.send(:available).count
+    expect(before_count - after_count).to eq number_of_urns_to_generate
+  end
+end


### PR DESCRIPTION
### Context

Creating test data can be a minefield if you don't have the correct tools in place. This rake task allows us to create batches of data for lead providers with representative samples of how the expected schools and participants would look.

- 11% sparsity_uplift
- 22% pupil_premium_uplift
- 14% withdrawn record sets for participants
- Randomised mentors and early_career_teachers with and without their equivalents (i.e. some mentors without ECTs and some ECTs without mentors)
- Even split of valid and missing TRN data for participants.

### Changes proposed in this pull request

- Move methods for generation of data into callable modules and classes and out of the rake task
- Cascade creation of records where required to fulfil the numbers of schools and participants per school for each lead provider.

### Guidance to review

Run the task and watch it generate up to 60k records for the 6 named lead_providers.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
