### PR TITLE
Use Teacher Training API solution to show api schemas and examples in docs

### DIFF
--- a/docs/config.rb
+++ b/docs/config.rb
@@ -2,12 +2,15 @@
 
 require "govuk_tech_docs"
 require "lib/govuk_tech_docs/table_of_contents/custom_helpers"
+require "lib/govuk_tech_docs/open_api/extension"
 
 GovukTechDocs.configure(self)
 
 helpers do
   include GovukTechDocs::TableOfContents::CustomHelpers
 end
+
+activate :open_api
 
 set :css_dir, "api-reference/stylesheets"
 set :js_dir, "api-reference/javascripts"

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -30,4 +30,4 @@ prevent_indexing: false
 show_contribution_banner: false
 github_repo: DFE-Digital/early-careers-framework
 
-api_path: ../swagger/v1/api_spec.json
+open_api_path: ../swagger/v1/api_spec.json

--- a/docs/lib/govuk_tech_docs/open_api/extension.rb
+++ b/docs/lib/govuk_tech_docs/open_api/extension.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "openapi3_parser"
+require "uri"
+require_relative "renderer"
+
+module GovukTechDocs
+  module OpenApi
+    class Extension < Middleman::Extension
+      expose_to_application api: :api
+
+      def initialize(app, options_hash = {}, &block)
+        super
+
+        @app = app
+        @config = @app.config[:tech_docs]
+
+        # If no api path then just return.
+        if api_path.empty?
+          @api_parser = false
+          return
+        end
+
+        if uri?(api_path)
+          @api_parser = true
+          @document = Openapi3Parser.load_url(api_path)
+        elsif File.exist?(api_path)
+          # Load api file and set existence flag.
+          @api_parser = true
+          @document = Openapi3Parser.load_file(api_path)
+        else
+          @api_parser = false
+          raise "Unable to load api path from tech-docs.yml"
+        end
+        @render = Renderer.new(@app, @document)
+      end
+
+      def api(text)
+        if @api_parser == true
+
+          keywords = {
+            "api&gt;" => "default",
+            "api_schema&gt;" => "schema",
+          }
+
+          regexp = keywords.map { |k, _| Regexp.escape(k) }.join("|")
+
+          md = text.match(/^<p>(#{regexp})/)
+
+          if md
+            key = md.captures[0]
+            type = keywords[key]
+
+            text.gsub!(/#{Regexp.escape(key)}\s+?/, "")
+
+            # Strip paragraph tags from text
+            text = text.gsub(/<\/?[^>]*>/, "")
+            text = text.strip
+
+            if text == "api&gt;"
+              @render.api_full
+            elsif type == "default"
+              output = @render.path(text)
+              # Render any schemas referenced in the above path
+              output += @render.schemas_from_path(text)
+              output
+            else
+              @render.schema(text)
+            end
+          else
+            text
+          end
+        else
+          text
+        end
+      end
+
+    private
+
+      def uri?(string)
+        uri = URI.parse(string)
+        %w[http https].include?(uri.scheme)
+      rescue URI::BadURIError
+        false
+      rescue URI::InvalidURIError
+        false
+      end
+
+      def api_path
+        @config["open_api_path"].to_s
+      end
+    end
+  end
+end
+
+::Middleman::Extensions.register(:open_api, GovukTechDocs::OpenApi::Extension)

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+require "erb"
+require "json"
+require "rouge"
+
+module GovukTechDocs
+  module OpenApi
+    class Renderer
+      attr_reader :app, :document
+
+      def initialize(app, document)
+        @app = app
+        @document = document
+
+        # Load template files
+        @template_api_full = get_renderer("api_reference_full.html.erb")
+        @template_path = get_renderer("path.html.erb")
+        @template_schema = get_renderer("schema.html.erb")
+        @template_operation = get_renderer("operation.html.erb")
+        @template_parameters = get_renderer("parameters.html.erb")
+        @template_responses = get_renderer("responses.html.erb")
+        @template_any_of = get_renderer("any_of.html.erb")
+        @template_curl_examples = get_renderer("curl_examples.html.erb")
+      end
+
+      def api_full
+        paths = ""
+        paths_data = @document.paths
+        paths_data.each do |path_data|
+          # For some reason paths.each returns an array of arrays [title, object]
+          # instead of an array of objects
+          text = path_data[0]
+          paths += path(text)
+        end
+        schemas = ""
+        schemas_data.each do |schema_data|
+          text = schema_data[0]
+          schemas += schema(text)
+        end
+        @template_api_full.result(binding)
+      end
+
+      def path(text)
+        path = @document.paths[text]
+        id = text.parameterize
+        operations = operations(text: text, path: path, path_id: id)
+        @template_path.result(binding)
+      end
+
+      def schema(text)
+        properties = properties_for_schema(text)
+
+        schema_data = schemas_data.find { |s| s[0] == text }
+
+        title = schema_data[0]
+        schema = schema_data[1]
+
+        if schema_data[1]["anyOf"]
+          return @template_any_of.result(binding)
+        end
+
+        @template_schema.result(binding)
+      end
+
+      def schemas_from_path(text)
+        path = @document.paths[text]
+        operations = get_operations(path)
+        # Get all referenced schemas
+        schemas = []
+        operations.compact.each_value do |operation|
+          responses = operation.responses
+          responses.each do |_rkey, response|
+            next unless response.content["application/json"]
+
+            schema = response.content["application/json"].schema
+            schema_name = get_schema_name(schema.node_context.source_location.to_s)
+            unless schema_name.nil?
+              schemas.push schema_name
+            end
+            schemas.concat(schemas_from_schema(schema))
+          end
+        end
+        # Render all referenced schemas
+        output = ""
+        schemas.uniq.each do |schema_name|
+          output += schema(schema_name)
+        end
+        unless output.empty?
+          output.prepend('<h2 id="schemas">Schemas</h2>')
+        end
+        output
+      end
+
+      def schemas_from_schema(schema)
+        schemas = []
+        properties = []
+        schema.properties.each do |property|
+          properties.push property[1]
+        end
+        if schema.type == "array"
+          properties.push schema.items
+        end
+        all_of = schema["allOf"]
+        if all_of.present?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties.push property[1]
+            end
+          end
+        end
+        properties.each do |property|
+          # Must be a schema be referenced by another schema
+          # And not a property of a schema
+          if property.node_context.resolved_input.to_s.include?("#/components/schemas") &&
+              !property.node_context.source_location.to_s.include?("/properties/")
+            schema_name = get_schema_name(property.node_context.source_location.to_s)
+          end
+          unless schema_name.nil?
+            schemas.push schema_name
+          end
+          # Check sub-properties for references
+          schemas.concat(schemas_from_schema(property))
+        end
+        schemas
+      end
+
+      def operations(text:, path:, path_id:)
+        output = ""
+        operations = get_operations(path)
+        operations.compact.each do |key, operation|
+          id = "#{path_id}-#{key.parameterize}"
+          text = text # rubocop:disable Lint/SelfAssignment
+          parameters = parameters(operation, id)
+          responses = responses(operation, id)
+          curl_examples = curl_examples(operation, id)
+          output += @template_operation.result(binding)
+        end
+        output
+      end
+
+      def parameters(operation, operation_id)
+        parameters = operation.parameters
+        id = "#{operation_id}-parameters"
+        @template_parameters.result(binding)
+      end
+
+      def curl_examples(operation, operation_id)
+        curl_examples = operation.node_data["x-curl-examples"] || []
+        id = "#{operation_id}-curl-examples"
+        @template_curl_examples.result(binding)
+      end
+
+      def responses(operation, operation_id)
+        responses = operation.responses
+        id = "#{operation_id}-responses"
+        @template_responses.result(binding)
+      end
+
+      def markdown(text)
+        if text
+          Tilt["markdown"].new(context: @app) { text }.render
+        end
+      end
+
+      def json_output(schema)
+        properties = schema_properties(schema)
+        JSON.pretty_generate(properties)
+      end
+
+      def json_prettyprint(data)
+        JSON.pretty_generate(data)
+      end
+
+      def schema_properties(schema_data)
+        properties = {}
+        if defined? schema_data.properties
+          schema_data.properties.each do |key, property|
+            properties[key] = property
+          end
+        end
+        properties.merge! get_all_of_hash(schema_data)
+        properties.merge! get_any_of_hash(schema_data)
+        properties_hash = {}
+        properties.each do |pkey, property|
+          case property.type
+          when "object"
+            properties_hash[pkey] = {}
+            items = property.items
+            if items.present?
+              properties_hash[pkey] = schema_properties(items)
+            end
+            if property.properties.present?
+              properties_hash[pkey] = schema_properties(property)
+            end
+          when "array"
+            properties_hash[pkey] = []
+            items = property.items
+            if items.present?
+              properties_hash[pkey].push schema_properties(items)
+            end
+          else
+            properties_hash[pkey] = !property.example.nil? ? property.example : property.type
+          end
+        end
+
+        properties_hash
+      end
+
+      def schema_is_referenced?(schema)
+        schema.node_context.source_location.pointer.segments[0..1] == %w[components schemas]
+      end
+
+    private
+
+      def info
+        document.info
+      end
+
+      def servers
+        document.servers
+      end
+
+      def get_all_of_array(schema)
+        properties = []
+        if schema.is_a?(Array)
+          schema = schema[1]
+        end
+        if schema["allOf"]
+          all_of = schema["allOf"]
+        end
+        if all_of.present?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              if property.is_a?(Array)
+                property = property[1]
+              end
+              properties.push property
+            end
+          end
+        end
+        properties
+      end
+
+      def get_all_of_hash(schema)
+        properties = {}
+        if schema["allOf"]
+          all_of = schema["allOf"]
+        end
+        if all_of.present?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |key, property|
+              properties[key] = property
+            end
+          end
+        end
+        properties
+      end
+
+      def get_any_of_hash(schema)
+        properties = {}
+        any_of = schema["anyOf"]
+
+        if any_of.present?
+          nested_schema = any_of.first
+          nested_schema.properties.each do |key, property|
+            properties[key] = property
+          end
+        end
+        properties
+      end
+
+      def get_renderer(file)
+        template_path = File.join(File.dirname(__FILE__), "templates/#{file}")
+        template = File.open(template_path, "r").read
+        ERB.new(template)
+      end
+
+      def get_operations(path)
+        operations = {}
+        operations["get"] = path.get if defined? path.get
+        operations["put"] = path.put if defined? path.put
+        operations["post"] = path.post if defined? path.post
+        operations["delete"] = path.delete if defined? path.delete
+        operations["patch"] = path.patch if defined? path.patch
+        operations
+      end
+
+      def get_schema_name(text)
+        unless text.is_a?(String)
+          return nil
+        end
+
+        # Schema dictates that it's always components['schemas']
+        text.gsub(/#\/components\/schemas\//, "")
+      end
+
+      def get_schema_link(schema)
+        schema_name = get_schema_name schema.node_context.source_location.to_s
+        unless schema_name.nil?
+          id = "schema-#{schema_name.parameterize}"
+          "<a href='\##{id}'>#{schema_name}</a>"
+
+        end
+      end
+
+      def schemas_data
+        @schemas_data ||= @document.components.schemas
+      end
+
+      def format_possible_value(possible_value)
+        if possible_value == ""
+          "<em>empty string</em>"
+        else
+          possible_value
+        end
+      end
+
+      def properties_for_schema(schema_name)
+        schema_data = schemas_data.find { |s| s[0] == schema_name }
+
+        properties = []
+
+        all_of = schema_data[1]["allOf"]
+        if all_of.present?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties.push property
+            end
+          end
+        end
+
+        any_of = schema_data[1]["anyOf"]
+        if any_of.present?
+          any_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties.push property
+            end
+          end
+        end
+
+        schema_data[1].properties.each do |property|
+          properties.push property
+        end
+
+        if schema_data[1] && schema_data[1].type == "array"
+          properties.push ["Item", schema_data[1].items]
+        end
+
+        properties
+      end
+    end
+  end
+end

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -25,19 +25,15 @@ module GovukTechDocs
       end
 
       def api_full
-        paths = ""
-        paths_data = @document.paths
-        paths_data.each do |path_data|
-          # For some reason paths.each returns an array of arrays [title, object]
-          # instead of an array of objects
-          text = path_data[0]
-          paths += path(text)
+        paths = @document.paths.keys.inject("") do |memo, text|
+          memo + path(text)
         end
-        schemas = ""
-        schemas_data.each do |schema_data|
-          text = schema_data[0]
-          schemas += schema(text)
+
+        schema_names = @document.components.schemas.keys
+        schemas = schema_names.inject("") do |memo, schema_name|
+          memo + schema(schema_name)
         end
+
         @template_api_full.result(binding)
       end
 
@@ -48,15 +44,13 @@ module GovukTechDocs
         @template_path.result(binding)
       end
 
-      def schema(text)
-        properties = properties_for_schema(text)
-
-        schema_data = schemas_data.find { |s| s[0] == text }
-
-        title = schema_data[0]
+      def schema(title)
+        schema_data = schemas_data.find { |s| s[0] == title }
         schema = schema_data[1]
 
-        if schema_data[1]["anyOf"]
+        properties = properties_for_schema(schema)
+
+        if schema["anyOf"]
           return @template_any_of.result(binding)
         end
 
@@ -64,79 +58,47 @@ module GovukTechDocs
       end
 
       def schemas_from_path(text)
-        path = @document.paths[text]
-        operations = get_operations(path)
-        # Get all referenced schemas
-        schemas = []
-        operations.compact.each_value do |operation|
-          responses = operation.responses
-          responses.each do |_rkey, response|
-            next unless response.content["application/json"]
+        operations = get_operations(@document.paths[text])
+        schemas = operations.flat_map do |_, operation|
+          operation.responses.inject([]) do |memo, (_, response)|
+            next memo unless response.content["application/json"]
 
             schema = response.content["application/json"].schema
-            schema_name = get_schema_name(schema.node_context.source_location.to_s)
-            unless schema_name.nil?
-              schemas.push schema_name
-            end
-            schemas.concat(schemas_from_schema(schema))
+
+            memo << schema.name if schema.name
+            memo + schemas_from_schema(schema)
           end
         end
+
         # Render all referenced schemas
-        output = ""
-        schemas.uniq.each do |schema_name|
-          output += schema(schema_name)
+        output = schemas.uniq.inject("") do |memo, schema_name|
+          memo + schema(schema_name)
         end
-        unless output.empty?
-          output.prepend('<h2 id="schemas">Schemas</h2>')
-        end
+
+        output.prepend('<h2 id="schemas">Schemas</h2>') unless output.empty?
         output
       end
 
       def schemas_from_schema(schema)
-        schemas = []
-        properties = []
-        schema.properties.each do |property|
-          properties.push property[1]
+        schemas = schema.properties.map(&:last)
+        schemas << schema.items if schema.items && schema.type == "array"
+        schemas += schema.all_of.to_a.flat_map { |s| s.properties.map(&:last) }
+
+        schemas.flat_map do |nested|
+          sub_schemas = schemas_from_schema(nested)
+          nested.name ? [nested.name] + sub_schemas : sub_schemas
         end
-        if schema.type == "array"
-          properties.push schema.items
-        end
-        all_of = schema["allOf"]
-        if all_of.present?
-          all_of.each do |schema_nested|
-            schema_nested.properties.each do |property|
-              properties.push property[1]
-            end
-          end
-        end
-        properties.each do |property|
-          # Must be a schema be referenced by another schema
-          # And not a property of a schema
-          if property.node_context.resolved_input.to_s.include?("#/components/schemas") &&
-              !property.node_context.source_location.to_s.include?("/properties/")
-            schema_name = get_schema_name(property.node_context.source_location.to_s)
-          end
-          unless schema_name.nil?
-            schemas.push schema_name
-          end
-          # Check sub-properties for references
-          schemas.concat(schemas_from_schema(property))
-        end
-        schemas
       end
 
       def operations(text:, path:, path_id:)
-        output = ""
-        operations = get_operations(path)
-        operations.compact.each do |key, operation|
+        get_operations(path).compact.inject("") do |memo, (key, operation)|
           id = "#{path_id}-#{key.parameterize}"
           text = text # rubocop:disable Lint/SelfAssignment
           parameters = parameters(operation, id)
           responses = responses(operation, id)
           curl_examples = curl_examples(operation, id)
-          output += @template_operation.result(binding)
+          memo + @template_operation.result(binding)
         end
-        output
       end
 
       def parameters(operation, operation_id)
@@ -173,38 +135,24 @@ module GovukTechDocs
       end
 
       def schema_properties(schema_data)
-        properties = {}
-        if defined? schema_data.properties
-          schema_data.properties.each do |key, property|
-            properties[key] = property
-          end
+        properties = schema_data.properties.to_h
+        schema_data.all_of.to_a.each do |all_of_schema|
+          properties.merge!(all_of_schema.properties.to_h)
         end
-        properties.merge! get_all_of_hash(schema_data)
-        properties.merge! get_any_of_hash(schema_data)
-        properties_hash = {}
-        properties.each do |pkey, property|
-          case property.type
-          when "object"
-            properties_hash[pkey] = {}
-            items = property.items
-            if items.present?
-              properties_hash[pkey] = schema_properties(items)
-            end
-            if property.properties.present?
-              properties_hash[pkey] = schema_properties(property)
-            end
-          when "array"
-            properties_hash[pkey] = []
-            items = property.items
-            if items.present?
-              properties_hash[pkey].push schema_properties(items)
-            end
-          else
-            properties_hash[pkey] = !property.example.nil? ? property.example : property.type
-          end
+        schema_data.any_of.to_a.each do |any_of_schema|
+          properties.merge!(any_of_schema.properties.to_h)
         end
 
-        properties_hash
+        properties.transform_values do |property|
+          case property.type
+          when "object"
+            schema_properties(property.items || property)
+          when "array"
+            property.items ? [schema_properties(property.items)] : []
+          else
+            property.example || property.type
+          end
+        end
       end
 
       def schema_is_referenced?(schema)
@@ -221,55 +169,6 @@ module GovukTechDocs
         document.servers
       end
 
-      def get_all_of_array(schema)
-        properties = []
-        if schema.is_a?(Array)
-          schema = schema[1]
-        end
-        if schema["allOf"]
-          all_of = schema["allOf"]
-        end
-        if all_of.present?
-          all_of.each do |schema_nested|
-            schema_nested.properties.each do |property|
-              if property.is_a?(Array)
-                property = property[1]
-              end
-              properties.push property
-            end
-          end
-        end
-        properties
-      end
-
-      def get_all_of_hash(schema)
-        properties = {}
-        if schema["allOf"]
-          all_of = schema["allOf"]
-        end
-        if all_of.present?
-          all_of.each do |schema_nested|
-            schema_nested.properties.each do |key, property|
-              properties[key] = property
-            end
-          end
-        end
-        properties
-      end
-
-      def get_any_of_hash(schema)
-        properties = {}
-        any_of = schema["anyOf"]
-
-        if any_of.present?
-          nested_schema = any_of.first
-          nested_schema.properties.each do |key, property|
-            properties[key] = property
-          end
-        end
-        properties
-      end
-
       def get_renderer(file)
         template_path = File.join(File.dirname(__FILE__), "templates/#{file}")
         template = File.open(template_path, "r").read
@@ -277,13 +176,13 @@ module GovukTechDocs
       end
 
       def get_operations(path)
-        operations = {}
-        operations["get"] = path.get if defined? path.get
-        operations["put"] = path.put if defined? path.put
-        operations["post"] = path.post if defined? path.post
-        operations["delete"] = path.delete if defined? path.delete
-        operations["patch"] = path.patch if defined? path.patch
-        operations
+        {
+          "get" => path.get,
+          "put" => path.put,
+          "post" => path.post,
+          "delete" => path.delete,
+          "patch" => path.patch,
+        }.compact
       end
 
       def get_schema_name(text)
@@ -316,35 +215,27 @@ module GovukTechDocs
         end
       end
 
-      def properties_for_schema(schema_name)
-        schema_data = schemas_data.find { |s| s[0] == schema_name }
-
+      def properties_for_schema(schema)
         properties = []
 
-        all_of = schema_data[1]["allOf"]
-        if all_of.present?
-          all_of.each do |schema_nested|
-            schema_nested.properties.each do |property|
-              properties.push property
-            end
+        schema["allOf"]&.each do |schema_nested|
+          schema_nested.properties.each do |property|
+            properties.push property
           end
         end
 
-        any_of = schema_data[1]["anyOf"]
-        if any_of.present?
-          any_of.each do |schema_nested|
-            schema_nested.properties.each do |property|
-              properties.push property
-            end
+        schema["anyOf"]&.each do |schema_nested|
+          schema_nested.properties.each do |property|
+            properties.push property
           end
         end
 
-        schema_data[1].properties.each do |property|
+        schema.properties.each do |property|
           properties.push property
         end
 
-        if schema_data[1] && schema_data[1].type == "array"
-          properties.push ["Item", schema_data[1].items]
+        if schema && schema.type == "array"
+          properties.push ["Item", schema.items]
         end
 
         properties

--- a/docs/lib/govuk_tech_docs/open_api/templates/any_of.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/any_of.html.erb
@@ -1,0 +1,11 @@
+<h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
+
+<p>
+  This schema can be any one of the following schemas:
+</p>
+
+<ul>
+  <% schema_data[1]["anyOf"].node_data.each do |schema| %>
+    <li><%= get_schema_link(schema) %></li>
+  <% end %>
+</ul>

--- a/docs/lib/govuk_tech_docs/open_api/templates/any_of.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/any_of.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <ul>
-  <% schema_data[1]["anyOf"].node_data.each do |schema| %>
+  <% schema["anyOf"].node_data.each do |schema| %>
     <li><%= get_schema_link(schema) %></li>
   <% end %>
 </ul>

--- a/docs/lib/govuk_tech_docs/open_api/templates/api_reference_full.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/api_reference_full.html.erb
@@ -1,0 +1,25 @@
+<style>
+  <%= Rouge::Themes::Github.render(scope: '.highlight') %>
+</style>
+
+<h1 id="<%= info.title.parameterize %>"><%= info.title %> v<%= info.version %></h1>
+
+<%= markdown(info.description) %>
+
+<% unless servers.empty? %>
+  <h2 id="servers">Servers</h2>
+  <div id="server-list">
+    <% servers.each do |server| %>
+      <% if server.description %>
+        <p><strong><%= server.description %></strong></p>
+      <% end %>
+      <a href="<%= server.url %>"><%= server.url %></a>
+    <% end %>
+  </div>
+<% end %>
+
+<%= paths %>
+
+<h2 id="schemas">Schemas</h2>
+
+<%= schemas %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/curl_examples.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/curl_examples.html.erb
@@ -1,0 +1,28 @@
+<% if curl_examples.any? %>
+  <h3 id="<%= id %>">Request examples</h3>
+
+  <div class="govuk-!-margin-bottom-5">
+    <% curl_examples.each do |example| %>
+      <% example = example.with_indifferent_access %>
+
+      <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            <%= example[:description] %>
+          </span>
+        </summary>
+
+        <div class="govuk-details__text">
+          <%
+            source = example[:command]
+            formatter = Rouge::Formatters::HTML.new
+            lexer = Rouge::Lexers::Shell.new
+            output = formatter.format(lexer.lex(source))
+          %>
+
+          <pre class="highlight"><code><%= output %></code></pre>
+        </div>
+      </details>
+    <% end %>
+  </div>
+<% end %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/operation.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/operation.html.erb
@@ -1,0 +1,24 @@
+<% if text %>
+  <h2 id="<%= id %>">
+    <span class="govuk-caption-l">
+      <%= key.upcase %>
+    </span>
+    <span class="govuk-heading-l">
+      <%= text %>
+    </span>
+  </h2>
+<% end %>
+
+<% if operation.summary %>
+  <p><em><%= operation.summary %></em></p>
+<% end %>
+
+<% if operation.description %>
+  <p><%= markdown(operation.description) %></p>
+<% end %>
+
+<%= parameters %>
+
+<%= curl_examples %>
+
+<%= responses %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/parameters.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/parameters.html.erb
@@ -1,0 +1,49 @@
+<% if parameters.any? %>
+  <h3 id="<%= id %>">Parameters</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>In</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Example</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% parameters.each do |parameter| %>
+        <tr>
+          <td><%= parameter.name %></td>
+          <td><%= parameter.in %></td>
+          <td><%= parameter.schema.type %></td>
+          <td><%= parameter.required? %></td>
+          <td>
+            <%= markdown(parameter.description) %>
+
+            <% if parameter.schema && schema_is_referenced?(parameter.schema) %>
+              <p>
+                This consumes a <%= get_schema_link(parameter.schema) %> schema.
+              </p>
+            <% end %>
+
+            <% if parameter.schema.enum %>
+              <p>Available items:</p>
+
+              <ul>
+                <% parameter.schema.enum.each do |item| %>
+                  <li><%= item %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </td>
+          <td>
+            <%= parameter.example %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/path.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/path.html.erb
@@ -1,0 +1,1 @@
+<%= operations %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
@@ -53,7 +53,7 @@
           end
         end %>
 
-        <% if !request_body.blank? %>
+        <% if request_body.present? %>
           <%
             source = request_body
             formatter = Rouge::Formatters::HTML.new

--- a/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
@@ -1,0 +1,71 @@
+<% if responses.any? %>
+  <h3 id="<%= id %>">Responses</h3>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% responses.each do |key,response| %>
+        <tr>
+          <td><%= key %></td>
+
+          <td>
+            <%= markdown(response.description) %>
+
+            <% if response.content['application/json'] %>
+              <p>
+                This response returns a <%= get_schema_link(response.content['application/json'].schema) %> schema.
+              </p>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <h3 id="<%= id %>-examples">Response examples</h3>
+
+  <% responses.each do |key,response| %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          <%= key %> - <%= response.description %>
+        </span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <% if response.content['application/json'] %>
+          <p>
+            This response returns a <%= get_schema_link(response.content['application/json'].schema) %> schema.
+          </p>
+        <% end %>
+
+        <% if response.content['application/json']
+          if response.content['application/json']["example"]
+            request_body = json_prettyprint(response.content['application/json']["example"])
+          else
+            request_body = json_output(response.content['application/json'].schema)
+          end
+        end %>
+
+        <% if !request_body.blank? %>
+          <%
+            source = request_body
+            formatter = Rouge::Formatters::HTML.new
+            lexer = Rouge::Lexers::JSON.new
+            output = formatter.format(lexer.lex(source))
+          %>
+
+          <pre class="highlight"><code><%= output %></code></pre>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+<% end %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
@@ -1,0 +1,51 @@
+<h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
+
+<%= markdown(schema.description) %>
+
+<% if properties.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Required</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% properties.each do |property| %>
+        <tr>
+          <td><%= property[0] %></td>
+          <td><%= property[1].type %></td>
+          <td><%= property[1].required.present? %></td>
+          <td>
+            <%= markdown(property[1].description) %>
+
+            <%=
+              schema = property[1]
+              # If property is an array, check the items property for a reference.
+              if property[1].type == 'array'
+                schema = property[1]['items']
+              end
+              # Only print a link if it's a referenced schema.
+              if schema.node_context.resolved_input.to_s.include? '#/components/schemas' and !schema.node_context.source_location.to_s.include? '/properties/'
+                "This returns a #{get_schema_link(schema)} schema."
+              end
+            %>
+
+            <% if enum = property[1].enum %>
+              <p>Possible values:</p>
+
+              <ul>
+                <% enum.each do |possible_value| %>
+                  <li><%= format_possible_value(possible_value) %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>


### PR DESCRIPTION
## Ticket and context

Turns out govuk tech docs gem shows some nice things in API, but is not very good at showing examples and schemas. https://ecf-dev.london.cloudapps.digital/api-reference/reference.html

I am not quite sure why, but I know for sure that teacher training solved this problem.

I intend to go through the templates and ruby code to improve it somewhat, but the gist of it is that the review app should contain a lot more useful schemas and examples. 
