### PR TITLE
Standardise updated_since filter processing

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -8,6 +8,7 @@ module Api
     rescue_from ActionController::ParameterMissing, with: :missing_parameter_response
     rescue_from ActionController::BadRequest, with: :bad_request_response
     rescue_from ActiveRecord::StatementInvalid, with: :bad_request_response
+    rescue_from ArgumentError, with: :bad_request_response
 
   private
 

--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -5,6 +5,7 @@ module Api
     class ECFUsersController < Api::ApiController
       include ApiTokenAuthenticatable
       include ApiPagination
+      include ApiFilter
 
       def index
         render json: ECFUserSerializer.new(paginate(users)).serializable_hash.to_json
@@ -42,12 +43,8 @@ module Api
         ApiToken.where(private_api_access: true)
       end
 
-      def updated_since
-        params.dig(:filter, :updated_since)
-      end
-
       def email
-        params.dig(:filter, :email)
+        filter[:email]
       end
 
       def users
@@ -59,13 +56,8 @@ module Api
                       ],
                     })
 
-        if updated_since.present?
-          users = users.changed_since(updated_since)
-        end
-
-        if email.present?
-          users = users.where(email: email)
-        end
+        users = users.changed_since(updated_since) if updated_since.present?
+        users = users.where(email: email) if email.present?
 
         users
       end

--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -7,6 +7,7 @@ module Api
     class NPQApplicationsController < Api::ApiController
       include ApiTokenAuthenticatable
       include ApiPagination
+      include ApiFilter
 
       def index
         respond_to do |format|
@@ -51,16 +52,8 @@ module Api
 
       def query_scope
         scope = npq_lead_provider.npq_profiles.includes(:user, :npq_course)
-        scope = scope.where("updated_at > ?", Time.iso8601(updated_since_filter)) if updated_since_filter.present?
+        scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
         scope
-      end
-
-      def filter
-        params[:filter] ||= {}
-      end
-
-      def updated_since_filter
-        filter[:updated_since]
       end
 
       def access_scope

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -8,6 +8,7 @@ module Api
       include ApiTokenAuthenticatable
       include ApiPagination
       include ApiCsv
+      include ApiFilter
 
       def index
         respond_to do |format|
@@ -40,11 +41,6 @@ module Api
         LeadProviderApiToken.joins(cpd_lead_provider: [:lead_provider])
       end
 
-      def updated_since
-        value = params.dig(:filter, :updated_since)
-        URI.decode_www_form_component(value) if value.present?
-      end
-
       def lead_provider
         current_user.lead_provider
       end
@@ -59,9 +55,7 @@ module Api
                                       },
                                     )
 
-        if updated_since.present?
-          participants = participants.changed_since(updated_since)
-        end
+        participants = participants.changed_since(updated_since) if updated_since.present?
 
         participants
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,6 +5,7 @@ module Api
     class UsersController < Api::ApiController
       include ApiTokenAuthenticatable
       include ApiPagination
+      include ApiFilter
 
       def index
         render json: UserSerializer.new(paginate(users)).serializable_hash.to_json
@@ -42,25 +43,14 @@ module Api
         ApiToken.where(private_api_access: true)
       end
 
-      def updated_since
-        params.dig(:filter, :updated_since)
-      end
-
       def email
-        params.dig(:filter, :email)
+        filter[:email]
       end
 
       def users
         users = User.all
-
-        if updated_since.present?
-          users = users.changed_since(updated_since)
-        end
-
-        if email.present?
-          users = users.where(email: email)
-        end
-
+        users = users.changed_since(updated_since) if updated_since.present?
+        users = users.where(email: email) if email.present?
         users
       end
     end

--- a/app/controllers/concerns/api_filter.rb
+++ b/app/controllers/concerns/api_filter.rb
@@ -8,9 +8,9 @@ private
   end
 
   def updated_since
-    return unless filter[:updated_since]
+    return if filter[:updated_since].blank?
 
-    Time.iso8601(filter[:updated_since]) if filter[:updated_since].present?
+    Time.iso8601(filter[:updated_since])
   rescue ArgumentError
     Time.iso8601(URI.decode_www_form_component(filter[:updated_since]))
   end

--- a/app/controllers/concerns/api_filter.rb
+++ b/app/controllers/concerns/api_filter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ApiFilter
+private
+
+  def filter
+    params[:filter] ||= {}
+  end
+
+  def updated_since
+    return unless filter[:updated_since]
+
+    Time.iso8601(filter[:updated_since]) if filter[:updated_since].present?
+  rescue ArgumentError
+    Time.iso8601(URI.decode_www_form_component(filter[:updated_since]))
+  end
+end

--- a/app/views/lead_providers/guidance/release_notes.html.erb
+++ b/app/views/lead_providers/guidance/release_notes.html.erb
@@ -2,6 +2,9 @@
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l">7th September 2021</h2>
+<p class="govuk-body-m">Standardise date filtering parameters between different api endpoints.</p>
+
 <h2 class="govuk-heading-l">19th July 2021</h2>
 <p class="govuk-body-m">Initial release of the NPQ usage guide.</p>
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
             expect(parsed_response["data"].size).to eql(3)
           end
 
+          it "returns users changed since the updated_since parameter with other formats" do
+            User.first.update!(updated_at: Date.new(1970, 1, 1))
+            get "/api/v1/participants", params: { filter: { updated_since: "1980-01-01T00%3A00%3A00%2B01%3A00" } }
+            expect(parsed_response["data"].size).to eql(3)
+          end
+
           context "when updated_since parameter is encoded/escaped" do
             it "unescapes the value and returns users changed since the updated_since date" do
               since = URI.encode_www_form_component(1.day.ago.iso8601)


### PR DESCRIPTION
## Ticket and context

A provider asked us why a format of a filter works on NPQ applications, but not on participants.
IMO they should work everywhere. And it does not hurt us to make the date format range a little wider.

## Tech review

### Is there anything that the code reviewer should know?
I added the test to participants api - I guess technically I could add tests to all places using the filter, but since it is a shared functionality, should I really?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Curl `/api/v1/participants.json?filter[updated_since]=1970-01-01T00%3A00%3A00%2B01%3A00&page[page]=1&page[per_page]=100` with proper authorisation (say, ambition-token).
3. You should get 200 response and a list of values.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes) - Yes
