### PR TITLE
Setting up action mailer default url host based on domain

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,6 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :notify
   config.action_mailer.perform_deliveries = true
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: config.domain }
   config.action_mailer.logger = Logger.new("log/mail.log", formatter: proc { |_, _, _, msg|
     if msg =~ /quoted-printable/
       message = Mail::Message.new(msg)

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActionMailer::Base.default_url_options[:host] ||= Rails.application.config.domain


### PR DESCRIPTION
Currently, `action_mailer.default_url_options.host` is blank in almost all environments. This leads to us adding `host: Rails.application.config.domain` to all url_helpers that are used for email purposes. If this is missed, the emails will work in development, but not in production, which is problematic.

Now, ideally this would be set in the application.rb to be shared by all environment. However, `config.domain` is set in each environment file which loads after the `application.rb` so this would not work - that's why we need to work within the initializer. Additionally, the initializer files run after railtie initializers, including ActionMailer::Railtie which is copying populating `ActionMailer::Base` configuration with `Rails.application.config.action_mailer`, whcih is why it is setting the host directly on `ActionMailer::Base` - changes to the config in intiializer won't take effect.