### PR TITLE
CPDTP-428: Csv participant declarations

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,7 +25,7 @@ KEY=$(
         perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])|(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}'
     )
 
-if [ "$KEY" != "" ]; then
+if [[ "$KEY" != "" ]] && [[ "$KEY" != /components/schemas/* ]]; then
     echo "Found patterns for AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
     echo "Please check your code and remove API keys."
     echo "$KEY"

--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -6,6 +6,7 @@ module Api
       include ApiAuditable
       include ApiTokenAuthenticatable
       include ApiPagination
+      include ApiCsv
 
       def create
         params = HashWithIndifferentAccess.new({ cpd_lead_provider: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
@@ -13,15 +14,26 @@ module Api
       end
 
       def index
-        participant_declarations = ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
-        participant_declarations_hash = ParticipantDeclarationSerializer.new(paginate(participant_declarations)).serializable_hash
-        render json: participant_declarations_hash.to_json
+        respond_to do |format|
+          format.json do
+            participant_declarations_hash = ParticipantDeclarationSerializer.new(paginate(participant_declarations)).serializable_hash
+            render json: participant_declarations_hash.to_json
+          end
+          format.csv do
+            participant_declarations_hash = ParticipantDeclarationSerializer.new(participant_declarations).serializable_hash
+            render body: to_csv(participant_declarations_hash)
+          end
+        end
       end
 
     private
 
       def cpd_lead_provider
         current_user
+      end
+
+      def participant_declarations
+        ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
       end
 
       def permitted_params

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -7,6 +7,7 @@ module Api
     class ParticipantsController < Api::ApiController
       include ApiTokenAuthenticatable
       include ApiPagination
+      include ApiCsv
 
       def index
         respond_to do |format|
@@ -37,21 +38,6 @@ module Api
 
       def access_scope
         LeadProviderApiToken.joins(cpd_lead_provider: [:lead_provider])
-      end
-
-      def to_csv(hash)
-        return "" if hash[:data].empty?
-
-        headers = %w[id]
-        attributes = hash[:data].first[:attributes].keys
-        headers.concat(attributes.map(&:to_s))
-        CSV.generate(headers: headers, write_headers: true) do |csv|
-          hash[:data].each do |item|
-            row = [item[:id]]
-            row.concat(attributes.map { |attribute| item[:attributes][attribute].to_s })
-            csv << row
-          end
-        end
       end
 
       def updated_since

--- a/app/controllers/concerns/api_csv.rb
+++ b/app/controllers/concerns/api_csv.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module ApiCsv
-  extend ActiveSupport::Concern
-
 private
 
   def to_csv(hash)

--- a/app/controllers/concerns/api_csv.rb
+++ b/app/controllers/concerns/api_csv.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ApiCsv
+  extend ActiveSupport::Concern
+
+private
+
+  def to_csv(hash)
+    return "" if hash[:data].empty?
+
+    headers = %w[id]
+    attributes = hash[:data].first[:attributes].keys
+    headers.concat(attributes.map(&:to_s))
+    CSV.generate(headers: headers, write_headers: true) do |csv|
+      hash[:data].each do |item|
+        row = [item[:id]]
+        row.concat(attributes.map { |attribute| item[:attributes][attribute].to_s })
+        csv << row
+      end
+    end
+  end
+end

--- a/app/serializers/participant_declaration_serializer.rb
+++ b/app/serializers/participant_declaration_serializer.rb
@@ -8,10 +8,14 @@ class ParticipantDeclarationSerializer
 
   set_id :id
   set_type :'participant-declaration'
-  attributes :participant_id, :declaration_type, :declaration_date, :course_identifier
+  attributes :participant_id, :declaration_type, :course_identifier
 
   attribute :eligible_for_payment do |declaration|
     declaration.payable || false
+  end
+
+  attribute :declaration_date do |declaration|
+    declaration.declaration_date.rfc3339
   end
 
   attribute(:participant_id, &:user_id)

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -128,4 +128,26 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
       end
     end
   end
+
+  path "/api/v1/participant-declarations.csv" do
+    get "Retrieve all participant declarations in CSV format" do
+      operationId :ecf_participant_declarations_csv
+      tags "ECF participant declarations"
+      security [bearerAuth: []]
+
+      response "200", "A CSV file of participant declarations" do
+        schema({ "$ref": "#/components/schemas/MultipleParticipantDeclarationsCsvResponse" }, content_type: "text/csv")
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" }, content_type: "application/vnd.api+json")
+
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/npq-applications/{id}/accept
         /api/v1/npq-applications/{id}/reject
         /api/v1/participant-declarations
+        /api/v1/participant-declarations.csv
         /api/v1/participants
         /api/v1/participants.csv
         /api/v1/participants/{id}/withdraw

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1230,7 +1230,6 @@
       "MultipleECFParticipantsCsvResponse": {
         "description": "A list of ECF participants in the Comma Separated Value (CSV) format",
         "type": "string",
-        "format": "base64",
         "required": [
           "data"
         ],
@@ -1317,7 +1316,6 @@
       "MultipleNPQApplicationsCsvResponse": {
         "description": "A list of participants in the Comma Separated Value (CSV) format",
         "type": "string",
-        "format": "base64",
         "required": [
           "data"
         ],
@@ -1369,7 +1367,6 @@
       "MultipleParticipantDeclarationsCsvResponse": {
         "description": "A list of participant declarations in the Comma Separated Value (CSV) format",
         "type": "string",
-        "format": "base64",
         "required": [
           "data"
         ],

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -370,6 +370,44 @@
         }
       }
     },
+    "/api/v1/participant-declarations.csv": {
+      "get": {
+        "summary": "Retrieve all participant declarations in CSV format",
+        "operationId": "ecf_participant_declarations_csv",
+        "tags": [
+          "ECF participant declarations"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A CSV file of participant declarations",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultipleParticipantDeclarationsCsvResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participants": {
       "get": {
         "summary": "Retrieve multiple participants",
@@ -1304,6 +1342,23 @@
           }
         }
       },
+      "MultipleParticipantDeclarationsCsvResponse": {
+        "description": "A list of participant declarations in the Comma Separated Value (CSV) format",
+        "type": "string",
+        "format": "base64",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantDeclarationCsvRow"
+            }
+          }
+        },
+        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z\n"
+      },
       "MultipleParticipantDeclarationsResponse": {
         "description": "A list of participant declarations",
         "type": "object",
@@ -1864,6 +1919,66 @@
           "declaration_type": "started",
           "declaration_date": "2021-05-31T02:21:32.000Z",
           "course_identifier": "ecf-mentor"
+        }
+      },
+      "ParticipantDeclarationCsvRow": {
+        "description": "The details of a participant declaration",
+        "type": "object",
+        "required": [
+          "id",
+          "participant_id",
+          "declaration_type",
+          "course_identifier",
+          "eligible_for_payment",
+          "declaration_date"
+        ],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the participant declaration record",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "participant_id": {
+            "description": "The unique identifier of the participant record the declaration refers to",
+            "type": "string",
+            "format": "uuid",
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "type": "string",
+            "enum": [
+              "started",
+              "retained-1",
+              "retained-2",
+              "retained-3",
+              "retained-4",
+              "completed"
+            ],
+            "example": "started"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_identifier": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
+            "enum": [
+              "ecf-induction",
+              "ecf-mentor",
+              "npq-leading-teaching",
+              "npq-leading-teaching-development",
+              "npq-leading-behaviour-culture",
+              "npq-headship",
+              "npq-senior-leadership",
+              "npq-executive-leadership"
+            ],
+            "example": "ecf-induction"
+          }
         }
       },
       "ParticipantDeclarationRecordedResponse": {

--- a/swagger/v1/component_schemas/MultipleECFParticipantsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleECFParticipantsCsvResponse.yml
@@ -1,6 +1,5 @@
 description: "A list of ECF participants in the Comma Separated Value (CSV) format"
 type: string
-format: base64
 required:
   - data
 properties:

--- a/swagger/v1/component_schemas/MultipleNPQApplicationsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleNPQApplicationsCsvResponse.yml
@@ -1,6 +1,5 @@
 description: "A list of participants in the Comma Separated Value (CSV) format"
 type: string
-format: base64
 required:
   - data
 properties:

--- a/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
@@ -1,6 +1,5 @@
 description: "A list of participant declarations in the Comma Separated Value (CSV) format"
 type: string
-format: base64
 required:
   - data
 properties:

--- a/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
@@ -1,0 +1,14 @@
+description: "A list of participant declarations in the Comma Separated Value (CSV) format"
+type: string
+format: base64
+required:
+  - data
+properties:
+  data:
+    type: array
+    items:
+      $ref: "#/components/schemas/ParticipantDeclarationCsvRow"
+example: |
+  id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date
+  c88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z
+  31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z

--- a/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
@@ -1,0 +1,49 @@
+description: "The details of a participant declaration"
+type: object
+required:
+  - id
+  - participant_id
+  - declaration_type
+  - course_identifier
+  - eligible_for_payment
+  - declaration_date
+properties:
+  id:
+    description: "The unique identifier of the participant declaration record"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  participant_id:
+    description: "The unique identifier of the participant record the declaration refers to"
+    type: string
+    format: uuid
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+  declaration_type:
+    description: "The event declaration type"
+    type: string
+    enum:
+      - started
+      - retained-1
+      - retained-2
+      - retained-3
+      - retained-4
+      - completed
+    example: started
+  declaration_date:
+    description: "The event declaration date"
+    type: string
+    format: date-time
+    example: 2021-05-31T02:21:32Z
+  course_identifier:
+    description: "The type of course the participant is enrolled in"
+    type: string
+    enum:
+      - ecf-induction
+      - ecf-mentor
+      - npq-leading-teaching
+      - npq-leading-teaching-development
+      - npq-leading-behaviour-culture
+      - npq-headship
+      - npq-senior-leadership
+      - npq-executive-leadership
+    example: ecf-induction


### PR DESCRIPTION
### Context
We want to support CSV formats to make ourselves as flexible to the providers importing data as possible.
https://dfedigital.atlassian.net/browse/CPDTP-428

### Changes proposed in this pull request
Add an csv format support to existing participant declarations index endpoint.
Pull 'to_csv' method into its own module to share it between controllers.
Specify the format of declaration date in serialiser explicitly to avoid `to_s` in csv computation returning a different format.
Add documentation and tests.
Fix the githook saying `/components/schemas/XXXXXX` is a bloody AWS key. 

### Guidance to review
I imagine it will have some conflicts with https://github.com/DFE-Digital/early-careers-framework/pull/952, but they shouldn't be too terrible. 

### Testing
Added request specs for the csv index endpoint

### How can I view this in a review app?
Hit the `/api/v1/participant-declarations.csv` endpoint with the right token. 