### PR TITLE
Support UKPRNs for NPQs

### DIFF
--- a/app/components/admin/participants/details/npq.html.erb
+++ b/app/components/admin/participants/details/npq.html.erb
@@ -20,7 +20,7 @@
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">School URN</th>
-      <td class="govuk-table__cell"><%= profile.school&.urn %></td>
+      <td class="govuk-table__cell"><%= profile.school_urn %></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Participant type</th>

--- a/app/components/admin/participants/details/npq_pending.html.erb
+++ b/app/components/admin/participants/details/npq_pending.html.erb
@@ -28,7 +28,7 @@
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">School URN</th>
-      <td class="govuk-table__cell"><%= profile.school&.urn %></td>
+      <td class="govuk-table__cell"><%= profile.school_urn %></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Participant type</th>

--- a/app/components/admin/participants/table_row.html.erb
+++ b/app/components/admin/participants/table_row.html.erb
@@ -15,7 +15,7 @@
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">School URN</span>
-    <%= school&.urn %>
+    <%= school_urn %>
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Date added</span>

--- a/app/components/admin/participants/table_row.rb
+++ b/app/components/admin/participants/table_row.rb
@@ -9,9 +9,14 @@ module Admin
         @profile = profile
       end
 
+      def school_urn
+        school&.urn || profile.school_urn
+      end
+
     private
 
       attr_reader :profile
+
       delegate :school, to: :profile
     end
   end

--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -50,6 +50,7 @@ module Api
             :headteacher_status,
             :national_insurance_number,
             :school_urn,
+            :school_ukprn,
             :teacher_reference_number,
             :teacher_reference_number_verified,
           ).transform_keys! { |key| key == "national_insurance_number" ? "nino" : key }

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -31,6 +31,7 @@ private
       teacher_reference_number
       teacher_reference_number_validated
       school_urn
+      school_ukprn
       headteacher_status
       eligible_for_funding
       funding_choice
@@ -49,6 +50,7 @@ private
       record.teacher_reference_number,
       record.teacher_reference_number_verified,
       record.school_urn,
+      record.school_ukprn,
       record.headteacher_status,
       record.eligible_for_funding,
       record.funding_choice,

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -13,6 +13,7 @@ class NPQApplicationSerializer
              :teacher_reference_number,
              :teacher_reference_number_validated,
              :school_urn,
+             :school_ukprn,
              :headteacher_status,
              :eligible_for_funding,
              :funding_choice,

--- a/app/serializers/npq_validation_data_serializer.rb
+++ b/app/serializers/npq_validation_data_serializer.rb
@@ -14,6 +14,7 @@ class NPQValidationDataSerializer
              :teacher_reference_number_verified,
              :active_alert,
              :school_urn,
+             :school_ukprn,
              :headteacher_status,
              :eligible_for_funding,
              :funding_choice

--- a/app/services/npq/create_or_update_profile.rb
+++ b/app/services/npq/create_or_update_profile.rb
@@ -13,14 +13,14 @@ module NPQ
         teacher_profile.trn = npq_validation_data.teacher_reference_number
       end
 
-      teacher_profile.school = school
       teacher_profile.save!
 
       participant_profile.schedule ||= Finance::Schedule.default
       participant_profile.npq_course ||= npq_validation_data.npq_course
-      participant_profile.school = school
       participant_profile.teacher_profile = teacher_profile
       participant_profile.user = user
+      participant_profile.school_urn = npq_validation_data.school_urn
+      participant_profile.school_ukprn = npq_validation_data.school_ukprn
       participant_profile.save!
     end
 
@@ -36,10 +36,6 @@ module NPQ
 
     def user
       @user ||= npq_validation_data.user
-    end
-
-    def school
-      @school ||= School.find_by(urn: npq_validation_data.school_urn)
     end
   end
 end

--- a/db/migrate/20210825123807_add_ukprn_to_npqs.rb
+++ b/db/migrate/20210825123807_add_ukprn_to_npqs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUkprnToNpqs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_profiles, :school_ukprn, :text, null: true
+  end
+end

--- a/db/migrate/20210827111927_add_urn_ukprn_to_participant_profiles.rb
+++ b/db/migrate/20210827111927_add_urn_ukprn_to_participant_profiles.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUrnUkprnToParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      change_table :participant_profiles, bulk: true do |t|
+        t.column :school_urn, :text, null: true
+        t.column :school_ukprn, :text, null: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -411,6 +411,7 @@ ActiveRecord::Schema.define(version: 2021_08_31_081434) do
     t.text "funding_choice"
     t.text "nino"
     t.text "lead_provider_approval_status", default: "pending", null: false
+    t.text "school_ukprn"
     t.index ["npq_course_id"], name: "index_npq_profiles_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_profiles_on_npq_lead_provider_id"
     t.index ["user_id"], name: "index_npq_profiles_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -479,6 +479,8 @@ ActiveRecord::Schema.define(version: 2021_08_31_081434) do
     t.uuid "teacher_profile_id"
     t.uuid "schedule_id", null: false
     t.uuid "npq_course_id"
+    t.text "school_urn"
+    t.text "school_ukprn"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/components/admin/participants/details_spec.rb
+++ b/spec/components/admin/participants/details_spec.rb
@@ -34,15 +34,20 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
   end
 
   context "for unvalidated npq profile" do
-    let(:profile) { create :participant_profile, :npq }
+    let(:npq_validation_data) { create(:npq_validation_data) }
+    let(:profile) { npq_validation_data.profile }
+
+    before do
+      Finance::Schedule.find_or_create_by!(name: "ECF September standard 2021")
+      NPQ::CreateOrUpdateProfile.new(npq_validation_data: npq_validation_data).call
+    end
 
     it "renders all the required information" do
       expect(rendered).to have_contents(
         profile.user.full_name,
         profile.user.email,
         profile.validation_data.teacher_reference_number,
-        profile.school.name,
-        profile.school.urn,
+        profile.validation_data.school_urn,
         t(:npq, scope: "schools.participants.type"),
         profile.validation_data.npq_lead_provider.name,
         profile.validation_data.npq_course.name,
@@ -51,7 +56,13 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
   end
 
   context "for validated npq profile" do
-    let(:profile) { create :participant_profile, :npq }
+    let(:npq_validation_data) { create(:npq_validation_data) }
+    let(:profile) { npq_validation_data.profile }
+
+    before do
+      Finance::Schedule.find_or_create_by!(name: "ECF September standard 2021")
+      NPQ::CreateOrUpdateProfile.new(npq_validation_data: npq_validation_data).call
+    end
 
     before do
       allow(profile).to receive(%i[approved? rejected?].sample).and_return true
@@ -63,8 +74,7 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
         profile.user.full_name,
         profile.user.email,
         profile.validation_data.teacher_reference_number,
-        profile.school.name,
-        profile.school.urn,
+        profile.validation_data.school_urn,
         t(:npq, scope: "schools.participants.type"),
         profile.validation_data.npq_lead_provider.name,
         profile.validation_data.npq_course.name,

--- a/spec/components/admin/participants/table_row_spec.rb
+++ b/spec/components/admin/participants/table_row_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe Admin::Participants::TableRow, type: :view_component do
     it { is_expected.to have_content school.name }
     it { is_expected.to have_content school.urn }
   end
+
+  context "when profile is not associated with the school" do
+    let(:participant_profile) { create :participant_profile, school: nil }
+
+    it { is_expected.to have_css(".govuk-table__cell:nth-child(3)", text: "\n    School\n    \n") }
+  end
+
+  context "when profile is not associated with the school but has school_urn" do
+    let(:participant_profile) { create :participant_profile, school: nil, school_urn: "123456" }
+
+    it { is_expected.to have_content("123456") }
+  end
 end

--- a/spec/factories/npq_validation_data.rb
+++ b/spec/factories/npq_validation_data.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     headteacher_status { NPQValidationData.headteacher_statuses.keys.sample }
     funding_choice { NPQValidationData.funding_choices.keys.sample }
     school_urn { rand(100_000..999_999).to_s }
-    school_ukprn { [rand(10_000_000..99_999_999).to_s, nil].sample }
+    school_ukprn { rand(10_000_000..99_999_999).to_s }
     date_of_birth { rand(25..50).years.ago + rand(0..365).days }
     teacher_reference_number { rand(1_000_000..9_999_999).to_s }
   end

--- a/spec/factories/npq_validation_data.rb
+++ b/spec/factories/npq_validation_data.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     headteacher_status { NPQValidationData.headteacher_statuses.keys.sample }
     funding_choice { NPQValidationData.funding_choices.keys.sample }
     school_urn { rand(100_000..999_999).to_s }
+    school_ukprn { [rand(10_000_000..99_999_999).to_s, nil].sample }
     date_of_birth { rand(25..50).years.ago + rand(0..365).days }
     teacher_reference_number { rand(1_000_000..9_999_999).to_s }
   end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -49,11 +49,10 @@ FactoryBot.define do
     end
 
     trait :npq do
-      school
-      teacher_profile { association :teacher_profile, school: school }
+      teacher_profile { association :teacher_profile }
       schedule
 
-      validation_data { association :npq_validation_data, user: teacher_profile.user }
+      validation_data { association :npq_validation_data, user: teacher_profile.user, school_urn: rand(100_000..999_999) }
 
       participant_type { :npq }
     end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(parsed_response["data"][0]["attributes"]["email"]).to eql(user.email)
           expect(parsed_response["data"][0]["attributes"]["email_validated"]).to eql(true)
           expect(parsed_response["data"][0]["attributes"]["school_urn"]).to eql(profile.school_urn)
+          expect(parsed_response["data"][0]["attributes"]["school_ukprn"]).to eql(profile.school_ukprn)
           expect(parsed_response["data"][0]["attributes"]["teacher_reference_number"]).to eql(profile.teacher_reference_number)
           expect(parsed_response["data"][0]["attributes"]["teacher_reference_number_validated"]).to eql(profile.teacher_reference_number_verified)
           expect(parsed_response["data"][0]["attributes"]["eligible_for_funding"]).to eql(profile.eligible_for_funding)
@@ -110,6 +111,7 @@ RSpec.describe "NPQ Applications API", type: :request do
               teacher_reference_number
               teacher_reference_number_validated
               school_urn
+              school_ukprn
               headteacher_status
               eligible_for_funding
               funding_choice
@@ -131,6 +133,7 @@ RSpec.describe "NPQ Applications API", type: :request do
           expect(row["teacher_reference_number"]).to eql(profile.teacher_reference_number)
           expect(row["teacher_reference_number_validated"]).to eql(profile.teacher_reference_number_verified.to_s)
           expect(row["school_urn"]).to eql(profile.school_urn)
+          expect(row["school_ukprn"]).to eql(profile.school_ukprn)
           expect(row["headteacher_status"]).to eql(profile.headteacher_status)
           expect(row["eligible_for_funding"]).to eql(profile.eligible_for_funding.to_s)
           expect(row["funding_choice"]).to eql(profile.funding_choice)

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
               date_of_birth: "1990-12-13",
               national_insurance_number: "AB123456C",
               school_urn: "123456",
+              school_ukprn: "12345678",
               headteacher_status: "no",
               eligible_for_funding: true,
               funding_choice: "school",
@@ -78,6 +79,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(validation_data.teacher_reference_number_verified).to be_truthy
         expect(validation_data.active_alert).to be_truthy
         expect(validation_data.school_urn).to eql("123456")
+        expect(validation_data.school_ukprn).to eql("12345678")
         expect(validation_data.headteacher_status).to eql("no")
         expect(validation_data.npq_course).to eql(npq_course)
         expect(validation_data.eligible_for_funding).to eql(true)
@@ -111,6 +113,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
           :headteacher_status,
           :date_of_birth,
           :school_urn,
+          :school_ukprn,
           :eligible_for_funding,
           :funding_choice,
         )

--- a/spec/services/npq/create_or_update_profile_spec.rb
+++ b/spec/services/npq/create_or_update_profile_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe NPQ::CreateOrUpdateProfile do
   end
 
   describe "#call" do
-    let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
     let(:trn) { rand(1_000_000..9_999_999).to_s }
     let(:user) { create(:user) }
     let(:npq_course) { create(:npq_course) }
@@ -24,6 +23,8 @@ RSpec.describe NPQ::CreateOrUpdateProfile do
         user: user,
         npq_course: npq_course,
         npq_lead_provider: npq_lead_provider,
+        school_urn: "123456",
+        school_ukprn: "12345678",
       )
     end
 
@@ -38,9 +39,17 @@ RSpec.describe NPQ::CreateOrUpdateProfile do
           .and change(ParticipantProfile::NPQ, :count).by(1)
       end
 
-      it "set NPQ course on participant profile" do
+      it "creates participant profile correctly" do
         subject.call
-        expect(user.teacher_profile.npq_profiles.last.npq_course).to eql(npq_validation_data.npq_course)
+
+        profile = user.teacher_profile.npq_profiles.last
+
+        expect(profile.schedule).to eql(Finance::Schedule.default)
+        expect(profile.npq_course).to eql(npq_validation_data.npq_course)
+        expect(profile.teacher_profile).to eql(user.teacher_profile)
+        expect(profile.user).to eql(user)
+        expect(profile.school_urn).to eql(npq_validation_data.school_urn)
+        expect(profile.school_ukprn).to eql(npq_validation_data.school_ukprn)
       end
 
       context "when trn is validated" do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1267,6 +1267,7 @@
                   "teacher_reference_number": "1234567",
                   "teacher_reference_number_validated": true,
                   "school_urn": "106286",
+                  "school_ukprn": "10079319",
                   "headteacher_status": "no",
                   "eligible_for_funding": true,
                   "funding_choice": "trust",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1355,7 +1355,6 @@
           "email_validated",
           "teacher_reference_number",
           "teacher_reference_number_validated",
-          "school_urn",
           "eligible_for_funding",
           "course_identifier",
           "status"
@@ -1401,6 +1400,11 @@
             "description": "The Unique Reference Number (URN) of the school where this NPQ participant is employed",
             "type": "string",
             "example": "106286"
+          },
+          "school_ukprn": {
+            "description": "The UK Provider Reference Number (UK Provider Reference Number) of the school where this NPQ participant is employed",
+            "type": "string",
+            "example": "10079319"
           },
           "headteacher_status": {
             "description": "Indicates whether this NPQ participant is or will be a head teacher",

--- a/swagger/v1/component_schemas/MultipleNPQApplicationsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleNPQApplicationsResponse.yml
@@ -18,6 +18,7 @@ properties:
           teacher_reference_number: "1234567"
           teacher_reference_number_validated: true
           school_urn: "106286"
+          school_ukprn: "10079319"
           headteacher_status: "no"
           eligible_for_funding: true
           funding_choice: "trust"

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -8,7 +8,6 @@ required:
   - email_validated
   - teacher_reference_number
   - teacher_reference_number_validated
-  - school_urn
   - eligible_for_funding
   - course_identifier
   - status
@@ -46,6 +45,10 @@ properties:
     description: "The Unique Reference Number (URN) of the school where this NPQ participant is employed"
     type: string
     example: "106286"
+  school_ukprn:
+    description: "The UK Provider Reference Number (UK Provider Reference Number) of the school where this NPQ participant is employed"
+    type: string
+    example: "10079319"
   headteacher_status:
     description: "Indicates whether this NPQ participant is or will be a head teacher"
     type: string


### PR DESCRIPTION
### Context

- UKPRN - UK Provider Reference Number - Another identifier for learning providers in the UK - register available at https://www.ukrlp.co.uk/ - It is an 8 digit number
- NPQ will officially support Further Education (FE) bodies in the near future although it is currently possible to sign up with an FE body
- These FE bodies include Local Authorities (LAs)
- These LAs only have UKPRNs associated with them and are not assigned a URN

### Changes proposed in this pull request

- Incoming new NPQs will have a URN and UKPRN populated where possible
- Outgoing NPQ applications will have URN and UKPRN where the data is available
- After deployment we can retro fill any missing UKPRNs that we have so these are available to providers and for consistency
- Updated NPQ docs + guidance

### Guidance to review

- none

### Testing

- Hook up to NPQ registrations app
- Register with a school with a `urn` and `ukprn`
- Should see `NPQValidationData` with `urn` and `ukprn` set
- Register a new application with an LA
- Should see new `NPQValidationData` with `urn` missing (as it will not have one assigned) and `ukprn` populated
- Fetch these 2 record via api calls with json and csv
- Should see correct `urn` and `ukprn`s

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?

- Might be easier to test locally, otherwise you'll have to hand craft all the api calls