### PR TITLE
CPDEL-829 Add two new emails to send in the first round of NQT+1 invites

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -16,8 +16,9 @@ class SchoolMailer < ApplicationMailer
   COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE = "e7a60b68-334e-4a25-8adf-55ebc70622f9"
   COORDINATOR_REMINDER_TO_CHOOSE_MATERIALS_EMAIL_TEMPLATE = "43baf25c-6a46-437b-9f30-77c57d68a59e"
   ADD_PARTICIPANTS_EMAIL_TEMPLATE = "721787d0-74bc-42a0-a064-ee0c1cb58edb"
-  YEAR2020_INVITE_EMAIL_TEMPLATE = "d4b53e26-4630-43a5-b89e-3c668061a41c"
   BASIC_TEMPLATE = "b1ab542e-a8d5-4fdf-a7aa-f0ce49b98262"
+  NQT_PLUS_ONE_SITLESS_EMAIL_TEMPLATE = "c10392e4-9d75-402d-a7fd-47df16fa6082"
+  NQT_PLUS_ONE_SIT_EMAIL_TEMPLATE = "9e01b5ac-a94c-4c71-a38d-6502d7c4c2e7"
 
   def remind_induction_coordinator_to_setup_cohort_email(recipient:, school_name:, campaign: nil)
     campaign_tracking = campaign ? UTMService.email(campaign, campaign) : {}
@@ -268,18 +269,6 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def year2020_invite_email(recipient:, start_url:)
-    template_mail(
-      YEAR2020_INVITE_EMAIL_TEMPLATE,
-      to: recipient,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        start_url: start_url,
-      },
-    )
-  end
-
   def year2020_add_participants_confirmation(school:, participants:)
     @school = school
     @participants = participants
@@ -291,6 +280,30 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       template_name: :year2020_ects_added_confirmation,
+    )
+  end
+
+  def nqt_plus_one_sitless_invite(recipient:, start_url:)
+    template_mail(
+      NQT_PLUS_ONE_SITLESS_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        start_url: start_url,
+      },
+    )
+  end
+
+  def nqt_plus_one_sit_invite(recipient:, start_url:)
+    template_mail(
+      NQT_PLUS_ONE_SIT_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        start_url: start_url,
+      },
     )
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -60,6 +60,10 @@ class School < ApplicationRecord
     left_outer_joins(:school_cohorts).where(school_cohorts: { cohort_id: [cohort.id, nil], opt_out_of_updates: [false, nil] })
   }
 
+  scope :opted_out, lambda { |cohort = Cohort.current|
+    joins(:school_cohorts).where(school_cohorts: { cohort_id: cohort.id, opt_out_of_updates: true })
+  }
+
   def partnered?(cohort)
     partnerships.unchallenged.where(cohort: cohort).any?
   end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -16,7 +16,6 @@ class UTMService
     choose_provider: "choose-provider",
     choose_materials: "choose-materials",
     add_participants: "add-participants",
-    year2020_nqt_invite: "year2020-nqt-invite",
     participant_validation_beta: "participant-validation-beta",
     participant_validation_research: "participant-validation-research",
     participant_validation_sit_notification: "participant-validation-sit-notification",
@@ -27,6 +26,8 @@ class UTMService
     induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
     sit_to_complete_steps: "sit-to-complete-steps",
+    year2020_nqt_invite_school: "year2020-nqt-invite-school",
+    year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -41,7 +42,6 @@ class UTMService
     choose_provider: "choose-provider",
     choose_materials: "choose-materials",
     add_participants: "add-participants",
-    year2020_nqt_invite: "year2020-nqt-invite",
     participant_validation_beta: "participant-validation-beta",
     participant_validation_research: "participant-validation-research",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
@@ -51,6 +51,8 @@ class UTMService
     induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
     sit_to_complete_steps: "sit-to-complete-steps",
+    year2020_nqt_invite_school: "year2020-nqt-invite-school",
+    year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -148,4 +148,32 @@ RSpec.describe SchoolMailer, type: :mailer do
       expect(year2020_add_participants_confirmation.from).to eq(["mail@example.com"])
     end
   end
+
+  describe "nqt_plus_one_sitless_invite" do
+    let(:email) do
+      SchoolMailer.nqt_plus_one_sitless_invite(
+        recipient: "hello@example.com",
+        start_url: "www.example.com",
+      ).deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(email.to).to eq(["hello@example.com"])
+      expect(email.from).to eq(["mail@example.com"])
+    end
+  end
+
+  describe "nqt_plus_one_sit_invite" do
+    let(:email) do
+      SchoolMailer.nqt_plus_one_sit_invite(
+        recipient: "hello@example.com",
+        start_url: "www.example.com",
+      ).deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(email.to).to eq(["hello@example.com"])
+      expect(email.from).to eq(["mail@example.com"])
+    end
+  end
 end


### PR DESCRIPTION
This includes eligible, opted-out schools and SITs

Remove the old year2020 invite email, this template will no longer be used

## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-829

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
