### PR TITLE
CPDTP-250 implement states for declarations

### DIFF
--- a/app/models/declaration_state.rb
+++ b/app/models/declaration_state.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class DeclarationState < ApplicationRecord
+  class << self
+    def submit!(participant_declaration:)
+      create!(participant_declaration: participant_declaration)
+    end
+
+    def void!(participant_declaration:)
+      create!(participant_declaration: participant_declaration, state: "voided")
+    end
+
+    def pay!(participant_declaration:)
+      create!(participant_declaration: participant_declaration, state: "paid")
+    end
+  end
+
+  belongs_to :participant_declaration
+
+  enum state: {
+    submitted: "submitted",
+    payable: "payable",
+    paid: "paid",
+    # awaiting_clawback: "awaiting_clawback",
+    # clawed_back: "clawed_back"
+    voided: "voided",
+  }
+end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -1,39 +1,44 @@
 # frozen_string_literal: true
 
 class ParticipantDeclaration < ApplicationRecord
-  has_many :profile_declarations
-  has_one :current_profile_declaration, -> { order(created_at: :desc) }, class_name: "ProfileDeclaration"
-  has_one :participant_profile, through: :current_profile_declaration
+  has_one :profile_declaration
+  has_one :participant_profile, through: :profile_declaration
+  has_many :declaration_states
+  has_one :current_state, -> { order(created_at: :desc).limit(1) }, class_name: "DeclarationState"
   belongs_to :cpd_lead_provider
   belongs_to :user
 
-  delegate :payable, to: :current_profile_declaration, allow_nil: true
+  delegate :submitted?, :payable?, :voided?, :paid?, to: :current_state, allow_nil: false
+  delegate :fundable?, to: :participant_profile, allow_nil: true
 
   validates :course_identifier, :user, :cpd_lead_provider, :declaration_date, :declaration_type, presence: true
 
   # Helper scopes
   scope :for_lead_provider, ->(cpd_lead_provider) { where(cpd_lead_provider: cpd_lead_provider) }
   scope :for_declaration, ->(declaration_type) { where(declaration_type: declaration_type) }
+  scope :for_profile, ->(profile) { joins(:profile_declaration).joins(:participant_profile).where(participant_profile: profile) }
   scope :started, -> { for_declaration("started").order(declaration_date: "desc").unique_id }
-  scope :uplift, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.uplift) }
-  scope :ect, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.ect_profiles) }
-  scope :mentor, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.mentor_profiles) }
-  scope :npq, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.npq_profiles) }
-  scope :payable, -> { joins(:current_profile_declaration).merge(ProfileDeclaration.where(payable: true)) }
+  scope :uplift, -> { joins(:profile_declaration).merge(ProfileDeclaration.uplift) }
+  scope :ect, -> { joins(:profile_declaration).merge(ProfileDeclaration.ect_profiles) }
+  scope :mentor, -> { joins(:profile_declaration).merge(ProfileDeclaration.mentor_profiles) }
+  scope :npq, -> { joins(:profile_declaration).merge(ProfileDeclaration.npq_profiles) }
+  scope :submitted, -> { joins(:current_state).where(current_state: { state: "submitted" }) }
+  scope :payable, -> { joins(:current_state).where(current_state: { state: "payable" }) }
+  scope :paid, -> { joins(:current_state).where(current_state: { state: "paid" }) }
+  scope :voided, -> { joins(:current_state).where(current_state: { state: "voided" }) }
+  scope :changeable, -> { joins(:current_state).where(current_state: { state: %w[submitted payable] }) }
   scope :unique_id, -> { select(:user_id).distinct }
-  scope :voided, -> { where.not(voided_at: nil) }
-  scope :not_voided, -> { where(voided_at: nil) }
 
   # Time dependent Range scopes
   scope :declared_as_between, ->(start_date, end_date) { where(declaration_date: start_date..end_date) }
   scope :submitted_between, ->(start_date, end_date) { where(created_at: start_date..end_date) }
 
   # Declaration aggregation scopes
-  scope :active_for_lead_provider, ->(lead_provider) { not_voided.started.for_lead_provider(lead_provider).unique_id }
-  scope :active_ects_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).ect }
-  scope :active_mentors_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).mentor }
-  scope :active_npqs_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).npq }
-  scope :active_uplift_for_lead_provider, ->(lead_provider) { not_voided.active_for_lead_provider(lead_provider).uplift }
+  scope :active_for_lead_provider, ->(lead_provider) { started.for_lead_provider(lead_provider).unique_id }
+  scope :active_ects_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).ect }
+  scope :active_mentors_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).mentor }
+  scope :active_npqs_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).npq }
+  scope :active_uplift_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).uplift }
 
   scope :payable_for_lead_provider, ->(lead_provider) { active_for_lead_provider(lead_provider).payable }
   scope :payable_ects_for_lead_provider, ->(lead_provider) { active_ects_for_lead_provider(lead_provider).payable }
@@ -41,28 +46,26 @@ class ParticipantDeclaration < ApplicationRecord
   scope :payable_npqs_for_lead_provider, ->(lead_provider) { active_npqs_for_lead_provider(lead_provider).payable }
   scope :payable_uplift_for_lead_provider, ->(lead_provider) { active_uplift_for_lead_provider(lead_provider).payable }
 
-  def currently_payable
-    participant_profile.fundable?
-  end
-
   def refresh_payability!
-    # TODO: Do not update it if the declaration was processed already
-    if current_profile_declaration&.payable != currently_payable
-      ProfileDeclaration.create!(
-        participant_profile: participant_profile,
-        participant_declaration: self,
-        payable: currently_payable,
-      )
-      reload
-    end
+    new_state = fundable? ? "payable" : "submitted"
+    return if current_state.state == new_state
+
+    DeclarationState.create!(participant_declaration: self, state: new_state) and reload if %w[submitted payable].include?(current_state.state)
   end
 
-  def voided
-    voided_at.present?
+  def submit
+    DeclarationState.submit!(participant_declaration: self) and reload if payable?
   end
 
   def void!
-    # TODO: Prevent voiding a processed declaration - that requires clawbacks
-    update!(voided_at: Time.zone.now)
+    DeclarationState.void!(participant_declaration: self) and reload unless voided?
+  end
+
+  def pay!
+    DeclarationState.pay!(participant_declaration: self) and reload if payable?
+  end
+
+  def changeable?
+    %w[submitted payable].include?(current_state.state)
   end
 end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -53,7 +53,7 @@ class ParticipantDeclaration < ApplicationRecord
     DeclarationState.create!(participant_declaration: self, state: new_state) and reload if %w[submitted payable].include?(current_state.state)
   end
 
-  def submit
+  def submit!
     DeclarationState.submit!(participant_declaration: self) and reload if payable?
   end
 

--- a/app/serializers/participant_declaration_serializer.rb
+++ b/app/serializers/participant_declaration_serializer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "jsonapi/serializer/instrumentation"
+ActiveSupport::Deprecation.warn("eligible_for_payment is deprecated as a returnable value for declarations")
+ActiveSupport::Deprecation.warn("voided is deprecated as a returnable value for declarations")
 
 class ParticipantDeclarationSerializer
   include JSONAPI::Serializer
@@ -8,15 +10,19 @@ class ParticipantDeclarationSerializer
 
   set_id :id
   set_type :'participant-declaration'
-  attributes :participant_id, :declaration_type, :course_identifier, :voided
+  attributes :participant_id, :declaration_type, :course_identifier
 
-  attribute :eligible_for_payment do |declaration|
-    declaration.payable || false
-  end
+  attribute :eligible_for_payment, &:payable?
 
   attribute :declaration_date do |declaration|
     declaration.declaration_date.rfc3339
   end
 
+  attribute :voided, &:voided?
+
   attribute(:participant_id, &:user_id)
+
+  attribute :state do |declaration|
+    declaration.current_state.state
+  end
 end

--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -30,17 +30,16 @@ module Participants
       end
 
       def schedule_valid_with_pending_declarations
-        return unless user_profile
+        user_profile&.participant_declarations&.each do |declaration|
+          if declaration.changeable?
+            milestone = schedule.milestones.find_by(declaration_type: declaration.declaration_type)
+            if declaration.declaration_date <= milestone.start_date.beginning_of_day
+              errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
+            end
 
-        declarations = user_profile.participant_declarations.not_voided
-        declarations.each do |declaration|
-          milestone = schedule.milestones.find_by(declaration_type: declaration.declaration_type)
-          if declaration.declaration_date <= milestone.start_date.beginning_of_day
-            errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
-          end
-
-          if milestone.milestone_date.end_of_day < declaration.declaration_date
-            errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
+            if milestone.milestone_date.end_of_day < declaration.declaration_date
+              errors.add(:schedule_identifier, I18n.t(:schedule_invalidates_declaration))
+            end
           end
         end
       end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -61,31 +61,32 @@ module RecordDeclarations
     end
 
     def create_declaration_attempt!
-      ParticipantDeclarationAttempt.create!(
+      ParticipantDeclarationAttempt.create!(declaration_parameters)
+    end
+
+    def find_or_create_record!
+      ApplicationRecord.transaction do
+        self.class.declaration_model.find_or_create_by!(declaration_parameters) do |participant_declaration|
+          DeclarationState.create!(
+            participant_declaration: participant_declaration,
+            state: user_profile.fundable? ? "payable" : "submitted",
+          )
+          ProfileDeclaration.create!(
+            participant_declaration: participant_declaration,
+            participant_profile: user_profile,
+          )
+        end
+      end
+    end
+
+    def declaration_parameters
+      {
         course_identifier: course_identifier,
         declaration_date: declaration_date,
         declaration_type: declaration_type,
         cpd_lead_provider: cpd_lead_provider,
         user: user,
-      )
-    end
-
-    def find_or_create_record!
-      ActiveRecord::Base.transaction do
-        self.class.declaration_model.find_or_create_by!(
-          course_identifier: course_identifier,
-          declaration_date: declaration_date,
-          declaration_type: declaration_type,
-          cpd_lead_provider: cpd_lead_provider,
-          user: user,
-        ) do |participant_declaration|
-          profile_declaration = ProfileDeclaration.create!(
-            participant_declaration: participant_declaration,
-            participant_profile: user_profile,
-          )
-          profile_declaration.update!(payable: participant_declaration.currently_payable)
-        end
-      end
+      }
     end
 
     def record_exists_with_different_declaration_date?

--- a/app/services/record_declarations/retained/base.rb
+++ b/app/services/record_declarations/retained/base.rb
@@ -21,34 +21,8 @@ module RecordDeclarations
         self.class.valid_evidence_types
       end
 
-      def create_declaration_attempt!
-        ParticipantDeclarationAttempt.create!(
-          course_identifier: course_identifier,
-          declaration_date: declaration_date,
-          declaration_type: declaration_type,
-          cpd_lead_provider: cpd_lead_provider,
-          user: user,
-          evidence_held: evidence_held,
-        )
-      end
-
-      def find_or_create_record!
-        ActiveRecord::Base.transaction do
-          self.class.declaration_model.find_or_create_by!(
-            course_identifier: course_identifier,
-            declaration_date: declaration_date,
-            declaration_type: declaration_type,
-            cpd_lead_provider: cpd_lead_provider,
-            user: user,
-            evidence_held: evidence_held,
-          ) do |participant_declaration|
-            profile_declaration = ProfileDeclaration.create!(
-              participant_declaration: participant_declaration,
-              participant_profile: user_profile,
-            )
-            profile_declaration.update!(payable: participant_declaration.currently_payable)
-          end
-        end
+      def declaration_parameters
+        super.merge({ evidence_held: evidence_held })
       end
     end
   end

--- a/app/services/record_declarations/retained/base.rb
+++ b/app/services/record_declarations/retained/base.rb
@@ -22,7 +22,7 @@ module RecordDeclarations
       end
 
       def declaration_parameters
-        super.merge({ evidence_held: evidence_held })
+        super.merge(evidence_held: evidence_held)
       end
     end
   end

--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -6,7 +6,7 @@ class VoidParticipantDeclaration
   def call
     declaration = ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(id)
 
-    raise Api::Errors::InvalidTransitionError, "Declaration is already voided" if declaration.voided
+    raise Api::Errors::InvalidTransitionError, "Declaration is already voided" if declaration.voided?
 
     latest_declaration = declaration.participant_profile.participant_declarations.order(declaration_date: :desc).first
     raise Api::Errors::InvalidTransitionError, "Can only void last declaration" if latest_declaration != declaration

--- a/db/migrate/20210930132253_create_declaration_states.rb
+++ b/db/migrate/20210930132253_create_declaration_states.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDeclarationStates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :declaration_states do |t|
+      t.references :participant_declaration
+      t.string :state, "submitted"
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_30_125828) do
+ActiveRecord::Schema.define(version: 2021_09_30_132253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -171,6 +171,15 @@ ActiveRecord::Schema.define(version: 2021_09_30_125828) do
     t.boolean "section_41_approved"
     t.string "la_code"
     t.index ["urn"], name: "index_data_stage_schools_on_urn", unique: true
+  end
+
+  create_table "declaration_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "participant_declaration_id", null: false
+    t.string "state"
+    t.string "submitted"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["participant_declaration_id"], name: "index_declaration_states_on_participant_declaration_id"
   end
 
   create_table "delayed_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/declaration_states.rb
+++ b/spec/factories/declaration_states.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :declaration_state do
+    participant_declaration
+    state { "submitted" }
+  end
+end

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -45,27 +45,46 @@ FactoryBot.define do
       uplift { :uplift_flags }
     end
 
+    trait :submitted do
+      transient do
+        state { "submitted" }
+      end
+    end
+
     trait :payable do
-      payable { true }
+      transient do
+        state { "payable" }
+      end
+    end
+
+    trait :voided do
+      transient do
+        state { "voided" }
+      end
     end
 
     transient do
       uplift { [] }
       profile_type { :ect }
-      payable { false }
+      state { "submitted" }
     end
 
     trait :with_profile_type do
       after(:create) do |participant_declaration, evaluator|
         create(:profile_declaration,
                participant_declaration: participant_declaration,
-               payable: evaluator.payable,
                participant_profile: create(
                  :participant_profile,
                  evaluator.profile_type,
                  *evaluator.uplift,
                ))
       end
+    end
+
+    after(:create) do |participant_declaration, evaluator|
+      create(:declaration_state,
+             evaluator.state,
+             participant_declaration: participant_declaration)
     end
   end
 end

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe ParticipantDeclaration, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:cpd_lead_provider) }
-    it { is_expected.to have_one(:participant_profile).through(:current_profile_declaration) }
+    it { is_expected.to have_one(:participant_profile).through(:profile_declaration) }
+    it { is_expected.to have_one(:current_state) }
+    it { is_expected.to have_many(:declaration_states) }
   end
 
   describe "uplift scope" do
@@ -40,28 +42,24 @@ RSpec.describe ParticipantDeclaration, type: :model do
     end
   end
 
-  describe "current_profile_declaration" do
+  describe "declaration state" do
     let!(:participant_declaration) { create(:ect_participant_declaration) }
-    let!(:participant_profile) { create(:participant_profile, :ect) }
 
-    it "returns latest profile declaration" do
-      create(:profile_declaration, participant_declaration: participant_declaration, participant_profile: participant_profile, created_at: Time.zone.now - 1.day)
-      declaration_new = create(:profile_declaration, participant_declaration: participant_declaration, participant_profile: participant_profile, created_at: Time.zone.now)
+    it "returns the current state" do
+      state_new = create(:declaration_state, :payable, participant_declaration: participant_declaration)
 
-      expect(participant_declaration.current_profile_declaration).to eq(declaration_new)
+      expect(participant_declaration.current_state).to eq(state_new)
     end
   end
 
   describe "refresh_payability!" do
-    let!(:participant_declaration) { create(:ect_participant_declaration) }
-    let!(:participant_profile) { create(:participant_profile, :ect) }
+    let!(:participant_declaration) { create(:ect_participant_declaration, :submitted) }
+    let!(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_declaration.participant_profile_id) }
 
     context "when declaration was payable" do
-      let(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_profile.id) }
-
       before do
         eligibility.eligible_status!
-        create(:profile_declaration, participant_declaration: participant_declaration, participant_profile: participant_profile, created_at: Time.zone.now, payable: true)
+        participant_declaration.refresh_payability!
       end
 
       context "when declaration becomes non-payable" do
@@ -69,32 +67,32 @@ RSpec.describe ParticipantDeclaration, type: :model do
           eligibility.manual_check_status!
         end
 
-        it "creates a new profile declaration which is non-payable" do
-          expect { participant_declaration.refresh_payability! }.to change { participant_declaration.profile_declarations.count }.by(1)
-          expect(participant_declaration.payable).to be_falsey
+        it "makes the declaration submitted if currently payable" do
+          expect(participant_declaration.payable?).to be_truthy
+          expect { participant_declaration.refresh_payability! }.to change { participant_declaration.declaration_states.count }.by(1)
+          expect(participant_declaration.payable?).to be_falsey
+          expect(participant_declaration.submitted?).to be_truthy
         end
 
         it "keeps the declaration voided if it was voided already" do
           participant_declaration.void!
-          expect { participant_declaration.refresh_payability! }.to change { participant_declaration.profile_declarations.count }.by(1)
-          expect(participant_declaration.voided).to be_truthy
+          expect { participant_declaration.refresh_payability! }.not_to change { participant_declaration.declaration_states.count }
+          expect(participant_declaration.voided?).to be_truthy
         end
       end
 
       context "when declaration remains payable" do
-        it "does not create a new profile declaration" do
-          expect { participant_declaration.refresh_payability! }.not_to change { participant_declaration.profile_declarations.count }
-          expect(participant_declaration.payable).to be_truthy
+        it "does not create a new declaration state" do
+          expect(participant_declaration.payable?).to be_truthy
+          expect { participant_declaration.refresh_payability! }.not_to change { participant_declaration.declaration_states.count }
+          expect(participant_declaration.payable?).to be_truthy
         end
       end
     end
 
     context "when declaration was not payable" do
-      let(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_profile.id) }
-
       before do
         eligibility.manual_check_status!
-        create(:profile_declaration, participant_declaration: participant_declaration, participant_profile: participant_profile, created_at: Time.zone.now, payable: false)
       end
 
       context "when declaration becomes payable" do
@@ -102,22 +100,24 @@ RSpec.describe ParticipantDeclaration, type: :model do
           eligibility.eligible_status!
         end
 
-        it "creates a new profile declaration which is payable" do
-          expect { participant_declaration.refresh_payability! }.to change { participant_declaration.profile_declarations.count }.by(1)
-          expect(participant_declaration.payable).to be_truthy
+        it "creates a new declaration state which is payable" do
+          expect(participant_declaration.submitted?).to be_truthy
+          eligibility.eligible_status!
+          expect { participant_declaration.refresh_payability! }.to change { participant_declaration.declaration_states.count }.by(1)
+          expect(participant_declaration.payable?).to be_truthy
         end
 
         it "keeps the declaration voided if it was voided already" do
           participant_declaration.void!
-          expect { participant_declaration.refresh_payability! }.to change { participant_declaration.profile_declarations.count }.by(1)
-          expect(participant_declaration.voided).to be_truthy
+          expect { participant_declaration.refresh_payability! }.not_to change { participant_declaration.declaration_states.count }
+          expect(participant_declaration.voided?).to be_truthy
         end
       end
 
       context "when declaration remains non-payable" do
-        it "does not create a new profile declaration" do
-          expect { participant_declaration.refresh_payability! }.not_to change { participant_declaration.profile_declarations.count }
-          expect(participant_declaration.payable).to be_falsey
+        it "does not create a new declaration state" do
+          expect { participant_declaration.refresh_payability! }.not_to change { participant_declaration.declaration_states.count }
+          expect(participant_declaration.payable?).to be_falsey
         end
       end
     end
@@ -125,35 +125,29 @@ RSpec.describe ParticipantDeclaration, type: :model do
 
   describe "void!" do
     let!(:participant_declaration) { create(:ect_participant_declaration) }
-    let!(:participant_profile) { create(:participant_profile, :ect) }
+    let!(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_declaration.participant_profile_id) }
 
     context "when declaration was payable" do
-      let(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_profile.id) }
-
       before do
         eligibility.eligible_status!
-        create(:profile_declaration, participant_declaration: participant_declaration, participant_profile: participant_profile, created_at: Time.zone.now, payable: true)
       end
 
-      it "voids the declaration and keeps it payable" do
+      it "voids the declaration" do
         participant_declaration.void!
-        expect(participant_declaration.payable).to be_truthy
-        expect(participant_declaration.voided).to be_truthy
+        expect(participant_declaration.payable?).to be_falsey
+        expect(participant_declaration.voided?).to be_truthy
       end
     end
 
     context "when declaration was not payable" do
-      let(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_profile.id) }
-
       before do
         eligibility.manual_check_status!
-        create(:profile_declaration, participant_declaration: participant_declaration, participant_profile: participant_profile, created_at: Time.zone.now, payable: false)
       end
 
       it "voids the declaration and keeps it non-payable" do
         participant_declaration.void!
-        expect(participant_declaration.payable).to be_falsy
-        expect(participant_declaration.voided).to be_truthy
+        expect(participant_declaration.payable?).to be_falsy
+        expect(participant_declaration.voided?).to be_truthy
       end
     end
   end

--- a/spec/models/profile_declaration_spec.rb
+++ b/spec/models/profile_declaration_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ProfileDeclaration, type: :model do
       end
 
       it "includes declaration with ect profile" do
-        expect(ProfileDeclaration.ect_profiles).to include(ect_declaration.current_profile_declaration)
+        expect(ProfileDeclaration.ect_profiles).to include(ect_declaration.profile_declaration)
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe ProfileDeclaration, type: :model do
       end
 
       it "includes declaration with mentor profile" do
-        expect(ProfileDeclaration.mentor_profiles).to include(mentor_declaration.current_profile_declaration)
+        expect(ProfileDeclaration.mentor_profiles).to include(mentor_declaration.profile_declaration)
       end
     end
   end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         eligibility = ECFParticipantEligibility.create!(participant_profile_id: ect_profile.id)
         eligibility.eligible_status!
         post "/api/v1/participant-declarations", params: params
-        expect(ParticipantDeclaration.order(:created_at).last.payable).to be_truthy
+        expect(ParticipantDeclaration.order(:created_at).last.payable?).to be_truthy
       end
 
       it "does not create duplicate declarations with the same declaration date, but stores the duplicate declaration attempts" do
@@ -240,7 +240,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
 
       context "when there is a voided declaration" do
         let(:expected_response) do
-          expected_json_response(declaration: participant_declaration, profile: ect_profile, voided: true)
+          expected_json_response(declaration: participant_declaration, profile: ect_profile, state: "voided")
         end
 
         before do
@@ -263,7 +263,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         end
 
         let(:expected_response) do
-          expected_json_response(declaration: participant_declaration, profile: ect_profile, eligible_for_payment: true)
+          expected_json_response(declaration: participant_declaration, profile: ect_profile, state: "payable")
         end
 
         before do
@@ -383,7 +383,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
 
     it "returns the correct headers" do
       expect(parsed_response.headers).to match_array(
-        %w[id course_identifier declaration_date declaration_type eligible_for_payment participant_id voided],
+        %w[id course_identifier declaration_date declaration_type participant_id state eligible_for_payment voided],
       )
     end
 
@@ -393,7 +393,9 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
       expect(participant_declaration_one_row["course_identifier"]).to eql participant_declaration_one.course_identifier
       expect(participant_declaration_one_row["declaration_date"]).to eql participant_declaration_one.declaration_date.rfc3339
       expect(participant_declaration_one_row["declaration_type"]).to eql participant_declaration_one.declaration_type
-      expect(participant_declaration_one_row["eligible_for_payment"]).to eql participant_declaration_one.payable.to_s
+      expect(participant_declaration_one_row["eligible_for_payment"]).to eql participant_declaration_one.payable?.to_s
+      expect(participant_declaration_one_row["voided"]).to eql participant_declaration_one.voided?.to_s
+      expect(participant_declaration_one_row["state"]).to eql participant_declaration_one.current_state.state.to_s
       expect(participant_declaration_one_row["participant_id"]).to eql participant_declaration_one.participant_profile.user.id
     end
 
@@ -405,23 +407,23 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
 
 private
 
-  def expected_json_response(declaration:, profile:, course_identifier: "ecf-induction", eligible_for_payment: false, voided: false)
+  def expected_json_response(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted")
     {
       "data" =>
           [
-            single_json_declaration(declaration: declaration, profile: profile, course_identifier: course_identifier, eligible_for_payment: eligible_for_payment, voided: voided),
+            single_json_declaration(declaration: declaration, profile: profile, course_identifier: course_identifier, state: state),
           ],
     }
   end
 
-  def expected_single_json_response(declaration:, profile:, course_identifier: "ecf-induction", eligible_for_payment: false)
+  def expected_single_json_response(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted")
     {
       "data" =>
-          single_json_declaration(declaration: declaration, profile: profile, course_identifier: course_identifier, eligible_for_payment: eligible_for_payment),
+          single_json_declaration(declaration: declaration, profile: profile, course_identifier: course_identifier, state: state),
     }
   end
 
-  def single_json_declaration(declaration:, profile:, course_identifier: "ecf-induction", eligible_for_payment: false, voided: false)
+  def single_json_declaration(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted")
     {
       "id" => declaration.id,
       "type" => "participant-declaration",
@@ -430,8 +432,9 @@ private
         "declaration_type" => "started",
         "declaration_date" => declaration.declaration_date.rfc3339,
         "course_identifier" => course_identifier,
-        "eligible_for_payment" => eligible_for_payment,
-        "voided" => voided,
+        "state" => state,
+        "eligible_for_payment" => state == "payable",
+        "voided" => state == "voided",
       },
     }
   end

--- a/spec/services/calculation_orchestrator_spec.rb
+++ b/spec/services/calculation_orchestrator_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe CalculationOrchestrator do
       let(:with_uplift) { :sparsity_uplift }
 
       before do
-        create_list(:ect_participant_declaration, 5, :payable, with_uplift, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
-        create_list(:mentor_participant_declaration, 5, :payable, with_uplift, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 5, with_uplift, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:mentor_participant_declaration, 5, with_uplift, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       context "when only sparsity_uplift flag was set" do
@@ -174,8 +174,8 @@ RSpec.describe CalculationOrchestrator do
 
     context "when no uplift flags were set" do
       before do
-        create_list(:ect_participant_declaration, 5, :payable, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
-        create_list(:mentor_participant_declaration, 5, :payable, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 5, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:mentor_participant_declaration, 5, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
         normal_outcome[:other_fees][:uplift].tap do |hash|
           hash[:participants] = 0
           hash[:subtotal] = 0
@@ -194,7 +194,7 @@ RSpec.describe CalculationOrchestrator do
 
     context "when only mentor profile declaration records available" do
       before do
-        create_list(:mentor_participant_declaration, 10, :sparsity_uplift, :payable, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:mentor_participant_declaration, 10, :sparsity_uplift, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "returns the total calculation" do
@@ -204,7 +204,7 @@ RSpec.describe CalculationOrchestrator do
 
     context "when only ect profile declaration records available" do
       before do
-        create_list(:ect_participant_declaration, 10, :sparsity_uplift, :payable, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 10, :sparsity_uplift, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "returns the total calculation" do
@@ -214,8 +214,8 @@ RSpec.describe CalculationOrchestrator do
 
     context "when both mentor profile and ect profile declaration records available" do
       before do
-        create_list(:ect_participant_declaration, 5, :sparsity_uplift, :payable, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
-        create_list(:mentor_participant_declaration, 5, :sparsity_uplift, :payable, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:ect_participant_declaration, 5, :sparsity_uplift, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        create_list(:mentor_participant_declaration, 5, :sparsity_uplift, state: "payable", cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
       end
 
       it "returns the total calculation" do

--- a/spec/services/void_participant_declaration_service_spec.rb
+++ b/spec/services/void_participant_declaration_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe VoidParticipantDeclaration do
     it "voids a participant declaration" do
       declaration = ParticipantDeclaration.order(:declaration_date).first
       described_class.new(cpd_lead_provider: cpd_lead_provider, id: declaration.id).call
-      expect(declaration.reload.voided).to be_truthy
+      expect(declaration.reload.voided?).to be_truthy
     end
 
     it "does not void a voided declaration" do
@@ -39,16 +39,16 @@ RSpec.describe VoidParticipantDeclaration do
     end
 
     it "only voids the last declaration" do
-      old_declaration = create(:participant_declaration, declaration_date: start_date + 1.day, course_identifier: "ecf-induction", declaration_type: "started", cpd_lead_provider: cpd_lead_provider)
+      old_declaration = create(:participant_declaration, :submitted, declaration_date: start_date + 1.day, course_identifier: "ecf-induction", declaration_type: "started", cpd_lead_provider: cpd_lead_provider)
       create(:profile_declaration, participant_declaration: old_declaration, participant_profile: ect_profile)
       expect {
         described_class.new(cpd_lead_provider: cpd_lead_provider, id: old_declaration.id).call
       }.to raise_error Api::Errors::InvalidTransitionError
-      expect(old_declaration.reload.voided).to be_falsey
+      expect(old_declaration.reload.voided?).to be_falsey
 
       new_declaration = ParticipantDeclaration.order(declaration_date: :desc).first
       described_class.new(cpd_lead_provider: cpd_lead_provider, id: new_declaration.id).call
-      expect(new_declaration.reload.voided).to be_truthy
+      expect(new_declaration.reload.voided?).to be_truthy
     end
   end
 end

--- a/spec/support/shared_examples/participant_actions_change_schedule_support.rb
+++ b/spec/support/shared_examples/participant_actions_change_schedule_support.rb
@@ -28,12 +28,12 @@ RSpec.shared_examples "a participant change schedule action service" do
       declaration
     end
 
-    it "fails when it would invalidate a non-voided declaration" do
+    it "fails when it would invalidate a valid declaration" do
       extended_schedule.milestones.each { |milestone| milestone.update!(start_date: milestone.start_date + 6.months, milestone_date: milestone.milestone_date + 6.months) }
       expect { described_class.call(params: given_params) }.to raise_error(ActionController::ParameterMissing)
     end
 
-    it "changes the schedule on user's profile when it would invalidate a voided declaration" do
+    it "ignores voided declarations when changing the schedule" do
       declaration.void!
       extended_schedule.milestones.each { |milestone| milestone.update!(start_date: milestone.start_date + 6.months, milestone_date: milestone.milestone_date + 6.months) }
 

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1794,7 +1794,7 @@
             }
           }
         },
-        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n"
+        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n"
       },
       "MultipleParticipantDeclarationsResponse": {
         "description": "A list of participant declarations",
@@ -2359,7 +2359,8 @@
           "declaration_date",
           "course_identifier",
           "eligible_for_payment",
-          "voided"
+          "voided",
+          "state"
         ],
         "properties": {
           "participant_id": {
@@ -2403,16 +2404,22 @@
             "example": "ecf-induction"
           },
           "eligible_for_payment": {
-            "description": "Indicates whether this declaration would be eligible for funding from the DfE",
+            "description": "[Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE",
             "type": "boolean",
             "nullable": false,
             "example": true
           },
           "voided": {
-            "description": "Indicates whether this declaration has been voided",
+            "description": "[Deprecated - use state instead] Indicates whether this declaration has been voided",
             "type": "boolean",
             "nullable": false,
             "example": false
+          },
+          "state": {
+            "description": "Indicates the state of this payment declaration",
+            "type": "string",
+            "nullable": false,
+            "example": "paid"
           }
         }
       },
@@ -2506,10 +2513,16 @@
             "example": true
           },
           "voided": {
-            "description": "Indicates whether this declaration has been voided",
+            "description": "[Deprecated - use state instead] Indicates whether this declaration has been voided",
             "type": "boolean",
             "nullable": false,
             "example": false
+          },
+          "state": {
+            "description": "[Deprecated - use state instead] Indicates the state of this payment declaration",
+            "type": "string",
+            "nullable": false,
+            "example": "paid"
           }
         }
       },

--- a/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
@@ -8,6 +8,6 @@ properties:
     items:
       $ref: "#/components/schemas/ParticipantDeclarationCsvRow"
 example: |
-  id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided
+  id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state
   c88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false
   31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false

--- a/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
@@ -7,6 +7,7 @@ required:
   - course_identifier
   - eligible_for_payment
   - voided
+  - state
 properties:
   participant_id:
     description: "The unique id of the participant"
@@ -43,12 +44,17 @@ properties:
       - npq-executive-leadership
     example: ecf-induction
   eligible_for_payment:
-    description: "Indicates whether this declaration would be eligible for funding from the DfE"
+    description: "[Deprecated - use state instead] Indicates whether this declaration would be eligible for funding from the DfE"
     type: boolean
     nullable: false
     example: true
   voided:
-    description: "Indicates whether this declaration has been voided"
+    description: "[Deprecated - use state instead] Indicates whether this declaration has been voided"
     type: boolean
     nullable: false
     example: false
+  state:
+    description: "Indicates the state of this payment declaration"
+    type: string
+    nullable: false
+    example: paid

--- a/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationCsvRow.yml
@@ -54,7 +54,13 @@ properties:
     nullable: false
     example: true
   voided:
-    description: "Indicates whether this declaration has been voided"
+    description: "[Deprecated - use state instead] Indicates whether this declaration has been voided"
     type: boolean
     nullable: false
     example: false
+  state:
+    description: "[Deprecated - use state instead] Indicates the state of this payment declaration"
+    type: string
+    nullable: false
+    example: paid
+


### PR DESCRIPTION
## Ticket and context

There is a lifecycle for declarations that follow a number of states (submitted, payable (after checking), paid, voided being the initial ones). These states don't conflict and are separate, but are currently implemented as flags and separated.

In order to implement payment, this cleans up the implementation and switches existing code to use them as states as opposed to flags. More PRs will follow to actually implement the payment and aggregations once paid declarations are triggered and the update to payment breakdowns to actually handle only new declaration aggregations (and any late payment requirements)

Ticket:  https://dfedigital.atlassian.net/jira/software/projects/CPDTP/boards/87?selectedIssue=CPDTP-250

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
