### PR TITLE
Fix formatting of alert rules

### DIFF
--- a/terraform/monitoring/config/development/alert.rules.yml
+++ b/terraform/monitoring/config/development/alert.rules.yml
@@ -48,7 +48,7 @@ groups:
 
   - name: Memory-utilisation
     rules:
-      - alert: MemoryUtilizationHigh
+      - alert: AppMemoryUtilizationHigh
         expr: avg by ( app ) (memory_utilization{app="ecf-dev"}) > 75
         for: 5m
         annotations:
@@ -57,8 +57,7 @@ groups:
         labels:
           environment: development
           severity: low
-    rules:
-      - alert: MemoryUtilizationHigh
+      - alert: WorkerMemoryUtilizationHigh
         expr: avg by ( app ) (memory_utilization{app="ecf-dev-worker"}) > 80
         for: 5m
         annotations:

--- a/terraform/monitoring/config/production/alert.rules.yml
+++ b/terraform/monitoring/config/production/alert.rules.yml
@@ -48,7 +48,7 @@ groups:
 
   - name: Memory-utilisation
     rules:
-      - alert: MemoryUtilizationHigh
+      - alert: AppMemoryUtilizationHigh
         expr: avg by ( app ) (memory_utilization{app="ecf-production"}) > 60
         for: 5m
         annotations:
@@ -57,8 +57,7 @@ groups:
         labels:
           environment: production
           severity: high
-    rules:
-      - alert: MemoryUtilizationHigh
+      - alert: WorkerMemoryUtilizationHigh
         expr: avg by ( app ) (memory_utilization{app="ecf-production-worker"}) > 80
         for: 5m
         annotations:

--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -48,7 +48,7 @@ groups:
 
   - name: Memory-utilisation
     rules:
-      - alert: MemoryUtilizationHigh
+      - alert: AppMemoryUtilizationHigh
         expr: avg by ( app ) (memory_utilization{app="ecf-staging"}) > 60
         for: 5m
         annotations:
@@ -57,8 +57,7 @@ groups:
         labels:
           environment: staging
           severity: medium
-    rules:
-      - alert: MemoryUtilizationHigh
+      - alert: WorkerMemoryUtilizationHigh
         expr: avg by ( app ) (memory_utilization{app="ecf-staging-worker"}) > 80
         for: 5m
         annotations:


### PR DESCRIPTION
I duplicated the rules keyword for the new memory utilisation alerts, which isn't valid.

I've tested this on our [dev](https://github.com/DFE-Digital/early-careers-framework/actions/runs/1336737897) monitoring stack and it works.