### PR TITLE
CPDTP-526: Add N+1 queries, but ensure the participant state is correct

### DIFF
--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -34,15 +34,7 @@ module Api
       end
 
       def participants
-        participants = lead_provider.ecf_participants
-                                    .distinct
-                                    .includes(
-                                      teacher_profile: {
-                                        ecf_profile: %i[cohort school ecf_participant_eligibility ecf_participant_validation_data participant_profile_state participant_profile_states schedule],
-                                        early_career_teacher_profile: :mentor,
-                                      },
-                                    )
-                                    .where(school_cohorts: { cohort_id: Cohort.current.id })
+        participants = lead_provider.ecf_participants.ecf_participants_endpoint_scope
 
         participants = participants.changed_since(updated_since) if updated_since.present?
 

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -14,6 +14,10 @@ class ParticipantProfile < ApplicationRecord
   has_many :participant_declarations, through: :profile_declarations
 
   has_many :participant_profile_states
+
+  # TODO: Store this on the model to avoid n+1 queries, or spend some time digging into sql / ActiveRecord
+  # Any ordering tools seem to not work when preloading ecf_participants_endpoint_scope
+  # https://github.com/rails/rails/issues/6769 seems to document it
   has_one :participant_profile_state, lambda {
     merge(ParticipantProfileState.most_recent)
   }, class_name: "ParticipantProfileState"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,6 +126,16 @@ class User < ApplicationRecord
     joins(:participant_profiles).merge(ParticipantProfile.active_record)
   }
 
+  scope :ecf_participants_endpoint_scope,
+        lambda {
+          distinct.includes(
+            teacher_profile: {
+              ecf_profile: %i[cohort school ecf_participant_eligibility ecf_participant_validation_data participant_profile_states schedule],
+              early_career_teacher_profile: :mentor,
+            },
+          ).where(school_cohorts: { cohort_id: Cohort.current.id })
+        }
+
 private
 
   def strip_whitespace

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -51,4 +51,21 @@ RSpec.describe ParticipantProfile, type: :model do
     it { is_expected.to belong_to(:school).optional }
     it { is_expected.to be_versioned }
   end
+
+  it "correctly shows the profile state when there are two deferred participants" do
+    create(:schedule, name: "ECF September standard 2021")
+
+    profile_one = EarlyCareerTeachers::Create.new(full_name: "Bob", email: "bob@example.com", school_cohort: create(:school_cohort)).call
+    profile_two = EarlyCareerTeachers::Create.new(full_name: "Ted", email: "ted@example.com", school_cohort: create(:school_cohort)).call
+
+    ParticipantProfileState.create!(participant_profile: profile_one, state: "deferred")
+    ParticipantProfileState.create!(participant_profile: profile_two, state: "deferred")
+
+    profile_one.reload
+    profile_two.reload
+
+    User.all.ecf_participants_endpoint_scope.each do |user|
+      expect(user.teacher_profile.ecf_profile&.state).to eq("deferred")
+    end
+  end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-526

## Tech review

### Is there anything that the code reviewer should know?
This seems to be a Rails issue. Order is not respected when you preload relations. https://github.com/rails/rails/issues/6769

There are a few ways we could fix it - use our own sql to load the ecf data, or store the current state on profile. But in the meantime the easiest is N+1 queries 😢 