### PR TITLE
CPDTP-205 Ensure no payment is made where a declaration has been voided

### DIFF
--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -53,7 +53,7 @@ module ParticipantDeclarationSteps
 
   def and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
     params = common_params(@ect_id, "ecf-induction")
-    submit_request(params)
+    @declaration_id = submit_request(params).dig("data", "id")
   end
 
   def and_the_lead_provider_submits_a_declaration_for_the_mentor_using_their_id

--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -77,6 +77,10 @@ module ParticipantDeclarationSteps
     submit_request(params)
   end
 
+  def and_the_lead_provider_voids_a_declaration
+    @session.put("/api/v1/participant-declarations/#{@declaration_id}/void", headers: { "Authorization": "Bearer #{@token}" })
+  end
+
   def then_the_declaration_made_is_valid
     expect(ParticipantDeclaration.find(@response["data"]["id"])).to be_present
   end

--- a/spec/features/participant-declarations/voided_declaration_in_payment_breakdown_spec.rb
+++ b/spec/features/participant-declarations/voided_declaration_in_payment_breakdown_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Voided declaration in payment breakdown", type: :feature do
     given_an_early_career_teacher_has_been_entered_onto_the_dfe_service
     and_call_off_contract_was_created_for_lead_provider
     when_the_participant_details_are_passed_to_the_lead_provider
-    @declaration_id = and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id.dig("data", "id")
+    and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
     and_the_lead_provider_voids_a_declaration
     and_profile_declaration_made_payable
     and_breakdown_calculation_was_run
@@ -37,10 +37,10 @@ private
 
   def and_profile_declaration_made_payable
     profile_declaration = ProfileDeclaration.find_by(participant_declaration_id: @declaration_id)
-    profile_declaration.update!({ payable: true })
+    profile_declaration.update!(payable: true)
   end
 
   def then_the_payment_breakdown_does_not_include_voided_declaration
-    expect(@breakdown.dig(:breakdown_summary, :ects)).to eq(0)
+    expect(@breakdown.dig(:breakdown_summary, :participants)).to eq(0)
   end
 end

--- a/spec/features/participant-declarations/voided_declaration_in_payment_breakdown_spec.rb
+++ b/spec/features/participant-declarations/voided_declaration_in_payment_breakdown_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./participant_declaration_steps"
+
+RSpec.feature "Voided declaration in payment breakdown", type: :feature do
+  include ParticipantDeclarationSteps
+
+  before(:each) do
+    setup
+  end
+
+  scenario "Payment breakdown does not include voided declarations" do
+    given_an_early_career_teacher_has_been_entered_onto_the_dfe_service
+    and_call_off_contract_was_created_for_lead_provider
+    when_the_participant_details_are_passed_to_the_lead_provider
+    @declaration_id = and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id.dig("data", "id")
+    and_the_lead_provider_voids_a_declaration
+    and_profile_declaration_made_payable
+    and_breakdown_calculation_was_run
+    then_the_payment_breakdown_does_not_include_voided_declaration
+  end
+
+private
+
+  def and_call_off_contract_was_created_for_lead_provider
+    create(:call_off_contract, lead_provider: @cpd_lead_provider.lead_provider)
+  end
+
+  def and_breakdown_calculation_was_run
+    @breakdown = CalculationOrchestrator.call(
+      cpd_lead_provider: @cpd_lead_provider,
+      contract: @cpd_lead_provider.lead_provider.call_off_contract,
+      event_type: :started,
+    )
+  end
+
+  def and_profile_declaration_made_payable
+    profile_declaration = ProfileDeclaration.find_by(participant_declaration_id: @declaration_id)
+    profile_declaration.update!({ payable: true })
+  end
+
+  def then_the_payment_breakdown_does_not_include_voided_declaration
+    expect(@breakdown.dig(:breakdown_summary, :ects)).to eq(0)
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-205

## Tech review

As the voided declarations are already not included in the query scope used in the aggregation then only a feature test is required to ensure the payment breakdown doesn't include a voided declaration 

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
