### PR TITLE
BUGFIX: ensure schools are transitioned to FIP

### DIFF
--- a/app/services/partnerships/report.rb
+++ b/app/services/partnerships/report.rb
@@ -26,7 +26,7 @@ module Partnerships
 
         partnership.challenge_reason = partnership.challenged_at = nil
         partnership.delivery_partner_id = delivery_partner_id
-        partnership.pending = school_cohort.core_induction_programme?
+        partnership.pending = delay_partnership?
         partnership.challenge_deadline = CHALLENGE_WINDOW.from_now
         partnership.report_id = SecureRandom.uuid
         partnership.save!
@@ -54,6 +54,10 @@ module Partnerships
 
   private
 
+    def delay_partnership?
+      !school_cohort.full_induction_programme?
+    end
+
     attr_reader :cohort_id, :school_id, :lead_provider_id, :delivery_partner_id
 
     def school_cohort
@@ -69,10 +73,6 @@ module Partnerships
         cohort_id: cohort_id,
         induction_programme_choice: "full_induction_programme",
       )
-    end
-
-    def partnership_pending?
-      school_cohort.core_induction_programme?
     end
   end
 end


### PR DESCRIPTION
When a partnership is reported for a school who has chosen a provision
other than FIP, we should delay changing their delivery method by two
weeks to give them time to challenge. Because this logic was written
when the only options were CIP or FIP, schools who chose NoECTs or DIY
were left in a sort of limbo

