### PR TITLE
BUGFIX: prevent NQT+1s from being sent validation invites

### DIFF
--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -85,6 +85,7 @@ module Schools
             email: participant[:email],
             school_cohort: school_cohort,
             mentor_profile_id: nil,
+            year_2020: true,
           )
         end
 

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -18,9 +18,13 @@ module EarlyCareerTeachers
 
         ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(ect_attributes)) do |profile|
           ParticipantProfileState.create!(participant_profile: profile)
-          ParticipantMailer.participant_added(participant_profile: profile).deliver_later
-          profile.update_column(:request_for_details_sent_at, Time.zone.now)
-          ParticipantDetailsReminderJob.schedule(profile)
+
+          unless @year_2020
+            ParticipantMailer.participant_added(participant_profile: profile).deliver_later
+            profile.update_column(:request_for_details_sent_at, Time.zone.now)
+            ParticipantDetailsReminderJob.schedule(profile)
+          end
+
           Analytics::ECFValidationService.upsert_record(profile)
         end
       end
@@ -30,11 +34,12 @@ module EarlyCareerTeachers
 
     attr_reader :full_name, :email, :school_cohort, :mentor_profile_id
 
-    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil)
+    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, year_2020: false)
       @full_name = full_name
       @email = email
       @school_cohort = school_cohort
       @mentor_profile_id = mentor_profile_id
+      @year_2020 = year_2020
     end
 
     def ect_attributes

--- a/spec/forms/schools/year2020_form_spec.rb
+++ b/spec/forms/schools/year2020_form_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Schools::Year2020Form, type: :model do
           email: participant.email,
           school_cohort: school_cohort,
           mentor_profile_id: nil,
+          year_2020: true,
         )
       end
     end


### PR DESCRIPTION
We're emailing NQT+1 s telling them they need to validate. We should not do this. This quick and dirty PR prevents that - it is a temporary solution to buy time for a better fix
