### PR TITLE
only install production yarn dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk -U upgrade && \
     bundle config set no-cache 'true' && \
     bundle config set no-binstubs 'true' && \
     bundle --retry=5 --jobs=4 --without=development test && \
-    yarn install --check-files && \
+    yarn install --check-files --production && \
     apk del .gem-installdeps && \
     rm -rf /usr/local/bundle/cache && \
     find /usr/local/bundle/gems -name "*.c" -delete && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,7 @@ ENV GOVUK_APP_DOMAIN="http://localhost:3000" \
 WORKDIR /app
 COPY . .
 
-RUN yarn jest --passWithNoTests && \
-    bundle exec rake assets:precompile && \
+RUN bundle exec rake assets:precompile && \
     apk del nodejs yarn && \
     rm -rf yarn.lock && \
     rm -rf tmp/* log/* node_modules /usr/local/share/.cache /tmp/*


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- We are installing yarn dev dependencies into our docker images
- These aren't needed as far as I can tell as the test suite does not go through our built images
- So it's just cluttering up the produced image
- From sample size of one test run, it has shaved off about 2 minutes of the deploy to review app time 

## Tech review

### Is there anything that the code reviewer should know?

- see inline comments

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- visit https://ecf-review-pr-972.london.cloudapps.digital
- app should function as normal

 ### External API changes

- none