### PR TITLE
Only return 2021 participants to lead provider in API

### DIFF
--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -42,6 +42,7 @@ module Api
                                         early_career_teacher_profile: :mentor,
                                       },
                                     )
+                                    .where(school_cohorts: { cohort_id: Cohort.current.id })
 
         participants = participants.changed_since(updated_since) if updated_since.present?
 

--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -7,9 +7,9 @@ class TeacherProfile < ApplicationRecord
   has_many :participant_profiles, dependent: :destroy
 
   # TODO: Legacy associations, to be removed
-  has_one :early_career_teacher_profile, -> { ects.active_record }, class_name: "ParticipantProfile"
-  has_one :mentor_profile, -> { mentors.active_record }, class_name: "ParticipantProfile"
-  has_one :ecf_profile, -> { ecf.active_record }, class_name: "ParticipantProfile"
+  has_one :early_career_teacher_profile, -> { active_record }, class_name: "ParticipantProfile::ECT"
+  has_one :mentor_profile, -> { active_record }, class_name: "ParticipantProfile::Mentor"
+  has_one :ecf_profile, -> { active_record }, class_name: "ParticipantProfile::ECF"
 
   has_many :npq_profiles, class_name: "ParticipantProfile::NPQ"
   # end: TODO

--- a/config/initializers/preload_stis.rb
+++ b/config/initializers/preload_stis.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Taken from https://github.com/rails/rails/blob/main/guides/source/autoloading_and_reloading_constants.md
+# Makes ParticipantProfile::ECF behave properly in dev and test
+unless Rails.application.config.eager_load
+  Rails.autoloaders.main.on_load("ParticipantProfile") do
+    ParticipantProfile.connection.select_values(<<~SQL).each(&:constantize)
+      SELECT DISTINCT("#{ParticipantProfile.inheritance_column}")
+      FROM "#{ParticipantProfile.table_name}"
+      WHERE "#{ParticipantProfile.inheritance_column}" IS NOT NULL
+    SQL
+  end
+end

--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -4,12 +4,14 @@ module ParticipantDeclarationSteps
   include Capybara::DSL
 
   def given_an_early_career_teacher_has_been_entered_onto_the_dfe_service
-    @ect_profile = create(:participant_profile, :ect)
+    cohort = create(:cohort, :current)
+    school_cohort = create(:school_cohort, cohort: cohort)
+    @ect_profile = create(:participant_profile, :ect, school_cohort: school_cohort)
     delivery_partner = create(:delivery_partner)
     create(:partnership,
            school: @ect_profile.school,
            lead_provider: @cpd_lead_provider.lead_provider,
-           cohort: @ect_profile.cohort,
+           cohort: cohort,
            delivery_partner: delivery_partner)
 
     @ect_id = @ect_profile.user.id
@@ -17,8 +19,10 @@ module ParticipantDeclarationSteps
   end
 
   def given_an_ecf_mentor_has_been_entered_onto_the_dfe_service
-    partnership = create(:partnership, lead_provider: @lead_provider)
-    mentor_profile = create(:participant_profile, :mentor, school: partnership.school, cohort: partnership.cohort)
+    cohort = create(:cohort, :current)
+    school_cohort = create(:school_cohort, cohort: cohort)
+    create(:partnership, lead_provider: @lead_provider, cohort: cohort, school: school_cohort.school)
+    mentor_profile = create(:participant_profile, :mentor, school_cohort: school_cohort)
     @mentor_id = mentor_profile.user.id
     travel_to mentor_profile.schedule.milestones.first.start_date + 1.day
   end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe "Participants API", type: :request, with_feature_flags: { partici
   describe "GET /api/v1/participants" do
     let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: lead_provider) }
     let(:lead_provider) { create(:lead_provider) }
-    let(:partnership) { create(:partnership, lead_provider: lead_provider) }
-    let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: partnership.cohort, induction_programme_choice: "full_induction_programme") }
+    let(:cohort) { create(:cohort, :current) }
+    let(:partnership) { create(:partnership, lead_provider: lead_provider, cohort: cohort) }
+    let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: cohort, induction_programme_choice: "full_induction_programme") }
     let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
 
     before :each do
-      mentor_profile = create(:participant_profile, :mentor, school: partnership.school, cohort: partnership.cohort)
+      mentor_profile = create(:participant_profile, :mentor, school_cohort: school_cohort)
       create_list :participant_profile, 2, :ect, mentor_profile: mentor_profile, school_cohort: school_cohort
       ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record = ParticipantProfile::ECT.first.teacher_profile
       create(:participant_profile,


### PR DESCRIPTION
The addition of NQT+1 as 2020 participants caused them to appear in the participants results for lead providers where they are at a partnered school. This change limits results to participants in the current cohort (for ECF only)