### PR TITLE
Handling email audit of emails without personalisations

### DIFF
--- a/lib/mail/delivery_recorder.rb
+++ b/lib/mail/delivery_recorder.rb
@@ -25,7 +25,7 @@ module Mail
           template_version: response.template["version"],
           uri: response.uri,
           tags: mail.tags,
-          personalisation: mail.header["personalisation"].unparsed_value,
+          personalisation: mail.header["personalisation"]&.unparsed_value,
         )
 
         email.create_association_with(*User.where(email: email.to).to_a, as: :recipient)


### PR DESCRIPTION
https://sentry.io/organizations/dfe-bat/issues/2679159558/?project=5748989&referrer=slack

There was an assumption made that all emails will be using notify templates with personalisation. This change fixes an issue with 2020 form submission.