### PR TITLE
CPDTP-463: Update participant action docs

### DIFF
--- a/app/views/lead_providers/guidance/_ecf_usage_participant_actions.html.erb
+++ b/app/views/lead_providers/guidance/_ecf_usage_participant_actions.html.erb
@@ -25,7 +25,7 @@
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#put-api-v1-participants-id-defer" class="govuk-link">deferred ECF participant</a> endpoint.</p>
 
 
-<h2 id="notifying-of-deferral" class="govuk-heading-l">Notify that an ECF participant is changing training schedule</h2>
+<h2 id="notifying-of-schedule-change" class="govuk-heading-l">Notify that an ECF participant is changing training schedule</h2>
 
 <p class="govuk-body-m">This operation allows the provider to tell the DfE that a participant has changed training schedules on their ECF course.</p>
 

--- a/app/views/lead_providers/guidance/_ecf_usage_participant_actions.html.erb
+++ b/app/views/lead_providers/guidance/_ecf_usage_participant_actions.html.erb
@@ -1,0 +1,37 @@
+<h2 id="notifying-of-withdrawal" class="govuk-heading-l">Notify that an ECF participant has withdrawn from their course</h2>
+
+<p class="govuk-body-m">This operation allows the provider to tell the DfE that a participant has withdrawn from their ECF course.</p>
+<p class="govuk-body-m">A participant that withdraws in a given milestone period after the submission of a retained event for the same period, will be paid for that period.</p>
+<p class="govuk-body-m">A participant that withdraws before the started milestone cut-off date will not be paid for by the department.</p>
+
+<h3 class="govuk-heading-m">1. Provider withdraws a participant</h3>
+
+<p class="govuk-body-m">Submit the withdrawal notification to the following endpoint</p>
+<p class="govuk-body-m"><code>PUT /api/v1/participants/{id}/withdraw</code></p>
+<p class="govuk-body-m">This will return an <a href="/lead-providers/guidance/reference#ecfparticipant-object" class="govuk-link">ECF participant record</a> with the updates to the record included.</p>
+<p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#put-api-v1-participants-id-withdraw" class="govuk-link">withdraw ECF participant</a> endpoint.</p>
+
+
+<h2 id="notifying-of-deferral" class="govuk-heading-l">Notifying that an ECF participant is taking a break from their course</h2>
+
+<p class="govuk-body-m">This operation allows the provider to tell the DfE that a participant has deferred from their ECF course.</p>
+<p class="govuk-body-m">A participant is deemed to have deferred from an ECF course if he or she will be resuming it at a later date.</p>
+
+<h3 class="govuk-heading-m">1. Provider defers a participant</h3>
+
+<p class="govuk-body-m">Submit the deferral notification to the following endpoint</p>
+<p class="govuk-body-m"><code>PUT /api/v1/participants/{id}/defer</code></p>
+<p class="govuk-body-m">This will return an <a href="/lead-providers/guidance/reference#ecfparticipant-object" class="govuk-link">ECF participant record</a> with the updates to the record included.</p>
+<p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#put-api-v1-participants-id-defer" class="govuk-link">deferred ECF participant</a> endpoint.</p>
+
+
+<h2 id="notifying-of-deferral" class="govuk-heading-l">Notify that an ECF participant is changing training schedule</h2>
+
+<p class="govuk-body-m">This operation allows the provider to tell the DfE that a participant has changed training schedules on their ECF course.</p>
+
+<h3 class="govuk-heading-m">1. Provider changes a participants schedule</h3>
+
+<p class="govuk-body-m">Submit the change of schedule notification to the following endpoint</p>
+<p class="govuk-body-m"><code>PUT /api/v1/participants/{id}/change-schedule</code></p>
+<p class="govuk-body-m">This will return an <a href="/lead-providers/guidance/reference#ecfparticipant-object" class="govuk-link">ECF participant record</a> with the updates to the record included.</p>
+<p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#put-api-v1-participants-id-change-schedule" class="govuk-link">deferred ECF participant</a> endpoint.</p>

--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -2,7 +2,9 @@
 
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="#continuing-the-ecf-registration-process" class="govuk-link">Continuing the ECF registration process</a></li>
+  <li><a href="#notifying-of-withdrawal" class="govuk-link">Notify that an ECF participant has withdrawn from their course</a></li>
   <li><a href="#notifying-of-deferral" class="govuk-link">Notify that an ECF participant is taking a break from their course</a></li>
+  <li><a href="#notifying-of-schedule-change" class="govuk-link">Notify that an ECF participant is changing training schedule</a></li>
   <li><a href="#declaring-that-an-ecf-participant-has-started-their-course" class="govuk-link">Declaring that an ECF participant has started their course</a></li>
   <li><a href="#declaring-that-an-ecf-participant-has-retained-their-course" class="govuk-link">Declaring that an ECF participant has reached a retained milestone</a></li>
   <li><a href="#declaring-that-an-ecf-participant-has-completed-their-course" class="govuk-link">Declaring that an ECF participant has completed their course</a></li>

--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -48,26 +48,7 @@
 
 <p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#get-api-v1-participants" class="govuk-link">retrieve multiple participants</a> endpoint.</p>
 
-
-<h2 id="notifying-of-deferral" class="govuk-heading-l">Notifying that an ECF participant is taking a break from their course</h2>
-
-<p class="govuk-body-m">This operation allows the provider to tell the DfE that a participant has deferred from their ECF course.</p>
-
-<p class="govuk-body-m">A participant is deemed to have deferred from an ECF course if he or she will be resuming it at a later date.</p>
-
-<h3 class="govuk-heading-m">1. Provider defers a participant</h3>
-
-<p class="govuk-body-m">
-  Submit the deferral notification to the following endpoint
-</p>
-
-<p class="govuk-body-m"><code>PUT /api/v1/participants/{id}/deferred</code></p>
-
-<p class="govuk-body-m">This will return an <a href="/lead-providers/guidance/reference#ecfparticipant-object" class="govuk-link">ECF participant record</a> with the updates to the record included.</p>
-
-<p class="govuk-body-m">See <a href="/lead-providers/guidance/reference#put-api-v1-participants-id-defer" class="govuk-link">deferred ECF participant</a> endpoint.</p>
-
-
+<%= render "ecf_usage_participant_actions" %>
 
 <h2 id="declaring-that-an-ecf-participant-has-started-their-course" class="govuk-heading-l">Declaring that an ECF participant has started their course</h2>
 
@@ -94,7 +75,7 @@
 <p class="govuk-body-m">This scenario begins after it has been confirmed that an ECF participant has completed enough of their course to meet a milestone.</p>
 <h3 class="govuk-heading-m">1. Provider confirms an ECF participant has been retained</h3>
 <p class="govuk-body-m">
-1. Confirm an ECF participant has been retained by the appropriate number of months for this retained event on their ECF course.
+  1. Confirm an ECF participant has been retained by the appropriate number of months for this retained event on their ECF course.
 </p>
 
 <p class="govuk-body-m">

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
       parameter name: :filter,
                 in: :query,
                 schema: {
-                  "$ref": "#/components/schemas/ListFilter",
+                  "$ref": "#/components/schemas/ListFilterDeclarations",
                 },
                 type: :object,
                 style: :deepObject,

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1339,6 +1339,11 @@
         "description": "Filter a list of declarations records to return more specific results",
         "type": "object",
         "properties": {
+          "updated_since": {
+            "description": "Return only records that have been updated since this date and time (ISO 8601 date format)",
+            "type": "string",
+            "example": "2021-05-13T11:21:55Z"
+          },
           "participant_id": {
             "description": "The unique id of the participant",
             "type": "string",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -334,7 +334,7 @@
             "name": "filter",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListFilter"
+              "$ref": "#/components/schemas/ListFilterDeclarations"
             },
             "style": "deepObject",
             "explode": true,
@@ -1331,7 +1331,13 @@
             "description": "Return only records that have been updated since this date and time (ISO 8601 date format)",
             "type": "string",
             "example": "2021-05-13T11:21:55Z"
-          },
+          }
+        }
+      },
+      "ListFilterDeclarations": {
+        "description": "Filter a list of declarations records to return more specific results",
+        "type": "object",
+        "properties": {
           "participant_id": {
             "description": "The unique id of the participant",
             "type": "string",

--- a/swagger/v1/component_schemas/ListFilter.yml
+++ b/swagger/v1/component_schemas/ListFilter.yml
@@ -5,7 +5,3 @@ properties:
     description: "Return only records that have been updated since this date and time (ISO 8601 date format)"
     type: :string
     example: "2021-05-13T11:21:55Z"
-  participant_id:
-    description: "The unique id of the participant"
-    type: :string
-    example: "ab3a7848-1208-7679-942a-b4a70eed400a"

--- a/swagger/v1/component_schemas/ListFilterDeclarations.yml
+++ b/swagger/v1/component_schemas/ListFilterDeclarations.yml
@@ -1,0 +1,7 @@
+description: "Filter a list of declarations records to return more specific results"
+type: object
+properties:
+  participant_id:
+    description: "The unique id of the participant"
+    type: :string
+    example: "ab3a7848-1208-7679-942a-b4a70eed400a"

--- a/swagger/v1/component_schemas/ListFilterDeclarations.yml
+++ b/swagger/v1/component_schemas/ListFilterDeclarations.yml
@@ -1,6 +1,10 @@
 description: "Filter a list of declarations records to return more specific results"
 type: object
 properties:
+  updated_since:
+    description: "Return only records that have been updated since this date and time (ISO 8601 date format)"
+    type: :string
+    example: "2021-05-13T11:21:55Z"
   participant_id:
     description: "The unique id of the participant"
     type: :string


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-463

Also fixes imperfect filter documentation in swagger

## Tech review

### Is there anything that the code reviewer should know?

The guidance was getting lengthy, so I started using partials. They have no variables or anything complex, so I don't think we need to componentise them. 

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Go to LP ecf guidance page

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes) - no api changes
