### PR TITLE
Improve PR template, in particular mention the changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,18 +2,17 @@
 
 Ticket:
 
-## Code review
+## Tech review
 
-### Is there anything weird that code reviewer should know?
-Nope, everything is straightforward.
+### Is there anything that the code reviewer should know?
 
 ### Code quality checks
 - [ ] All commit messages are meaningful and true
 - [ ] Added enough automated tests
 
-### Html Checks
+### HTML Checks
 - [ ] All new pages have automated accessibility checks
-- [ ] All new pages have visual tests via percy
+- [ ] All new pages have visual tests via Percy
 
 ### Gotchas
 - [ ] All `School` queries are correctly scoped - `eligible` when they need to be
@@ -24,9 +23,6 @@ Nope, everything is straightforward.
 1. Click the link to review app (posted by a `github-actions` bot below)
 2. Follow the steps from the ticket.
 
-## Lead Providers
+## External API changes
 
-Does this change anything in apis that LPs can access?
-
-If so, did you remember to update the changelog? (lead-providers/guidance/release-notes)
-
+Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,32 @@
-### Context
+## Ticket and context
 
-### Changes proposed in this pull request
+Ticket:
 
-### Guidance to review
+## Code review
 
-### Testing
+### Is there anything weird that code reviewer should know?
+Nope, everything is straightforward.
 
-### Review Checks
-- [ ] All pages have automated accessibility checks via cypress
-- [ ] All pages have visual tests via cypress + percy
+### Code quality checks
+- [ ] All commit messages are meaningful and true
+- [ ] Added enough automated tests
+
+### Html Checks
+- [ ] All new pages have automated accessibility checks
+- [ ] All new pages have visual tests via percy
+
+### Gotchas
 - [ ] All `School` queries are correctly scoped - `eligible` when they need to be
 
-### How can I view this in a review app?
+## Product review
+
+### How can someone see it it review app?
+1. Click the link to review app (posted by a `github-actions` bot below)
+2. Follow the steps from the ticket.
+
+## Lead Providers
+
+Does this change anything in apis that LPs can access?
+
+If so, did you remember to update the changelog? (lead-providers/guidance/release-notes)
+

--- a/app/views/lead_providers/guidance/release_notes.html.erb
+++ b/app/views/lead_providers/guidance/release_notes.html.erb
@@ -1,13 +1,6 @@
 <p class="govuk-body-m">
-  The dates in this file tend to correspond to the time the code was written - which might be slightly before it was released.
-  This is to minimise the overhead during deployments.
-
-  If the notes are unclear or incomplete, contact DfE via Slack (preferably) or ia email.
+  If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
-
-
-<h2 class="govuk-heading-l">6th September 2021</h2>
-<p class="govuk-body-m">Rebooting changelog - planning to use this page much more consistently from now on.</p>
 
 <h2 class="govuk-heading-l">19th July 2021</h2>
 <p class="govuk-body-m">Initial release of the NPQ usage guide.</p>

--- a/app/views/lead_providers/guidance/release_notes.html.erb
+++ b/app/views/lead_providers/guidance/release_notes.html.erb
@@ -1,3 +1,14 @@
+<p class="govuk-body-m">
+  The dates in this file tend to correspond to the time the code was written - which might be slightly before it was released.
+  This is to minimise the overhead during deployments.
+
+  If the notes are unclear or incomplete, contact DfE via Slack (preferably) or ia email.
+</p>
+
+
+<h2 class="govuk-heading-l">6th September 2021</h2>
+<p class="govuk-body-m">Rebooting changelog - planning to use this page much more consistently from now on.</p>
+
 <h2 class="govuk-heading-l">19th July 2021</h2>
 <p class="govuk-body-m">Initial release of the NPQ usage guide.</p>
 


### PR DESCRIPTION
## Ticket and context
Ticket: https://dfedigital.atlassian.net/browse/CPDTP-470

LPs and their relationships managers are not particularly happy with how little we broadcast the changes we work on and deploy. I think we should revive the changelog and start updating it regularly - so that we can tell them to look for changes at that page first.

This should limit the surprise when we introduce new fields, endpoints, etc. Or at least give us an option of saying "this was in changelog, please follow that page closely".

For this to work we need to remember about changelog, and I reckon a PR template is a good place for it.

## Code review

### Is there anything weird that code reviewer should know?
I used the new template for this PR, I hope it is neater :) 

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### Html Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Go to `/lead-providers/guidance/release-notes`.

## Lead Providers

Does this change anything in apis that LPs can access? - No.
If so, did you remember to update the changelog? (lead-providers/guidance/release-notes) - Updated anyway

