### PR TITLE
CPDTP-465 Fix incorrect swagger documentation for training_status vs state

### DIFF
--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -749,12 +749,13 @@
             "nullable": true,
             "example": true
           },
-          "state": {
-            "description": "The state of the ECF participant",
+          "training_status": {
+            "description": "The training status of the ECF participant",
             "type": "string",
             "example": "active",
             "enum": [
               "active",
+              "deferred",
               "withdrawn"
             ]
           },

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -70,12 +70,13 @@ properties:
     type: boolean
     nullable: true
     example: true
-  state:
-    description: "The state of the ECF participant"
+  training_status:
+    description: "The training status of the ECF participant"
     type: string
     example: active
     enum:
       - active
+      - deferred
       - withdrawn
   schedule_identifier:
     description: "The schedule of the ECF participant"

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -7,6 +7,7 @@ required:
   - participant_type
   - cohort
   - status
+  - training_status
   - schedule_identifier
 properties:
   email:
@@ -76,7 +77,6 @@ properties:
     example: active
     enum:
       - active
-      - deferred
       - withdrawn
   schedule_identifier:
     description: "The schedule of the ECF participant"


### PR DESCRIPTION
### Context

Training status wasn't updated in the swagger documentation. This PR fixes that.

### Changes proposed in this pull request

### Guidance to review

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
