### PR TITLE
Change the participant_serializer to use cached uplift

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -72,11 +72,11 @@ class ParticipantSerializer
   end
 
   active_participant_attribute :pupil_premium_uplift do |user|
-    user.teacher_profile.ecf_profile&.school&.pupil_premium_uplift?(user.teacher_profile.ecf_profile.cohort.start_year)
+    user.teacher_profile.ecf_profile&.pupil_premium_uplift
   end
 
   active_participant_attribute :sparsity_uplift do |user|
-    user.teacher_profile.ecf_profile&.school&.sparsity_uplift?(user.teacher_profile.ecf_profile.cohort.start_year)
+    user.teacher_profile.ecf_profile&.sparsity_uplift
   end
 
   active_participant_attribute :training_status do |user|

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe ParticipantSerializer do
 
       context "when participant belongs to a school" do
         context "eligible pupil premium uplift" do
-          before { create(:pupil_premium, :eligible, school: ect.school) }
+          before { ect_profile.update!(pupil_premium_uplift: true) }
 
           it "returns true" do
             expect(result[:data][:attributes][:pupil_premium_uplift]).to be true
@@ -211,29 +211,15 @@ RSpec.describe ParticipantSerializer do
         end
 
         context "not eligible pupil premium uplift" do
-          before { create(:pupil_premium, :not_eligible, school: ect.school) }
+          before { ect_profile.update!(pupil_premium_uplift: false) }
 
-          it "returns false" do
-            expect(result[:data][:attributes][:pupil_premium_uplift]).to be false
-          end
-        end
-
-        context "previously eligible for pupil premium uplift " do
-          before { create(:pupil_premium, :eligible, start_year: 2020, school: ect.school) }
-
-          it "returns false" do
-            expect(result[:data][:attributes][:pupil_premium_uplift]).to be false
-          end
-        end
-
-        context "no pupil premium record" do
           it "returns false" do
             expect(result[:data][:attributes][:pupil_premium_uplift]).to be false
           end
         end
 
         context "eligible sparsity uplift" do
-          before { create(:school_local_authority_district, :sparse, school: ect.school) }
+          before { ect_profile.update!(sparsity_uplift: true) }
 
           it "returns true" do
             expect(result[:data][:attributes][:sparsity_uplift]).to be true
@@ -241,24 +227,7 @@ RSpec.describe ParticipantSerializer do
         end
 
         context "not eligible sparsity uplift" do
-          before { create(:school_local_authority_district, school: ect.school) }
-
-          it "returns false" do
-            expect(result[:data][:attributes][:sparsity_uplift]).to be false
-          end
-        end
-
-        context "no sparsity uplift record" do
-          it "returns false" do
-            expect(result[:data][:attributes][:sparsity_uplift]).to be false
-          end
-        end
-
-        context "previously eligible for sparsity uplift" do
-          before do
-            district = create(:local_authority_district, district_sparsities: [create(:district_sparsity, start_year: 2020, end_year: 2021)])
-            create(:school_local_authority_district, local_authority_district: district, school: ect.school, start_year: 2020, end_year: 2021)
-          end
+          before { ect_profile.update!(sparsity_uplift: false) }
 
           it "returns false" do
             expect(result[:data][:attributes][:sparsity_uplift]).to be false


### PR DESCRIPTION
Context: https://ukgovernmentdfe.slack.com/archives/D021MT22UEL/p1632147075009000

This should also fix the N+1 query on the endpoint: https://sentry.io/organizations/dfe-bat/performance/early-careers-framework:690e901e4b274632af4c4664b578b1cf/?project=5748989&query=transaction.duration%3A%3C15m+transaction.op%3Arails.request+event.type%3Atransaction+http.method%3AGET&statsPeriod=24h&transaction=Api%3A%3AV1%3A%3AParticipantsController%23index&unselectedSeries=p100%28%29