### PR TITLE
Decouple the api eligibility from the UI

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -76,7 +76,7 @@ class ParticipantSerializer
 
   active_participant_attribute :eligible_for_funding do |user|
     # TODO: we want to check eligibility without communicating it yet - except for sandbox
-    if Rails.env.sandbox? || FeatureFlag.active?(:eligibility_notifications)
+    if Rails.env.sandbox? || FeatureFlag.active?(:eligibility_in_api)
       eligible_for_funding?(user)
     end
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,6 +17,7 @@ class FeatureFlag
 
   # Short-lived feature flags
   TEMPORARY_FEATURE_FLAGS = %i[
+    eligibility_in_api
     eligibility_notifications
     participant_data_api
     induction_tutor_manage_participants

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ParticipantSerializer do
           expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
         end
 
-        context "when the feature flag is active", with_feature_flags: { eligibility_notifications: "active" } do
+        context "when the feature flag is active", with_feature_flags: { eligibility_in_api: "active" } do
           it "returns true" do
             expect(ect_profile.ecf_participant_eligibility.status).to eql "eligible"
 
@@ -117,7 +117,7 @@ RSpec.describe ParticipantSerializer do
           expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
         end
 
-        context "when the feature flag is active", with_feature_flags: { eligibility_notifications: "active" } do
+        context "when the feature flag is active", with_feature_flags: { eligibility_in_api: "active" } do
           it "returns false" do
             expect(ect_profile.ecf_participant_eligibility.status).to eql "ineligible"
 


### PR DESCRIPTION
We want to be able to show eligibility in the API before the UI is ready. Use a new feature flag to achieve this