### PR TITLE
Add schedule to a failing spec

### DIFF
--- a/spec/services/npq/create_or_update_profile_spec.rb
+++ b/spec/services/npq/create_or_update_profile_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe NPQ::CreateOrUpdateProfile do
   end
 
   describe "#call" do
+    let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
     let(:trn) { rand(1_000_000..9_999_999).to_s }
     let(:user) { create(:user) }
     let(:npq_course) { create(:npq_course) }


### PR DESCRIPTION
### Context
Hopefully the last ever silent merge conflict in tests to do with schedules, now that the db-level enforcement is on `develop`.