### PR TITLE
CPDTP-440 New Banding payment rules

### DIFF
--- a/app/components/finance/ecf/breakdown_summary.html.erb
+++ b/app/components/finance/ecf/breakdown_summary.html.erb
@@ -25,7 +25,7 @@
       <%=recruitment_target %>
     </dd>
   </div>
-  <%- if revised_target.present? %>
+  <% if revised_target.present? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         <%=t("finance.contract.revised_target") %>

--- a/app/components/finance/ecf/breakdown_summary.html.erb
+++ b/app/components/finance/ecf/breakdown_summary.html.erb
@@ -25,6 +25,16 @@
       <%=recruitment_target %>
     </dd>
   </div>
+  <%- if revised_target.present? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%=t("finance.contract.revised_target") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%=revised_target %>
+      </dd>
+    </div>
+  <% end %>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%=t("finance.ects") %>

--- a/app/components/finance/ecf/breakdown_summary.rb
+++ b/app/components/finance/ecf/breakdown_summary.rb
@@ -3,7 +3,7 @@
 module Finance
   module ECF
     class BreakdownSummary < BaseComponent
-      attr_accessor :name, :declaration, :recruitment_target, :ects, :mentors, :participants
+      attr_accessor :name, :declaration, :recruitment_target, :revised_target, :ects, :mentors, :participants
 
     private
 

--- a/app/components/finance/ecf/contract.html.erb
+++ b/app/components/finance/ecf/contract.html.erb
@@ -17,6 +17,16 @@
       <%=recruitment_target %>
     </dd>
   </div>
+  <%- if revised_target.present? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%=t("finance.contract.revised_target") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%=revised_target %>
+      </dd>
+    </div>
+  <% end %>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       <%=t("finance.contract.uplift_target") %>

--- a/app/components/finance/ecf/contract.html.erb
+++ b/app/components/finance/ecf/contract.html.erb
@@ -17,7 +17,7 @@
       <%=recruitment_target %>
     </dd>
   </div>
-  <%- if revised_target.present? %>
+  <% if revised_target.present? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         <%=t("finance.contract.revised_target") %>

--- a/app/components/finance/ecf/contract.rb
+++ b/app/components/finance/ecf/contract.rb
@@ -5,7 +5,7 @@ module Finance
     class Contract < BaseComponent
       include FinanceHelper
       attr_accessor :contract
-      delegate :uplift_target, :uplift_amount, :recruitment_target, :set_up_fee, to: :contract
+      delegate :uplift_target, :uplift_amount, :recruitment_target, :revised_target, :set_up_fee, to: :contract
 
       def name
         contract.lead_provider.name

--- a/app/components/finance/ecf/contract_band_row.html.erb
+++ b/app/components/finance/ecf/contract_band_row.html.erb
@@ -1,5 +1,5 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell"><%= band_to_identifier index %></td>
+  <td class="govuk-table__cell"><%= t("finance.ecf.bands.#{index}") %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= min || t("finance.contract.bands.floor") %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= max || t("finance.contract.bands.ceiling") %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds per_participant %></td>

--- a/app/components/finance/ecf/output_payment_row.html.erb
+++ b/app/components/finance/ecf/output_payment_row.html.erb
@@ -1,5 +1,5 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell"><%= band %></td>
+  <td class="govuk-table__cell"><%= t("finance.ecf.bands.#{band}") %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= participants %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds per_participant %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds subtotal %></td>

--- a/app/components/finance/ecf/service_fee_row.html.erb
+++ b/app/components/finance/ecf/service_fee_row.html.erb
@@ -1,5 +1,5 @@
 <tr class="govuk-table__row">
-  <td class="govuk-table__cell"><%= band %></td>
+  <td class="govuk-table__cell"><%= t("finance.ecf.bands.#{band}") %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= participants %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds per_participant %></td>
   <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds monthly %></td>

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -10,6 +10,6 @@ module FinanceHelper
   end
 
   def band_to_identifier(index)
-    ("A".ord + index).chr
+    ("a".ord + index).chr
   end
 end

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -8,8 +8,4 @@ module FinanceHelper
   def float_to_percentage(number)
     number_to_percentage(number * 100, precision: 0)
   end
-
-  def band_to_identifier(index)
-    ("a".ord + index).chr
-  end
 end

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -14,6 +14,10 @@ class ParticipantBand < ApplicationRecord
     end
   end
 
+  def output_payment_per_participant
+    (per_participant * output_payment_contribution_percantage)/100
+  end
+
   def deduction_for_setup?
     lower_boundary.zero?
   end

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -2,7 +2,7 @@
 
 class ParticipantBand < ApplicationRecord
   belongs_to :call_off_contract
-  delegate :set_up_fee, to: :call_off_contract
+  delegate :set_up_fee, :recruitment_target, to: :call_off_contract
 
   scope :min_nulls_first, -> { order("min asc nulls first") }
 
@@ -18,6 +18,10 @@ class ParticipantBand < ApplicationRecord
 
   def output_payment_per_participant
     (per_participant * output_payment_percantage) / 100
+  end
+
+  def service_fee_total
+    number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant
   end
 
   def service_fee_per_participant

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -2,6 +2,8 @@
 
 class ParticipantBand < ApplicationRecord
   belongs_to :call_off_contract
+  delegate :set_up_fee, to: :call_off_contract
+
   scope :min_nulls_first, -> { order("min asc nulls first") }
 
   def number_of_participants_in_this_band(total_number_of_participants)
@@ -15,15 +17,15 @@ class ParticipantBand < ApplicationRecord
   end
 
   def output_payment_per_participant
-    (per_participant * output_payment_contribution_percantage) / 100
+    (per_participant * output_payment_percantage) / 100
   end
 
-  def deduction_for_setup?
-    lower_boundary.zero?
+  def service_fee_per_participant
+    (per_participant * service_fee_percentage) / 100 - set_up_cost_per_participant
   end
 
-  def set_up_recruitment_basis
-    deduction_for_setup? ? upper_boundary : 0
+  def set_up_cost_per_participant
+    lower_boundary.zero? ? set_up_fee / upper_boundary : 0
   end
 
 private

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -15,7 +15,7 @@ class ParticipantBand < ApplicationRecord
   end
 
   def output_payment_per_participant
-    (per_participant * output_payment_contribution_percantage)/100
+    (per_participant * output_payment_contribution_percantage) / 100
   end
 
   def deduction_for_setup?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,11 @@ en:
         floor: 0
         ceiling: Unlimited
     ecf:
+      bands:
+        "0": ECF FIP Band A
+        "1": ECF FIP Band B
+        "2": ECF FIP Band C
+        "3": Additional
       payment_breakdown: ECF Payment Breakdown
       contract_information: ECF Contract Information
     service_fee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
       uplift_target: Uplift target
       uplift_amount: Uplift amount
       recuitment_target: Recruitment target
+      revised_target: Revised recruitment target
       set_up_fee: Set-up Fee
       band: Band
       bands:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
       uplift_target: Uplift target
       uplift_amount: Uplift amount
       recuitment_target: Recruitment target
-      revised_target: Revised recruitment target
+      revised_target: Revised recruitment target (+2%)
       set_up_fee: Set-up Fee
       band: Band
       bands:

--- a/db/migrate/20210915155919_add_output_payment_contribution_percentage_to_band.rb
+++ b/db/migrate/20210915155919_add_output_payment_contribution_percentage_to_band.rb
@@ -1,0 +1,5 @@
+class AddOutputPaymentContributionPercentageToBand < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_bands, :output_payment_contribution_percantage, :integer, default: 60
+  end
+end

--- a/db/migrate/20210915155919_add_output_payment_contribution_percentage_to_band.rb
+++ b/db/migrate/20210915155919_add_output_payment_contribution_percentage_to_band.rb
@@ -1,5 +1,0 @@
-class AddOutputPaymentContributionPercentageToBand < ActiveRecord::Migration[6.1]
-  def change
-    add_column :participant_bands, :output_payment_contribution_percantage, :integer, default: 60
-  end
-end

--- a/db/migrate/20210915155919_add_percentages_to_band.rb
+++ b/db/migrate/20210915155919_add_percentages_to_band.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPercentagesToBand < ActiveRecord::Migration[6.1]
   def change
     add_column :participant_bands, :output_payment_percantage, :integer, default: 60

--- a/db/migrate/20210915155919_add_percentages_to_band.rb
+++ b/db/migrate/20210915155919_add_percentages_to_band.rb
@@ -1,0 +1,6 @@
+class AddPercentagesToBand < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_bands, :output_payment_percantage, :integer, default: 60
+    add_column :participant_bands, :service_fee_percentage, :integer, default: 40
+  end
+end

--- a/db/migrate/20210915161312_add_revised_target_to_call_off_contract.rb
+++ b/db/migrate/20210915161312_add_revised_target_to_call_off_contract.rb
@@ -1,0 +1,5 @@
+class AddRevisedTargetToCallOffContract < ActiveRecord::Migration[6.1]
+  def change
+    column_add :call_off_contract, :revised_target, :integer, default: null
+  end
+end

--- a/db/migrate/20210915161312_add_revised_target_to_call_off_contract.rb
+++ b/db/migrate/20210915161312_add_revised_target_to_call_off_contract.rb
@@ -1,5 +1,5 @@
 class AddRevisedTargetToCallOffContract < ActiveRecord::Migration[6.1]
   def change
-    column_add :call_off_contract, :revised_target, :integer, default: null
+    add_column :call_off_contracts, :revised_target, :integer, default: nil
   end
 end

--- a/db/migrate/20210915161312_add_revised_target_to_call_off_contract.rb
+++ b/db/migrate/20210915161312_add_revised_target_to_call_off_contract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRevisedTargetToCallOffContract < ActiveRecord::Migration[6.1]
   def change
     add_column :call_off_contracts, :revised_target, :integer, default: nil

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_155919) do
+ActiveRecord::Schema.define(version: 2021_09_15_161312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_155919) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "lead_provider_id", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "revised_target"
     t.index ["lead_provider_id"], name: "index_call_off_contracts_on_lead_provider_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_10_101052) do
+ActiveRecord::Schema.define(version: 2021_09_15_155919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -434,6 +434,7 @@ ActiveRecord::Schema.define(version: 2021_09_10_101052) do
     t.decimal "per_participant"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "output_payment_contribution_percantage", default: 60
     t.index ["call_off_contract_id"], name: "index_participant_bands_on_call_off_contract_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_161312) do
+ActiveRecord::Schema.define(version: 2021_09_16_150823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -435,7 +435,9 @@ ActiveRecord::Schema.define(version: 2021_09_15_161312) do
     t.decimal "per_participant"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "output_payment_contribution_percantage", default: 60
+    t.integer "output_payment_percantage", default: 60
+    t.integer "service_fee_percentage", default: 40
+    t.integer "service_fee_contribution_percentage", default: 40
     t.index ["call_off_contract_id"], name: "index_participant_bands_on_call_off_contract_id"
   end
 

--- a/lib/payment_calculator/ecf/breakdown_summary.rb
+++ b/lib/payment_calculator/ecf/breakdown_summary.rb
@@ -14,6 +14,7 @@ module PaymentCalculator
           name: lead_provider.name,
           declaration: event_type,
           recruitment_target: recruitment_target,
+          revised_target: revised_target,
           ects: aggregations[:ects],
           mentors: aggregations[:mentors],
           participants: aggregations[:all],
@@ -23,7 +24,7 @@ module PaymentCalculator
     private
 
       attr_accessor :contract
-      delegate :recruitment_target, to: :contract
+      delegate :recruitment_target, :revised_target, to: :contract
 
       def initialize(contract:)
         self.contract = contract

--- a/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
@@ -12,25 +12,16 @@ module PaymentCalculator
           include HasDIParameters
         end
 
-        def output_payment_per_participant(band)
-          band.per_participant * output_payment_contribution_percentage
-        end
-
         def output_payment_for_event(event_type:, total_participants:, band:)
           band.number_of_participants_in_this_band(total_participants) * output_payment_per_participant_for_event(event_type: event_type, band: band)
         end
 
         def output_payment_per_participant_for_event(event_type:, band:)
           event_type = event_type.parameterize.underscore.intern if event_type.is_a?(String)
-          send(event_type) * output_payment_per_participant(band)
+          send(event_type) * band.output_payment_per_participant
         end
 
       private
-
-        def output_payment_contribution_percentage
-          0.6
-        end
-
         def start_and_completion_event_percentage
           0.2
         end

--- a/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/output_payment_calculations.rb
@@ -22,6 +22,7 @@ module PaymentCalculator
         end
 
       private
+
         def start_and_completion_event_percentage
           0.2
         end

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -12,34 +12,17 @@ module PaymentCalculator
           include HasDIParameters
         end
 
-        delegate :recruitment_target, :set_up_fee, :set_up_recruitment_basis, to: :contract
+        delegate :recruitment_target, to: :contract
 
         def service_fee_total(band)
-          band.number_of_participants_in_this_band(recruitment_target) * service_fee_per_participant(band)
+          band.number_of_participants_in_this_band(recruitment_target) * band.service_fee_per_participant
         end
 
         def service_fee_monthly(band)
-          (service_fee_total(band) / number_of_service_fee_payments)
-        end
-
-        def service_fee_per_participant(band)
-          band.per_participant * service_fee_payment_contribution_percentage - deduction_for_band(band)
+          service_fee_total(band) / number_of_service_fee_payments
         end
 
       private
-
-        def deduction_for_band(band)
-          band.deduction_for_setup? ? set_up_cost_per_participant : 0
-        end
-
-        def service_fee_payment_contribution_percentage
-          0.4
-        end
-
-        def set_up_cost_per_participant
-          set_up_fee / set_up_recruitment_basis
-        end
-
         def number_of_service_fee_payments
           29
         end

--- a/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/service_fee_calculations.rb
@@ -12,17 +12,12 @@ module PaymentCalculator
           include HasDIParameters
         end
 
-        delegate :recruitment_target, to: :contract
-
-        def service_fee_total(band)
-          band.number_of_participants_in_this_band(recruitment_target) * band.service_fee_per_participant
-        end
-
         def service_fee_monthly(band)
-          service_fee_total(band) / number_of_service_fee_payments
+          band.service_fee_total / number_of_service_fee_payments
         end
 
       private
+
         def number_of_service_fee_payments
           29
         end

--- a/lib/payment_calculator/ecf/output_payment_aggregator.rb
+++ b/lib/payment_calculator/ecf/output_payment_aggregator.rb
@@ -16,18 +16,12 @@ module PaymentCalculator
       def call(event_type:, total_participants:)
         bands.each_with_index.map do |band, i|
           {
-            band: band_to_identifier(i),
+            band: i,
             participants: band.number_of_participants_in_this_band(total_participants),
             per_participant: output_payment_per_participant_for_event(event_type: event_type, band: band),
             subtotal: output_payment_for_event(total_participants: total_participants, event_type: event_type, band: band),
           }
         end
-      end
-
-    private
-
-      def band_to_identifier(index)
-        ("A".ord + index).chr
       end
     end
   end

--- a/lib/payment_calculator/ecf/service_fees.rb
+++ b/lib/payment_calculator/ecf/service_fees.rb
@@ -11,14 +11,8 @@ module PaymentCalculator
 
       def call
         bands.each_with_index.map do |band, i|
-          { band: band_to_identifier(i) }.merge(ECF::ServiceFeesForBand.call(params, band: band))
+          { band: i }.merge(ECF::ServiceFeesForBand.call(params, band: band))
         end
-      end
-
-    private
-
-      def band_to_identifier(index)
-        ("A".ord + index).chr
       end
     end
   end

--- a/lib/payment_calculator/ecf/service_fees_for_band.rb
+++ b/lib/payment_calculator/ecf/service_fees_for_band.rb
@@ -6,6 +6,7 @@ module PaymentCalculator
   module ECF
     class ServiceFeesForBand
       include ECF::Contract::ServiceFeeCalculations
+      delegate :recruitment_target, to: :contract
 
       def call(band:)
         {

--- a/lib/payment_calculator/ecf/service_fees_for_band.rb
+++ b/lib/payment_calculator/ecf/service_fees_for_band.rb
@@ -10,7 +10,7 @@ module PaymentCalculator
       def call(band:)
         {
           participants: band.number_of_participants_in_this_band(recruitment_target),
-          per_participant: service_fee_per_participant(band),
+          per_participant: band.service_fee_per_participant,
           monthly: service_fee_monthly(band),
         }
       end

--- a/lib/tasks/payment_breakdown.rake
+++ b/lib/tasks/payment_breakdown.rake
@@ -18,8 +18,8 @@ namespace :payment_calculation do
     raise "Unknown lead provider: #{ARGV[1]}" if cpd_lead_provider.nil?
     raise "Not an ECF lead provider #{ARGV[1]}" if cpd_lead_provider.lead_provider.nil?
 
-    total_participants = (ARGV[2] || ParticipantDeclaration::ECF.payable_for_lead_provider(cpd_lead_provider).count)
-    uplift_participants = (ARGV[3] || ParticipantDeclaration::ECF.payable_uplift_for_lead_provider(cpd_lead_provider).count)
+    total_participants = (ARGV[2] || ParticipantDeclaration::ECF.payable_for_lead_provider(cpd_lead_provider).count).to_i
+    uplift_participants = (ARGV[3] || ParticipantDeclaration::ECF.payable_uplift_for_lead_provider(cpd_lead_provider).count).to_i
     total_ects = (ARGV[2].present? ? ARGV[2].to_i / 2 : ParticipantDeclaration::ECF.payable_ects_for_lead_provider(cpd_lead_provider).count)
     total_mentors = (ARGV[2].present? ? ARGV[2].to_i - ARGV[2].to_i / 2 : ParticipantDeclaration::ECF.payable_mentors_for_lead_provider(cpd_lead_provider).count)
     Tasks::PaymentBreakdown.new(contract: cpd_lead_provider.lead_provider.call_off_contract, total_participants: total_participants, uplift_participants: uplift_participants, total_ects: total_ects, total_mentors: total_mentors).to_table

--- a/lib/tasks/payment_breakdown.rb
+++ b/lib/tasks/payment_breakdown.rb
@@ -32,7 +32,7 @@ module Tasks
     end
 
     def service_fee_per_participant(band)
-      service_fee_calculator.send(:service_fee_per_participant, band)
+      band.service_fee_per_participant
     end
 
     def service_fee_monthly(band)

--- a/lib/tasks/payment_breakdown.rb
+++ b/lib/tasks/payment_breakdown.rb
@@ -3,7 +3,7 @@
 module Tasks
   class PaymentBreakdown
     attr_accessor :total_participants, :uplift_participants, :contract, :total_ects, :total_mentors, :service_fee_calculator, :output_calculator, :uplift_calculator
-    delegate :bands, :recruitment_target, to: :contract
+    delegate :bands, :recruitment_target, :revised_target, to: :contract
 
     class << self
       def call(contract:, total_participants:, uplift_participants:, total_ects: 0, total_mentors: 0)
@@ -49,7 +49,7 @@ module Tasks
 
     # Output helper methods
     def index_to_heading(number)
-      ("a".."c").to_a[number]
+      I18n.t("finance.ecf.bands.#{number}")
     end
 
     def lead_provider_name
@@ -75,10 +75,11 @@ module Tasks
           ["Provider", lead_provider_name],
           %w[Milestone Started],
           ["Recruitment target", recruitment_target],
+          (["Revised target", revised_target] if revised_target),
           ["Current ECTs", total_ects],
           ["Current mentors", total_mentors],
           ["Current participants", total_participants],
-        ]
+        ].compact
       end
     end
 
@@ -86,10 +87,9 @@ module Tasks
       Terminal::Table.new do |t|
         t.title = "Service fee"
         t.headings = ["Band", "Number of Participants", "Payment amount per person", "Payment amount monthly"]
-        t.rows = (0..2).map do |row|
-          band = contract.bands[row]
+        t.rows = contract.bands.map.with_index do |band, row|
           [
-            index_to_heading(row).upcase,
+            I18n.t("finance.ecf.bands.#{row}"),
             band.number_of_participants_in_this_band(recruitment_target),
             as_financial { service_fee_per_participant(band) },
             as_financial { service_fee_monthly(band) },
@@ -103,10 +103,9 @@ module Tasks
       Terminal::Table.new do |t|
         t.title = "Output fee"
         t.headings = ["Band", "Number of Participants", "Payment amount per person", "Payment amount for period"]
-        t.rows = (0..2).map do |row|
-          band = contract.bands[row]
+        t.rows = contract.bands.map.with_index do |band, row|
           [
-            ("A".."C").to_a[row],
+            I18n.t("finance.ecf.bands.#{row}"),
             band.number_of_participants_in_this_band(total_participants),
             as_financial { output_payment_per_participant(band) },
             as_financial { output_payment_total(band) },

--- a/spec/factories/call_off_contract.rb
+++ b/spec/factories/call_off_contract.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     uplift_target { 0.33 }
     uplift_amount { 100 }
     recruitment_target { 2000 }
+    revised_target { nil }
     set_up_fee { 149_651 }
     lead_provider { build(:lead_provider, cpd_lead_provider: build(:cpd_lead_provider)) }
     raw do
@@ -28,13 +29,20 @@ FactoryBot.define do
         }.to_json,
       }
     end
+
     after(:build) do |contract, evaluator|
       contract.lead_provider = evaluator.lead_provider
     end
+
     after(:create) do |contract|
       create(:participant_band, :band_a, { call_off_contract: contract })
       create(:participant_band, :band_b, { call_off_contract: contract })
-      create(:participant_band, :band_c, { call_off_contract: contract })
+      if contract.revised_target.present?
+        create(:participant_band, :band_c_with_additional, { max: contract.recruitment_target, call_off_contract: contract })
+        create(:participant_band, :additional, { min: contract.recruitment_target + 1, max: contract.revised_target, call_off_contract: contract })
+      else
+        create(:participant_band, :band_c, { call_off_contract: contract })
+      end
     end
   end
 end

--- a/spec/factories/participant_band.rb
+++ b/spec/factories/participant_band.rb
@@ -15,5 +15,15 @@ FactoryBot.define do
       min { 4001 }
       per_participant { 966 }
     end
+    trait :band_c_with_additional do
+      min { 4001 }
+      max { 4500 }
+      per_participant { 966 }
+    end
+    trait :additional do
+      min { 4501 }
+      max { 5100 }
+      per_participant { 966 }
+    end
   end
 end

--- a/spec/models/participant_band_spec.rb
+++ b/spec/models/participant_band_spec.rb
@@ -3,29 +3,71 @@
 require "rails_helper"
 
 RSpec.describe ParticipantBand, type: :model do
-  let(:call_off_contract) { create(:call_off_contract) }
-  let(:band_a) { create(:participant_band, :band_a, call_off_contract: call_off_contract) }
-  let(:band_b) { create(:participant_band, :band_b, call_off_contract: call_off_contract) }
-  let(:band_c) { create(:participant_band, :band_c, call_off_contract: call_off_contract) }
+  context "without revision of recruitment target" do
+    let(:call_off_contract) { create(:call_off_contract) }
 
-  describe "associations" do
-    it { is_expected.to belong_to(:call_off_contract) }
+    %i[band_c band_a band_b].each do |band|
+      create(:participant_band, band, call_off_contract: call_off_contract)
+    end
+
+    describe "associations" do
+      it { is_expected.to belong_to(:call_off_contract) }
+    end
+
+    describe "ranges" do
+      it {
+        expect(band_a.number_of_participants_in_this_band(100)).to eq(100)
+        expect(band_b.number_of_participants_in_this_band(100)).to eq(0)
+        expect(band_c.number_of_participants_in_this_band(100)).to eq(0)
+        expect(band_a.number_of_participants_in_this_band(2000)).to eq(2000)
+        expect(band_b.number_of_participants_in_this_band(2000)).to eq(0)
+        expect(band_c.number_of_participants_in_this_band(2000)).to eq(0)
+        expect(band_a.number_of_participants_in_this_band(2001)).to eq(2000)
+        expect(band_b.number_of_participants_in_this_band(2001)).to eq(1)
+        expect(band_c.number_of_participants_in_this_band(2001)).to eq(0)
+        expect(band_a.number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(band_b.number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(band_c.number_of_participants_in_this_band(10_000)).to eq(6000)
+      }
+    end
+
   end
 
-  describe "ranges" do
-    it {
-      expect(band_a.number_of_participants_in_this_band(100)).to eq(100)
-      expect(band_b.number_of_participants_in_this_band(100)).to eq(0)
-      expect(band_c.number_of_participants_in_this_band(100)).to eq(0)
-      expect(band_a.number_of_participants_in_this_band(2000)).to eq(2000)
-      expect(band_b.number_of_participants_in_this_band(2000)).to eq(0)
-      expect(band_c.number_of_participants_in_this_band(2000)).to eq(0)
-      expect(band_a.number_of_participants_in_this_band(2001)).to eq(2000)
-      expect(band_b.number_of_participants_in_this_band(2001)).to eq(1)
-      expect(band_c.number_of_participants_in_this_band(2001)).to eq(0)
-      expect(band_a.number_of_participants_in_this_band(10_000)).to eq(2000)
-      expect(band_b.number_of_participants_in_this_band(10_000)).to eq(2000)
-      expect(band_c.number_of_participants_in_this_band(10_000)).to eq(6000)
-    }
+  context "with revised recruitment target" do
+    let(:call_off_contract) { create(:call_off_contract) }
+
+    %i[band_b additional band_a band_c_with_additional].each do |band|
+      create(:participant_band, band, call_off_contract: call_off_contract)
+    end
+
+    describe "associations" do
+      it { is_expected.to belong_to(:call_off_contract) }
+    end
+
+    describe "ranges" do
+      it "uses only the first band if there are enough participants" do
+        expect(bands[0].number_of_participants_in_this_band(100)).to eq(100)
+        expect(bands[1].number_of_participants_in_this_band(100)).to eq(0)
+        expect(bands[2].number_of_participants_in_this_band(100)).to eq(0)
+        expect(bands[3].number_of_participants_in_this_band(100)).to eq(0)
+      end
+
+      it "fills band_a only if there are enough participants for just band_a" do
+        expect(band_a.number_of_participants_in_this_band(2000)).to eq(2000)
+        expect(band_b.number_of_participants_in_this_band(2000)).to eq(0)
+        expect(band_c.number_of_participants_in_this_band(2000)).to eq(0)
+        expect(band_d.number_of_participants_in_this_band(2000)).to eq(0)
+      end
+
+      it "fills band_a only if there are enough participants for just band_a" do
+        expect(band_a.number_of_participants_in_this_band(2001)).to eq(2000)
+        expect(band_b.number_of_participants_in_this_band(2001)).to eq(1)
+        expect(band_c.number_of_participants_in_this_band(2001)).to eq(0)
+        expect(band_a.number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(band_b.number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(band_c.number_of_participants_in_this_band(10_000)).to eq(500)
+        expect(band_d.number_of_participants_in_this_band(10_000)).to eq(600)
+      end
+    end
   end
 end

--- a/spec/models/participant_band_spec.rb
+++ b/spec/models/participant_band_spec.rb
@@ -5,46 +5,63 @@ require "rails_helper"
 RSpec.describe ParticipantBand, type: :model do
   context "without revision of recruitment target" do
     let(:call_off_contract) { create(:call_off_contract) }
-
-    %i[band_c band_a band_b].each do |band|
-      create(:participant_band, band, call_off_contract: call_off_contract)
-    end
+    let(:bands) { call_off_contract.bands }
 
     describe "associations" do
       it { is_expected.to belong_to(:call_off_contract) }
     end
 
     describe "ranges" do
-      it {
-        expect(band_a.number_of_participants_in_this_band(100)).to eq(100)
-        expect(band_b.number_of_participants_in_this_band(100)).to eq(0)
-        expect(band_c.number_of_participants_in_this_band(100)).to eq(0)
-        expect(band_a.number_of_participants_in_this_band(2000)).to eq(2000)
-        expect(band_b.number_of_participants_in_this_band(2000)).to eq(0)
-        expect(band_c.number_of_participants_in_this_band(2000)).to eq(0)
-        expect(band_a.number_of_participants_in_this_band(2001)).to eq(2000)
-        expect(band_b.number_of_participants_in_this_band(2001)).to eq(1)
-        expect(band_c.number_of_participants_in_this_band(2001)).to eq(0)
-        expect(band_a.number_of_participants_in_this_band(10_000)).to eq(2000)
-        expect(band_b.number_of_participants_in_this_band(10_000)).to eq(2000)
-        expect(band_c.number_of_participants_in_this_band(10_000)).to eq(6000)
-      }
-    end
+      it "orders the bands appropriately regardless of creation order" do
+        expect(bands[0].min).to be_nil
+        expect(bands[1].min).to eq(bands[0].max + 1)
+        expect(bands[2].min).to eq(bands[1].max + 1)
+        expect(bands[2].max).to be_nil
+        expect(bands[3]).to be_nil
+      end
 
+      it "uses only the first band if there are only enough participants for this band" do
+        expect(bands[0].number_of_participants_in_this_band(100)).to eq(100)
+        expect(bands[1].number_of_participants_in_this_band(100)).to eq(0)
+        expect(bands[2].number_of_participants_in_this_band(100)).to eq(0)
+        expect(bands[0].number_of_participants_in_this_band(2000)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(2000)).to eq(0)
+        expect(bands[2].number_of_participants_in_this_band(2000)).to eq(0)
+      end
+
+      it "uses the first two bands if there are only enough participants for the first two bands" do
+        expect(bands[0].number_of_participants_in_this_band(2001)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(2001)).to eq(1)
+        expect(bands[2].number_of_participants_in_this_band(2001)).to eq(0)
+      end
+
+      it "uses three bands if there are enough participants for the first two bands" do
+        expect(bands[0].number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(bands[2].number_of_participants_in_this_band(10_000)).to eq(6000)
+      end
+    end
   end
 
   context "with revised recruitment target" do
-    let(:call_off_contract) { create(:call_off_contract) }
-
-    %i[band_b additional band_a band_c_with_additional].each do |band|
-      create(:participant_band, band, call_off_contract: call_off_contract)
-    end
+    let(:call_off_contract) { create(:call_off_contract, recruitment_target: 4500, revised_target: 5100) }
+    let(:bands) { call_off_contract.bands }
 
     describe "associations" do
       it { is_expected.to belong_to(:call_off_contract) }
     end
 
     describe "ranges" do
+      it "orders the bands appropriately regardless of creation order" do
+        expect(bands[0].min).to be_nil
+        expect(bands[1].min).to eq(bands[0].max + 1)
+        expect(bands[2].min).to eq(bands[1].max + 1)
+        expect(bands[2].max).to eq(call_off_contract.recruitment_target)
+        expect(bands[3].min).to eq(bands[2].max + 1)
+        expect(bands[3].max).to eq(call_off_contract.revised_target)
+        expect(bands[4]).to be_nil
+      end
+
       it "uses only the first band if there are enough participants" do
         expect(bands[0].number_of_participants_in_this_band(100)).to eq(100)
         expect(bands[1].number_of_participants_in_this_band(100)).to eq(0)
@@ -52,21 +69,32 @@ RSpec.describe ParticipantBand, type: :model do
         expect(bands[3].number_of_participants_in_this_band(100)).to eq(0)
       end
 
-      it "fills band_a only if there are enough participants for just band_a" do
-        expect(band_a.number_of_participants_in_this_band(2000)).to eq(2000)
-        expect(band_b.number_of_participants_in_this_band(2000)).to eq(0)
-        expect(band_c.number_of_participants_in_this_band(2000)).to eq(0)
-        expect(band_d.number_of_participants_in_this_band(2000)).to eq(0)
+      it "fills bands[0] only if there are enough participants for just bands[0]" do
+        expect(bands[0].number_of_participants_in_this_band(2000)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(2000)).to eq(0)
+        expect(bands[2].number_of_participants_in_this_band(2000)).to eq(0)
+        expect(bands[3].number_of_participants_in_this_band(2000)).to eq(0)
       end
 
-      it "fills band_a only if there are enough participants for just band_a" do
-        expect(band_a.number_of_participants_in_this_band(2001)).to eq(2000)
-        expect(band_b.number_of_participants_in_this_band(2001)).to eq(1)
-        expect(band_c.number_of_participants_in_this_band(2001)).to eq(0)
-        expect(band_a.number_of_participants_in_this_band(10_000)).to eq(2000)
-        expect(band_b.number_of_participants_in_this_band(10_000)).to eq(2000)
-        expect(band_c.number_of_participants_in_this_band(10_000)).to eq(500)
-        expect(band_d.number_of_participants_in_this_band(10_000)).to eq(600)
+      it "populates bands[1] if there are enough participants for bands[0] + bands[1]" do
+        expect(bands[0].number_of_participants_in_this_band(2001)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(2001)).to eq(1)
+        expect(bands[2].number_of_participants_in_this_band(2001)).to eq(0)
+        expect(bands[3].number_of_participants_in_this_band(2000)).to eq(0)
+      end
+
+      it "fills bands[1] if there are enough participants for just bands[0] + bands[1]" do
+        expect(bands[0].number_of_participants_in_this_band(4000)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(4000)).to eq(2000)
+        expect(bands[2].number_of_participants_in_this_band(4000)).to eq(0)
+        expect(bands[3].number_of_participants_in_this_band(4000)).to eq(0)
+      end
+
+      it "fills all the bands but no more if there are more participants than the revised recruitment target" do
+        expect(bands[0].number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(bands[1].number_of_participants_in_this_band(10_000)).to eq(2000)
+        expect(bands[2].number_of_participants_in_this_band(10_000)).to eq(500)
+        expect(bands[3].number_of_participants_in_this_band(10_000)).to eq(600)
       end
     end
   end

--- a/spec/models/participant_band_spec.rb
+++ b/spec/models/participant_band_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ParticipantBand, type: :model do
         expect(bands[0].number_of_participants_in_this_band(2001)).to eq(2000)
         expect(bands[1].number_of_participants_in_this_band(2001)).to eq(1)
         expect(bands[2].number_of_participants_in_this_band(2001)).to eq(0)
-        expect(bands[3].number_of_participants_in_this_band(2000)).to eq(0)
+        expect(bands[3].number_of_participants_in_this_band(2001)).to eq(0)
       end
 
       it "fills bands[1] if there are enough participants for just bands[0] + bands[1]" do

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -23,19 +23,19 @@ RSpec.describe CalculationOrchestrator do
   let(:service_fees) do
     [
       {
-        band: "A",
+        band: 0,
         participants: 2000,
         monthly: 22_287.90,
         per_participant: 323.17,
       },
       {
-        band: "B",
+        band: 1,
         participants: 0,
         monthly: 0.0,
         per_participant: 391.60,
       },
       {
-        band: "C",
+        band: 2,
         participants: 0,
         monthly: 0.0,
         per_participant: 386.40,
@@ -45,19 +45,19 @@ RSpec.describe CalculationOrchestrator do
   let(:output_payments) do
     [
       {
-        band: "A",
+        band: 0,
         participants: 10,
         per_participant: 119.40,
         subtotal: 1194.0,
       },
       {
-        band: "B",
+        band: 1,
         participants: 0,
         per_participant: 117.48,
         subtotal: 0.0,
       },
       {
-        band: "C",
+        band: 2,
         participants: 0,
         per_participant: 115.92,
         subtotal: 0.0,

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CalculationOrchestrator do
       name: "Lead Provider",
       participants: 10,
       recruitment_target: 2000,
+      revised_target: nil,
     }
   end
   let(:ect_focussed_headings) do


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-440

New banding rules are applicable to some lead providers who have been issued with revised target
This change reflects the changes to banding to support these.

1. The variable amount has changed from a fixed calculation of 60% to a variable one depending on the band, so has been moved to the DB.
2. An optional revised target which has been added to the call_off_contract as a 2nd target (with a 2% uplifted top level). NOTE: There is currently no cap on the existing 3rd band, but this may be revised too. The existing code will cope with this too if it becomes something that we set as the max value in the database. (which appears likely)
3. Output display has become conditional depending on whether the provider has contracted a revised target or not.

## Tech review

### Is there anything that the code reviewer should know?

Viewable to the finance user in the payment breakdown and contract screens.
Rake task for payment calculation has been updated to support this.
Banding strings have been moved to indexes and we're using I18n to look them up for both the rake task and breakdown pages.


### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
