### PR TITLE
Remove a warning each time participant declaration serializer is loaded

### DIFF
--- a/app/serializers/participant_declaration_serializer.rb
+++ b/app/serializers/participant_declaration_serializer.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require "jsonapi/serializer/instrumentation"
-ActiveSupport::Deprecation.warn("eligible_for_payment is deprecated as a returnable value for declarations")
-ActiveSupport::Deprecation.warn("voided is deprecated as a returnable value for declarations")
 
 class ParticipantDeclarationSerializer
   include JSONAPI::Serializer
   include JSONAPI::Serializer::Instrumentation
+
+  # TODO: eligible_for_payment is deprecated, will need removing in one of next api versions
+  # TODO: voided is deprecated, will need removing in one of next api versions
 
   set_id :id
   set_type :'participant-declaration'


### PR DESCRIPTION
## Ticket and context

I don't like reading those each time I run anything, and I don't think I am the only one. I am sure we can come up with a better way of not forgetting about it, and a code comment seems sufficient to me. 