### PR TITLE
Email: CIP mentors who have not added their details for validation

### DIFF
--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -16,6 +16,7 @@ class ParticipantValidationMailer < ApplicationMailer
 
   ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
   FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "691eb49b-f23f-49dd-b799-f8efdd5e010f"
+  CIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "e0198213-c09d-41aa-8197-b167e495e49d"
 
   STATUTORY_GUIDANCE_LINK = "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"
 
@@ -183,6 +184,19 @@ class ParticipantValidationMailer < ApplicationMailer
   def fip_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
     template_mail(
       FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def cip_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
+    template_mail(
+      CIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -22,6 +22,7 @@ class UTMService
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
     ects_to_add_validation_information: "ects-to-add-validation-information",
     fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
+    cip_mentors_to_add_validation_information: "cip-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 
@@ -42,6 +43,7 @@ class UTMService
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
     ects_to_add_validation_information: "ects-to-add-validation-information",
     fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
+    cip_mentors_to_add_validation_information: "cip-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
   }.freeze
 

--- a/spec/mailers/participant_validation_mailer_spec.rb
+++ b/spec/mailers/participant_validation_mailer_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
   end
 
   describe "#fip_mentors_to_add_validation_information_email" do
-    let(:induction_coordinator_email) do
+    let(:email) do
       described_class.fip_mentors_to_add_validation_information_email(
         recipient: recipient,
         school_name: school_name,
@@ -171,8 +171,23 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
 
     it "renders the right headers" do
-      expect(induction_coordinator_email.from).to match_array ["mail@example.com"]
-      expect(induction_coordinator_email.to).to match_array [recipient]
+      expect(email.from).to match_array ["mail@example.com"]
+      expect(email.to).to match_array [recipient]
+    end
+  end
+
+  describe "#cip_mentors_to_add_validation_information_email" do
+    let(:email) do
+      described_class.cip_mentors_to_add_validation_information_email(
+        recipient: recipient,
+        school_name: school_name,
+        start_url: "example.com/start-validation",
+      )
+    end
+
+    it "renders the right headers" do
+      expect(email.from).to match_array ["mail@example.com"]
+      expect(email.to).to match_array [recipient]
     end
   end
 


### PR DESCRIPTION
Add mailer for CIP mentors who have not added their details for validation.

Notify template: https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/e0198213-c09d-41aa-8197-b167e495e49d

(This PR is still a draft because I'm confirming whether the ((statutory_guidance)) variable is applicable. I suspect it's not.)