### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ We use Cypress for end-to-end tests. This integrates with Axe for automated acce
 
 We aim to have an accessibility and snapshot test for every page on the service.
 
-## Smoke tests
-
-We run smoke tests against review apps. After a review app is deployed, a smoke test will be run against it automatically.
-
-Tests are written in rspec, so if you need to debug them, you can run them locally - just make sure to set the domain to the review app you want to debug against.
-
 ### Setup
 
 ```
@@ -111,6 +105,12 @@ bin/rails server -e test -p 5017
 ```
 yarn cypress:open
 ```
+
+## Smoke tests
+
+We run smoke tests against review apps. After a review app is deployed, a smoke test will be run against it automatically.
+
+Tests are written in rspec, so if you need to debug them, you can run them locally - just make sure to set the domain to the review app you want to debug against.
 
 ## Review apps
 Review apps are automatically created when a PR is opened. A link to the app will be posted on the review.


### PR DESCRIPTION
Move the smoke test description to after the cypress section, instead of in the middle
