### PR TITLE
Reduce needless touching of participants

### DIFF
--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -18,6 +18,13 @@ class Partnership < ApplicationRecord
 
   has_paper_trail
 
+  after_save do |partnership|
+    unless partnership.saved_changes.empty?
+      school.ecf_participant_profiles.touch_all
+      school.ecf_participants.touch_all
+    end
+  end
+
   def challenged?
     challenge_reason.present?
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -34,11 +34,6 @@ class School < ApplicationRecord
 
   has_many :additional_school_emails
 
-  after_commit do
-    ecf_participant_profiles.touch_all
-    ecf_participants.touch_all
-  end
-
   scope :with_local_authority, lambda { |local_authority|
     joins(%i[school_local_authorities local_authorities])
       .where(school_local_authorities: { end_year: nil }, local_authorities: local_authority)

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -27,9 +27,11 @@ class SchoolCohort < ApplicationRecord
 
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
 
-  after_commit do
-    ecf_participant_profiles.touch_all
-    ecf_participants.touch_all
+  after_save do |school_cohort|
+    unless school_cohort.saved_changes.empty?
+      ecf_participant_profiles.touch_all
+      ecf_participants.touch_all
+    end
   end
 
   def training_provider_status

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Partnership, type: :model do
     user = profile.user
     user.update!(updated_at: 2.weeks.ago)
 
-    partnership.touch
+    partnership.update!(updated_at: 2.weeks.ago)
+
     expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
     expect(profile.reload.updated_at).to be_within(1.second).of Time.zone.now
   end

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -8,16 +8,30 @@ RSpec.describe SchoolCohort, type: :model do
     it { is_expected.to belong_to(:school) }
   end
 
-  it "updates the updated_at on participant profiles and users" do
+  it "updates the updated_at on participant profiles and users when meaningfully updated" do
     freeze_time
     school_cohort = create(:school_cohort)
     profile = create(:participant_profile, :ect, school_cohort: school_cohort, updated_at: 2.weeks.ago)
     user = profile.user
     user.update!(updated_at: 2.weeks.ago)
 
-    school_cohort.touch
+    school_cohort.update!(updated_at: Time.zone.now - 1.day)
+
     expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
     expect(profile.reload.updated_at).to be_within(1.second).of Time.zone.now
+  end
+
+  it "does not update the updated_at on participant profiles and users when not changed" do
+    freeze_time
+    school_cohort = create(:school_cohort)
+    profile = create(:participant_profile, :ect, school_cohort: school_cohort, updated_at: 2.weeks.ago)
+    user = profile.user
+    user.update!(updated_at: 2.weeks.ago)
+
+    school_cohort.save!
+
+    expect(user.reload.updated_at).to be_within(1.second).of 2.weeks.ago
+    expect(profile.reload.updated_at).to be_within(1.second).of 2.weeks.ago
   end
 
   it {

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -39,18 +39,6 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:additional_school_emails) }
   end
 
-  it "updates the updated_at on participant profiles and users" do
-    freeze_time
-    school_cohort = create(:school_cohort)
-    profile = create(:participant_profile, :ect, school_cohort: school_cohort, updated_at: 2.weeks.ago)
-    user = profile.user
-    user.update!(updated_at: 2.weeks.ago)
-
-    school_cohort.school.touch
-    expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
-    expect(profile.reload.updated_at).to be_within(1.second).of Time.zone.now
-  end
-
   describe "eligibility" do
     let!(:open_school) { create(:school, school_status_code: 1) }
     let!(:closed_school) { create(:school, school_status_code: 2) }


### PR DESCRIPTION
### Context
This morning a provider asked us why we updated a lot of participant records on sandbox around 6am this morning.

Well... because our gias import job ran at 6am, it saved all schools (most with no changes), which triggered `after_commit` hook for ALL schools. Which touched all participants for all GIAS schools.

### Changes proposed in this pull request
1. Remove touching participants when school is updated. I am not sure we should update participants of school when school name changes.
2. Reduce touching participants on school cohort. Here I think we need to update them, because school cohort has a lot of things that matter for participants. Say, what induction programme they are following.

### Guidance to review
I can alter point 1 to be more like point 2. If we really want to. I just am not sure we really want to. 

### Testing
Unit tests documenting new behaviour.
