### PR TITLE
Add NPQ course to ParticipantProfile

### DIFF
--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -3,6 +3,7 @@
 class ParticipantProfile::NPQ < ParticipantProfile
   self.ignored_columns = %i[mentor_profile_id school_cohort_id]
   belongs_to :school, optional: true
+  belongs_to :npq_course, optional: true
 
   has_one :validation_data, class_name: "NPQValidationData", foreign_key: :id, dependent: :destroy
 

--- a/app/services/npq/create_or_update_profile.rb
+++ b/app/services/npq/create_or_update_profile.rb
@@ -14,6 +14,7 @@ module NPQ
       teacher_profile.save!
 
       participant_profile.schedule ||= Finance::Schedule.default
+      participant_profile.npq_course ||= npq_validation_data.npq_course
       participant_profile.school = school
       participant_profile.teacher_profile = teacher_profile
       participant_profile.user = user

--- a/db/migrate/20210819104745_add_npq_course_to_participant_profile.rb
+++ b/db/migrate/20210819104745_add_npq_course_to_participant_profile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddNPQCourseToParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :participant_profiles, :npq_course, null: true, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_17_084817) do
+ActiveRecord::Schema.define(version: 2021_08_19_104745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -468,9 +468,11 @@ ActiveRecord::Schema.define(version: 2021_08_17_084817) do
     t.uuid "school_cohort_id"
     t.uuid "teacher_profile_id"
     t.uuid "schedule_id", null: false
+    t.uuid "npq_course_id"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"
+    t.index ["npq_course_id"], name: "index_participant_profiles_on_npq_course_id"
     t.index ["schedule_id"], name: "index_participant_profiles_on_schedule_id"
     t.index ["school_cohort_id"], name: "index_participant_profiles_on_school_cohort_id"
     t.index ["school_id"], name: "index_participant_profiles_on_school_id"
@@ -738,6 +740,7 @@ ActiveRecord::Schema.define(version: 2021_08_17_084817) do
   add_foreign_key "participant_declaration_attempts", "participant_declarations"
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
+  add_foreign_key "participant_profiles", "npq_courses"
   add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
   add_foreign_key "participant_profiles", "schedules"
   add_foreign_key "participant_profiles", "school_cohorts"

--- a/spec/services/npq/create_or_update_profile_spec.rb
+++ b/spec/services/npq/create_or_update_profile_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe NPQ::CreateOrUpdateProfile do
           .and change(ParticipantProfile::NPQ, :count).by(1)
       end
 
+      it "set NPQ course on participant profile" do
+        subject.call
+        expect(user.teacher_profile.npq_profiles.last.npq_course).to eql(npq_validation_data.npq_course)
+      end
+
       it "stores the TRN on teacher profile" do
         subject.call
         npq_validation_data.reload


### PR DESCRIPTION
### Context

- A `TeacherProfile` can have many `ParticipantProfile::NPQ`
- At the moment these are mapped one-to-one for each NPQ application that comes in
- However we only want an `ParticipantProfile::NPQ` per NPQ course

### Changes proposed in this pull request

- This adds NPQ course to `participant_profiles` table
- This will enable the ability for `ParticipantProfile::NPQ` to be scoped on courses in a later change
- For new applications populate `ParticipantProfile::NPQ` with the NPQ course
- Once deployed I will retro back fill `ParticipantProfile::NPQ#npq_course` based on the attached application

### Guidance to review

- `safety_assured` was used in the migration as since it is new column with no data i don't see the duration of the operation being particularly very long

### Testing

- See how to test in review app

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Via api calls
- Create a new NPQ application
- Should now see the course being populated for the new participant profile