### PR TITLE
CPDTP-250 flatten profile declarations

### DIFF
--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -61,7 +61,7 @@ module RecordDeclarations
     end
 
     def create_declaration_attempt!
-      ParticipantDeclarationAttempt.create!(declaration_parameters)
+      ParticipantDeclarationAttempt.create!(declaration_parameters.except(:participant_profile_id))
     end
 
     def find_or_create_record!
@@ -86,6 +86,7 @@ module RecordDeclarations
         declaration_type: declaration_type,
         cpd_lead_provider: cpd_lead_provider,
         user: user,
+        participant_profile_id: user_profile.id,
       }
     end
 

--- a/db/migrate/20211008032520_add_profile_to_participant_declarations.rb
+++ b/db/migrate/20211008032520_add_profile_to_participant_declarations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddProfileToParticipantDeclarations < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :participant_declarations, :participant_profile, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20211008032520_add_profile_to_participant_declarations.rb
+++ b/db/migrate/20211008032520_add_profile_to_participant_declarations.rb
@@ -4,6 +4,6 @@ class AddProfileToParticipantDeclarations < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   def change
-    add_reference :participant_declarations, :participant_profile, index: { algorithm: :concurrently }
+    add_reference :participant_declarations, :participant_profile, index: { algorithm: :concurrently }, null: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_07_131604) do
+ActiveRecord::Schema.define(version: 2021_10_08_032520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -500,7 +500,9 @@ ActiveRecord::Schema.define(version: 2021_10_07_131604) do
     t.uuid "cpd_lead_provider_id"
     t.datetime "voided_at"
     t.string "state", default: "submitted", null: false
+    t.uuid "participant_profile_id"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
+    t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
     t.index ["user_id"], name: "index_participant_declarations_on_user_id"
   end
 

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -18,4 +18,15 @@ namespace :data do
       )
     end
   end
+
+  namespace :profile_declarations do
+    desc "Copies the profile to the declarations from the deprecated profile_declarations table"
+    task copy: :environment do
+      ProfileDeclaration.in_batches(of: 1000) do |batch|
+        batch.each do |declaration|
+          declaration.participant_declaration.update(participant_profile_id: declaration.participant_profile_id)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
 
   describe "refresh_payability!" do
     let!(:participant_declaration) { create(:ect_participant_declaration, :submitted) }
-    let!(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_declaration.participant_profile_id) }
+    let!(:eligibility) { ECFParticipantEligibility.create!(participant_profile: participant_declaration.participant_profile) }
 
     context "when declaration was eligible for payment" do
       before do
@@ -122,7 +122,7 @@ RSpec.describe ParticipantDeclaration, type: :model do
 
   describe "voided!" do
     let!(:participant_declaration) { create(:ect_participant_declaration) }
-    let!(:eligibility) { ECFParticipantEligibility.create!(participant_profile_id: participant_declaration.participant_profile_id) }
+    let!(:eligibility) { ECFParticipantEligibility.create!(participant_profile: participant_declaration.participant_profile) }
 
     context "when declaration was payable" do
       before do


### PR DESCRIPTION
## Ticket and context

Prepare to move the profile declaration data to the participant declaration by creating a duplicate that can later replace the intermediate table.

This ticket just stands up the new column in the table and ensures that any new requests prior to the full data migration and implementation of the full switchover are written to both locations.

Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDTP/boards/87?selectedIssue=CPDTP-250

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
