### PR TITLE
Redirect NQT+1 to no access page on sign in

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def participant_start_path(user)
-    return participants_no_access_path unless user.teacher_profile.participant_profiles.active_record.ecf.any?
+    return participants_no_access_path unless post_2020_ecf_participant?(user)
 
     participants_validation_start_path
   end
@@ -52,6 +52,10 @@ module ApplicationHelper
   end
 
 private
+
+  def post_2020_ecf_participant?(user)
+    (user.teacher_profile.ecf_profile&.school_cohort&.cohort&.start_year || 0) > 2020
+  end
 
   def induction_coordinator_mentor_path(user)
     profile = user.participant_profiles.active_record.mentors.first

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -19,7 +19,7 @@ module EarlyCareerTeachers
         ParticipantProfile::ECT.create!({ teacher_profile: teacher_profile, schedule: Finance::Schedule.default }.merge(ect_attributes)) do |profile|
           ParticipantProfileState.create!(participant_profile: profile)
 
-          unless @year_2020
+          unless year_2020
             ParticipantMailer.participant_added(participant_profile: profile).deliver_later
             profile.update_column(:request_for_details_sent_at, Time.zone.now)
             ParticipantDetailsReminderJob.schedule(profile)
@@ -32,7 +32,7 @@ module EarlyCareerTeachers
 
   private
 
-    attr_reader :full_name, :email, :school_cohort, :mentor_profile_id
+    attr_reader :full_name, :email, :school_cohort, :mentor_profile_id, :year_2020
 
     def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, year_2020: false)
       @full_name = full_name

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.profile_dashboard_path(participant_profile.user)).to eq("/participants/validation")
     end
 
-    it "returns something for NQT+1s" do
+    it "returns the no access path for NQT+1s" do
       expect(helper.profile_dashboard_path(year_2020_participant_profile.user)).to eq("/participants/no_access")
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   let(:school) { induction_coordinator.induction_coordinator_profile.schools.first }
   let!(:cohort) { create(:cohort, :current) }
   let(:participant_profile) { create(:participant_profile, :ect) }
+  let(:year_2020_participant_profile) { create(:participant_profile, :ect, school_cohort: build(:school_cohort, cohort: build(:cohort, start_year: 2020))) }
   let(:participant_school) { participant_profile.school }
   let(:lead_provider) { create(:user, :lead_provider) }
 
@@ -50,6 +51,10 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it "returns the validation start path" do
       expect(helper.profile_dashboard_path(participant_profile.user)).to eq("/participants/validation")
+    end
+
+    it "returns something for NQT+1s" do
+      expect(helper.profile_dashboard_path(year_2020_participant_profile.user)).to eq("/participants/no_access")
     end
 
     it "returns the dashboard path for lead providers" do
@@ -102,7 +107,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#service_name" do
-    context "when the curent path doesn't contain 'year-2020'" do
+    context "when the current path doesn't contain 'year-2020'" do
       it "displays the default service name" do
         helper.request.path = "/"
         expect(helper.service_name).to eq "Manage training for early career teachers"

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -78,6 +78,32 @@ RSpec.describe EarlyCareerTeachers::Create do
     expect(ParticipantDetailsReminderJob).to have_received(:schedule).with(profile)
   end
 
+  context "when creating a participant for 2020" do
+    it "does not schedule participant_added email" do
+      described_class.call(
+        email: user.email,
+        full_name: Faker::Name.name,
+        school_cohort: school_cohort,
+        year_2020: true,
+      )
+
+      expect(ParticipantMailer).not_to delay_email_delivery_of(:participant_added)
+    end
+
+    it "scheduled reminder email job" do
+      allow(ParticipantDetailsReminderJob).to receive(:schedule)
+
+      described_class.call(
+        email: user.email,
+        full_name: Faker::Name.name,
+        school_cohort: school_cohort,
+        year_2020: true,
+      )
+
+      expect(ParticipantDetailsReminderJob).not_to have_received(:schedule)
+    end
+  end
+
   context "when the user has an active participant profile" do
     before do
       create(:participant_profile, teacher_profile: create(:teacher_profile, user: user))


### PR DESCRIPTION
Attempt to prevent NQT+1 from validating by redirecting them to the no-access page on login. They could probably still validate if they knew the correct URL - are we concerned?

I've also cleaned up some of the changes from the related #1098 