### PR TITLE
Add training status states to all places creating new profiles

### DIFF
--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -17,7 +17,7 @@ module EarlyCareerTeachers
         end
 
         ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(ect_attributes)) do |profile|
-          ParticipantProfileState.create!({ participant_profile: profile })
+          ParticipantProfileState.find_or_create_by!(participant_profile: profile)
         end
       end
     end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -17,7 +17,7 @@ module EarlyCareerTeachers
         end
 
         ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(ect_attributes)) do |profile|
-          ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+          ParticipantProfileState.create!(participant_profile: profile)
         end
       end
     end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -20,7 +20,7 @@ module Mentors
         end
 
         ParticipantProfile::Mentor.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(mentor_attributes)) do |mentor_profile|
-          ParticipantProfileState.create!({ participant_profile: mentor_profile })
+          ParticipantProfileState.create!(participant_profile: mentor_profile)
         end
       end
     end

--- a/app/services/npq/create_or_update_profile.rb
+++ b/app/services/npq/create_or_update_profile.rb
@@ -23,7 +23,7 @@ module NPQ
       participant_profile.school_ukprn = npq_validation_data.school_ukprn
       participant_profile.save!
 
-      ParticipantProfileState.find_or_create_by!({ participant_profile: participant_profile })
+      ParticipantProfileState.find_or_create_by!(participant_profile: participant_profile)
     end
 
   private

--- a/app/services/npq/create_or_update_profile.rb
+++ b/app/services/npq/create_or_update_profile.rb
@@ -22,6 +22,8 @@ module NPQ
       participant_profile.school_urn = npq_validation_data.school_urn
       participant_profile.school_ukprn = npq_validation_data.school_ukprn
       participant_profile.save!
+
+      ParticipantProfileState.find_or_create_by!({ participant_profile: participant_profile })
     end
 
   private

--- a/db/seeds/dummy_structures.rb
+++ b/db/seeds/dummy_structures.rb
@@ -66,6 +66,7 @@ User.find_or_create_by!(email: "npq-registrant@example.com") do |user|
 
   ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 
@@ -75,6 +76,7 @@ mentor = User.find_or_create_by!(email: "rp-mentor-ambition@example.com") do |us
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"), schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 
@@ -84,6 +86,7 @@ mentor_two = User.find_or_create_by!(email: "rp-mentor-edt@example.com") do |use
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 
@@ -93,6 +96,7 @@ mentor_three = User.find_or_create_by!(email: "rp-mentor-ucl@example.com") do |u
 
   ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 
@@ -102,6 +106,7 @@ User.find_or_create_by!(email: "rp-ect-ambition@example.com") do |user|
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Ambition Institute"), mentor_profile: mentor.mentor_profile, schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 
@@ -111,6 +116,7 @@ User.find_or_create_by!(email: "rp-ect-edt@example.com") do |user|
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_two_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "Education Development Trust"), mentor_profile: mentor_two.mentor_profile, schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 
@@ -120,6 +126,7 @@ User.find_or_create_by!(email: "rp-ect-ucl@example.com") do |user|
 
   ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |profile|
     profile.update!(school_cohort: school_three_cohort, core_induction_programme: CoreInductionProgramme.find_by(name: "UCL Institute of Education"), mentor_profile: mentor_three.mentor_profile, schedule: Finance::Schedule.default)
+    ParticipantProfileState.find_or_create_by!(participant_profile: profile)
   end
 end
 

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -273,7 +273,8 @@ ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) 
   mentor_profile.schedule = Finance::Schedule.default
   ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
-ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+npq_profile = ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+ParticipantProfileState.find_or_create_by!({ participant_profile: npq_profile })
 
 # FIP mentor already doing an NPQ with a different email
 user = User.find_or_create_by!(email: "fip-mentor-npq-other-email@example.com") do |u|
@@ -282,7 +283,8 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
   profile.trn = "2369848"
 end
-ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+npq_profile = ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+ParticipantProfileState.find_or_create_by!({ participant_profile: npq_profile })
 
 user = User.find_or_create_by!(email: "fip-mentor2@example.com") do |u|
   u.full_name = "FIP Mentor"
@@ -412,7 +414,8 @@ ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) 
   mentor_profile.schedule = Finance::Schedule.default
   ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
-ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+npq_profile = ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+ParticipantProfileState.find_or_create_by!({ participant_profile: npq_profile })
 
 # CIP mentor already doing an NPQ with a different email
 user = User.find_or_create_by!(email: "cip-mentor-npq-other-email@example.com") do |u|
@@ -421,7 +424,8 @@ end
 teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
   profile.trn = "2631405"
 end
-ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+npq_profile = ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
+ParticipantProfileState.find_or_create_by!({ participant_profile: npq_profile })
 
 user = User.find_or_create_by!(email: "cip-mentor2@example.com") do |u|
   u.full_name = "CIP Mentor"

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -247,7 +247,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000103").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: ect_profile)
 end
 
 # FIP mentor
@@ -258,7 +258,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000104").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # FIP mentor already doing an NPQ with the same email
@@ -271,7 +271,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 npq_profile = ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
 ParticipantProfileState.find_or_create_by!({ participant_profile: npq_profile })
@@ -293,7 +293,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # FIP mentor already mentoring at another school with another email
@@ -306,7 +306,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 user = User.find_or_create_by!(email: "fip-mentor3@example.com") do |u|
@@ -316,7 +316,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000106").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # SIT also a mentor
@@ -325,7 +325,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = user.induction_coordinator_profile.schools.first.school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # Extra participant records
@@ -336,7 +336,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000107").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: ect_profile)
 end
 
 user = User.find_or_create_by!(email: "fip-mentor4@example.com") do |u|
@@ -346,7 +346,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000108").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 user = User.find_or_create_by!(email: "fip-mentor5@example.com") do |u|
@@ -356,7 +356,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000109").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 # TODO: add validation data and eligibility records when merged
 
@@ -388,7 +388,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000200").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: ect_profile)
 end
 
 # FIP mentor
@@ -399,7 +399,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000201").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # CIP mentor already doing an NPQ with the same email
@@ -412,7 +412,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000202").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 npq_profile = ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
 ParticipantProfileState.find_or_create_by!({ participant_profile: npq_profile })
@@ -434,7 +434,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000203").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # FIP mentor already mentoring at another school with another email
@@ -447,7 +447,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000204").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 user = User.find_or_create_by!(email: "cip-mentor3@example.com") do |u|
@@ -457,7 +457,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000205").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # SIT also a mentor
@@ -466,7 +466,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = user.induction_coordinator_profile.schools.first.school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 # Extra participant records
@@ -477,7 +477,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000207").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: ect_profile)
 end
 
 user = User.find_or_create_by!(email: "cip-mentor4@example.com") do |u|
@@ -487,7 +487,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000208").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 user = User.find_or_create_by!(email: "cip-mentor5@example.com") do |u|
@@ -497,7 +497,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000209").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
-  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+  ParticipantProfileState.find_or_create_by!(participant_profile: mentor_profile)
 end
 
 ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Ambition Institute", "Education Development Trust"].each do |provider|

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -247,6 +247,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000103").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # FIP mentor
@@ -257,6 +258,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000104").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # FIP mentor already doing an NPQ with the same email
@@ -269,6 +271,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
 
@@ -288,6 +291,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # FIP mentor already mentoring at another school with another email
@@ -300,6 +304,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000105").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 user = User.find_or_create_by!(email: "fip-mentor3@example.com") do |u|
@@ -309,6 +314,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000106").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # SIT also a mentor
@@ -317,6 +323,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = user.induction_coordinator_profile.schools.first.school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # Extra participant records
@@ -327,6 +334,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000107").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 user = User.find_or_create_by!(email: "fip-mentor4@example.com") do |u|
@@ -336,6 +344,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000108").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 user = User.find_or_create_by!(email: "fip-mentor5@example.com") do |u|
@@ -345,6 +354,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000109").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 # TODO: add validation data and eligibility records when merged
 
@@ -376,6 +386,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000200").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # FIP mentor
@@ -386,6 +397,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000201").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # CIP mentor already doing an NPQ with the same email
@@ -398,6 +410,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000202").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 ParticipantProfile::NPQ.find_or_create_by!(teacher_profile: teacher_profile, schedule: Finance::Schedule.default)
 
@@ -417,6 +430,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000203").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # FIP mentor already mentoring at another school with another email
@@ -429,6 +443,7 @@ end
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000204").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 user = User.find_or_create_by!(email: "cip-mentor3@example.com") do |u|
@@ -438,6 +453,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000205").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # SIT also a mentor
@@ -446,6 +462,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = user.induction_coordinator_profile.schools.first.school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 # Extra participant records
@@ -456,6 +473,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000207").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 user = User.find_or_create_by!(email: "cip-mentor4@example.com") do |u|
@@ -465,6 +483,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000208").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 user = User.find_or_create_by!(email: "cip-mentor5@example.com") do |u|
@@ -474,6 +493,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::Mentor.find_or_create_by!(teacher_profile: teacher_profile) do |mentor_profile|
   mentor_profile.school_cohort = School.find_by(urn: "000209").school_cohorts.find_by(cohort: Cohort.current)
   mentor_profile.schedule = Finance::Schedule.default
+  ParticipantProfileState.find_or_create_by!(participant_profile: profile)
 end
 
 ["Capita", "Teach First", "UCL Institute of Education", "Best Practice Network", "Ambition Institute", "Education Development Trust"].each do |provider|

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -60,11 +60,11 @@ module ValidTestDataGenerator
       schedule = Finance::Schedule.default
       if profile_type == :ect
         ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift, schedule: schedule) do |profile|
-          ParticipantProfileState.create!({ participant_profile: profile })
+          ParticipantProfileState.find_or_create_by!(participant_profile: profile)
         end
       else
         ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift, schedule: schedule) do |profile|
-          ParticipantProfileState.create!({ participant_profile: profile })
+          ParticipantProfileState.find_or_create_by!(participant_profile: profile)
         end
       end
     end

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -60,11 +60,11 @@ module ValidTestDataGenerator
       schedule = Finance::Schedule.default
       if profile_type == :ect
         ParticipantProfile::ECT.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, mentor_profile: mentor_profile, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift, schedule: schedule) do |profile|
-          ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+          ParticipantProfileState.create!(participant_profile: profile)
         end
       else
         ParticipantProfile::Mentor.create!(teacher_profile: teacher_profile, school_cohort: school_cohort, status: status, sparsity_uplift: sparsity_uplift, pupil_premium_uplift: pupil_premium_uplift, schedule: schedule) do |profile|
-          ParticipantProfileState.find_or_create_by!(participant_profile: profile)
+          ParticipantProfileState.create!(participant_profile: profile)
         end
       end
     end


### PR DESCRIPTION
## Ticket and context

https://github.com/DFE-Digital/early-careers-framework/pull/990 adds resuming participants. We should not resume a participant when they are already active.

But we haven't made a training status for each participant profile yet - some are active by the fact of not having a training status.

Soo, we should just add a training status to all existing profiles. When this is merged and deployed I will run something like 
```
ParticipantProfile.each { |profile| ParticipantProfileState.find_or_create_by!({ participant_profile: profile }) }
```

## Tech review

### Is there anything that the code reviewer should know?
Nothing I can think of.

### Code quality checks
- [x] All commit messages are meaningful and true
