### PR TITLE
CDPTP-362 Stop swagger generator creating new UUIDs every time

### DIFF
--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -104,7 +104,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                 in: :path,
                 type: :string,
                 required: true,
-                example: SecureRandom.uuid,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
                 description: "The ID of the NPQ application to accept."
 
       response "200", "The NPQ application being accepted" do
@@ -136,7 +136,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                 in: :path,
                 type: :string,
                 required: true,
-                example: SecureRandom.uuid,
+                example: "14b1b4ab-fa81-4f7a-b4b5-f632412e8c5c",
                 description: "The ID of the NPQ application to reject."
 
       response "200", "The NPQ application being rejected" do


### PR DESCRIPTION
### Context

Swagger generation creates a unique uuid for the examples even when nothing changes

### Changes proposed in this pull request

- Force the uuid used in the examples to a fixed value to enable generation of the same json api code rather than having it change every time and possibly mask other more relevant changes.

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
