### PR TITLE
CPDTP-362 Consistent errors in the declaration API

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -19,11 +19,11 @@ module Api
     end
 
     def missing_parameter_response(exception)
-      render json: { bad_or_missing_parameters: exception.param }, status: :unprocessable_entity
+      render json: { errors: Api::ParamErrorFactory.new(error: "Bad or missing parameters", params: exception.param).call }, status: :unprocessable_entity
     end
 
     def bad_request_response(exception)
-      render json: { bad_request: exception.message }, status: :bad_request
+      render json: { errors: Api::ParamErrorFactory.new(error: "Bad request", params: exception.message).call }, status: :bad_request
     end
   end
 end

--- a/app/services/api/param_error_factory.rb
+++ b/app/services/api/param_error_factory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  class ParamErrorFactory
+    attr_reader :error, :params
+
+    def initialize(error:, params:)
+      @params = params
+      @error = error
+    end
+
+    def call
+      params.map do |param|
+        {
+          title: error,
+          detail: param,
+        }
+      end
+    rescue StandardError
+      [{
+        title: error,
+        detail: params,
+      }]
+    end
+  end
+end

--- a/app/services/participants/profile_attributes.rb
+++ b/app/services/participants/profile_attributes.rb
@@ -7,10 +7,8 @@ module Participants
 
     included do
       attr_accessor :course_identifier, :participant_id, :cpd_lead_provider
-      validates :course_identifier, presence: { message: I18n.t(:missing_course_identifier) }
-      validates :participant_id, presence: { message: I18n.t(:invalid_participant) }
+      validates :participant_id, :course_identifier, :cpd_lead_provider, presence: true
       validates :participant_id, format: /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/, allow_blank: true
-      validates :cpd_lead_provider, presence: { message: I18n.t(:missing_lead_provider) }
       validate :course_valid_for_participant
       validate :participant_has_user_profile
     end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -5,7 +5,7 @@ module RecordDeclarations
     include Participants::ProfileAttributes
     RFC3339_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/i.freeze
 
-    attr_accessor :declaration_date, :declaration_type, :evidence_held
+    attr_accessor :declaration_date, :declaration_type
     validates :declaration_date, :declaration_type, presence: true
     validates :parsed_date, future_date: true, allow_blank: true
     validate :date_has_the_right_format
@@ -65,7 +65,6 @@ module RecordDeclarations
         declaration_type: declaration_type,
         cpd_lead_provider: cpd_lead_provider,
         user: user,
-        evidence_held: evidence_held,
       )
     end
 
@@ -77,7 +76,6 @@ module RecordDeclarations
           declaration_type: declaration_type,
           cpd_lead_provider: cpd_lead_provider,
           user: user,
-          evidence_held: evidence_held,
         ) do |participant_declaration|
           profile_declaration = ProfileDeclaration.create!(
             participant_declaration: participant_declaration,

--- a/app/services/record_declarations/retained.rb
+++ b/app/services/record_declarations/retained.rb
@@ -22,7 +22,7 @@ module RecordDeclarations
         cpd_lead_provider: cpd_lead_provider,
         user: user,
         evidence_held: evidence_held,
-        )
+      )
     end
 
     def find_or_create_record!
@@ -34,15 +34,14 @@ module RecordDeclarations
           cpd_lead_provider: cpd_lead_provider,
           user: user,
           evidence_held: evidence_held,
-          ) do |participant_declaration|
+        ) do |participant_declaration|
           profile_declaration = ProfileDeclaration.create!(
             participant_declaration: participant_declaration,
             participant_profile: user_profile,
-            )
+          )
           profile_declaration.update!(payable: participant_declaration.currently_payable)
         end
       end
     end
-
   end
 end

--- a/app/services/record_declarations/retained.rb
+++ b/app/services/record_declarations/retained.rb
@@ -5,6 +5,7 @@ module RecordDeclarations
     extend ActiveSupport::Concern
 
     included do
+      attr_accessor :evidence_held
       validates :evidence_held, presence: { message: I18n.t(:missing_evidence_held) }
       validates :evidence_held, inclusion: { in: :valid_evidence_types, message: I18n.t(:invalid_evidence_type) }, allow_blank: true
     end
@@ -12,5 +13,36 @@ module RecordDeclarations
     def valid_evidence_types
       self.class.valid_evidence_types
     end
+
+    def create_declaration_attempt!
+      ParticipantDeclarationAttempt.create!(
+        course_identifier: course_identifier,
+        declaration_date: declaration_date,
+        declaration_type: declaration_type,
+        cpd_lead_provider: cpd_lead_provider,
+        user: user,
+        evidence_held: evidence_held,
+        )
+    end
+
+    def find_or_create_record!
+      ActiveRecord::Base.transaction do
+        self.class.declaration_model.find_or_create_by!(
+          course_identifier: course_identifier,
+          declaration_date: declaration_date,
+          declaration_type: declaration_type,
+          cpd_lead_provider: cpd_lead_provider,
+          user: user,
+          evidence_held: evidence_held,
+          ) do |participant_declaration|
+          profile_declaration = ProfileDeclaration.create!(
+            participant_declaration: participant_declaration,
+            participant_profile: user_profile,
+            )
+          profile_declaration.update!(payable: participant_declaration.currently_payable)
+        end
+      end
+    end
+
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,8 +50,6 @@ en:
   invalid_participant: "The property '#/participant_id' must be a valid Participant ID"
   invalid_identifier: "The property '#/course_identifier' must be an available course to '#/participant_id'"
   invalid_declaration_type: "The property '#/declaration_type' must be available for '#/course_identifier'"
-  missing_course_identifier: "The property '#/course_identifier' must be present"
-  missing_declaration_date: "The property '#/declaration_date' must be present"
   invalid_declaration_date: "The property '#/declaration_date' must be a valid RCF3339 date"
   future_declaration_date: "The property '#/declaration_date' can not declare a future date"
   missing_declaration_type: "The property '#/declaration_type' must be present"
@@ -90,6 +88,13 @@ en:
       does_not_match: "The name you entered does not match our records"
     withdrawn_reason:
       invalid: "Cannot withdraw without a valid reason"
+    course_identifier: &course_identifier_error_messages
+      blank: The property '#/course_identifier' must be present
+    participant_id: &participant_id_error_messages
+      blank: The property '#/participant_id' must be present
+      invalid: The property '#/participant_id' must have a valid UUID format
+    cpd_lead_provider: &cpd_lead_provider_error_messages
+      blank: The lead provider must be present
 
   finance:
     provider: Provider
@@ -155,6 +160,29 @@ en:
           attributes:
             choice:
               blank: "Choose whether to replace or update the tutor"
+        participants/base:
+          attributes:
+            course_identifier:
+              <<: *course_identifier_error_messages
+            cpd_lead_provider:
+              <<: *cpd_lead_provider_error_messages
+            participant_id:
+              <<: *participant_id_error_messages
+        record_declarations/base:
+          attributes:
+            course_identifier:
+              <<: *course_identifier_error_messages
+            cpd_lead_provider:
+              <<: *cpd_lead_provider_error_messages
+            participant_id:
+              <<: *participant_id_error_messages
+            declaration_date:
+              blank: The property '#/declaration_date' must be present
+            declaration_type:
+              inclusion:   The property '#/declaration_type' must be available for '#/course_identifier'
+            evidence_held:
+              blank: The property '#/evidence_held' must be present
+              present: The propert '#/evidence_held' should not be supplied for '#/declaration_type' started or completed
   activerecord:
     attributes:
       npq_validation_data:

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
           }
         end
 
-        schema "$ref": "#/components/schemas/BadOrMissingParametersResponse"
+        schema "$ref": "#/components/schemas/ErrorResponse"
 
         run_test!
       end

--- a/spec/features/participant-declarations/submit_participant_declarations_spec.rb
+++ b/spec/features/participant-declarations/submit_participant_declarations_spec.rb
@@ -160,7 +160,7 @@ private
   end
 
   def then_the_declaration_made_is_invalid
-    expect(@response["bad_or_missing_parameters"]).not_to be_empty
+    expect(@response["errors"]).not_to be_empty
   end
 
   def and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_was_successful

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         missing_attribute = valid_params.except(:participant_id)
         post "/api/v1/participant-declarations", params: build_params(missing_attribute)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ bad_or_missing_parameters: [I18n.t(:invalid_participant)] }.to_json)
+        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }] }.to_json)
       end
 
       it "returns 422 when supplied an incorrect course type" do
@@ -121,19 +121,19 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         invalid_participant_for_course_type = valid_params.merge({ course_identifier: "ecf-mentor" })
         post "/api/v1/participant-declarations", params: build_params(invalid_participant_for_course_type)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ bad_or_missing_parameters: [I18n.t(:invalid_participant)] }.to_json)
+        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }] }.to_json)
       end
 
       it "returns 422 when there are multiple errors" do
         post "/api/v1/participant-declarations", params: build_params("")
         expect(response.status).to eq 422
-        expect(response.body).to eq({ bad_or_missing_parameters: [I18n.t(:invalid_declaration_type)] }.to_json)
+        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t(:invalid_declaration_type) }] }.to_json)
       end
 
       it "returns 400 when the data block is incorrect" do
         post "/api/v1/participant-declarations", params: {}.to_json
         expect(response.status).to eq 400
-        expect(response.body).to eq({ bad_request: I18n.t(:invalid_data_structure) }.to_json)
+        expect(response.body).to eq({ errors: [{ title: "Bad request", detail: I18n.t(:invalid_data_structure) }] }.to_json)
       end
     end
 

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         missing_attribute = valid_params.except(:participant_id)
         post "/api/v1/participant-declarations", params: build_params(missing_attribute)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }] }.to_json)
+        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t("activemodel.errors.models.record_declarations/base.attributes.participant_id.blank") }] }.to_json)
       end
 
       it "returns 422 when supplied an incorrect course type" do

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
-  let(:retained_params) { params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
-  let(:retained_npq_params) { npq_params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
+  let(:retained_params) { params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339, evidence_held: "other") }
+  let(:retained_npq_params) { npq_params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339, evidence_held: "yes") }
   let(:milestone_start_date) { npq_profile.schedule.milestones[1].start_date }
 
   before do

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -9,7 +9,6 @@ RSpec.shared_context "service record declaration params" do
       declaration_type: "started",
       course_identifier: "ecf-induction",
       cpd_lead_provider: another_lead_provider,
-      evidence_held: "other",
     }
   end
   let(:ect_params) do
@@ -27,7 +26,6 @@ RSpec.shared_context "service record declaration params" do
       cpd_lead_provider: cpd_lead_provider,
       participant_id: npq_profile.user.id,
       course_identifier: npq_profile.validation_data.npq_course.identifier,
-      evidence_held: "yes",
       declaration_date: npq_declaration_date.rfc3339,
     })
   end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -289,7 +289,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadOrMissingParametersResponse"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1126,6 +1126,32 @@
         "example": {
           "reason": "career-break",
           "course_identifier": "ecf-mentor"
+        }
+      },
+      "Error": {
+        "description": "An single error element",
+        "type": "object",
+        "properties": {
+          "title": {
+            "description": "A title of the error",
+            "type": "string"
+          },
+          "detail": {
+            "description": "Additional details of the error",
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "description": "A list of errors",
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
         }
       },
       "ListFilter": {

--- a/swagger/v1/component_schemas/Error.yml
+++ b/swagger/v1/component_schemas/Error.yml
@@ -1,0 +1,9 @@
+description: "An single error element"
+type: object
+properties:
+  title:
+    description: "A title of the error"
+    type: :string
+  detail:
+    description: "Additional details of the error"
+    type: :string

--- a/swagger/v1/component_schemas/ErrorResponse.yml
+++ b/swagger/v1/component_schemas/ErrorResponse.yml
@@ -1,0 +1,7 @@
+description: "A list of errors"
+type: object
+properties:
+  error:
+    type: array
+    items:
+      $ref: "#/components/schemas/Error"


### PR DESCRIPTION
### Context

Errors are wrapped in the expected format i.e.

```
{
  "errors": [
    {
      "title": "Bad or missing parameters",
      "detail": "is invalid"
    }
  ]
}
```

### Changes proposed in this pull request

New factory to generate the json error object from the provided parameters.
Also validation for evidence_held has been fixed

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
