### PR TITLE
CPDTP-483 Change closing tags on two of the lines from link to paragraph

### DIFF
--- a/app/views/lead_providers/guidance/ecf_usage.html.erb
+++ b/app/views/lead_providers/guidance/ecf_usage.html.erb
@@ -135,7 +135,7 @@
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/participant-declarations</code></pre></p>
 
-<p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#singleparticipantdeclarationresponse-object" class="govuk-link">participant declarations</a>.</a>
+<p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#singleparticipantdeclarationresponse-object" class="govuk-link">participant declarations</a>.</p>
 
 <h3 class="govuk-heading-m">2. Checking a single previously submitted declarations</h3>
 
@@ -145,4 +145,4 @@
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/participant-declarations/{id}</code></pre></p>
 
-<p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#singleparticipantdeclarationresponse-object" class="govuk-link">participant declaration</a>.</a>
+<p class="govuk-body-m">This returns <a href="/lead-providers/guidance/reference#singleparticipantdeclarationresponse-object" class="govuk-link">participant declaration</a>.</p>


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-483

Two of the paragraphs in the updated usage guide had badly formed html. This fixes it.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
