### PR TITLE
Scope rejections when Accepting NPQ applications

### DIFF
--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -15,7 +15,6 @@ module NPQ
     end
 
     def call
-      other_applications = NPQValidationData.where(user_id: user.id).where.not(id: npq_application.id)
       ApplicationRecord.transaction do
         teacher_profile.update!(trn: npq_application.teacher_reference_number) if npq_application.teacher_reference_number_verified?
         create_profile
@@ -24,6 +23,12 @@ module NPQ
     end
 
   private
+
+    def other_applications
+      @other_applications ||= NPQValidationData.where(user_id: user.id)
+                                               .where(npq_course: npq_course)
+                                               .where.not(id: npq_application.id)
+    end
 
     def create_profile
       ParticipantProfile::NPQ.create!(
@@ -44,6 +49,10 @@ module NPQ
 
     def user
       @user ||= npq_application.user
+    end
+
+    def npq_course
+      npq_application.npq_course
     end
   end
 end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -253,16 +253,17 @@ RSpec.describe "NPQ Applications API", type: :request do
     end
 
     context "when participant has applied for multiple NPQs" do
-      let!(:other_npq_validation_data) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, user: user) }
-      let!(:other_accepted_npq_validation_data) { create(:npq_validation_data, npq_lead_provider: npq_lead_provider, user: user, lead_provider_approval_status: "accepted") }
+      let(:npq_course) { default_npq_validation_data.npq_course }
+      let!(:other_npq_validation_data) { create(:npq_validation_data, npq_course: npq_course, npq_lead_provider: npq_lead_provider, user: user) }
+      let!(:other_accepted_npq_validation_data) { create(:npq_validation_data, npq_course: npq_course, npq_lead_provider: npq_lead_provider, user: user, lead_provider_approval_status: "accepted") }
 
-      it "rejects all pending NPQs" do
+      it "rejects all pending NPQs on same course" do
         post "/api/v1/npq-applications/#{default_npq_validation_data.id}/accept"
 
         expect(other_npq_validation_data.reload.lead_provider_approval_status).to eql("rejected")
       end
 
-      it "does not reject non-pending NPQs" do
+      it "does not reject non-pending NPQs on same course" do
         post "/api/v1/npq-applications/#{default_npq_validation_data.id}/accept"
 
         expect(other_accepted_npq_validation_data.reload.lead_provider_approval_status).to eql("accepted")


### PR DESCRIPTION
## Ticket and context

Ticket: https://trello.com/c/yOJFfO9p/555-build-aso-journey

- When a provider accepts an NPQ application at the moment it rejects all other applications
- This change makes it so when the accept comes in, it only rejects other applications from the user on the same course. 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- ssh in to the box
- find or create a lead provider
- submit 3 NPQ applications all from the same user - 2 (a+b) on the same course and 1 (c) on another course
- in the block of 2 (a+b), accept `a` and `b` should be rejected. `c` should remain unchanged 

## External API changes

- There is a minor impact on the API on accepting. However do we need to document this as this feature?