### PR TITLE
Allowing admin to select programme for a new school cohort

### DIFF
--- a/app/controllers/admin/schools/cohorts/change_programme_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_programme_controller.rb
@@ -38,7 +38,7 @@ module Admin
         end
 
         def school_cohort
-          @school_cohort ||= @school.school_cohorts.find_by!(cohort: @cohort)
+          @school_cohort ||= @school.school_cohorts.find_or_initialize_by(cohort: @cohort)
         end
       end
     end

--- a/spec/requests/admin/schools/cohorts/change_programme_spec.rb
+++ b/spec/requests/admin/schools/cohorts/change_programme_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
   let(:cohort) { school_cohort.cohort }
 
   before do
-    user = create(:user, :admin)
-    sign_in user
+    sign_in create(:user, :admin)
   end
 
   describe "GET /admin/schools/:school_slug/cohorts/:id/change-programme" do
@@ -53,6 +52,16 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
       expect(response).to redirect_to "/admin/schools/#{school.slug}/cohorts"
       follow_redirect!
       expect(response.body).to include "Induction programme has been changed"
+    end
+  end
+
+  context "when given school cohort does not yet exist" do
+    let(:school) { create :school }
+    let(:cohort) { create :cohort }
+
+    it "renders show page" do
+      get "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/change-programme"
+      expect(assigns(:school_cohort)).not_to be_persisted
     end
   end
 end


### PR DESCRIPTION
There was an error when admin tried to change the programme for a cohort that has not been created yet. This PR fixes it together with a minimal regression test.