### PR TITLE
Add email format check for sign in

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -40,11 +40,6 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def create
-    self.resource = validate_email
-    if resource.errors.any?
-      render :new and return
-    end
-
     super
   rescue Devise::Strategies::PasswordlessAuthenticatable::Error
     render :login_email_sent
@@ -90,30 +85,5 @@ private
 
     sign_in(user, scope: :user)
     redirect_to profile_dashboard_path(user)
-  end
-
-  def validate_email
-    email = params.dig(:user, :email)
-
-    if email.blank?
-      user = User.new
-      user.errors.add :email, :blank
-      return user
-    end
-
-    unless email.match(/^\S+@\S+\.\S+$/)
-      user = User.new
-      user.errors.add :email, :invalid
-      return user
-    end
-
-    user = User.find_by(email: params[:user][:email])
-
-    if user.blank?
-      user = User.new(email: email)
-      user
-    end
-
-    user
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -40,6 +40,11 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   def create
+    self.resource = validate_email
+    if resource.errors.any?
+      render :new and return
+    end
+
     super
   rescue Devise::Strategies::PasswordlessAuthenticatable::Error
     render :login_email_sent
@@ -85,5 +90,30 @@ private
 
     sign_in(user, scope: :user)
     redirect_to profile_dashboard_path(user)
+  end
+
+  def validate_email
+    email = params.dig(:user, :email)
+
+    if email.blank?
+      user = User.new
+      user.errors.add :email, :blank
+      return user
+    end
+
+    unless email.match(/^\S+@\S+\.\S+$/)
+      user = User.new
+      user.errors.add :email, :invalid
+      return user
+    end
+
+    user = User.find_by(email: params[:user][:email])
+
+    if user.blank?
+      user = User.new(email: email)
+      user
+    end
+
+    user
   end
 end

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -13,7 +13,7 @@ module Devise
       class LoginIncompleteError < Error; end
 
       def valid?
-        !!params.dig(:user, :email)&.match(/^\S+@\S+\.\S+$/)
+        NotifyEmailValidator.valid?(params.dig(:user, :email))
       end
 
       def authenticate!

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -12,6 +12,10 @@ module Devise
 
       class LoginIncompleteError < Error; end
 
+      def valid?
+        !!params.dig(:user, :email)&.match(/^\S+@\S+\.\S+$/)
+      end
+
       def authenticate!
         if params[:user].present?
           user = User.find_by(email: params[:user][:email])

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe "Users::Sessions", type: :request do
         post "/users/sign_in", params: { user: { email: email } }
       end
     end
+
+    context "when a blank email is inputted" do
+      email = ""
+      it "renders the new template" do
+        post "/users/sign_in", params: { user: { email: email } }
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context "when an invalid email is inputted" do
+      emails = ["invalid@email,com", "email", "invalid@email", "@email.com"]
+      emails.each do |email|
+        it "renders the new template" do
+          post "/users/sign_in", params: { user: { email: email } }
+          expect(response).to render_template(:new)
+        end
+      end
+    end
   end
 
   describe "Valid mock login" do
@@ -115,7 +133,7 @@ RSpec.describe "Users::Sessions", type: :request do
     context "email domain not in the whitelist" do
       let(:test_email) { "admin@some.other.example.com" }
 
-      context "using a non-production enviromment" do
+      context "using a non-production environment" do
         it "renders the login_email_sent template" do
           post "/users/sign_in", params: { user: { email: test_email } }
           expect(response).to render_template(:login_email_sent) # falls back to prod behaviour


### PR DESCRIPTION
## Ticket and context

Ticket: [921](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDRP-921)

## Tech review

### Is there anything that the code reviewer should know?

The regex in Devise initializer hasn't been used as it didn't cover many invalid formats i tried, e.g "invalid@email,com"

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Try to log in with an incorrect email format 

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)

https://user-images.githubusercontent.com/69353998/135220212-c39613f8-92d5-46fd-99ca-2f6f254e9437.mov
