### PR TITLE
Switch over validation to match against first name only

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -145,7 +145,8 @@ module Participants
       result = ParticipantValidationService.validate(trn: participant_details[:trn],
                                                      full_name: participant_details[:name],
                                                      date_of_birth: participant_details[:date_of_birth],
-                                                     nino: participant_details[:national_insurance_number])
+                                                     nino: participant_details[:national_insurance_number],
+                                                     config: { check_first_name_only: true })
 
       if result.nil?
         @participant_validation_form.increment_validation_attempts

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -73,28 +73,29 @@ module ParticipantValidationSteps
   def when_i_click_continue_to_proceed_with_validation
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
-      .with(@participant_data)
-      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
+                          .with(@participant_data)
+                          .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
     click_on "Continue"
   end
 
   def when_i_click_continue_to_proceed_with_validation_for_updated_name
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
-      .with(@participant_data)
-      .with(trn: @participant_data[:trn],
-            full_name: "Sally Participant",
-            date_of_birth: @participant_data[:date_of_birth],
-            nino: @participant_data[:nino])
-      .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
+                          .with(@participant_data)
+                          .with(trn: @participant_data[:trn],
+                                full_name: "Sally Participant",
+                                date_of_birth: @participant_data[:date_of_birth],
+                                nino: @participant_data[:nino],
+                                config: { check_first_name_only: true })
+                          .and_return({ trn: @participant_data[:trn], qts: true, active_alert: false })
     click_on "Continue"
   end
 
   def when_i_click_continue_but_my_details_are_invalid
     validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
     allow(validator).to receive(:validate)
-      .with(@participant_data)
-      .and_return(nil)
+                          .with(@participant_data)
+                          .and_return(nil)
     click_on "Continue"
   end
 
@@ -309,6 +310,7 @@ module ParticipantValidationSteps
       full_name: "Sally Teacher",
       date_of_birth: Date.new(1998, 3, 22),
       nino: nil,
+      config: { check_first_name_only: true },
     }
   end
 end


### PR DESCRIPTION
Aim to boost automatic validation rate of mentors by only comparing their first name 