### PR TITLE
Minor admin participant tweaks

### DIFF
--- a/app/components/admin/participants/table_row.html.erb
+++ b/app/components/admin/participants/table_row.html.erb
@@ -13,15 +13,15 @@
     <span class="nhsuk-table-responsive__heading">School</span>
     <%= school&.name %>
   </td>
-  <td class="govuk-table__cell nhsuk-table__cell govuk-table__cell--numeric">
+  <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">School URN</span>
     <%= school&.urn %>
   </td>
-  <td class="govuk-table__cell nhsuk-table__cell govuk-table__cell--numeric">
+  <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Date added</span>
     <%= profile.created_at.to_date.to_s(:govuk_short) %>
   </td>
-  <td class="govuk-table__cell nhsuk-table__cell govuk-table__cell--numeric">
+  <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Validation status</span>
     <%= render Admin::Participants::ValidationStatusTag.new(profile: profile) %>
   </td>

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -14,6 +14,7 @@ module Admin
       query = "%#{(params[:query] || '').downcase}%"
       @participant_profiles = policy_scope(ParticipantProfile).joins(:user)
                                                               .active
+                                                              .includes(:validation_decisions)
                                                               .where("lower(users.full_name) LIKE ? OR school_cohort_id IN (?)", query, school_cohort_ids)
                                                               .order("DATE(users.created_at) asc, users.full_name")
     end


### PR DESCRIPTION
### Context

- Minor tweaks around admin participants area

### Changes proposed in this pull request

- Eager load validation decisions to prevent n+1
- Stop treating data in table as numerical, this removes it from being right aligned

### Guidance to review

- None

### Testing

- Login as an admin
- View admin participants area
- Assuming there is data, there should be no n+1 queries in the logs
- All data in the table should be left aligned

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Same as local testing