### PR TITLE
CPDRP-908 Don't email schools that have opted out of updates

### DIFF
--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -24,7 +24,7 @@ class ValidationBetaService
 
   def tell_induction_coordinators_to_check_ect_and_mentor_information
     InductionCoordinatorProfile.find_each do |ic|
-      if ic.schools.any? { |school| chosen_programme_and_not_in_beta(school) }
+      if ic.schools.not_opted_out.any? { |school| chosen_programme_and_not_in_beta(school) }
         send_check_ect_and_mentor(ic)
       end
     end

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -222,6 +222,13 @@ RSpec.describe ValidationBetaService do
       create(:user, :induction_coordinator, school_ids: [chosen_programme_and_not_in_beta_school.id, chosen_programme_and_not_in_beta_school2.id])
     end
 
+    let!(:chosen_programme_and_not_in_beta_opted_out_school) do
+      create(:school_cohort, induction_programme_choice: :no_early_career_teachers, opt_out_of_updates: true).school
+    end
+    let!(:chosen_programme_and_not_in_beta_opted_out_ic) do
+      create(:user, :induction_coordinator, school_ids: [chosen_programme_and_not_in_beta_opted_out_school.id])
+    end
+
     let!(:not_chosen_programme_and_not_in_beta_school) { create(:school) }
     let!(:not_chosen_programme_and_not_in_beta_ic) do
       create(:user, :induction_coordinator, school_ids: [not_chosen_programme_and_not_in_beta_school.id])
@@ -242,7 +249,7 @@ RSpec.describe ValidationBetaService do
       validation_beta_service.tell_induction_coordinators_to_check_ect_and_mentor_information
     end
 
-    it "emails SITs that have added chosen programme but not in validation beta, once per SIT even with multiple matching schools" do
+    it "emails SITs that have chosen programme but not in validation beta, once per SIT even with multiple matching schools" do
       expect(ParticipantValidationMailer).to delay_email_delivery_of(:induction_coordinator_check_ect_and_mentor_email)
                                                .with(hash_including(
                                                        recipient: chosen_programme_and_not_in_beta_ic.email,
@@ -263,6 +270,13 @@ RSpec.describe ValidationBetaService do
       expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:induction_coordinator_check_ect_and_mentor_email)
                                                .with(hash_including(
                                                        recipient: chosen_programme_and_in_beta_ic.email,
+                                                     ))
+    end
+
+    it "doesn't email schools that have chosen programme and not in validation beta if they have opted out of updates" do
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:induction_coordinator_check_ect_and_mentor_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_and_not_in_beta_opted_out_ic.email,
                                                      ))
     end
   end


### PR DESCRIPTION
### Context

A piece of logic was missed in this previous PR: https://github.com/DFE-Digital/early-careers-framework/pull/938

We need to adjust this to make sure we don't email any schools that have opted out of updates

### Changes proposed in this pull request

As above

### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
