### PR TITLE
Preventing accidental inclusion of url_helpers into ALL ruby objects

### DIFF
--- a/lib/tasks/manage_admins.rake
+++ b/lib/tasks/manage_admins.rake
@@ -4,11 +4,13 @@ desc "Manage admin users"
 namespace :admin do
   desc "Create admin user"
   task :create, %i[full_name email] => :environment do |_task, args|
-    include Rails.application.routes.url_helpers
-    default_url_options[:host] = Rails.configuration.domain
-
     puts "Creating user"
-    AdminProfile.create_admin(args[:full_name], args[:email], new_user_session_url(**UTMService.email(:new_admin)))
+    sign_in_url = Rails.application.routes.url_helpers.new_user_session_url(
+      host: Rails.configuration.domain,
+      **UTMService.email(:new_admin),
+    )
+
+    AdminProfile.create_admin(args[:full_name], args[:email], sign_in_url)
     puts "User created; email sent"
   end
 end

--- a/spec/smoke_tests/participant_declarations_spec.rb
+++ b/spec/smoke_tests/participant_declarations_spec.rb
@@ -3,24 +3,19 @@
 require "capybara/rspec"
 require "yaml"
 
-CLOUDAPPS_DOMAIN = "london.cloudapps.digital"
-
 RSpec.describe "Participant API availability", smoke_test: true do
   context "ECF participant declarations" do
     let(:smoke_test_domain) { fetch_smoke_test_domain }
 
     before do
+      skip "No domain for smoke tests found" unless smoke_test_domain
       WebMock.allow_net_connect!
     end
 
     it "ensures participant declaration api allows declarations" do
-      if smoke_test_domain
-        participant = fetch_first_active_participant
-        res = make_started_declaration(participant)
-        expect(res).to be_a Net::HTTPSuccess
-      else
-        puts "No domain for smoke tests found, skipping..."
-      end
+      participant = fetch_first_active_participant
+      res = make_started_declaration(participant)
+      expect(res).to be_a Net::HTTPSuccess
     end
   end
 
@@ -30,7 +25,7 @@ private
     paas_environment = ENV.fetch("ENVIRONMENT")
     YAML.load_file("#{__dir__}/../../terraform/workspace-variables/#{paas_environment}_app_env.yml")["DOMAIN"]
   rescue Errno::ENOENT
-    "ecf-#{paas_environment}.#{CLOUDAPPS_DOMAIN}"
+    "ecf-#{paas_environment}.london.cloudapps.digital"
   rescue KeyError
     nil
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,14 +96,16 @@ RSpec.configure do |config|
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  # config.order = :random
+  config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
-  # Kernel.srand config.seed
+  Kernel.srand config.seed
   config.extend WithModel
+
+  config.bisect_runner = :shell
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDRP-893

There seems to be just a single test causing issues in other tests. This PR fixes the issues.

One of the tests were invoking one of the rake tasks, which in turn was calling `include <URL_HELPERS>` without any receiver. In result, url_helpers has been included into Object, making it available for all the application objects (including `nil`). In the meantime, the depth of rails routing is invoking `url_for` on the `_routes` - `_routes` is a memoized method and its memoization is dependant on `@router.respond_to?(:url_for)` (`_routes` should be an instance of ActionDispatch::Routing::RouteSet`). After the inclusion of url_helpers into `nil`, this caused the instance variable not to be set at all leading to `wrong number of arguments 4, expecting 0..1` as it was invoking `<helpers>#url_for` on `nil` instead of `RouteSet#url_for`.