### PR TITLE
Increase the rate limiting to api endpoints from 300 to 1000 per 5 minutes

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,8 @@
 
 # Throttle general requests by IP
 class Rack::Attack
+  API_PATH = "/api/"
+
   # Throttle /csp_reports requests by IP (5rpm)
   throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
     req.ip if req.path == "/csp_reports"
@@ -11,7 +13,17 @@ class Rack::Attack
     request.path == "/api/notify-callback" && request.post?
   end
 
-  throttle("General requests by ip", limit: 300, period: 5.minutes, &:ip)
+  throttle("Non-API requests by ip", limit: 300, period: 5.minutes) do |request|
+    unless request.path.starts_with?(API_PATH)
+      request.ip
+    end
+  end
+
+  throttle("API requests by ip", limit: 1000, period: 5.minutes) do |request|
+    if request.path.starts_with?(API_PATH)
+      request.ip
+    end
+  end
 
   throttle("Login attempts by ip", limit: 5, period: 20.seconds) do |request|
     if request.path == "/users/sign_in" && request.post?


### PR DESCRIPTION
### Context

We had some integration tests with LPs this week, and they ran into 300 rate limit. They mentioned it might be a bit low in some rare situations. I checked grafana for sandbox, and we reached like 16% of our processor at peak time. Request time spiked to like 0.07 seconds.

It seems not too close to our limit, so it would be interesting to see what happens when they try out more requests next week. 

### Changes proposed in this pull request
Bump API endpoint throttling to 1000 per 5 minutes. 

### Guidance to review
If we are very worried about letting it into prod, I could make it environment aware, but I am not sure it's a good idea. Thoughts? 

### How can I view this in a review app?
Make more than 300 api calls in 5 minutes. If you really want to. 
