### PR TITLE
Add a foreign key between npq applications and users

### DIFF
--- a/db/migrate/20211011085500_add_foreign_key_on_user_to_npq_validation_data.rb
+++ b/db/migrate/20211011085500_add_foreign_key_on_user_to_npq_validation_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddForeignKeyOnUserToNPQValidationData < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :npq_profiles, :users, null: false, validate: false
+  end
+end

--- a/db/migrate/20211011085631_validate_foreign_key_on_user_to_npq_validation_data.rb
+++ b/db/migrate/20211011085631_validate_foreign_key_on_user_to_npq_validation_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateForeignKeyOnUserToNPQValidationData < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :npq_profiles, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_131604) do
+ActiveRecord::Schema.define(version: 2021_10_11_085631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -801,6 +801,7 @@ ActiveRecord::Schema.define(version: 2021_10_07_131604) do
   add_foreign_key "nomination_emails", "partnership_notification_emails"
   add_foreign_key "nomination_emails", "schools"
   add_foreign_key "npq_lead_providers", "cpd_lead_providers"
+  add_foreign_key "npq_profiles", "users"
   add_foreign_key "participant_bands", "call_off_contracts"
   add_foreign_key "participant_declaration_attempts", "participant_declarations"
   add_foreign_key "participant_profile_states", "participant_profiles"


### PR DESCRIPTION
## Ticket and context

A support request to delete a duplicate user resulted in an npq application without a user, which resulted in a crash. Unfortunate.

This should prevent that from happening again. I made sure there are no more applications like that in prod or sandbox so we should be in the clear as long as nobody deletes any more users before we deploy this :) 