### PR TITLE
Fixed  issues with `.not_to permit_actions`

### DIFF
--- a/spec/policies/partnership_policy_spec.rb
+++ b/spec/policies/partnership_policy_spec.rb
@@ -8,24 +8,25 @@ RSpec.describe PartnershipPolicy, type: :policy do
   let(:user) { create(:user) }
   let(:partnership) { create :partnership }
 
-  it { is_expected.not_to permit_actions(%i[create show edit update]) }
+  it { is_expected.to forbid_actions(%i[create show edit update]) }
 
   context "being an induction coordinator from the partnership school" do
     let(:user) { create(:user, :induction_coordinator, schools: [partnership.school]) }
 
-    it { is_expected.to permit_action(:update) }
-    it { is_expected.not_to permit_actions(%i[create show edit]) }
+    it { is_expected.to permit_actions(%i[update edit]) }
+    it { is_expected.to forbid_actions(%i[create show]) }
   end
 
   context "being an induction coordinator from a different school" do
     let(:user) { create(:user, :induction_coordinator) }
 
-    it { is_expected.not_to permit_actions(%i[create show edit update]) }
+    it { is_expected.to forbid_actions(%i[create show edit update]) }
   end
 
   context "being an admin" do
     let(:user) { create(:user, :admin) }
 
-    it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_actions(%i[update edit]) }
+    it { is_expected.to forbid_actions(%i[create show]) }
   end
 end

--- a/spec/policies/school_cohort_policy.rb
+++ b/spec/policies/school_cohort_policy.rb
@@ -8,7 +8,7 @@ RSpec.describe SchoolCohortPolicy, type: :policy do
   let(:user) { create(:user) }
   let(:school_cohort) { create :school_cohort }
 
-  it { is_expected.not_to permit_actions(%i[info show edit update success]) }
+  it { is_expected.to forbid_actions(%i[info show edit update success]) }
 
   context "being an admin" do
     let(:user) { create(:user, :admin) }
@@ -20,7 +20,7 @@ RSpec.describe SchoolCohortPolicy, type: :policy do
     let(:user) { create(:user, :induction_coordinator) }
 
     context "but not coordinating given school" do
-      it { is_expected.not_to permit_actions(%i[info show edit update success]) }
+      it { is_expected.to forbid_actions(%i[info show edit update success]) }
     end
 
     context "coordinating induction for given school" do


### PR DESCRIPTION
```
        Using expect { }.not_to permit_actions could produce \
        confusing results. Please use `.to forbid_actions` instead. To \
        clarify, `.not_to permit_actions` will look at all of the actions and \
        checks if ANY actions fail, not if all actions fail. Therefore, you \
        could result in something like this: \

        it { is_expected.to permit_actions([:new, :create, :edit]) } \
        it { is_expected.not_to permit_actions([:edit, :destroy]) } \

        In this case, edit would be true and destroy would be false, but both \
        tests would pass.
```