### PR TITLE
Allow eligible status in ECFParticipantEligiblilty

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -101,7 +101,6 @@ module Participants
       if participant_profile.ecf_participant_eligibility&.eligible_status? ||
           participant_profile.ecf_participant_eligibility&.matched_status?
         # Probably successful - show success message.
-        # TODO CPDRP-884: change line above to be eligible_status?
         # Will become: TRN has been validated, qts, no flags, not done before, no previous induction
         render_completed_page
       else

--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -98,7 +98,8 @@ module Participants
 
     def complete
       @school = participant_profile.school
-      if participant_profile.ecf_participant_eligibility&.matched_status?
+      if participant_profile.ecf_participant_eligibility&.eligible_status? ||
+          participant_profile.ecf_participant_eligibility&.matched_status?
         # Probably successful - show success message.
         # TODO CPDRP-884: change line above to be eligible_status?
         # Will become: TRN has been validated, qts, no flags, not done before, no previous induction

--- a/app/models/ecf_participant_eligibility.rb
+++ b/app/models/ecf_participant_eligibility.rb
@@ -18,9 +18,7 @@ class ECFParticipantEligibility < ApplicationRecord
                   elsif !qts?
                     :matched
                   else
-                    # NOTE: this should be :eligible here but we are putting
-                    # everyone in the holding pen until we have the data to validate further
-                    :matched
+                    :eligible
                   end
   end
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -67,8 +67,10 @@ class ParticipantSerializer
     trn(user).nil? ? nil : validated_trn(user).present?
   end
 
-  active_participant_attribute :eligible_for_funding do |user|
-    user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible_status? || nil
+  active_participant_attribute :eligible_for_funding do |_user|
+    nil
+    # TODO: we want to check eligibility without communicating it yet
+    # user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible_status? || nil
   end
 
   active_participant_attribute :pupil_premium_uplift do |user|

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -67,10 +67,11 @@ class ParticipantSerializer
     trn(user).nil? ? nil : validated_trn(user).present?
   end
 
-  active_participant_attribute :eligible_for_funding do |_user|
-    nil
-    # TODO: we want to check eligibility without communicating it yet
-    # user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible_status? || nil
+  active_participant_attribute :eligible_for_funding do |user|
+    # TODO: we want to check eligibility without communicating it yet - except for sandbox
+    if Rails.env.sandbox?
+      user.teacher_profile.ecf_profile.ecf_participant_eligibility&.eligible_status? || nil
+    end
   end
 
   active_participant_attribute :pupil_premium_uplift do |user|

--- a/app/services/validate_participant.rb
+++ b/app/services/validate_participant.rb
@@ -24,13 +24,16 @@ class ValidateParticipant < BaseService
     @eligibility_data = store_eligibility_data!(validation_result)
     store_trn_on_teacher_profile!(validation_result[:trn])
 
-    if @eligibility_data.eligible_status?
-      remove_validation_data!
-    else
-      # store validation data for manual re-check later
-      # if different TRN already exists or not eligible
-      store_validation_data!
-    end
+    # TODO: remove the validation data once we have the complete set of
+    # previous induction participants from the full API to validate against.
+    # if @eligibility_data.eligible_status?
+    #   remove_validation_data!
+    # else
+    #   # store validation data for manual re-check later
+    #   # if different TRN already exists or not eligible
+    #   store_validation_data!
+    # end
+    store_validation_data!
     true
   rescue StandardError => e
     Rails.logger.error("Problem with DQT API: " + e.message)

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -187,8 +187,8 @@ module ParticipantValidationSteps
   def then_i_should_see_the_complete_page_for_matched_user
     then_i_should_see_the_complete_page
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_matched_status
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_present
   end
 
   def then_i_should_see_the_complete_page_for_matched_cip_ect_participant
@@ -196,8 +196,8 @@ module ParticipantValidationSteps
     expect(page).to have_text("We may need to contact you for more information to complete your registration.")
     expect(page).to have_text("We’ll email you a link to access your materials within the next 24 hours.")
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_matched_status
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_present
   end
 
   def then_i_should_see_the_complete_page_for_matched_cip_mentor_participant
@@ -206,8 +206,8 @@ module ParticipantValidationSteps
     expect(page).not_to have_text("Your training materials will be available by the end of August. We’ll email you with a link to access them.")
     expect(page).to have_text("If you need access to materials, we’ll email you a link within the next 24 hours.")
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_matched_status
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_present
   end
 
   def then_i_should_see_the_checking_details_page

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -188,7 +188,7 @@ module ParticipantValidationSteps
     then_i_should_see_the_complete_page
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
   end
 
   def then_i_should_see_the_complete_page_for_matched_cip_ect_participant
@@ -197,7 +197,7 @@ module ParticipantValidationSteps
     expect(page).to have_text("We’ll email you a link to access your materials within the next 24 hours.")
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
   end
 
   def then_i_should_see_the_complete_page_for_matched_cip_mentor_participant
@@ -207,7 +207,7 @@ module ParticipantValidationSteps
     expect(page).to have_text("If you need access to materials, we’ll email you a link within the next 24 hours.")
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
-    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).not_to be_present
+    expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_validation_data).to be_present
   end
 
   def then_i_should_see_the_checking_details_page

--- a/spec/jobs/validation_retry_job_spec.rb
+++ b/spec/jobs/validation_retry_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "ValidationRetryJob" do
         validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
         allow(validator).to receive(:validate)
           .with(participant_data.merge(config: { check_first_name_only: true }))
-          .and_return({ trn: participant_data[:trn], qts: true, active_alert: false })
+          .and_return({ trn: participant_data[:trn], qts: true, active_alert: false, previous_induction: true })
       end
 
       it "rechecks the eligibility" do
@@ -36,7 +36,7 @@ RSpec.describe "ValidationRetryJob" do
         ValidationRetryJob.new.perform
         expect(validation_data.reload.api_failure).to be false
         expect(validation_data.participant_profile.ecf_participant_eligibility).to be_present
-        expect(validation_data.participant_profile.ecf_participant_eligibility.status).to eql "matched"
+        expect(validation_data.participant_profile.ecf_participant_eligibility.status).to eql "manual_check"
         expect(validation_data.participant_profile.teacher_profile.trn).to eql "1234567"
       end
 

--- a/spec/models/ecf_participant_eligibility_spec.rb
+++ b/spec/models/ecf_participant_eligibility_spec.rb
@@ -58,13 +58,10 @@ RSpec.describe ECFParticipantEligibility, type: :model do
     end
 
     context "when QTS status is true and no other flags are set" do
-      # NOTE: this is the holding pen functionality to make all requests
-      # go via a manual validation until we have more supporting data
-      # This scenario should set the status to :eligible otherwise
-      it "sets the status to matched" do
+      it "sets the status to eligible" do
         eligibility.qts = true
         eligibility.valid?
-        expect(eligibility).to be_matched_status
+        expect(eligibility).to be_eligible_status
       end
     end
   end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe ParticipantSerializer do
       end
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":null}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":null}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end
@@ -87,11 +87,12 @@ RSpec.describe ParticipantSerializer do
           eligibility.eligible_status!
         end
 
-        it "returns true" do
+        # TODO: this should be true once we no longer hide the eligibility status
+        it "returns nil" do
           expect(ect_profile.ecf_participant_eligibility.status).to eql "eligible"
 
           result = ParticipantSerializer.new(ect).serializable_hash
-          expect(result[:data][:attributes][:eligible_for_funding]).to be true
+          expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
         end
       end
     end

--- a/spec/services/validate_participant_spec.rb
+++ b/spec/services/validate_participant_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ValidateParticipant do
             .and_return(eligible_record)
         end
 
-        it "does not save the validation data" do
+        xit "does not save the validation data" do
           service.call(participant_profile: participant_profile, validation_data: request_data)
           expect(participant_profile.reload.ecf_participant_validation_data).to be_nil
         end

--- a/spec/services/validate_participant_spec.rb
+++ b/spec/services/validate_participant_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe ValidateParticipant do
       it "creates an eligibility record for the participant" do
         service.call(participant_profile: participant_profile, validation_data: request_data)
         eligibility = participant_profile.reload.ecf_participant_eligibility
-        expect(eligibility).to be_matched_status
+        expect(eligibility).to be_eligible_status
       end
 
       context "when the participant is not eligible" do
@@ -194,7 +194,7 @@ RSpec.describe ValidateParticipant do
 
       it "updates the eligibility data" do
         service.call(participant_profile: participant_profile, validation_data: request_data)
-        expect(existing_eligibility.reload).to be_matched_status
+        expect(existing_eligibility.reload).to be_eligible_status
         expect(existing_eligibility.previous_participation).to be false
       end
 


### PR DESCRIPTION
## Ticket and context

Enable the `:eligible` status to be set in `ECFParticipantEligibility` instead of forcing the status to `:matched`. Ensure that this is still handled in the validations controller as though it were `:matched` status. This is to enable us to get a picture of who will successfully validate and the different outcomes that will need to be handled.

## Tech review
When we have matched the participants TRN, the qts flag is set and there are no other flags, the eligibility status should be `:eligible`.  In this instance we should delete/not store the validation data, however as this is not complete yet, we need to hang on to the personal data needed to re-run validation against the participant once it is complete.

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
