### PR TITLE
Increase API pagination max per page from 100 to 250

### DIFF
--- a/app/controllers/concerns/api_pagination.rb
+++ b/app/controllers/concerns/api_pagination.rb
@@ -23,7 +23,7 @@ private
   end
 
   def max_per_page
-    100
+    250
   end
 
   def page

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1357,7 +1357,7 @@
           },
           "per_page": {
             "type": "integer",
-            "description": "The number items to display on a page. Defaults to 100. Maximum is 100, if the value is greater that the maximum allowed it will fallback to 100.",
+            "description": "The number items to display on a page. Defaults to 100. Maximum is 250, if the value is greater that the maximum allowed it will fallback to 250.",
             "example": 10
           }
         }

--- a/swagger/v1/component_schemas/Pagination.yml
+++ b/swagger/v1/component_schemas/Pagination.yml
@@ -7,5 +7,5 @@ properties:
     example: 3
   per_page:
     type: integer
-    description: "The number items to display on a page. Defaults to 100. Maximum is 100, if the value is greater that the maximum allowed it will fallback to 100."
+    description: "The number items to display on a page. Defaults to 100. Maximum is 250, if the value is greater that the maximum allowed it will fallback to 250."
     example: 10


### PR DESCRIPTION
### Context

Some providers were confused re: the limit. I think this is quite conservative so let's gradually increase it.