### PR TITLE
Add job to stream batched participant declarations to BigQuery

### DIFF
--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class StreamBigQueryParticipantDeclarationsJob < ApplicationJob
+  # Streams every attribute of a participant declarations (plus the lead provider name) that was
+  # updated during the previous hour.
+  def perform
+    bigquery = Google::Cloud::Bigquery.new
+    dataset = bigquery.dataset "provider_declarations", skip_lookup: true
+    table = dataset.table "participant_declarations_#{Rails.env.downcase}", skip_lookup: true
+
+    rows = ParticipantDeclaration
+      .where(updated_at: 1.hour.ago.beginning_of_hour..1.hour.ago.end_of_hour)
+      .map do |participant_declaration|
+        participant_declaration.attributes.merge(
+          "cpd_lead_provider_name" => participant_declaration.cpd_lead_provider.name,
+        )
+      end
+
+    table.insert rows
+  end
+end

--- a/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
+++ b/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require_relative "../shared/context/service_record_declaration_params"
+require_relative "../shared/context/lead_provider_profiles_and_courses"
+
+RSpec.describe StreamBigQueryParticipantDeclarationsJob do
+  include_context "lead provider profiles and courses"
+  include_context "service record declaration params"
+
+  let(:valid_updated_at) { 1.hour.ago }
+  let!(:streamable_declaration) do
+    create(:participant_declaration,
+           cpd_lead_provider: cpd_lead_provider,
+           participant_profile: ect_profile,
+           course_identifier: "ecf-induction",
+           declaration_date: Time.zone.parse("10/10/2021"),
+           updated_at: valid_updated_at)
+  end
+  let!(:other_declarations) do
+    [
+      create(:participant_declaration, participant_profile: ect_profile, course_identifier: "ecf-induction"), # updated this hour
+      create(:participant_declaration, updated_at: 2.hours.ago, participant_profile: ect_profile, course_identifier: "ecf-induction"), # updated 1+ hours ago
+    ]
+  end
+
+  describe "#perform" do
+    let(:bigquery) { double("bigquery") }
+    let(:dataset) { double("dataset") }
+    let(:table) { double("table", insert: nil) }
+
+    before do
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery)
+      allow(bigquery).to receive(:dataset).and_return(dataset)
+      allow(dataset).to receive(:table).and_return(table)
+    end
+
+    it "sends correct data to BigQuery" do
+      described_class.perform_now
+
+      expect(table).to have_received(:insert).with([
+        streamable_declaration.attributes.merge(
+          "cpd_lead_provider_name" => cpd_lead_provider.name,
+        ),
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDTP-241

Add a job to stream participant declarations to BigQuery. There were some concerns that we would exceed BigQuery quotas (5 ops/dataset/10 seconds) so this job sends so it only sends records that were updated in the previous hour.

This job isn't scheduled yet. I'll make that change later if, after testing, this approach works for us.