### PR TITLE
CPDTP-475: Schedule change validation

### DIFF
--- a/app/models/finance/schedule.rb
+++ b/app/models/finance/schedule.rb
@@ -7,15 +7,4 @@ class Finance::Schedule < ApplicationRecord
   def self.default
     find_by(name: "ECF September standard 2021")
   end
-
-  def milestone_for_declaration_type
-    {
-      "started" => milestones[0],
-      "retained-1" => milestones[1],
-      "retained-2" => milestones[2],
-      "retained-3" => milestones[3],
-      "retained-4" => milestones[4],
-      "completed" => milestones.last,
-    }
-  end
 end

--- a/app/models/finance/schedule.rb
+++ b/app/models/finance/schedule.rb
@@ -7,4 +7,15 @@ class Finance::Schedule < ApplicationRecord
   def self.default
     find_by(name: "ECF September standard 2021")
   end
+
+  def milestone_for_declaration_type
+    {
+      "started" => milestones[0],
+      "retained-1" => milestones[1],
+      "retained-2" => milestones[2],
+      "retained-3" => milestones[3],
+      "retained-4" => milestones[4],
+      "completed" => milestones.last,
+    }
+  end
 end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -21,17 +21,19 @@ class ParticipantDeclaration < ApplicationRecord
   scope :npq, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.npq_profiles) }
   scope :payable, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.where(payable: true)) }
   scope :unique_id, -> { select(:user_id).distinct }
+  scope :voided, -> { where.not(voided_at: nil) }
+  scope :not_voided, -> { where(voided_at: nil) }
 
   # Time dependent Range scopes
   scope :declared_as_between, ->(start_date, end_date) { where(declaration_date: start_date..end_date) }
   scope :submitted_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
 
   # Declaration aggregation scopes
-  scope :active_for_lead_provider, ->(lead_provider) { started.for_lead_provider(lead_provider).unique_id }
-  scope :active_ects_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).ect }
-  scope :active_mentors_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).mentor }
-  scope :active_npqs_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).npq }
-  scope :active_uplift_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).uplift }
+  scope :active_for_lead_provider, ->(lead_provider) { not_voided.started.for_lead_provider(lead_provider).unique_id }
+  scope :active_ects_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).ect }
+  scope :active_mentors_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).mentor }
+  scope :active_npqs_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).npq }
+  scope :active_uplift_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).uplift }
 
   scope :payable_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).payable }
   scope :payable_ects_for_lead_provider, ->(lead_provider) { active_ects_for_lead_provider(lead_provider).payable }

--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -29,6 +29,8 @@ module Participants
       end
 
       def schedule_valid_with_pending_declarations
+        return unless user_profile
+
         declarations = user_profile.participant_declarations.not_voided
         declarations.each do |declaration|
           milestone = schedule.milestone_for_declaration_type[declaration.declaration_type]

--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -33,12 +33,12 @@ module Participants
 
         declarations = user_profile.participant_declarations.not_voided
         declarations.each do |declaration|
-          milestone = schedule.milestone_for_declaration_type[declaration.declaration_type]
-          if declaration.declaration_date > milestone.start_date.beginning_of_day
+          milestone = schedule.milestones.find_by(declaration_type: declaration.declaration_type)
+          if declaration.declaration_date <= milestone.start_date.beginning_of_day
             errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
           end
 
-          if milestone.milestone_date.end_of_day >= declaration.declaration_date
+          if milestone.milestone_date.end_of_day < declaration.declaration_date
             errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
           end
         end

--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -35,11 +35,11 @@ module Participants
         declarations.each do |declaration|
           milestone = schedule.milestone_for_declaration_type[declaration.declaration_type]
           unless milestone.start_date.beginning_of_day < declaration.declaration_date
-            errors.add(:schedule_identifier, "Changing schedule would invalidate existing declarations. Please void them first.")
+            errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
           end
 
           unless declaration.declaration_date <= milestone.milestone_date.end_of_day
-            errors.add(:schedule_identifier, "Changing schedule would invalidate existing declarations. Please void them first.")
+            errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
           end
         end
       end

--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -34,11 +34,11 @@ module Participants
         declarations = user_profile.participant_declarations.not_voided
         declarations.each do |declaration|
           milestone = schedule.milestone_for_declaration_type[declaration.declaration_type]
-          unless milestone.start_date.beginning_of_day < declaration.declaration_date
+          if declaration.declaration_date > milestone.start_date.beginning_of_day
             errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
           end
 
-          unless declaration.declaration_date <= milestone.milestone_date.end_of_day
+          if milestone.milestone_date.end_of_day >= declaration.declaration_date
             errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
           end
         end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -130,18 +130,7 @@ module RecordDeclarations
         raise ActionController::ParameterMissing, I18n.t(:schedule_missing)
       end
 
-      declaration_to_milestone_map[declaration_type]
-    end
-
-    def declaration_to_milestone_map
-      {
-        "started" => schedule.milestones[0],
-        "retained-1" => schedule.milestones[1],
-        "retained-2" => schedule.milestones[2],
-        "retained-3" => schedule.milestones[3],
-        "retained-4" => schedule.milestones[4],
-        "completed" => schedule.milestones.last,
-      }
+      schedule.milestone_for_declaration_type[declaration_type]
     end
 
     def valid_declaration_types

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -111,11 +111,11 @@ module RecordDeclarations
     end
 
     def validate_milestone!
-      if parsed_date > milestone.start_date.beginning_of_day
+      if parsed_date <= milestone.start_date.beginning_of_day
         raise ActionController::ParameterMissing, I18n.t(:declaration_before_milestone_start)
       end
 
-      if milestone.milestone_date.end_of_day >= parsed_date
+      if milestone.milestone_date.end_of_day < parsed_date
         raise ActionController::ParameterMissing, I18n.t(:declaration_after_milestone_cutoff)
       end
     end
@@ -130,7 +130,7 @@ module RecordDeclarations
         raise ActionController::ParameterMissing, I18n.t(:schedule_missing)
       end
 
-      schedule.milestone_for_declaration_type[declaration_type]
+      schedule.milestones.find_by(declaration_type: declaration_type)
     end
 
     def valid_declaration_types

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -111,11 +111,11 @@ module RecordDeclarations
     end
 
     def validate_milestone!
-      unless milestone.start_date.beginning_of_day < parsed_date
+      if parsed_date > milestone.start_date.beginning_of_day
         raise ActionController::ParameterMissing, I18n.t(:declaration_before_milestone_start)
       end
 
-      unless parsed_date <= milestone.milestone_date.end_of_day
+      if milestone.milestone_date.end_of_day >= parsed_date
         raise ActionController::ParameterMissing, I18n.t(:declaration_after_milestone_cutoff)
       end
     end

--- a/app/views/lead_providers/guidance/release_notes.html.erb
+++ b/app/views/lead_providers/guidance/release_notes.html.erb
@@ -2,6 +2,9 @@
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l">22nd September 2021</h2>
+<p class="govuk-body-m">Prevent changing schedule if the new schedule makes existing pending declaration invalid.</p>
+
 <h2 class="govuk-heading-l">17th September 2021</h2>
 <p class="govuk-body-m">Add <code>GET /api/v1/participants/ecf</code> endpoint.</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
   invalid_course: "The property '#/course_identifier' must be an available course to '#/participant_id'"
   invalid_evidence_type: "The property '#/evidence_held' must be an available type to the event type and course type"
   invalid_schedule: "The property '#/schedule_identifier' must be present and correspond to a valid schedule"
+  schedule_invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
   withdrawn_participant: Cannot perform actions on a withdrawn participant
   declaration_on_incorrect_state: "The declaration on withdrawn or deferred participant can not be accepted"
   schedule_missing: "The participant does not have a schedule"

--- a/db/migrate/20210922082602_add_declaration_type_for_milestone.rb
+++ b/db/migrate/20210922082602_add_declaration_type_for_milestone.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeclarationTypeForMilestone < ActiveRecord::Migration[6.1]
+  def change
+    add_column :milestones, :declaration_type, :string
+  end
+end

--- a/db/migrate/20210922082603_populate_declaration_type_for_milestone.rb
+++ b/db/migrate/20210922082603_populate_declaration_type_for_milestone.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class PopulateDeclarationTypeForMilestone < ActiveRecord::Migration[6.1]
+  def up
+    Finance::Schedule.all.each do |schedule|
+      schedule.milestones[0]&.update!(declaration_type: "started")
+      schedule.milestones[1]&.update!(declaration_type: "retained-1")
+      schedule.milestones[2]&.update!(declaration_type: "retained-2")
+      schedule.milestones[3]&.update!(declaration_type: "retained-3")
+      schedule.milestones[4]&.update!(declaration_type: "retained-4")
+      schedule.milestones[5]&.update!(declaration_type: "completed")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_161312) do
+ActiveRecord::Schema.define(version: 2021_09_22_082603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -359,6 +359,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_161312) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.date "start_date"
+    t.string "declaration_type"
     t.index ["schedule_id"], name: "index_milestones_on_schedule_id"
   end
 

--- a/db/seeds/schedules.rb
+++ b/db/seeds/schedules.rb
@@ -3,12 +3,12 @@
 ecf_september_standard_2021 = Finance::Schedule.find_or_create_by!(name: "ECF September standard 2021")
 ecf_september_standard_2021.update!(schedule_identifier: "ecf-september-standard-2021")
 [
-  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
-  { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
-  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
 ].each do |hash|
   Finance::Milestone.find_or_create_by!(
     schedule: ecf_september_standard_2021,
@@ -16,18 +16,18 @@ ecf_september_standard_2021.update!(schedule_identifier: "ecf-september-standard
     start_date: hash[:start_date],
     milestone_date: hash[:milestone_date],
     payment_date: hash[:payment_date],
-  )
+  ).update!(declaration_type: hash[:declaration_type])
 end
 
 ecf_september_extended_2021 = Finance::Schedule.find_or_create_by!(name: "ECF September extended 2021")
 ecf_september_extended_2021.update!(schedule_identifier: "ecf-september-extended-2021")
 [
-  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30) },
-  { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
-  { name: "Output 5 – Retention Point 4", start_date: Date.new(2023, 5, 1), milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
-  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 11, 1), milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-1" },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-2" },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "retained-3" },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2023, 5, 1), milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30), declaration_type: "retained-4" },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 11, 1), milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31), declaration_type: "completed" },
 ].each do |hash|
   Finance::Milestone.find_or_create_by!(
     schedule: ecf_september_extended_2021,
@@ -35,18 +35,18 @@ ecf_september_extended_2021.update!(schedule_identifier: "ecf-september-extended
     start_date: hash[:start_date],
     milestone_date: hash[:milestone_date],
     payment_date: hash[:payment_date],
-  )
+  ).update!(declaration_type: hash[:declaration_type])
 end
 
 ecf_january_reduced_2021 = Finance::Schedule.find_or_create_by!(name: "ECF January reduced 2021")
 ecf_january_reduced_2021.update!(schedule_identifier: "ecf-january-reduced-2021")
 [
-  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-  { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31) },
-  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28) },
-  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "started" },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-1" },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
 ].each do |hash|
   Finance::Milestone.find_or_create_by!(
     schedule: ecf_january_reduced_2021,
@@ -54,18 +54,18 @@ ecf_january_reduced_2021.update!(schedule_identifier: "ecf-january-reduced-2021"
     start_date: hash[:start_date],
     milestone_date: hash[:milestone_date],
     payment_date: hash[:payment_date],
-  )
+  ).update!(declaration_type: hash[:declaration_type])
 end
 
 ecf_january_extended_2021 = Finance::Schedule.find_or_create_by!(name: "ECF January extended 2021")
 ecf_january_extended_2021.update!(schedule_identifier: "ecf-january-extended-2021")
 [
-  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-  { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31) },
-  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31) },
-  { name: "Output 5 – Retention Point 4", start_date: Date.new(2023, 5, 1), milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30) },
-  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 11, 1), milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31) },
+  { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "started" },
+  { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-1" },
+  { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-2" },
+  { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "retained-3" },
+  { name: "Output 5 – Retention Point 4", start_date: Date.new(2023, 5, 1), milestone_date: Date.new(2023, 10, 31), payment_date: Date.new(2023, 11, 30), declaration_type: "retained-4" },
+  { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 11, 1), milestone_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 31), declaration_type: "completed" },
 ].each do |hash|
   Finance::Milestone.find_or_create_by!(
     schedule: ecf_january_extended_2021,
@@ -73,5 +73,5 @@ ecf_january_extended_2021.update!(schedule_identifier: "ecf-january-extended-202
     start_date: hash[:start_date],
     milestone_date: hash[:milestone_date],
     payment_date: hash[:payment_date],
-  )
+  ).update!(declaration_type: hash[:declaration_type])
 end

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -3,16 +3,24 @@
 FactoryBot.define do
   factory :schedule, class: "Finance::Schedule" do
     name { "ECF September standard 2021" }
+    schedule_identifier { "ecf-september-standard-2021" }
 
     after(:create) do |schedule|
-      [Date.new(2021, 9, 1), Date.new(2021, 11, 1), Date.new(2022, 2, 1)].each do |start_date|
-        create(
-          :milestone,
+      [
+        { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 10, 31), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
+        { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
+        { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
+        { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
+        { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
+        { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
+      ].each do |hash|
+        Finance::Milestone.find_or_create_by!(
           schedule: schedule,
-          start_date: start_date,
-          milestone_date: start_date + 1.month,
-          payment_date: start_date + 2.months,
-        )
+          name: hash[:name],
+          start_date: hash[:start_date],
+          milestone_date: hash[:milestone_date],
+          payment_date: hash[:payment_date],
+        ).update!(declaration_type: hash[:declaration_type])
       end
     end
   end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe ParticipantSerializer do
       end
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":\"ecf-september-standard-2021\"}}}"
         expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":null}}}"
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":\"ecf-september-standard-2021\"}}}"
         expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
       end
     end

--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
     }
   end
 
-  before do
-    create(:schedule, schedule_identifier: "ecf-september-extended-2021")
-  end
+  let!(:extended_schedule) { create(:schedule, schedule_identifier: "ecf-september-extended-2021") }
 
   context "when lead providers don't match" do
     it "raises a ParameterMissing error" do
@@ -52,6 +50,25 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
     it "fails when course is for an npq-course" do
       params = participant_params.merge({ course_identifier: "npq-leading-teacher" })
       expect { described_class.call(params: params) }.to raise_error(ActionController::ParameterMissing)
+    end
+
+    it "fails when it would invalidate a non-voided declaration" do
+      start_date = ect_profile.schedule.milestones.first.start_date
+      declaration = create(:participant_declaration, declaration_date: start_date + 1.day, course_identifier: "ecf-induction", declaration_type: "started", cpd_lead_provider: cpd_lead_provider)
+      create(:profile_declaration, participant_declaration: declaration, participant_profile: ect_profile)
+      extended_schedule.milestones.each { |milestone| milestone.update!(start_date: milestone.start_date + 6.months, milestone_date: milestone.milestone_date + 6.months) }
+      expect { described_class.call(params: participant_params) }.to raise_error(ActionController::ParameterMissing)
+    end
+
+    it "changes the schedule on user's profile when it would invalidate a voided declaration" do
+      start_date = ect_profile.schedule.milestones.first.start_date
+      declaration = create(:participant_declaration, declaration_date: start_date + 1.day, course_identifier: "ecf-induction", declaration_type: "started", cpd_lead_provider: cpd_lead_provider)
+      create(:profile_declaration, participant_declaration: declaration, participant_profile: ect_profile)
+      declaration.void!
+      extended_schedule.milestones.each { |milestone| milestone.update!(start_date: milestone.start_date + 6.months, milestone_date: milestone.milestone_date + 6.months) }
+
+      described_class.call(params: participant_params)
+      expect(ect_profile.reload.schedule.schedule_identifier).to eq("ecf-september-extended-2021")
     end
   end
 

--- a/spec/services/record_declarations/retained/mentor_spec.rb
+++ b/spec/services/record_declarations/retained/mentor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RecordDeclarations::Retained::Mentor do
 
   let(:retained_params) { params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
   let(:retained_mentor_params) { mentor_params.merge(declaration_type: "retained-1", declaration_date: (milestone_start_date + 1.day).rfc3339) }
-  let(:milestone_start_date) { mentor_profile.schedule.milestones[1].start_date }
+  let(:milestone_start_date) { mentor_profile.schedule.milestones.find_by(declaration_type: "retained-1").start_date }
 
   before do
     travel_to milestone_start_date + 2.days

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
-  let(:cutoff_start_datetime) { ect_profile.schedule.milestones.first.start_date.beginning_of_day }
-  let(:cutoff_end_datetime) { ect_profile.schedule.milestones.first.milestone_date.end_of_day }
+  let(:cutoff_start_datetime) { ect_profile.schedule.milestones.find_by(declaration_type: "started").start_date.beginning_of_day }
+  let(:cutoff_end_datetime) { ect_profile.schedule.milestones.find_by(declaration_type: "started").milestone_date.end_of_day }
 
   before do
     travel_to cutoff_start_datetime + 2.days

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -4,7 +4,7 @@ RSpec.shared_context "lead provider profiles and courses" do
   # lead providers setup
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Unknown") }
-  let!(:default_schedule) { create(:schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-september-standard-2021") }
+  let!(:default_schedule) { create(:schedule) }
 
   # ECF setup
   let(:ecf_lead_provider) { cpd_lead_provider.lead_provider }

--- a/spec/shared/context/service_record_declaration_params.rb
+++ b/spec/shared/context/service_record_declaration_params.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "service record declaration params" do
-  let(:ect_declaration_date) { ect_profile.schedule.milestones.first.start_date + 1.day }
+  let(:ect_declaration_date) { ect_profile.schedule.milestones.find_by(declaration_type: "started").start_date + 1.day }
   let(:params) do
     {
       participant_id: ect_profile.user.id,
@@ -14,7 +14,7 @@ RSpec.shared_context "service record declaration params" do
   let(:ect_params) do
     params.merge({ cpd_lead_provider: cpd_lead_provider })
   end
-  let(:mentor_declaration_date) { mentor_profile.schedule.milestones.first.start_date + 1.day }
+  let(:mentor_declaration_date) { mentor_profile.schedule.milestones.find_by(declaration_type: "started").start_date + 1.day }
   let(:mentor_params) do
     ect_params.merge({ participant_id: mentor_profile.user.id, course_identifier: "ecf-mentor", declaration_date: mentor_declaration_date.rfc3339 })
   end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-475

If there is a pending (unprocessed) declaration, and the provider tries to change schedule, we want them to void it first. The common case is someone having a declaration in September and switching to a January start schedule - we don't think the declaration from September would make much sense for them.

## Tech review

### Is there anything that the code reviewer should know?

I added `voided` and `not_ voided` scopes to declarations because they were useful in this PR.

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Make a declaration in Septmber for a participant
3. Try changing their schedule to a January one
4. It should fail and tell you why

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes) - I guess I will add release notes
