### PR TITLE
BugFix: Apply reverse logic to TRA previous induction list

### DIFF
--- a/app/services/check_participant_eligibility.rb
+++ b/app/services/check_participant_eligibility.rb
@@ -9,6 +9,21 @@ class CheckParticipantEligibility < BaseService
 
   def call
     ineligible_record = ECFIneligibleParticipant.find_by(trn: trn)
-    return ineligible_record.reason.to_sym if ineligible_record.present?
+
+    # logic is reversed in the data snapshot from TRA (:previous_induction)
+    # so if your TRN is present, you're valid
+    if ineligible_record.present?
+      case ineligible_record.reason.to_sym
+      when :previous_induction
+        # this is reversed and indicates that the TRN is eligible
+        nil
+      when :previous_induction_and_participation
+        :previous_participation
+      when :previous_participation
+        :previous_induction_and_participation
+      end
+    else
+      :previous_induction
+    end
   end
 end

--- a/spec/services/check_participant_eligibility_spec.rb
+++ b/spec/services/check_participant_eligibility_spec.rb
@@ -10,13 +10,29 @@ RSpec.describe CheckParticipantEligibility do
       let!(:ineligible_participant) { create(:ineligible_participant, trn: "1234567", reason: "previous_participation") }
 
       it "returns the ineligibility reason" do
-        expect(service.call(trn: "1234567")).to eq :previous_participation
+        expect(service.call(trn: "1234567")).to eq :previous_induction_and_participation
       end
     end
 
     context "when no matching ineligible participant record exists" do
+      it "returns previous_induction" do
+        expect(service.call(trn: "9876543")).to eq :previous_induction
+      end
+    end
+
+    context "when an previous_induction record exists" do
+      let!(:eligible_participant) { create(:ineligible_participant, trn: "1234567", reason: "previous_induction") }
+
       it "returns nil" do
-        expect(service.call(trn: "9876543")).to be_nil
+        expect(service.call(trn: "1234567")).to be_nil
+      end
+    end
+
+    context "when a previous_induction and previous_participation record exists" do
+      let!(:ineligible_participant) { create(:ineligible_participant, trn: "1234567", reason: "previous_induction_and_participation") }
+
+      it "returns previous_participation" do
+        expect(service.call(trn: "1234567")).to eq :previous_participation
       end
     end
   end

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe ParticipantValidationService do
 
     context "when the participant has previously had an induction" do
       before do
-        ECFIneligibleParticipant.find_by(trn: trn).destroy
+        ECFIneligibleParticipant.find_by(trn: trn).destroy!
         expect_any_instance_of(Dqt::Api::V1::DQTRecord).to receive(:show).and_return(dqt_record)
       end
 


### PR DESCRIPTION
## Ticket and context

Transpires that the "previous inductee" list we are using to validate participants against is, in fact, a list of eligible TRNs.
This PR reverses the logic when validating participants against the list, removing the previous_induction flag when present and adding the previous_induction flag when not present.
This will no doubt be superceded shortly by the API
 
## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
