### PR TITLE
Participant validation - Fix problem with removed attributes and stale session data

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -15,7 +15,10 @@ module Participants
                   :trn,
                   :name,
                   :national_insurance_number,
-                  :validation_attempts
+                  :validation_attempts,
+                  # legacy values kept here to prevent breakages with old sessions
+                  :do_you_know_your_trn_choice
+
     attr_reader :date_of_birth
 
     validate :add_mentor_info_choice, on: :do_you_want_to_add_mentor_information

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -5,6 +5,28 @@ require "rails_helper"
 RSpec.describe Participants::ParticipantValidationForm, type: :model do
   subject(:form) { described_class.new }
 
+  describe "populating from session" do
+    let(:saved_attributes) do
+      {
+        step: "start",
+        do_you_know_your_trn_choice: nil,
+        do_you_want_to_add_mentor_information_choice: nil,
+        have_you_changed_your_name_choice: nil,
+        updated_record_choice: nil,
+        name_not_updated_choice: nil,
+        trn: nil,
+        name: nil,
+        date_of_birth: nil,
+        national_insurance_number: nil,
+        validation_attempts: nil,
+      }
+    end
+
+    it "does not raise an error when legacy values are passed in" do
+      expect { described_class.new(saved_attributes) }.not_to raise_error
+    end
+  end
+
   describe "do_you_want_to_add_mentor_information validations" do
     context "when a valid choice is made" do
       it "returns true" do


### PR DESCRIPTION
## Ticket and context

We have seen some support issues where users are experiencing an error that is caused by them having partially completed participant validation and the session data saved at their end.   Since the change to the TRN question in the validation journey some steps were removed and an old session will have data regarding those steps in. This causes a `ActiveModel::UnknownAttributeError` error to be raised when populating the form from the session data.
This fix reintroduces the missing attribute to smooth this out. As soon as the step is submitted the session data will get overwritten with the correct set of attributes.
This is something we can remove in due course.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
