### PR TITLE
fix error when no induction start_state

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -37,6 +37,7 @@ private
   def previous_induction?(validation_data)
     return false if validation_data["induction"].nil?
     return true if validation_data["induction"]["completion_date"].present?
+    return false if validation_data["induction"]["start_date"].nil?
 
     validation_data["induction"]["start_date"] < Date.new(Cohort.current.start_year, 9, 1)
   end

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -209,6 +209,22 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
+      context "when the participant has an induction with nil start_date" do
+        let(:induction) do
+          {
+            "start_date" => nil,
+          }
+        end
+
+        it "does not raise an error" do
+          expect { validation_result }.not_to raise_error
+        end
+
+        it "returns previous_induction as false" do
+          expect(validation_result[:previous_induction]).to be_falsey
+        end
+      end
+
       context "when the participant has previously had an induction and participation" do
         let!(:eligibility) { create(:ineligible_participant, trn: trn, reason: :previous_participation) }
         let(:induction) do


### PR DESCRIPTION
## Ticket and context

Ticket: none

- if no induction `start_date` then treat as no previous induction
- Otherwise it throws an error if `start_date` is `nil` as it does `nil < value` and `nil` does not implement `<`
- For the records I found a `nil` `start_date` that are erroring, seems to have inductions with the status of `Exempt`

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Not sure if this is possible with the data available in the database

## External API changes

- none