### PR TITLE
Fix annoying scopes

### DIFF
--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -7,9 +7,9 @@ class TeacherProfile < ApplicationRecord
   has_many :participant_profiles, dependent: :destroy
 
   # TODO: Legacy associations, to be removed
-  has_one :early_career_teacher_profile, -> { active_record }, class_name: "ParticipantProfile::ECT"
-  has_one :mentor_profile, -> { active_record }, class_name: "ParticipantProfile::Mentor"
-  has_one :ecf_profile, -> { active_record }, class_name: "ParticipantProfile::ECF"
+  has_one :early_career_teacher_profile, -> { ects.active_record }, class_name: "ParticipantProfile"
+  has_one :mentor_profile, -> { mentors.active_record }, class_name: "ParticipantProfile"
+  has_one :ecf_profile, -> { ecf.active_record }, class_name: "ParticipantProfile"
 
   has_many :npq_profiles, class_name: "ParticipantProfile::NPQ"
   # end: TODO


### PR DESCRIPTION
## Ticket and context

Slack conversation and past experience show that the teacher profile - participant profile relations don't work great

## Tech review

### Is there anything that the code reviewer should know?

I tried quite hard to replicate the original behaviour in tests, to no avail. I think there is something clever going on with ActiveRecord caching :(

If someone can produce a test that fails on develop when it shouldn't - say, the profile exists but `user.teacher_profile.ecf_profile` doesn't get it - I would gladly bring it in. 

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

## Product review

### How can someone see it it review app?
1. ssh into the review app
2. Get an ecf participant id - `ParticipantProfile.ecf.first.user.id`
3. exit
4. ssh again
5. `User.find("<your id from step 2>").teacher_profile.ecf_profile` - should not be nil. 
