### PR TITLE
CPDTP-280 Limit uplift payments

### DIFF
--- a/app/models/call_off_contract.rb
+++ b/app/models/call_off_contract.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
 class CallOffContract < ApplicationRecord
-  has_many :participant_bands
   belongs_to :lead_provider
+  delegate :total_contract_value, to: :bands
+  has_many :participant_bands do
+    def total_contract_value
+      map(&:contract_value).reduce(&:+)
+    end
+  end
+
+  def uplift_cap
+    total_contract_value * 0.05
+  end
 
   def band_a
     bands.first

--- a/app/models/participant_band.rb
+++ b/app/models/participant_band.rb
@@ -16,6 +16,10 @@ class ParticipantBand < ApplicationRecord
     end
   end
 
+  def contract_value
+    number_of_participants_in_this_band(recruitment_target) * per_participant
+  end
+
   def output_payment_per_participant
     (per_participant * output_payment_percantage) / 100
   end

--- a/app/services/participant_event_aggregator.rb
+++ b/app/services/participant_event_aggregator.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ParticipantEventAggregator
+  class << self
+    def call(cpd_lead_provider:, recorder: ParticipantDeclaration::ECF, event_type: started)
+      new(cpd_lead_provider: cpd_lead_provider, recorder: recorder).call(event_type: event_type)
+    end
+  end
+
+  def call(event_type: :started)
+    aggregations(event_type: event_type)
+  end
+
+private
+
+  attr_reader :cpd_lead_provider, :recorder
+
+  def initialize(cpd_lead_provider:, recorder: ParticipantDeclaration::ECF)
+    @cpd_lead_provider = cpd_lead_provider
+    @recorder = recorder
+  end
+
+  def aggregators(event_type:)
+    @aggregators ||= Hash.new { |hash, key| hash[key] = aggregate(aggregation_type: key, event_type: event_type) }
+  end
+
+  def aggregate(aggregation_type:, event_type:)
+    recorder.send(aggregation_types[event_type][aggregation_type], cpd_lead_provider).count
+  end
+
+  def aggregation_types
+    {
+      started: {
+        all: :payable_for_lead_provider,
+        uplift: :payable_uplift_for_lead_provider,
+        ects: :payable_ects_for_lead_provider,
+        mentors: :payable_mentors_for_lead_provider,
+      },
+    }
+  end
+
+  def aggregations(event_type:)
+    aggregation_types[event_type].keys.index_with do |key|
+      aggregators(event_type: event_type)[key]
+    end
+  end
+end

--- a/lib/payment_calculator/ecf/contract/uplift_payment_calculations.rb
+++ b/lib/payment_calculator/ecf/contract/uplift_payment_calculations.rb
@@ -12,7 +12,7 @@ module PaymentCalculator
           include HasDIParameters
         end
 
-        delegate :uplift_amount, to: :contract
+        delegate :uplift_amount, :uplift_cap, to: :contract
 
         def uplift_payment_per_participant
           uplift_amount
@@ -23,7 +23,7 @@ module PaymentCalculator
         end
 
         def uplift_payment_for_event(uplift_participants:, event_type:)
-          uplift_participants * uplift_payment_per_participant_for_event(event_type: event_type)
+          [uplift_participants * uplift_payment_per_participant_for_event(event_type: event_type), uplift_cap].min
         end
       end
     end

--- a/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentCalculator::ECF::Contract::UpliftPaymentCalculations do
+  let(:dummy_class) { Class.new { include PaymentCalculator::ECF::Contract::UpliftPaymentCalculations } }
+  let(:call_off_contract) { create(:call_off_contract) }
+  let(:calculator) { dummy_class.new({ contract: call_off_contract }) }
+
+  context "when condition" do
+    it "returns the uplift_payment_per_participant" do
+      expect(calculator.uplift_payment_per_participant).to eq(100)
+    end
+
+    it "returns the expected uplift_payment_per_participant for a each event type" do
+      expect(calculator.uplift_payment_per_participant_for_event(event_type: :started)).to eq(100)
+      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_1)).to eq(0)
+      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_2)).to eq(0)
+      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_3)).to eq(0)
+      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_4)).to eq(0)
+      expect(calculator.uplift_payment_per_participant_for_event(event_type: :completed)).to eq(0)
+    end
+
+    it "returns a capped uplift_payment_for_events when the total exceeds 5% of the total contract value" do
+      expect(calculator.uplift_payment_for_event(uplift_participants: 10_000, event_type: :started)).to eq(99_500)
+    end
+  end
+end

--- a/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
+++ b/spec/lib/payment_calculator/ecf/contract/uplift_payment_calculations_spec.rb
@@ -7,22 +7,20 @@ RSpec.describe PaymentCalculator::ECF::Contract::UpliftPaymentCalculations do
   let(:call_off_contract) { create(:call_off_contract) }
   let(:calculator) { dummy_class.new({ contract: call_off_contract }) }
 
-  context "when condition" do
-    it "returns the uplift_payment_per_participant" do
-      expect(calculator.uplift_payment_per_participant).to eq(100)
-    end
+  it "returns the uplift_payment_per_participant" do
+    expect(calculator.uplift_payment_per_participant).to eq(100)
+  end
 
-    it "returns the expected uplift_payment_per_participant for a each event type" do
-      expect(calculator.uplift_payment_per_participant_for_event(event_type: :started)).to eq(100)
-      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_1)).to eq(0)
-      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_2)).to eq(0)
-      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_3)).to eq(0)
-      expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_4)).to eq(0)
-      expect(calculator.uplift_payment_per_participant_for_event(event_type: :completed)).to eq(0)
-    end
+  it "returns the expected uplift_payment_per_participant for a each event type" do
+    expect(calculator.uplift_payment_per_participant_for_event(event_type: :started)).to eq(100)
+    expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_1)).to eq(0)
+    expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_2)).to eq(0)
+    expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_3)).to eq(0)
+    expect(calculator.uplift_payment_per_participant_for_event(event_type: :retained_4)).to eq(0)
+    expect(calculator.uplift_payment_per_participant_for_event(event_type: :completed)).to eq(0)
+  end
 
-    it "returns a capped uplift_payment_for_events when the total exceeds 5% of the total contract value" do
-      expect(calculator.uplift_payment_for_event(uplift_participants: 10_000, event_type: :started)).to eq(99_500)
-    end
+  it "returns a capped uplift_payment_for_events when the total exceeds 5% of the total contract value" do
+    expect(calculator.uplift_payment_for_event(uplift_participants: 10_000, event_type: :started)).to eq(99_500)
   end
 end

--- a/spec/models/call_off_contract_spec.rb
+++ b/spec/models/call_off_contract_spec.rb
@@ -8,8 +8,16 @@ RSpec.describe CallOffContract, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:participant_bands) }
 
-    it "is expected to have band_a with nil as the lowest min value" do
-      expect(call_off_contract.band_a.min).to eq(nil)
+    it "is expected to have band_a with the lowest minimum value" do
+      expect(call_off_contract.band_a.min.to_i).to eq(0)
+    end
+
+    it "is expected to have a total contract value" do
+      expect(call_off_contract.total_contract_value).to eq(2000 * 995) # recruitment_target * per_participant
+    end
+
+    it "is expected to have an uplift cap of 5% of the total contract value" do
+      expect(call_off_contract.uplift_cap).to eq(99_500.0)
     end
   end
 end

--- a/spec/models/call_off_contract_spec.rb
+++ b/spec/models/call_off_contract_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe CallOffContract, type: :model do
   let(:call_off_contract) { create(:call_off_contract) }
+  let(:total_contract_value) { call_off_contract.recruitment_target * call_off_contract.band_a.per_participant }
 
   describe "associations" do
     it { is_expected.to have_many(:participant_bands) }
@@ -13,11 +14,11 @@ RSpec.describe CallOffContract, type: :model do
     end
 
     it "is expected to have a total contract value" do
-      expect(call_off_contract.total_contract_value).to eq(2000 * 995) # recruitment_target * per_participant
+      expect(call_off_contract.total_contract_value).to eq(total_contract_value) # recruitment_target * per_participant
     end
 
     it "is expected to have an uplift cap of 5% of the total contract value" do
-      expect(call_off_contract.uplift_cap).to eq(99_500.0)
+      expect(call_off_contract.uplift_cap).to eq(total_contract_value * 0.05)
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: 

Calculate the total contract value from the participants in the target * the price per band for each band.
Limit the uplift to 5% of this (currently a hardcoded value)

## Tech review

### Is there anything that the code reviewer should know?

Split out the aggregator from the calculator again for a couple of reasons.

1. It's becoming big enough to be independent and will be more so when it will need to capture "paid" historic numbers to reconcile against future milestones and stories.
2. Doing it now, rather than when 1 becomes an issue make is easier to test the uplift cap without needing to seed the database.

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
