### PR TITLE
CDPTP-206_Fix up the broken validation catch-all at the controller as a pre-step for implementing the withdrawn action

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -7,9 +7,8 @@ module Api
       include ApiTokenAuthenticatable
 
       def create
-        params = HashWithIndifferentAccess.new({ lead_provider_from_token: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
-        validate_params!(params)
-        render json: RecordParticipantDeclaration.call(convert_params_for_declaration(params))
+        params = HashWithIndifferentAccess.new({ cpd_lead_provider: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
+        render json: RecordParticipantDeclaration.call(params)
       end
 
     private
@@ -18,36 +17,14 @@ module Api
         current_user
       end
 
-      def convert_params_for_declaration(params)
-        params.transform_keys do |key|
-          key == "participant_id" ? "user_id" : key
-        end
-      end
-
-      def validate_params!(params)
-        raise ActionController::ParameterMissing, missing_params(params) unless missing_params(params).empty?
-      end
-
-      def missing_params(params)
-        required_params - params.keys
-      end
-
       def permitted_params
-        params.require(:data).permit(:type, { attributes: required_params + optional_params })
+        params.require(:data).permit(:type, attributes: {})
       rescue ActionController::ParameterMissing => e
         if e.param == :data
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
         else
           raise
         end
-      end
-
-      def optional_params
-        %w[evidence_held]
-      end
-
-      def required_params
-        %w[participant_id declaration_date declaration_type course_identifier]
       end
     end
   end

--- a/app/services/record_declarations/early_career_teacher.rb
+++ b/app/services/record_declarations/early_career_teacher.rb
@@ -5,12 +5,19 @@ module RecordDeclarations
     extend ActiveSupport::Concern
 
     included do
+      extend EarlyCareerTeacherClassMethods
       include ECF
       delegate :early_career_teacher_profile, to: :user
     end
 
     def user_profile
       early_career_teacher_profile
+    end
+
+    module EarlyCareerTeacherClassMethods
+      def valid_courses_for_user
+        %w[ecf-induction]
+      end
     end
   end
 end

--- a/app/services/record_declarations/event_factory.rb
+++ b/app/services/record_declarations/event_factory.rb
@@ -4,7 +4,9 @@ module RecordDeclarations
   class EventFactory
     class << self
       def call(event)
-        event_namespace_for_event(event)
+        event_namespace_for_event(event).presence || (raise ActionController::ParameterMissing, [I18n.t(:invalid_declaration_type)])
+      rescue StandardError
+        raise ActionController::ParameterMissing, [I18n.t(:invalid_declaration_type)]
       end
 
     private

--- a/app/services/record_declarations/mentor.rb
+++ b/app/services/record_declarations/mentor.rb
@@ -5,12 +5,19 @@ module RecordDeclarations
     extend ActiveSupport::Concern
 
     included do
+      extend MentorClassMethods
       include ECF
       delegate :mentor_profile, to: :user
     end
 
     def user_profile
       mentor_profile
+    end
+
+    module MentorClassMethods
+      def valid_courses_for_user
+        %w[ecf-mentor]
+      end
     end
   end
 end

--- a/app/services/record_declarations/npq.rb
+++ b/app/services/record_declarations/npq.rb
@@ -6,6 +6,7 @@ module RecordDeclarations
 
     included do
       delegate :npq?, :npq_profiles, to: :user
+      extend NPQClassMethods
     end
 
     def participant?
@@ -26,6 +27,12 @@ module RecordDeclarations
 
     def valid_declaration_types
       %w[started completed retained-1 retained-2]
+    end
+
+    module NPQClassMethods
+      def valid_courses_for_user
+        NPQCourse.identifiers
+      end
     end
   end
 end

--- a/app/services/record_declarations/recorder_factory.rb
+++ b/app/services/record_declarations/recorder_factory.rb
@@ -4,7 +4,7 @@ module RecordDeclarations
   class RecorderFactory
     class << self
       def call(course)
-        recorder_klass_name_for_course_identifier(course)
+        recorder_klass_name_for_course_identifier(course).presence || (raise ActionController::ParameterMissing, [I18n.t(:invalid_course)])
       end
 
     private

--- a/app/services/record_participant_declaration.rb
+++ b/app/services/record_participant_declaration.rb
@@ -15,8 +15,6 @@ class RecordParticipantDeclaration
   def call
     recorder = "::RecordDeclarations::#{::RecordDeclarations::EventFactory.call(event)}::#{::RecordDeclarations::RecorderFactory.call(course_identifier)}".constantize
     recorder.call(params)
-  rescue NameError
-    raise ActionController::ParameterMissing, I18n.t(:invalid_course)
   end
 
 private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
   parameter_required: Parameter is required
   invalid_participant: "The property '#/participant_id' must be a valid Participant ID"
   invalid_identifier: "The property '#/course_identifier' must be an available course to '#/participant_id'"
-  invalid_declaration_type: "The property '#/declaration_type' must be available for course_identifier '#/course_identifier'"
+  invalid_declaration_type: "The property '#/declaration_type' must be available for '#/course_identifier'"
   missing_course_identifier: "The property '#/course_identifier' must be present"
   missing_declaration_date: "The property '#/declaration_date' must be present"
   invalid_declaration_date: "The property '#/declaration_date' must be a valid RCF3339 date"

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         missing_attribute = valid_params.except(:participant_id)
         post "/api/v1/participant-declarations", params: build_params(missing_attribute)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ bad_or_missing_parameters: %w[participant_id] }.to_json)
+        expect(response.body).to eq({ bad_or_missing_parameters: [I18n.t(:invalid_participant)] }.to_json)
       end
 
       it "returns 422 when supplied an incorrect course type" do
@@ -99,13 +99,13 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         invalid_course_identifier = valid_params.merge({ course_identifier: "ecf-mentor" })
         post "/api/v1/participant-declarations", params: build_params(invalid_course_identifier)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ bad_or_missing_parameters: ["The property '#/course_identifier' must be an available course to '#/participant_id'"] }.to_json)
+        expect(response.body).to eq({ bad_or_missing_parameters: [I18n.t(:invalid_course)] }.to_json)
       end
 
       it "returns 422 when there are multiple errors" do
         post "/api/v1/participant-declarations", params: build_params("")
         expect(response.status).to eq 422
-        expect(response.body).to eq({ bad_or_missing_parameters: %w[participant_id declaration_date declaration_type course_identifier] }.to_json)
+        expect(response.body).to eq({ bad_or_missing_parameters: [I18n.t(:invalid_declaration_type)] }.to_json)
       end
 
       it "returns 400 when the data block is incorrect" do

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -3,13 +3,13 @@
 RSpec.shared_context "lead provider profiles and courses" do
   # lead providers setup
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
-  let(:another_lead_provider) { create(:cpd_lead_provider, name: "Unknown") }
+  let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Unknown") }
   let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
 
   # ECF setup
   let(:ecf_lead_provider) { cpd_lead_provider.lead_provider }
   let!(:ect_profile) { create(:early_career_teacher_profile) }
-  let!(:mentor_profile) { create(:mentor_profile) }
+  let!(:mentor_profile) { create(:mentor_profile, school_cohort: ect_profile.school_cohort) }
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:delivery_partner) { create(:delivery_partner) }
   let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -4,28 +4,28 @@ RSpec.shared_context "service record declaration params" do
   let(:ect_declaration_date) { ect_profile.schedule.milestones.first.start_date + 1.day }
   let(:params) do
     {
-      user_id: ect_profile.user.id,
+      participant_id: ect_profile.user.id,
       declaration_date: ect_declaration_date.rfc3339,
       declaration_type: "started",
       course_identifier: "ecf-induction",
-      lead_provider_from_token: another_lead_provider,
+      cpd_lead_provider: another_lead_provider,
       evidence_held: "other",
     }
   end
   let(:ect_params) do
-    params.merge({ lead_provider_from_token: cpd_lead_provider })
+    params.merge({ cpd_lead_provider: cpd_lead_provider })
   end
 
   let(:mentor_declaration_date) { mentor_profile.schedule.milestones.first.start_date + 1.day }
   let(:mentor_params) do
-    ect_params.merge({ user_id: mentor_profile.user.id, course_identifier: "ecf-mentor", declaration_date: mentor_declaration_date.rfc3339 })
+    ect_params.merge({ participant_id: mentor_profile.user.id, course_identifier: "ecf-mentor", declaration_date: mentor_declaration_date.rfc3339 })
   end
 
   let(:npq_declaration_date) { npq_profile.schedule.milestones.first.start_date + 1.day }
   let(:npq_params) do
     params.merge({
-      lead_provider_from_token: cpd_lead_provider,
-      user_id: npq_profile.user.id,
+      cpd_lead_provider: cpd_lead_provider,
+      participant_id: npq_profile.user.id,
       course_identifier: npq_profile.validation_data.npq_course.identifier,
       evidence_held: "yes",
       declaration_date: npq_declaration_date.rfc3339,
@@ -33,6 +33,6 @@ RSpec.shared_context "service record declaration params" do
   end
 
   let(:induction_coordinator_params) do
-    ect_params.merge({ user_id: induction_coordinator_profile.user_id })
+    ect_params.merge({ participant_id: induction_coordinator_profile.user_id })
   end
 end


### PR DESCRIPTION
### Context

The participant-declaration controller had a global "catch-all" exception handler which was incorrectly always returning a message stating that the participant_id didn't match the course_identifier.
Working on the common interface for the withdrawn message highlighted this problem, when, for example, the underlying user didn't exist and a user.mentor? call (for example) would raise an exception that was then swallowed.

### Changes proposed in this pull request

Refactor "participant-declarations" controller and validations as a step towards merging participant validation code into a block which will support both.
Move constant values into the class to avoid failures when the user creation fails for other validation types.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
