### PR TITLE
Remove spurious failure in email sending test

### DIFF
--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe ValidationBetaService do
                                                .with(hash_including(
                                                        recipient: chosen_programme_and_not_in_beta_ic.email,
                                                        sign_in: sign_in_url,
-                                                       school_name: chosen_programme_and_not_in_beta_school.name,
                                                      ))
     end
 


### PR DESCRIPTION
## Ticket and context

The test breaks often enough that it is annoying, at least in CI.

## Tech review

### Is there anything that the code reviewer should know?
The reason the test broke was that in the email sending service, we only send the email to the first school of the IC. But our test IC has two schools that are 'valid choices' for the service.

And then the test checks that the service sent an email to the specific first school - so sometimes it fails. For some reason failure on my local machine I needed to run it 80 times before getting 50% failure rate, but it seems on CI it happened more.

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
