### PR TITLE
Fix sandbox issue with encoded updated_since date

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,6 +7,7 @@ module Api
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
     rescue_from ActionController::ParameterMissing, with: :missing_parameter_response
     rescue_from ActionController::BadRequest, with: :bad_request_response
+    rescue_from ActiveRecord::StatementInvalid, with: :bad_request_response
 
   private
 

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -55,7 +55,8 @@ module Api
       end
 
       def updated_since
-        params.dig(:filter, :updated_since)
+        value = params.dig(:filter, :updated_since)
+        URI.decode_www_form_component(value) if value.present?
       end
 
       def lead_provider


### PR DESCRIPTION
### Context
@blackrat triaged a Sentry issue in the sandbox to a problem with "www-form" encoding of the optional `updated_since` param

### Changes proposed in this pull request
Unescape the `updated_since` value
Add `rescue_from` handler to catch invalid SQL statement errors and return 400 status to caller.

### Guidance to review
Accessing the participants api and passing an invalid `updated_since` param will now return a 400 error instead of a 500
If the `updated_since` is encoded e.g. "2021-09-01T11\%3A48%3A09" it will be unencoded before used in the query.

### Testing

### Review Checks
- [ ] All pages have automated accessibility checks via cypress
- [ ] All pages have visual tests via cypress + percy
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
