### PR TITLE
CPDTP-362 Change to return full participant json object instead of just an ID

### DIFF
--- a/app/serializers/participant_declaration_serializer.rb
+++ b/app/serializers/participant_declaration_serializer.rb
@@ -7,6 +7,7 @@ class ParticipantDeclarationSerializer
   include JSONAPI::Serializer::Instrumentation
 
   set_id :id
+  set_type :'participant-declaration'
   attributes :participant_id, :declaration_type, :declaration_date, :course_identifier
 
   attribute :eligible_for_payment do |declaration|

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -43,9 +43,7 @@ module RecordDeclarations
       declaration.refresh_payability!
       declaration_attempt.update!(participant_declaration: declaration)
 
-      participant_declarations_hash = ParticipantDeclarationSerializer.new(declaration).serializable_hash
-
-      participant_declarations_hash.to_json
+      ParticipantDeclarationSerializer.new(declaration).serializable_hash.to_json
     end
 
   private

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -43,7 +43,9 @@ module RecordDeclarations
       declaration.refresh_payability!
       declaration_attempt.update!(participant_declaration: declaration)
 
-      { id: declaration.id }
+      participant_declarations_hash = ParticipantDeclarationSerializer.new(declaration).serializable_hash
+
+      participant_declarations_hash.to_json
     end
 
   private

--- a/spec/features/participant-declarations/submit_participant_declarations_spec.rb
+++ b/spec/features/participant-declarations/submit_participant_declarations_spec.rb
@@ -156,7 +156,7 @@ private
   end
 
   def then_the_declaration_made_is_valid
-    expect(ParticipantDeclaration.find(@response["id"])).to be_present
+    expect(ParticipantDeclaration.find(@response["data"]["id"])).to be_present
   end
 
   def then_the_declaration_made_is_invalid

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
             [
               {
                 "id" => participant_declaration.id,
-                "type" => "participant_declaration",
+                "type" => "participant-declaration",
                 "attributes" => {
                   "participant_id" => ect_profile.user.id,
                   "declaration_type" => "started",
@@ -212,7 +212,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
             [
               {
                 "id" => participant_declaration.id,
-                "type" => "participant_declaration",
+                "type" => "participant-declaration",
                 "attributes" => {
                   "participant_id" => ect_profile.user.id,
                   "declaration_type" => "started",

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
             .and change(ParticipantDeclarationAttempt, :count).by(1)
         expect(ApiRequestAudit.order(created_at: :asc).last.body).to eq(params.to_s)
         expect(response.status).to eq 200
-        expect(parsed_response["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)
+        expect(parsed_response["data"]["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)
       end
 
       it "create payable declaration record when user is eligible" do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -166,7 +166,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "example": "ab6a62bb-3b56-491c-ae40-1e7212ef00c5",
             "description": "The ID of the NPQ application to accept.",
             "schema": {
               "type": "string"
@@ -216,7 +216,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "14b1b4ab-fa81-4f7a-b4b5-f632412e8c5c",
+            "example": "80aa8e2e-dd68-491d-b730-d6f0645fa973",
             "description": "The ID of the NPQ application to reject.",
             "schema": {
               "type": "string"
@@ -1629,7 +1629,6 @@
         "description": "The data attributes associated with a participant declaration response",
         "type": "object",
         "required": [
-          "id",
           "participant_id",
           "declaration_type",
           "declaration_date",
@@ -1637,7 +1636,7 @@
           "eligible_for_payment"
         ],
         "properties": {
-          "id": {
+          "participant_id": {
             "description": "The unique id of the participant",
             "type": "string",
             "format": "uuid",
@@ -1713,14 +1712,11 @@
         "description": "A confirmation that the participant declaration has been recorded successfully",
         "type": "object",
         "required": [
-          "id"
+          "data"
         ],
         "properties": {
-          "id": {
-            "description": "A unique identifier to reference the declaration in future actions",
-            "type": "string",
-            "format": "uuid",
-            "example": "b0f657a7-9a81-4a89-a6b0-627c774ff753"
+          "data": {
+            "$ref": "#/components/schemas/ParticipantDeclarationResponse"
           }
         }
       },

--- a/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
@@ -1,14 +1,13 @@
 description: "The data attributes associated with a participant declaration response"
 type: object
 required:
-  - id
   - participant_id
   - declaration_type
   - declaration_date
   - course_identifier
   - eligible_for_payment
 properties:
-  id:
+  participant_id:
     description: "The unique id of the participant"
     type: string
     format: uuid

--- a/swagger/v1/component_schemas/ParticipantDeclarationRecordedResponse.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationRecordedResponse.yml
@@ -1,10 +1,7 @@
 description: "A confirmation that the participant declaration has been recorded successfully"
 type: object
 required:
-  - id
+  - data
 properties:
-  id:
-    description: "A unique identifier to reference the declaration in future actions"
-    type: string
-    format: uuid
-    example: "b0f657a7-9a81-4a89-a6b0-627c774ff753"
+  data:
+    $ref: "#/components/schemas/ParticipantDeclarationResponse"


### PR DESCRIPTION
### Context

Submission of a participant declaration should return a full participant declaration json object rather than just an ID

### Changes proposed in this pull request

Modified response
Fixed rspec tests

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
