### PR TITLE
CPDTP-485: Add unpermitted parameters to participant declarations api

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -6,6 +6,7 @@ module Api
     before_action :remove_charset
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
     rescue_from ActionController::ParameterMissing, with: :missing_parameter_response
+    rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response
     rescue_from ActionController::BadRequest, with: :bad_request_response
     rescue_from ActiveRecord::StatementInvalid, with: :bad_request_response
     rescue_from ArgumentError, with: :bad_request_response
@@ -23,6 +24,10 @@ module Api
 
     def missing_parameter_response(exception)
       render json: { errors: Api::ParamErrorFactory.new(error: "Bad or missing parameters", params: exception.param).call }, status: :unprocessable_entity
+    end
+
+    def unpermitted_parameter_response(exception)
+      render json: { errors: Api::ParamErrorFactory.new(error: "Unpermitted parameters", params: exception.params).call }, status: :unprocessable_entity
     end
 
     def bad_request_response(exception)

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -49,6 +49,8 @@ module RecordDeclarations
     def initialize(params)
       params.each do |param, value|
         send("#{param}=", value)
+      rescue NoMethodError
+        raise ActionController::UnpermittedParameters, ["Unpermitted parameter: #{param}"]
       end
     end
 

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t("activemodel.errors.models.record_declarations/base.attributes.participant_id.blank") }] }.to_json)
       end
 
+      it "returns 422 when sending an unpermitted parameter" do
+        missing_attribute = valid_params.merge(evidence_held: "test")
+        post "/api/v1/participant-declarations", params: build_params(missing_attribute)
+        expect(response.status).to eq 422
+        expect(response.body).to eq({ errors: [{ title: "Unpermitted parameters", detail: "Unpermitted parameter: evidence_held" }] }.to_json)
+      end
+
       it "returns 422 when supplied an incorrect course type" do
         incorrect_course_identifier = valid_params.merge({ course_identifier: "typoed-course-name" })
         post "/api/v1/participant-declarations", params: build_params(incorrect_course_identifier)

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
     end
   end
 
+  context "when including evidence_held" do
+    it "raised ParameterMissing error" do
+      params = ect_params.merge(evidence_held: "self-study-material-completed")
+      expected_msg = /Unpermitted parameter: evidence_held/
+      expect { described_class.call(params) }.to raise_error(ActionController::UnpermittedParameters, expected_msg)
+    end
+  end
+
   context "when declaration date is in the past" do
     it "does not raise ParameterMissing error" do
       params = ect_params.merge({ declaration_date: (Time.zone.now - 1.day).rfc3339(9) })


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-485

## Tech review

### Is there anything that the code reviewer should know?
The only case when we need it (as far as I can tell) is participant declarations endpoint. But if you know of more, let me know and I will fix those too. 

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Submit a started declaration, with `evidence_held` field.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes) - not really a change. I can add something to the changelog if we think it is worth it.
