### PR TITLE
Fix missing delegate "allow_nil" for mentor

### DIFF
--- a/app/services/participants/mentor.rb
+++ b/app/services/participants/mentor.rb
@@ -6,7 +6,7 @@ module Participants
     extend ActiveSupport::Concern
     included do
       extend MentorClassMethods
-      delegate :mentor_profile, to: :user
+      delegate :mentor_profile, to: :user, allow_nil: true
     end
 
     def user_profile


### PR DESCRIPTION
### Context

The delegation to mentor_profile requires that a valid user exists. Calling this with an invalid user throws rather than returning nil.

### Changes proposed in this pull request

Update delegation to allow_nil: true for the mentor_profile delegation.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
