### PR TITLE
Remove N+1 queries caused by serialising state

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -61,9 +61,8 @@ module Api
                                     .distinct
                                     .includes(
                                       teacher_profile: {
-                                        ecf_profile: %i[cohort school ecf_participant_eligibility],
+                                        ecf_profile: %i[cohort school ecf_participant_eligibility ecf_participant_validation_data participant_profile_state participant_profile_states],
                                         early_career_teacher_profile: :mentor,
-                                        participant_profiles: :participant_profile_state,
                                       },
                                     )
 


### PR DESCRIPTION
### Context
Withdraw participants change added some n+1 queries. I also saw some relating to `ecf_participant_validation_data`, so I fixed those too.

### Changes proposed in this pull request
Load more things in the query in participants api.

### Testing
Do we have (want?) tests for n+1 queries? 