### PR TITLE
Return participants ordered by created_at asc

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -72,7 +72,7 @@ module Api
 
         participants = participants.changed_since(updated_since) if updated_since.present?
 
-        participants
+        participants.order(:created_at)
       end
 
       def participant_id

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(second_page_ids).not_to include first_page_id
         end
 
+        it "returns users in a consistent order" do
+          users = User.all
+          users.first.update!(created_at: 1.day.ago)
+          users.last.update!(created_at: 2.days.ago)
+
+          get "/api/v1/participants"
+          expect(parsed_response["data"][0]["id"]).to eq User.last.id
+          expect(parsed_response["data"][1]["id"]).to eq User.first.id
+        end
+
         context "when updated_since parameter is supplied" do
           before do
             User.first.update!(updated_at: 2.days.ago)


### PR DESCRIPTION
## Context

A provider noted that we are re-ordering results while they’re trying to paginate through results. We _are_ ordering results when providers use the `updated_since` filter but we don't when they aren't.

This is the first stab at allowing providers to pull results with consistent ordering from the API. Later, I think we will need to add an `updated_before` filter so that they can scope result sets properly.

---

This PR returns participants so that the oldest users are on page 1.