### PR TITLE
Add updated_since filter to /api/v1/participant-declarations

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -31,6 +31,7 @@ module Api
       def query_scope
         scope = ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
         scope = scope.where("user_id = ?", participant_id_filter) if participant_id_filter.present?
+        scope = scope.where("updated_at > ?", Time.iso8601(updated_since_filter)) if updated_since_filter.present?
         scope
       end
 
@@ -40,6 +41,10 @@ module Api
 
       def participant_id_filter
         filter[:participant_id]
+      end
+
+      def updated_since_filter
+        filter[:updated_since]
       end
 
       def cpd_lead_provider

--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -7,6 +7,7 @@ module Api
       include ApiTokenAuthenticatable
       include ApiPagination
       include ApiCsv
+      include ApiFilter
 
       def create
         params = HashWithIndifferentAccess.new({ cpd_lead_provider: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
@@ -31,7 +32,7 @@ module Api
       def query_scope
         scope = ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
         scope = scope.where("user_id = ?", participant_id_filter) if participant_id_filter.present?
-        scope = scope.where("updated_at > ?", Time.iso8601(updated_since_filter)) if updated_since_filter.present?
+        scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
         scope
       end
 
@@ -41,10 +42,6 @@ module Api
 
       def participant_id_filter
         filter[:participant_id]
-      end
-
-      def updated_since_filter
-        filter[:updated_since]
       end
 
       def cpd_lead_provider

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
                 description: "Refine participant declarations to return.",
                 example: {
                   participant_id: "ab3a7848-1208-7679-942a-b4a70eed400a",
-                  updated_since: "2020-11-13T11:21:55Z"
+                  updated_since: "2020-11-13T11:21:55Z",
                 }
 
       parameter name: :page,

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -111,7 +111,10 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
                 explode: true,
                 required: false,
                 description: "Refine participant declarations to return.",
-                example: { participant_id: "ab3a7848-1208-7679-942a-b4a70eed400a" }
+                example: {
+                  participant_id: "ab3a7848-1208-7679-942a-b4a70eed400a",
+                  updated_since: "2020-11-13T11:21:55Z"
+                }
 
       parameter name: :page,
                 in: :query,

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -341,7 +341,8 @@
             "required": false,
             "description": "Refine participant declarations to return.",
             "example": {
-              "participant_id": "ab3a7848-1208-7679-942a-b4a70eed400a"
+              "participant_id": "ab3a7848-1208-7679-942a-b4a70eed400a",
+              "updated_since": "2020-11-13T11:21:55Z"
             }
           },
           {


### PR DESCRIPTION
## Ticket and context

Add updated_since filter to `GET /api/v1/participant-declarations`

Allow participant declarations to be filtered by when they were created (or last updated). A provider tried to do this previously and I don't see any reason why we wouldn't let them.

## Tech review

### Code quality checks
- [X] All commit messages are meaningful and true
- [X] Added enough automated tests
