### PR TITLE
Change so that one lead provider gets a different batch of data when the rake task is run

### DIFF
--- a/lib/tasks/sandbox_data.rake
+++ b/lib/tasks/sandbox_data.rake
@@ -10,8 +10,9 @@ namespace :lead_providers do
       "#{msg}\n"
     end
 
-    ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Ambition Institute", "Education Development Trust"].each do |provider|
+    ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Education Development Trust"].each do |provider|
       ValidTestDataGenerator::LeadProviderPopulater.call(name: provider, total_schools: 100, participants_per_school: 100)
     end
+    ValidTestDataGenerator::AmbitionSpecificPopulater.call(name: "Ambition Institute", total_schools: 3, participants_per_school: 1500)
   end
 end

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -104,4 +104,24 @@ module ValidTestDataGenerator
       }.flatten.sample
     end
   end
+
+  class AmbitionSpecificPopulater < LeadProviderPopulater
+    class << self
+      def call(name:, total_schools: 3, participants_per_school: 3000)
+        new(name: name).call(total_schools: total_schools, participants_per_school: participants_per_school)
+      end
+    end
+
+    def generate_new_participants(school:, count:, sparsity_uplift:, pupil_premium_uplift:)
+      (count / 2).times do
+        status = "active"
+        mentor = create_participant(school_cohort: school_cohort(school: school), profile_type: :mentor, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+        create_participant(school_cohort: school_cohort(school: school), profile_type: :ect, mentor_profile: mentor, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift)
+      end
+    end
+
+    def random_or_nil_trn
+      TRNGenerator.next
+    end
+  end
 end


### PR DESCRIPTION
### Context

One of the lead providers has asked for a different set of test data to run their tests against.

### Changes proposed in this pull request

- Generate an equal spread of mentors and early career teachers
- Limited to 3 schools with 1500 of each type
- All "active" participants
- No missing TRNs

### Guidance to review

Since the existing code works on deltas and the previous run has been made, the database will need to be cleansed from the previous run. This will be done by removing schools, profiles and users and their associations created and updated between two points for this lead provider

i.e. The following snippet will be used

```where(created_at: "2021-08-18 13:43".."2021-08-18 13:49")```

The new script can then be run and will only add new schools and participants to make up the delta again (i.e. can be safely run and will only verify that the other providers have the correct numbers and won't add any more if they do).