### PR TITLE
Only set TRN on teacher profile if NPQ validated

### DIFF
--- a/app/services/npq/create_or_update_profile.rb
+++ b/app/services/npq/create_or_update_profile.rb
@@ -9,7 +9,10 @@ module NPQ
     end
 
     def call
-      teacher_profile.trn = npq_validation_data.teacher_reference_number
+      if npq_validation_data.teacher_reference_number_verified?
+        teacher_profile.trn = npq_validation_data.teacher_reference_number
+      end
+
       teacher_profile.school = school
       teacher_profile.save!
 


### PR DESCRIPTION
### Context

- My understanding is the `TeacherProfile` should be a source of truth for a TRN
- At the moment this is set when an NPQ comes in which may contain an unvalidated TRN

### Changes proposed in this pull request

- Ensure only set `TeacherProfile#trn` if the trn on the NPQ has been validated

### Guidance to review

- My assumptions for TRN on `TeacherProfile` are correct?

### Testing

- See testing on review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Through api calls
- Create an NPQ registration with an unvalidated TRN
- TRN should not be set on `TeacherProfile`
- Create an NPQ registration with a validated TRN
- TRN should be set on the `TeacherProfile`