### PR TITLE
CPDRP-929: Add Section 41 schools invite mailer

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -10,6 +10,7 @@ class SchoolMailer < ApplicationMailer
   MAT_INVITE_EMAIL_TEMPLATE = "f856f50e-6f49-441e-8018-f8303367eb5c"
   CIP_ONLY_INVITE_EMAIL_TEMPLATE = "ee814b67-52e3-409d-8350-5140e6741124"
   FEDERATION_INVITE_EMAIL_TEMPLATE = "9269c50d-b579-425b-b55b-4c93f67074d4"
+  SECTION_41_INVITE_EMAIL_TEMPLATE = "a4ba1de4-e401-47f4-ac77-60c1da17a0e5"
   COORDINATOR_SIGN_IN_CHASER_EMAIL_TEMPLATE = "b5c318a4-2171-4ded-809a-af72dd87e7a7"
   COORDINATOR_REMINDER_TO_CHOOSE_ROUTE_EMAIL_TEMPLATE = "c939c27a-9951-4ac3-817d-56b7bf343fb4"
   COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE = "e7a60b68-334e-4a25-8adf-55ebc70622f9"
@@ -157,6 +158,19 @@ class SchoolMailer < ApplicationMailer
   def cip_only_invite_email(recipient:, school_name:, nomination_url:)
     template_mail(
       CIP_ONLY_INVITE_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        nomination_link: nomination_url,
+      },
+    )
+  end
+
+  def section_41_invite_email(recipient:, school_name:, nomination_url:)
+    template_mail(
+      SECTION_41_INVITE_EMAIL_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -115,6 +115,10 @@ class InviteSchools
     invite_group(school_urns, :send_federation_invite_email)
   end
 
+  def invite_section_41(school_urns)
+    invite_group(school_urns, :send_section_41_invite_email)
+  end
+
   def send_induction_coordinator_sign_in_chasers(send_at: Time.zone.now)
     induction_coordinators_never_signed_in = User.joins(:induction_coordinator_profile).where("last_sign_in_at IS NULL and users.created_at < ?", 2.days.ago)
     induction_coordinators_never_signed_in.each do |induction_coordinator|
@@ -374,6 +378,16 @@ private
       recipient: nomination_email.sent_to,
       school_name: nomination_email.school.name,
       nomination_url: nomination_email.nomination_url(utm_source: :nominate_tutor_cip_only),
+    ).deliver_now.delivery_method.response.id
+
+    nomination_email.update!(notify_id: notify_id)
+  end
+
+  def send_section_41_invite_email(nomination_email)
+    notify_id = SchoolMailer.section_41_invite_email(
+      recipient: nomination_email.sent_to,
+      school_name: nomination_email.school.name,
+      nomination_url: nomination_email.nomination_url(utm_source: :nominate_section_41),
     ).deliver_now.delivery_method.response.id
 
     nomination_email.update!(notify_id: notify_id)

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe SchoolMailer, type: :mailer do
     end
   end
 
+  describe "#section_41_invite_email" do
+    let(:primary_contact_email) { "contact@example.com" }
+    let(:nomination_url) { "https://ecf-dev.london.cloudapps/nominations?token=abc123" }
+
+    let(:section_41_invite_email) do
+      SchoolMailer.section_41_invite_email(
+        recipient: primary_contact_email,
+        nomination_url: nomination_url,
+        school_name: "Great Ouse Academy",
+      ).deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(section_41_invite_email.from).to eq(["mail@example.com"])
+      expect(section_41_invite_email.to).to eq([primary_contact_email])
+    end
+  end
+
   describe "#nomination_email_confirmation" do
     let(:school) { create(:school) }
     let(:user) { create(:user, :induction_coordinator) }

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -363,6 +363,56 @@ RSpec.describe InviteSchools do
     end
   end
 
+  describe "#invite_section_41" do
+    context "when the is an induction coordinator" do
+      let(:induction_coordinator) { create(:user, :induction_coordinator) }
+      let(:school) { induction_coordinator.schools.first }
+
+      it "sends the email to the induction coordinator" do
+        expect { InviteSchools.new.invite_section_41([school.urn]) }.to change { NominationEmail.count }.by(1)
+        expect(an_instance_of(InviteSchools)).to delay_execution_of(:send_section_41_invite_email).with(
+          an_object_having_attributes(
+            class: NominationEmail,
+            sent_to: induction_coordinator.email,
+            school: school,
+          ),
+        )
+      end
+    end
+
+    context "when the school has a primary contact email" do
+      let(:primary_email) { "primary@example.com" }
+      let(:school) { create(:school, primary_contact_email: primary_email) }
+
+      it "sends an email to the primary contact" do
+        expect { InviteSchools.new.invite_section_41([school.urn]) }.to change { NominationEmail.count }.by(1)
+        expect(an_instance_of(InviteSchools)).to delay_execution_of(:send_section_41_invite_email).with(
+          an_object_having_attributes(
+            class: NominationEmail,
+            sent_to: primary_email,
+            school: school,
+          ),
+        )
+      end
+    end
+
+    context "when the school has a secondary contact email" do
+      let(:secondary_email) { "secondary@example.com" }
+      let(:school) { create(:school, primary_contact_email: nil, secondary_contact_email: secondary_email) }
+
+      it "sends an email to the secondary contact" do
+        expect { InviteSchools.new.invite_section_41([school.urn]) }.to change { NominationEmail.count }.by(1)
+        expect(an_instance_of(InviteSchools)).to delay_execution_of(:send_section_41_invite_email).with(
+          an_object_having_attributes(
+            class: NominationEmail,
+            sent_to: secondary_email,
+            school: school,
+          ),
+        )
+      end
+    end
+  end
+
   describe "#invite_cip_only_schools" do
     context "when the school has a primary contact email" do
       let!(:cip_only_school) { create(:school, :cip_only, school_type_code: 10) }


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-929

## Tech review

Adds a mailer so that we can send a separate nomination email to Section 41 schools.

The notify template is: https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/a4ba1de4-e401-47f4-ac77-60c1da17a0e5