### PR TITLE
Set defaults to docker variables to prevent destroy workflow failing

### DIFF
--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -14,9 +14,11 @@ variable paas_app_docker_image {
 }
 
 variable docker_username {
+  default = null
 }
 
 variable docker_password {
+  default = null
 }
 
 variable paas_app_start_timeout {


### PR DESCRIPTION
### Context
After yesterdays fix for dockerhub horrors, it seems our destroy setup is not working: https://github.com/DFE-Digital/early-careers-framework/runs/3361905808?check_suite_focus=true

### Changes proposed in this pull request
Set default values to the docker variables in terraform. I hope this will make them non-required.

I guess we could add them to the destroy workflow, I just don't know if it is the good idea in principle. 