### PR TITLE
Update participant serializer to correct trn verified

### DIFF
--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -22,10 +22,8 @@ class ParticipantSerializer
     end
 
     def validated_trn(user)
-      eligibility_status = user.teacher_profile.current_ecf_profile.ecf_participant_eligibility&.status
-      if %w[matched eligible].include?(eligibility_status)
-        user.teacher_profile.trn
-      end
+      eligibility = user.teacher_profile.current_ecf_profile.ecf_participant_eligibility
+      eligibility.present? && !eligibility.different_trn_reason?
     end
 
     def eligible_for_funding?(user)

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -192,6 +192,18 @@ RSpec.describe ParticipantSerializer do
             eligibility.manual_check_status!
           end
 
+          it "returns true" do
+            result = ParticipantSerializer.new(ect).serializable_hash
+            expect(result[:data][:attributes][:teacher_reference_number_validated]).to be true
+          end
+        end
+
+        context "when the reason is different_trn" do
+          before do
+            eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
+            eligibility.different_trn_reason!
+          end
+
           it "returns false" do
             result = ParticipantSerializer.new(ect).serializable_hash
             expect(result[:data][:attributes][:teacher_reference_number_validated]).to be false


### PR DESCRIPTION
Ineligibility should not result in us saying the trn is not verified -
only when the reason is "different_trn"

