### PR TITLE
Provide registration detail in ECF user api endpoint

### DIFF
--- a/app/serializers/ecf_user_serializer.rb
+++ b/app/serializers/ecf_user_serializer.rb
@@ -57,9 +57,8 @@ class ECFUserSerializer
     find_school_cohort(user)&.induction_programme_choice
   end
 
-  # TODO: CPDRP-508 use the actual users registration completed value as part of participant validation journey
-  attributes :registration_completed do
-    false
+  attributes :registration_completed do |user|
+    user.teacher_profile.ecf_profile&.completed_validation_wizard?
   end
 
   attributes :cohort do |user|

--- a/spec/serializers/ecf_user_serializer_spec.rb
+++ b/spec/serializers/ecf_user_serializer_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ECFUserSerializer do
+  let(:ect_profile) { create(:participant_profile, :ect) }
+
+  describe "registration_completed" do
+    context "before validation started" do
+      it "returns false" do
+        expect(user_attributes(ect_profile.user)[:registration_completed]).to be false
+      end
+    end
+
+    context "when details were not matched" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: ect_profile)
+      end
+
+      it "returns true" do
+        expect(user_attributes(ect_profile.user)[:registration_completed]).to be true
+      end
+    end
+
+    context "when the details were matched" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: ect_profile)
+        eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
+        eligibility.matched_status!
+      end
+
+      it "returns true" do
+        expect(user_attributes(ect_profile.user)[:registration_completed]).to be true
+      end
+    end
+  end
+
+private
+
+  def user_attributes(user)
+    described_class.new(user).serializable_hash[:data][:attributes]
+  end
+end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
