### PR TITLE
NPQ manual validation no longer updates profile

### DIFF
--- a/app/services/importers/npq_manual_validation.rb
+++ b/app/services/importers/npq_manual_validation.rb
@@ -18,11 +18,7 @@ class Importers::NPQManualValidation
 
       puts "updating trn for NPQApplication: #{row['application_ecf_id']} with trn: #{row['validated_trn']}"
 
-      ApplicationRecord.transaction do
-        data.update!(teacher_reference_number: row["validated_trn"], teacher_reference_number_verified: true)
-        teacher_profile = data.user.teacher_profile
-        teacher_profile.update!(trn: row["validated_trn"])
-      end
+      data.update!(teacher_reference_number: row["validated_trn"], teacher_reference_number_verified: true)
     end
   end
 

--- a/spec/lib/importers/npq_manual_validation_spec.rb
+++ b/spec/lib/importers/npq_manual_validation_spec.rb
@@ -47,12 +47,6 @@ RSpec.describe Importers::NPQManualValidation do
           subject.call
         }.to change { npq_application.reload.teacher_reference_number_verified }.to(true)
       end
-
-      it "updates TRN on teacher profile" do
-        expect {
-          subject.call
-        }.to change { npq_application.reload.user.teacher_profile.trn }.from(nil).to("7654321")
-      end
     end
 
     context "with malformed csv" do


### PR DESCRIPTION
## Ticket and context

Ticket: none

- We no longer update the teach profile as this  is now created on marking an application as accepted which happens after validation

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

- ssh into review app
- create some npq applications where TRNs are not validated
- craft a CSV updating the applications so TRNs will become validated
- in rails console call `Importers::NPQManualValidation` with crafted CSV
- npq applications should now be validated

## External API changes

- none