### PR TITLE
Improve error message for an npq application if it's already submitted for this participant

### DIFF
--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -20,6 +20,8 @@ module NPQ
         create_profile
         npq_application.update(lead_provider_approval_status: "accepted") && other_applications.update(lead_provider_approval_status: "rejected")
       end
+    rescue ActiveRecord::StatementInvalid
+      raise ActionController::BadRequest, I18n.t(:npq_application_already_accepted)
     end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
   declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"
   invalid_data_structure: correct json data structure required. See API docs for reference
+  npq_application_already_accepted: The participant submitted in this NPQ application has already an accepted NPQ application
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults
     not_a_number: *default_message

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe NPQ::Accept do
         npq_validation_data.update!(teacher_reference_number: new_trn)
 
         expect { subject.call }
-          .to raise_error(ActiveRecord::RecordNotUnique)
+          .to raise_error(ActionController::BadRequest)
           .and change(TeacherProfile, :count).by(0)
           .and change(ParticipantProfile::NPQ, :count).by(0)
       end


### PR DESCRIPTION
## Tech review

### Is there anything that the code reviewer should know?

Previous error message looked like this:

```
{
  "errors": [
    {
      "title": "Bad request",
      "detail": "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"participant_profiles_pkey1\"\nDETAIL:  Key (id)=(9e22ff42-116d-4b9a-a281-79e37686832c) already exists.\n"
    }
  ]
}
```

now it's: 

```
{
  "errors": [
    {
      "title": "Bad request",
      "detail": "The participant submitted in this NPQ application has already an accepted NPQ application"
    }
  ]
}
```

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (lead-providers/guidance/release-notes)
