### PR TITLE
CDPTP-206_Withdrawal_docs_wrap-up

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -79,7 +79,7 @@ class ParticipantSerializer
     nil # TODO: CPDRP-534 - Share when we know we have the correct information
   end
 
-  active_participant_attribute :state do |user|
+  active_participant_attribute :training_status do |user|
     user.teacher_profile.ecf_profile&.state || "active"
   end
 end

--- a/spec/docs/participants_spec.rb
+++ b/spec/docs/participants_spec.rb
@@ -57,8 +57,42 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_fl
     end
   end
 
+  path "/api/v1/participants.csv" do
+    get "Retrieve all participants in CSV format" do
+      operationId :ecf_participants_csv
+      tags "ECF participants"
+      security [bearerAuth: []]
+
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/ListFilter",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine ECF participants to return.",
+                example: { updated_since: "2020-11-13T11:21:55Z" }
+
+      response "200", "A CSV file of ECF participants" do
+        schema({ "$ref": "#/components/schemas/MultipleEcfParticipantsCsvResponse" }, content_type: "text/csv")
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" }, content_type: "application/vnd.api+json")
+
+        run_test!
+      end
+    end
+  end
+
   path "/api/v1/participants/{id}/withdraw" do
-    put "Manage participant" do
+    put "Withdraw a participant from a course" do
       operationId :participant
       tags "ECF Participant"
       security [bearerAuth: []]
@@ -107,40 +141,6 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json", with_feature_fl
         end
 
         schema "$ref": "#/components/schemas/EcfParticipantResponse"
-        run_test!
-      end
-    end
-  end
-
-  path "/api/v1/participants.csv" do
-    get "Retrieve all participants in CSV format" do
-      operationId :ecf_participants_csv
-      tags "ECF participants"
-      security [bearerAuth: []]
-
-      parameter name: :filter,
-                in: :query,
-                schema: {
-                  "$ref": "#/components/schemas/ListFilter",
-                },
-                type: :object,
-                style: :deepObject,
-                explode: true,
-                required: false,
-                description: "Refine ECF participants to return.",
-                example: { updated_since: "2020-11-13T11:21:55Z" }
-
-      response "200", "A CSV file of ECF participants" do
-        schema({ "$ref": "#/components/schemas/MultipleEcfParticipantsCsvResponse" }, content_type: "text/csv")
-
-        run_test!
-      end
-
-      response "401", "Unauthorized" do
-        let(:Authorization) { "Bearer invalid" }
-
-        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" }, content_type: "application/vnd.api+json")
-
         run_test!
       end
     end

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/npq-applications/{id}/reject
         /api/v1/participant-declarations
         /api/v1/participants
-        /api/v1/participants/{id}/withdraw
         /api/v1/participants.csv
+        /api/v1/participants/{id}/withdraw
       ]
 
       expect(LeadProviderApiSpecification.as_hash["paths"].keys).to eq(paths)

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
               :eligible_for_funding,
               :pupil_premium_uplift,
               :sparsity_uplift,
-              :state,
+              :training_status,
             ).exactly)
         end
 
@@ -150,7 +150,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
                eligible_for_funding
                pupil_premium_uplift
                sparsity_uplift
-               state],
+               training_status],
           )
         end
 
@@ -169,7 +169,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["eligible_for_funding"]).to be_empty
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty
-          expect(mentor_row["state"]).to eql "active"
+          expect(mentor_row["training_status"]).to eql "active"
 
           ect = ParticipantProfile::ECT.active_record.first.user
           ect_row = parsed_response.find { |row| row["id"] == ect.id }
@@ -185,7 +185,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["eligible_for_funding"]).to be_empty
           expect(mentor_row["pupil_premium_uplift"]).to be_empty
           expect(mentor_row["sparsity_uplift"]).to be_empty
-          expect(mentor_row["state"]).to eql "active"
+          expect(mentor_row["training_status"]).to eql "active"
 
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
@@ -200,7 +200,7 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(withdrawn_record_row["eligible_for_funding"]).to be_empty
           expect(withdrawn_record_row["pupil_premium_uplift"]).to be_empty
           expect(withdrawn_record_row["sparsity_uplift"]).to be_empty
-          expect(withdrawn_record_row["state"]).to be_empty
+          expect(withdrawn_record_row["training_status"]).to be_empty
         end
 
         it "ignores pagination parameters" do
@@ -218,12 +218,12 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
       describe "JSON Participant Withdrawal" do
         let(:parsed_response) { JSON.parse(response.body) }
 
-        it "changes the state of a participant to withdrawn" do
+        it "changes the training status of a participant to withdrawn" do
           put "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw", params: { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } }
 
           expect(response).to be_successful
 
-          expect(parsed_response.dig("data", "attributes", "state")).to eql("withdrawn")
+          expect(parsed_response.dig("data", "attributes", "training_status")).to eql("withdrawn")
         end
       end
     end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe ParticipantSerializer do
       end
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"state\":\"active\"}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"training_status\":\"active\"}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"state\":\"active\"}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"training_status\":\"active\"}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end
@@ -35,12 +35,12 @@ RSpec.describe ParticipantSerializer do
       let(:ect) { create(:participant_profile, :ect, :withdrawn_record, mentor_profile: mentor.mentor_profile).user }
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"state\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"training_status\":null}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"state\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"training_status\":null}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -166,7 +166,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "40c0fb7b-9b58-45f2-9c3c-70b562ab678c",
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
             "description": "The ID of the NPQ application to accept.",
             "schema": {
               "type": "string"
@@ -216,7 +216,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "e7fb63cb-d71c-4bcc-ab3d-f411ea3da7c4",
+            "example": "14b1b4ab-fa81-4f7a-b4b5-f632412e8c5c",
             "description": "The ID of the NPQ application to reject.",
             "schema": {
               "type": "string"
@@ -439,55 +439,6 @@
         }
       }
     },
-    "/api/v1/participants/{id}/withdraw": {
-      "put": {
-        "summary": "Manage participant",
-        "operationId": "participant",
-        "tags": [
-          "ECF Participant"
-        ],
-        "security": [
-          {
-            "bearerAuth": [
-
-            ]
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ECFParticipantAction"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "example": "",
-            "description": "The ID of the participant to withdraw",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The ECF participant being withdrawn",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EcfParticipantResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/participants.csv": {
       "get": {
         "summary": "Retrieve all participants in CSV format",
@@ -535,6 +486,55 @@
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/participants/{id}/withdraw": {
+      "put": {
+        "summary": "Withdraw a participant from a course",
+        "operationId": "participant",
+        "tags": [
+          "ECF Participant"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ECFParticipantAction"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "",
+            "description": "The ID of the participant to withdraw",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ECF participant being withdrawn",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EcfParticipantResponse"
                 }
               }
             }
@@ -716,15 +716,20 @@
         }
       },
       "ECFParticipantWithdrawal": {
-        "description": "An ECF withdrawal action",
+        "description": "An ECF participant withdrawal action",
         "type": "object",
         "properties": {
           "reason": {
-            "description": "The reason for withdrawal",
+            "description": "The reason for the withdrawal",
             "type": "string",
             "enum": [
+              "left-teaching-profession",
+              "moved-school",
+              "mentor-no-longer-being-mentor",
+              "school-left-fip",
               "career-break",
-              "mentor-no-longer-being-mentor"
+              "passed-induction",
+              "other"
             ],
             "example": "career-break"
           },

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawal.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawal.yml
@@ -1,12 +1,17 @@
-description: "An ECF withdrawal action"
+description: "An ECF participant withdrawal action"
 type: object
 properties:
   reason:
-    description: "The reason for withdrawal"
+    description: "The reason for the withdrawal"
     type: string
     enum:
-      - career-break
+      - left-teaching-profession
+      - moved-school
       - mentor-no-longer-being-mentor
+      - school-left-fip
+      - career-break
+      - passed-induction
+      - other
     example: career-break
   course_identifier:
     description: "The type of course the participant is enrolled in"


### PR DESCRIPTION
### Context

A few changes to the layout and content of the swagger documentation.

### Changes proposed in this pull request

- Change the group order for the API endpoints
- Add in missing ECF withdrawal reasons from the withdrawal object
- Change the generated description to something less vague.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
