### PR TITLE
CDRP-1028 Add catch all invite email for NQT+1

### DIFF
--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -303,6 +303,25 @@ class InviteSchools
       end
   end
 
+  def catch_all_invite_sits_for_nqt_plus_one
+    School
+      .eligible
+      .joins(:induction_coordinators, :school_cohorts)
+      .where.not(
+        school_cohorts: {
+          cohort: Cohort.find_by_start_year(2020),
+        },
+      ).distinct.find_each do |school|
+        next if Email.associated_with(school).tagged_with(:year2020_invite).any?
+
+        SchoolMailer.nqt_plus_one_sit_invite(
+          school: school,
+          recipient: school.induction_coordinators.first.email,
+          start_url: year2020_start_url(school, utm_source: :year2020_nqt_invite_sit_catchall),
+        ).deliver_later
+      end
+  end
+
   def invite_unpartnered_cip_sits_to_add_ects_and_mentors
     School.unpartnered(Cohort.current.start_year)
       .joins(:school_cohorts, :induction_coordinator_profiles)

--- a/app/services/utm_service.rb
+++ b/app/services/utm_service.rb
@@ -36,6 +36,7 @@ class UTMService
     remind_fip_sit_to_complete_steps: "remind-fip-sit-to-complete-steps",
     add_participants_unpartnered_cip: "add-participants-unpartnered-cip",
     unvalidated_participants_reminder: "unvalidated-participants-reminder",
+    year2020_nqt_invite_sit_catchall: "year2020-nqt-invite-sit-catchall",
   }.freeze
 
   # Campaigns aren't showing up in GA at the moment, so use specific sources
@@ -68,6 +69,7 @@ class UTMService
     partnered_invite_sit_reminder: "partnered-invite-sit-reminder",
     add_participants_unpartnered_cip: "add-participants-unpartnered-cip",
     unvalidated_participants_reminder: "unvalidated-participants-reminder",
+    year2020_nqt_invite_sit_catchall: "year2020-nqt-invite-sit-catchall",
   }.freeze
 
   def self.email(campaign, source = :service)


### PR DESCRIPTION
To send to all the eligible schools that we haven't previously sent invites to

There were some eligible schools that were invited before we were tracking email sends. We have decided it is ok to email them again if they haven't added any NQT+1 users, so don't include schools that have a 2020 school cohort (created upon confirming inviting NQT+1s - see year2020 form)

## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-1028

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
