### PR TITLE
Make cip_only? return false for Section 41 schools

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -115,7 +115,7 @@ class School < ApplicationRecord
   end
 
   def cip_only?
-    open? && cip_only_establishment_type?
+    !eligible? && open? && cip_only_establishment_type?
   end
 
   def local_authority_district

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe School, type: :model do
         expect(open_school.cip_only?).to eql false
         expect(eligible_school_type.cip_only?).to eql false
         expect(english_school.cip_only?).to eql false
+        expect(s41_school.cip_only?).to eql false
       end
 
       it "should be true for welsh schools" do


### PR DESCRIPTION
This currently prevents lead providers from declaring partnerships with these schools