### PR TITLE
Add ECT and FIP mentor emails

### DIFF
--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -13,7 +13,9 @@ class ParticipantValidationMailer < ApplicationMailer
   INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE = "d560fb2e-243d-48b1-bf61-c7e111f56858"
   COORDINATOR_AND_MENTOR_UR_TEMPLATE = "5e53ac12-65e2-4196-a894-2b23bf07f334"
   COORDINATOR_AND_MENTOR_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
-  ECF_WE_NEED_YOUR_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
+
+  ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
+  FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "691eb49b-f23f-49dd-b799-f8efdd5e010f"
 
   STATUTORY_GUIDANCE_LINK = "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"
 
@@ -125,19 +127,6 @@ class ParticipantValidationMailer < ApplicationMailer
     )
   end
 
-  def tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email(recipient:, sign_in:, school_name:)
-    template_mail(
-      INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE,
-      to: recipient,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        sign_in: sign_in,
-        school_name: school_name,
-      },
-    )
-  end
-
   def induction_coordinator_ur_email(recipient:, school_name:, start_url:)
     template_mail(
       INDUCTION_COORDINATOR_NOTIFICATION_UR_TEMPLATE,
@@ -178,15 +167,41 @@ class ParticipantValidationMailer < ApplicationMailer
     )
   end
 
-  def we_need_information_for_your_programme_email(recipient:, school_name:, start_url:)
+  def ects_to_add_validation_information_email(recipient:, school_name:, start_url:)
     template_mail(
-      ECF_WE_NEED_YOUR_INFO_TEMPLATE,
+      ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
         school_name: school_name,
         participant_start: start_url,
+      },
+    )
+  end
+
+  def fip_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
+    template_mail(
+      FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def induction_coordinators_we_asked_ects_and_mentors_for_information_email(recipient:, sign_in:, school_name:)
+    template_mail(
+      INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sign_in: sign_in,
+        school_name: school_name,
       },
     )
   end

--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -17,6 +17,7 @@ class ParticipantValidationMailer < ApplicationMailer
   ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
   FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "691eb49b-f23f-49dd-b799-f8efdd5e010f"
   CIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "e0198213-c09d-41aa-8197-b167e495e49d"
+  INDUCTION_COORDINATORS_WHO_ARE_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
 
   STATUTORY_GUIDANCE_LINK = "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"
 
@@ -197,6 +198,19 @@ class ParticipantValidationMailer < ApplicationMailer
   def cip_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
     template_mail(
       CIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def induction_coordinators_who_are_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
+    template_mail(
+      INDUCTION_COORDINATORS_WHO_ARE_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -68,6 +68,10 @@ class ParticipantProfile < ApplicationRecord
     !approved? && !rejected?
   end
 
+  def request_for_details_sent?
+    request_for_details_sent_at.present?
+  end
+
   def validation_decision(name)
     unless self.class.validation_steps.include?(name.to_sym)
       raise "Unknown validation step: #{name} for #{self.class.name}. Known steps: #{self.class.validation_steps.join(', ')}"

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -23,6 +23,7 @@ class UTMService
     ects_to_add_validation_information: "ects-to-add-validation-information",
     fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
     cip_mentors_to_add_validation_information: "cip-mentors-to-add-validation-information",
+    induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 
@@ -44,6 +45,7 @@ class UTMService
     ects_to_add_validation_information: "ects-to-add-validation-information",
     fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
     cip_mentors_to_add_validation_information: "cip-mentors-to-add-validation-information",
+    induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -20,7 +20,8 @@ class UTMService
     participant_validation_research: "participant-validation-research",
     participant_validation_sit_notification: "participant-validation-sit-notification",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
-    we_need_information_for_your_programme: "we-need-information-for-your-programme",
+    ects_to_add_validation_information: "ects-to-add-validation-information",
+    fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 
@@ -39,7 +40,8 @@ class UTMService
     participant_validation_beta: "participant-validation-beta",
     participant_validation_research: "participant-validation-research",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
-    we_need_information_for_your_programme: "we-need-information-for-your-programme",
+    ects_to_add_validation_information: "ects-to-add-validation-information",
+    fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 

--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -34,8 +34,12 @@ class ValidationBetaService
   def tell_ects_to_add_validation_information
     ParticipantProfile::ECT
       .includes(:ecf_participant_eligibility, :ecf_participant_validation_data, :school_cohort, :school)
-      .where(school_cohort: { cohort: Cohort.current })
-      .where(ecf_participant_eligibility: { participant_profile_id: nil })
+      .where(
+        school_cohort: {
+          cohort: Cohort.current,
+          induction_programme_choice: %w[core_induction_programme full_induction_programme],
+        }
+      ).where(ecf_participant_eligibility: { participant_profile_id: nil })
       .where(ecf_participant_validation_data: { participant_profile_id: nil })
       .find_each { |profile| send_ects_to_add_validation_information(profile, profile.school) }
   end

--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -30,24 +30,35 @@ class ValidationBetaService
     end
   end
 
+  # ECTs who have not added their details for validation
+  def tell_ects_to_add_validation_information
+    ParticipantProfile::ECT
+      .includes(:ecf_participant_eligibility, :ecf_participant_validation_data, :school_cohort, :school)
+      .where(school_cohort: { cohort: Cohort.current })
+      .where(ecf_participant_eligibility: { participant_profile_id: nil })
+      .where(ecf_participant_validation_data: { participant_profile_id: nil })
+      .find_each { |profile| send_ects_to_add_validation_information(profile, profile.school) }
+  end
+
+  # FIP mentors who have not added their details for validation
+  def tell_fip_mentors_to_add_validation_information
+    ParticipantProfile::Mentor
+      .includes(:ecf_participant_eligibility, :ecf_participant_validation_data, :school_cohort, :school)
+      .where(school_cohort: { cohort: Cohort.current, induction_programme_choice: "full_induction_programme" })
+      .where(ecf_participant_eligibility: { participant_profile_id: nil })
+      .where(ecf_participant_validation_data: { participant_profile_id: nil })
+      .find_each { |profile| send_fip_mentors_to_add_validation_information(profile, profile.school) }
+  end
+
   def tell_induction_coordinators_we_asked_ects_and_mentors_for_information
     InductionCoordinatorProfile.find_each do |ic|
       ic.schools.not_opted_out.each do |school|
         if chosen_programme_and_not_in_beta(school)
-          send_asked_ects_and_mentors_for_information(ic, school)
+          send_induction_coordinators_we_asked_ects_and_mentors_for_information(ic, school)
           break
         end
       end
     end
-  end
-
-  def tell_ects_and_mentors_to_add_validation_information
-    ParticipantProfile::ECF
-      .includes(:ecf_participant_eligibility, :ecf_participant_validation_data, :school_cohort, :school)
-      .where(school_cohort: { cohort: Cohort.current }) # Chosen program
-      .where(ecf_participant_eligibility: { participant_profile_id: nil })
-      .or(ParticipantProfile::ECF.where(ecf_participant_validation_data: { participant_profile_id: nil }))
-      .find_each { |profile| send_we_need_information_for_your_programme(profile, profile.school) }
   end
 
 private
@@ -239,7 +250,37 @@ private
     ).deliver_later
   end
 
-  def send_asked_ects_and_mentors_for_information(induction_coordinator, school)
+  def send_ects_to_add_validation_information(profile, school)
+    campaign = :ects_to_add_validation_information
+
+    participant_validation_start_url = Rails.application.routes.url_helpers.participants_start_registrations_url(
+      host: Rails.application.config.domain,
+      **UTMService.email(campaign, campaign),
+    )
+
+    ParticipantValidationMailer.ects_to_add_validation_information_email(
+      recipient: profile.user.email,
+      school_name: school.name,
+      start_url: participant_validation_start_url,
+    ).deliver_later
+  end
+
+  def send_fip_mentors_to_add_validation_information(profile, school)
+    campaign = :fip_mentors_to_add_validation_information
+
+    participant_validation_start_url = Rails.application.routes.url_helpers.participants_start_registrations_url(
+      host: Rails.application.config.domain,
+      **UTMService.email(campaign, campaign),
+    )
+
+    ParticipantValidationMailer.fip_mentors_to_add_validation_information_email(
+      recipient: profile.user.email,
+      school_name: school.name,
+      start_url: participant_validation_start_url,
+    ).deliver_later
+  end
+
+  def send_induction_coordinators_we_asked_ects_and_mentors_for_information(induction_coordinator, school)
     campaign = :asked_ects_and_mentors_for_information
 
     sign_in_url = Rails.application.routes.url_helpers.new_user_session_url(
@@ -247,25 +288,10 @@ private
       **UTMService.email(campaign, campaign),
     )
 
-    ParticipantValidationMailer.tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email(
+    ParticipantValidationMailer.induction_coordinators_we_asked_ects_and_mentors_for_information_email(
       recipient: induction_coordinator.user.email,
       school_name: school.name,
       sign_in: sign_in_url,
-    ).deliver_later
-  end
-
-  def send_we_need_information_for_your_programme(profile, school)
-    campaign = :we_need_information_for_your_programme
-
-    participant_validation_start_url = Rails.application.routes.url_helpers.participants_start_registrations_url(
-      host: Rails.application.config.domain,
-      **UTMService.email(campaign, campaign),
-    )
-
-    ParticipantValidationMailer.we_need_information_for_your_programme_email(
-      recipient: profile.user.email,
-      school_name: school.name,
-      start_url: participant_validation_start_url,
     ).deliver_later
   end
 

--- a/db/migrate/20210906164616_add_request_for_details_sent_at_to_participant_profiles.rb
+++ b/db/migrate/20210906164616_add_request_for_details_sent_at_to_participant_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRequestForDetailsSentAtToParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_profiles, :request_for_details_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_31_081434) do
+ActiveRecord::Schema.define(version: 2021_09_06_164616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -481,6 +481,7 @@ ActiveRecord::Schema.define(version: 2021_08_31_081434) do
     t.uuid "npq_course_id"
     t.text "school_urn"
     t.text "school_ukprn"
+    t.datetime "request_for_details_sent_at"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/factories/ecf_participant_eligibility.rb
+++ b/spec/factories/ecf_participant_eligibility.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_participant_eligibility, class: ECFParticipantEligibility do
+    association :participant_profile, :ecf
+  end
+end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -52,6 +52,10 @@ FactoryBot.define do
       ecf_participant_validation_data { association :ecf_participant_validation_data }
     end
 
+    trait :ecf_participant_eligibility do
+      ecf_participant_eligibility { association :ecf_participant_eligibility }
+    end
+
     trait :npq do
       teacher_profile { association :teacher_profile }
       schedule

--- a/spec/mailers/participant_validation_mailer_spec.rb
+++ b/spec/mailers/participant_validation_mailer_spec.rb
@@ -131,9 +131,9 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
   end
 
-  describe "#tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email" do
+  describe "#induction_coordinators_we_asked_ects_and_mentors_for_information_email" do
     let(:induction_coordinator_email) do
-      described_class.tell_induction_coordinators_we_asked_ects_and_mentors_for_information_email(
+      described_class.induction_coordinators_we_asked_ects_and_mentors_for_information_email(
         recipient: recipient,
         school_name: school_name,
         sign_in: "example.com/sign-in",
@@ -146,9 +146,24 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
   end
 
-  describe "#we_need_information_for_your_programme_email" do
+  describe "#ects_to_add_validation_information_email" do
     let(:induction_coordinator_email) do
-      described_class.we_need_information_for_your_programme_email(
+      described_class.ects_to_add_validation_information_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: "example.com/start-validation",
+      )
+    end
+
+    it "renders the right headers" do
+      expect(induction_coordinator_email.from).to match_array ["mail@example.com"]
+      expect(induction_coordinator_email.to).to match_array [recipient]
+    end
+  end
+
+  describe "#fip_mentors_to_add_validation_information_email" do
+    let(:induction_coordinator_email) do
+      described_class.fip_mentors_to_add_validation_information_email(
         recipient: recipient,
         school_name: school_name,
         start_url: "example.com/start-validation",

--- a/spec/mailers/participant_validation_mailer_spec.rb
+++ b/spec/mailers/participant_validation_mailer_spec.rb
@@ -191,6 +191,21 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
   end
 
+  describe "#induction_coordinators_who_are_mentors_to_add_validation_information_email" do
+    let(:email) do
+      described_class.induction_coordinators_who_are_mentors_to_add_validation_information_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: "example.com/start-validation",
+      )
+    end
+
+    it "renders the right headers" do
+      expect(email.from).to match_array ["mail@example.com"]
+      expect(email.to).to match_array [recipient]
+    end
+  end
+
   describe "#induction_coordinator_ur_email" do
     let(:induction_coordinator_email) do
       described_class.induction_coordinator_ur_email(

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -350,6 +350,9 @@ RSpec.describe ValidationBetaService do
     let!(:chosen_programme_ect) do
       create(:participant_profile, :ect, school: chosen_programme_school)
     end
+    let!(:chosen_programme_ect_already_received) do
+      create(:participant_profile, :ect, school: chosen_programme_school, request_for_details_sent_at: Time.zone.now)
+    end
     let!(:chosen_programme_mentor) do
       create(:participant_profile, :mentor, school: chosen_programme_school)
     end
@@ -375,6 +378,13 @@ RSpec.describe ValidationBetaService do
                                                        recipient: chosen_programme_ect.user.email,
                                                        school_name: chosen_programme_school.name,
                                                        start_url: start_url,
+                                                     )).once
+    end
+
+    it "doesn't email ECTs that have already received an invitation email" do
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:ects_to_add_validation_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_ect_already_received.user.email,
                                                      )).once
     end
 
@@ -414,6 +424,9 @@ RSpec.describe ValidationBetaService do
     let!(:chosen_programme_mentor) do
       create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort)
     end
+    let!(:chosen_programme_mentor_already_received) do
+      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort, request_for_details_sent_at: Time.zone.now)
+    end
     let!(:chosen_programme_ect) do
       create(:participant_profile, :ect, school_cohort: chosen_programme_cohort)
     end
@@ -444,6 +457,13 @@ RSpec.describe ValidationBetaService do
                                                        recipient: chosen_programme_mentor.user.email,
                                                        school_name: chosen_programme_school.name,
                                                        start_url: start_url,
+                                                     )).once
+    end
+
+    it "doesn't email FIP mentors that have already received an invitation email" do
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_mentor_already_received.user.email,
                                                      )).once
     end
 
@@ -490,6 +510,9 @@ RSpec.describe ValidationBetaService do
     let!(:chosen_programme_mentor) do
       create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort)
     end
+    let!(:chosen_programme_mentor_already_received) do
+      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort, request_for_details_sent_at: Time.zone.now)
+    end
     let!(:chosen_programme_ect) do
       create(:participant_profile, :ect, school_cohort: chosen_programme_cohort)
     end
@@ -520,6 +543,13 @@ RSpec.describe ValidationBetaService do
                                                        recipient: chosen_programme_mentor.user.email,
                                                        school_name: chosen_programme_school.name,
                                                        start_url: start_url,
+                                                     )).once
+    end
+
+    it "doesn't email CIP mentors that have already received an invitation email" do
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_mentor_already_received.user.email,
                                                      )).once
     end
 
@@ -568,7 +598,11 @@ RSpec.describe ValidationBetaService do
       create(:induction_coordinator_profile, user: mentor_profile.user)
       mentor_profile
     end
-
+    let!(:chosen_programme_mentor_and_ic_already_received) do
+      mentor_profile = create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort, request_for_details_sent_at: Time.zone.now)
+      create(:induction_coordinator_profile, user: mentor_profile.user)
+      mentor_profile
+    end
     let!(:chosen_programme_mentor) do
       create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort)
     end
@@ -588,11 +622,11 @@ RSpec.describe ValidationBetaService do
     end
 
     let(:cohort_without_programme) { create :school_cohort, induction_programme_choice: "not_yet_known" }
-    let!(:not_chosen_programme_mentor_and_ic) {
+    let!(:not_chosen_programme_mentor_and_ic) do
       mentor_profile = create(:participant_profile, :ect, school_cohort: cohort_without_programme)
       create(:induction_coordinator_profile, user: mentor_profile.user)
       mentor_profile
-    }
+    end
 
     let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=induction-coordinators-who-are-mentors-to-add-validation-information&utm_medium=email&utm_source=induction-coordinators-who-are-mentors-to-add-validation-information" }
 
@@ -606,6 +640,13 @@ RSpec.describe ValidationBetaService do
                                                        recipient: chosen_programme_mentor_and_ic.user.email,
                                                        school_name: chosen_programme_school.name,
                                                        start_url: start_url,
+                                                     )).once
+    end
+
+    it "doesn't mentors who are SITS that have already received an invitation email" do
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:induction_coordinators_who_are_mentors_to_add_validation_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_mentor_and_ic_already_received.user.email,
                                                      )).once
     end
 

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -360,10 +360,8 @@ RSpec.describe ValidationBetaService do
       create(:participant_profile, :ect, :ecf_participant_eligibility, school: chosen_programme_school)
     end
 
-    let!(:not_chosen_programme_school) { create(:school, school_cohorts: []) }
-    let!(:not_chosen_programme_ect) do
-      create(:participant_profile, :ect, school: not_chosen_programme_school)
-    end
+    let(:cohort_without_programme) { create :school_cohort, induction_programme_choice: "not_yet_known" }
+    let!(:not_chosen_programme_ect) { create(:participant_profile, :ect, school_cohort: cohort_without_programme) }
 
     let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=ects-to-add-validation-information&utm_medium=email&utm_source=ects-to-add-validation-information" }
 
@@ -420,7 +418,7 @@ RSpec.describe ValidationBetaService do
     end
 
     let!(:cip_chosen_programme_mentor) do
-      create(:participant_profile, :mentor, school: create(:school_cohort, :cip).school)
+      create(:participant_profile, :mentor, school_cohort: create(:school_cohort, :cip))
     end
 
     let!(:provided_validation_details_mentor) do

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -408,13 +408,14 @@ RSpec.describe ValidationBetaService do
   end
 
   describe "#tell_fip_mentors_to_add_validation_information" do
-    let!(:chosen_programme_school) { create(:school_cohort, :fip).school }
+    let(:chosen_programme_cohort) { create(:school_cohort, :fip) }
+    let!(:chosen_programme_school) { chosen_programme_cohort.school }
 
     let!(:chosen_programme_mentor) do
-      create(:participant_profile, :mentor, school: chosen_programme_school)
+      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort)
     end
     let!(:chosen_programme_ect) do
-      create(:participant_profile, :ect, school: chosen_programme_school)
+      create(:participant_profile, :ect, school_cohort: chosen_programme_cohort)
     end
 
     let!(:cip_chosen_programme_mentor) do
@@ -422,16 +423,14 @@ RSpec.describe ValidationBetaService do
     end
 
     let!(:provided_validation_details_mentor) do
-      create(:participant_profile, :mentor, :ecf_participant_validation_data, school: chosen_programme_school)
+      create(:participant_profile, :mentor, :ecf_participant_validation_data, school_cohort: chosen_programme_cohort)
     end
     let!(:provided_eligibility_details_mentor) do
-      create(:participant_profile, :mentor, :ecf_participant_eligibility, school: chosen_programme_school)
+      create(:participant_profile, :mentor, :ecf_participant_eligibility, school_cohort: chosen_programme_cohort)
     end
 
-    let!(:not_chosen_programme_school) { create(:school, school_cohorts: []) }
-    let!(:not_chosen_programme_mentor) do
-      create(:participant_profile, :mentor, school: not_chosen_programme_school)
-    end
+    let(:cohort_without_programme) { create :school_cohort, induction_programme_choice: "not_yet_known" }
+    let!(:not_chosen_programme_mentor) { create(:participant_profile, :ect, school_cohort: cohort_without_programme) }
 
     let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=fip-mentors-to-add-validation-information&utm_medium=email&utm_source=fip-mentors-to-add-validation-information" }
 


### PR DESCRIPTION
# Context

We would like to send out a number of emails requesting that participants give us more information. The first three are:

- ECTs who have not added their details for validation
- FIP mentors who have not added their details for validation
- CIP mentors who have not added their details for validation
- SITs who are ALSO mentors AND have not added their details for validation

TODO:

- [X] Tests to cover each can only receive one email
- [ ] Remove validation beta feature flag — will be done in https://github.com/DFE-Digital/early-careers-framework/pull/973

This PR also includes code to track whether we have already sent out such emails to participants.