### PR TITLE
Send batched declarations on the hour

### DIFF
--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StreamBigQueryParticipantDeclarationsJob < CronJob
-  self.cron_expression = "5 * * * *"
+  self.cron_expression = "0 * * * *"
 
   queue_as :big_query_participant_declarations
 


### PR DESCRIPTION
## Ticket and context

I realised that it opens a 5 minute gap for things updated in the previous hour to be updated in this hour. It would add an unnecessary delay.