### PR TITLE
Cpdtp 408 block participants from being paid for one declaration type twice

### DIFF
--- a/spec/features/participant-declarations/block_participant_declaration_paid_twice_spec.rb
+++ b/spec/features/participant-declarations/block_participant_declaration_paid_twice_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Block participant declaration paid twice", type: :feature do
     then_the_declaration_made_is_valid
     and_schedule_change_is_submitted_for_this_participant
     and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
-    then_new_declaration_is_not_created
+    then_second_declaration_is_not_created
   end
 
   scenario "Declaration submitted for a changed lead provider" do
@@ -27,6 +27,6 @@ RSpec.feature "Block participant declaration paid twice", type: :feature do
     then_the_declaration_made_is_valid
     and_lead_provider_changed_for_the_participant
     and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
-    then_new_declaration_is_not_created
+    then_second_declaration_is_not_created
   end
 end

--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -123,7 +123,7 @@ module ParticipantDeclarationSteps
     partnership.destroy!
   end
 
-  def then_new_declaration_is_not_created
+  def then_second_declaration_is_not_created
     expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started").count).to eq(1)
   end
 


### PR DESCRIPTION
## Ticket and context

Ticket:

https://dfedigital.atlassian.net/browse/CPDTP-408

## Tech review

Couple of new feature tests for participant changing schedule and participant changing lead provider. In both cases a new declaration won't be created and the participant won't be paid again.

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
