### PR TITLE
Adjust SIT reminder mailers so they can be resent

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -311,7 +311,7 @@ class SchoolMailer < ApplicationMailer
         school_name: school_name,
         sign_in: new_user_session_url(**campaign_tracking),
       },
-    ).tag(:third_request_to_add_ects_and_mentors).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+    ).tag(:fourth_request_to_add_ects_and_mentors).associate_with(induction_coordinator, as: :induction_coordinator_profile)
   end
 
   def year2020_add_participants_confirmation(recipient:, school_name:, teacher_name_list:)

--- a/app/services/partnership_notification_service.rb
+++ b/app/services/partnership_notification_service.rb
@@ -60,7 +60,8 @@ class PartnershipNotificationService
             challenge_url: challenge_url(notification_email.token, utm_source: :partnered_invite_sit_reminder),
           ).deliver_now.delivery_method.response.id
 
-          partnership.update!(challenge_deadline: 2.weeks.from_now)
+          # This would usually be two weeks, but we don't want providers to be able challenge after the first milestone date.
+          partnership.update!(challenge_deadline: Date.parse("Oct 31 2021").end_of_day)
           notification_email.update!(notify_id: notify_id)
         end
       end

--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -33,7 +33,7 @@ class ValidationBetaService
 
     School.where(id: empty_school_cohorts.select(:school_id)).includes(:induction_coordinators).find_each do |school|
       school.induction_coordinator_profiles.each do |sit|
-        next if Email.associated_with(sit).tagged_with(:third_request_to_add_ects_and_mentors).any?
+        next if Email.associated_with(sit).tagged_with(:fourth_request_to_add_ects_and_mentors).any?
 
         SchoolMailer.remind_fip_induction_coordinators_to_add_ects_and_mentors_email(
           induction_coordinator: sit,

--- a/spec/services/partnership_notification_service_spec.rb
+++ b/spec/services/partnership_notification_service_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe PartnershipNotificationService do
         expect(partnership_notification_email.sent_to).to eq(contact_email)
         expect(partnership_notification_email.notify_id).to eq(notify_id)
         expect(partnership_notification_email.email_type).to eq("nominate_sit_email")
-        expect(partnership_notification_email.reload.challenge_deadline).to be_within(1.second).of(2.weeks.from_now)
+        expect(partnership_notification_email.reload.challenge_deadline).to be_within(1.second).of(Date.parse("Oct 31 2021").end_of_day)
       end
     end
 


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-1061

We're re-sending out two mailers that we've already sent. This PR adjusts the tagging so we can attribute them correctly. I also modify the challenge deadline extension so that it doesn't exceed the Oct 31 milestone date.