### PR TITLE
admins can filter participants by type

### DIFF
--- a/app/components/search_box.html.erb
+++ b/app/components/search_box.html.erb
@@ -9,6 +9,18 @@
           )
       %>
     </div>
+
+    <% filters.each do |filter| %>
+      <div class="search-box__input">
+        <%= f.govuk_collection_select filter[:field],
+          filter[:options],
+          :id,
+          :name,
+          label: { text: "Filter by #{filter[:field]}" },
+          options: { selected: filter[:value] } %>
+      </div>
+    <% end %>
+
     <%= f.govuk_submit "Search", classes: "search-box__button", "data-test": "search-button" %>
   <% end %>
 </div>

--- a/app/components/search_box.rb
+++ b/app/components/search_box.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class SearchBox < BaseComponent
-  def initialize(query:, title: "Search", hint: nil, param_name: :query)
+  def initialize(query:, title: "Search", hint: nil, param_name: :query, filters: [])
     @query = query
     @title = title
     @hint = hint
     @param_name = param_name
+    @filters = filters
   end
 
 private
 
-  attr_reader :query, :title, :hint, :param_name
+  attr_reader :query, :title, :hint, :param_name, :filters
 end

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -17,6 +17,10 @@ module Admin
                                                               .includes(:validation_decisions)
                                                               .where("lower(users.full_name) LIKE ? OR school_cohort_id IN (?)", query, school_cohort_ids)
                                                               .order("DATE(users.created_at) asc, users.full_name")
+
+      if params[:type].present?
+        @participant_profiles = @participant_profiles.where(type: params[:type])
+      end
     end
 
     def remove; end

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -1,4 +1,20 @@
 <h1 class="govuk-header-xl">Participants</h1>
 
-<%= render SearchBox.new(query: params[:query], title: "Search participants", hint: "Enter the participant’s name, school’s name or URN") %>
+<%= render SearchBox.new(
+  query: params[:query],
+  title: "Search participants",
+  hint: "Enter the participant’s name, school’s name or URN",
+  filters: [
+    {
+      field: :type,
+      value: params[:type],
+      options: [
+        OpenStruct.new(id: "", name: ""),
+        OpenStruct.new(id: "ParticipantProfile::ECT", name: "ECT"),
+        OpenStruct.new(id: "ParticipantProfile::Mentor", name: "Mentor"),
+        OpenStruct.new(id: "ParticipantProfile::NPQ", name: "NPQ"),
+      ],
+    },
+  ],
+) %>
 <%= render Admin::Participants::Table.new(profiles: @participant_profiles, page: params.fetch(:page, 1)) %>

--- a/app/webpacker/styles/search_box.scss
+++ b/app/webpacker/styles/search_box.scss
@@ -6,6 +6,14 @@
     margin-bottom: 0;
   }
 
+  &__input {
+    .govuk-form-group {
+      select {
+        width: 100%;
+      }
+    }
+  }
+
   @include govuk-media-query($from: tablet) {
     &__form {
       display: flex;
@@ -18,12 +26,16 @@
       .govuk-form-group {
         margin-bottom: 0;
       }
+
+      &:nth-of-type(n+2) {
+        margin-left: govuk-spacing(3);
+      }
     }
 
     &__button {
       flex-grow: 0;
       margin-left: govuk-spacing(3);
-     transform: translateY(-2px);
+      transform: translateY(-2px);
     }
   }
 }

--- a/spec/components/search_component_spec.rb
+++ b/spec/components/search_component_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SearchBox, type: :component do
+  context "with filters" do
+    subject do
+      described_class.new(
+        query: "",
+        filters: [
+          {
+            field: :type,
+            value: "ParticipantProfile::NPQ",
+            options: [
+              OpenStruct.new(id: "", name: ""),
+              OpenStruct.new(id: "ParticipantProfile::ECT", name: "ECT"),
+              OpenStruct.new(id: "ParticipantProfile::Mentor", name: "Mentor"),
+              OpenStruct.new(id: "ParticipantProfile::NPQ", name: "NPQ"),
+            ],
+          },
+        ],
+      )
+    end
+
+    it "displays filter" do
+      with_request_url "/admin/participants" do
+        dom = render_inline(subject)
+
+        expect(dom).to have_css("select[name=type]")
+        expect(dom.css("select option").count).to eql(4)
+      end
+    end
+
+    it "pre-selects option of passed value" do
+      with_request_url "/admin/participants" do
+        dom = render_inline(subject)
+
+        expect(dom.css("select option[selected]").text).to eql("NPQ")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,6 +102,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
   config.include Rails.application.routes.url_helpers
 
   config.before(:suite) do

--- a/spec/requests/admin/participants_spec.rb
+++ b/spec/requests/admin/participants_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe "Admin::Participants", type: :request do
       expect(assigns(:participant_profiles)).to include npq_profile
       expect(assigns(:participant_profiles)).not_to include withdrawn_ect_profile_record
     end
+
+    it "can filter by type" do
+      get "/admin/participants?type=ParticipantProfile::NPQ"
+      expect(assigns(:participant_profiles)).not_to include ect_profile
+      expect(assigns(:participant_profiles)).not_to include mentor_profile
+      expect(assigns(:participant_profiles)).to include npq_profile
+      expect(assigns(:participant_profiles)).not_to include withdrawn_ect_profile_record
+    end
   end
 
   describe "GET /admin/participants/:id" do


### PR DESCRIPTION
## Ticket and context

Ticket: A tiny part of https://trello.com/c/3FttpebV/406-handle-duplicate-signups

## Tech review

### Is there anything that the code reviewer should know?

### Screenshots

Desktop
![Screenshot 2021-09-09 at 12 14 00](https://user-images.githubusercontent.com/92580/132676074-1c75f8d1-7e7e-49c3-82c6-afddaf6571df.png)

Mobile
![Screenshot 2021-09-09 at 12 14 46](https://user-images.githubusercontent.com/92580/132676152-165ddc0a-a5da-4adc-9b99-f82cd347b124.png)

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- login as an admin
- filter participants by different types
- should only return participants of selected type

## External API changes

- none