### PR TITLE
Add invite SIT email for partnered fip schools without a SIT

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -19,6 +19,7 @@ class SchoolMailer < ApplicationMailer
   BASIC_TEMPLATE = "b1ab542e-a8d5-4fdf-a7aa-f0ce49b98262"
   NQT_PLUS_ONE_SITLESS_EMAIL_TEMPLATE = "c10392e4-9d75-402d-a7fd-47df16fa6082"
   NQT_PLUS_ONE_SIT_EMAIL_TEMPLATE = "9e01b5ac-a94c-4c71-a38d-6502d7c4c2e7"
+  PARTNERED_SCHOOL_INVITE_SIT_EMAIL_TEMPLATE = "8cac177e-b094-4a00-9179-94fadde8ced0"
 
   def remind_induction_coordinator_to_setup_cohort_email(recipient:, school_name:, campaign: nil)
     campaign_tracking = campaign ? UTMService.email(campaign, campaign) : {}
@@ -89,6 +90,28 @@ class SchoolMailer < ApplicationMailer
         challenge_url: challenge_url,
         challenge_deadline: challenge_deadline,
         subject: "FAO: NQT coordinator. Training provider confirmed.",
+      },
+    )
+  end
+
+  def partnered_school_invite_sit_email(
+    recipient:,
+    lead_provider_name:,
+    delivery_partner_name:,
+    nominate_url:,
+    challenge_url:
+  )
+
+    template_mail(
+      PARTNERED_SCHOOL_INVITE_SIT_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        lead_provider_name: lead_provider_name,
+        delivery_partner_name: delivery_partner_name,
+        nominate_url: nominate_url,
+        challenge_url: challenge_url,
       },
     )
   end

--- a/app/models/partnership_notification_email.rb
+++ b/app/models/partnership_notification_email.rb
@@ -14,5 +14,6 @@ class PartnershipNotificationEmail < ApplicationRecord
     induction_coordinator_reminder_email: "induction_coordinator_reminder_email",
     school_email: "school_email",
     school_reminder_email: "school_reminder_email",
+    nominate_sit_email: "nominate_sit_email",
   }
 end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -31,6 +31,9 @@ class UTMService
     mentor_validation_info_2709: "mentor-validation-info-2709",
     sit_mentor_validation_info_2709: "sit-mentor-validation-info-2709",
     year2020_nqt_invite_school_not_opted_out: "year2020-nqt-invite-school-not-opted-out",
+    year2020_nqt_invite_sit_validated: "year2020-nqt-invite-sit-validated",
+    year2020_nqt_invite_sit_no_participants: "year2020-nqt-invite-sit-no-participants",
+    partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -59,6 +62,9 @@ class UTMService
     ect_validation_info_2709: "ect-validation-info-2709",
     mentor_validation_info_2709: "mentor-validation-info-2709",
     sit_mentor_validation_info_2709: "sit-mentor-validation-info-2709",
+    year2020_nqt_invite_sit_validated: "year2020-nqt-invite-sit-validated",
+    year2020_nqt_invite_sit_no_participants: "year2020-nqt-invite-sit-no-participants",
+    partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/services/partnership_notification_service_spec.rb
+++ b/spec/services/partnership_notification_service_spec.rb
@@ -158,4 +158,62 @@ RSpec.describe PartnershipNotificationService do
       end
     end
   end
+
+  describe "#send_invite_sit_reminder_to_partnered_schools" do
+    let(:contact_email) { Faker::Internet.email }
+    let(:school) do
+      create(:school_cohort, :fip).school.tap do |s|
+        s.update!(primary_contact_email: contact_email)
+      end
+    end
+
+    before(:all) do
+      RSpec::Mocks.configuration.verify_partial_doubles = false
+    end
+
+    after(:all) do
+      RSpec::Mocks.configuration.verify_partial_doubles = true
+    end
+
+    it "emails schools that are fip partnered with no SIT, and extends the challenge deadline by 2 weeks" do
+      expect(SchoolMailer).to receive(:partnered_school_invite_sit_email).with(
+        hash_including(
+          lead_provider_name: partnership.lead_provider.name,
+          delivery_partner_name: partnership.delivery_partner.name,
+          challenge_url: a_string_including("utm_campaign=partnered-invite-sit-reminder&utm_medium=email&utm_source=partnered-invite-sit-reminder"),
+          nominate_url: a_string_including("utm_campaign=partnered-invite-sit-reminder&utm_medium=email&utm_source=partnered-invite-sit-reminder"),
+          recipient: contact_email,
+        ),
+      ).and_call_original
+      allow_any_instance_of(Mail::TestMailer).to receive_message_chain(:response, :id) { notify_id }
+
+      Timecop.freeze do
+        partnership_notification_service.send_invite_sit_reminder_to_partnered_schools
+
+        expect(partnership_notification_email.sent_to).to eq(contact_email)
+        expect(partnership_notification_email.notify_id).to eq(notify_id)
+        expect(partnership_notification_email.email_type).to eq("nominate_sit_email")
+        expect(partnership_notification_email.reload.challenge_deadline).to be_within(1.second).of(2.weeks.from_now)
+      end
+    end
+
+    it "doesn't email schools that aren't partnered" do
+      expect(SchoolMailer).to_not receive(:partnered_school_invite_sit_email)
+      partnership_notification_service.send_invite_sit_reminder_to_partnered_schools
+    end
+
+    it "doesn't email schools that aren't fip" do
+      expect(SchoolMailer).to_not receive(:partnered_school_invite_sit_email)
+      school.school_cohorts.first.update!(induction_programme_choice: :core_induction_programme)
+      partnership
+      partnership_notification_service.send_invite_sit_reminder_to_partnered_schools
+    end
+
+    it "doesn't email schools that have a SIT" do
+      expect(SchoolMailer).to_not receive(:partnered_school_invite_sit_email)
+      partnership
+      create(:user, :induction_coordinator, schools: [school])
+      partnership_notification_service.send_invite_sit_reminder_to_partnered_schools
+    end
+  end
 end


### PR DESCRIPTION
includes extending the partnership challenge deadline by 2 weeks since these schools have presumably ignored their first partnership notification email

## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-993

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
