### PR TITLE
BUGFIX: Find correct TRNs for people with 3/4 match

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -85,8 +85,8 @@ private
 
     # If a participant mistypes their TRN and enters someone else's, we should search by NINO instead
     # The API first matches by (mandatory) TRN, then by NINO if it finds no results. This works around that.
-    if trn_matches && trn != "0"
-      matching_record(trn: "0", nino: nino, full_name: full_name, dob: dob)
+    if trn_matches && trn != "1"
+      matching_record(trn: "1", nino: nino, full_name: full_name, dob: dob)
     end
   end
 end


### PR DESCRIPTION
The DQT has recently added a whole load of people with TRN 0. That breaks our system to find people who gave us the wrong TRN
