### PR TITLE
CPDTP-250 Post run cleanup of old data migration script

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -18,15 +18,4 @@ namespace :data do
       )
     end
   end
-
-  namespace :profile_declarations do
-    desc "Copies the profile to the declarations from the deprecated profile_declarations table"
-    task copy: :environment do
-      ProfileDeclaration.in_batches(of: 1000) do |batch|
-        batch.each do |declaration|
-          declaration.participant_declaration.update(participant_profile_id: declaration.participant_profile_id)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
## Ticket and context

This removes the old rake task that was used to migrate the old profile_declarations table and assign the profile to the participant_declaration directly.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
