### PR TITLE
CDPTP-206 Change current status to suffix existing actions with _record for the current enumerated values

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -13,7 +13,7 @@ module Admin
       school_cohort_ids = SchoolCohort.ransack(school_name_or_school_urn_cont: params[:query]).result.pluck(:id)
       query = "%#{(params[:query] || '').downcase}%"
       @participant_profiles = policy_scope(ParticipantProfile).joins(:user)
-                                                              .active
+                                                              .active_record
                                                               .includes(:validation_decisions)
                                                               .where("lower(users.full_name) LIKE ? OR school_cohort_id IN (?)", query, school_cohort_ids)
                                                               .order("DATE(users.created_at) asc, users.full_name")
@@ -22,7 +22,7 @@ module Admin
     def remove; end
 
     def destroy
-      @participant_profile.withdrawn!
+      @participant_profile.withdrawn_record!
       render :destroy_success
     end
 

--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def index
       @participant_profiles = policy_scope(ParticipantProfile::ECF, policy_scope_class: ParticipantProfilePolicy::Scope)
-        .active
+        .active_record
         .where(school_cohort_id: SchoolCohort.where(school: school).select(:id))
         .includes(:user)
         .order("users.full_name")

--- a/app/controllers/participants/base_controller.rb
+++ b/app/controllers/participants/base_controller.rb
@@ -10,6 +10,6 @@ class Participants::BaseController < ApplicationController
 private
 
   def ensure_participant
-    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.participant_profiles.active.ecf.any?
+    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.participant_profiles.active_record.ecf.any?
   end
 end

--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -195,7 +195,7 @@ module Participants
     end
 
     def participant_profile
-      @participant_profile ||= current_user.participant_profiles.active.ecf.first
+      @participant_profile ||= current_user.participant_profiles.active_record.ecf.first
     end
 
     def set_form

--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -19,7 +19,7 @@ class NominateInductionTutorForm
   end
 
   def email_already_taken?
-    ParticipantProfile.active.ects.joins(:user).where(user: { email: email }).any?
+    ParticipantProfile.active_record.ects.joins(:user).where(user: { email: email }).any?
   end
 
   def name_different?

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -82,7 +82,7 @@ module Schools
       User.find_by(email: email)
         &.teacher_profile
         &.participant_profiles
-        &.active
+        &.active_record
         &.ecf
         &.any?
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def participant_start_path(user)
-    if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school)
+    if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active_record&.first&.school)
       participants_validation_start_path
     else
       dashboard_path
@@ -48,8 +48,8 @@ module ApplicationHelper
 private
 
   def induction_coordinator_mentor_path(user)
-    if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school)
-      profile = user.participant_profiles.active.mentors.first
+    if FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active_record&.first&.school)
+      profile = user.participant_profiles.active_record.mentors.first
       return participants_validation_start_path unless profile&.completed_validation_wizard?
     end
 

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -17,7 +17,7 @@ class ParticipantProfile < ApplicationRecord
   enum status: {
     active: "active",
     withdrawn: "withdrawn",
-  }
+  }, _suffix: :record
 
   scope :mentors, -> { where(type: Mentor.name) }
   scope :ects, -> { where(type: ECT.name) }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -81,11 +81,11 @@ class School < ApplicationRecord
   end
 
   def early_career_teacher_profiles_for(cohort)
-    school_cohorts.find_by(cohort: cohort)&.ecf_participant_profiles&.ects&.active || []
+    school_cohorts.find_by(cohort: cohort)&.ecf_participant_profiles&.ects&.active_record || []
   end
 
   def mentor_profiles_for(cohort)
-    school_cohorts.find_by(cohort: cohort)&.ecf_participant_profiles&.mentors&.active || []
+    school_cohorts.find_by(cohort: cohort)&.ecf_participant_profiles&.mentors&.active_record || []
   end
 
   def full_address

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -17,12 +17,12 @@ class SchoolCohort < ApplicationRecord
 
   has_many :ecf_participant_profiles, class_name: "ParticipantProfile"
   has_many :ecf_participants, through: :ecf_participant_profiles, source: :user
-  has_many :active_ecf_participant_profiles, -> { ecf.active }, class_name: "ParticipantProfile"
+  has_many :active_ecf_participant_profiles, -> { ecf.active_record }, class_name: "ParticipantProfile"
   has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user
 
   has_many :mentor_profiles, -> { mentors }, class_name: "ParticipantProfile"
   has_many :mentors, through: :mentor_profiles, source: :user
-  has_many :active_mentor_profiles, -> { mentors.active }, class_name: "ParticipantProfile"
+  has_many :active_mentor_profiles, -> { mentors.active_record }, class_name: "ParticipantProfile"
   has_many :active_mentors, through: :active_mentor_profiles, source: :user
 
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }

--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -7,9 +7,9 @@ class TeacherProfile < ApplicationRecord
   has_many :participant_profiles, dependent: :destroy
 
   # TODO: Legacy associations, to be removed
-  has_one :early_career_teacher_profile, -> { active }, class_name: "ParticipantProfile::ECT"
-  has_one :mentor_profile, -> { active }, class_name: "ParticipantProfile::Mentor"
-  has_one :ecf_profile, -> { active }, class_name: "ParticipantProfile::ECF"
+  has_one :early_career_teacher_profile, -> { active_record }, class_name: "ParticipantProfile::ECT"
+  has_one :mentor_profile, -> { active_record }, class_name: "ParticipantProfile::Mentor"
+  has_one :ecf_profile, -> { active_record }, class_name: "ParticipantProfile::ECF"
 
   has_many :npq_profiles, class_name: "ParticipantProfile::NPQ"
   # end: TODO

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,7 @@ class User < ApplicationRecord
   end
 
   def npq?
-    npq_profiles.any?(&:active?)
+    npq_profiles.any?(&:active_record?)
   end
 
   def participant?
@@ -115,11 +115,11 @@ class User < ApplicationRecord
   }
 
   scope :is_ecf_participant, lambda {
-    joins(:participant_profiles).merge(ParticipantProfile.ecf.active).includes(mentor_profile: :school_cohort, early_career_teacher_profile: :school_cohort)
+    joins(:participant_profiles).merge(ParticipantProfile.ecf.active_record).includes(mentor_profile: :school_cohort, early_career_teacher_profile: :school_cohort)
   }
 
   scope :is_participant, lambda {
-    joins(:participant_profiles).merge(ParticipantProfile.active)
+    joins(:participant_profiles).merge(ParticipantProfile.active_record)
   }
 
 private

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -28,7 +28,7 @@ private
   def user_can_access?(participant)
     return false unless participant.participant?
     # Prevent NPQ only participants from being accessed
-    return false unless participant.participant_profiles.ecf.active.any?
+    return false unless participant.participant_profiles.ecf.active_record.any?
 
     user.schools.include?(participant.school)
   end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -14,7 +14,7 @@ class ParticipantSerializer
     end
 
     def participant_active?(user)
-      user.teacher_profile.ecf_profile&.active?
+      user.teacher_profile.ecf_profile&.active_record?
     end
 
     def trn(user)

--- a/app/services/admin/change_induction_service.rb
+++ b/app/services/admin/change_induction_service.rb
@@ -50,7 +50,7 @@ module Admin
     def withdraw_participants_if_required(new_provision)
       return if %i[core_induction_programme full_induction_programme].include? new_provision
 
-      school_cohort.active_ecf_participant_profiles.each(&:withdrawn!)
+      school_cohort.active_ecf_participant_profiles.each(&:withdrawn_record!)
     end
   end
 end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -9,7 +9,7 @@ module EarlyCareerTeachers
         user = User.find_or_create_by!(email: email) do |ect|
           ect.full_name = full_name
         end
-        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active&.any?
+        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active_record&.any?
 
         teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
           profile.school = school_cohort.school

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -13,7 +13,7 @@ module Mentors
         user = User.find_or_create_by!(email: email) do |mentor|
           mentor.full_name = full_name
         end
-        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active&.any?
+        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active_record&.any?
 
         teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
           profile.school = school_cohort.school

--- a/app/views/layouts/school_cohort.html.erb
+++ b/app/views/layouts/school_cohort.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: 'layouts/width_container' do %>
   <%= render SchoolRecruitedTransitionComponent.new(school_cohort: @school_cohort) if @school_cohort %>
-  <% if FeatureFlag.active?(:participant_validation, for: current_user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school) %>
+  <% if FeatureFlag.active?(:participant_validation, for: current_user.teacher_profile&.participant_profiles&.ecf&.active_record&.first&.school) %>
     <% if current_user.induction_coordinator_and_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
       <%= render GovukComponent::NotificationBanner.new(title: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
         banner.slot(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,7 +248,7 @@ Rails.application.routes.draw do
   namespace :participants do
     resource :start_registrations, path: "/start-registration", only: :show
 
-    authenticated :user, ->(user) { FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active&.first&.school) } do
+    authenticated :user, ->(user) { FeatureFlag.active?(:participant_validation, for: user.teacher_profile&.participant_profiles&.ecf&.active_record&.first&.school) } do
       scope :validation, as: :validation do
         get "/", to: "validations#start", as: :start
         get "/do-you-want-to-add-your-mentor-information", to: "validations#do_you_want_to_add_mentor_information", as: :do_you_want_to_add_mentor_information

--- a/spec/factories/early_career_teacher_profiles.rb
+++ b/spec/factories/early_career_teacher_profiles.rb
@@ -18,5 +18,9 @@ FactoryBot.define do
       sparsity_uplift
       pupil_premium_uplift
     end
+
+    trait :withdrawn_record do
+      status { :withdrawn }
+    end
   end
 end

--- a/spec/factories/mentor_profiles.rb
+++ b/spec/factories/mentor_profiles.rb
@@ -18,5 +18,9 @@ FactoryBot.define do
       sparsity_uplift
       pupil_premium_uplift
     end
+
+    trait :withdrawn_record do
+      status { :withdrawn }
+    end
   end
 end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -71,7 +71,7 @@ FactoryBot.define do
       pupil_premium_uplift
     end
 
-    trait :withdrawn do
+    trait :withdrawn_record do
       status { :withdrawn }
     end
   end

--- a/spec/forms/participant_mentor_form_spec.rb
+++ b/spec/forms/participant_mentor_form_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe ParticipantMentorForm, type: :model do
 
     subject { described_class.new(school_id: school.id, cohort_id: school_cohort.cohort_id) }
 
-    it "does not include withdrawn mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort, status: "withdrawn").user
+    it "does not include mentors with withdrawn records" do
+      withdrawn_mentor_record = create(:participant_profile, :withdrawn_record, :mentor, school_cohort: school_cohort).user
 
-      expect(subject.available_mentors).not_to include(withdrawn_mentor)
+      expect(subject.available_mentors).not_to include(withdrawn_mentor_record)
     end
 
     it "includes active mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort).user
+      active_mentor_record = create(:participant_profile, :mentor, school_cohort: school_cohort).user
 
-      expect(subject.available_mentors).to include(withdrawn_mentor)
+      expect(subject.available_mentors).to include(active_mentor_record)
     end
   end
 end

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -38,16 +38,16 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
   end
 
   describe "mentor_options" do
-    it "does not include withdrawn mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort, status: "withdrawn").user
+    it "does not include mentors with withdrawn records" do
+      withdrawn_mentor_record = create(:participant_profile, :mentor, :withdrawn_record, school_cohort: school_cohort).user
 
-      expect(subject.mentor_options).not_to include(withdrawn_mentor)
+      expect(subject.mentor_options).not_to include(withdrawn_mentor_record)
     end
 
     it "includes active mentors" do
-      withdrawn_mentor = create(:participant_profile, :mentor, school_cohort: school_cohort).user
+      active_mentor_record = create(:participant_profile, :mentor, school_cohort: school_cohort).user
 
-      expect(subject.mentor_options).to include(withdrawn_mentor)
+      expect(subject.mentor_options).to include(active_mentor_record)
     end
   end
 
@@ -71,9 +71,9 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         expect(subject).to be_email_already_taken
       end
 
-      context "when the ECT is withdrawn" do
+      context "when the ECT profile record is withdrawn" do
         let!(:ect_profile) do
-          create(:participant_profile, :withdrawn, :ect, user: create(:user, email: "ray.clemence@example.com"))
+          create(:participant_profile, :withdrawn_record, :ect, user: create(:user, email: "ray.clemence@example.com"))
         end
 
         it "returns false" do
@@ -91,9 +91,9 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         expect(subject).to be_email_already_taken
       end
 
-      context "when the mentor is withdrawn" do
+      context "when the mentor profile record is withdrawn" do
         let!(:mentor_profile) do
-          create(:participant_profile, :withdrawn, :mentor, user: create(:user, email: "ray.clemence@example.com"))
+          create(:participant_profile, :withdrawn_record, :mentor, user: create(:user, email: "ray.clemence@example.com"))
         end
 
         it "returns false" do

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe LeadProvider, type: :model do
         expect(lead_provider.ecf_participant_profiles).to include participant_profile
       end
 
-      it "should include withdrawn participants" do
-        participant_profile = create(:participant_profile, :ect, status: "withdrawn", school_cohort: school_cohort)
+      it "should include participants whose records have been withdrawn" do
+        participant_profile = create(:participant_profile, :ect, :withdrawn_record, school_cohort: school_cohort)
         expect(lead_provider.ecf_participant_profiles).to include participant_profile
       end
 
@@ -76,8 +76,8 @@ RSpec.describe LeadProvider, type: :model do
         expect(lead_provider.active_ecf_participant_profiles).to include participant_profile
       end
 
-      it "should not include withdrawn participants" do
-        participant_profile = create(:participant_profile, :ect, school_cohort: school_cohort, status: "withdrawn")
+      it "should not include participants whose records have been withdrawn" do
+        participant_profile = create(:participant_profile, :withdrawn_record, :ect, school_cohort: school_cohort)
         expect(lead_provider.active_ecf_participant_profiles).not_to include participant_profile
       end
 

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ParticipantProfile, type: :model do
     is_expected.to define_enum_for(:status).with_values(
       active: "active",
       withdrawn: "withdrawn",
-    ).backed_by_column_of_type(:text)
+    ).with_suffix(:record).backed_by_column_of_type(:text)
   }
 
   it "updates the updated_at on the users" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -482,9 +482,9 @@ RSpec.describe School, type: :model do
       expect(school.participants_for(cohort)).to include(ect_profile.user, mentor_profile.user)
     end
 
-    it "does not include withdrawn participants" do
-      ect = create(:early_career_teacher_profile, status: "withdrawn", school_cohort: school_cohort).user
-      mentor = create(:mentor_profile, status: "withdrawn", school_cohort: school_cohort).user
+    it "does not include participants with withdrawn records" do
+      ect = create(:early_career_teacher_profile, :withdrawn_record, school_cohort: school_cohort).user
+      mentor = create(:mentor_profile, :withdrawn_record, school_cohort: school_cohort).user
 
       expect(school.participants_for(cohort)).not_to include(ect, mentor)
     end
@@ -513,8 +513,8 @@ RSpec.describe School, type: :model do
       expect(school.early_career_teacher_profiles_for(cohort)).to include ect_profile
     end
 
-    it "does not include withdrawn ECTs" do
-      ect_profile = create(:early_career_teacher_profile, status: "withdrawn", school_cohort: school_cohort)
+    it "does not include ECTs with withdrawn records" do
+      ect_profile = create(:early_career_teacher_profile, :withdrawn_record, school_cohort: school_cohort)
 
       expect(school.early_career_teacher_profiles_for(cohort)).not_to include ect_profile
     end
@@ -547,8 +547,8 @@ RSpec.describe School, type: :model do
       expect(school.mentor_profiles_for(cohort)).to include mentor_profile
     end
 
-    it "does not include withdrawn mentors" do
-      mentor_profile = create(:mentor_profile, status: "withdrawn", school_cohort: school_cohort)
+    it "does not include mentors with withdrawn records" do
+      mentor_profile = create(:mentor_profile, :withdrawn_record, school_cohort: school_cohort)
 
       expect(school.mentor_profiles_for(cohort)).not_to include mentor_profile
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe User, type: :model do
       end
 
       it "returns nil when there is no active profile" do
-        user = create(:participant_profile, :ect, status: "withdrawn").user
+        user = create(:participant_profile, :ect, :withdrawn_record).user
         expect(user.early_career_teacher_profile).to be_nil
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe User, type: :model do
       end
 
       it "returns nil when there is no active profile" do
-        user = create(:participant_profile, :mentor, status: :withdrawn).user
+        user = create(:participant_profile, :mentor, :withdrawn_record).user
 
         expect(user.mentor_profile).to be_nil
       end
@@ -145,7 +145,7 @@ RSpec.describe User, type: :model do
     end
 
     it "is false when the ect profile is withdrawn" do
-      user = create(:participant_profile, :ect, status: "withdrawn").user
+      user = create(:participant_profile, :ect, :withdrawn_record).user
       expect(user.early_career_teacher?).to be false
     end
   end
@@ -164,7 +164,7 @@ RSpec.describe User, type: :model do
     end
 
     it "is false when the mentor profile is withdrawn" do
-      user = create(:mentor_profile, status: "withdrawn").user
+      user = create(:mentor_profile, :withdrawn_record).user
       expect(user.mentor?).to be false
     end
   end

--- a/spec/policies/participant_policy_spec.rb
+++ b/spec/policies/participant_policy_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe ParticipantPolicy, type: :policy do
 
           it { is_expected.to permit_action(:show) }
 
-          context "when the participant is withdrawn" do
-            let(:profile) { create(:participant_profile, profile_type, status: :withdrawn) }
+          context "when the participant profile is withdrawn" do
+            let(:profile) { create(:participant_profile, profile_type, :withdrawn_record) }
 
             it { is_expected.to forbid_action(:show) }
           end

--- a/spec/requests/admin/participants_spec.rb
+++ b/spec/requests/admin/participants_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe "Admin::Participants", type: :request do
   describe "DELETE /admin/participants/:id" do
     it "marks the participant as withdrawn" do
       delete "/admin/participants/#{ect_profile.id}"
-      expect(ect_profile.reload.withdrawn?).to be true
+      expect(ect_profile.reload.withdrawn_record?).to be true
     end
 
     it "does not withdraw NPQ participants" do
       expect { delete "/admin/participants/#{npq_profile.id}" }.to raise_error Pundit::NotAuthorizedError
-      expect(npq_profile.active?).to be true
+      expect(npq_profile.active_record?).to be true
     end
 
     it "shows a success message" do

--- a/spec/requests/admin/participants_spec.rb
+++ b/spec/requests/admin/participants_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin::Participants", type: :request do
   let!(:mentor_profile) { create :participant_profile, :mentor, school_cohort: school_cohort }
   let!(:ect_profile) { create :participant_profile, :ect, school_cohort: school_cohort, mentor_profile: mentor_profile }
   let!(:npq_profile) { create(:participant_profile, :npq, school: school) }
-  let!(:withdrawn_ect_profile) { create(:participant_profile, :ect, status: "withdrawn", school_cohort: school_cohort) }
+  let!(:withdrawn_ect_profile_record) { create(:participant_profile, :ect, :withdrawn_record, school_cohort: school_cohort) }
 
   before do
     sign_in admin_user
@@ -28,7 +28,7 @@ RSpec.describe "Admin::Participants", type: :request do
       expect(assigns(:participant_profiles)).to include ect_profile
       expect(assigns(:participant_profiles)).to include mentor_profile
       expect(assigns(:participant_profiles)).to include npq_profile
-      expect(assigns(:participant_profiles)).not_to include withdrawn_ect_profile
+      expect(assigns(:participant_profiles)).not_to include withdrawn_ect_profile_record
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe "Admin::Participants", type: :request do
   end
 
   describe "DELETE /admin/participants/:id" do
-    it "marks the participant as withdrawn" do
+    it "marks the participant record as withdrawn" do
       delete "/admin/participants/#{ect_profile.id}"
       expect(ect_profile.reload.withdrawn_record?).to be true
     end

--- a/spec/requests/admin/schools/participants_spec.rb
+++ b/spec/requests/admin/schools/participants_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
   let!(:mentor_profile) { create :participant_profile, :mentor, school_cohort: school_cohort }
   let!(:npq_profile) { create(:participant_profile, :npq, school: school) }
   let!(:unrelated_profile) { create :participant_profile }
-  let!(:withdrawn_profile) { create :participant_profile, :withdrawn, :mentor, school_cohort: school_cohort }
+  let!(:withdrawn_profile_record) { create :participant_profile, :withdrawn_record, :mentor, school_cohort: school_cohort }
 
   before do
     sign_in admin_user
@@ -32,7 +32,7 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
       expect(assigns(:participant_profiles)).to include ect_profile
       expect(assigns(:participant_profiles)).not_to include npq_profile
       expect(assigns(:participant_profiles)).not_to include unrelated_profile
-      expect(assigns(:participant_profiles)).not_to include withdrawn_profile
+      expect(assigns(:participant_profiles)).not_to include withdrawn_profile_record
     end
   end
 end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
     before :each do
       mentor_profile = create(:participant_profile, :mentor, school: partnership.school, cohort: partnership.cohort)
       create_list :participant_profile, 2, :ect, mentor_profile: mentor_profile, school_cohort: school_cohort
-      ect_teacher_profile_with_one_active_and_one_withdrawn_profile = ParticipantProfile::ECT.first.teacher_profile
+      ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record = ParticipantProfile::ECT.first.teacher_profile
       create(:participant_profile,
-             :withdrawn,
+             :withdrawn_record,
              :ect,
-             teacher_profile: ect_teacher_profile_with_one_active_and_one_withdrawn_profile,
+             teacher_profile: ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record,
              school_cohort: school_cohort)
     end
-    let!(:withdrawn_ect_profile) { create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort) }
+    let!(:withdrawn_ect_profile_record) { create(:participant_profile, :withdrawn_record, :ect, school_cohort: school_cohort) }
 
     context "when authorized" do
       before do
@@ -75,7 +75,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           get "/api/v1/participants"
           mentors = 0
           ects = 0
-          withdrawn = 0
+          withdrawn_participant_record = 0
 
           parsed_response["data"].each do |user|
             user_type = user["attributes"]["participant_type"]
@@ -85,13 +85,13 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
             elsif user_type == "ect"
               ects += 1
             elsif user_type.nil? && status == "withdrawn"
-              withdrawn += 1
+              withdrawn_participant_record += 1
             end
           end
 
           expect(mentors).to eql(1)
           expect(ects).to eql(2)
-          expect(withdrawn).to eql(1)
+          expect(withdrawn_participant_record).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -181,16 +181,16 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty
 
-          withdrawn_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile.user.id }
-          expect(withdrawn_row).not_to be_nil
-          expect(withdrawn_row["email"]).to be_empty
-          expect(withdrawn_row["full_name"]).to be_empty
-          expect(withdrawn_row["mentor_id"]).to be_empty
-          expect(withdrawn_row["school_urn"]).to be_empty
-          expect(withdrawn_row["participant_type"]).to be_empty
-          expect(withdrawn_row["cohort"]).to be_empty
-          expect(withdrawn_row["teacher_reference_number"]).to be_empty
-          expect(withdrawn_row["teacher_reference_number_validated"]).to be_empty
+          withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
+          expect(withdrawn_record_row).not_to be_nil
+          expect(withdrawn_record_row["email"]).to be_empty
+          expect(withdrawn_record_row["full_name"]).to be_empty
+          expect(withdrawn_record_row["mentor_id"]).to be_empty
+          expect(withdrawn_record_row["school_urn"]).to be_empty
+          expect(withdrawn_record_row["participant_type"]).to be_empty
+          expect(withdrawn_record_row["cohort"]).to be_empty
+          expect(withdrawn_record_row["teacher_reference_number"]).to be_empty
+          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_empty
           expect(mentor_row["eligible_for_funding"]).to be_empty
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty
 
-          ect = ParticipantProfile::ECT.active.first.user
+          ect = ParticipantProfile::ECT.active_record.first.user
           ect_row = parsed_response.find { |row| row["id"] == ect.id }
           expect(ect_row).not_to be_nil
           expect(ect_row["email"]).to eql ect.email

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Schools::Participants", type: :request do
   let!(:mentor_user) { create(:participant_profile, :mentor, school_cohort: school_cohort).user }
   let!(:mentor_user_2) { create(:participant_profile, :mentor, school_cohort: school_cohort).user }
   let!(:ect_user) { create(:participant_profile, :ect, mentor_profile: mentor_user.mentor_profile, school_cohort: school_cohort).user }
-  let!(:withdrawn_ect) { create(:participant_profile, :ect, status: "withdrawn", school_cohort: school_cohort).user }
+  let!(:withdrawn_ect_record) { create(:participant_profile, :ect, :withdrawn_record, school_cohort: school_cohort).user }
   let!(:unrelated_mentor) { create(:participant_profile, :mentor, school_cohort: another_cohort).user }
   let!(:unrelated_ect) { create(:participant_profile, :ect, school_cohort: another_cohort).user }
 
@@ -44,10 +44,10 @@ RSpec.describe "Schools::Participants", type: :request do
       expect(response.body).not_to include(CGI.escapeHTML(unrelated_ect.full_name))
     end
 
-    it "does not list withdrawn participants" do
+    it "does not list participants with withdrawn profile records" do
       get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants"
 
-      expect(response.body).not_to include(CGI.escapeHTML(withdrawn_ect.full_name))
+      expect(response.body).not_to include(CGI.escapeHTML(withdrawn_ect_record.full_name))
     end
 
     context "when there are no mentors" do

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe ParticipantSerializer do
       end
     end
 
-    context "when the participant is withdrawn" do
-      let(:mentor) { create(:participant_profile, :mentor, status: "withdrawn").user }
-      let(:ect) { create(:participant_profile, :ect, mentor_profile: mentor.mentor_profile, status: "withdrawn").user }
+    context "when the participant record is withdrawn" do
+      let(:mentor) { create(:participant_profile, :mentor, :withdrawn_record).user }
+      let(:ect) { create(:participant_profile, :ect, :withdrawn_record, mentor_profile: mentor.mentor_profile).user }
 
       it "outputs correctly formatted serialized Mentors" do
         expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null}}}"

--- a/spec/services/admin/change_induction_choice_service_spec.rb
+++ b/spec/services/admin/change_induction_choice_service_spec.rb
@@ -141,18 +141,18 @@ RSpec.describe Admin::ChangeInductionService do
         let(:school) { create(:school_cohort, induction_programme_choice: "core_induction_programme", cohort: cohort).school }
         it "withdraws all participants when changing to NoECTs" do
           service.change_induction_provision(:no_early_career_teachers)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_withdrawn_record
         end
 
         it "withdraws all participants when changing to DIY" do
           service.change_induction_provision(:design_our_own)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_withdrawn_record
         end
 
         it "does not change participants when changing to FIP" do
           expect { service.change_induction_provision(:full_induction_programme) }
             .not_to change { school.participants_for(cohort).map(&:id) }
-          expect(participant_profiles.each(&:reload)).to all be_active
+          expect(participant_profiles.each(&:reload)).to all be_active_record
         end
       end
 
@@ -160,18 +160,18 @@ RSpec.describe Admin::ChangeInductionService do
         let(:school) { create(:school_cohort, induction_programme_choice: "full_induction_programme", cohort: cohort).school }
         it "withdraws all participants when changing to NoECTs" do
           service.change_induction_provision(:no_early_career_teachers)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_withdrawn_record
         end
 
         it "withdraws all participants when changing to DIY" do
           service.change_induction_provision(:design_our_own)
-          expect(participant_profiles.each(&:reload)).to all be_withdrawn
+          expect(participant_profiles.each(&:reload)).to all be_withdrawn_record
         end
 
         it "does not change participants when changing to CIP" do
           expect { service.change_induction_provision(:core_induction_programme) }
             .not_to change { school.participants_for(cohort).map(&:id) }
-          expect(participant_profiles.each(&:reload)).to all be_active
+          expect(participant_profiles.each(&:reload)).to all be_active_record
         end
       end
     end

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe InviteSchools do
     it "sends emails to tutors who have withdrawn all of their participants" do
       induction_coordinator = create(:user, :induction_coordinator)
       school_cohort = create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme")
-      create(:participant_profile, :withdrawn, :ect, school_cohort: school_cohort)
+      create(:participant_profile, :withdrawn_record, :ect, school_cohort: school_cohort)
 
       InviteSchools.new.send_induction_coordinator_add_participants_email
       expect_send_participants_email(induction_coordinator)


### PR DESCRIPTION
### Context

The current "active" and "withdrawn" status flags refer to the participant_profile record status as opposed to the participant and show if the record itself is available.

There is a new state coming in a follow-up PR that also sets a "withdrawn" state which is more about modelling the participant and their relationships with the course that they are or may no longer be following. i.e. withdrawn from a course as opposed to a withdrawn record.

In order to avoid some confusion and complexity around the differences and similarities of these logically distinct states, this first changes the actions and queries on this "active" and "withdrawn" status.

### Changes proposed in this pull request

- modify the existing dynamically generated actions and queries to have an "_record" suffix, so that "withdrawn" becomes "withdrawn_record" and "withdrawn?" becomes "withdrawn_record?" and perform the same changes for "active" to "active_record" and "active_record?" (Confusion with ActiveRecord should be minor and easily overcome in comparison). 
- Update tests with these. Since this is an internal code method change only, API and database should not be effected.
- Change the trait "withdrawn" to "withdrawn_record" to reflect the intent.
- Clean up the tests so it's clear what they are testing vis a vis record withdrawal prior to putting in the lead_provider withdrawal.

### Guidance to review

This should only change the method calls

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
