### PR TITLE
Do not send ineligibility emails about ERO mentors

### DIFF
--- a/app/mailers/ineligible_participant_mailer.rb
+++ b/app/mailers/ineligible_participant_mailer.rb
@@ -2,7 +2,6 @@
 
 class IneligibleParticipantMailer < ApplicationMailer
   ECT_PREVIOUS_INDUCTION_TEMPLATE = "e27eabc4-2d54-4356-8073-85cf9a559ce4"
-  MENTOR_PREVIOUS_PARTICIPATION_TEMPLATE = "d64d1f3b-d156-444c-bf05-b5254a0dd0ad"
 
   ACTIVE_FLAGS_TEMPLATES = {
     ect: "dcab5e33-c7c3-4d5a-84b6-458ae7640061",
@@ -71,18 +70,6 @@ class IneligibleParticipantMailer < ApplicationMailer
       personalisation: {
         ineligible_ECT_name: participant_profile.user.full_name,
         "NQT+1_materials_link": start_schools_year_2020_url(school_id: participant_profile.school.id),
-      },
-    ).tag(:ineligible_participant).associate_with(participant_profile, as: :participant_profile)
-  end
-
-  def mentor_previous_participation_email(induction_tutor_email:, participant_profile:)
-    template_mail(
-      MENTOR_PREVIOUS_PARTICIPATION_TEMPLATE,
-      to: induction_tutor_email,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        ineligible_mentor_name: participant_profile.user.full_name,
       },
     ).tag(:ineligible_participant).associate_with(participant_profile, as: :participant_profile)
   end

--- a/app/services/store_participant_eligibility.rb
+++ b/app/services/store_participant_eligibility.rb
@@ -40,6 +40,8 @@ private
   def send_ineligible_notification_email
     participant_profile.school_cohort.school.induction_coordinators.each do |induction_tutor|
       mailer_name = "#{participant_profile.participant_type}_#{@participant_eligibility.reason}_email"
+      next if mailer_name == "mentor_previous_participation_email" # Do not send emails about ERO mentors
+
       if IneligibleParticipantMailer.respond_to? mailer_name
         IneligibleParticipantMailer.send(mailer_name, **{ induction_tutor_email: induction_tutor.email, participant_profile: participant_profile }).deliver_later
       else

--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -96,13 +96,10 @@ RSpec.describe StoreParticipantEligibility do
         end
 
         context "when participant is a Mentor" do
-          it "sends the mentor_previous_participation_email when reason is previous_participation" do
+          it "does not send the mentor_previous_participation_email when reason is previous_participation" do
             eligibility_options[:previous_participation] = true
             service.call(participant_profile: mentor_profile, eligibility_options: eligibility_options)
-            expect(IneligibleParticipantMailer).to delay_email_delivery_of(:mentor_previous_participation_email).with(
-              induction_tutor_email: induction_tutor.email,
-              participant_profile: mentor_profile,
-            )
+            expect(IneligibleParticipantMailer).not_to delay_email_delivery_of("") # Matches any email
           end
 
           it "sends the mentor_no_qts_email when reason is no_qts" do


### PR DESCRIPTION
We don't want to send these emails any more because we're not sure what's going on with them