### PR TITLE
add POST endpoint for participant validation

### DIFF
--- a/app/controllers/api/v1/participant_validation_controller.rb
+++ b/app/controllers/api/v1/participant_validation_controller.rb
@@ -21,6 +21,22 @@ module Api
         end
       end
 
+      def create
+        record = ParticipantValidationService.validate(
+          trn: params[:trn],
+          full_name: params[:full_name],
+          date_of_birth: Date.iso8601(params[:date_of_birth]),
+          nino: params[:nino],
+          config: { check_first_name_only: true },
+        )
+
+        if record.present?
+          render json: ParticipantValidationSerializer.new(OpenStruct.new(record)).serializable_hash.to_json
+        else
+          head :not_found
+        end
+      end
+
     private
 
       def access_scope

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,7 @@ Rails.application.routes.draw do
       end
       resources :users, only: %i[index create]
       resources :ecf_users, only: %i[index create], path: "ecf-users"
-      resources :participant_validation, only: :show, path: "participant-validation"
+      resources :participant_validation, only: %i[show create], path: "participant-validation"
       resources :npq_applications, only: :index, path: "npq-applications" do
         member do
           post :accept

--- a/spec/requests/api/v1/participant_validation_spec.rb
+++ b/spec/requests/api/v1/participant_validation_spec.rb
@@ -84,4 +84,111 @@ RSpec.describe "participant validation api endpoint", type: :request do
       end
     end
   end
+
+  describe "#create" do
+    let(:token) { NPQRegistrationApiToken.create_with_random_token! }
+    let(:bearer_token) { "Bearer #{token}" }
+    let(:parsed_response) { JSON.parse(response.body) }
+    let(:trn) { rand(1_000_000..9_999_999).to_s }
+    let(:full_name) { "John Doe" }
+    let(:date_of_birth) { rand(50.years.ago..20.years.ago).to_date }
+    let(:nino) { "AB123456C" }
+
+    let(:service_response) do
+      {
+        trn: trn,
+        qts: "1999-12-13",
+        active_alert: false,
+      }
+    end
+
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+
+        allow(ParticipantValidationService).to receive(:validate).with(
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+          config: { check_first_name_only: true },
+        ).and_return(service_response)
+      end
+
+      it "returns correct jsonapi content type header" do
+        post "/api/v1/participant-validation", params: {
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+        }
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns correct type" do
+        post "/api/v1/participant-validation", params: {
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+        }
+        expect(parsed_response["data"]).to have_type("participant_validation")
+      end
+
+      it "has correct attributes" do
+        post "/api/v1/participant-validation", params: {
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+        }
+
+        expect(parsed_response["data"]["id"]).to eql(service_response[:trn])
+        expect(parsed_response["data"]).to have_jsonapi_attributes(:trn, :qts, :active_alert).exactly
+      end
+
+      context "when no record is found for given teacher_reference_number" do
+        let(:service_response) { nil }
+
+        it "returns a 404" do
+          post "/api/v1/participant-validation", params: {
+            trn: trn,
+            full_name: full_name,
+            date_of_birth: date_of_birth,
+            nino: nino,
+          }
+
+          expect(response).to be_not_found
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        post "/api/v1/participant-validation", params: {
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+        }
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "using valid token but for different scope" do
+      let(:other_token) { DummyToken.create_with_random_token! }
+
+      it "returns 403" do
+        default_headers[:Authorization] = "Bearer #{other_token}"
+        post "/api/v1/participant-validation", params: {
+          trn: trn,
+          full_name: full_name,
+          date_of_birth: date_of_birth,
+          nino: nino,
+        }
+        expect(response.status).to eq 403
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://trello.com/c/4ivWyY5L/621-convert-trn-validation-from-get-to-post

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
