### PR TITLE
CPDRP-1000 Participant eligibility logic update

### DIFF
--- a/app/models/ecf_participant_eligibility.rb
+++ b/app/models/ecf_participant_eligibility.rb
@@ -10,15 +10,29 @@ class ECFParticipantEligibility < ApplicationRecord
     eligible: "eligible",
     matched: "matched",
     manual_check: "manual_check",
+    ineligible: "ineligible",
+  }, _suffix: true
+
+  enum reason: {
+    active_flags: "active_flags",
+    previous_participation: "previous_participation",
+    previous_induction: "previous_induction",
+    no_qts: "no_qts",
+    different_trn: "different_trn",
+    none: "none",
   }, _suffix: true
 
   def determine_status
-    self.status = if active_flags? || previous_participation? || previous_induction?
-                    :manual_check
-                  elsif !qts?
-                    :matched
-                  else
-                    :eligible
-                  end
+    self.status, self.reason = if active_flags?
+                                 %i[manual_check active_flags]
+                               elsif previous_participation? # ERO mentors
+                                 %i[manual_check previous_participation]
+                               elsif previous_induction? && participant_profile.ect?
+                                 %i[manual_check previous_induction]
+                               elsif !qts?
+                                 %i[matched no_qts]
+                               else
+                                 %i[eligible none]
+                               end
   end
 end

--- a/app/services/validate_participant.rb
+++ b/app/services/validate_participant.rb
@@ -69,7 +69,7 @@ private
   def store_trn_on_teacher_profile!(trn)
     if participant_profile.teacher_profile.trn.present? && participant_profile.teacher_profile.trn != trn
       Rails.logger.warn("Different TRN already set for user [#{participant_profile.user.email}]")
-      @eligibility_data.manual_check_status!
+      @eligibility_data.update!(status: :manual_check, reason: :different_trn)
     else
       participant_profile.teacher_profile.update!(trn: trn)
     end

--- a/db/migrate/20210930125828_add_reason_to_ecf_participant_eligibilities.rb
+++ b/db/migrate/20210930125828_add_reason_to_ecf_participant_eligibilities.rb
@@ -2,6 +2,6 @@
 
 class AddReasonToECFParticipantEligibilities < ActiveRecord::Migration[6.1]
   def change
-    add_column :ecf_participant_eligibilities, :reason, :string, null: false, default: "none" 
+    add_column :ecf_participant_eligibilities, :reason, :string, null: false, default: "none"
   end
 end

--- a/db/migrate/20210930125828_add_reason_to_ecf_participant_eligibilities.rb
+++ b/db/migrate/20210930125828_add_reason_to_ecf_participant_eligibilities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReasonToECFParticipantEligibilities < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ecf_participant_eligibilities, :reason, :string, null: false, default: "none" 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_24_124114) do
+ActiveRecord::Schema.define(version: 2021_09_30_125828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -224,6 +224,7 @@ ActiveRecord::Schema.define(version: 2021_09_24_124114) do
     t.string "status", default: "manual_check", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "reason", default: "none", null: false
     t.index ["participant_profile_id"], name: "index_ecf_participant_eligibilities_on_participant_profile_id", unique: true
   end
 

--- a/spec/jobs/validation_retry_job_spec.rb
+++ b/spec/jobs/validation_retry_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "ValidationRetryJob" do
         validator = class_double("ParticipantValidationService").as_stubbed_const(transfer_nested_constants: true)
         allow(validator).to receive(:validate)
           .with(participant_data.merge(config: { check_first_name_only: true }))
-          .and_return({ trn: participant_data[:trn], qts: true, active_alert: false, previous_induction: true })
+          .and_return({ trn: participant_data[:trn], qts: true, active_alert: false, previous_participation: true })
       end
 
       it "rechecks the eligibility" do
@@ -36,7 +36,8 @@ RSpec.describe "ValidationRetryJob" do
         ValidationRetryJob.new.perform
         expect(validation_data.reload.api_failure).to be false
         expect(validation_data.participant_profile.ecf_participant_eligibility).to be_present
-        expect(validation_data.participant_profile.ecf_participant_eligibility.status).to eql "manual_check"
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_manual_check_status
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_previous_participation_reason
         expect(validation_data.participant_profile.teacher_profile.trn).to eql "1234567"
       end
 
@@ -47,7 +48,8 @@ RSpec.describe "ValidationRetryJob" do
         ValidationRetryJob.new.perform
         expect(validation_data.reload.api_failure).to be false
         expect(validation_data.participant_profile.ecf_participant_eligibility).to be_present
-        expect(validation_data.participant_profile.ecf_participant_eligibility.status).to eql "manual_check"
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_manual_check_status
+        expect(validation_data.participant_profile.ecf_participant_eligibility).to be_different_trn_reason
         expect(validation_data.participant_profile.teacher_profile.trn).to eql "0123456"
       end
     end


### PR DESCRIPTION
## Ticket and context

Ticket: [Jira](https://dfedigital.atlassian.net/browse/CPDRP-1000)
Updates participant eligibility logic to account for the participant profile type.
Adds reason enum so that we can easily see the reason for the given status.

We will want to run this manually against prod, primarily to update the status for mentors that have a previous induction. Currently these are flagged for manual check but we should ignore the previous induction flag for mentors.

```ruby
ECFParticipantEligibility.where(manually_validated: false).find_each { |eligibility| eligibility.determine_status; eligibility.save! }
```

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
