### PR TITLE
Correct json api types in api docs

### DIFF
--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1069,7 +1069,7 @@
               "type": {
                 "description": "The data type",
                 "type": "string",
-                "example": "participant"
+                "example": "participant-change-schedule"
               },
               "attributes": {
                 "$ref": "#/components/schemas/ECFParticipantChangeSchedule"
@@ -1245,7 +1245,7 @@
               "type": {
                 "description": "The data type",
                 "type": "string",
-                "example": "participant"
+                "example": "participant-defer"
               },
               "attributes": {
                 "$ref": "#/components/schemas/ECFParticipantDefer"
@@ -1305,7 +1305,7 @@
               "type": {
                 "description": "The data type",
                 "type": "string",
-                "example": "participant"
+                "example": "participant-resume"
               },
               "attributes": {
                 "$ref": "#/components/schemas/ECFParticipantResume"
@@ -1479,7 +1479,7 @@
               "type": {
                 "description": "The data type",
                 "type": "string",
-                "example": "participant"
+                "example": "participant-withdraw"
               },
               "attributes": {
                 "$ref": "#/components/schemas/ECFParticipantWithdraw"
@@ -2349,7 +2349,7 @@
         ],
         "properties": {
           "id": {
-            "description": "The unique identifier of the participant record",
+            "description": "The unique identifier of the participant declaration record",
             "type": "string",
             "format": "uuid",
             "example": "cd3a12347-7308-4879-942a-c4a70ced400a"
@@ -2357,7 +2357,7 @@
           "type": {
             "description": "The data type",
             "type": "string",
-            "example": "participant"
+            "example": "participant-declaration"
           },
           "attributes": {
             "$ref": "#/components/schemas/ParticipantDeclarationAttributes"

--- a/swagger/v1/component_schemas/ECFParticipantChangeScheduleRequest.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeScheduleRequest.yml
@@ -13,6 +13,6 @@ properties:
       type:
         description: "The data type"
         type: string
-        example: participant
+        example: participant-change-schedule
       attributes:
         $ref: "#/components/schemas/ECFParticipantChangeSchedule"

--- a/swagger/v1/component_schemas/ECFParticipantDeferRequest.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferRequest.yml
@@ -13,6 +13,6 @@ properties:
       type:
         description: "The data type"
         type: string
-        example: participant
+        example: participant-defer
       attributes:
         $ref: "#/components/schemas/ECFParticipantDefer"

--- a/swagger/v1/component_schemas/ECFParticipantResumeRequest.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeRequest.yml
@@ -13,6 +13,6 @@ properties:
       type:
         description: "The data type"
         type: string
-        example: participant
+        example: participant-resume
       attributes:
         $ref: "#/components/schemas/ECFParticipantResume"

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawRequest.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawRequest.yml
@@ -13,6 +13,6 @@ properties:
       type:
         description: "The data type"
         type: string
-        example: participant
+        example: participant-withdraw
       attributes:
         $ref: "#/components/schemas/ECFParticipantWithdraw"

--- a/swagger/v1/component_schemas/ParticipantDeclarationResponse.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationResponse.yml
@@ -6,13 +6,13 @@ required:
   - attributes
 properties:
   id:
-    description: "The unique identifier of the participant record"
+    description: "The unique identifier of the participant declaration record"
     type: string
     format: uuid
     example: cd3a12347-7308-4879-942a-c4a70ced400a
   type:
     description: "The data type"
     type: string
-    example: participant
+    example: participant-declaration
   attributes:
     $ref: "#/components/schemas/ParticipantDeclarationAttributes"


### PR DESCRIPTION
## Ticket and context

The types in our api docs are not quite right. This should fix it. 
