### PR TITLE
Remove some percy randomness

### DIFF
--- a/spec/cypress/app_commands/scenarios/schools/multiple_schools.rb
+++ b/spec/cypress/app_commands/scenarios/schools/multiple_schools.rb
@@ -2,10 +2,10 @@
 
 cohort = FactoryBot.create(:cohort, :current)
 first_school = FactoryBot.create(:school, name: "Test School 1", slug: "111111-test-school-1", urn: "111111")
-FactoryBot.create(:school_cohort, school: first_school, cohort: cohort)
+FactoryBot.create(:school_cohort, school: first_school, cohort: cohort, induction_programme_choice: "core_induction_programme")
 second_school = FactoryBot.create(:school, name: "Test School 2", slug: "111112-test-school-2", urn: "111112")
-FactoryBot.create(:school_cohort, school: second_school, cohort: cohort)
+FactoryBot.create(:school_cohort, school: second_school, cohort: cohort, induction_programme_choice: "core_induction_programme")
 third_school = FactoryBot.create(:school, name: "Test School 3", slug: "111113-test-school-3", urn: "111113")
-FactoryBot.create(:school_cohort, school: third_school, cohort: cohort)
+FactoryBot.create(:school_cohort, school: third_school, cohort: cohort, induction_programme_choice: "core_induction_programme")
 
 FactoryBot.create(:user, :induction_coordinator, email: "school-leader@example.com", school_ids: [first_school.id, second_school.id])

--- a/spec/features/schools/participants/remove_from_cohort_spec.rb
+++ b/spec/features/schools/participants/remove_from_cohort_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "STI removing participants from the cohort", js: true, with_featu
   let(:sti_profile) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
   let(:school_cohort) { create(:school_cohort) }
   let!(:mentor_profile) { create(:participant_profile, :mentor, school_cohort: school_cohort) }
-  let!(:ect_profile) { create(:participant_profile, :ect, school_cohort: school_cohort, mentor_profile: mentor_profile) }
+  let!(:ect_profile) { create(:participant_profile, :ect, school_cohort: school_cohort, mentor_profile: mentor_profile, user: create(:user, full_name: "John Smith", email: "john-smith@example.com")) }
   let(:privacy_policy) { create :privacy_policy }
 
   before do

--- a/spec/features/schools/participants/remove_from_cohort_spec.rb
+++ b/spec/features/schools/participants/remove_from_cohort_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "STI removing participants from the cohort", js: true, with_feature_flags: { induction_tutor_manage_participants: "active" } do
   let(:sti_profile) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
   let(:school_cohort) { create(:school_cohort) }
-  let!(:mentor_profile) { create(:participant_profile, :mentor, school_cohort: school_cohort) }
+  let!(:mentor_profile) { create(:participant_profile, :mentor, school_cohort: school_cohort, user: create(:user, full_name: "John Doe", email: "john-doe@example.com")) }
   let!(:ect_profile) { create(:participant_profile, :ect, school_cohort: school_cohort, mentor_profile: mentor_profile, user: create(:user, full_name: "John Smith", email: "john-smith@example.com")) }
   let(:privacy_policy) { create :privacy_policy }
 


### PR DESCRIPTION
### Context
https://percy.io/c72bbcf6/early-careers-framework/builds/12451301/changed/702884991?browser=chrome&browser_ids=16&subcategories=approved&viewLayout=overlay&viewMode=new&width=1280&widths=1280

### Changes proposed in this pull request
Set induction programme choice for school cohorts. Not sure why it became random recently, but oh well...