### PR TITLE
CPDTP-427: Document idempotency of declarations endpoint

### DIFF
--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -59,6 +59,7 @@
 <p class="govuk-body-m">With a <a href="/lead-providers/guidance/reference#ecfparticipantstarteddeclaration-object" class="govuk-link">request body containing an ECF participant declaration</a>.</p>
 
 <p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#participantdeclarationrecordedresponse-object" class="govuk-link">participant declaration recorded</a>.</p>
+<p class="govuk-body-m">This endpoint is idempotent - submitting exact copy of a request will return the same response body as submitting it the first time.</p>
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">confirm ECF participant declarations</a> endpoint.</p>
 

--- a/app/views/lead_providers/guidance/npq_usage.html.erb
+++ b/app/views/lead_providers/guidance/npq_usage.html.erb
@@ -185,6 +185,9 @@
     participant declaration recorded
   </a>.
 </p>
+<p class="govuk-body-m">
+  This endpoint is idempotent - submitting exact copy of a request will return the same response body as submitting it the first time.
+</p>
 <p class="govuk-body-m">See
   <a href="/lead-providers/guidance/reference#post-api-v1-participant-declarations" class="govuk-link">
     confirm NPQ participant declarations

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
   end
 
   path "/api/v1/participant-declarations" do
-    post "Declare a participant has reached a milestone" do
+    post "Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time." do
       operationId :participant_declarations
       tags "Participant declarations"
       consumes "application/json"

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -249,7 +249,7 @@
     },
     "/api/v1/participant-declarations": {
       "post": {
-        "summary": "Declare a participant has reached a milestone",
+        "summary": "Declare a participant has reached a milestone. Idempotent endpoint - submitting exact copy of a request will return the same response body as submitting it the first time.",
         "operationId": "participant_declarations",
         "tags": [
           "Participant declarations"


### PR DESCRIPTION
### Context
Idempotency can be a funny thing when unexpected. 
We should mention that our post endpoint will be idempotent in the docs. 

### Changes proposed in this pull request
Add some flavour text to swagger and to guidance to indicate that the declarations endpoint is idempotent. 

### How can I view this in a review app?
Go to the ecf usage / npq usage pages. Go to swagger docs and look at participant declarations endpoint .