### PR TITLE
Bypass the checking for initial state declaration state setting.

### DIFF
--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -65,6 +65,7 @@ module RecordDeclarations
 
     def find_or_create_record!
       self.class.declaration_model.find_or_create_by!(declaration_parameters).tap do |participant_declaration|
+        DeclarationState.submitted!(participant_declaration)
         participant_declaration.make_eligible! if fundable?
       end
     end


### PR DESCRIPTION
## Ticket and context

For declarations, if the participant is fundable, the first recorded state is eligible and the submitted date is the created_at date of the declaration. If they aren't fundable, the submitted date is the created_at, but there is nothing in the history for this state. This ticket adds in history for submitted and toggles it eligible if the profile is deemed fundable.

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
