### PR TITLE
CPDTP-369: Add january schedules into the seeds and the documentation

### DIFF
--- a/db/seeds/schedules.rb
+++ b/db/seeds/schedules.rb
@@ -37,3 +37,41 @@ ecf_september_extended_2021.update!(schedule_identifier: "ecf-september-extended
     payment_date: hash[:payment_date],
   )
 end
+
+ecf_january_reduced_2021 = Finance::Schedule.find_or_create_by!(name: "ECF January reduced 2021")
+ecf_january_reduced_2021.update!(schedule_identifier: "ecf-january-reduced-2021")
+[
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+].each do |hash|
+  Finance::Milestone.find_or_create_by!(
+    schedule: ecf_january_reduced_2021,
+    name: hash[:name],
+    start_date: hash[:start_date],
+    milestone_date: hash[:milestone_date],
+    payment_date: hash[:payment_date],
+  )
+end
+
+ecf_january_extended_2021 = Finance::Schedule.find_or_create_by!(name: "ECF January extended 2021")
+ecf_january_extended_2021.update!(schedule_identifier: "ecf-january-extended-2021")
+[
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2023, 5, 1), milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 11, 1), milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
+].each do |hash|
+  Finance::Milestone.find_or_create_by!(
+    schedule: ecf_january_extended_2021,
+    name: hash[:name],
+    start_date: hash[:start_date],
+    milestone_date: hash[:milestone_date],
+    payment_date: hash[:payment_date],
+  )
+end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -764,7 +764,9 @@
             "example": "ecf-september-extended-2021",
             "enum": [
               "ecf-september-standard-2021",
-              "ecf-september-extended-2021"
+              "ecf-september-extended-2021",
+              "ecf-january-reduced-2021",
+              "ecf-january-extended-2021"
             ]
           }
         }
@@ -778,7 +780,9 @@
             "type": "string",
             "enum": [
               "ecf-september-standard-2021",
-              "ecf-september-extended-2021"
+              "ecf-september-extended-2021",
+              "ecf-january-reduced-2021",
+              "ecf-january-extended-2021"
             ],
             "example": "career-break"
           },

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -84,3 +84,5 @@ properties:
     enum:
       - ecf-september-standard-2021
       - ecf-september-extended-2021
+      - ecf-january-reduced-2021
+      - ecf-january-extended-2021

--- a/swagger/v1/component_schemas/ECFParticipantChangeSchedule.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeSchedule.yml
@@ -7,6 +7,8 @@ properties:
     enum:
       - ecf-september-standard-2021
       - ecf-september-extended-2021
+      - ecf-january-reduced-2021
+      - ecf-january-extended-2021
     example: career-break
   course_identifier:
     description: "The type of course the participant is enrolled in"


### PR DESCRIPTION
### Context
https://docs.google.com/presentation/d/1HBVEZabnGuakaAKJ6d5AGJthC7Bl21cex4MN5K8rus4/edit#slide=id.ge582d819d0_0_304 has details of two January schedules, and I think they have been communicated to the providers. 

### Changes proposed in this pull request
Add two January schedules to the seeds - I will run that when deployed
Add the january identifiers to the api docs

### Guidance to review
I opted to make duplicate milestones for the big milestone "Output 2 – Retention Point 1, Output 3 – Retention Point 2" from the slides. That way we can still have one declaration type per milestone. This might be changing soon, but for now it should work well enough.

### Testing
Everything should already be tested.

### How can I view this in a review app?
The api docs for change schedule should have january schedule identifiers.
