### PR TITLE
CDPTP-473 Add basic ECF contract display for validation of contract information

### DIFF
--- a/app/components/finance/ecf/breakdown_summary.html.erb
+++ b/app/components/finance/ecf/breakdown_summary.html.erb
@@ -19,10 +19,10 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      <%=t("finance.target") %>
+      <%=t("finance.contract.recuitment_target") %>
     </dt>
     <dd class="govuk-summary-list__value">
-      <%=target %>
+      <%=recruitment_target %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/app/components/finance/ecf/breakdown_summary.rb
+++ b/app/components/finance/ecf/breakdown_summary.rb
@@ -3,7 +3,7 @@
 module Finance
   module ECF
     class BreakdownSummary < BaseComponent
-      attr_accessor :name, :declaration, :target, :ects, :mentors, :participants
+      attr_accessor :name, :declaration, :recruitment_target, :ects, :mentors, :participants
 
     private
 

--- a/app/components/finance/ecf/contract.html.erb
+++ b/app/components/finance/ecf/contract.html.erb
@@ -1,0 +1,59 @@
+<dl class="govuk-summary-list govuk-summary-list--no-border">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%=t("finance.provider") %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%=name %>
+    </dd>
+  </div>
+</dl>
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%=t("finance.contract.recuitment_target") %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%=recruitment_target %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%=t("finance.contract.uplift_target") %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= float_to_percentage uplift_target %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%=t("finance.contract.uplift_amount") %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= number_to_pounds uplift_amount %>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%=t("finance.contract.set_up_fee") %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= number_to_pounds set_up_fee %>
+    </dd>
+  </div>
+</dl>
+
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th class="govuk-table__header"><%=t "finance.contract.band" %></th>
+    <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.contract.bands.min" %></th>
+    <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.contract.bands.max" %></th>
+    <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.per_participant"%></th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <%= render Finance::ECF::ContractBandRow.with_collection(bands) %>
+  </tbody>
+</table>

--- a/app/components/finance/ecf/contract.rb
+++ b/app/components/finance/ecf/contract.rb
@@ -15,7 +15,7 @@ module Finance
         contract.bands.each_with_index.map do |band, index|
           {
             index: index,
-            band: band
+            band: band,
           }
         end
       end

--- a/app/components/finance/ecf/contract.rb
+++ b/app/components/finance/ecf/contract.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    class Contract < BaseComponent
+      include FinanceHelper
+      attr_accessor :contract
+      delegate :uplift_target, :uplift_amount, :recruitment_target, :set_up_fee, to: :contract
+
+      def name
+        contract.lead_provider.name
+      end
+
+      def bands
+        contract.bands.each_with_index.map do |band, index|
+          {
+            index: index,
+            band: band
+          }
+        end
+      end
+
+    private
+
+      def initialize(contract:)
+        @contract = contract
+      end
+    end
+  end
+end

--- a/app/components/finance/ecf/contract_band_row.html.erb
+++ b/app/components/finance/ecf/contract_band_row.html.erb
@@ -1,0 +1,6 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell"><%= band_to_identifier index %></td>
+  <td class="govuk-table__cell govuk-table__cell--numeric"><%= min || t("finance.contract.bands.floor") %></td>
+  <td class="govuk-table__cell govuk-table__cell--numeric"><%= max || t("finance.contract.bands.ceiling") %></td>
+  <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds per_participant %></td>
+</tr>

--- a/app/components/finance/ecf/contract_band_row.rb
+++ b/app/components/finance/ecf/contract_band_row.rb
@@ -5,7 +5,7 @@ module Finance
     class ContractBandRow < BaseComponent
       include FinanceHelper
 
-      private
+    private
 
       attr_reader :band, :index
       delegate :min, :max, :per_participant, to: :band

--- a/app/components/finance/ecf/contract_band_row.rb
+++ b/app/components/finance/ecf/contract_band_row.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    class ContractBandRow < BaseComponent
+      include FinanceHelper
+
+      private
+
+      attr_reader :band, :index
+      delegate :min, :max, :per_participant, to: :band
+
+      def initialize(contract_band_row:)
+        @band = contract_band_row[:band]
+        @index = contract_band_row[:index]
+      end
+    end
+  end
+end

--- a/app/components/finance/ecf/output_payments.html.erb
+++ b/app/components/finance/ecf/output_payments.html.erb
@@ -2,7 +2,7 @@
   <caption class="govuk-table__caption govuk-table__caption--l"><%=t "finance.output_payment.caption" %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header"><%=t "finance.band"%></th>
+      <th class="govuk-table__header"><%=t "finance.contract.band"%></th>
       <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.output_payment.participants"%></th>
       <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.per_participant"%></th>
       <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.period"%></th>

--- a/app/components/finance/ecf/service_fees.html.erb
+++ b/app/components/finance/ecf/service_fees.html.erb
@@ -2,7 +2,7 @@
   <caption class="govuk-table__caption govuk-table__caption--l"><%=t "finance.service_fee.caption" %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header"><%=t "finance.band"%></th>
+      <th class="govuk-table__header"><%=t "finance.contract.band"%></th>
       <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.service_fee.participants"%></th>
       <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.per_participant"%></th>
       <th class="govuk-table__header govuk-table__cell--numeric"><%=t "finance.monthly"%></th>

--- a/app/controllers/finance/lead_providers_controller.rb
+++ b/app/controllers/finance/lead_providers_controller.rb
@@ -6,15 +6,17 @@ class Finance::LeadProvidersController < Finance::BaseController
   end
 
   def show
-    ecf_lead_provider = lead_provider_scope.find(params[:id])
-
-    calculations = CalculationOrchestrator.call(
-      cpd_lead_provider: ecf_lead_provider.cpd_lead_provider,
-      contract: ecf_lead_provider.call_off_contract,
+    @ecf_lead_provider = lead_provider_scope.find(params[:id])
+    @breakdown = CalculationOrchestrator.call(
+      cpd_lead_provider: @ecf_lead_provider.cpd_lead_provider,
+      contract: @ecf_lead_provider.call_off_contract,
       event_type: :started,
     )
+  end
 
-    @breakdown = calculations
+  def show_contract
+    ecf_lead_provider = lead_provider_scope.find(params[:id])
+    @contract = ecf_lead_provider.call_off_contract
   end
 
 private

--- a/app/controllers/finance/lead_providers_controller.rb
+++ b/app/controllers/finance/lead_providers_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+#TODO: The views will change when the actual payment prototypes are created. Remember that we may need feature tests
+# to be added in and the current one will need the show_contract to be added when we refactor them from cypress to
+# rspec/capybara
+
 class Finance::LeadProvidersController < Finance::BaseController
   def index
     @ecf_lead_providers = LeadProvider.all

--- a/app/controllers/finance/lead_providers_controller.rb
+++ b/app/controllers/finance/lead_providers_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#TODO: The views will change when the actual payment prototypes are created. Remember that we may need feature tests
+# TODO: The views will change when the actual payment prototypes are created. Remember that we may need feature tests
 # to be added in and the current one will need the show_contract to be added when we refactor them from cypress to
 # rspec/capybara
 

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -4,4 +4,12 @@ module FinanceHelper
   def number_to_pounds(number)
     number_to_currency number, precision: 2, unit: "£"
   end
+
+  def float_to_percentage(number)
+    number_to_percentage(number * 100, precision: 0)
+  end
+
+  def band_to_identifier(index)
+    ("A".ord + index).chr
+  end
 end

--- a/app/views/finance/lead_providers/show.html.erb
+++ b/app/views/finance/lead_providers/show.html.erb
@@ -1,7 +1,9 @@
-<% content_for :title, t("finance.ecf.caption") %>
+<% content_for :title, t("finance.ecf.payment_breakdown") %>
 
 <h1 class="govuk-caption-xl"><%= @breakdown[:breakdown_summary][:name] %></h1>
-<h2 class="govuk-heading-l"><%=t "finance.ecf.caption" %></h2>
+<h2 class="govuk-heading-l"><%=t "finance.ecf.payment_breakdown" %></h2>
+
+<%= govuk_link_to t("finance.show_contract"), contract_finance_lead_provider_path(@ecf_lead_provider), button: true %>
 
 <%= render Finance::ECF::BreakdownSummary.new(breakdown_summary: @breakdown[:breakdown_summary]) %>
 <%= render Finance::ECF::ServiceFees.new(service_fees: @breakdown[:service_fees]) %>

--- a/app/views/finance/lead_providers/show.html.erb
+++ b/app/views/finance/lead_providers/show.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-caption-xl"><%= @breakdown[:breakdown_summary][:name] %></h1>
 <h2 class="govuk-heading-l"><%=t "finance.ecf.payment_breakdown" %></h2>
 
-<%= govuk_link_to t("finance.show_contract"), contract_finance_lead_provider_path(@ecf_lead_provider), button: true %>
+<%= govuk_button_link_to t("finance.show_contract"), contract_finance_lead_provider_path(@ecf_lead_provider) %>
 
 <%= render Finance::ECF::BreakdownSummary.new(breakdown_summary: @breakdown[:breakdown_summary]) %>
 <%= render Finance::ECF::ServiceFees.new(service_fees: @breakdown[:service_fees]) %>

--- a/app/views/finance/lead_providers/show_contract.html.erb
+++ b/app/views/finance/lead_providers/show_contract.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, t("finance.ecf.contract_information") %>
+
+<h1 class="govuk-caption-xl"><%= @contract.lead_provider.name %></h1>
+<h2 class="govuk-heading-l"><%=t "finance.ecf.contract_information" %></h2>
+
+<%= render Finance::ECF::Contract.new(contract: @contract) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,7 @@ en:
 
   finance:
     choose_programme: Choose programme scheme
+    show_contract: View contract information
     provider: Provider
     milestone: Milestone
     target: Recruitment target
@@ -123,7 +124,8 @@ en:
         floor: 0
         ceiling: Unlimited
     ecf:
-      caption: ECF Payment Breakdown
+      payment_breakdown: ECF Payment Breakdown
+      contract_information: ECF Contract Information
     service_fee:
       caption: Service Fee
       participants: Target Participants

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,17 +100,28 @@ en:
       blank: The lead provider must be present
 
   finance:
+    choose_programme: Choose programme scheme
     provider: Provider
     milestone: Milestone
     target: Recruitment target
     ects: Current ECTs
     mentors: Current Mentors
-    band: Band
     participants: Current Participants
     per_participant: Payment amount per person
     monthly: Payment amount monthly
     subtotal: Sub total
     period: Payment amount for period
+    contract:
+      uplift_target: Uplift target
+      uplift_amount: Uplift amount
+      recuitment_target: Recruitment target
+      set_up_fee: Set-up Fee
+      band: Band
+      bands:
+        min: Min
+        max: Max
+        floor: 0
+        ceiling: Unlimited
     ecf:
       caption: ECF Payment Breakdown
     service_fee:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,7 +248,11 @@ Rails.application.routes.draw do
   end
 
   namespace :finance do
-    resources :lead_providers, only: %i[index show], path: "lead-providers"
+    resources :lead_providers, only: %i[index show], path: "lead-providers" do
+      member do
+        get :contract, to: "lead_providers#show_contract"
+      end
+    end
   end
 
   namespace :participants do

--- a/lib/payment_calculator/ecf/breakdown_summary.rb
+++ b/lib/payment_calculator/ecf/breakdown_summary.rb
@@ -13,7 +13,7 @@ module PaymentCalculator
         {
           name: lead_provider.name,
           declaration: event_type,
-          target: recruitment_target,
+          recruitment_target: recruitment_target,
           ects: aggregations[:ects],
           mentors: aggregations[:mentors],
           participants: aggregations[:all],

--- a/spec/requests/finance/lead_providers_controller_spec.rb
+++ b/spec/requests/finance/lead_providers_controller_spec.rb
@@ -35,4 +35,17 @@ RSpec.describe "Lead Providers for Finance users", type: :request do
       expect(response).to render_template("finance/lead_providers/show")
     end
   end
+
+  describe "GET /finance/lead-providers/{:id}/contract" do
+    it "renders the ECF contract" do
+      # Arrange
+      create(:call_off_contract, lead_provider: ecf_lead_provider)
+
+      # Act
+      get "/finance/lead-providers/#{ecf_lead_provider.id}/contract"
+
+      # Assert
+      expect(response).to render_template("finance/lead_providers/show_contract")
+    end
+  end
 end

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CalculationOrchestrator do
       mentors: 5,
       name: "Lead Provider",
       participants: 10,
-      target: 2000,
+      recruitment_target: 2000,
     }
   end
   let(:ect_focussed_headings) do


### PR DESCRIPTION
## Ticket and context

This adds a view of contract information which allows the underlying providers contract details which forms the basis of the calculations.
There will be a wider "contract summary" and proper design, but for now, this gives a general shape that can be viewed.

Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDTP/boards/87?selectedIssue=CPDTP-473

## Tech review

This PR is mainly for the view components and controller actions, since it's more likely that we'll have a landing page and a more details Contract Summary once it's gone through the content design phase.

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
