### PR TITLE
CPDEL 768 limit adding 2020 nqts to once only

### DIFF
--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -3,6 +3,7 @@
 module Schools
   class Year2020Controller < ApplicationController
     before_action :load_year_2020_form
+    before_action :check_school_has_no_existing_2020_ects, except: %i[start cohort_already_have_access]
     SESSION_KEY = :schools_year2020_form
 
     def start
@@ -76,11 +77,20 @@ module Schools
 
     def no_accredited_materials; end
 
+    def cohort_already_have_access; end
+
   private
 
     def load_year_2020_form
       @year_2020_form = Year2020Form.new(get_year_2020_session.merge(school_id: params[:school_id]))
       @year_2020_form.assign_attributes(year_2020_params)
+    end
+
+    def check_school_has_no_existing_2020_ects
+      school_cohort = SchoolCohort.find_by(school: @year_2020_form.school, cohort: @year_2020_form.cohort)&.ecf_participants
+      if school_cohort.count.positive?
+        redirect_to action: :cohort_already_have_access
+      end
     end
 
     def year_2020_params

--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -3,7 +3,7 @@
 module Schools
   class Year2020Controller < ApplicationController
     before_action :load_year_2020_form
-    before_action :check_school_has_no_existing_2020_ects, except: %i[start cohort_already_have_access]
+    before_action :check_school_has_no_existing_2020_ects, except: %i[start cohort_already_have_access success]
     SESSION_KEY = :schools_year2020_form
 
     def start
@@ -87,8 +87,8 @@ module Schools
     end
 
     def check_school_has_no_existing_2020_ects
-      school_cohort = SchoolCohort.find_by(school: @year_2020_form.school, cohort: @year_2020_form.cohort)&.ecf_participants
-      if school_cohort.count.positive?
+      school_cohort = SchoolCohort.find_by(school: @year_2020_form.school, cohort: @year_2020_form.cohort)
+      if school_cohort&.ecf_participants&.present?
         redirect_to action: :cohort_already_have_access
       end
     end

--- a/app/views/schools/year2020/cohort_already_have_access.html.erb
+++ b/app/views/schools/year2020/cohort_already_have_access.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= @year_2020_form.school.name %>'s 2020 to 2021 NQT cohort already have access to these materials'</h1>
+
+    <p>Contact <%= render MailToSupportComponent.new %> if you think this is wrong.</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -309,6 +309,7 @@ Rails.application.routes.draw do
         post "check-your-answers", action: :confirm
         get "success", action: :success
 
+        get "2020-cohort-already-have-access", action: :cohort_already_have_access
         get "no-accredited-materials", action: :no_accredited_materials
       end
 

--- a/lib/email_redirector.rb
+++ b/lib/email_redirector.rb
@@ -28,14 +28,10 @@ module EmailRedirector
   private
 
     def overide_personalisation(mail, key, &block)
-      value = mail.header["personalisation"].unparsed_value[key]
+      value = mail.header["personalisation"]&.unparsed_value&.fetch(key, nil)
       return if value.blank?
 
       mail.header["personalisation"].unparsed_value[key] = block.call(value)
-    end
-
-    def add_default_personalisation(mail, key, value)
-      mail.header["personalisation"].unparsed_value[key] ||= value
     end
 
     def tags(mail)

--- a/spec/requests/schools/year2020_spec.rb
+++ b/spec/requests/schools/year2020_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "Schools::AddParticipant", type: :request do
 
     describe "GET /schools/:school_id/year-2020/start" do
       before do
-        get "/schools/#{school.slug}/year-2020/start"
+        get "/schools/#{school.slug}/year-2020/support-materials-for-NQTs"
       end
 
       it { is_expected.to render_template("schools/year2020/start") }

--- a/spec/requests/schools/year2020_spec.rb
+++ b/spec/requests/schools/year2020_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Schools::AddParticipant", type: :request do
   let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021") }
   let!(:school) { create :school }
   let!(:cohort) { create :cohort, start_year: 2020 }
+  let!(:school_cohort) { create(:school_cohort, school: school, cohort: cohort) }
   let!(:core_induction_programme) { create :core_induction_programme }
 
   subject { response }
@@ -163,6 +164,74 @@ RSpec.describe "Schools::AddParticipant", type: :request do
     it { is_expected.to render_template("schools/year2020/success") }
   end
 
+  context "trying to add more ects when a schools 2020 cohort has already been to the service" do
+    before do
+      create(:participant_profile, :ect, school_cohort: school_cohort)
+    end
+
+    describe "GET /schools/:school_id/year-2020/start" do
+      before do
+        get "/schools/#{school.slug}/year-2020/start"
+      end
+
+      it { is_expected.to render_template("schools/year2020/start") }
+    end
+
+    describe "GET /schools/:school_id/year-2020/choose-core-induction-programme" do
+      before do
+        get "/schools/#{school.slug}/year-2020/choose-core-induction-programme"
+      end
+
+      it { is_expected.to redirect_to "/schools/#{school.slug}/year-2020/2020-cohort-already-have-access" }
+    end
+
+    describe "PUT /schools/:school_id/year-2020/add-teacher" do
+      it "redirects to the cohort already have access page" do
+        put "/schools/#{school.slug}/year-2020/choose-core-induction-programme", params: {
+          schools_year2020_form: { core_induction_programme_id: core_induction_programme.id },
+        }
+        expect(response).to redirect_to "/schools/#{school.slug}/year-2020/2020-cohort-already-have-access"
+      end
+    end
+
+    describe "GET /schools/:school_id/year-2020/check-your-answers" do
+      before do
+        set_default_complete_session
+        get "/schools/#{school.slug}/year-2020/check-your-answers"
+      end
+
+      it { is_expected.to redirect_to "/schools/#{school.slug}/year-2020/2020-cohort-already-have-access" }
+    end
+
+    describe "GET /schools/:school_id/year-2020/edit-teacher?index=x" do
+      before do
+        set_default_complete_session
+        get "/schools/#{school.slug}/year-2020/edit-teacher?index=1"
+      end
+
+      it { is_expected.to redirect_to "/schools/#{school.slug}/year-2020/2020-cohort-already-have-access" }
+    end
+
+    describe "POST /schools/:school_id/year-2020/check-your-answers" do
+      before do
+        set_default_complete_session
+      end
+
+      it "redirects to the 2020-cohort-already-have-access" do
+        post "/schools/#{school.slug}/year-2020/check-your-answers"
+        expect(response).to redirect_to "/schools/#{school.slug}/year-2020/2020-cohort-already-have-access"
+      end
+
+      it "does not save additional teachers trying to be added" do
+        post "/schools/#{school.slug}/year-2020/check-your-answers"
+        school_cohort = SchoolCohort.find_by(school: school, cohort: cohort)
+
+        expect(school_cohort.ecf_participants.count).to eq(1)
+        expect(additional_teacher_has_saved?).to be false
+      end
+    end
+  end
+
 private
 
   def set_default_complete_session
@@ -170,5 +239,9 @@ private
                 school_id: school.friendly_id,
                 core_induction_programme_id: core_induction_programme.id,
                 participants: [{ full_name: "Joe Bloggs", email: "joe@example.com", index: 1 }])
+  end
+
+  def additional_teacher_has_saved?
+    school_cohort.ecf_participants.any? { |participant| participant.full_name == "Joe Bloggs" }
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-768 (all error states except from the first were done in a separate PR)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
