### PR TITLE
Make sure NQT+1s are immune from providers API

### DIFF
--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -30,5 +30,9 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
     def given_params
       participant_params
     end
+
+    def user_profile
+      ect_profile.reload
+    end
   end
 end

--- a/spec/services/participants/defer/early_career_teacher_spec.rb
+++ b/spec/services/participants/defer/early_career_teacher_spec.rb
@@ -29,5 +29,9 @@ RSpec.describe Participants::Defer::EarlyCareerTeacher do
     def given_params
       participant_params
     end
+
+    def user_profile
+      ect_profile.reload
+    end
   end
 end

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -28,5 +28,9 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
     def given_params
       participant_params
     end
+
+    def user_profile
+      ect_profile.reload
+    end
   end
 end

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -29,5 +29,9 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
     def given_params
       participant_params
     end
+
+    def user_profile
+      ect_profile.reload
+    end
   end
 end

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -41,4 +41,17 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
       retained_ect_params
     end
   end
+
+  context "when user is for 2020 cohort" do
+    let!(:cohort_2020) { create(:cohort, start_year: 2020) }
+    let!(:school_cohort_2020) { create(:school_cohort, cohort: cohort_2020, school: ect_profile.school) }
+
+    before do
+      ect_profile.update!(school_cohort: school_cohort_2020)
+    end
+
+    it "raises a ParameterMissing error" do
+      expect { described_class.call(params: retained_ect_params) }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
 end

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -31,4 +31,17 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
       ect_params
     end
   end
+
+  context "when user is for 2020 cohort" do
+    let!(:cohort_2020) { create(:cohort, start_year: 2020) }
+    let!(:school_cohort_2020) { create(:school_cohort, cohort: cohort_2020, school: ect_profile.school) }
+
+    before do
+      ect_profile.update!(school_cohort: school_cohort_2020)
+    end
+
+    it "raises a ParameterMissing error" do
+      expect { described_class.call(params: ect_params) }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
 end

--- a/spec/support/shared_examples/participant_service_ect_support.rb
+++ b/spec/support/shared_examples/participant_service_ect_support.rb
@@ -11,5 +11,18 @@ RSpec.shared_examples "a participant service for ect" do
       params = given_params.merge({ course_identifier: "npq-leading-teacher" })
       expect { described_class.call(params: params) }.to raise_error(ActionController::ParameterMissing)
     end
+
+    context "when user is for 2020 cohort" do
+      let!(:cohort_2020) { create(:cohort, start_year: 2020) }
+      let!(:school_cohort_2020) { create(:school_cohort, cohort: cohort_2020, school: user_profile.school) }
+
+      before do
+        user_profile.update!(school_cohort: school_cohort_2020)
+      end
+
+      it "raises a ParameterMissing error" do
+        expect { described_class.call(params: given_params) }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Ticket and context

Providers should not be able to do anything with NQT+1s.
Turns out by a lucky coincidence (well, not that lucky, part of it is by design) they can't. But we should add tests showing that that's the case, and preserving that behaviour for the future.
