### PR TITLE
Add mailer for SITs who have still not chosen a programme

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -26,12 +26,12 @@ class SchoolMailer < ApplicationMailer
   UNPARTNERED_CIP_SIT_ADD_PARTICIPANTS_EMAIL_TEMPLATE = "ebc96223-c2ea-416e-8d3e-1f591bbd2f98"
 
   # This email is currently (30/09/2021) only used for manually sent chaser emails
-  def remind_induction_coordinator_to_setup_cohort_email(recipient:, school_name:, campaign: nil)
+  def remind_induction_coordinator_to_setup_cohort_email(induction_coordinator_profile:, school_name:, campaign: nil)
     campaign_tracking = campaign ? UTMService.email(campaign, campaign) : {}
 
     template_mail(
       "14aabb56-1d6e-419f-8144-58a0439c61a6",
-      to: recipient,
+      to: induction_coordinator_profile.user.email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
@@ -40,7 +40,7 @@ class SchoolMailer < ApplicationMailer
         sign_in: new_user_session_url(**campaign_tracking),
         step_by_step: step_by_step_url(**campaign_tracking),
       },
-    )
+    ).tag(:sit_to_complete_steps).associate_with(induction_coordinator_profile)
   end
 
   # This email is sent to schools to request an appointment of SIT to coordinate their cohorts

--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -12,7 +12,7 @@ class ValidationBetaService
         next if sit.reminder_email_sent_at.present?
 
         email = SchoolMailer.remind_induction_coordinator_to_setup_cohort_email(
-          recipient: sit.user.email,
+          induction_coordinator_profile: sit,
           school_name: school.name,
           campaign: :sit_to_complete_steps,
         )
@@ -21,6 +21,23 @@ class ValidationBetaService
           sit.update_column(:reminder_email_sent_at, Time.zone.now)
           email.deliver_later
         end
+      end
+    end
+  end
+
+  # SITs who have not chosen a programme and are not in a partnership with a training provider
+  def remind_sits_at_schools_without_partnership_to_add_participants
+    School.unpartnered(Cohort.current).where.missing(:school_cohorts).includes(:induction_coordinators).find_each do |school|
+      next unless school.eligible?
+
+      school.induction_coordinator_profiles.each do |sit|
+        next if Email.associated_with(sit).tagged_with(:sit_to_complete_steps)
+
+        SchoolMailer.remind_induction_coordinator_to_setup_cohort_email(
+          induction_coordinator_profile: sit,
+          school_name: school.name,
+          campaign: :sit_to_complete_steps_1058,
+        ).deliver_later
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-1058

Add mailer for SITs who have still not chosen a programme. This is using the same mailer as `ValidationBetaService#remind_sits_to_add_participants` but with a different audience. 

I'll revert this PR once it has been sent tomorrow.