### PR TITLE
CPDRP-200: Add basic security.txt

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,2 @@
+Contact: mailto:cpd-developers@digital.education.gov.uk
+Policy: https://github.com/ukncsc/Vulnerability-Disclosure/blob/master/UK-Government-Vulnerability-Disclosure-Policy.md


### PR DESCRIPTION
## Ticket and context

Ticket: CPDRP-200

Add basic security.txt to meet minimum vulnerability disclosure standards. Details: https://www.ncsc.gov.uk/information/vulnerability-disclosure-toolkit

Adding a PGP key would probably be sensible, but it seems like overkill at this point