### PR TITLE
Add parallel tests for rspec for dev use

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,5 @@
+--require rails_helper
+--require spec_helper
+--require payment_calculator
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,8 @@ group :development, :test do
   # Swagger generator
   gem "multi_json"
   gem "open_api-rswag-specs", ">= 0.1.0"
+
+  gem "parallel_tests"
 end
 
 group :development, :deployed_development, :test, :sandbox do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,8 @@ GEM
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.20.1)
+    parallel_tests (3.7.1)
+      parallel
     parser (3.0.0.0)
       ast (~> 2.4.1)
     percy-capybara (5.0.0)
@@ -626,6 +628,7 @@ DEPENDENCIES
   openapi3_parser (= 0.9.0)
   pagy (~> 3.13)
   paper_trail
+  parallel_tests
   percy-capybara
   pg (>= 0.18, < 2.0)
   pretender (>= 0.3.4)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ bundle exec rake
 bundle exec rspec
 ```
 
+## Running specs in parallel
+
+### One time Setup
+```
+bundle exec rake parallel:create
+```
+
+### Running specs thereafter
+```
+bundle exec rake parallel:spec
+```
+
 ## Running swagger doc generator
 
 It auto-generates swagger/*/api_spec.json from the schema files located in spec/docs

--- a/app/controllers/lead_providers/openapi_controller.rb
+++ b/app/controllers/lead_providers/openapi_controller.rb
@@ -2,6 +2,8 @@
 
 # source: https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/controllers/api_docs/vendor_api_docs/openapi_controller.rb
 
+require "lead_provider_api_specification"
+
 module LeadProviders
   class OpenapiController < ApplicationController
     def api_docs

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ sandbox:
 
 test:
   <<: *default
-  database: 'early_careers_framework_test'
+  database: early_careers_framework_test<%= ENV['TEST_ENV_NUMBER'] %>
   variables:
     idle_in_transaction_session_timeout: 0
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -75,4 +75,8 @@ Rails.application.configure do
   # config.action_view.annotate_rendered_view_with_filenames = true
 
   config.cip_resource_bucket = "https://paas-s3-broker-prod-lon-ac28a7a5-2bc2-4d3b-8d16-a88eaef65526.s3.amazonaws.com"
+
+  if config.respond_to?(:web_console)
+    config.web_console.development_only = false
+  end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: none

- Adds ability to run rspec test suite in parallel
- This at the moment is for local developer use only as a first step
- Maybe after we can patch it into the CI process
- Has dropped down from 5/6 minutes runtime to about 90 seconds for my local machine

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- n/a

## External API changes

- none