### PR TITLE
CPDRP-902 Add pupil premium and sparsity uplifts to participants endpoint

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -71,12 +71,12 @@ class ParticipantSerializer
     user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible_status? || nil
   end
 
-  active_participant_attribute :pupil_premium_uplift do
-    nil # TODO: CPDRP-534 - Share when we know we have the correct information
+  active_participant_attribute :pupil_premium_uplift do |user|
+    user.teacher_profile.ecf_profile&.school&.pupil_premium_uplift?(user.teacher_profile.ecf_profile.cohort.start_year)
   end
 
-  active_participant_attribute :sparsity_uplift do
-    nil # TODO: CPDRP-534 - Share when we know we have the correct information
+  active_participant_attribute :sparsity_uplift do |user|
+    user.teacher_profile.ecf_profile&.school&.sparsity_uplift?(user.teacher_profile.ecf_profile.cohort.start_year)
   end
 
   active_participant_attribute :training_status do |user|

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -205,8 +205,8 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(mentor_row["teacher_reference_number"]).to eql mentor.teacher_profile.trn
           expect(mentor_row["teacher_reference_number_validated"]).to eql "false"
           expect(mentor_row["eligible_for_funding"]).to be_empty
-          expect(mentor_row["pupil_premium_uplift"]).to be_empty
-          expect(mentor_row["sparsity_uplift"]).to be_empty
+          expect(mentor_row["pupil_premium_uplift"]).to eql "false"
+          expect(mentor_row["sparsity_uplift"]).to eql "false"
           expect(mentor_row["training_status"]).to eql "active"
 
           ect = ParticipantProfile::ECT.active_record.first.user
@@ -221,8 +221,8 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
           expect(ect_row["teacher_reference_number"]).to eql ect.teacher_profile.trn
           expect(ect_row["teacher_reference_number_validated"]).to eql "false"
           expect(mentor_row["eligible_for_funding"]).to be_empty
-          expect(mentor_row["pupil_premium_uplift"]).to be_empty
-          expect(mentor_row["sparsity_uplift"]).to be_empty
+          expect(mentor_row["pupil_premium_uplift"]).to eql "false"
+          expect(mentor_row["sparsity_uplift"]).to eql "false"
           expect(mentor_row["training_status"]).to eql "active"
 
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1562,8 +1562,8 @@
                   "teacher_reference_number": null,
                   "teacher_reference_number_validated": false,
                   "eligible_for_funding": null,
-                  "pupil_premium_uplift": null,
-                  "sparsity_uplift": null,
+                  "pupil_premium_uplift": true,
+                  "sparsity_uplift": false,
                   "training_status": "deferred"
                 }
               },


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-902

Following an investigation into whether we need to update the pupil premium data following the initial import earlier in the year, it was concluded that this data was not going to change this cohort.

That means we can start to expose `pupil_premium_uplift` and `sparsity_uplift` to lead providers via the participants endpoint.

## Tech review

### Is there anything that the code reviewer should know?

- These fields can only be `true` or `false` unless the participant is withdrawn. Is that correct?