### PR TITLE
I think this should fix multi-comments noise

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           msg: "Created review app at https://ecf-review-pr-${{ github.event.number }}.london.cloudapps.digital"
           check_for_duplicate_msg: true
+          duplicate_msg_pattern: Created review app at*
 
       - name: Trigger Smoke Test
         uses: benc-uk/workflow-dispatch@v1.1
@@ -143,3 +144,4 @@ jobs:
         with:
           msg: "Smoke tests passed against the review app."
           check_for_duplicate_msg: true
+          duplicate_msg_pattern: Smoke tests passed against the review app*


### PR DESCRIPTION
## Ticket and context

Our github actions bot just keeps commenting. I think https://github.com/unsplash/comment-on-pr/pull/44 is what made it fail for us. In particular 
```
if !duplicate_msg_pattern.empty? || !delete_prev_regex_msg.empty?
```
is a guard for any duplication checks. I hope providing a pattern will fix our issues. 