### PR TITLE
Check for applications before deleting an ex-IC user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,8 @@ class User < ApplicationRecord
   has_many :npq_profiles, through: :teacher_profile
   # end: TODO
 
+  has_many :npq_applications
+
   before_validation :strip_whitespace
 
   validates :full_name, presence: true
@@ -61,6 +63,10 @@ class User < ApplicationRecord
 
   def npq?
     npq_profiles.any?(&:active_record?)
+  end
+
+  def npq_registered?
+    npq? || npq_applications.any?
   end
 
   def participant?

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -55,7 +55,7 @@ private
 
     if existing_induction_coordinator.induction_coordinator_profile.schools.count > 1
       existing_induction_coordinator.induction_coordinator_profile.schools.delete(school)
-    elsif existing_induction_coordinator.mentor? || existing_induction_coordinator.npq?
+    elsif existing_induction_coordinator.mentor? || existing_induction_coordinator.npq_registered?
       existing_induction_coordinator.induction_coordinator_profile.destroy!
     else
       existing_induction_coordinator.destroy!

--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe CreateInductionTutor do
           expect(ParticipantProfile::NPQ.exists?(npq_profile.id)).to be true
         end
       end
+
+      context "when the induction coordinator applied for npq" do
+        let!(:npq_application) { create(:npq_application, user: existing_profile.user) }
+
+        it "retains the user but deletes the induction coordinator profile" do
+          expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
+
+          CreateInductionTutor.call(school: school, email: email, full_name: name)
+
+          user = User.find_by(email: email)
+          expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
+          expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be false
+          expect(User.exists?(existing_user.id)).to be true
+          expect(NPQApplication.exists?(npq_application.id)).to be true
+        end
+      end
     end
 
     context "when the details match an existing induction coordinator" do


### PR DESCRIPTION
## Ticket and context

Ticket: https://sentry.io/organizations/dfe-bat/issues/2714871921/?project=5748989&referrer=RegressionActivityEmail

Turns out npq applications also have a user foreign key on them... I wonder if we should even bother with deleting that user, but oh well. 