### PR TITLE
Change participant validation to be case insensitive on name

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -51,9 +51,9 @@ private
     matches += 1 if trn_matches
 
     name_matches = if check_first_name_only?
-                     full_name.split(" ").first == dqt_record[:full_name].split(" ").first
+                     full_name.split(" ").first.downcase == dqt_record[:full_name].split(" ").first.downcase
                    else
-                     full_name == dqt_record[:full_name]
+                     full_name.downcase == dqt_record[:full_name].downcase
                    end
 
     matches += 1 if name_matches

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe ParticipantValidationService do
           ParticipantValidationService.validate(trn: trn, nino: nino.downcase, full_name: "John Smithe", date_of_birth: dob),
         ).to eql({ trn: trn, qts: true, active_alert: false })
       end
+
+      it "returns validated details when the name is cased differently and the nino is missing" do
+        expect(
+          ParticipantValidationService.validate(trn: trn, nino: "", full_name: "John SMITH", date_of_birth: dob),
+        ).to eql({ trn: trn, qts: true, active_alert: false })
+      end
     end
 
     context "when 3 of 4 things match and only first name matches" do


### PR DESCRIPTION
### Context
Make `McC...` and `Mcc...` match

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
