### PR TITLE
CPDTP-434 Reject different date duplicates

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -9,6 +9,7 @@ module Api
     rescue_from ActionController::BadRequest, with: :bad_request_response
     rescue_from ActiveRecord::StatementInvalid, with: :bad_request_response
     rescue_from ArgumentError, with: :bad_request_response
+    rescue_from ActiveRecord::RecordNotUnique, with: :conflict_response
 
   private
 
@@ -26,6 +27,10 @@ module Api
 
     def bad_request_response(exception)
       render json: { errors: Api::ParamErrorFactory.new(error: "Bad request", params: exception.message).call }, status: :bad_request
+    end
+
+    def conflict_response(exception)
+      render json: { errors: Api::ParamErrorFactory.new(error: "Conflict", params: exception.message).call }, status: :conflict
     end
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -9,7 +9,7 @@ module Api
     rescue_from ActionController::BadRequest, with: :bad_request_response
     rescue_from ActiveRecord::StatementInvalid, with: :bad_request_response
     rescue_from ArgumentError, with: :bad_request_response
-    rescue_from ActiveRecord::RecordNotUnique, with: :conflict_response
+    rescue_from ActiveRecord::RecordNotUnique, with: :bad_request_response
 
   private
 
@@ -27,10 +27,6 @@ module Api
 
     def bad_request_response(exception)
       render json: { errors: Api::ParamErrorFactory.new(error: "Bad request", params: exception.message).call }, status: :bad_request
-    end
-
-    def conflict_response(exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: "Conflict", params: exception.message).call }, status: :conflict
     end
   end
 end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -96,7 +96,7 @@ module RecordDeclarations
         declaration_type: declaration_type,
       )
 
-      declaration.present? && declaration.declaration_date.rfc3339 != Time.zone.parse(declaration_date)&.rfc3339
+      declaration.present? && declaration.declaration_date != Time.zone.parse(declaration_date)
     end
 
     def date_has_the_right_format

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -39,7 +39,7 @@ module RecordDeclarations
       validate_provider!
       validate_milestone!
 
-      raise ActiveRecord::RecordNotUnique, "Declaration with given participant ID already exists" if record_exist?
+      raise ActiveRecord::RecordNotUnique, "Declaration with given participant ID already exists" if record_exists_with_different_declaration_date?
 
       declaration = find_or_create_record!
 
@@ -89,12 +89,11 @@ module RecordDeclarations
       end
     end
 
-    def record_exist?
+    def record_exists_with_different_declaration_date?
       declaration = self.class.declaration_model.find_by(
         user: user,
         course_identifier: course_identifier,
         declaration_type: declaration_type,
-        cpd_lead_provider: cpd_lead_provider,
       )
 
       declaration.present? && declaration.declaration_date.rfc3339 != Time.zone.parse(declaration_date)&.rfc3339

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect { post "/api/v1/participant-declarations", params: params_with_different_declaration_date }
             .to change(ParticipantDeclarationAttempt, :count).by(1)
 
-        expect(response.status).to eq 409
+        expect(response.status).to eq 400
         expect(parsed_response["id"]).to eq(original_id)
       end
 

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
       }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
     end
 
+    it "does not create exact duplicates and throws an error" do
+      expect {
+        described_class.call(ect_params)
+        described_class.call(ect_params_with_different_date)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
     it "fails when course is for mentor" do
       params = ect_params.merge({ course_identifier: "ecf-mentor" })
       expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
   end
 
   context "when valid user is an early_career_teacher" do
+    let(:ect_params_with_different_date) do
+      ect_params.merge({ declaration_date: (ect_declaration_date + 1.second).rfc3339 })
+    end
+
     it "creates a participant and profile declaration" do
       expect { described_class.call(ect_params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
     end

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -14,10 +14,6 @@ RSpec.shared_context "service record declaration params" do
   let(:ect_params) do
     params.merge({ cpd_lead_provider: cpd_lead_provider })
   end
-  let(:ect_params_with_different_date) do
-    ect_params.merge({ declaration_date: (ect_declaration_date + 1.second).rfc3339 })
-  end
-
   let(:mentor_declaration_date) { mentor_profile.schedule.milestones.first.start_date + 1.day }
   let(:mentor_params) do
     ect_params.merge({ participant_id: mentor_profile.user.id, course_identifier: "ecf-mentor", declaration_date: mentor_declaration_date.rfc3339 })

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -14,6 +14,9 @@ RSpec.shared_context "service record declaration params" do
   let(:ect_params) do
     params.merge({ cpd_lead_provider: cpd_lead_provider })
   end
+  let(:ect_params_with_different_date) do
+    ect_params.merge({ declaration_date: (ect_declaration_date + 1.second).rfc3339 })
+  end
 
   let(:mentor_declaration_date) { mentor_profile.schedule.milestones.first.start_date + 1.day }
   let(:mentor_params) do


### PR DESCRIPTION
## Ticket and context

When a participant declaration has been created, any subsequent duplicate declaration for this participant with any different declaration date will be rejected with the 409 status code.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
