### PR TITLE
CPDTP-294: Enforce schedules on participant profiles

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -4,8 +4,7 @@ class ParticipantProfile < ApplicationRecord
   has_paper_trail
   belongs_to :teacher_profile, touch: true
 
-  # TODO: Back-fill, so that every profile has a schedule. Add touch: true afterwards
-  belongs_to :schedule, optional: true, class_name: "Finance::Schedule"
+  belongs_to :schedule, class_name: "Finance::Schedule", touch: true
 
   has_one :user, through: :teacher_profile
 

--- a/db/migrate/20210817084816_remove_null_from_participant_profile_schedules.rb
+++ b/db/migrate/20210817084816_remove_null_from_participant_profile_schedules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNullFromParticipantProfileSchedules < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :participant_profiles, :schedule_id, true
+  end
+end

--- a/db/migrate/20210817084816_remove_null_from_participant_profile_schedules.rb
+++ b/db/migrate/20210817084816_remove_null_from_participant_profile_schedules.rb
@@ -2,6 +2,6 @@
 
 class RemoveNullFromParticipantProfileSchedules < ActiveRecord::Migration[6.1]
   def change
-    change_column_null :participant_profiles, :schedule_id, true
+    add_check_constraint :participant_profiles, "schedule_id IS NOT NULL", name: "participant_profiles_schedule_id_null", validate: false
   end
 end

--- a/db/migrate/20210817084817_validate_remove_null_from_participant_profile_schedules.rb
+++ b/db/migrate/20210817084817_validate_remove_null_from_participant_profile_schedules.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ValidateRemoveNullFromParticipantProfileSchedules < ActiveRecord::Migration[6.1]
+  def change
+    validate_check_constraint :participant_profiles, name: "participant_profiles_schedule_id_null"
+    change_column_null :participant_profiles, :schedule_id, false
+    remove_check_constraint :participant_profiles, name: "participant_profiles_schedule_id_null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_11_124609) do
+ActiveRecord::Schema.define(version: 2021_08_17_084816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_17_084816) do
+ActiveRecord::Schema.define(version: 2021_08_17_084817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -467,7 +467,7 @@ ActiveRecord::Schema.define(version: 2021_08_17_084816) do
     t.text "status", default: "active", null: false
     t.uuid "school_cohort_id"
     t.uuid "teacher_profile_id"
-    t.uuid "schedule_id"
+    t.uuid "schedule_id", null: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -74,8 +74,7 @@ mentor = User.find_or_create_by!(email: "rp-mentor-ambition@example.com") do |us
   teacher_profile = user.teacher_profile || user.create_teacher_profile
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-    profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"))
-    profile.update!(schedule: Finance::Schedule.default)
+    profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"), schedule: Finance::Schedule.default)
   end
 end
 
@@ -84,8 +83,7 @@ mentor_two = User.find_or_create_by!(email: "rp-mentor-edt@example.com") do |use
   teacher_profile = user.teacher_profile || user.create_teacher_profile
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-    profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"))
-    profile.update!(schedule: Finance::Schedule.default)
+    profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), schedule: Finance::Schedule.default)
   end
 end
 
@@ -94,8 +92,7 @@ mentor_three = User.find_or_create_by!(email: "rp-mentor-ucl@example.com") do |u
   teacher_profile = user.teacher_profile || user.create_teacher_profile
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-    profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"))
-    profile.update!(schedule: Finance::Schedule.default)
+    profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), schedule: Finance::Schedule.default)
   end
 end
 
@@ -104,8 +101,7 @@ User.find_or_create_by!(email: "rp-ect-ambition@example.com") do |user|
   teacher_profile = user.teacher_profile || user.create_teacher_profile
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-    profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"), mentor_profile: mentor.mentor_profile)
-    profile.update!(schedule: Finance::Schedule.default)
+    profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"), mentor_profile: mentor.mentor_profile, schedule: Finance::Schedule.default)
   end
 end
 
@@ -114,8 +110,7 @@ User.find_or_create_by!(email: "rp-ect-edt@example.com") do |user|
   teacher_profile = user.teacher_profile || user.create_teacher_profile
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-    profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), mentor_profile: mentor_two.mentor_profile)
-    profile.update!(schedule: Finance::Schedule.default)
+    profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), mentor_profile: mentor_two.mentor_profile, schedule: Finance::Schedule.default)
   end
 end
 
@@ -124,8 +119,7 @@ User.find_or_create_by!(email: "rp-ect-ucl@example.com") do |user|
   teacher_profile = user.teacher_profile || user.create_teacher_profile
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
-    profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), mentor_profile: mentor_three.mentor_profile)
-    profile.update!(schedule: Finance::Schedule.default)
+    profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), mentor_profile: mentor_three.mentor_profile, schedule: Finance::Schedule.default)
   end
 end
 

--- a/spec/cypress/integration/schools/Year2020.feature
+++ b/spec/cypress/integration/schools/Year2020.feature
@@ -2,6 +2,7 @@ Feature: School leaders should be able to add participants
 
   Background:
     Given school was created with name "Test School" and slug "test-school"
+    And schedule was created with name "ECF September standard 2021"
     And cohort was created with start_year "2020"
     And core_induction_programme was created with name "Awesome induction course"
     And feature year_2020_data_entry is active

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -3,6 +3,7 @@
 require "swagger_helper"
 
 describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :schedule, class: "Finance::Schedule" do
-    name { "Test schedule" }
+    name { "ECF September standard 2021" }
     after(:create) do |schedule|
       [Date.new(2021, 9, 1), Date.new(2021, 11, 1), Date.new(2022, 2, 1)].each do |start_date|
         create(

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
     trait :ect do
       school_cohort
       teacher_profile { association :teacher_profile, school: school_cohort.school }
+      schedule
 
       participant_type { :ect }
     end
@@ -42,6 +43,7 @@ FactoryBot.define do
     trait :mentor do
       school_cohort
       teacher_profile { association :teacher_profile, school: school_cohort.school }
+      schedule
 
       participant_type { :mentor }
     end
@@ -49,6 +51,7 @@ FactoryBot.define do
     trait :npq do
       school
       teacher_profile { association :teacher_profile, school: school }
+      schedule
 
       validation_data { association :npq_validation_data, user: teacher_profile.user }
 

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Schools::Year2020Form, type: :model do
   let!(:school) { create :school }
   let!(:cohort) { create :cohort, start_year: 2020 }
   let!(:core_induction_programme) { create :core_induction_programme }
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
 
   subject { described_class.new(school_id: school.id) }
 

--- a/spec/models/npq_validation_data_spec.rb
+++ b/spec/models/npq_validation_data_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe NPQValidationData, type: :model do
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
+
   it {
     is_expected.to define_enum_for(:headteacher_status).with_values(
       no: "no",

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ParticipantProfile, type: :model do
   it { is_expected.to belong_to(:teacher_profile) }
-  it { is_expected.to belong_to(:schedule).optional }
+  it { is_expected.to belong_to(:schedule) }
   it { is_expected.to have_one(:user).through(:teacher_profile) }
   it {
     is_expected.to define_enum_for(:status).with_values(

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe "NPQ Applications API", type: :request do
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "NPQ profiles api endpoint", type: :request do
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
   let(:token) { NPQRegistrationApiToken.create_with_random_token! }
   let(:bearer_token) { "Bearer #{token}" }
   let(:parsed_response) { JSON.parse(response.body) }

--- a/spec/requests/schools/year2020_spec.rb
+++ b/spec/requests/schools/year2020_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Schools::AddParticipant", type: :request do
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
   let!(:school) { create :school }
   let!(:cohort) { create :cohort, start_year: 2020 }
   let!(:core_induction_programme) { create :core_induction_programme }

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -4,6 +4,7 @@ RSpec.shared_context "lead provider profiles and courses" do
   # lead providers setup
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
+  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
 
   # ECF setup
   let(:ecf_lead_provider) { cpd_lead_provider.lead_provider }


### PR DESCRIPTION
### Context
Participant profiles need schedules to validate that their declarations are sent at the right time.

### Changes proposed in this pull request
Make all participant profiles require schedules. I will double check that this is the case in prod and sandbox before merging, but it should be.