### PR TITLE
Fix for dynamic dates in Percy

### DIFF
--- a/spec/features/schools/dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/dashboard/manage_fip_training_spec.rb
@@ -6,6 +6,10 @@ require_relative "./manage_training_steps"
 RSpec.describe "Manage FIP training", js: true, with_feature_flags: { induction_tutor_manage_participants: "active" } do
   include ManageTrainingSteps
 
+  before { freeze_dynamic_dates_or_times_for_percy }
+
+  after { return_from_timecop }
+
   scenario "FIP Induction Coordinator with training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator

--- a/spec/features/schools/dashboard/manage_training_steps.rb
+++ b/spec/features/schools/dashboard/manage_training_steps.rb
@@ -3,6 +3,14 @@
 module ManageTrainingSteps
   include Capybara::DSL
 
+  def freeze_dynamic_dates_or_times_for_percy
+    Timecop.freeze(Time.zone.local(2021, 9, 17, 16, 15, 0))
+  end
+
+  def return_from_timecop
+    Timecop.return
+  end
+
   def given_there_is_a_school_that_has_chosen_fip_for_2021
     @cohort = create(:cohort, start_year: 2021)
     @school = create(:school, name: "Fip School")


### PR DESCRIPTION
## Ticket and context
A recent ticket introduced feature specs that sent screenshots to Percy. Some of the views had dynamic dates. This PR is to freeze dates within the feature specs causing the problem.

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
