### PR TITLE
Add current_user class and id to our logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     head :ok
   end
 
+  def append_info_to_payload(payload)
+    super
+    payload[:current_user_class] = current_user&.class&.name
+    payload[:current_user_id] = current_user&.id
+  end
+
 private
 
   def previous_url_for_cookies_page

--- a/config/environments/deployed_development.rb
+++ b/config/environments/deployed_development.rb
@@ -116,6 +116,8 @@ Rails.application.configure do
     {
       params: event.payload[:params].except(*exceptions),
       exception: event.payload[:exception], # ["ExceptionClass", "the message"]
+      current_user_class: event.payload[:current_user_class],
+      current_user_id: event.payload[:current_user_id],
     }
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,6 +114,8 @@ Rails.application.configure do
     {
       params: event.payload[:params].except(*exceptions),
       exception: event.payload[:exception], # ["ExceptionClass", "the message"]
+      current_user_class: event.payload[:current_user_class],
+      current_user_id: event.payload[:current_user_id],
     }
   end
 

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -115,6 +115,8 @@ Rails.application.configure do
     {
       params: event.payload[:params].except(*exceptions),
       exception: event.payload[:exception], # ["ExceptionClass", "the message"]
+      current_user_class: event.payload[:current_user_class],
+      current_user_id: event.payload[:current_user_id],
     }
   end
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -112,6 +112,8 @@ Rails.application.configure do
     {
       params: event.payload[:params].except(*exceptions),
       exception: event.payload[:exception], # ["ExceptionClass", "the message"]
+      current_user_class: event.payload[:current_user_class],
+      current_user_id: event.payload[:current_user_id],
     }
   end
 


### PR DESCRIPTION
## Ticket and context

When we look at logs, it is useful to know who is causing them. So we can figure out what their state is in the db.

## Tech review

### Is there anything that the code reviewer should know?
I checked that the hook in application cntroller works.
I still need to test this in a review app, cause our logs work differently in local environment. Should hopefully work just fine.
