### PR TITLE
Increase API pagination max per page from 250 to 3000

### DIFF
--- a/app/controllers/concerns/api_pagination.rb
+++ b/app/controllers/concerns/api_pagination.rb
@@ -23,7 +23,7 @@ private
   end
 
   def max_per_page
-    250
+    3000
   end
 
   def page

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1718,7 +1718,7 @@
           },
           "per_page": {
             "type": "integer",
-            "description": "The number items to display on a page. Defaults to 100. Maximum is 250, if the value is greater that the maximum allowed it will fallback to 250.",
+            "description": "The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000.",
             "example": 10
           }
         }

--- a/swagger/v1/component_schemas/Pagination.yml
+++ b/swagger/v1/component_schemas/Pagination.yml
@@ -7,5 +7,5 @@ properties:
     example: 3
   per_page:
     type: integer
-    description: "The number items to display on a page. Defaults to 100. Maximum is 250, if the value is greater that the maximum allowed it will fallback to 250."
+    description: "The number items to display on a page. Defaults to 100. Maximum is 3000, if the value is greater that the maximum allowed it will fallback to 3000."
     example: 10


### PR DESCRIPTION
### Context

A provider would like to be able to retrieve more participants using the API so that they can continue their integration. I have tested up to 3000 participants which was returned in c. 1.5s, which seems reasonable to me.
