### PR TITLE
Fix special character display in firefox

### DIFF
--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
+    <%= tag :meta, charset: 'utf-8' %>
     <% if Rails.env.to_s.in? Sentry.configuration.enabled_environments %>
       <%= tag :meta, name: :release, content: Sentry.configuration.release %>
       <%= tag :meta, name: :"sentry-dsn", content: Sentry.configuration.dsn.to_s %>
@@ -15,7 +16,6 @@
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= tag :meta, charset: 'utf-8' %>
     <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>


### PR DESCRIPTION
Firefox requires charset to appear in first 1024 bytes of response. Move the meta tag to the top of the layout to fix this. Report: https://ukgovernmentdigital.slack.com/archives/C0Q2PT1S9/p1632134954402500

![image](https://user-images.githubusercontent.com/40488007/134013720-484fc4aa-11f2-41e7-805f-dd55b1d79436.png)

![image](https://user-images.githubusercontent.com/40488007/134013731-c1aa5b31-1187-4c05-ba8e-dfaa68dd9c0a.png)
