### PR TITLE
CPDRP-973 Adjust mentor validation info chaser emails

### DIFF
--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -15,8 +15,7 @@ class ParticipantValidationMailer < ApplicationMailer
   COORDINATOR_AND_MENTOR_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
 
   ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
-  FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "691eb49b-f23f-49dd-b799-f8efdd5e010f"
-  CIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "e0198213-c09d-41aa-8197-b167e495e49d"
+  MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "e0198213-c09d-41aa-8197-b167e495e49d"
   INDUCTION_COORDINATORS_WHO_ARE_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
 
   STATUTORY_GUIDANCE_LINK = "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"
@@ -182,22 +181,9 @@ class ParticipantValidationMailer < ApplicationMailer
     )
   end
 
-  def fip_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
+  def mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
     template_mail(
-      FIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
-      to: recipient,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        school_name: school_name,
-        participant_start: start_url,
-      },
-    )
-  end
-
-  def cip_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
-    template_mail(
-      CIP_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
+      MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -20,14 +20,13 @@ class UTMService
     participant_validation_research: "participant-validation-research",
     participant_validation_sit_notification: "participant-validation-sit-notification",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
-    fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
-    cip_mentors_to_add_validation_information: "cip-mentors-to-add-validation-information",
     induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
     sit_to_complete_steps: "sit-to-complete-steps",
     year2020_nqt_invite_school: "year2020-nqt-invite-school",
     year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
     ect_validation_info_2109: "ect-validation-info-2109",
+    mentor_validation_info_2309: "mentor-validation-info-2309",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -45,14 +44,13 @@ class UTMService
     participant_validation_beta: "participant-validation-beta",
     participant_validation_research: "participant-validation-research",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
-    fip_mentors_to_add_validation_information: "fip-mentors-to-add-validation-information",
-    cip_mentors_to_add_validation_information: "cip-mentors-to-add-validation-information",
     induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
     asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
     sit_to_complete_steps: "sit-to-complete-steps",
     year2020_nqt_invite_school: "year2020-nqt-invite-school",
     year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
     ect_validation_info_2109: "ect-validation-info-2109",
+    mentor_validation_info_2309: "mentor-validation-info-2309",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/factories/school_cohort.rb
+++ b/spec/factories/school_cohort.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     trait :cip do
       induction_programme_choice { "core_induction_programme" }
     end
+
+    trait :school_funded_fip do
+      induction_programme_choice { "school_funded_fip" }
+    end
   end
 end

--- a/spec/mailers/participant_validation_mailer_spec.rb
+++ b/spec/mailers/participant_validation_mailer_spec.rb
@@ -161,24 +161,9 @@ RSpec.describe ParticipantValidationMailer, type: :mailer do
     end
   end
 
-  describe "#fip_mentors_to_add_validation_information_email" do
+  describe "#mentors_to_add_validation_information_email" do
     let(:email) do
-      described_class.fip_mentors_to_add_validation_information_email(
-        recipient: recipient,
-        school_name: school_name,
-        start_url: "example.com/start-validation",
-      )
-    end
-
-    it "renders the right headers" do
-      expect(email.from).to match_array ["mail@example.com"]
-      expect(email.to).to match_array [recipient]
-    end
-  end
-
-  describe "#cip_mentors_to_add_validation_information_email" do
-    let(:email) do
-      described_class.cip_mentors_to_add_validation_information_email(
+      described_class.mentors_to_add_validation_information_email(
         recipient: recipient,
         school_name: school_name,
         start_url: "example.com/start-validation",

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe ValidationBetaService do
     let!(:chosen_programme_mentor) do
       create(:participant_profile, :mentor, school: chosen_programme_school)
     end
+
     let!(:provided_validation_details_ect) do
       create(:participant_profile, :ect, :ecf_participant_validation_data, school: chosen_programme_school)
     end
@@ -180,16 +181,20 @@ RSpec.describe ValidationBetaService do
     end
   end
 
-  describe "#tell_fip_mentors_to_add_validation_information" do
+  describe "#tell_mentors_to_add_validation_information" do
     let(:chosen_programme_cohort) { create(:school_cohort, :fip) }
     let!(:chosen_programme_school) { chosen_programme_cohort.school }
 
     let!(:chosen_programme_mentor) do
       create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort)
     end
-    let!(:chosen_programme_mentor_already_received) do
-      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort, request_for_details_sent_at: Time.zone.now)
+    let!(:chosen_programme_mentor_already_received_before_automation_launch) do
+      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort, request_for_details_sent_at: Time.zone.parse("2021-09-16"))
     end
+    let!(:chosen_programme_mentor_already_received_after_automation_launch) do
+      create(:participant_profile, :mentor, school: chosen_programme_school, request_for_details_sent_at: Time.zone.now)
+    end
+
     let!(:chosen_programme_ect) do
       create(:participant_profile, :ect, school_cohort: chosen_programme_cohort)
     end
@@ -197,6 +202,13 @@ RSpec.describe ValidationBetaService do
     let!(:cip_chosen_programme_mentor) do
       create(:participant_profile, :mentor, school_cohort: create(:school_cohort, :cip))
     end
+    let!(:cip_chosen_programme_school) do
+      cip_chosen_programme_mentor.school_cohort.school
+    end
+
+    let!(:school_funded_fip_chosen_programme_mentor) do
+      create(:participant_profile, :mentor, school_cohort: create(:school_cohort, :school_funded_fip))
+    end
 
     let!(:provided_validation_details_mentor) do
       create(:participant_profile, :mentor, :ecf_participant_validation_data, school_cohort: chosen_programme_cohort)
@@ -208,147 +220,89 @@ RSpec.describe ValidationBetaService do
     let(:cohort_without_programme) { create :school_cohort, induction_programme_choice: "not_yet_known" }
     let!(:not_chosen_programme_mentor) { create(:participant_profile, :ect, school_cohort: cohort_without_programme) }
 
-    let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=fip-mentors-to-add-validation-information&utm_medium=email&utm_source=fip-mentors-to-add-validation-information" }
-
-    before do
-      validation_beta_service.tell_fip_mentors_to_add_validation_information
-    end
+    let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=mentor-validation-info-2309&utm_medium=email&utm_source=mentor-validation-info-2309" }
 
     it "emails FIP mentors that have chosen programme but have not provided details" do
-      expect(ParticipantValidationMailer).to delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).to delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
                                                        recipient: chosen_programme_mentor.user.email,
                                                        school_name: chosen_programme_school.name,
                                                        start_url: start_url,
                                                      )).once
-    end
-
-    it "doesn't email FIP mentors that have already received an invitation email" do
-      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
-                                               .with(hash_including(
-                                                       recipient: chosen_programme_mentor_already_received.user.email,
-                                                     )).once
-    end
-
-    it "doesn't email ECTs that have chosen programme but have not provided details" do
-      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
-                                               .with(hash_including(
-                                                       recipient: chosen_programme_ect.user.email,
-                                                     )).once
-    end
-
-    it "doesn't email CIP mentors that have chosen programme but have not provided details" do
-      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
-                                               .with(hash_including(
-                                                       recipient: cip_chosen_programme_mentor.user.email,
-                                                     )).once
-    end
-
-    it "doesn't email mentors that have not chosen programme" do
-      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
-                                               .with(hash_including(
-                                                       recipient: not_chosen_programme_mentor.user.email,
-                                                     ))
-    end
-
-    it "doesn't email mentors that have provided validation details" do
-      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
-                                               .with(hash_including(
-                                                       recipient: provided_validation_details_mentor.user.email,
-                                                     ))
-    end
-
-    it "doesn't email mentors that have provided eligibility details" do
-      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:fip_mentors_to_add_validation_information_email)
-                                               .with(hash_including(
-                                                       recipient: provided_eligibility_details_mentor.user.email,
-                                                     ))
-    end
-  end
-
-  describe "#tell_cip_mentors_to_add_validation_information" do
-    let(:chosen_programme_cohort) { create(:school_cohort, :cip) }
-    let!(:chosen_programme_school) { chosen_programme_cohort.school }
-
-    let!(:chosen_programme_mentor) do
-      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort)
-    end
-    let!(:chosen_programme_mentor_already_received) do
-      create(:participant_profile, :mentor, school_cohort: chosen_programme_cohort, request_for_details_sent_at: Time.zone.now)
-    end
-    let!(:chosen_programme_ect) do
-      create(:participant_profile, :ect, school_cohort: chosen_programme_cohort)
-    end
-
-    let!(:fip_chosen_programme_mentor) do
-      create(:participant_profile, :mentor, school_cohort: create(:school_cohort, :fip))
-    end
-
-    let!(:provided_validation_details_mentor) do
-      create(:participant_profile, :mentor, :ecf_participant_validation_data, school_cohort: chosen_programme_cohort)
-    end
-    let!(:provided_eligibility_details_mentor) do
-      create(:participant_profile, :mentor, :ecf_participant_eligibility, school_cohort: chosen_programme_cohort)
-    end
-
-    let(:cohort_without_programme) { create :school_cohort, induction_programme_choice: "not_yet_known" }
-    let!(:not_chosen_programme_mentor) { create(:participant_profile, :ect, school_cohort: cohort_without_programme) }
-
-    let(:start_url) { "http://www.example.com/participants/start-registration?utm_campaign=cip-mentors-to-add-validation-information&utm_medium=email&utm_source=cip-mentors-to-add-validation-information" }
-
-    before do
-      validation_beta_service.tell_cip_mentors_to_add_validation_information
     end
 
     it "emails CIP mentors that have chosen programme but have not provided details" do
-      expect(ParticipantValidationMailer).to delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).to delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
-                                                       recipient: chosen_programme_mentor.user.email,
+                                                       recipient: cip_chosen_programme_mentor.user.email,
+                                                       school_name: cip_chosen_programme_school.name,
+                                                       start_url: start_url,
+                                                     )).once
+    end
+
+    it "email mentors that have already received an invitation email before automation launch" do
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).to delay_email_delivery_of(:mentors_to_add_validation_information_email)
+                                               .with(hash_including(
+                                                       recipient: chosen_programme_mentor_already_received_before_automation_launch.user.email,
                                                        school_name: chosen_programme_school.name,
                                                        start_url: start_url,
                                                      )).once
     end
 
-    it "doesn't email CIP mentors that have already received an invitation email" do
-      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+    it "doesn't email mentors that have already received an invitation email after automation launch" do
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
-                                                       recipient: chosen_programme_mentor_already_received.user.email,
+                                                       recipient: chosen_programme_mentor_already_received_after_automation_launch.user.email,
                                                      )).once
     end
 
     it "doesn't email ECTs that have chosen programme but have not provided details" do
-      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
                                                        recipient: chosen_programme_ect.user.email,
                                                      )).once
     end
 
-    it "doesn't email FIP mentors that have chosen programme but have not provided details" do
-      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+    it "doesn't email non CIP/FIP mentors that have chosen programme but have not provided details" do
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).not_to delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
-                                                       recipient: fip_chosen_programme_mentor.user.email,
+                                                       recipient: school_funded_fip_chosen_programme_mentor.user.email,
                                                      )).once
     end
 
     it "doesn't email mentors that have not chosen programme" do
-      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
                                                        recipient: not_chosen_programme_mentor.user.email,
                                                      ))
     end
 
     it "doesn't email mentors that have provided validation details" do
-      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
                                                        recipient: provided_validation_details_mentor.user.email,
                                                      ))
     end
 
     it "doesn't email mentors that have provided eligibility details" do
-      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:cip_mentors_to_add_validation_information_email)
+      validation_beta_service.tell_mentors_to_add_validation_information
+      expect(ParticipantValidationMailer).to_not delay_email_delivery_of(:mentors_to_add_validation_information_email)
                                                .with(hash_including(
                                                        recipient: provided_eligibility_details_mentor.user.email,
                                                      ))
+    end
+
+    it "only emails the number of times specified by the limit" do
+      validation_beta_service.tell_mentors_to_add_validation_information(limit: 1)
+      expect(ParticipantValidationMailer).to delay_email_delivery_of(:mentors_to_add_validation_information_email).once
     end
   end
 


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-973

- Combine CIP and FIP templates into one email
- Add a limit so we only send a maximum of 5000 emails
- Update the utm campaign for this specific send including the date
- Allow resending of validation info emails if the mentor received one prior to the automation launch, similar to https://github.com/DFE-Digital/early-careers-framework/pull/1076

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
