### PR TITLE
Reduce sentry capture rate to avoid sentry quota

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -27,7 +27,7 @@ Sentry.init do |config|
       when /check/
         0.0 # ignore healthcheck requests
       else
-        0.1
+        0.01
       end
     when /delayed_job/
       0.001


### PR DESCRIPTION
### Context
We are getting a lot of new traffic, and it seems we ran into sentry quota.
This should reduce the number of transactions we send to centry by quite a lot.

### Changes proposed in this pull request
Decrease the rate of capturing requests from 0.1 to 0.01