### PR TITLE
Fix selenium deprecation warning

### DIFF
--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -13,7 +13,7 @@ Capybara.register_driver :chrome_headless do |app|
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--window-size=1400,1400")
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: options)
 end
 
 Capybara.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i


### PR DESCRIPTION
message: `Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.`
Changelog: https://raw.githubusercontent.com/SeleniumHQ/selenium/trunk/rb/CHANGES
changed in  4.0.0.beta1 (2021-02-15)

