### PR TITLE
Schedule job to stream declarations to BigQuery

### DIFF
--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-class StreamBigQueryParticipantDeclarationsJob < ApplicationJob
+class StreamBigQueryParticipantDeclarationsJob < CronJob
+  self.cron_expression = "5 * * * *"
+
+  queue_as :big_query_participant_declarations
+
   # Streams every attribute of a participant declarations (plus the lead provider name) that was
   # updated during the previous hour.
   def perform

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -7,6 +7,7 @@ namespace :cron do
     ImportGiasDataJob.schedule
     ValidationRetryJob.schedule
     SchoolAnalyticsJob.schedule
+    StreamBigQueryParticipantDeclarationsJob.schedule if Rails.env.production?
     CreateNewFakeSandboxDataJob.schedule if Rails.env.sandbox?
   end
 end


### PR DESCRIPTION
## Ticket and context

In https://github.com/DFE-Digital/early-careers-framework/pull/1265 I added a job to stream participant declarations that had been updated in the previous hour to Google BigQuery. It is now merged and deployed.

I've tested the job on [other environments](https://console.cloud.google.com/bigquery?project=ecf-bq&ws=!1m14!1m3!3m2!1secf-bq!2sprovider_declarations!1m4!4m3!1secf-bq!2sprovider_declarations!3sparticipant_declarations_sandbox!1m4!4m3!1secf-bq!2sprovider_declarations!3sparticipant_declarations_production&d=provider_declarations&p=ecf-bq&page=table&t=participant_declarations_sandbox) and I'm content that the mechanism is working as it should. The next step is to schedule the job on production to run every hour.

Once this is merged and deployed we'll want to seed BigQuery with all the existing declarations:

```ruby
bigquery = Google::Cloud::Bigquery.new
dataset = bigquery.dataset "provider_declarations", skip_lookup: true
table = dataset.table "participant_declarations_#{Rails.env.downcase}", skip_lookup: true

rows = ParticipantDeclaration
  .find_each
  .map do |participant_declaration|
    participant_declaration.attributes.merge(
      "cpd_lead_provider_name" => participant_declaration.cpd_lead_provider.name,
    )
  end

table.insert rows
```