### PR TITLE
CPDRP-958: Update chaser for SITs to choose a provider

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -13,7 +13,7 @@ class SchoolMailer < ApplicationMailer
   SECTION_41_INVITE_EMAIL_TEMPLATE = "a4ba1de4-e401-47f4-ac77-60c1da17a0e5"
   COORDINATOR_SIGN_IN_CHASER_EMAIL_TEMPLATE = "b5c318a4-2171-4ded-809a-af72dd87e7a7"
   COORDINATOR_REMINDER_TO_CHOOSE_ROUTE_EMAIL_TEMPLATE = "c939c27a-9951-4ac3-817d-56b7bf343fb4"
-  COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE = "e7a60b68-334e-4a25-8adf-55ebc70622f9"
+  COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE = "11cdb6d8-8a59-4618-ba35-0ebd7e47180c"
   COORDINATOR_REMINDER_TO_CHOOSE_MATERIALS_EMAIL_TEMPLATE = "43baf25c-6a46-437b-9f30-77c57d68a59e"
   ADD_PARTICIPANTS_EMAIL_TEMPLATE = "721787d0-74bc-42a0-a064-ee0c1cb58edb"
   BASIC_TEMPLATE = "b1ab542e-a8d5-4fdf-a7aa-f0ce49b98262"
@@ -228,17 +228,13 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def induction_coordinator_reminder_to_choose_provider_email(recipient:, name:, school_name:, sign_in_url:)
+  def induction_coordinator_reminder_to_choose_provider_email(recipient:)
     template_mail(
       COORDINATOR_REMINDER_TO_CHOOSE_PROVIDER_EMAIL_TEMPLATE,
       to: recipient,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
-      personalisation: {
-        name: name,
-        school_name: school_name,
-        sign_in_url: sign_in_url,
-      },
+      personalisation: {},
     )
   end
 

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -493,7 +493,7 @@ RSpec.describe InviteSchools do
       induction_coordinator = create_signed_in_induction_tutor
       create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "full_induction_programme", cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_provider_chasers
-      expect_choose_provider_email(induction_coordinator, induction_coordinator.schools.first)
+      expect_choose_provider_email(induction_coordinator)
     end
 
     it "does not email coordinators who have chosen providers for all their schools" do
@@ -509,20 +509,6 @@ RSpec.describe InviteSchools do
       create(:school_cohort, school: induction_coordinator.schools.first, induction_programme_choice: "core_induction_programme", cohort: cohort)
       InviteSchools.new.send_induction_coordinator_choose_provider_chasers
       expect(SchoolMailer).not_to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
-    end
-
-    it "uses the name of a school without a provider chosen" do
-      partnered_schools = create_list(
-        :school_cohort,
-        10,
-        induction_programme_choice: "full_induction_programme",
-        cohort: cohort,
-      ).map(&:school)
-      partnered_schools.each { |school| create(:partnership, school: school, cohort: cohort) }
-      target_school = create(:school_cohort, induction_programme_choice: "full_induction_programme", cohort: cohort).school
-      induction_coordinator = create(:user, :induction_coordinator, school_ids: [target_school.id, *partnered_schools.map(&:id)])
-      InviteSchools.new.send_induction_coordinator_choose_provider_chasers
-      expect_choose_provider_email(induction_coordinator, target_school)
     end
 
     it "sends one email per tutor" do
@@ -826,13 +812,11 @@ private
     )
   end
 
-  def expect_choose_provider_email(induction_coordinator, target_school)
-    expect_email(
-      :induction_coordinator_reminder_to_choose_provider_email,
-      induction_coordinator,
-      sign_in_url: String,
-      school_name: target_school.name,
-    )
+  def expect_choose_provider_email(induction_coordinator)
+    expect(SchoolMailer).to delay_email_delivery_of(:induction_coordinator_reminder_to_choose_provider_email)
+                              .with(hash_including(
+                                      recipient: induction_coordinator.email,
+                                    ))
   end
 
   def expect_choose_route_email(induction_coordinator, target_school)


### PR DESCRIPTION
## Ticket and context

Ticket: CPDRP-958

Another email ticket. This one had an existing method I adapted. The old template is now being deleted

## Tech review

### Is there anything that the code reviewer should know?
I've added `delivery_params` so that you can do for example `send_induction_coordinator_choose_provider_chasers(delivery_params: {wait_until: Time.zone.parse("2021-09-22T08:00Z")})`

This probably better than delaying the entire method call, because you won't accidentally email someone lots of times if there's an error and delayed_jobs retried. One thing to bear in mind though is that the information might be out of date by the time the email is sent, so it shouldn't be scheduled too far ahead

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests
