### PR TITLE
Guard against unpermitted params in participants api

### DIFF
--- a/app/services/participants/base.rb
+++ b/app/services/participants/base.rb
@@ -31,6 +31,8 @@ module Participants
     def initialize(params:)
       params.each do |param, value|
         send("#{param}=", value)
+      rescue NoMethodError
+        raise ActionController::UnpermittedParameters, ["Unpermitted parameter: #{param}"]
       end
     end
 

--- a/app/services/participants/base.rb
+++ b/app/services/participants/base.rb
@@ -29,11 +29,9 @@ module Participants
     implement_instance_method :participant_profile_state, :perform_action!, :matches_lead_provider?
 
     def initialize(params:)
-      params.each do |param, value|
-        send("#{param}=", value)
-      rescue NoMethodError
-        raise ActionController::UnpermittedParameters, ["Unpermitted parameter: #{param}"]
-      end
+      self.participant_id = params[:participant_id]
+      self.course_identifier = params[:course_identifier]
+      self.cpd_lead_provider = params[:cpd_lead_provider]
     end
 
     def validate_provider!

--- a/app/services/participants/change_schedule/base.rb
+++ b/app/services/participants/change_schedule/base.rb
@@ -4,7 +4,7 @@ require "abstract_interface"
 
 module Participants
   module ChangeSchedule
-    class Base < ::Participants::Base
+    class Base < Participants::Base
     private
 
       def initialize(params:)

--- a/app/services/participants/change_schedule/base.rb
+++ b/app/services/participants/change_schedule/base.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "abstract_interface"
+
+module Participants
+  module ChangeSchedule
+    class Base < ::Participants::Base
+    private
+
+      def initialize(params:)
+        super(params: params)
+        self.schedule_identifier = params[:schedule_identifier]
+      end
+    end
+  end
+end

--- a/app/services/participants/change_schedule/ecf.rb
+++ b/app/services/participants/change_schedule/ecf.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module ChangeSchedule
-    class ECF < ::Participants::Base
+    class ECF < Base
       include Participants::ECF
       include ValidateAndChangeSchedule
     end

--- a/app/services/participants/change_schedule/npq.rb
+++ b/app/services/participants/change_schedule/npq.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module ChangeSchedule
-    class NPQ < ::Participants::Base
+    class NPQ < Base
       include Participants::NPQ
       include ValidateAndChangeSchedule
     end

--- a/app/services/participants/defer/base.rb
+++ b/app/services/participants/defer/base.rb
@@ -4,7 +4,7 @@ require "abstract_interface"
 
 module Participants
   module Defer
-    class Base < ::Participants::Base
+    class Base < Participants::Base
     private
 
       def initialize(params:)

--- a/app/services/participants/defer/base.rb
+++ b/app/services/participants/defer/base.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "abstract_interface"
+
+module Participants
+  module Defer
+    class Base < ::Participants::Base
+    private
+
+      def initialize(params:)
+        super(params: params)
+        self.reason = params[:reason]
+      end
+    end
+  end
+end

--- a/app/services/participants/defer/ecf.rb
+++ b/app/services/participants/defer/ecf.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module Defer
-    class ECF < ::Participants::Base
+    class ECF < Base
       class << self
         def reasons
           %w[

--- a/app/services/participants/defer/npq.rb
+++ b/app/services/participants/defer/npq.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module Defer
-    class NPQ < ::Participants::Base
+    class NPQ < Base
       class << self
         def reasons
           %w[

--- a/app/services/participants/resume/base.rb
+++ b/app/services/participants/resume/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "abstract_interface"
+
+module Participants
+  module Resume
+    class Base < ::Participants::Base; end
+  end
+end

--- a/app/services/participants/resume/base.rb
+++ b/app/services/participants/resume/base.rb
@@ -4,6 +4,6 @@ require "abstract_interface"
 
 module Participants
   module Resume
-    class Base < ::Participants::Base; end
+    class Base < Participants::Base; end
   end
 end

--- a/app/services/participants/resume/ecf.rb
+++ b/app/services/participants/resume/ecf.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module Resume
-    class ECF < ::Participants::Base
+    class ECF < Base
       include Participants::ECF
       include ValidateAndChangeState
     end

--- a/app/services/participants/resume/npq.rb
+++ b/app/services/participants/resume/npq.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module Resume
-    class NPQ < ::Participants::Base
+    class NPQ < Base
       include Participants::NPQ
       include ValidateAndChangeState
     end

--- a/app/services/participants/withdraw/base.rb
+++ b/app/services/participants/withdraw/base.rb
@@ -4,7 +4,7 @@ require "abstract_interface"
 
 module Participants
   module Withdraw
-    class Base < ::Participants::Base
+    class Base < Participants::Base
     private
 
       def initialize(params:)

--- a/app/services/participants/withdraw/base.rb
+++ b/app/services/participants/withdraw/base.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "abstract_interface"
+
+module Participants
+  module Withdraw
+    class Base < ::Participants::Base
+    private
+
+      def initialize(params:)
+        super(params: params)
+        self.reason = params[:reason]
+      end
+    end
+  end
+end

--- a/app/services/participants/withdraw/ecf.rb
+++ b/app/services/participants/withdraw/ecf.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module Withdraw
-    class ECF < ::Participants::Base
+    class ECF < Base
       class << self
         def reasons
           %w[

--- a/app/services/participants/withdraw/npq.rb
+++ b/app/services/participants/withdraw/npq.rb
@@ -2,7 +2,7 @@
 
 module Participants
   module Withdraw
-    class NPQ < ::Participants::Base
+    class NPQ < Base
       class << self
         def reasons
           %w[

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -6,8 +6,8 @@ module RecordDeclarations
   class Base
     include Participants::ProfileAttributes
     include AbstractInterface
-    implement_class_method :required_params
-    implement_instance_method :valid_declaration_types, :user_profile
+    implement_class_method :required_params, :valid_declaration_types
+    implement_instance_method :user_profile
 
     RFC3339_DATE_REGEX = /\A\d{4}-\d{2}-\d{2}T(\d{2}):(\d{2}):(\d{2})([\.,]\d+)?(Z|[+-](\d{2})(:?\d{2})?)?\z/i.freeze
 
@@ -48,11 +48,11 @@ module RecordDeclarations
   private
 
     def initialize(params)
-      params.each do |param, value|
-        send("#{param}=", value)
-      rescue NoMethodError
-        raise ActionController::UnpermittedParameters, ["Unpermitted parameter: #{param}"]
-      end
+      self.participant_id = params[:participant_id]
+      self.course_identifier = params[:course_identifier]
+      self.cpd_lead_provider = params[:cpd_lead_provider]
+      self.declaration_date = params[:declaration_date]
+      self.declaration_type = params[:declaration_type]
     end
 
     def parsed_date

--- a/app/services/record_declarations/retained.rb
+++ b/app/services/record_declarations/retained.rb
@@ -3,45 +3,5 @@
 module RecordDeclarations
   module Retained
     extend ActiveSupport::Concern
-
-    included do
-      attr_accessor :evidence_held
-      validates :evidence_held, presence: { message: I18n.t(:missing_evidence_held) }
-      validates :evidence_held, inclusion: { in: :valid_evidence_types, message: I18n.t(:invalid_evidence_type) }, allow_blank: true
-    end
-
-    def valid_evidence_types
-      self.class.valid_evidence_types
-    end
-
-    def create_declaration_attempt!
-      ParticipantDeclarationAttempt.create!(
-        course_identifier: course_identifier,
-        declaration_date: declaration_date,
-        declaration_type: declaration_type,
-        cpd_lead_provider: cpd_lead_provider,
-        user: user,
-        evidence_held: evidence_held,
-      )
-    end
-
-    def find_or_create_record!
-      ActiveRecord::Base.transaction do
-        self.class.declaration_model.find_or_create_by!(
-          course_identifier: course_identifier,
-          declaration_date: declaration_date,
-          declaration_type: declaration_type,
-          cpd_lead_provider: cpd_lead_provider,
-          user: user,
-          evidence_held: evidence_held,
-        ) do |participant_declaration|
-          profile_declaration = ProfileDeclaration.create!(
-            participant_declaration: participant_declaration,
-            participant_profile: user_profile,
-          )
-          profile_declaration.update!(payable: participant_declaration.currently_payable)
-        end
-      end
-    end
   end
 end

--- a/app/services/record_declarations/retained/base.rb
+++ b/app/services/record_declarations/retained/base.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "abstract_interface"
+
+module RecordDeclarations
+  module Retained
+    class Base < ::RecordDeclarations::Base
+      attr_accessor :evidence_held
+      validates :evidence_held, presence: { message: I18n.t(:missing_evidence_held) }
+      validates :evidence_held, inclusion: { in: :valid_evidence_types, message: I18n.t(:invalid_evidence_type) }, allow_blank: true
+
+    private
+
+      def initialize(params)
+        super(params)
+        self.evidence_held = params[:evidence_held]
+      end
+
+      def valid_evidence_types
+        self.class.valid_evidence_types
+      end
+
+      def create_declaration_attempt!
+        ParticipantDeclarationAttempt.create!(
+          course_identifier: course_identifier,
+          declaration_date: declaration_date,
+          declaration_type: declaration_type,
+          cpd_lead_provider: cpd_lead_provider,
+          user: user,
+          evidence_held: evidence_held,
+        )
+      end
+
+      def find_or_create_record!
+        ActiveRecord::Base.transaction do
+          self.class.declaration_model.find_or_create_by!(
+            course_identifier: course_identifier,
+            declaration_date: declaration_date,
+            declaration_type: declaration_type,
+            cpd_lead_provider: cpd_lead_provider,
+            user: user,
+            evidence_held: evidence_held,
+          ) do |participant_declaration|
+            profile_declaration = ProfileDeclaration.create!(
+              participant_declaration: participant_declaration,
+              participant_profile: user_profile,
+            )
+            profile_declaration.update!(payable: participant_declaration.currently_payable)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/record_declarations/retained/ecf.rb
+++ b/app/services/record_declarations/retained/ecf.rb
@@ -2,9 +2,8 @@
 
 module RecordDeclarations
   module Retained
-    class ECF < ::RecordDeclarations::Base
+    class ECF < Base
       include RecordDeclarations::ECF
-      include Retained
 
       class << self
         def valid_evidence_types

--- a/app/services/record_declarations/retained/npq.rb
+++ b/app/services/record_declarations/retained/npq.rb
@@ -2,10 +2,9 @@
 
 module RecordDeclarations
   module Retained
-    class NPQ < ::RecordDeclarations::Base
+    class NPQ < Base
       include Participants::NPQ
       include RecordDeclarations::NPQ
-      include Retained
 
       class << self
         def valid_evidence_types

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -154,11 +154,10 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t("activemodel.errors.models.record_declarations/base.attributes.participant_id.blank") }] }.to_json)
       end
 
-      it "returns 422 when sending an unpermitted parameter" do
-        missing_attribute = valid_params.merge(evidence_held: "test")
-        post "/api/v1/participant-declarations", params: build_params(missing_attribute)
-        expect(response.status).to eq 422
-        expect(response.body).to eq({ errors: [{ title: "Unpermitted parameters", detail: "Unpermitted parameter: evidence_held" }] }.to_json)
+      it "ignores an unpermitted parameter" do
+        post "/api/v1/participant-declarations", params: build_params(valid_params.merge(evidence_held: "test"))
+        expect(response.status).to eq 200
+        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
       end
 
       it "returns 422 when supplied an incorrect course type" do

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
       params = participant_params.merge({ course_identifier: "npq-leading-teacher" })
       expect { described_class.call(params: params) }.to raise_error(ActionController::ParameterMissing)
     end
+
+    it "fails when sending unpermitted parameters" do
+      params = participant_params.merge({ "": "null" })
+      expect { described_class.call(params: params) }.to raise_error(ActionController::UnpermittedParameters)
+    end
   end
 
   context "when user is not a participant" do

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -57,11 +57,6 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
       params = participant_params.merge({ course_identifier: "npq-leading-teacher" })
       expect { described_class.call(params: params) }.to raise_error(ActionController::ParameterMissing)
     end
-
-    it "fails when sending unpermitted parameters" do
-      params = participant_params.merge({ "": "null" })
-      expect { described_class.call(params: params) }.to raise_error(ActionController::UnpermittedParameters)
-    end
   end
 
   context "when user is not a participant" do

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
   end
 
   context "when including evidence_held" do
-    it "raised ParameterMissing error" do
+    it "ignores the extra parameter" do
       params = ect_params.merge(evidence_held: "self-study-material-completed")
-      expected_msg = /Unpermitted parameter: evidence_held/
-      expect { described_class.call(params) }.to raise_error(ActionController::UnpermittedParameters, expected_msg)
+      expect { described_class.call(params) }.to change { ParticipantDeclaration.count }.by(1).and change { ProfileDeclaration.count }.by(1)
+      expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
     end
   end
 


### PR DESCRIPTION
## Ticket and context

Someone sent us some unpermitted parameters on participant actions, and we don't want to 500 for that.

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Try to send a 'withdraw' request for a participant, sending an extra parameter along the way.
