### PR TITLE
CPDRP-904 Add school funded fip induction choice

### DIFF
--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -30,7 +30,7 @@ class Schools::ChooseProgrammeController < Schools::BaseController
     render "shared/choice_saved_no_early_career_teachers"
   end
 
-  def choise_saved_school_funded_fip
+  def choice_saved_school_funded_fip
     @cohort = cohort
     @school = school
   end

--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -30,6 +30,11 @@ class Schools::ChooseProgrammeController < Schools::BaseController
     render "shared/choice_saved_no_early_career_teachers"
   end
 
+  def choise_saved_school_funded_fip
+    @cohort = cohort
+    @school = school
+  end
+
   def confirm_programme; end
 
   def save_programme

--- a/app/forms/induction_choice_form.rb
+++ b/app/forms/induction_choice_form.rb
@@ -8,7 +8,7 @@ class InductionChoiceForm
   attr_writer :cohort
   attr_accessor :school
 
-  PROGRAMME_OPTIONS = %i[full_induction_programme core_induction_programme design_our_own no_early_career_teachers].freeze
+  PROGRAMME_OPTIONS = %i[full_induction_programme core_induction_programme school_funded_fip design_our_own no_early_career_teachers].freeze
 
   def attributes
     { programme_choice: nil }
@@ -21,7 +21,7 @@ class InductionChoiceForm
       if school.cip_only?
         PROGRAMME_OPTIONS.excluding(:full_induction_programme)
       else
-        PROGRAMME_OPTIONS
+        PROGRAMME_OPTIONS.excluding(:school_funded_fip)
       end
 
     options.map do |option|
@@ -37,7 +37,7 @@ class InductionChoiceForm
   end
 
   def opt_out_choice_selected?
-    programme_choice&.in? %i[design_our_own no_early_career_teachers]
+    programme_choice&.in? %i[school_funded_fip design_our_own no_early_career_teachers]
   end
 
   def cohort

--- a/app/forms/induction_choice_form.rb
+++ b/app/forms/induction_choice_form.rb
@@ -8,7 +8,7 @@ class InductionChoiceForm
   attr_writer :cohort
   attr_accessor :school
 
-  PROGRAMME_OPTIONS = %i[full_induction_programme core_induction_programme school_funded_fip design_our_own no_early_career_teachers].freeze
+  PROGRAMME_OPTIONS = %i[full_induction_programme core_induction_programme design_our_own school_funded_fip no_early_career_teachers].freeze
 
   def attributes
     { programme_choice: nil }

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -75,6 +75,10 @@ class SchoolCohort < ApplicationRecord
     induction_programme_choice == "full_induction_programme"
   end
 
+  def school_chose_school_funded_fip?
+    induction_programme_choice == "school_funded_fip"
+  end
+
 private
 
   def cip_status

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -5,6 +5,7 @@ class SchoolCohort < ApplicationRecord
     full_induction_programme: "full_induction_programme",
     core_induction_programme: "core_induction_programme",
     design_our_own: "design_our_own",
+    school_funded_fip: "school_funded_fip",
     no_early_career_teachers: "no_early_career_teachers",
     not_yet_known: "not_yet_known",
   }

--- a/app/views/schools/choose_programme/choice_saved_school_funded_fip.html.erb
+++ b/app/views/schools/choose_programme/choice_saved_school_funded_fip.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, "Choice saved - training provider funded by your school" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel(
+      title: "Your choice has been saved for #{@cohort.academic_year}",
+      body: nil,
+      classes: "govuk-!-margin-bottom-8",
+      html_attributes: { "data-test": "success-panel" }
+    ) %>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you do not need to use this service to set up your training programme</li>
+      <li>you will need to make your own arrangements with a <%= govuk_link_to "training provider", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL" %>, approved by the DfE</li>
+      <li>if you change your mind about how you want to run your training, contact: <%= render MailToSupportComponent.new %></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -27,7 +27,11 @@
         <% @school_cohorts.each do |school_cohort| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <%= govuk_link_to school_cohort.cohort.start_year, schools_cohort_path(cohort_id: school_cohort.cohort) %>
+              <% if school_cohort.school_chose_school_funded_fip? %>
+                <%= school_cohort.cohort.start_year %>
+              <% else %>
+                <%= govuk_link_to school_cohort.cohort.start_year, schools_cohort_path(cohort_id: school_cohort.cohort) %>
+              <% end %>
             </td>
             <td class="govuk-table__cell">
               <%= t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes]) %>

--- a/config/locales/admin/induction_choice_form.yml
+++ b/config/locales/admin/induction_choice_form.yml
@@ -5,10 +5,12 @@ en:
         core_induction_programme: "Deliver their own programme using DfE accredited materials (core induction programme)"
         full_induction_programme: "Use a training provider, funded by the DfE (full induction programme)"
         design_our_own: "Design and deliver their own programme based on the Early Career Framework (ECF)"
+        school_funded_fip: "Use a training provider funded by their school"
         no_early_career_teachers: "They don’t expect to have any early career teachers starting in %{cohort}"
 
       confirmation_options:
         core_induction_programme: "deliver their own programme using DfE accredited materials"
         full_induction_programme: "use a training provider, funded by the DfE"
         design_our_own: "design and deliver their own programme based on the Early Career Framework (ECF)"
+        school_funded_fip: "use a training provider funded by their school."
         no_early_career_teachers: "opt out of notifications because they don't expect to have any early career teachers starting in %{cohort}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
       full_induction_programme: "Use a training provider funded by the DfE"
       core_induction_programme: "Use DfE accredited materials"
       design_our_own: "Design and deliver your own programme based on the Early Career Framework (ECF)"
+      school_funded_fip: "Use a training provider funded by your school"
       no_early_career_teachers: "No early career teachers for this cohort"
       not_yet_known: "Not yet decided"
 

--- a/config/locales/schools/induction_choice_form.yml
+++ b/config/locales/schools/induction_choice_form.yml
@@ -5,10 +5,12 @@ en:
         core_induction_programme: "Deliver your own programme using DfE accredited materials (core induction programme)"
         full_induction_programme: "Use a training provider, funded by the DfE (full induction programme)"
         design_our_own: "Design and deliver your own programme based on the Early Career Framework (ECF)"
+        school_funded_fip: "Use a training provider funded by your school"
         no_early_career_teachers: "We don’t expect to have any early career teachers starting in %{cohort}"
 
       confirmation_options:
         core_induction_programme: "deliver your own programme using DfE accredited materials"
         full_induction_programme: "use a training provider, funded by the DfE"
         design_our_own: "design and deliver your own programme based on the Early Career Framework (ECF)"
+        school_funded_fip: "use a training provider funded by your school."
         no_early_career_teachers: "opt out of notifications because you don't expect to have any early career teachers starting in %{cohort}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -289,6 +289,7 @@ Rails.application.routes.draw do
       resource :choose_programme, controller: :choose_programme, only: %i[show create], path: "choose-programme" do
         get :confirm_programme, path: "confirm-programme"
         get :choice_saved_design_our_own, path: "design-your-programme"
+        get :choice_saved_school_funded_fip, path: "school-funded-fip"
         get :choice_saved_no_early_career_teachers, path: "no-early-career-teachers"
         post :save_programme, path: "save-programme"
         get :success

--- a/spec/cypress/app_commands/scenarios/cip_only_school.rb
+++ b/spec/cypress/app_commands/scenarios/cip_only_school.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+School.find_or_create_by!(urn: "181989") do |school|
+  school.name = "CIP only school"
+  school.postcode = "XM4 5HQ"
+  school.address_line1 = "North pole"
+  school.primary_contact_email = "cip-only-school-info@example.com"
+  school.school_status_code = 1
+  school.school_type_code = 10
+end

--- a/spec/cypress/integration/schools/ChooseProgrammeCIPOnly.feature
+++ b/spec/cypress/integration/schools/ChooseProgrammeCIPOnly.feature
@@ -1,0 +1,20 @@
+Feature: Induction tutors choosing programmes
+
+  Background:
+    Given scenario "cip_only_school" has been run
+    And cohort was created with start_year "2021"
+    And I am logged in as an induction coordinator for created school
+    Then I should be on "choose programme" page
+
+  Scenario: Choosing the school funded fip programme
+    When I click on "use a training provider funded by your school radio button"
+    And I click the submit button
+    Then I should be on "choose programme confirm" page
+    And the page should be accessible
+    And percy should be sent snapshot called "Confirm school funded fip page"
+
+    When I click the submit button
+
+    Then I should be on "school funded fip success" page
+    And the page should be accessible
+    And percy should be sent snapshot called "school funded fip success"

--- a/spec/cypress/support/step_definitions/common-interaction.js
+++ b/spec/cypress/support/step_definitions/common-interaction.js
@@ -22,6 +22,8 @@ const inputs = {
     "input[value=i_dont_know].govuk-radios__input",
   "design and deliver our own programme radio button":
     "input[value=design_our_own].govuk-radios__input",
+  "use a training provider funded by your school radio button":
+    "input[value=school_funded_fip].govuk-radios__input",
   "no early career teachers radio button":
     "input[value=no_early_career_teachers].govuk-radios__input",
   "new participant mentor radio":

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -84,6 +84,8 @@ const pagePaths = {
   "choose programme success": "/schools/:id/choose-programme/success",
   "design your programme success":
     "/schools/:id/choose-programme/design-your-programme",
+  "school funded fip success":
+    "/schools/:id/choose-programme/school-funded-fip",
   "no early career teachers success":
     "/schools/:id/choose-programme/no-early-career-teachers",
   schools: "/schools",

--- a/spec/features/schools/dashboard_spec.rb
+++ b/spec/features/schools/dashboard_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Viewing the school dashboard", type: :feature do
+  let(:user) { create(:user, :induction_coordinator) }
+  let(:school) { user.schools.first }
+  let(:privacy_policy) { create :privacy_policy }
+  let(:cohort) { create(:cohort, start_year: "2021") }
+
+  before do
+    privacy_policy.accept!(user)
+  end
+
+  context "the school has chosen a programme" do
+    let!(:school_cohort) do
+      create(
+        :school_cohort,
+        cohort: cohort,
+        school: user.induction_coordinator_profile.schools[0],
+      )
+    end
+
+    specify "there is a link to the school cohort" do
+      sign_in_as user
+      visit "/schools/#{school.slug}"
+
+      expect(page).to have_link("2021", href: schools_cohort_path(school_id: school.slug, cohort_id: school_cohort.cohort))
+    end
+  end
+
+  context "the school has chosen the school funded fip programme" do
+    before do
+      create(
+        :school_cohort,
+        cohort: cohort,
+        induction_programme_choice: "school_funded_fip",
+        school: user.induction_coordinator_profile.schools[0],
+      )
+    end
+
+    specify "there is not a link to the school cohort" do
+      sign_in_as user
+      visit "/schools/#{school.slug}"
+
+      expect(page).to_not have_link("2021")
+      expect(page).to have_text("2021")
+    end
+  end
+end

--- a/spec/forms/induction_choice_form_spec.rb
+++ b/spec/forms/induction_choice_form_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe InductionChoiceForm, type: :model do
     end
 
     context "the school is eligible for the full induction programme" do
-      it "provides options for the all programme choices" do
-        options = SchoolCohort.induction_programme_choices.except("not_yet_known").keys
+      it "provides options for the all programme choices except school_funded_fip" do
+        options = SchoolCohort.induction_programme_choices.except("not_yet_known", "school_funded_fip").keys
         expect(form.programme_choices.map(&:id)).to match_array options.map(&:to_sym)
       end
     end

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe SchoolCohort, type: :model do
       full_induction_programme: "full_induction_programme",
       core_induction_programme: "core_induction_programme",
       design_our_own: "design_our_own",
+      school_funded_fip: "school_funded_fip",
       no_early_career_teachers: "no_early_career_teachers",
       not_yet_known: "not_yet_known",
     ).backed_by_column_of_type(:string)


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDRP-904

### Changes proposed in this pull request

- Add a new "school funded fip" programme choice for cip-only schools, this is an "opt-out" choice.
- Remove the link to the school cohort from the school dashboard when the chosen programme is school funded fip. We would need a new page for this as without any changes it would tell the user that they had chosen the DfE funded FIP. We are rebuilding this dashboard where the link will be removed so it isn't worth creating a new school cohort page just for this choice.

### Guidance to review

### Testing

### Review Checks
- [x] All pages have automated accessibility checks via cypress
- [x] All pages have visual tests via cypress + percy
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

### How can I view this in a review app?
Log in as the induction coordinator for a cip only shool, eg cip-only-induction-tutor@example.com and choose "Training provider funded by your school" as the programme choice.