### PR TITLE
Bump all production-like environments to four instances

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -9,7 +9,7 @@ paas_postgres_service_plan = "small-ha-11"
 paas_app_start_timeout = "180"
 paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
-paas_web_app_instances = 2
+paas_web_app_instances = 4
 paas_web_app_memory = 8192
 paas_worker_app_instances = 1
 paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=*:2 start && bundle exec rake jobs:work"

--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -9,7 +9,7 @@ paas_postgres_service_plan = "small-11"
 paas_app_start_timeout = "180"
 paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
-paas_web_app_instances = 1
+paas_web_app_instances = 4
 paas_web_app_memory = 8192
 paas_worker_app_instances = 1
 paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=*:2 start && bundle exec rake jobs:work"

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -9,7 +9,7 @@ paas_postgres_service_plan = "small-ha-11"
 paas_app_start_timeout = "180"
 paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
-paas_web_app_instances = 2
+paas_web_app_instances = 4
 paas_web_app_memory = 8192
 paas_worker_app_instances = 1
 paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=*:2 start && bundle exec rake jobs:work"


### PR DESCRIPTION
We're expecting an increase in load at the beginning of September. Throw more compute at the problem - bound to work