### PR TITLE
Extract NPQValidationData callback to service

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -11,7 +11,7 @@ module Api
         validation_data.npq_lead_provider = NPQLeadProvider.find_by(id: npq_lead_provider_param)
         validation_data.user = User.find_by(id: user_param)
 
-        if validation_data.save
+        if validation_data.save && NPQ::CreateOrUpdateProfile.new(npq_validation_data: validation_data).call
           render status: :created,
                  content_type: "application/vnd.api+json",
                  json: NPQValidationDataSerializer.new(validation_data).serializable_hash

--- a/app/models/npq_validation_data.rb
+++ b/app/models/npq_validation_data.rb
@@ -43,21 +43,4 @@ class NPQValidationData < ApplicationRecord
       errors.add(:lead_provider_approval_status, :invalid, message: "Once accepted an application cannot change state")
     end
   end
-
-  after_save :update_participant_profile
-
-private
-
-  def update_participant_profile
-    profile = ParticipantProfile::NPQ.find_or_initialize_by(id: id)
-    teacher_profile = user.teacher_profile || user.build_teacher_profile
-    teacher_profile.trn = teacher_reference_number
-    teacher_profile.school = profile.school = School.find_by(urn: school_urn)
-    teacher_profile.save!
-
-    profile.schedule ||= Finance::Schedule.default
-    profile.teacher_profile = teacher_profile
-    profile.user_id = user_id
-    profile.save!
-  end
 end

--- a/app/services/npq/create_or_update_profile.rb
+++ b/app/services/npq/create_or_update_profile.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module NPQ
+  class CreateOrUpdateProfile
+    attr_reader :npq_validation_data
+
+    def initialize(npq_validation_data:)
+      @npq_validation_data = npq_validation_data
+    end
+
+    def call
+      teacher_profile.trn = npq_validation_data.teacher_reference_number
+      teacher_profile.school = school
+      teacher_profile.save!
+
+      participant_profile.schedule ||= Finance::Schedule.default
+      participant_profile.school = school
+      participant_profile.teacher_profile = teacher_profile
+      participant_profile.user = user
+      participant_profile.save!
+    end
+
+  private
+
+    def participant_profile
+      @participant_profile ||= ParticipantProfile::NPQ.find_or_initialize_by(id: npq_validation_data.id)
+    end
+
+    def teacher_profile
+      @teacher_profile ||= user.teacher_profile || user.build_teacher_profile
+    end
+
+    def user
+      @user ||= npq_validation_data.user
+    end
+
+    def school
+      @school ||= School.find_by(urn: npq_validation_data.school_urn)
+    end
+  end
+end

--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -47,18 +47,13 @@ FactoryBot.create :participant_profile,
 
 npq_user = FactoryBot.create(:user, full_name: "Natalie Portman Quebec", email: "natalie.portman@quebec.ca")
 
-npq_profile = FactoryBot.create :participant_profile,
-                                :npq,
-                                validation_data: nil,
-                                user: npq_user,
-                                created_at: Date.parse("19/09/2019")
+Timecop.freeze(Date.parse("19/09/2019")) do
+  npq_validation_data = FactoryBot.create :npq_validation_data,
+                                          user: npq_user,
+                                          date_of_birth: Date.parse("10/12/1982"),
+                                          nino: "NI123456",
+                                          teacher_reference_number: "9780824",
+                                          school_urn: school.urn
 
-FactoryBot.create :npq_validation_data,
-                  id: npq_profile.id,
-                  user: npq_user,
-                  date_of_birth: Date.parse("10/12/1982"),
-                  nino: "NI123456",
-                  created_at: Date.parse("19/09/2019"),
-                  teacher_reference_number: "9780824"
-
-npq_profile.update!(updated_at: Date.parse("19/09/2019"))
+  NPQ::CreateOrUpdateProfile.new(npq_validation_data: npq_validation_data).call
+end

--- a/spec/features/participant-declarations/submit_participant_declarations_spec.rb
+++ b/spec/features/participant-declarations/submit_participant_declarations_spec.rb
@@ -105,9 +105,12 @@ private
     create(:schedule, name: "ECF September standard 2021")
     npq_lead_provider = create(:npq_lead_provider, cpd_lead_provider: @cpd_lead_provider)
     npq_course = create(:npq_course, identifier: "npq-leading-teaching")
-    npq_validation_date = create(:npq_validation_data, npq_lead_provider: npq_lead_provider, npq_course: npq_course)
-    @npq_id = npq_validation_date.user.id
-    travel_to npq_validation_date.profile.schedule.milestones.first.start_date + 1.day
+    npq_validation_data = create(:npq_validation_data, npq_lead_provider: npq_lead_provider, npq_course: npq_course)
+    @npq_id = npq_validation_data.user.id
+
+    NPQ::CreateOrUpdateProfile.new(npq_validation_data: npq_validation_data).call
+
+    travel_to npq_validation_data.profile.schedule.milestones.first.start_date + 1.day
   end
 
   def when_the_participant_details_are_passed_to_the_lead_provider

--- a/spec/models/npq_validation_data_spec.rb
+++ b/spec/models/npq_validation_data_spec.rb
@@ -9,45 +9,4 @@ RSpec.describe NPQValidationData, type: :model do
       yes_over_two_years: "yes_over_two_years",
     ).backed_by_column_of_type(:text)
   }
-
-  describe "profile synchronisation" do
-    let(:trn) { Array.new(10) { rand 0..9 }.join }
-    let(:validation_data) do
-      described_class.new(
-        teacher_reference_number: trn,
-        user: create(:user),
-        npq_course: create(:npq_course),
-        npq_lead_provider: create(:npq_lead_provider),
-      )
-    end
-
-    context "on create" do
-      it "creates teacher and participant profile" do
-        expect { validation_data.save! }
-          .to change(TeacherProfile, :count).by(1)
-          .and change(ParticipantProfile::NPQ, :count).by(1)
-      end
-
-      it "stores the TRN on teacher profile" do
-        validation_data.tap(&:save!).reload
-        expect(validation_data.user.teacher_profile.trn).to eq trn
-      end
-    end
-
-    context "on update" do
-      before { validation_data.tap(&:save!).reload }
-      let(:new_trn) { Array.new(10) { rand 0..9 }.join }
-
-      it "does not create neither teacher nor participant profile" do
-        expect { validation_data.update!(teacher_reference_number: new_trn) }
-          .to change(TeacherProfile, :count).by(0)
-          .and change(ParticipantProfile::NPQ, :count).by(0)
-      end
-
-      it "updates the TRN on teacher profile" do
-        validation_data.update!(teacher_reference_number: new_trn)
-        expect(validation_data.reload.user.teacher_profile.trn).to eq new_trn
-      end
-    end
-  end
 end

--- a/spec/services/npq/create_or_update_profile_spec.rb
+++ b/spec/services/npq/create_or_update_profile_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::CreateOrUpdateProfile do
+  subject do
+    described_class.new(npq_validation_data: npq_validation_data)
+  end
+
+  describe "#call" do
+    let(:trn) { rand(1_000_000..9_999_999).to_s }
+    let(:user) { create(:user) }
+    let(:npq_course) { create(:npq_course) }
+    let(:npq_lead_provider) { create(:npq_lead_provider) }
+
+    let(:npq_validation_data) do
+      NPQValidationData.new(
+        teacher_reference_number: trn,
+        user: user,
+        npq_course: npq_course,
+        npq_lead_provider: npq_lead_provider,
+      )
+    end
+
+    context "after creating a NPQValidationData record" do
+      before do
+        npq_validation_data.save!
+      end
+
+      it "creates teacher and participant profile" do
+        expect { subject.call }
+          .to change(TeacherProfile, :count).by(1)
+          .and change(ParticipantProfile::NPQ, :count).by(1)
+      end
+
+      it "stores the TRN on teacher profile" do
+        subject.call
+        npq_validation_data.reload
+        expect(npq_validation_data.user.teacher_profile.trn).to eql trn
+      end
+    end
+
+    context "after updating an existing NPQValidationData record" do
+      before do
+        npq_validation_data.save!
+        subject.call
+      end
+
+      let(:new_trn) { (trn.to_i + 1).to_s }
+
+      it "does not create neither teacher nor participant profile" do
+        npq_validation_data.update!(teacher_reference_number: new_trn)
+
+        expect { subject.call }
+          .to change(TeacherProfile, :count).by(0)
+          .and change(ParticipantProfile::NPQ, :count).by(0)
+      end
+
+      it "updates the TRN on teacher profile" do
+        npq_validation_data.update!(teacher_reference_number: new_trn)
+
+        subject.call
+
+        expect(npq_validation_data.reload.user.teacher_profile.trn).to eql new_trn
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- This is the second attempt after https://github.com/DFE-Digital/early-careers-framework/pull/863 due to other shifting changes
- There is a callback `NPQValidationData#update_participant_profile`
- It creates and persists multiple database records
- It needs to be removed so we can have finer grain control of when it happens and the behaviour of it

### Changes proposed in this pull request

- Remove the callback `NPQValidationData#update_participant_profile`
- Extract the contents to a new service `NPQ::CreateOrUpdateProfile`
- Call this new service in the api controller and in tests where the data is depended upon

### Guidance to review

- There should be no behavioural changes for existing use cases
- One would be required to call this service class if `NPQValidationData` is mutated

### Testing

- Not sure

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Use api calls to submit NPQ registrations
- `NPQValidationData`, `TeacherProfile`, `ParticipantProfile::NPQ` should all get persisted correctly