### PR TITLE
CPDRP-908 Add mailer for ECTs and mentors who have not yet added validation info

### DIFF
--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -12,6 +12,7 @@ class ParticipantValidationMailer < ApplicationMailer
   INDUCTION_COORDINATOR_CHECK_ECT_AND_MENTOR_TEMPLATE = "127f972e-3b78-4780-9933-c9bb889af663"
   COORDINATOR_AND_MENTOR_UR_TEMPLATE = "5e53ac12-65e2-4196-a894-2b23bf07f334"
   COORDINATOR_AND_MENTOR_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
+  ECF_WE_NEED_YOUR_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
 
   STATUTORY_GUIDANCE_LINK = "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"
 
@@ -159,6 +160,19 @@ class ParticipantValidationMailer < ApplicationMailer
         school_name: school_name,
         participant_start: start_url,
         ur_sign_up_url: user_research_url,
+      },
+    )
+  end
+
+  def we_need_information_for_your_programme_email(recipient:, school_name:, start_url:)
+    template_mail(
+      ECF_WE_NEED_YOUR_INFO_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
       },
     )
   end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -20,6 +20,7 @@ class UTMService
     participant_validation_research: "participant-validation-research",
     participant_validation_sit_notification: "participant-validation-sit-notification",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
+    we_need_information_for_your_programme: "we-need-information-for-your-programme",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -37,6 +38,7 @@ class UTMService
     participant_validation_beta: "participant-validation-beta",
     participant_validation_research: "participant-validation-research",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
+    we_need_information_for_your_programme: "we-need-information-for-your-programme",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -30,6 +30,15 @@ class ValidationBetaService
     end
   end
 
+  def tell_ects_and_mentors_to_add_validation_information
+    ParticipantProfile::ECF
+      .includes(:ecf_participant_eligibility, :ecf_participant_validation_data, :school_cohort, :school)
+      .where(school_cohort: { cohort: Cohort.current }) # Chosen program
+      .where(ecf_participant_eligibility: { participant_profile_id: nil })
+      .or(ParticipantProfile::ECF.where(ecf_participant_validation_data: { participant_profile_id: nil }))
+      .find_each { |profile| send_we_need_information_for_your_programme(profile, profile.school) }
+  end
+
 private
 
   def participant_validation_start_url
@@ -216,6 +225,21 @@ private
       sign_in: sign_in_url,
       step_by_step: step_by_step_url,
       resend_email: resend_email_url,
+    ).deliver_later
+  end
+
+  def send_we_need_information_for_your_programme(profile, school)
+    campaign = :we_need_information_for_your_programme
+
+    participant_validation_start_url = Rails.application.routes.url_helpers.participants_start_registrations_url(
+      host: Rails.application.config.domain,
+      **UTMService.email(campaign, campaign),
+    )
+
+    ParticipantValidationMailer.we_need_information_for_your_programme_email(
+      recipient: profile.user.email,
+      school_name: school.name,
+      start_url: participant_validation_start_url,
     ).deliver_later
   end
 

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
       participant_type { :mentor }
     end
 
+    trait :ecf_participant_validation_data do
+      ecf_participant_validation_data { association :ecf_participant_validation_data }
+    end
+
     trait :npq do
       teacher_profile { association :teacher_profile }
       schedule

--- a/spec/mailers/participant_validation_mailer_spec.rb
+++ b/spec/mailers/participant_validation_mailer_spec.rb
@@ -131,6 +131,21 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
   end
 
+  describe "#we_need_information_for_your_programme_email" do
+    let(:induction_coordinator_email) do
+      described_class.we_need_information_for_your_programme_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: "example.com/start-validation",
+      )
+    end
+
+    it "renders the right headers" do
+      expect(induction_coordinator_email.from).to match_array ["mail@example.com"]
+      expect(induction_coordinator_email.to).to match_array [recipient]
+    end
+  end
+
   describe "#induction_coordinator_ur_email" do
     let(:induction_coordinator_email) do
       described_class.induction_coordinator_ur_email(


### PR DESCRIPTION
### Context

This PR sends an email to ECTs and mentors who have not yet added validation information, irrespective of whether they are in the beta or not.

Template: https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/50ee41e5-06b9-41cf-9afd-d5bc4db356c4

Things to check:

1. Is the query correct?
2. Are the email template params correct?