### PR TITLE
Add NQT+1 invite email for SITs who have all validated participants

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -315,7 +315,7 @@ class SchoolMailer < ApplicationMailer
     )
   end
 
-  def nqt_plus_one_sit_invite(recipient:, start_url:)
+  def nqt_plus_one_sit_invite(recipient:, start_url:, school:)
     template_mail(
       NQT_PLUS_ONE_SIT_EMAIL_TEMPLATE,
       to: recipient,
@@ -324,6 +324,6 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         start_url: start_url,
       },
-    )
+    ).tag(:year2020_invite).associate_with(school, as: :school)
   end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -65,7 +65,7 @@ class School < ApplicationRecord
   }
 
   scope :all_ecf_participants_validated, lambda {
-    left_outer_joins(ecf_participant_profiles: %i[ecf_participant_eligibility ecf_participant_validation_data])
+    left_outer_joins(active_ecf_participant_profiles: %i[ecf_participant_eligibility ecf_participant_validation_data])
       .group(:id)
       .having(<<~SQL)
         SUM(

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -18,7 +18,7 @@ class SchoolCohort < ApplicationRecord
 
   has_many :ecf_participant_profiles, class_name: "ParticipantProfile"
   has_many :ecf_participants, through: :ecf_participant_profiles, source: :user
-  has_many :active_ecf_participant_profiles, -> { ecf.active_record }, class_name: "ParticipantProfile"
+  has_many :active_ecf_participant_profiles, -> { ecf.active_record }, class_name: "ParticipantProfile::ECF"
   has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user
 
   has_many :mentor_profiles, -> { mentors }, class_name: "ParticipantProfile"

--- a/app/policies/participant_profile/ecf_policy.rb
+++ b/app/policies/participant_profile/ecf_policy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ParticipantProfile::ECFPolicy = ParticipantProfilePolicy

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -273,6 +273,20 @@ class InviteSchools
     end
   end
 
+  def invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one
+    School
+      .eligible
+      .not_opted_out
+      .joins(:induction_coordinators)
+      .all_ecf_participants_validated
+      .find_each do |school|
+        SchoolMailer.nqt_plus_one_sit_invite(
+          recipient: school.induction_coordinators.first.email,
+          start_url: year2020_start_url(school, utm_source: :year2020_nqt_invite_sit_validated),
+        ).deliver_later
+      end
+  end
+
 private
 
   def private_beta_start_url

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -249,6 +249,7 @@ class InviteSchools
   def invite_opted_out_sits_for_nqt_plus_one
     School.eligible.opted_out.joins(:induction_coordinators).each do |school|
       SchoolMailer.nqt_plus_one_sit_invite(
+        school: school,
         recipient: school.induction_coordinators.first.email,
         start_url: year2020_start_url(school, utm_source: :year2020_nqt_invite_sit),
       ).deliver_later
@@ -280,7 +281,10 @@ class InviteSchools
       .joins(:induction_coordinators)
       .all_ecf_participants_validated
       .find_each do |school|
+        next if Email.associated_with(school).tagged_with(:year2020_invite).any?
+
         SchoolMailer.nqt_plus_one_sit_invite(
+          school: school,
           recipient: school.induction_coordinators.first.email,
           start_url: year2020_start_url(school, utm_source: :year2020_nqt_invite_sit_validated),
         ).deliver_later

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe SchoolMailer, type: :mailer do
   describe "nqt_plus_one_sit_invite" do
     let(:email) do
       SchoolMailer.nqt_plus_one_sit_invite(
+        school: create(:school),
         recipient: "hello@example.com",
         start_url: "www.example.com",
       ).deliver_now

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -39,6 +39,84 @@ RSpec.describe School, type: :model do
     it { is_expected.to have_many(:additional_school_emails) }
   end
 
+  describe "scopes" do
+    describe "all_ecf_participants_validated" do
+      it "includes only schools with ecf participants that are all validated" do
+        school_with_mentor_with_eligibilty = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_mentor_with_validation_data = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_validation_data, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_ect_with_eligibility = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_ect_with_validation_data = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :ect, :ecf_participant_validation_data, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_mentor_with_eligibilty_and_unvalidated_ect = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :ect, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_mentor_with_validation_data_and_unvalidated_ect = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_validation_data, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :ect, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_ect_with_eligibility_and_unvalidated_ect = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :ect, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_ect_with_validation_data_and_unvalidated_ect = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :ect, :ecf_participant_validation_data, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :ect, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_mentor_with_eligibilty_and_unvalidated_mentor = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :mentor, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_mentor_with_validation_data_and_unvalidated_mentor = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_validation_data, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :mentor, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_ect_with_eligibility_and_unvalidated_mentor = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :mentor, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_ect_with_validation_data_and_unvalidated_mentor = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :ect, :ecf_participant_validation_data, school_cohort: school.school_cohorts.first)
+          create(:participant_profile, :mentor, school_cohort: school.school_cohorts.first)
+        end
+
+        school_with_no_participants = create(:school_cohort).school
+
+        expect(School.all_ecf_participants_validated).to include(school_with_mentor_with_eligibilty)
+        expect(School.all_ecf_participants_validated).to include(school_with_mentor_with_validation_data)
+        expect(School.all_ecf_participants_validated).to include(school_with_ect_with_eligibility)
+        expect(School.all_ecf_participants_validated).to include(school_with_ect_with_validation_data)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_mentor_with_eligibilty_and_unvalidated_ect)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_mentor_with_validation_data_and_unvalidated_ect)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_ect_with_eligibility_and_unvalidated_ect)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_ect_with_validation_data_and_unvalidated_ect)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_mentor_with_eligibilty_and_unvalidated_mentor)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_mentor_with_validation_data_and_unvalidated_mentor)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_ect_with_eligibility_and_unvalidated_mentor)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_ect_with_validation_data_and_unvalidated_mentor)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_no_participants)
+      end
+    end
+  end
+
   describe "eligibility" do
     let!(:open_school) { create(:school, school_status_code: 1) }
     let!(:closed_school) { create(:school, school_status_code: 2) }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe School, type: :model do
           create(:participant_profile, :mentor, school_cohort: school.school_cohorts.first)
         end
 
+        school_with_inactive_mentor_with_eligibilty = create(:school_cohort).school.tap do |school|
+          create(:participant_profile, :mentor, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first, status: :withdrawn)
+        end
+
         school_with_no_participants = create(:school_cohort).school
 
         expect(School.all_ecf_participants_validated).to include(school_with_mentor_with_eligibilty)
@@ -113,6 +117,7 @@ RSpec.describe School, type: :model do
         expect(School.all_ecf_participants_validated).to_not include(school_with_ect_with_eligibility_and_unvalidated_mentor)
         expect(School.all_ecf_participants_validated).to_not include(school_with_ect_with_validation_data_and_unvalidated_mentor)
         expect(School.all_ecf_participants_validated).to_not include(school_with_no_participants)
+        expect(School.all_ecf_participants_validated).to_not include(school_with_inactive_mentor_with_eligibilty)
       end
     end
   end

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -686,7 +686,6 @@ RSpec.describe InviteSchools do
                                         recipient: school.contact_email,
                                         start_url: expected_url,
                                       ))
-      InviteSchools.new.invite_sitless_opted_out_schools_for_nqt_plus_one
     end
 
     it "doesn't email ineligible schools" do
@@ -851,6 +850,83 @@ RSpec.describe InviteSchools do
 
       InviteSchools.new.invite_sitless_not_opted_out_schools_for_nqt_plus_one
       expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sitless_invite)
+    end
+  end
+
+  describe "#invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one" do
+    it "sends an email to eligible not-opted-out schools with induction coordinators and all participants validated" do
+      school = create(:school)
+      sit = create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             core_induction_programme: nil,
+             opt_out_of_updates: false)
+      create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+
+      expected_url = "http://www.example.com/schools/#{school.friendly_id}/year-2020/support-materials-for-NQTs?utm_campaign=year2020-nqt-invite-sit-validated&utm_medium=email&utm_source=year2020-nqt-invite-sit-validated"
+      InviteSchools.new.invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one
+      expect(SchoolMailer).to delay_email_delivery_of(:nqt_plus_one_sit_invite)
+                                .with(hash_including(
+                                        recipient: sit.email,
+                                        start_url: expected_url,
+                                      )).once
+    end
+
+    it "doesn't email schools with unvalidated participants" do
+      school = create(:school)
+      create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             core_induction_programme: nil,
+             opt_out_of_updates: false)
+      create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+      create(:participant_profile, :ect, school_cohort: school.school_cohorts.first)
+
+      InviteSchools.new.invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sit_invite)
+    end
+
+    it "doesn't email ineligible schools" do
+      school = create(:school, :cip_only)
+      create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             core_induction_programme: nil,
+             opt_out_of_updates: false)
+      create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+
+      InviteSchools.new.invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sit_invite)
+    end
+
+    it "doesn't email opted out schools" do
+      school = create(:school)
+      create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             core_induction_programme: nil,
+             opt_out_of_updates: true)
+      create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+
+      InviteSchools.new.invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sit_invite)
+    end
+
+    it "doesn't email schools without an induction coordinator" do
+      school = create(:school)
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme",
+             core_induction_programme: nil,
+             opt_out_of_updates: false)
+      create(:participant_profile, :ect, :ecf_participant_eligibility, school_cohort: school.school_cohorts.first)
+
+      InviteSchools.new.invite_not_opted_out_sits_with_all_validated_participants_for_nqt_plus_one
+      expect(SchoolMailer).to_not delay_email_delivery_of(:nqt_plus_one_sit_invite)
     end
   end
 


### PR DESCRIPTION
## Ticket and context

Criteria as per email schedule:
```
SITs with ECTs and mentors who have ALL been validated
- Do NOT include schools who are NOT eligible for FIP aka CIP only
- Do NOT include SITs who have opted out
```

Also includes adding a column to track which SITs we send emails to. We will follow this up the week after (or after that) to all eligible non-opted-out SITs that weren't sent an email in this one-off send.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
