### PR TITLE
CPDEL-860 Add NQT+1 invite email for sitless non-opted-out schools

### DIFF
--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -265,6 +265,24 @@ class InviteSchools
     end
   end
 
+  def invite_sitless_not_opted_out_schools_for_nqt_plus_one
+    School
+      .eligible
+      .not_opted_out
+      .where.missing(:induction_coordinators)
+      .find_each do |school|
+        if school.contact_email.blank?
+          logger.info "No contact details for school urn: #{school.urn} ... skipping"
+          next
+        end
+
+        SchoolMailer.nqt_plus_one_sitless_invite(
+          recipient: school.contact_email,
+          start_url: year2020_start_url(school, utm_source: :year2020_nqt_invite_school_not_opted_out),
+        ).deliver_later
+      end
+  end
+
 private
 
   def private_beta_start_url

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -27,6 +27,7 @@ class UTMService
     year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
     ect_validation_info_2109: "ect-validation-info-2109",
     mentor_validation_info_2309: "mentor-validation-info-2309",
+    year2020_nqt_invite_school_not_opted_out: "year2020-nqt-invite-school-not-opted-out",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -51,6 +52,7 @@ class UTMService
     year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
     ect_validation_info_2109: "ect-validation-info-2109",
     mentor_validation_info_2309: "mentor-validation-info-2309",
+    year2020_nqt_invite_school_not_opted_out: "year2020-nqt-invite-school-not-opted-out",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -807,6 +807,67 @@ RSpec.describe InviteSchools do
     end
   end
 
+  describe "#invite_sitless_not_opted_out_schools_for_nqt_plus_one" do
+    it "sends an email to eligible non-opted out schools with induction coordindators" do
+      school = create(:school)
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             cohort: cohort,
+             opt_out_of_updates: false)
+
+      expected_url = "http://www.example.com/schools/#{school.friendly_id}/year-2020/support-materials-for-NQTs?utm_campaign=year2020-nqt-invite-school-not-opted-out&utm_medium=email&utm_source=year2020-nqt-invite-school-not-opted-out"
+
+      InviteSchools.new.invite_sitless_not_opted_out_schools_for_nqt_plus_one
+      expect(SchoolMailer).to delay_email_delivery_of(:nqt_plus_one_sitless_invite)
+                                .with(hash_including(
+                                        recipient: school.contact_email,
+                                        start_url: expected_url,
+                                      )).once
+    end
+
+    it "doesn't email ineligible schools" do
+      school = create(:school, :cip_only)
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             cohort: cohort,
+             core_induction_programme: nil,
+             opt_out_of_updates: false)
+
+      InviteSchools.new.invite_sitless_not_opted_out_schools_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sitless_invite)
+    end
+
+    it "doesn't email opted-out schools" do
+      school = create(:school)
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             cohort: cohort,
+             core_induction_programme: nil,
+             opt_out_of_updates: true)
+
+      InviteSchools.new.invite_sitless_not_opted_out_schools_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sitless_invite)
+    end
+
+    it "doesn't email schools with induction coordinators" do
+      school = create(:school)
+      ic_profile = build(:induction_coordinator_profile, schools: [school])
+      create(:user, induction_coordinator_profile: ic_profile)
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             cohort: cohort,
+             core_induction_programme: nil,
+             opt_out_of_updates: false)
+
+      InviteSchools.new.invite_sitless_not_opted_out_schools_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sitless_invite)
+    end
+  end
+
 private
 
   def create_signed_in_induction_tutor


### PR DESCRIPTION


## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDEL-860

- Only eligible schools
- not opted out
- only schools that haven't nominated an induction coordinator

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
