### PR TITLE
CPDRP-1009 Add reminder email for SITs with unvalidated participants

### DIFF
--- a/app/mailers/participant_validation_mailer.rb
+++ b/app/mailers/participant_validation_mailer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class ParticipantValidationMailer < ApplicationMailer
+  INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE = "d560fb2e-243d-48b1-bf61-c7e111f56858"
+
+  ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE = "50ee41e5-06b9-41cf-9afd-d5bc4db356c4"
+  MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "e0198213-c09d-41aa-8197-b167e495e49d"
+  INDUCTION_COORDINATORS_WHO_ARE_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE = "7e7d3fdb-41f5-4e04-a4ae-acf92e8fefe6"
+
+  STATUTORY_GUIDANCE_LINK = "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england"
+
+  def ects_to_add_validation_information_email(recipient:, school_name:, start_url:)
+    template_mail(
+      ECTS_TO_ADD_VALIDATIN_INFO_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
+    template_mail(
+      MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def induction_coordinators_who_are_mentors_to_add_validation_information_email(recipient:, school_name:, start_url:)
+    template_mail(
+      INDUCTION_COORDINATORS_WHO_ARE_MENTORS_TO_ADD_VALIDATION_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        school_name: school_name,
+        participant_start: start_url,
+      },
+    )
+  end
+
+  def induction_coordinators_we_asked_ects_and_mentors_for_information_email(recipient:, sign_in:, start_url:)
+    template_mail(
+      INDUCTION_COORDINATOR_WE_ASKED_YOUR_ECTS_AND_MENTORS_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sign_in: sign_in,
+        participant_start: start_url,
+      },
+    )
+  end
+end

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -21,7 +21,6 @@ class UTMService
     participant_validation_sit_notification: "participant-validation-sit-notification",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
     induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
-    asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
     sit_to_complete_steps: "sit-to-complete-steps",
     year2020_nqt_invite_school: "year2020-nqt-invite-school",
     year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
@@ -36,6 +35,7 @@ class UTMService
     partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
     remind_fip_sit_to_complete_steps: "remind-fip-sit-to-complete-steps",
     add_participants_unpartnered_cip: "add-participants-unpartnered-cip",
+    unvalidated_participants_reminder: "unvalidated-participants-reminder",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -54,7 +54,6 @@ class UTMService
     participant_validation_research: "participant-validation-research",
     check_ect_and_mentor_info: "check-ect-and-mentor-info",
     induction_coordinators_who_are_mentors_to_add_validation_information: "induction-coordinators-who-are-mentors-to-add-validation-information",
-    asked_ects_and_mentors_for_information: "asked-ects-and-mentors-for-information",
     sit_to_complete_steps: "sit-to-complete-steps",
     year2020_nqt_invite_school: "year2020-nqt-invite-school",
     year2020_nqt_invite_sit: "year2020-nqt-invite-sit",
@@ -68,6 +67,7 @@ class UTMService
     year2020_nqt_invite_sit_no_participants: "year2020-nqt-invite-sit-no-participants",
     partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
     add_participants_unpartnered_cip: "add-participants-unpartnered-cip",
+    unvalidated_participants_reminder: "unvalidated-participants-reminder",
   }.freeze
 
   def self.email(campaign, source = :service)


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-1009

- add new email for manual send: remind SITs that have unvalidated participants
- remove `tell_induction_coordinators_we_asked_ects_and_mentors_for_information`, this email used the same template (which has now been changed in notify to have different variables), so would no longer work.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
