### PR TITLE
update guidance to expand which NPQ id to use

### DIFF
--- a/app/views/lead_providers/guidance/npq_usage.html.erb
+++ b/app/views/lead_providers/guidance/npq_usage.html.erb
@@ -110,8 +110,8 @@
   <code>POST /api/v1/npq-applications/{id}/accept</code>
 </p>
 
-<p class="govuk-body-m">This returns an
-  <a href="/lead-providers/guidance/reference#npqapplicationresponse-object" class="govuk-link">NPQ application record</a>.
+<p class="govuk-body-m">
+  Where <code>{id}</code> is the <code>id</code> of the corresponding NPQ application. This returns an <a href="/lead-providers/guidance/reference#npqapplicationresponse-object" class="govuk-link">NPQ application record</a>.
 </p>
 
 <h3 id="reject-npq-application" class="govuk-heading-m">
@@ -132,8 +132,8 @@
   <code>POST /api/v1/npq-applications/{id}/reject</code>
 </p>
 
-<p class="govuk-body-m">This returns an
-  <a href="/lead-providers/guidance/reference#npqapplicationresponse-object" class="govuk-link">NPQ application record</a>.
+<p class="govuk-body-m">
+  Where <code>{id}</code> is the <code>id</code> of the corresponding NPQ application. This returns an <a href="/lead-providers/guidance/reference#npqapplicationresponse-object" class="govuk-link">NPQ application record</a>.
 </p>
 
 <h3 id="handling-deferrals" class="govuk-heading-m">


### PR DESCRIPTION
## Ticket and context

Ticket: https://trello.com/c/AIB5ITbs/467-improve-docs-on-accept-reject-around-id

- Providers are unclear on what id to pass to the `/api/v1/npq-applications/{id}/accept` and reject endpoints
- On the guidance pages explicitly clarify that the `id` is that of the NPQ application 

## Tech review

### Is there anything that the code reviewer should know?

- none

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- visit https://ecf-review-pr-971.london.cloudapps.digital/lead-providers/guidance/npq-usage#accept-npq-application
- see updated changes from that point onwards

## External API changes

- none