### PR TITLE
CPDRP-908 Add email to tell SITs we have asked ECTs and mentors for info

### DIFF
--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -10,6 +10,7 @@ class ParticipantValidationMailer < ApplicationMailer
   INDUCTION_COORDINATOR_NOTIFICATION_TEMPLATE = "d560fb2e-243d-48b1-bf61-c7e111f56858"
   INDUCTION_COORDINATOR_NOTIFICATION_UR_TEMPLATE = "afb54050-7ebd-43af-ad83-7fa6795d1523"
   INDUCTION_COORDINATOR_CHECK_ECT_AND_MENTOR_TEMPLATE = "127f972e-3b78-4780-9933-c9bb889af663"
+  INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE = "d560fb2e-243d-48b1-bf61-c7e111f56858"
   COORDINATOR_AND_MENTOR_UR_TEMPLATE = "5e53ac12-65e2-4196-a894-2b23bf07f334"
   COORDINATOR_AND_MENTOR_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
   ECF_WE_NEED_YOUR_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
@@ -120,6 +121,19 @@ class ParticipantValidationMailer < ApplicationMailer
         sign_in: sign_in,
         step_by_step: step_by_step,
         resend_email: resend_email,
+      },
+    )
+  end
+
+  def tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email(recipient:, sign_in:, school_name:)
+    template_mail(
+      INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sign_in: sign_in,
+        school_name: school_name,
       },
     )
   end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -21,6 +21,7 @@ class UTMService
     participant_validation_sit_notification: "participant-validation-sit-notification",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
     we_need_information_for_your_programme: "we-need-information-for-your-programme",
+    asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -39,6 +40,7 @@ class UTMService
     participant_validation_research: "participant-validation-research",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
     we_need_information_for_your_programme: "we-need-information-for-your-programme",
+    asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/mailers/participant_validation_mailer_spec.rb
+++ b/spec/mailers/participant_validation_mailer_spec.rb
@@ -131,6 +131,21 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
   end
 
+  describe "#tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email" do
+    let(:induction_coordinator_email) do
+      described_class.tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email(
+        recipient: recipient,
+        school_name: school_name,
+        sign_in: "example.com/sign-in",
+      )
+    end
+
+    it "renders the right headers" do
+      expect(induction_coordinator_email.from).to match_array ["mail@example.com"]
+      expect(induction_coordinator_email.to).to match_array [recipient]
+    end
+  end
+
   describe "#we_need_information_for_your_programme_email" do
     let(:induction_coordinator_email) do
       described_class.we_need_information_for_your_programme_email(

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -281,6 +281,69 @@ RSpec.describe ValidationBetaService do
     end
   end
 
+  describe "#tell_induction_coordinators_we_asked_ects_and_mentors_for_information" do
+    let!(:chosen_programme_and_not_in_beta_school) { create(:school_cohort, :fip).school }
+    let!(:chosen_programme_and_not_in_beta_school2) { create(:school_cohort, :fip).school }
+    let!(:chosen_programme_and_not_in_beta_ic) do
+      create(:user, :induction_coordinator, school_ids: [chosen_programme_and_not_in_beta_school.id, chosen_programme_and_not_in_beta_school2.id])
+    end
+
+    let!(:chosen_programme_and_not_in_beta_opted_out_school) do
+      create(:school_cohort, induction_programme_choice: :no_early_career_teachers, opt_out_of_updates: true).school
+    end
+    let!(:chosen_programme_and_not_in_beta_opted_out_ic) do
+      create(:user, :induction_coordinator, school_ids: [chosen_programme_and_not_in_beta_opted_out_school.id])
+    end
+
+    let!(:not_chosen_programme_and_not_in_beta_school) { create(:school) }
+    let!(:not_chosen_programme_and_not_in_beta_ic) do
+      create(:user, :induction_coordinator, school_ids: [not_chosen_programme_and_not_in_beta_school.id])
+    end
+
+    let!(:chosen_programme_and_in_beta_school) { create(:school_cohort, :fip).school }
+    let!(:chosen_programme_and_in_beta_ic) do
+      create(:user, :induction_coordinator, school_ids: [chosen_programme_and_in_beta_school.id])
+    end
+
+    let(:sign_in_url) { "http://www.example.com/users/sign_in?utm_campaign=asked-ects-and-mentors-for-information&utm_medium=email&utm_source=asked-ects-and-mentors-for-information" }
+
+    before do
+      FeatureFlag.activate(:participant_validation, for: chosen_programme_and_in_beta_school)
+
+      validation_beta_service.tell_induction_coordinators_we_asked_ects_and_mentors_for_information
+    end
+
+    it "emails SITs that have chosen programme but not in validation beta, once per SIT even with multiple matching schools" do
+      expect(ParticipantValidationMailer).to delay_email_delivery_of(:tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_and_not_in_beta_ic.email,
+                                                       sign_in: sign_in_url,
+                                                       school_name: chosen_programme_and_not_in_beta_school.name,
+                                                     ))
+    end
+
+    it "doesn't emails schools that have not chosen programme and were not in validation beta" do
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email)
+                                               .with(hash_including(
+                                                       recipient: not_chosen_programme_and_not_in_beta_ic.email,
+                                                     ))
+    end
+
+    it "doesn't email schools that have chosen a programme and were in validation beta" do
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_and_in_beta_ic.email,
+                                                     ))
+    end
+
+    it "doesn't email schools that have chosen programme and not in validation beta if they have opted out of updates" do
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_and_not_in_beta_opted_out_ic.email,
+                                                     ))
+    end
+  end
+
   describe "#tell_ects_and_mentors_to_add_validation_information" do
     let!(:chosen_programme_school) { create(:school_cohort, :cip).school }
 


### PR DESCRIPTION
### Context

Send another mailer to tell SITs that we have asked their ECTs and mentors for validation information. This largely uses the same criteria as https://github.com/DFE-Digital/early-careers-framework/pull/938 but because we needed a school name I had to make sure that we weren't sending to the same SIT for multiple schools. Other than that, the criteria and tests are the same.

Notify template: https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/d560fb2e-243d-48b1-bf61-c7e111f56858