### PR TITLE
CPDRP-998 Add email for unpartnered cip sits with no participants

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -21,6 +21,7 @@ class SchoolMailer < ApplicationMailer
   ADD_2020_PARTICIPANT_CONFIRMATION_TEMPLATE = "08d45879-1f94-48a2-88c1-108f596fa59e"
   DIY_WORDPRESS_NOTIFICATION_TEMPLATE = "e1067a2f-b027-45a6-8e51-668e170090d1"
   PARTNERED_SCHOOL_INVITE_SIT_EMAIL_TEMPLATE = "8cac177e-b094-4a00-9179-94fadde8ced0"
+  UNPARTNERED_CIP_SIT_ADD_PARTICIPANTS_EMAIL_TEMPLATE = "ebc96223-c2ea-416e-8d3e-1f591bbd2f98"
 
   def remind_induction_coordinator_to_setup_cohort_email(recipient:, school_name:, campaign: nil)
     campaign_tracking = campaign ? UTMService.email(campaign, campaign) : {}
@@ -326,6 +327,19 @@ class SchoolMailer < ApplicationMailer
         start_url: start_url,
       },
     ).tag(:year2020_invite).associate_with(school, as: :school)
+  end
+
+  def unpartnered_cip_sit_add_participants_email(recipient:, induction_coordinator:, sign_in_url:, school_name:)
+    template_mail(
+      UNPARTNERED_CIP_SIT_ADD_PARTICIPANTS_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sign_in: sign_in_url,
+        school_name: school_name,
+      },
+    ).tag(:unpartnered_cip_add_participants).associate_with(induction_coordinator, as: :induction_coordinator)
   end
 
   def diy_wordpress_notification(user:)

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -303,6 +303,23 @@ class InviteSchools
       end
   end
 
+  def invite_unpartnered_cip_sits_to_add_ects_and_mentors
+    School.unpartnered(Cohort.current.start_year)
+      .joins(:school_cohorts, :induction_coordinator_profiles)
+      .where(school_cohorts: { induction_programme_choice: "core_induction_programme" })
+      .where.missing(:ecf_participants)
+      .find_each do |school|
+        induction_coordinator = school.induction_coordinators.first
+
+        SchoolMailer.unpartnered_cip_sit_add_participants_email(
+          recipient: induction_coordinator.email,
+          induction_coordinator: induction_coordinator,
+          sign_in_url: sign_in_url_with_campaign(:add_participants_unpartnered_cip),
+          school_name: school.name,
+        ).deliver_later
+      end
+  end
+
 private
 
   def private_beta_start_url

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -34,6 +34,7 @@ class UTMService
     year2020_nqt_invite_sit_validated: "year2020-nqt-invite-sit-validated",
     year2020_nqt_invite_sit_no_participants: "year2020-nqt-invite-sit-no-participants",
     partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
+    add_participants_unpartnered_cip: "add-participants-unpartnered-cip",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -65,6 +66,7 @@ class UTMService
     year2020_nqt_invite_sit_validated: "year2020-nqt-invite-sit-validated",
     year2020_nqt_invite_sit_no_participants: "year2020-nqt-invite-sit-no-participants",
     partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
+    add_participants_unpartnered_cip: "add-participants-unpartnered-cip",
   }.freeze
 
   def self.email(campaign, source = :service)

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -930,6 +930,65 @@ RSpec.describe InviteSchools do
     end
   end
 
+  describe "#invite_unpartnered_cip_sits_to_add_ects_and_mentors" do
+    it "invites unpartnered cip schools with no participants" do
+      school = create(:school)
+      sit = create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme")
+
+      expected_url = "http://www.example.com/users/sign_in?utm_campaign=add-participants-unpartnered-cip&utm_medium=email&utm_source=add-participants-unpartnered-cip"
+      InviteSchools.new.invite_unpartnered_cip_sits_to_add_ects_and_mentors
+      expect(SchoolMailer).to delay_email_delivery_of(:unpartnered_cip_sit_add_participants_email)
+                                .with(hash_including(
+                                        recipient: sit.email,
+                                        sign_in_url: expected_url,
+                                        induction_coordinator: sit,
+                                        school_name: school.name,
+                                      )).once
+    end
+
+    it "doesn't invite schools with participants" do
+      school = create(:school)
+      create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "core_induction_programme")
+      create(:participant_profile, :ect, school_cohort: school.school_cohorts.first)
+      InviteSchools.new.invite_unpartnered_cip_sits_to_add_ects_and_mentors
+
+      expect(SchoolMailer).to_not delay_email_delivery_of(:unpartnered_cip_sit_add_participants_email)
+    end
+
+    it "doesn't invite non-cip schools" do
+      school = create(:school)
+      create(:user, :induction_coordinator, schools: [school])
+      create(:school_cohort,
+             school: school,
+             induction_programme_choice: "full_induction_programme")
+
+      InviteSchools.new.invite_unpartnered_cip_sits_to_add_ects_and_mentors
+
+      expect(SchoolMailer).to_not delay_email_delivery_of(:unpartnered_cip_sit_add_participants_email)
+    end
+
+    it "doesn't invite schools in a partnership" do
+      school = create(:school)
+      create(:induction_coordinator_profile, schools: [school])
+      school_cohort = create(
+        :school_cohort,
+        school: school,
+        induction_programme_choice: "core_induction_programme",
+      )
+      create(:partnership, school: school, cohort: school_cohort.cohort)
+
+      InviteSchools.new.invite_unpartnered_cip_sits_to_add_ects_and_mentors
+
+      expect(SchoolMailer).to_not delay_email_delivery_of(:unpartnered_cip_sit_add_participants_email)
+    end
+  end
+
 private
 
   def create_signed_in_induction_tutor


### PR DESCRIPTION
SITs who chose 'use DfE materials' aka CIP BUT have NOT added ECTs or mentors.

## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-998

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
