### PR TITLE
CPDRP-672 update eligibility checks

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -196,10 +196,8 @@ module Participants
     def store_eligibility_data!(dqt_data)
       participant_profile.create_ecf_participant_eligibility!(qts: dqt_data[:qts],
                                                               active_flags: dqt_data[:active_alert],
-                                                              # TODO: CPDRP-672 use ERO data
-                                                              previous_participation: nil,
-                                                              # TODO: CPDRP-900 use previous induction data
-                                                              previous_induction: nil)
+                                                              previous_participation: dqt_data[:previous_participation],
+                                                              previous_induction: dqt_data[:previous_induction])
     end
 
     def participant_profile

--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -142,30 +142,21 @@ module Participants
     end
 
     def validate_participant_details_and_redirect
-      result = ParticipantValidationService.validate(trn: participant_details[:trn],
-                                                     full_name: participant_details[:name],
-                                                     date_of_birth: participant_details[:date_of_birth],
-                                                     nino: participant_details[:national_insurance_number],
-                                                     config: { check_first_name_only: true })
+      result = ValidateParticipant.call(participant_profile: participant_profile,
+                                        validation_data: participant_details,
+                                        config: { check_first_name_only: true, save_validation_data_without_match: false })
 
-      if result.nil?
-        @participant_validation_form.increment_validation_attempts
-        store_form_and_redirect_to_step :cannot_find_details
-      else
-        eligibility_data = store_eligibility_data!(result)
-        eligibility_data.manual_check_status! unless store_trn!(result[:trn])
-
-        # store validation data for manual re-check later
-        # if different TRN already exists or not eligible
-        store_validation_data! unless eligibility_data.eligible_status?
-
+      if result
         store_analytics(matched: true)
         reset_form_data
         store_form_and_redirect_to_step :complete
+      else
+        store_analytics(matched: false)
+        @participant_validation_form.increment_validation_attempts
+        store_form_and_redirect_to_step :cannot_find_details
       end
     rescue StandardError => e
-      Rails.logger.error("Problem with DQT API: " + e.message)
-      store_validation_data!(api_failure: true)
+      Rails.logger.error("Problem with ValidateParticipant: " + e.message)
       store_analytics(matched: false)
       reset_form_data
       store_form_and_redirect_to_step :complete
@@ -175,29 +166,13 @@ module Participants
       @participant_details ||= @participant_validation_form.attributes.slice(:trn, :name, :date_of_birth, :national_insurance_number)
     end
 
-    def store_validation_data!(opts = {})
+    def store_validation_data!
       participant_profile.create_ecf_participant_validation_data!({
         trn: participant_details[:trn],
         full_name: participant_details[:name],
         date_of_birth: participant_details[:date_of_birth],
         nino: participant_details[:national_insurance_number],
-      }.merge(opts))
-    end
-
-    def store_trn!(trn)
-      if participant_profile.teacher_profile.trn.present? && participant_profile.teacher_profile.trn != trn
-        Rails.logger.warn("Different TRN already set for user [#{current_user.email}]")
-        false
-      else
-        participant_profile.teacher_profile.update!(trn: trn)
-      end
-    end
-
-    def store_eligibility_data!(dqt_data)
-      participant_profile.create_ecf_participant_eligibility!(qts: dqt_data[:qts],
-                                                              active_flags: dqt_data[:active_alert],
-                                                              previous_participation: dqt_data[:previous_participation],
-                                                              previous_induction: dqt_data[:previous_induction])
+      })
     end
 
     def participant_profile

--- a/app/jobs/validation_retry_job.rb
+++ b/app/jobs/validation_retry_job.rb
@@ -6,46 +6,12 @@ class ValidationRetryJob < CronJob
   queue_as :validation_retry
 
   def perform
-    ECFParticipantValidationData.where(api_failure: true).each do |validation_data|
-      validation_result = ParticipantValidationService.validate(trn: validation_data.trn,
-                                                                full_name: validation_data.full_name,
-                                                                date_of_birth: validation_data.date_of_birth,
-                                                                nino: validation_data.nino)
-      ActiveRecord::Base.transaction do
-        validation_data.update!(api_failure: false)
-        if validation_result.present?
-          eligibility_data = store_eligibility_data!(validation_data, validation_result)
-          eligibility_data.manual_check_status! unless store_trn!(validation_result[:trn], validation_data.participant_profile)
-
-          validation_data.destroy! if eligibility_data.eligible_status?
-        end
-      end
+    ECFParticipantValidationData.where(api_failure: true).find_each do |validation_data|
+      ValidateParticipant.call(participant_profile: validation_data.participant_profile)
     rescue StandardError => e
       Rails.logger.error("Problem with DQT API on retry: " + e.message)
       Sentry.capture_message("Problem with DQT API on retry: " + e.message)
       next
-    end
-  end
-
-private
-
-  def store_eligibility_data!(validation_data, validation_result)
-    validation_data.participant_profile.create_ecf_participant_eligibility!(
-      qts: validation_result[:qts],
-      active_flags: validation_result[:active_alert],
-      # TODO: CPDRP-672 use ERO data
-      previous_participation: nil,
-      # TODO: CPDRP-900 use previous induction data
-      previous_induction: nil,
-    )
-  end
-
-  def store_trn!(trn, participant_profile)
-    if participant_profile.teacher_profile.trn.present? && participant_profile.teacher_profile.trn != trn
-      Rails.logger.warn("Different TRN already set for user [#{participant_profile.user.email}]")
-      false
-    else
-      participant_profile.teacher_profile.update!(trn: trn)
     end
   end
 end

--- a/app/jobs/validation_retry_job.rb
+++ b/app/jobs/validation_retry_job.rb
@@ -7,7 +7,8 @@ class ValidationRetryJob < CronJob
 
   def perform
     ECFParticipantValidationData.where(api_failure: true).find_each do |validation_data|
-      ValidateParticipant.call(participant_profile: validation_data.participant_profile)
+      ValidateParticipant.call(participant_profile: validation_data.participant_profile,
+                               config: { check_first_name_only: true })
     rescue StandardError => e
       Rails.logger.error("Problem with DQT API on retry: " + e.message)
       Sentry.capture_message("Problem with DQT API on retry: " + e.message)

--- a/app/models/ecf_ineligible_participant.rb
+++ b/app/models/ecf_ineligible_participant.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class ECFIneligibleParticipant < ApplicationRecord
-
   enum reason: {
     previous_participant: "previous_participant",
     previous_induction: "previous_induction",
   }
-
 end

--- a/app/models/ecf_ineligible_participant.rb
+++ b/app/models/ecf_ineligible_participant.rb
@@ -4,5 +4,6 @@ class ECFIneligibleParticipant < ApplicationRecord
   enum reason: {
     previous_participation: "previous_participation",
     previous_induction: "previous_induction",
+    previous_induction_and_participation: "previous_induction_and_participation",
   }
 end

--- a/app/models/ecf_ineligible_participant.rb
+++ b/app/models/ecf_ineligible_participant.rb
@@ -2,7 +2,7 @@
 
 class ECFIneligibleParticipant < ApplicationRecord
   enum reason: {
-    previous_participant: "previous_participant",
+    previous_participation: "previous_participation",
     previous_induction: "previous_induction",
   }
 end

--- a/app/models/ecf_ineligible_participant.rb
+++ b/app/models/ecf_ineligible_participant.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ECFIneligibleParticipant < ApplicationRecord
+
+  enum reason: {
+    previous_participant: "previous_participant",
+    previous_induction: "previous_induction",
+  }
+
+end

--- a/app/services/check_participant_eligibility.rb
+++ b/app/services/check_participant_eligibility.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CheckParticipantEligibility < BaseService
+  attr_reader :trn
+
+  def initialize(trn:)
+    @trn = trn
+  end
+
+  def call
+    ineligible_record = ECFIneligibleParticipant.find_by(trn: trn)
+    return ineligible_record.reason.to_sym if ineligible_record.present?
+  end
+end

--- a/app/services/importers/ineligible_participants.rb
+++ b/app/services/importers/ineligible_participants.rb
@@ -15,29 +15,16 @@ class Importers::IneligibleParticipants < BaseService
 
     CSV.foreach(@path_to_csv, headers: true) do |row|
       if row["trn"].present?
-        add_ineligible_record!(trn: row["trn"])
-      elsif row["name"].present?
-        if row["dob"].present? || row["urn"].present?
-          add_ineligible_record!(full_name: row["name"], date_of_birth: row["dob"], urn: row["urn"])
-        else
-          @logger.info "Not enough info to add #{row['name']}"
-          invalid_count += 1
+        ECFIneligibleParticipant.find_or_create_by!(trn: row["trn"]) do |record|
+          record.reason = @reason
         end
       else
-        @logger.info "Not adding #{row}"
+        @logger.info "Skipping row <#{row}> ..."
         invalid_count += 1
       end
       row_count += 1
     end
 
-    @logger.info "Processed #{row_count} - (#{invalid_count} incomplete rows)"
-  end
-
-private
-
-  def add_ineligible_record!(attrs)
-    ECFIneligibleParticipant.find_or_create_by!(attrs) do |record|
-      record.reason = @reason
-    end
+    @logger.info "Processed #{row_count} - (#{invalid_count} invalid rows)"
   end
 end

--- a/app/services/importers/ineligible_participants.rb
+++ b/app/services/importers/ineligible_participants.rb
@@ -20,7 +20,7 @@ class Importers::IneligibleParticipants < BaseService
         if row["dob"].present? || row["urn"].present?
           add_ineligible_record!(full_name: row["name"], date_of_birth: row["dob"], urn: row["urn"])
         else
-          @logger.info "Not enough info to add #{row["name"]}"
+          @logger.info "Not enough info to add #{row['name']}"
           invalid_count += 1
         end
       else

--- a/app/services/importers/ineligible_participants.rb
+++ b/app/services/importers/ineligible_participants.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Importers::IneligibleParticipants < BaseService
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:, reason:, logger: Rails.logger)
+    @path_to_csv = path_to_csv
+    @reason = reason
+    @logger = logger
+  end
+
+  def call
+    row_count = 0
+    invalid_count = 0
+
+    CSV.foreach(@path_to_csv, headers: true) do |row|
+      if row["trn"].present?
+        add_ineligible_record!(trn: row["trn"])
+      elsif row["name"].present?
+        if row["dob"].present? || row["urn"].present?
+          add_ineligible_record!(full_name: row["name"], date_of_birth: row["dob"], urn: row["urn"])
+        else
+          @logger.info "Not enough info to add #{row["name"]}"
+          invalid_count += 1
+        end
+      else
+        @logger.info "Not adding #{row}"
+        invalid_count += 1
+      end
+      row_count += 1
+    end
+
+    @logger.info "Processed #{row_count} - (#{invalid_count} incomplete rows)"
+  end
+
+private
+
+  def add_ineligible_record!(attrs)
+    ECFIneligibleParticipant.find_or_create_by!(attrs) do |record|
+      record.reason = @reason
+    end
+  end
+end

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -19,14 +19,25 @@ class ParticipantValidationService
     validated_record = matching_record(trn: trn, nino: nino, full_name: full_name, dob: date_of_birth)
     return if validated_record.nil?
 
-    {
+    validation_data = {
       trn: validated_record[:teacher_reference_number],
       qts: validated_record[:qts_date].present? && validated_record[:qts_date] != "null",
       active_alert: validated_record[:active_alert],
+      previous_participation: false,
+      previous_induction: false,
     }
+
+    set_eligibility_flags(validation_data)
   end
 
 private
+
+  def set_eligibility_flags(validation_data)
+    ineligibility_flag = CheckParticipantEligibility.call(trn: validation_data[:trn])
+
+    validation_data[ineligibility_flag] = true if ineligibility_flag.present?
+    validation_data
+  end
 
   def check_first_name_only?
     config[:check_first_name_only]

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -35,7 +35,14 @@ private
   def set_eligibility_flags(validation_data)
     ineligibility_flag = CheckParticipantEligibility.call(trn: validation_data[:trn])
 
-    validation_data[ineligibility_flag] = true if ineligibility_flag.present?
+    if ineligibility_flag.present?
+      if ineligibility_flag == :previous_induction_and_participation
+        validation_data[:previous_participation] = validation_data[:previous_induction] = true
+      else
+        validation_data[ineligibility_flag] = true
+      end
+    end
+
     validation_data
   end
 

--- a/app/services/validate_participant.rb
+++ b/app/services/validate_participant.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+class ValidateParticipant < BaseService
+  attr_reader :participant_profile, :validation_data, :config
+
+  def initialize(participant_profile:, validation_data: {}, config: {})
+    @participant_profile = participant_profile
+    @validation_data = validation_data.presence || fetch_validation_data
+    @config = config
+  end
+
+  def call
+    validation_result = query_dqt
+    # TODO: what should we do with their eligibility record if this is a
+    # revalidation and we can't match this time?
+    if validation_result.nil?
+      # if we always store the validation data it makes it difficult to reenter
+      # or check answers in the UI flow as the presence of the validation data is
+      # used to indicate the journey is complete.
+      store_validation_data! if config.fetch(:save_validation_data_without_match, true)
+      return false
+    end
+
+    @eligibility_data = store_eligibility_data!(validation_result)
+    store_trn_on_teacher_profile!(validation_result[:trn])
+
+    if @eligibility_data.eligible_status?
+      remove_validation_data!
+    else
+      # store validation data for manual re-check later
+      # if different TRN already exists or not eligible
+      store_validation_data!
+    end
+    true
+  rescue StandardError => e
+    Rails.logger.error("Problem with DQT API: " + e.message)
+    store_validation_data!(api_failure: true)
+    raise
+  end
+
+private
+
+  def fetch_validation_data
+    participant_data = @participant_profile.ecf_participant_validation_data&.attributes
+    participant_data ||= {}
+
+    {
+      trn: participant_data["trn"],
+      name: participant_data["full_name"],
+      date_of_birth: participant_data["date_of_birth"],
+      national_insurance_number: participant_data["nino"],
+    }
+  end
+
+  def store_eligibility_data!(dqt_data)
+    record = ECFParticipantEligibility.find_or_initialize_by(participant_profile: participant_profile)
+    record.qts = dqt_data[:qts]
+    record.active_flags = dqt_data[:active_alert]
+    record.previous_participation = dqt_data[:previous_participation]
+    record.previous_induction = dqt_data[:previous_induction]
+    record.determine_status
+    record.save!
+    record
+  end
+
+  def store_trn_on_teacher_profile!(trn)
+    if participant_profile.teacher_profile.trn.present? && participant_profile.teacher_profile.trn != trn
+      Rails.logger.warn("Different TRN already set for user [#{participant_profile.user.email}]")
+      @eligibility_data.manual_check_status!
+    else
+      participant_profile.teacher_profile.update!(trn: trn)
+    end
+  end
+
+  def store_validation_data!(opts = {})
+    record = ECFParticipantValidationData.find_or_initialize_by(participant_profile: participant_profile)
+    record.trn = validation_data[:trn]
+    record.full_name = validation_data[:name]
+    record.date_of_birth = validation_data[:date_of_birth]
+    record.nino = validation_data[:national_insurance_number]
+    record.assign_attributes(opts)
+    record.save!
+    record
+  end
+
+  def remove_validation_data!
+    participant_profile.ecf_participant_validation_data&.destroy!
+  end
+
+  def query_dqt
+    ParticipantValidationService.validate(trn: validation_data[:trn],
+                                          full_name: validation_data[:name],
+                                          date_of_birth: validation_data[:date_of_birth],
+                                          nino: validation_data[:national_insurance_number],
+                                          config: config.except(:save_validation_data_without_match))
+  end
+end

--- a/app/services/validate_participant.rb
+++ b/app/services/validate_participant.rb
@@ -78,6 +78,7 @@ private
     record.full_name = validation_data[:name]
     record.date_of_birth = validation_data[:date_of_birth]
     record.nino = validation_data[:national_insurance_number]
+    record.api_failure = false
     record.assign_attributes(opts)
     record.save!
     record

--- a/db/migrate/20210910101052_create_ecf_ineligible_participants.rb
+++ b/db/migrate/20210910101052_create_ecf_ineligible_participants.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateECFIneligibleParticipants < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ecf_ineligible_participants, id: :uuid do |t|
+      t.string :trn, index: true
+      t.string :full_name
+      t.date :date_of_birth
+      t.string :urn
+      t.string :reason, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210910101052_create_ecf_ineligible_participants.rb
+++ b/db/migrate/20210910101052_create_ecf_ineligible_participants.rb
@@ -3,10 +3,7 @@
 class CreateECFIneligibleParticipants < ActiveRecord::Migration[6.1]
   def change
     create_table :ecf_ineligible_participants, id: :uuid do |t|
-      t.string :trn, index: true
-      t.string :full_name
-      t.date :date_of_birth
-      t.string :urn
+      t.string :trn, index: { unique: true }
       t.string :reason, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_09_154907) do
+ActiveRecord::Schema.define(version: 2021_09_10_101052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -203,6 +203,17 @@ ActiveRecord::Schema.define(version: 2021_09_09_154907) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["local_authority_district_id"], name: "index_district_sparsities_on_local_authority_district_id"
+  end
+
+  create_table "ecf_ineligible_participants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "trn"
+    t.string "full_name"
+    t.date "date_of_birth"
+    t.string "urn"
+    t.string "reason", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["trn"], name: "index_ecf_ineligible_participants_on_trn"
   end
 
   create_table "ecf_participant_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -207,13 +207,10 @@ ActiveRecord::Schema.define(version: 2021_09_10_101052) do
 
   create_table "ecf_ineligible_participants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "trn"
-    t.string "full_name"
-    t.date "date_of_birth"
-    t.string "urn"
     t.string "reason", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["trn"], name: "index_ecf_ineligible_participants_on_trn"
+    t.index ["trn"], name: "index_ecf_ineligible_participants_on_trn", unique: true
   end
 
   create_table "ecf_participant_eligibilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/ineligible_participants.rake
+++ b/lib/tasks/ineligible_participants.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :ineligible_participants do
+  desc "Import ineligible participants from CSV"
+  task :import, %i[csv_path reason] => :environment do |_t, args|
+    logger = Logger.new($stdout)
+    logger.info "Importing ineligible participants, this may take a couple minutes..."
+    Importers::IneligibleParticipants.call(path_to_csv: args.csv_path, reason: args.reason, logger: logger)
+    logger.info "Ineligible participant data import complete!"
+  end
+end

--- a/spec/factories/ecf_participant_eligibility.rb
+++ b/spec/factories/ecf_participant_eligibility.rb
@@ -3,5 +3,28 @@
 FactoryBot.define do
   factory :ecf_participant_eligibility, class: ECFParticipantEligibility do
     association :participant_profile, :ecf
+
+    qts { true }
+    active_flags { false }
+    previous_participation { false }
+    previous_induction { false }
+
+    trait :eligible do
+      after(:create) do |record, _evaluator|
+        record.eligible_status!
+      end
+    end
+
+    trait :matched do
+      after(:create) do |record, _evaluator|
+        record.matched_status!
+      end
+    end
+
+    trait :manual_check do
+      after(:create) do |record, _evaluator|
+        record.manual_check_status!
+      end
+    end
   end
 end

--- a/spec/factories/ineligible_participant.rb
+++ b/spec/factories/ineligible_participant.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ineligible_participant, class: ECFIneligibleParticipant do
-    trn { Faker::Number.unique.between(from: 1000000, to: 9999999) }
+    trn { Faker::Number.unique.between(from: 1_000_000, to: 9_999_999) }
     reason { %w[previous_participation previous_induction].sample }
   end
 end

--- a/spec/factories/ineligible_participant.rb
+++ b/spec/factories/ineligible_participant.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ineligible_participant, class: ECFIneligibleParticipant do
+    trn { Faker::Number.unique.between(from: 1000000, to: 9999999) }
+    reason { %w[previous_participation previous_induction].sample }
+  end
+end

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -73,29 +73,29 @@ module ParticipantValidationSteps
   def when_i_click_continue_to_proceed_with_validation
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
-                          .with(@participant_data)
-                          .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
+      .with(@participant_data)
+      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
     click_on "Continue"
   end
 
   def when_i_click_continue_to_proceed_with_validation_for_updated_name
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
-                          .with(@participant_data)
-                          .with(trn: @participant_data[:trn],
-                                full_name: "Sally Participant",
-                                date_of_birth: @participant_data[:date_of_birth],
-                                nino: @participant_data[:nino],
-                                config: { check_first_name_only: true })
-                          .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
+      .with(@participant_data)
+      .with(trn: @participant_data[:trn],
+            full_name: "Sally Participant",
+            date_of_birth: @participant_data[:date_of_birth],
+            nino: @participant_data[:nino],
+            config: { check_first_name_only: true })
+      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
     click_on "Continue"
   end
 
   def when_i_click_continue_but_my_details_are_invalid
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
-                          .with(@participant_data)
-                          .and_return(nil)
+      .with(@participant_data)
+      .and_return(nil)
     click_on "Continue"
   end
 

--- a/spec/fixtures/files/ineligible_participants.csv
+++ b/spec/fixtures/files/ineligible_participants.csv
@@ -2,6 +2,6 @@ trn,name,dob,urn
 1234567,,,
 9876543,Edna Wallis,1992-8-22,144011
 ,Sally Smith,,145091
-,Walter Ponds,,
+4488331,Walter Ponds,,
 ,,1990-10-14,141333
 ,,,132132

--- a/spec/fixtures/files/ineligible_participants.csv
+++ b/spec/fixtures/files/ineligible_participants.csv
@@ -1,0 +1,7 @@
+trn,name,dob,urn
+1234567,,,
+9876543,Edna Wallis,1992-8-22,144011
+,Sally Smith,,145091
+,Walter Ponds,,
+,,1990-10-14,141333
+,,,132132

--- a/spec/jobs/validation_retry_job_spec.rb
+++ b/spec/jobs/validation_retry_job_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "ValidationRetryJob" do
       before do
         validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
         allow(validator).to receive(:validate)
-                              .with(participant_data)
-                              .and_return({ trn: participant_data[:trn], qts: true, active_alert: false })
+          .with(participant_data.merge(config: {}))
+          .and_return({ trn: participant_data[:trn], qts: true, active_alert: false })
       end
 
       it "rechecks the eligibility" do
@@ -56,8 +56,8 @@ RSpec.describe "ValidationRetryJob" do
       before do
         validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
         allow(validator).to receive(:validate)
-                              .with(participant_data)
-                              .and_raise(StandardError)
+          .with(participant_data.merge(config: {}))
+          .and_raise(StandardError)
       end
 
       it "does not change the record" do

--- a/spec/jobs/validation_retry_job_spec.rb
+++ b/spec/jobs/validation_retry_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "ValidationRetryJob" do
       before do
         validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
         allow(validator).to receive(:validate)
-          .with(participant_data.merge(config: {}))
+          .with(participant_data.merge(config: { check_first_name_only: true }))
           .and_return({ trn: participant_data[:trn], qts: true, active_alert: false })
       end
 
@@ -56,7 +56,7 @@ RSpec.describe "ValidationRetryJob" do
       before do
         validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
         allow(validator).to receive(:validate)
-          .with(participant_data.merge(config: {}))
+          .with(participant_data.merge(config: { check_first_name_only: true }))
           .and_raise(StandardError)
       end
 

--- a/spec/services/check_participant_eligibility_spec.rb
+++ b/spec/services/check_participant_eligibility_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CheckParticipantEligibility do
       end
     end
 
-    context "when no matching ineligible participan record exists" do
+    context "when no matching ineligible participant record exists" do
       it "returns nil" do
         expect(service.call(trn: "9876543")).to be_nil
       end

--- a/spec/services/check_participant_eligibility_spec.rb
+++ b/spec/services/check_participant_eligibility_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe CheckParticipantEligibility do
   subject(:service) { described_class }
 
-
   describe ".call" do
     context "when a matching ineligible participant record exists" do
       let!(:ineligible_participant) { create(:ineligible_participant, trn: "1234567", reason: "previous_participation") }

--- a/spec/services/check_participant_eligibility_spec.rb
+++ b/spec/services/check_participant_eligibility_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CheckParticipantEligibility do
+  subject(:service) { described_class }
+
+
+  describe ".call" do
+    context "when a matching ineligible participant record exists" do
+      let!(:ineligible_participant) { create(:ineligible_participant, trn: "1234567", reason: "previous_participation") }
+
+      it "returns the ineligibility reason" do
+        expect(service.call(trn: "1234567")).to eq :previous_participation
+      end
+    end
+
+    context "when no matching ineligible participan record exists" do
+      it "returns nil" do
+        expect(service.call(trn: "9876543")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/importers/ineligible_participants_spec.rb
+++ b/spec/services/importers/ineligible_participants_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe Importers::IneligibleParticipants do
+  let(:csv_file) { file_fixture "ineligible_participants.csv" }
+  subject(:service) { described_class }
+
+  describe ".call" do
+    before do
+      service.call(path_to_csv: csv_file, reason: "previous_participant")
+    end
+
+    it "adds inelgible participant records from the file" do
+      expect(ECFIneligibleParticipant.count).to be 3
+    end
+
+    it "sets the reason for the ineligibility" do
+      expect(ECFIneligibleParticipant.previous_participant.count).to be 3
+    end
+
+    it "only populates the TRN field when the TRN is present in the file" do
+      record = ECFIneligibleParticipant.find_by(trn: "9876543")
+      expect(record.full_name).to be_nil
+      expect(record.date_of_birth).to be_nil
+      expect(record.urn).to be_nil
+    end
+
+    it "does not duplicate records given the same information" do
+      expect {
+        service.call(path_to_csv: csv_file, reason: "previous_participant")
+      }.not_to change { ECFIneligibleParticipant.count }
+    end
+
+    context "when trn is not present" do
+      it "populates full_name and either/both of date_of_birth and urn" do
+        record = ECFIneligibleParticipant.find_by(full_name: "Sally Smith")
+        expect(record.trn).to be_nil
+        expect(record.date_of_birth).to be_nil
+        expect(record.urn).to eq "145091"
+      end
+
+      context "when name is not present" do
+        it "does not create a record" do
+          expect(ECFIneligibleParticipant.find_by(urn: "132132")).to be_nil
+          expect(ECFIneligibleParticipant.find_by(urn: "141333")).to be_nil
+        end
+      end
+
+      context "when only name is present" do
+        it "does not create a record" do
+          expect(ECFIneligibleParticipant.find_by(full_name: "Walter Ponds")).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/importers/ineligible_participants_spec.rb
+++ b/spec/services/importers/ineligible_participants_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Importers::IneligibleParticipants do
 
   describe ".call" do
     before do
-      service.call(path_to_csv: csv_file, reason: "previous_participant")
+      service.call(path_to_csv: csv_file, reason: "previous_participation")
     end
 
     context "when the trn field is present" do
@@ -21,13 +21,13 @@ RSpec.describe Importers::IneligibleParticipants do
       end
 
       it "sets the reason for the ineligibility" do
-        expect(ECFIneligibleParticipant.previous_participant.count).to be 3
+        expect(ECFIneligibleParticipant.previous_participation.count).to be 3
       end
 
       context "when the trn already exists" do
         it "does not create a duplicate record" do
           expect {
-            service.call(path_to_csv: csv_file, reason: "previous_participant")
+            service.call(path_to_csv: csv_file, reason: "previous_participation")
           }.not_to change { ECFIneligibleParticipant.count }
         end
       end

--- a/spec/services/importers/ineligible_participants_spec.rb
+++ b/spec/services/importers/ineligible_participants_spec.rb
@@ -12,45 +12,23 @@ RSpec.describe Importers::IneligibleParticipants do
       service.call(path_to_csv: csv_file, reason: "previous_participant")
     end
 
-    it "adds inelgible participant records from the file" do
-      expect(ECFIneligibleParticipant.count).to be 3
-    end
-
-    it "sets the reason for the ineligibility" do
-      expect(ECFIneligibleParticipant.previous_participant.count).to be 3
-    end
-
-    it "only populates the TRN field when the TRN is present in the file" do
-      record = ECFIneligibleParticipant.find_by(trn: "9876543")
-      expect(record.full_name).to be_nil
-      expect(record.date_of_birth).to be_nil
-      expect(record.urn).to be_nil
-    end
-
-    it "does not duplicate records given the same information" do
-      expect {
-        service.call(path_to_csv: csv_file, reason: "previous_participant")
-      }.not_to change { ECFIneligibleParticipant.count }
-    end
-
-    context "when trn is not present" do
-      it "populates full_name and either/both of date_of_birth and urn" do
-        record = ECFIneligibleParticipant.find_by(full_name: "Sally Smith")
-        expect(record.trn).to be_nil
-        expect(record.date_of_birth).to be_nil
-        expect(record.urn).to eq "145091"
+    context "when the trn field is present" do
+      it "adds inelgible participant records from the file" do
+        expect(ECFIneligibleParticipant.find_by(trn: "1234567")).to be_present
+        expect(ECFIneligibleParticipant.find_by(trn: "9876543")).to be_present
+        expect(ECFIneligibleParticipant.find_by(trn: "4488331")).to be_present
+        expect(ECFIneligibleParticipant.count).to be 3
       end
 
-      context "when name is not present" do
-        it "does not create a record" do
-          expect(ECFIneligibleParticipant.find_by(urn: "132132")).to be_nil
-          expect(ECFIneligibleParticipant.find_by(urn: "141333")).to be_nil
-        end
+      it "sets the reason for the ineligibility" do
+        expect(ECFIneligibleParticipant.previous_participant.count).to be 3
       end
 
-      context "when only name is present" do
-        it "does not create a record" do
-          expect(ECFIneligibleParticipant.find_by(full_name: "Walter Ponds")).to be_nil
+      context "when the trn already exists" do
+        it "does not create a duplicate record" do
+          expect {
+            service.call(path_to_csv: csv_file, reason: "previous_participant")
+          }.not_to change { ECFIneligibleParticipant.count }
         end
       end
     end

--- a/spec/services/importers/ineligible_participants_spec.rb
+++ b/spec/services/importers/ineligible_participants_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe Importers::IneligibleParticipants do
             service.call(path_to_csv: csv_file, reason: "previous_participation")
           }.not_to change { ECFIneligibleParticipant.count }
         end
+
+        context "when the reason is different" do
+          before do
+            @both_types = ECFIneligibleParticipant.find_by(trn: "4488331")
+            @both_types.previous_induction!
+          end
+
+          it "updates the reason to previous_induction_and_participation" do
+            service.call(path_to_csv: csv_file, reason: "previous_participation")
+            expect(@both_types.reload).to be_previous_induction_and_participation
+          end
+        end
       end
     end
   end

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -225,6 +225,18 @@ RSpec.describe ParticipantValidationService do
         expect(validation_result).to eql(build_validation_result(trn: trn, options: { previous_induction: true }))
       end
     end
+
+    context "when the participant has previously had an induction and participation" do
+      let!(:ineligibity) { create(:ineligible_participant, trn: trn, reason: :previous_induction_and_participation) }
+
+      before do
+        expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)
+      end
+
+      it "returns returns both flags" do
+        expect(validation_result).to eql(build_validation_result(trn: trn, options: { previous_induction: true, previous_participation: true }))
+      end
+    end
   end
 
   def build_validation_result(trn:, options: {})

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe ParticipantValidationService do
       end
 
       it "returns record with padded trn when trn is not padded" do
-        expect(validation_result).to eql({ trn: padded_trn, qts: true, active_alert: false })
+        expect(validation_result).to eql(build_validation_result(trn: padded_trn))
       end
     end
 
@@ -75,37 +75,37 @@ RSpec.describe ParticipantValidationService do
       end
 
       it "returns true when all fields match" do
-        expect(validation_result).to eql({ trn: trn, qts: true, active_alert: false })
+        expect(validation_result).to eql(build_validation_result(trn: trn))
       end
 
       it "returns the validated details when date of birth is wrong" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: nino, full_name: full_name, date_of_birth: Date.new(1980, 1, 2)),
-        ).to eql({ trn: trn, qts: true, active_alert: false })
+        ).to eql(build_validation_result(trn: trn))
       end
 
       it "returns the validated details when name is wrong" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: nino, full_name: "John Smithe", date_of_birth: dob),
-        ).to eql({ trn: trn, qts: true, active_alert: false })
+        ).to eql(build_validation_result(trn: trn))
       end
 
       it "returns the validated details when nino is wrong" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: "AA654321A", full_name: full_name, date_of_birth: dob),
-        ).to eql({ trn: trn, qts: true, active_alert: false })
+        ).to eql(build_validation_result(trn: trn))
       end
 
       it "returns the validated details when name is wrong and nino is cased differently" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: nino.downcase, full_name: "John Smithe", date_of_birth: dob),
-        ).to eql({ trn: trn, qts: true, active_alert: false })
+        ).to eql(build_validation_result(trn: trn))
       end
 
       it "returns validated details when the name is cased differently and the nino is missing" do
         expect(
           ParticipantValidationService.validate(trn: trn, nino: "", full_name: "John SMITH", date_of_birth: dob),
-        ).to eql({ trn: trn, qts: true, active_alert: false })
+        ).to eql(build_validation_result(trn: trn))
       end
     end
 
@@ -139,7 +139,7 @@ RSpec.describe ParticipantValidationService do
         it "returns validated details" do
           expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)
 
-          expect(validation_result).to eql({ trn: trn, qts: true, active_alert: false })
+          expect(validation_result).to eql(build_validation_result(trn: trn))
         end
       end
     end
@@ -165,7 +165,7 @@ RSpec.describe ParticipantValidationService do
                  nino: nino,
                  full_name: full_name,
                  date_of_birth: dob,
-               )).to eql({ trn: trn, qts: true, active_alert: false })
+               )).to eql(build_validation_result(trn: trn))
       end
     end
 
@@ -176,7 +176,7 @@ RSpec.describe ParticipantValidationService do
       end
 
       it "returns correct QTS information" do
-        expect(validation_result).to eql({ trn: trn, qts: false, active_alert: false })
+        expect(validation_result).to eql(build_validation_result(trn: trn, options: { qts: false }))
       end
     end
 
@@ -187,7 +187,7 @@ RSpec.describe ParticipantValidationService do
       end
 
       it "returns returns the correct alert details" do
-        expect(validation_result).to eql({ trn: trn, qts: true, active_alert: true })
+        expect(validation_result).to eql(build_validation_result(trn: trn, options: { active_alert: true }))
       end
     end
 
@@ -201,5 +201,39 @@ RSpec.describe ParticipantValidationService do
         expect(ParticipantValidationService.validate(trn: trn, nino: "", full_name: "John Smithe", date_of_birth: dob)).to be_nil
       end
     end
+
+    context "when the participant has previously participated" do
+      let!(:ineligibity) { create(:ineligible_participant, trn: trn, reason: :previous_participation) }
+
+      before do
+        expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)
+      end
+
+      it "returns returns the correct previous_participation flags" do
+        expect(validation_result).to eql(build_validation_result(trn: trn, options: { previous_participation: true }))
+      end
+    end
+
+    context "when the participant has previously had an induction" do
+      let!(:ineligibity) { create(:ineligible_participant, trn: trn, reason: :previous_induction) }
+
+      before do
+        expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)
+      end
+
+      it "returns returns the correct previous_participation flags" do
+        expect(validation_result).to eql(build_validation_result(trn: trn, options: { previous_induction: true }))
+      end
+    end
+  end
+
+  def build_validation_result(trn:, options: {})
+    {
+      trn: trn,
+      qts: true,
+      active_alert: false,
+      previous_participation: false,
+      previous_induction: false,
+    }.merge(options)
   end
 end

--- a/spec/services/validate_participant_spec.rb
+++ b/spec/services/validate_participant_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ValidateParticipant do
+  describe ".call" do
+    subject(:service) { described_class }
+    let(:school_cohort) { create(:school_cohort) }
+    let(:teacher_profile) { create(:teacher_profile, school: school_cohort.school, trn: nil) }
+    let(:participant_profile) { create(:participant_profile, :ect, school_cohort: school_cohort, teacher_profile: teacher_profile) }
+
+    let(:request_data) do
+      {
+        trn: "1234567",
+        name: "Karen Hastings",
+        date_of_birth: Date.new(1993, 11, 16),
+        national_insurance_number: "QQ123456A",
+      }
+    end
+
+    let(:validation_request) do
+      {
+        trn: request_data[:trn],
+        full_name: request_data[:name],
+        date_of_birth: request_data[:date_of_birth],
+        nino: request_data[:national_insurance_number],
+        config: {},
+      }
+    end
+
+    let(:validation_response) do
+      {
+        trn: "1234567",
+        qts: true,
+        active_alert: false,
+        previous_participation: false,
+        previous_induction: false,
+      }
+    end
+
+    let(:manual_check_record) { create(:ecf_participant_eligibility, :manual_check) }
+    let(:eligible_record) { create(:ecf_participant_eligibility, :eligible) }
+
+    let(:validation_service) { class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true) }
+
+    context "when validation data is supplied" do
+      it "performs checks using the supplied data" do
+        allow(validation_service).to receive(:validate)
+          .with(validation_request)
+          .and_return(validation_response)
+
+        service.call(participant_profile: participant_profile, validation_data: request_data)
+      end
+    end
+
+    context "when validation data is not supplied" do
+      let(:validation_request) do
+        {
+          trn: "1234567",
+          full_name: "Arthur Askey",
+          date_of_birth: Date.new(1965, 1, 17),
+          nino: "QQ112233A",
+        }
+      end
+
+      before do
+        participant_profile.create_ecf_participant_validation_data!(validation_request)
+      end
+
+      it "performs checks using validation data from the profile" do
+        allow(validation_service).to receive(:validate)
+          .with(validation_request.merge(config: {}))
+          .and_return(validation_response)
+
+        service.call(participant_profile: participant_profile)
+      end
+    end
+
+    context "when a match is found at the DQT" do
+      before do
+        allow(validation_service).to receive(:validate)
+          .with(validation_request)
+          .and_return(validation_response)
+      end
+
+      it "returns true" do
+        expect(service.call(participant_profile: participant_profile, validation_data: request_data)).to be true
+      end
+
+      it "creates an eligibility record for the participant" do
+        service.call(participant_profile: participant_profile, validation_data: request_data)
+        eligibility = participant_profile.reload.ecf_participant_eligibility
+        expect(eligibility).to be_matched_status
+      end
+
+      context "when the participant is not eligible" do
+        before do
+          allow_any_instance_of(described_class).to receive(:store_eligibility_data!)
+            .with(validation_response)
+            .and_return(manual_check_record)
+        end
+
+        it "saves the validation data against the profile" do
+          service.call(participant_profile: participant_profile, validation_data: request_data)
+          validation_data = participant_profile.reload.ecf_participant_validation_data
+          expect(validation_data.trn).to eq request_data[:trn]
+          expect(validation_data.full_name).to eq request_data[:name]
+          expect(validation_data.date_of_birth).to eq request_data[:date_of_birth]
+          expect(validation_data.nino).to eq request_data[:national_insurance_number]
+        end
+      end
+
+      context "when the participant is eligible" do
+        before do
+          allow_any_instance_of(described_class).to receive(:store_eligibility_data!)
+            .with(validation_response)
+            .and_return(eligible_record)
+        end
+
+        it "does not save the validation data" do
+          service.call(participant_profile: participant_profile, validation_data: request_data)
+          expect(participant_profile.reload.ecf_participant_validation_data).to be_nil
+        end
+      end
+    end
+
+    context "when a match is not found at the DQT" do
+      before do
+        allow(validation_service).to receive(:validate)
+          .with(validation_request)
+          .and_return(nil)
+      end
+
+      it "returns false" do
+        result = service.call(participant_profile: participant_profile, validation_data: request_data)
+        expect(result).to be false
+      end
+
+      it "saves the validation data against the profile" do
+        service.call(participant_profile: participant_profile, validation_data: request_data)
+        validation_data = participant_profile.reload.ecf_participant_validation_data
+        expect(validation_data.trn).to eq request_data[:trn]
+        expect(validation_data.full_name).to eq request_data[:name]
+        expect(validation_data.date_of_birth).to eq request_data[:date_of_birth]
+        expect(validation_data.nino).to eq request_data[:national_insurance_number]
+      end
+
+      context "when the save_validation_data_without_match is not set" do
+        it "does not save the validation data" do
+          service.call(participant_profile: participant_profile, validation_data: request_data,
+                       config: { save_validation_data_without_match: false })
+          expect(participant_profile.reload.ecf_participant_validation_data).to be_nil
+        end
+      end
+    end
+
+    context "when eligibility data already exists" do
+      let!(:existing_eligibility) { create(:ecf_participant_eligibility, :manual_check, participant_profile: participant_profile, previous_participation: true) }
+
+      before do
+        allow(validation_service).to receive(:validate)
+          .with(validation_request)
+          .and_return(validation_response)
+      end
+
+      it "updates the eligibility data" do
+        service.call(participant_profile: participant_profile, validation_data: request_data)
+        expect(existing_eligibility.reload).to be_matched_status
+        expect(existing_eligibility.previous_participation).to be false
+      end
+
+      it "does not create another eligibility record" do
+        expect {
+          service.call(participant_profile: participant_profile, validation_data: request_data)
+        }.not_to change { ECFParticipantEligibility.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: [Jira](https://dfedigital.atlassian.net/browse/CPDRP-672)

Create means to hold ineligible participants and populate from CSV files. These are be checked against during automatic participant validation.  The CSV data is sensitive so will be a one-off manual task to import.

## Tech review

Added the `ValidateParticipant` "service" to wrap up the `ParticipantValidationService` and the handling of creating/updating validation data and eligibility data.
In addition, the `ParticipantValidationService` now calls `CheckParticipantEligibility` during validation. This simply looks up the `trn` and returns an ineligibility reason if the TRN is in the list.
Update `Participants::ValidationController` and `ValidationRetryJob` to use new `ValidateParticipant` service.

__NOTE:__ This does not yet change the behaviour of the everyone in the manual bucket validation.

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
