### PR TITLE
move axe js dependencies as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "@sentry/browser": "^6.10.0",
     "@sentry/tracing": "^6.10.0",
     "accessible-autocomplete": "^2.0.3",
-    "axe-core": "^4.2.1",
-    "cypress-axe": "^0.12.2",
     "govuk-frontend": "^3.12.0",
     "serialize-javascript": "^5.0.1",
     "set-value": "^3.0.2",
@@ -20,7 +18,9 @@
   "devDependencies": {
     "@percy/cli": "^1.0.0-beta.47",
     "@percy/cypress": "^3.0.0",
+    "axe-core": "^4.2.1",
     "cypress": "7.5.0",
+    "cypress-axe": "^0.12.2",
     "cypress-cucumber-preprocessor": "^4.0.1",
     "cypress-file-upload": "^5.0.7",
     "cypress-intellij-reporter": "^0.0.6",


### PR DESCRIPTION
## Ticket and context

Ticket: none

Move JS development dependencies into the development group. So they are not cluttering the production docker image

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Visit the review app
- Should behave as normal

## External API changes

- none