### PR TITLE
CPDRP-672 Part-1 Add ECFIneligibleParticipant and CSV importer

### DIFF
--- a/app/models/ecf_ineligible_participant.rb
+++ b/app/models/ecf_ineligible_participant.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class ECFIneligibleParticipant < ApplicationRecord
-
   enum reason: {
     previous_participant: "previous_participant",
     previous_induction: "previous_induction",
   }
-
 end

--- a/app/models/ecf_ineligible_participant.rb
+++ b/app/models/ecf_ineligible_participant.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ECFIneligibleParticipant < ApplicationRecord
+
+  enum reason: {
+    previous_participant: "previous_participant",
+    previous_induction: "previous_induction",
+  }
+
+end

--- a/app/services/importers/ineligible_participants.rb
+++ b/app/services/importers/ineligible_participants.rb
@@ -20,7 +20,7 @@ class Importers::IneligibleParticipants < BaseService
         if row["dob"].present? || row["urn"].present?
           add_ineligible_record!(full_name: row["name"], date_of_birth: row["dob"], urn: row["urn"])
         else
-          @logger.info "Not enough info to add #{row["name"]}"
+          @logger.info "Not enough info to add #{row['name']}"
           invalid_count += 1
         end
       else

--- a/app/services/importers/ineligible_participants.rb
+++ b/app/services/importers/ineligible_participants.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Importers::IneligibleParticipants < BaseService
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:, reason:, logger: Rails.logger)
+    @path_to_csv = path_to_csv
+    @reason = reason
+    @logger = logger
+  end
+
+  def call
+    row_count = 0
+    invalid_count = 0
+
+    CSV.foreach(@path_to_csv, headers: true) do |row|
+      if row["trn"].present?
+        add_ineligible_record!(trn: row["trn"])
+      elsif row["name"].present?
+        if row["dob"].present? || row["urn"].present?
+          add_ineligible_record!(full_name: row["name"], date_of_birth: row["dob"], urn: row["urn"])
+        else
+          @logger.info "Not enough info to add #{row["name"]}"
+          invalid_count += 1
+        end
+      else
+        @logger.info "Not adding #{row}"
+        invalid_count += 1
+      end
+      row_count += 1
+    end
+
+    @logger.info "Processed #{row_count} - (#{invalid_count} incomplete rows)"
+  end
+
+private
+
+  def add_ineligible_record!(attrs)
+    ECFIneligibleParticipant.find_or_create_by!(attrs) do |record|
+      record.reason = @reason
+    end
+  end
+end

--- a/db/migrate/20210910101052_create_ecf_ineligible_participants.rb
+++ b/db/migrate/20210910101052_create_ecf_ineligible_participants.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateECFIneligibleParticipants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ecf_ineligible_participants, id: :uuid do |t|
+      t.string :trn, index: true
+      t.string :full_name
+      t.date :date_of_birth
+      t.string :urn
+      t.string :reason, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_09_154906) do
+ActiveRecord::Schema.define(version: 2021_09_10_101052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -203,6 +203,17 @@ ActiveRecord::Schema.define(version: 2021_09_09_154906) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["local_authority_district_id"], name: "index_district_sparsities_on_local_authority_district_id"
+  end
+
+  create_table "ecf_ineligible_participants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "trn"
+    t.string "full_name"
+    t.date "date_of_birth"
+    t.string "urn"
+    t.string "reason", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["trn"], name: "index_ecf_ineligible_participants_on_trn"
   end
 
   create_table "ecf_participant_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/ineligible_participants.rake
+++ b/lib/tasks/ineligible_participants.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :ineligible_participants do
+  desc "Import ineligible participants from CSV"
+  task :import, %i[csv_path reason] => :environment do |_t, args|
+    logger = Logger.new($stdout)
+    logger.info "Importing ineligible participants, this may take a couple minutes..."
+    Importers::IneligibleParticipants.call(path_to_csv: args.csv_path, reason: args.reason, logger: logger)
+    logger.info "Ineligible participant data import complete!"
+  end
+end

--- a/spec/fixtures/files/ineligible_participants.csv
+++ b/spec/fixtures/files/ineligible_participants.csv
@@ -1,0 +1,7 @@
+trn,name,dob,urn
+1234567,,,
+9876543,Edna Wallis,1992-8-22,144011
+,Sally Smith,,145091
+,Walter Ponds,,
+,,1990-10-14,141333
+,,,132132

--- a/spec/services/importers/ineligible_participants_spec.rb
+++ b/spec/services/importers/ineligible_participants_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe Importers::IneligibleParticipants do
+  let(:csv_file) { file_fixture "ineligible_participants.csv" }
+  subject(:service) { described_class }
+
+  describe ".call" do
+    before do
+      service.call(path_to_csv: csv_file, reason: "previous_participant")
+    end
+
+    it "adds inelgible participant records from the file" do
+      expect(ECFIneligibleParticipant.count).to be 3
+    end
+
+    it "sets the reason for the ineligibility" do
+      expect(ECFIneligibleParticipant.previous_participant.count).to be 3
+    end
+
+    it "only populates the TRN field when the TRN is present in the file" do
+      record = ECFIneligibleParticipant.find_by(trn: "9876543")
+      expect(record.full_name).to be_nil
+      expect(record.date_of_birth).to be_nil
+      expect(record.urn).to be_nil
+    end
+
+    it "does not duplicate records given the same information" do
+      expect {
+        service.call(path_to_csv: csv_file, reason: "previous_participant")
+      }.not_to change { ECFIneligibleParticipant.count }
+    end
+
+    context "when trn is not present" do
+      it "populates full_name and either/both of date_of_birth and urn" do
+        record = ECFIneligibleParticipant.find_by(full_name: "Sally Smith")
+        expect(record.trn).to be_nil
+        expect(record.date_of_birth).to be_nil
+        expect(record.urn).to eq "145091"
+      end
+
+      context "when name is not present" do
+        it "does not create a record" do
+          expect(ECFIneligibleParticipant.find_by(urn: "132132")).to be_nil
+          expect(ECFIneligibleParticipant.find_by(urn: "141333")).to be_nil
+        end
+      end
+
+      context "when only name is present" do
+        it "does not create a record" do
+          expect(ECFIneligibleParticipant.find_by(full_name: "Walter Ponds")).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: [Jira](https://dfedigital.atlassian.net/browse/CPDRP-672)

Create means to hold ineligible participants and populate from CSV files. These will be checked against during automatic participant validation.  The CSV data is sensitive so will be a one-off manual task to import.

Part 2 will add the checks to the participant validation

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
