### PR TITLE
Set a minimum number of requests captured on staging before we raise an alert

### DIFF
--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: RequestsFailuresElevated
         # Condition for alerting
-        expr: ((sum(rate(requests{app="ecf-staging", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1) and ((sum(rate(requests{app="ecf-staging"}[5m])) > 20)
+        expr: (sum(rate(requests{app="ecf-staging", status_range=~"0xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1)
         # Annotation - additional informational labels to store more information
         annotations:
           summary: High rate of failing requests

--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: RequestsFailuresElevated
         # Condition for alerting
-        expr: (sum(rate(requests{app="ecf-staging", status_range=~"0xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1)
+        expr: (sum(rate(requests{app="ecf-staging", status_range=~"0xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1
         # Annotation - additional informational labels to store more information
         annotations:
           summary: High rate of failing requests

--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -3,7 +3,7 @@ groups:
     rules:
       - alert: RequestsFailuresElevated
         # Condition for alerting
-        expr: (sum(rate(requests{app="ecf-staging", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1
+        expr: ((sum(rate(requests{app="ecf-staging", status_range=~"0xx|4xx|5xx"}[5m]))) / (sum(rate(requests{app="ecf-staging"}[5m])) ) > 0.1) and ((sum(rate(requests{app="ecf-staging"}[5m])) > 20)
         # Annotation - additional informational labels to store more information
         annotations:
           summary: High rate of failing requests


### PR DESCRIPTION
## Ticket and context
I got annoyed by "high rate of failing requests" notification on staging. They seem to be 404s by bots, they happen every now and then in low volumes. But staging is just not ussed for much, so they compose a high percentage of requests, which triggers our alarms.

## Tech review

### Is there anything that the code reviewer should know?
https://www.robustperception.io/combining-alert-conditions is where I got the `and` from. 
