### PR TITLE
Add job to retry failed validations

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -192,7 +192,9 @@ module Participants
     def store_eligibility_data!(dqt_data)
       participant_profile.create_ecf_participant_eligibility!(qts: dqt_data[:qts],
                                                               active_flags: dqt_data[:active_alert],
+                                                              # TODO: CPDRP-672 use ERO data
                                                               previous_participation: nil,
+                                                              # TODO: CPDRP-900 use previous induction data
                                                               previous_induction: nil)
     end
 

--- a/app/jobs/validation_retry_job.rb
+++ b/app/jobs/validation_retry_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ValidationRetryJob < CronJob
+  self.cron_expression = "15 3 * * *"
+
+  queue_as :validation_retry
+
+  def perform
+    ECFParticipantValidationData.where(api_failure: true).each do |validation_data|
+      validation_result = ParticipantValidationService.validate(trn: validation_data.trn,
+                                                                full_name: validation_data.full_name,
+                                                                date_of_birth: validation_data.date_of_birth,
+                                                                nino: validation_data.nino)
+      ActiveRecord::Base.transaction do
+        validation_data.update!(api_failure: false)
+        if validation_result.present?
+          eligibility_data = store_eligibility_data!(validation_data, validation_result)
+          eligibility_data.manual_check_status! unless store_trn!(validation_result[:trn], validation_data.participant_profile)
+
+          validation_data.destroy! if eligibility_data.eligible_status?
+        end
+      end
+    rescue StandardError => e
+      Rails.logger.error("Problem with DQT API on retry: " + e.message)
+      Sentry.capture_message("Problem with DQT API on retry: " + e.message)
+      next
+    end
+  end
+
+private
+
+  def store_eligibility_data!(validation_data, validation_result)
+    validation_data.participant_profile.create_ecf_participant_eligibility!(
+      qts: validation_result[:qts],
+      active_flags: validation_result[:active_alert],
+      # TODO: CPDRP-672 use ERO data
+      previous_participation: nil,
+      # TODO: CPDRP-900 use previous induction data
+      previous_induction: nil,
+    )
+  end
+
+  def store_trn!(trn, participant_profile)
+    if participant_profile.teacher_profile.trn.present? && participant_profile.teacher_profile.trn != trn
+      Rails.logger.warn("Different TRN already set for user [#{participant_profile.user.email}]")
+      false
+    else
+      participant_profile.teacher_profile.update!(trn: trn)
+    end
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -5,5 +5,6 @@ namespace :cron do
   task schedule: :environment do
     SessionTrimJob.schedule
     SchoolDataImporterJob.schedule
+    ValidationRetryJob.schedule
   end
 end

--- a/spec/jobs/validation_retry_job_spec.rb
+++ b/spec/jobs/validation_retry_job_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ValidationRetryJob" do
+  let(:participant_data) do
+    {
+      trn: "1234567",
+      full_name: "Sally Teacher",
+      date_of_birth: Date.new(1998, 3, 22),
+      nino: "",
+    }
+  end
+  let!(:validation_data) do
+    create(:ecf_participant_validation_data,
+           trn: participant_data[:trn],
+           full_name: participant_data[:full_name],
+           date_of_birth: participant_data[:date_of_birth],
+           nino: participant_data[:nino],
+           api_failure: true)
+  end
+
+  describe "#perform" do
+    context "when the API is working" do
+      before do
+        validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
+        allow(validator).to receive(:validate)
+                              .with(participant_data)
+                              .and_return({ trn: participant_data[:trn], qts: true, active_alert: false })
+      end
+
+      it "rechecks the eligibility" do
+        # Given the teacher profile has no TRN
+        validation_data.participant_profile.teacher_profile.update!(trn: nil)
+
+        ValidationRetryJob.new.perform
+        expect(validation_data.reload.api_failure).to be false
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_present
+        expect(validation_data.participant_profile.ecf_participant_eligibility.status).to eql "matched"
+        expect(validation_data.participant_profile.teacher_profile.trn).to eql "1234567"
+      end
+
+      it "does not update the TRN when a different one is present" do
+        # Given the teacher profile has a different TRN
+        validation_data.participant_profile.teacher_profile.update!(trn: "0123456")
+
+        ValidationRetryJob.new.perform
+        expect(validation_data.reload.api_failure).to be false
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_present
+        expect(validation_data.participant_profile.ecf_participant_eligibility.status).to eql "manual_check"
+        expect(validation_data.participant_profile.teacher_profile.trn).to eql "0123456"
+      end
+    end
+
+    context "when the API is not working" do
+      before do
+        validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
+        allow(validator).to receive(:validate)
+                              .with(participant_data)
+                              .and_raise(StandardError)
+      end
+
+      it "does not change the record" do
+        ValidationRetryJob.new.perform
+        expect(validation_data.reload.api_failure).to be true
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
The DQT API went down last week, and there are records marked with API failure. We could fix it as a one-off, but I think the API is flaky enough that it's worth making this a regular thing.

I looked for ways to commonise this with the logic in the controller, but couldn't quite figure it out

