### PR TITLE
add filter parameter check on npq applications api

### DIFF
--- a/app/controllers/concerns/api_filter.rb
+++ b/app/controllers/concerns/api_filter.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 
 module ApiFilter
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :validate_filter_param
+  end
+
 private
+
+  def validate_filter_param
+    unless filter.as_json.is_a?(Hash)
+      error_factory = Api::ParamErrorFactory.new(params: ["Filter must be a hash"], error: "Bad parameter")
+      render json: { errors: error_factory.call }, status: :bad_request
+    end
+  end
 
   def filter
     params[:filter] ||= {}

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe "NPQ Applications API", type: :request do
             get "/api/v1/npq-applications", params: { filter: { updated_since: 2.days.ago.iso8601 } }
             expect(parsed_response["data"].size).to eql(3)
           end
+
+          context "with invalid filter of a string" do
+            it "returns an error" do
+              get "/api/v1/npq-applications", params: { filter: 2.days.ago.iso8601 }
+              expect(response).to be_bad_request
+              expect(parsed_response).to eql(HashWithIndifferentAccess.new({
+                "errors": [
+                  {
+                    "title": "Bad parameter",
+                    "detail": "Filter must be a hash",
+                  },
+                ],
+              }))
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## Ticket and context

Ticket: https://trello.com/c/pTTNAH4t/466-ecf-api-handle-incorrect-input-for-filters

- An error is raised when api users pass incorrect filter to npq applications api endpoint
- This should now no longer error
- It should now return meaningful error message to the api user

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- create a private api token
```
LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: CpdLeadProvider.all.sample)
```
- make malformed request
```
curl -H "Authorization: Bearer TOKEN" "https://ecf-review-pr-975.london.cloudapps.digital/api/v1/npq-applications?filter=asd"
```
- expect:
```
{"errors":[{"title":"Bad parameter","detail":"Filter must be a hash"}]}
```

## External API changes

- Although this does affect the external api I don't feel it needs to be documented on the specific endpoint
- Do we have general documentation around errors? if not I assume we should add some outside the scope of this change