### PR TITLE
Split out distinct web and worker memory utilisation alerts

### DIFF
--- a/terraform/monitoring/config/development/alert.rules.yml
+++ b/terraform/monitoring/config/development/alert.rules.yml
@@ -49,11 +49,21 @@ groups:
   - name: Memory-utilisation
     rules:
       - alert: MemoryUtilizationHigh
-        expr: avg by ( app ) (memory_utilization{app=~"ecf-dev"}) > 75
+        expr: avg by ( app ) (memory_utilization{app="ecf-dev"}) > 75
         for: 5m
         annotations:
           summary: Memory Utilization High
-          description: "ecf-dev: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+          description: "ecf-dev: Memory utilization at least 75% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: development
+          severity: low
+    rules:
+      - alert: MemoryUtilizationHigh
+        expr: avg by ( app ) (memory_utilization{app="ecf-dev-worker"}) > 80
+        for: 5m
+        annotations:
+          summary: Memory Utilization High
+          description: "ecf-dev: Memory utilization at least 80% for more than 5 minutes (current value: {{ $value }})"
         labels:
           environment: development
           severity: low

--- a/terraform/monitoring/config/production/alert.rules.yml
+++ b/terraform/monitoring/config/production/alert.rules.yml
@@ -49,11 +49,21 @@ groups:
   - name: Memory-utilisation
     rules:
       - alert: MemoryUtilizationHigh
-        expr: avg by ( app ) (memory_utilization{app=~"ecf-production"}) > 60
+        expr: avg by ( app ) (memory_utilization{app="ecf-production"}) > 60
         for: 5m
         annotations:
           summary: Memory Utilization High
           description: "ecf-production: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: production
+          severity: high
+    rules:
+      - alert: MemoryUtilizationHigh
+        expr: avg by ( app ) (memory_utilization{app="ecf-production-worker"}) > 80
+        for: 5m
+        annotations:
+          summary: Memory Utilization High
+          description: "ecf-production: Worker memory utilization at least 80% for more than 5 minutes (current value: {{ $value }})"
         labels:
           environment: production
           severity: high

--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -49,11 +49,21 @@ groups:
   - name: Memory-utilisation
     rules:
       - alert: MemoryUtilizationHigh
-        expr: avg by ( app ) (memory_utilization{app=~"ecf-staging"}) > 60
+        expr: avg by ( app ) (memory_utilization{app="ecf-staging"}) > 60
         for: 5m
         annotations:
           summary: Memory Utilization High
           description: "ecf-staging: Memory utilization at least 60% for more than 5 minutes (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium
+    rules:
+      - alert: MemoryUtilizationHigh
+        expr: avg by ( app ) (memory_utilization{app="ecf-staging-worker"}) > 80
+        for: 5m
+        annotations:
+          summary: Memory Utilization High
+          description: "ecf-staging: Memory utilization at least 80% for more than 5 minutes (current value: {{ $value }})"
         labels:
           environment: staging
           severity: medium


### PR DESCRIPTION
## Context

We were previously alerting on memory usage across both web and worker instances. This doesn't work because each instance type has different memory tolerances. I'm quite content seeing high memory utilisation of worker instances, for example.

This PR splits out memory utilisation alerts for web and worker instances. The new thresholds are:

```
- Dev web: 75% 
- Dev worker: 80%

- Staging web: 60% 
- Staging worker: 80%

- Production web: 60% 
- Production worker: 80%
```