### PR TITLE
CPDTP-429 Give providers feedback about declaration pay-ability

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -13,12 +13,25 @@ module Api
       end
 
       def index
-        participant_declarations = ParticipantDeclaration.for_lead_provider(cpd_lead_provider).for_participant(params[:participant_id])
-        participant_declarations_hash = ParticipantDeclarationSerializer.new(paginate(participant_declarations)).serializable_hash
+        participant_declarations_hash = ParticipantDeclarationSerializer.new(paginate(query_scope)).serializable_hash
         render json: participant_declarations_hash.to_json
       end
 
     private
+
+      def query_scope
+        scope = ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
+        scope = scope.where("user_id = ?", participant_id_filter) if participant_id_filter.present?
+        scope
+      end
+
+      def filter
+        params[:filter] ||= {}
+      end
+
+      def participant_id_filter
+        filter[:participant_id]
+      end
 
       def cpd_lead_provider
         current_user

--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def index
-        participant_declarations = ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
+        participant_declarations = ParticipantDeclaration.for_lead_provider(cpd_lead_provider).for_participant(params[:participant_id])
         participant_declarations_hash = ParticipantDeclarationSerializer.new(paginate(participant_declarations)).serializable_hash
         render json: participant_declarations_hash.to_json
       end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -21,7 +21,6 @@ class ParticipantDeclaration < ApplicationRecord
   scope :npq, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.npq_profiles) }
   scope :payable, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.where(payable: true)) }
   scope :unique_id, -> { select(:user_id).distinct }
-  scope :for_participant, ->(*args) { where(user_id: args[0]) if args.any? }
 
   # Time dependent Range scopes
   scope :declared_as_between, ->(start_date, end_date) { where(declaration_date: start_date..end_date) }

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -21,6 +21,7 @@ class ParticipantDeclaration < ApplicationRecord
   scope :npq, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.npq_profiles) }
   scope :payable, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.where(payable: true)) }
   scope :unique_id, -> { select(:user_id).distinct }
+  scope :for_participant, ->(*args) { where(user_id: args[0]) if args.any? }
 
   # Time dependent Range scopes
   scope :declared_as_between, ->(start_date, end_date) { where(declaration_date: start_date..end_date) }

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -101,6 +101,18 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
       tags "participants declarations"
       security [bearerAuth: []]
 
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/ListFilter",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine participant declarations to return.",
+                example: { participant_id: "ab3a7848-1208-7679-942a-b4a70eed400a" }
+
       parameter name: :page,
                 in: :query,
                 schema: {

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
           expect(JSON.parse(response.body)).to eq(expected_response)
         end
 
-        it "does not load declaration for an unexistent participant id" do
+        it "does not load declaration for a non-existent participant id" do
           get "/api/v1/participant-declarations?participant_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
           expect(response.status).to eq 200
 

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -276,14 +276,14 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         end
 
         it "loads only declarations for the chosen participant id" do
-          get "/api/v1/participant-declarations?participant_id=#{second_ect_profile.user.id}"
+          get "/api/v1/participant-declarations", params: { filter: { participant_id: second_ect_profile.user.id } }
           expect(response.status).to eq 200
 
           expect(JSON.parse(response.body)).to eq(expected_response)
         end
 
         it "does not load declaration for a non-existent participant id" do
-          get "/api/v1/participant-declarations?participant_id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+          get "/api/v1/participant-declarations", params: { filter: { participant_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" } }
           expect(response.status).to eq 200
 
           expect(JSON.parse(response.body)).to eq({ "data" => [] })

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -166,7 +166,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "ab6a62bb-3b56-491c-ae40-1e7212ef00c5",
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
             "description": "The ID of the NPQ application to accept.",
             "schema": {
               "type": "string"
@@ -216,7 +216,7 @@
             "name": "id",
             "in": "path",
             "required": true,
-            "example": "80aa8e2e-dd68-491d-b730-d6f0645fa973",
+            "example": "14b1b4ab-fa81-4f7a-b4b5-f632412e8c5c",
             "description": "The ID of the NPQ application to reject.",
             "schema": {
               "type": "string"
@@ -330,6 +330,20 @@
           }
         ],
         "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ListFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine participant declarations to return.",
+            "example": {
+              "participant_id": "ab3a7848-1208-7679-942a-b4a70eed400a"
+            }
+          },
           {
             "name": "page",
             "in": "query",
@@ -1009,6 +1023,11 @@
             "description": "Return only records that have been updated since this date and time (ISO 8601 date format)",
             "type": "string",
             "example": "2021-05-13T11:21:55Z"
+          },
+          "participant_id": {
+            "description": "The unique id of the participant",
+            "type": "string",
+            "example": "ab3a7848-1208-7679-942a-b4a70eed400a"
           }
         }
       },

--- a/swagger/v1/component_schemas/ListFilter.yml
+++ b/swagger/v1/component_schemas/ListFilter.yml
@@ -5,3 +5,7 @@ properties:
     description: "Return only records that have been updated since this date and time (ISO 8601 date format)"
     type: :string
     example: "2021-05-13T11:21:55Z"
+  participant_id:
+    description: "The unique id of the participant"
+    type: :string
+    example: "ab3a7848-1208-7679-942a-b4a70eed400a"


### PR DESCRIPTION
### Context

Lead providers need information about their declarations for a specific participant

### Changes proposed in this pull request

A new filter ```participant_id``` has been added to the participant-declarations API 

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
