### PR TITLE
CPDRP-881 Remove internal whitespace and force uppercase before validation of NINo

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -33,7 +33,7 @@ module Participants
         trn: trn&.squish,
         name: name&.squish,
         date_of_birth: date_of_birth,
-        national_insurance_number: national_insurance_number&.squish,
+        national_insurance_number: tidy_national_insurance_number,
         validation_attempts: validation_attempts.to_i, # coerce nil to 0
       }
     end
@@ -121,7 +121,7 @@ module Participants
     def teacher_details
       @trn = trn&.squish
       @name = name&.squish
-      @national_insurance_number = national_insurance_number&.squish
+      @national_insurance_number = tidy_national_insurance_number
 
       if trn.blank?
         errors.add(:trn, :blank)
@@ -145,9 +145,15 @@ module Participants
         errors.add(:date_of_birth, :in_the_future)
       end
 
-      if national_insurance_number.present? && national_insurance_number.squish !~ NINO_REGEX
+      if national_insurance_number.present? && national_insurance_number !~ NINO_REGEX
         errors.add(:national_insurance_number, :invalid)
       end
+    end
+
+    def tidy_national_insurance_number
+      return if national_insurance_number.blank?
+
+      national_insurance_number.gsub(/\s+/, "").upcase
     end
   end
 end

--- a/app/views/participants/validations/tell_us_your_details.html.erb
+++ b/app/views/participants/validations/tell_us_your_details.html.erb
@@ -28,7 +28,8 @@
       <%= f.govuk_text_field :national_insurance_number,
         width: "three-quarters",
         label: { text: "National Insurance number (optional)", class: "govuk-label bold-label" },
-        hint: { text: "This will help us match your details" }
+        hint: { text: "This will help us match your details" },
+        spellcheck: false
       %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -308,7 +308,7 @@ module ParticipantValidationSteps
       trn: "1234567",
       full_name: "Sally Teacher",
       date_of_birth: Date.new(1998, 3, 22),
-      nino: "",
+      nino: nil,
     }
   end
 end

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
         attributes = form.attributes
         expect(attributes[:trn]).to eq "1231222"
         expect(attributes[:name]).to eq "Shiela Smith"
-        expect(attributes[:national_insurance_number]).to eq "AW 23 44 44 A"
+        expect(attributes[:national_insurance_number]).to eq "AW234444A"
       end
     end
   end


### PR DESCRIPTION
### Context
[Jira](https://dfedigital.atlassian.net/browse/CPDRP-881) On the participant validation form, allow entry of mixed case and internal whitespace for the National Insurance Number and remove whitespace and force uppercase before validation

### Changes proposed in this pull request
Remove all whitespace and for uppercase before validation of national insurance number on the "Tell us your details" page of the participant validation journey.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
