### PR TITLE
Handle invalid date of birth for participant validation

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -48,6 +48,7 @@ module Participants
 
       if invalid_date?(value)
         @date_of_birth_invalid = true
+        @date_of_birth = value
       end
     rescue StandardError
       @date_of_birth_invalid = true

--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -45,6 +45,10 @@ module Participants
     def date_of_birth=(value)
       @date_of_birth_invalid = false
       @date_of_birth = ActiveRecord::Type::Date.new.cast(value)
+
+      if invalid_date?(value)
+        @date_of_birth_invalid = true
+      end
     rescue StandardError
       @date_of_birth_invalid = true
     end
@@ -158,6 +162,15 @@ module Participants
       return if national_insurance_number.blank?
 
       national_insurance_number.gsub(/\s+/, "").upcase
+    end
+
+    def invalid_date?(value)
+      return if value.blank?
+
+      day = value[3]
+      month = value[2]
+      year = value[1]
+      !Date.valid_date?(year, month, day)
     end
   end
 end

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
   end
 
   describe "teacher_details validations" do
-    let(:teacher_details) { { trn: "1234567", name: "Wilma Flintstone", date_of_birth: "1996-4-17", national_insurance_number: "AB123456C" } }
+    let(:teacher_details) { { trn: "1234567", name: "Wilma Flintstone", date_of_birth: { 3 => 17, 2 => 4, 1 => 1996 }, national_insurance_number: "AB123456C" } }
     subject(:form) { described_class.new(teacher_details) }
 
     context "when all fields are valid" do
@@ -166,6 +166,14 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
     context "when date_of_birth is not supplied" do
       it "returns false" do
         form.date_of_birth = nil
+        expect(form.valid?(:tell_us_your_details)).to be false
+        expect(form.errors).to include :date_of_birth
+      end
+    end
+
+    context "when date_of_birth is an invalid date" do
+      it "returns false" do
+        form.date_of_birth = { 3 => 31, 2 => 9, 1 => 1988 }
         expect(form.valid?(:tell_us_your_details)).to be false
         expect(form.errors).to include :date_of_birth
       end
@@ -206,7 +214,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
         name_not_updated_choice: form.name_not_updated_choices.map(&:id).sample,
         trn: "1234567",
         name: "Ted Smith",
-        date_of_birth: Date.new(1993, 6, 15),
+        date_of_birth: form.date_of_birth,
         national_insurance_number: "AB123456C",
         validation_attempts: 1,
       }

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
 
   describe "#pretty_date_of_birth" do
     it "formats the date of birth correctly" do
-      form.date_of_birth = "1989-3-22"
+      form.date_of_birth = { 3 => 22, 2 => 3, 1 => 1989 }
       expect(form.pretty_date_of_birth).to eq "22 March 1989"
     end
   end


### PR DESCRIPTION
## Ticket and context

Ticket: [882](https://dfedigital.atlassian.net/jira/software/projects/CPDEL/boards/102?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDRP-882)

## Tech review

### Is there anything that the code reviewer should know?

Dates aren't fun.

`ActiveRecord::Type::Date.new.cast(value)` will, for example, go to 1st October 1991 when putting 31 September but Date.new(31, 9, 1991) will raise an invalid error. 

Happy to chat about if this if anyone if free. I have a couple questions about the form and how it's handling the dob.

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. login as an example email 
3. go to `/participants/validation/tell-us-your-details`
4. Try various different d.o.b's, valid and invalid

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
