### PR TITLE
Monitor AlertManager health in StatusCake

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -27,6 +27,12 @@ statuscake_alerts = {
     contact_group = [206487]
     find_string   = "Manage training for early career teachers"
   }
+  "alertmanager-prod" = {
+    website_name  = "alertmanager-cpd-monitoring-prod"
+    website_url   = "https://alertmanager-cpd-monitoring-prod.london.cloudapps.digital/-/healthy"
+    contact_group = [206487]
+    find_string   = "OK"
+  }
   "PaaS500String" = {
     website_name  = "manage-training-for-early-career-teachers-production"
     website_url   = "https://manage-training-for-early-career-teachers.education.gov.uk"


### PR DESCRIPTION
### Context

> Who monitors the monitor monitor?

During the [incident on August 18th ](https://docs.google.com/document/d/11YmZXr9zXoSo8eTYxt8nAQg16Q-2pHZQ28NKaJ9jd7A/edit#heading=h.q5fo44kyn96f)we noticed that the Prometheus instances were recycled but were not coming up again for the same reason as the web app. Unfortunately we had no external monitoring of AlertManager so we didn't know that alerts were broken straight away.

This change will make StatusCake externally monitor that AlertManager is healthy.