### PR TITLE
noindex nqt plus 1 pages

### DIFF
--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -2,7 +2,7 @@
 
 module Schools
   class Year2020Controller < ApplicationController
-    before_action :set_headers
+    before_action :set_no_index_headers
     before_action :load_year_2020_form
     before_action :check_school_has_no_existing_2020_ects, except: %i[start cohort_already_have_access success]
     SESSION_KEY = :schools_year2020_form
@@ -112,7 +112,7 @@ module Schools
       params[:index].to_i
     end
 
-    def set_headers
+    def set_no_index_headers
       response.set_header("X-Robots-Tag", "noindex")
     end
   end

--- a/app/controllers/schools/year2020_controller.rb
+++ b/app/controllers/schools/year2020_controller.rb
@@ -2,6 +2,7 @@
 
 module Schools
   class Year2020Controller < ApplicationController
+    before_action :set_headers
     before_action :load_year_2020_form
     before_action :check_school_has_no_existing_2020_ects, except: %i[start cohort_already_have_access success]
     SESSION_KEY = :schools_year2020_form
@@ -109,6 +110,10 @@ module Schools
 
     def participant_index
       params[:index].to_i
+    end
+
+    def set_headers
+      response.set_header("X-Robots-Tag", "noindex")
     end
   end
 end

--- a/spec/controllers/schools/year2020_controller_spec.rb
+++ b/spec/controllers/schools/year2020_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Schools::Year2020Controller, type: :controller do

--- a/spec/controllers/schools/year2020_controller_spec.rb
+++ b/spec/controllers/schools/year2020_controller_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Schools::Year2020Controller, type: :controller do
+  let!(:school) { create :school }
+
+  describe "sets headers" do
+    it "robots are asked not to index" do
+      get :start, params: { school_id: school.slug }
+      expect(response.headers["X-Robots-Tag"]).to eq("noindex")
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: [855](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/89?selectedIssue=CPDEL-855)

We want to noindex nqt plus one pages so that they don't show in search engine results

I've had a look at what other DfE services do for this and there's a few different ways. I wanted eyes on it to know whether this is right/wrong. Happy to chat about how best to do this. 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

