### PR TITLE
CPDRP-905 Add and refactor tests

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -7,7 +7,7 @@ class Schools::ParticipantsController < Schools::BaseController
   before_action :set_mentors_added, only: %i[index show]
 
   def index
-    participant_categories = SetParticipantCategories.call(@school_cohort)
+    participant_categories = SetParticipantCategories.call(@school_cohort, current_user)
     @eligible = participant_categories.eligible
     @ineligible = participant_categories.ineligible
     @contacted_for_info = participant_categories.contacted_for_info

--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -7,13 +7,11 @@ class Schools::ParticipantsController < Schools::BaseController
   before_action :set_mentors_added, only: %i[index show]
 
   def index
-    if @school_cohort.core_induction_programme?
-      cip_participant_categories
-    elsif FeatureFlag.active?(:eligibility_notifications)
-      fip_participant_categories_feature_flag_active
-    else
-      fip_participant_categories_feature_flag_inactive
-    end
+    participant_categories = SetParticipantCategories.call(@school_cohort)
+    @eligible = participant_categories.eligible
+    @ineligible = participant_categories.ineligible
+    @contacted_for_info = participant_categories.contacted_for_info
+    @details_being_checked = participant_categories.details_being_checked
   end
 
   def show
@@ -125,46 +123,5 @@ private
 
   def email_used?
     User.where.not(id: @profile.user.id).where(email: @profile.user.email).any?
-  end
-
-  def active_participant_profiles
-    @school_cohort.active_ecf_participant_profiles
-  end
-
-  def ineligible_participants
-    policy_scope(active_participant_profiles.ineligible_status.includes(:user).order("users.full_name"))
-  end
-
-  def eligible_participants
-    policy_scope(active_participant_profiles.eligible_status.includes(:user).order("users.full_name"))
-  end
-
-  def contacted_for_info_participants
-    policy_scope(active_participant_profiles.contacted_for_info.includes(:user).order("users.full_name"))
-  end
-
-  def details_being_checked_participants
-    policy_scope(active_participant_profiles.details_being_checked.includes(:user).order("users.full_name"))
-  end
-
-  def fip_participant_categories_feature_flag_active
-    @eligible = eligible_participants
-    @ineligible = ineligible_participants.without(@eligible)
-    @contacted_for_info = contacted_for_info_participants
-    @details_being_checked = details_being_checked_participants
-  end
-
-  def fip_participant_categories_feature_flag_inactive
-    @eligible = []
-    @ineligible = []
-    @contacted_for_info = contacted_for_info_participants
-    @details_being_checked = [*details_being_checked_participants, *ineligible_participants, *eligible_participants]
-  end
-
-  def cip_participant_categories
-    @eligible = [*eligible_participants, *ineligible_participants, *details_being_checked_participants].uniq
-    @ineligible = []
-    @contacted_for_info = contacted_for_info_participants
-    @details_being_checked = []
   end
 end

--- a/app/services/set_participant_categories.rb
+++ b/app/services/set_participant_categories.rb
@@ -9,12 +9,15 @@ class SetParticipantCategories < BaseService
 
 private
 
-  def initialize(school_cohort)
+  attr_reader :school_cohort, :user
+
+  def initialize(school_cohort, user)
     @school_cohort = school_cohort
+    @user = user
   end
 
   def set_participant_categories
-    if @school_cohort.core_induction_programme?
+    if school_cohort.core_induction_programme?
       cip_participant_categories
     elsif FeatureFlag.active?(:eligibility_notifications)
       fip_participant_categories_feature_flag_active
@@ -36,7 +39,7 @@ private
   end
 
   def active_participant_profiles
-    @school_cohort.active_ecf_participant_profiles
+    ParticipantProfilePolicy::Scope.new(user, ParticipantProfile::ECF.active_record).resolve
   end
 
   def ineligible_participants

--- a/app/services/set_participant_categories.rb
+++ b/app/services/set_participant_categories.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class SetParticipantCategories < BaseService
+  ParticipantCategories = Struct.new(:eligible, :ineligible, :contacted_for_info, :details_being_checked)
+
+  def call
+    set_participant_categories
+  end
+
+private
+
+  def initialize(school_cohort)
+    @school_cohort = school_cohort
+  end
+
+  def set_participant_categories
+    if @school_cohort.core_induction_programme?
+      cip_participant_categories
+    elsif FeatureFlag.active?(:eligibility_notifications)
+      fip_participant_categories_feature_flag_active
+    else
+      fip_participant_categories_feature_flag_inactive
+    end
+  end
+
+  def fip_participant_categories_feature_flag_active
+    ParticipantCategories.new(eligible_participants, fip_flag_active_ineligible_participants, contacted_for_info_participants, details_being_checked_participants)
+  end
+
+  def fip_participant_categories_feature_flag_inactive
+    ParticipantCategories.new([], [], contacted_for_info_participants, fip_flag_inactive_details_being_checked_participants)
+  end
+
+  def cip_participant_categories
+    ParticipantCategories.new(cip_eligible_participants, [], contacted_for_info_participants, [])
+  end
+
+  def active_participant_profiles
+    @school_cohort.active_ecf_participant_profiles
+  end
+
+  def ineligible_participants
+    active_participant_profiles.ineligible_status.includes(:user).order("users.full_name")
+  end
+
+  def eligible_participants
+    active_participant_profiles.eligible_status.includes(:user).order("users.full_name")
+  end
+
+  def contacted_for_info_participants
+    active_participant_profiles.contacted_for_info.includes(:user).order("users.full_name")
+  end
+
+  def details_being_checked_participants
+    active_participant_profiles.details_being_checked.includes(:user).order("users.full_name")
+  end
+
+  def fip_flag_active_ineligible_participants
+    ineligible_participants - eligible_participants
+  end
+
+  def cip_eligible_participants
+    [*eligible_participants, *ineligible_participants, *details_being_checked_participants].uniq
+  end
+
+  def fip_flag_inactive_details_being_checked_participants
+    [*details_being_checked_participants, *ineligible_participants, *eligible_participants].uniq
+  end
+end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Sorry, there's a problem with the service</h1>
+    <h1 class="govuk-heading-xl">Sorry, there’s a problem with the service</h1>
     <p class="govuk-body">Try again later.</p>
     <p class="govuk-body">If you need to do something urgently, contact: <%= render MailToSupportComponent.new %></p>
   </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
-    <p class="govuk-body">Maybe you tried to change something you didn't have access to.</p>
+    <p class="govuk-body">Maybe you tried to change something you didn’t have access to.</p>
     <p class="govuk-body">If you are the application owner check the logs for more information.</p>
   </div>
 </div>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,7 +7,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page<%= 'current' if page.current? %>">
+<span class="page<%= ' current' if page.current? %>">
   <% if page.current? %>
     <span><%= page %></span>
   <% else %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,7 +7,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page<%= ' current' if page.current? %>">
+<span class="page<%= 'current' if page.current? %>">
   <% if page.current? %>
     <span><%= page %></span>
   <% else %>

--- a/app/views/pages/core_materials_info.html.erb
+++ b/app/views/pages/core_materials_info.html.erb
@@ -110,7 +110,7 @@
   <% end %>
 
   <% accordion.section heading_text: "Module 8: how pupils learn - memory and cognition" do %>
-    <p>Teachers will consider how they can make new learning stick over time so pupils remember what they've been taught.</p>
+    <p>Teachers will consider how they can make new learning stick over time so pupils remember what they’ve been taught.</p>
   <% end %>
 
   <% accordion.section heading_text: "Module 9: enhancing classroom practice - grouping and tailoring" do %>
@@ -118,7 +118,7 @@
   <% end %>
 
   <% accordion.section heading_text: "Module 10: revisiting the importance of subject and curriculum knowledge" do %>
-    <p>Teachers will focus on how they can use their in-depth understanding of the subjects they teach to strengthen their pupils' knowledge.</p>
+    <p>Teachers will focus on how they can use their in-depth understanding of the subjects they teach to strengthen their pupils’ knowledge.</p>
   <% end %>
 
   <% accordion.section heading_text: "Module 11: deepening assessment, feedback and questioning" do %>
@@ -159,7 +159,7 @@
   <% end %>
 
   <% accordion.section heading_text: "Module 4: how to use assessment and feedback to greatest effect" do %>
-    <p>Teachers will hear from education experts about why assessment should be at the heart of their teaching. They'll also explore ways to give purposeful feedback to their pupils and what they can learn from summative data sets.</p>
+    <p>Teachers will hear from education experts about why assessment should be at the heart of their teaching. They’ll also explore ways to give purposeful feedback to their pupils and what they can learn from summative data sets.</p>
   <% end %>
 
   <% accordion.section heading_text: "Module 5: how to support all pupils to succeed" do %>
@@ -191,7 +191,7 @@
 
 <%= govuk_accordion do |accordion| %>
   <% accordion.section heading_text: "Module 1: enabling pupil learning" do %>
-    <p>Teachers will focus on how they set up their classroom as a learning environment. They'll be able to reflect on the different ways they can influence their environment, and learn practical strategies that keep pupils safe, motivated and focused on learning.</p>
+    <p>Teachers will focus on how they set up their classroom as a learning environment. They’ll be able to reflect on the different ways they can influence their environment, and learn practical strategies that keep pupils safe, motivated and focused on learning.</p>
   <% end %>
 
   <% accordion.section heading_text: "Module 2: engaging pupils in learning" do %>

--- a/app/views/pages/induction_tutor_materials/education_development_trust/_handbooks_and_outlines.html.erb
+++ b/app/views/pages/induction_tutor_materials/education_development_trust/_handbooks_and_outlines.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-9">
-  Education Development Trust's handbooks and training outlines
+  Education Development Trust’s handbooks and training outlines
 </h1>
 
 <h2 class="govuk-heading-l govuk-!-margin-bottom-3">Handbooks</h2>

--- a/app/views/participants/validations/cip_eligible.html.erb
+++ b/app/views/participants/validations/cip_eligible.html.erb
@@ -1,4 +1,4 @@
-<% title = "You're eligible for this programme" %>
+<% title = "You’re eligible for this programme" %>
 <% content_for :title, title %>
 
 <div class="govuk-grid-row">

--- a/app/views/participants/validations/fip_eligible_no_partnership.html.erb
+++ b/app/views/participants/validations/fip_eligible_no_partnership.html.erb
@@ -1,4 +1,4 @@
-<% title = "You're eligible for this programme" %>
+<% title = "You’re eligible for this programme" %>
 <% content_for :title, title %>
 
 <div class="govuk-grid-row">

--- a/app/views/participants/validations/fip_eligible_partnership.html.erb
+++ b/app/views/participants/validations/fip_eligible_partnership.html.erb
@@ -1,4 +1,4 @@
-<% title = "You're eligible for this programme" %>
+<% title = "You’re eligible for this programme" %>
 <% content_for :title, title %>
 
 <div class="govuk-grid-row">

--- a/app/views/participants/validations/fip_mentor_previous_participation.html.erb
+++ b/app/views/participants/validations/fip_mentor_previous_participation.html.erb
@@ -1,4 +1,4 @@
-<% title = "You're ready to mentor ECTs" %>
+<% title = "You’re ready to mentor ECTs" %>
 <% content_for :title, title %>
 
 <div class="govuk-grid-row">

--- a/app/views/sandbox/show.html.erb
+++ b/app/views/sandbox/show.html.erb
@@ -20,7 +20,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>retrieve a list of ECF participants or NPQ applications</li>
-        <li>declare a participant's engagement with the programmes</li>
+        <li>declare a participant’s engagement with the programmes</li>
       </ul>
 
       <p class="govuk-body">Throughout, you’ll be able to give us feedback so we can improve the service.</p>
@@ -29,7 +29,7 @@
       <p class="govuk-body">You’ll be asked to enter your email address during the NPQ registration process on Teacher
         CPD sandbox.</p>
 
-      <p class="govuk-body">Please do not use anyone's real email address, unless it is your own, as the system will
+      <p class="govuk-body">Please do not use anyone’s real email address, unless it is your own, as the system will
         record the real email addresses as part of the test.</p>
 
       <h3 class="govuk-heading-m">A note on email addresses</h3>

--- a/app/views/schools/add_participants/complete.html.erb
+++ b/app/views/schools/add_participants/complete.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% if participant_profile.user == current_user %>
-      <%= govuk_panel title_text: "You've been added as a mentor", text: nil, classes: "govuk-!-margin-bottom-8" %>
+      <%= govuk_panel title_text: "You’ve been added as a mentor", text: nil, classes: "govuk-!-margin-bottom-8" %>
 
       <h2 class="govuk-heading-m">What happens next</h2>
 
@@ -19,8 +19,8 @@
 
       <h2 class="govuk-heading-m">What happens next</h2>
 
-      <p class="govuk-body">We'll contact them to ask for information needed to check they're eligible for this training.</p>
-      <p class="govuk-body">We'll let you know if they're not eligible, or if we need any further information.</p>
+      <p class="govuk-body">We’ll contact them to ask for information needed to check they’re eligible for this training.</p>
+      <p class="govuk-body">We’ll let you know if they’re not eligible, or if we need any further information.</p>
       <p class="govuk-body">You can track the status of these checks by viewing your ECTs and mentors.</p>
     <% end %>
 

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -26,7 +26,7 @@
   <div class="govuk-grid-column-full">
     <% if @ineligible.any? %>
       <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Not eligible for funded training</h2>
-      <p class="govuk-!-margin-bottom-3">We’ve checked these people's details and found they’re not eligible for this
+      <p class="govuk-!-margin-bottom-3">We’ve checked these people’s details and found they’re not eligible for this
         programme.</p>
 
       <table class="govuk-table govuk-!-margin-bottom-9">
@@ -102,7 +102,7 @@
     <% if @details_being_checked.any? %>
       <h2 class="govuk-heading-m govuk-!-margin-bottom-0">DfE checking eligibility</h2>
       <p class="govuk-!-margin-bottom-3">We’re checking these people’s details with the Teaching Regulation Agency.
-        We'll confirm if they’re eligible for this programme soon.</p>
+        We’ll confirm if they’re eligible for this programme soon.</p>
 
       <table class="govuk-table govuk-!-margin-bottom-9">
         <thead class="govuk-table__head">

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -29,7 +29,7 @@
       <p class="govuk-!-margin-bottom-3">We’ve checked these people’s details and found they’re not eligible for this
         programme.</p>
 
-      <table class="govuk-table govuk-!-margin-bottom-9">
+      <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligible">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name</th>
@@ -46,7 +46,7 @@
             <td class="govuk-table__cell"><%= profile.user.full_name %></td>
             <td class="govuk-table__cell"><%= format_type(profile.participant_type) %></td>
             <td class="govuk-table__cell">None</td>
-            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="ineligible"><%= govuk_link_to "Check", schools_participant_path(id: profile.id) %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= govuk_link_to "Check", schools_participant_path(id: profile.id) %></td>
           </tr>
         <% end %>
         </tbody>
@@ -57,7 +57,7 @@
       <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Contacted for information</h2>
       <p class="govuk-!-margin-bottom-3">We need this to check their eligibility with the Teaching Regulation Agency.</p>
 
-      <table class="govuk-table govuk-!-margin-bottom-9">
+      <table class="govuk-table govuk-!-margin-bottom-9" data-test="checked">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name</th>
@@ -84,7 +84,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="checked">
+            <td class="govuk-table__cell govuk-table__cell--numeric">
             <% if profile.request_for_details_sent_at %>
               <%= govuk_link_to "Check", schools_participant_path(id: profile.id) %>
             <% elsif profile.request_for_details_sent_at.nil? && profile.mentor_profile_id.nil? %>
@@ -104,7 +104,7 @@
       <p class="govuk-!-margin-bottom-3">We’re checking these people’s details with the Teaching Regulation Agency.
         We’ll confirm if they’re eligible for this programme soon.</p>
 
-      <table class="govuk-table govuk-!-margin-bottom-9">
+      <table class="govuk-table govuk-!-margin-bottom-9" data-test="details">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name</th>
@@ -127,7 +127,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="details">
+            <td class="govuk-table__cell govuk-table__cell--numeric">
               <% if profile.ect? %>
                 <%= govuk_link_to (profile.mentor_profile_id ? "Details" : "Check"), schools_participant_path(id: profile.id) %>
               <% else %>
@@ -150,7 +150,7 @@
         <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
       <% end %>
 
-      <table class="govuk-table govuk-!-margin-bottom-9">
+      <table class="govuk-table govuk-!-margin-bottom-9" data-test="eligible">
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-!-width-one-third">Name</th>
@@ -173,7 +173,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="eligible">
+            <td class="govuk-table__cell govuk-table__cell--numeric">
               <% if profile.ect? %>
                 <%= govuk_link_to (profile.mentor_profile_id ? "Details" : "Check"), schools_participant_path(id: profile.id) %>
               <% elsif profile.ecf_participant_eligibility.ineligible_status? %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -46,7 +46,7 @@
             <td class="govuk-table__cell"><%= profile.user.full_name %></td>
             <td class="govuk-table__cell"><%= format_type(profile.participant_type) %></td>
             <td class="govuk-table__cell">None</td>
-            <td class="govuk-table__cell govuk-table__cell--numeric ineligible"><%= govuk_link_to "Check", schools_participant_path(id: profile.id) %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="ineligible"><%= govuk_link_to "Check", schools_participant_path(id: profile.id) %></td>
           </tr>
         <% end %>
         </tbody>
@@ -84,7 +84,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric contacted">
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="checked">
             <% if profile.request_for_details_sent_at %>
               <%= govuk_link_to "Check", schools_participant_path(id: profile.id) %>
             <% elsif profile.request_for_details_sent_at.nil? && profile.mentor_profile_id.nil? %>
@@ -127,7 +127,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric details">
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="details">
               <% if profile.ect? %>
                 <%= govuk_link_to (profile.mentor_profile_id ? "Details" : "Check"), schools_participant_path(id: profile.id) %>
               <% else %>
@@ -173,7 +173,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric eligible">
+            <td class="govuk-table__cell govuk-table__cell--numeric" data-test="eligible">
               <% if profile.ect? %>
                 <%= govuk_link_to (profile.mentor_profile_id ? "Details" : "Check"), schools_participant_path(id: profile.id) %>
               <% elsif profile.ecf_participant_eligibility.ineligible_status? %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -78,7 +78,7 @@
                 Remind them
               <% elsif latest_email_failed_for(profile) %>
                 Check email address
-              <% elsif profile.mentor_profile_id.nil? %>
+              <% elsif profile.ect? && profile.mentor_profile_id.nil? %>
                 Assign mentor
               <% else %>
                 None

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -46,7 +46,7 @@
             <td class="govuk-table__cell"><%= profile.user.full_name %></td>
             <td class="govuk-table__cell"><%= format_type(profile.participant_type) %></td>
             <td class="govuk-table__cell">None</td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= govuk_link_to "Check", schools_participant_path(id: profile.id) %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric ineligible"><%= govuk_link_to "Check", schools_participant_path(id: profile.id) %></td>
           </tr>
         <% end %>
         </tbody>
@@ -84,7 +84,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
+            <td class="govuk-table__cell govuk-table__cell--numeric contacted">
             <% if profile.request_for_details_sent_at %>
               <%= govuk_link_to "Check", schools_participant_path(id: profile.id) %>
             <% elsif profile.request_for_details_sent_at.nil? && profile.mentor_profile_id.nil? %>
@@ -127,7 +127,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
+            <td class="govuk-table__cell govuk-table__cell--numeric details">
               <% if profile.ect? %>
                 <%= govuk_link_to (profile.mentor_profile_id ? "Details" : "Check"), schools_participant_path(id: profile.id) %>
               <% else %>
@@ -173,7 +173,7 @@
                 None
               <% end %>
             </td>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
+            <td class="govuk-table__cell govuk-table__cell--numeric eligible">
               <% if profile.ect? %>
                 <%= govuk_link_to (profile.mentor_profile_id ? "Details" : "Check"), schools_participant_path(id: profile.id) %>
               <% elsif profile.ecf_participant_eligibility.ineligible_status? %>

--- a/config/locales/schools/participants.yml
+++ b/config/locales/schools/participants.yml
@@ -44,7 +44,7 @@ en:
             - "If this person has not completed their ITT, %{contact_us}."
 
         ero_mentor:
-          header: "This person is ready to mentor ECTs this year. Our checks show they're already receiving funded mentor training as part of the early roll-out of the early career framework (ECF) reforms."
+          header: "This person is ready to mentor ECTs this year. Our checks show they’re already receiving funded mentor training as part of the early roll-out of the early career framework (ECF) reforms."
           content: ""
 
         eligible_cip:

--- a/spec/features/participants/participant_validation_steps.rb
+++ b/spec/features/participants/participant_validation_steps.rb
@@ -183,7 +183,7 @@ module ParticipantValidationSteps
   end
 
   def then_i_should_see_the_complete_page
-    expect(page).to have_selector("h1", text: "You're eligible for this programme")
+    expect(page).to have_selector("h1", text: "You’re eligible for this programme")
     expect(page).to have_text("You will not need to use this service again during your training.")
     expect(page).to have_text("Big Provider Ltd")
     expect(page).to have_text("Amazing Delivery Team")
@@ -207,7 +207,7 @@ module ParticipantValidationSteps
   end
 
   def then_i_should_see_the_complete_page_for_matched_cip_ect_participant
-    expect(page).to have_selector("h1", text: "You're eligible for this programme")
+    expect(page).to have_selector("h1", text: "You’re eligible for this programme")
     expect(page).to have_text("We’ll email you a link to access your materials within the next 24 hours.")
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
@@ -215,7 +215,7 @@ module ParticipantValidationSteps
   end
 
   def then_i_should_see_the_complete_page_for_matched_cip_mentor_participant
-    expect(page).to have_selector("h1", text: "You're eligible for this programme")
+    expect(page).to have_selector("h1", text: "You’re eligible for this programme")
     expect(page).to have_text("We’ll email you a link to access your materials within the next 24 hours.")
     expect(@user.reload.teacher_profile.trn).to eq(@participant_data[:trn])
     expect(@user.teacher_profile.participant_profiles.ecf.first.ecf_participant_eligibility).to be_eligible_status
@@ -239,7 +239,7 @@ module ParticipantValidationSteps
   end
 
   def then_i_should_see_the_cip_checking_details_page_for_invalid_cip_ect
-    expect(page).to have_selector("h1", text: "You're eligible for this programme")
+    expect(page).to have_selector("h1", text: "You’re eligible for this programme")
     expect(page).to have_text("We’ll email you a link to access your materials within the next 24 hours.")
     expect(page).not_to have_link("Manage induction for your school")
     expect(@user.reload.teacher_profile.trn).to be_nil

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { induct
     end
   end
 
+  context "ERO mentor" do
+    before { and_i_have_added_an_ero_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
   context "Eligible ECTs with a mentor assigned" do
     before do
       and_i_have_added_a_contacted_for_info_mentor

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../training_dashboard/manage_training_steps"
+
+RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { induction_tutor_manage_participants: "active", eligibility_notifications: "active" } do
+  include ManageTrainingSteps
+
+  before do
+    given_there_is_a_school_that_has_chosen_cip_for_2021
+    and_i_am_signed_in_as_an_induction_coordinator
+  end
+
+  context "Ineligible ECTs with mentor assigned" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_an_ineligible_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Ineligible ECTs without mentor assigned" do
+    before { and_i_have_added_an_ineligible_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check_within_eligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Ineligible mentor" do
+    before { and_i_have_added_an_ineligible_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Eligible ECTs with a mentor assigned" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_an_eligible_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Eligible ECTs without a mentor assigned" do
+    before { and_i_have_added_an_eligible_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Eligible mentor" do
+    before { and_i_have_added_an_eligible_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details_within_eligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Contacted for info ECTs with mentor assigned" do
+    before do
+      and_i_have_added_a_mentor
+      and_i_have_added_a_contacted_for_info_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_remind_them
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_status
+    end
+  end
+
+  context "Contacted for info ECTs without mentor assigned" do
+    before { and_i_have_added_a_contacted_for_info_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_check_email_address
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_bounced_email_status
+    end
+  end
+
+  context "Contacted for info mentor" do
+    before { and_i_have_added_a_contacted_for_info_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_remind_them
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_status
+    end
+  end
+
+  context "Details being checked ECT with mentor" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_a_details_being_checked_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Details being checked ECT without mentor" do
+    before { and_i_have_added_a_details_being_checked_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+
+  context "Details being checked mentor" do
+    before { and_i_have_added_a_details_being_checked_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_on_the_cip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_cip_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_cip_status
+    end
+  end
+end

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../training_dashboard/manage_training_steps"
 
-RSpec.describe "Manage FIP partnered participants", js: true, with_feature_flags: { induction_tutor_manage_participants: "active", eligibility_notifications: "active" } do
+RSpec.describe "Manage FIP partnered participants", js: true, with_feature_flags: { eligibility_notifications: "active" } do
   include ManageTrainingSteps
 
   before do

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe "Manage FIP partnered participants", js: true, with_feature_flags
     end
   end
 
+  context "ERO mentor" do
+    before { and_i_have_added_an_ero_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_see_ero_status
+    end
+  end
+
   context "Eligible ECTs with a mentor assigned" do
     before do
       and_i_have_added_a_contacted_for_info_mentor

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../training_dashboard/manage_training_steps"
+
+RSpec.describe "Manage FIP partnered participants", js: true, with_feature_flags: { induction_tutor_manage_participants: "active", eligibility_notifications: "active" } do
+  include ManageTrainingSteps
+
+  before do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_an_induction_coordinator
+  end
+
+  context "Ineligible ECTs with mentor assigned" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_an_ineligible_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_ineligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check_within_ineligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_ineligible_participant_status
+    end
+  end
+
+  context "Ineligible ECTs without mentor assigned" do
+    before { and_i_have_added_an_ineligible_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_ineligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check_within_ineligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_ineligible_participant_status
+    end
+  end
+
+  context "Ineligible mentor" do
+    before { and_i_have_added_an_ineligible_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_ineligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check_within_ineligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_ineligible_participant_status
+    end
+  end
+
+  context "Eligible ECTs with a mentor assigned" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_an_eligible_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_fip_partnered_ect_status
+    end
+  end
+
+  context "Eligible ECTs without a mentor assigned" do
+    before { and_i_have_added_an_eligible_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_eligible_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_fip_partnered_ect_status
+    end
+  end
+
+  context "Eligible mentor" do
+    before { and_i_have_added_an_eligible_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details_within_eligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_fip_partnered_ect_status
+    end
+  end
+
+  context "Contacted for info ECTs with mentor assigned" do
+    before do
+      and_i_have_added_a_mentor
+      and_i_have_added_a_contacted_for_info_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_remind_them
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_status
+    end
+  end
+
+  context "Contacted for info ECTs without mentor assigned" do
+    before { and_i_have_added_a_contacted_for_info_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_check_email_address
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_bounced_email_status
+    end
+  end
+
+  context "Contacted for info mentor" do
+    before { and_i_have_added_a_contacted_for_info_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_remind_them
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_status
+    end
+  end
+
+  context "Details being checked ECT with mentor" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_a_details_being_checked_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_details_being_checked_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details_within_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_details_being_checked_status
+    end
+  end
+
+  context "Details being checked ECT without mentor" do
+    before { and_i_have_added_a_details_being_checked_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_details_being_checked_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_details_being_checked_status
+    end
+  end
+
+  context "Details being checked mentor" do
+    before { and_i_have_added_a_details_being_checked_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_am_taken_to_fip_induction_dashboard
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_details_being_checked_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_details_being_checked_mentor_status
+    end
+  end
+end

--- a/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../training_dashboard/manage_training_steps"
+
+RSpec.describe "Manage FIP unpartnered participants", js: true, with_feature_flags: { induction_tutor_manage_participants: "active", eligibility_notifications: "active" } do
+  include ManageTrainingSteps
+
+  before do
+    given_there_is_a_school_that_has_chosen_fip_for_2021
+    and_i_am_signed_in_as_an_induction_coordinator
+  end
+
+  context "Ineligible ECTs with mentor assigned" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_an_ineligible_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_ineligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check_within_ineligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_ineligible_participant_status
+    end
+  end
+
+  context "Ineligible ECTs without mentor assigned" do
+    before { and_i_have_added_an_ineligible_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_ineligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check_within_ineligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_ineligible_participant_status
+    end
+  end
+
+  context "Ineligible mentor" do
+    before { and_i_have_added_an_ineligible_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_ineligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_check_within_ineligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_ineligible_participant_status
+    end
+  end
+
+  context "Eligible ECTs with a mentor assigned" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_an_eligible_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_fip_unpartnered_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_fip_unpartnered_status
+    end
+  end
+
+  context "Eligible ECTs without a mentor assigned" do
+    before { and_i_have_added_an_eligible_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_fip_unpartnered_eligible_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_fip_unpartnered_status
+    end
+  end
+
+  context "Eligible mentor" do
+    before { and_i_have_added_an_eligible_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_fip_unpartnered_eligible_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details_within_eligible
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_eligible_fip_unpartnered_status
+    end
+  end
+
+  context "Contacted for info ECTs with mentor assigned" do
+    before do
+      and_i_have_added_a_mentor
+      and_i_have_added_a_contacted_for_info_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_remind_them
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_status
+    end
+  end
+
+  context "Contacted for info ECTs without mentor assigned" do
+    before { and_i_have_added_a_contacted_for_info_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_check_email_address
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_bounced_email_status
+    end
+  end
+
+  context "Contacted for info mentor" do
+    before { and_i_have_added_a_contacted_for_info_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_contacted_for_info_participants
+      then_the_action_required_is_remind_them
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_contacted_for_info_status
+    end
+  end
+
+  context "Details being checked ECT with mentor" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_a_details_being_checked_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_details_being_checked_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details_within_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_details_being_checked_status
+    end
+  end
+
+  context "Details being checked ECT without mentor" do
+    before { and_i_have_added_a_details_being_checked_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_details_being_checked_participants
+      then_the_action_required_is_assign_mentor
+
+      when_i_click_on_check
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_details_being_checked_status
+    end
+  end
+
+  context "Details being checked mentor" do
+    before { and_i_have_added_a_details_being_checked_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_details_being_checked_participants
+      then_the_action_required_is_none
+
+      when_i_click_on_details
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_details_being_checked_mentor_status
+    end
+  end
+end

--- a/spec/features/schools/participants/add_participants_spec.rb
+++ b/spec/features/schools/participants/add_participants_spec.rb
@@ -10,107 +10,117 @@ RSpec.describe "Add participants", js: true do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_added_an_ect
-    then_i_should_see_the_fip_induction_dashboard
-    when_i_click_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_fip_induction_dashboard
   end
 
   scenario "Induction tutor can add new ECT participant" do
-    when_i_am_taken_to_roles_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "ECF roles information"
-    and_select_continue
-    then_i_am_taken_to_your_ect_and_mentors_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT and mentors"
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "ECF roles information"
 
-    when_i_select_add_ect
-    and_select_continue
+    when_i_click_on_continue
+    then_i_am_taken_to_your_ect_and_mentors_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT and mentors"
+
+    when_i_click_on_add_ect
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT name"
-    and_select_continue
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT name"
+
+    when_i_click_on_continue
     then_i_receive_a_missing_name_error_message
 
     when_i_add_ect_or_mentor_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT email"
-    and_select_continue
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT email"
+
+    when_i_click_on_continue
     then_i_receive_a_missing_email_error_message
 
     when_i_add_ect_or_mentor_email
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor checks ECT details"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor checks ECT details"
 
-    when_i_select_confirm_and_add
-    then_i_should_be_taken_to_ect_confirmation_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor receives add ECT Confirmation"
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_ect_confirmation_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor receives add ECT Confirmation"
   end
 
   scenario "Induction tutor can add new mentor participant" do
-    when_i_am_taken_to_roles_page
-    and_select_continue
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    when_i_click_on_continue
     then_i_am_taken_to_your_ect_and_mentors_page
-    when_i_select_add_mentor
-    and_select_continue
 
+    when_i_click_on_add_mentor
+    when_i_click_on_continue
     then_i_am_taken_to_add_mentor_name_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor adds mentor name"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor adds mentor name"
 
     when_i_add_ect_or_mentor_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor adds mentor email"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor adds mentor email"
 
     when_i_add_ect_or_mentor_email
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
 
-    when_i_select_confirm_and_add
-    then_i_should_be_taken_to_mentor_confirmation_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor receives add mentor Confirmation"
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_mentor_confirmation_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor receives add mentor Confirmation"
   end
 
   scenario "Induction tutor can add themselves as a mentor" do
-    when_i_am_taken_to_roles_page
-    and_select_continue
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    when_i_click_on_continue
     then_i_am_taken_to_your_ect_and_mentors_page
-    when_i_select_add_myself_as_mentor
+
+    when_i_click_on_add_myself_as_mentor
     then_i_am_taken_to_are_you_sure_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor check"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor check"
 
     when_i_click_on_check_what_each_role_needs_to_do
-    when_i_am_taken_to_roles_page
-    and_select_back
+    then_i_am_taken_to_roles_page
+
+    when_i_click_on_back
     then_i_am_taken_to_are_you_sure_page
-    and_select_confirm
+
+    when_i_click_on_confirm
     then_i_am_taken_to_yourself_as_mentor_confirmation_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor confirmation"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor confirmation"
   end
 
   scenario "Induction tutor cannot add existing ECT/mentor" do
-    when_i_am_taken_to_roles_page
-    and_select_continue
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    when_i_click_on_continue
     then_i_am_taken_to_your_ect_and_mentors_page
-    when_i_select_add_mentor
-    and_select_continue
+
+    when_i_click_on_add_mentor
+    when_i_click_on_continue
     then_i_am_taken_to_add_mentor_name_page
 
     when_i_add_ect_or_mentor_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
 
     when_i_add_ect_or_mentor_email_that_already_exists
-    and_select_continue
-    then_i_will_see_email_already_taken_error_message
+    when_i_click_on_continue
+    then_i_receive_an_email_already_taken_error_message
   end
 end

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -10,77 +10,91 @@ RSpec.describe "Update participants details", js: true do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_added_an_ect
-    then_i_should_see_the_fip_induction_dashboard
-    when_i_click_add_your_early_career_teacher_and_mentor_details
-    when_i_am_taken_to_roles_page
-    and_select_continue
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    when_i_click_on_continue
     then_i_am_taken_to_your_ect_and_mentors_page
+    and_i_have_added_a_mentor
   end
 
   scenario "Induction tutor can change ECT / mentor name from check details page" do
-    when_i_select_add_ect
+    when_i_click_on_add_ect
     then_i_am_taken_to_add_ect_name_page
+
     when_i_add_ect_or_mentor_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
+
     when_i_add_ect_or_mentor_email
-    and_select_continue
+    when_i_click_on_continue
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
 
-    when_i_select_change_name
+    when_i_click_on_change_name
     then_i_am_taken_to_add_ect_name_page
+
     when_i_add_ect_or_mentor_updated_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_updated_email_page
-    and_select_continue
+
+    when_i_click_on_continue
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
     then_i_can_view_updated_name
   end
 
   scenario "Induction tutor can change ECT / mentor email from check details page" do
-    when_i_select_add_ect
-    and_select_continue
+    when_i_click_on_add_ect
     then_i_am_taken_to_add_ect_name_page
+
     when_i_add_ect_or_mentor_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
+
     when_i_add_ect_or_mentor_email
-    and_select_continue
+    when_i_click_on_continue
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
 
-    when_i_select_change_email
+    when_i_click_on_change_email
     then_i_am_taken_to_add_ect_or_mentor_email_page
+
     when_i_add_ect_or_mentor_updated_email
-    and_select_continue
+    when_i_click_on_continue
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
     then_i_can_view_updated_email
   end
 
   scenario "Induction tutor can change ECTs mentor from check details page" do
-    and_i_have_added_a_mentor
-    when_i_select_add_ect
-    and_select_continue
+    when_i_click_on_add_ect
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
 
     when_i_add_ect_or_mentor_name
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
 
     when_i_add_ect_or_mentor_email
-    and_select_continue
+    when_i_click_on_continue
     then_i_am_taken_to_add_mentor_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction tutor chooses mentor for ECT"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor chooses mentor for ECT"
 
-    when_i_select_a_mentor
-    and_select_continue
+    when_i_choose_a_mentor
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
     then_i_can_view_mentor_name
 
-    when_i_select_change_mentor
+    when_i_click_on_change_mentor
     then_i_am_taken_to_add_mentor_page
-    when_i_select_assign_mentor_later
-    and_select_continue
+
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
     then_i_am_taken_to_check_details_page
     then_i_can_view_assign_mentor_later_status
   end

--- a/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
@@ -9,49 +9,50 @@ RSpec.describe "Manage CIP training", js: true do
   scenario "CIP Induction Mentor without materials chosen" do
     given_there_is_a_school_that_has_chosen_cip_for_2021
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_cip_induction_dashboard
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "CIP induction dashboard without materials"
+    then_i_am_taken_to_cip_induction_dashboard
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "CIP induction dashboard without materials"
 
-    when_i_click_add_your_early_career_teacher_and_mentor_details
-    when_i_am_taken_to_roles_page
-    and_then_return_to_dashboard
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
 
+    when_i_visit_manage_training_dashboard
     when_i_click_on_view_details
     then_i_am_taken_to_cip_programme_choice_info_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "CIP programme info"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "CIP programme info"
   end
 
   scenario "CIP Induction Mentor with materials chosen" do
     given_there_is_a_school_that_has_chosen_cip_for_2021
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_cip_induction_dashboard
+    then_i_am_taken_to_cip_induction_dashboard
 
-    when_i_click_on_add_materials
+    when_i_click_on_add
+    when_i_click_on_continue
     then_i_am_taken_to_course_choice_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Course choice"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Course choice"
 
-    when_i_select_materials
-    and_i_am_taken_to_course_confirmed_page
-    and_then_return_to_dashboard
+    when_i_choose_materials
+    when_i_click_on_continue
+    when_i_visit_manage_training_dashboard
     then_i_can_view_the_added_materials
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "CIP induction dashboard with materials"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "CIP induction dashboard with materials"
   end
 
   scenario "CIP Induction Mentor who has not added ECT or mentors" do
     given_there_is_a_school_that_has_chosen_cip_for_2021
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_add_your_ect_and_mentor_link
+    then_i_can_view_the_add_your_ect_and_mentor_link
   end
 
   scenario "CIP Induction Mentor who has added ECT or mentors" do
     given_there_is_a_school_that_has_chosen_cip_for_2021
     and_i_have_added_an_ect
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_view_your_ect_and_mentor_link
+    then_i_can_view_the_view_your_ect_and_mentor_link
   end
 
   scenario "Change induction programme to CIP" do

--- a/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Manage Design Our Own training", js: true, with_feature_flags: {
   scenario "Design Our Own Induction Coordinator" do
     given_there_is_a_school_that_has_chosen_design_our_own_for_2021
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_design_our_own_induction_dashboard
+    then_i_can_view_the_design_our_own_induction_dashboard
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named "Design Our Own dashboard"
   end

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -13,31 +13,31 @@ RSpec.describe "Manage FIP training", js: true do
   scenario "FIP Induction Coordinator with training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_fip_induction_dashboard
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "FIP dashboard with partnership"
-    when_i_click_add_your_early_career_teacher_and_mentor_details
-    when_i_am_taken_to_roles_page
-    and_then_return_to_dashboard
+    then_i_am_taken_to_fip_induction_dashboard
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "FIP dashboard with partnership"
 
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+
+    when_i_visit_manage_training_dashboard
     when_i_click_on_view_details
     then_i_am_taken_to_fip_programme_choice_info_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "FIP programme info"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "FIP programme info"
   end
 
   scenario "FIP Induction Coordinator without training provider" do
     given_there_is_a_school_that_has_chosen_fip_for_2021
     and_i_am_signed_in_as_an_induction_coordinator
-
-    then_i_should_see_the_fip_induction_dashboard_without_partnership_details
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "FIP dashboard without partnership"
+    then_i_can_view_the_fip_induction_dashboard_without_partnership_details
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "FIP dashboard without partnership"
 
     when_i_click_on_sign_up
     then_i_am_taken_to_sign_up_to_training_provider_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Sign up to training provider"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Sign up to training provider"
   end
 
   scenario "Change induction programme to FIP" do

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe "Manage No ECT training", js: true, with_feature_flags: { inducti
   scenario "Manage No ECT Induction Coordinator" do
     given_there_is_a_school_that_has_chosen_no_ect_for_2021
     and_i_am_signed_in_as_an_induction_coordinator
-    then_i_should_see_the_no_ect_induction_dashboard
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "No ECT dashboard"
+    then_i_can_view_the_no_ect_induction_dashboard
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "No ECT dashboard"
 
-    when_i_select_change
+    when_i_click_on_change
     then_i_am_taken_to_change_how_you_run_programme_page
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "No ECT training info"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "No ECT training info"
   end
 
   scenario "Change induction programme to No ECTs" do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -11,6 +11,8 @@ module ManageTrainingSteps
     Timecop.return
   end
 
+  # Given_steps
+
   def given_there_is_a_school_that_has_chosen_fip_for_2021
     @cohort = create(:cohort, start_year: 2021)
     @school = create(:school, name: "Fip School")
@@ -48,6 +50,34 @@ module ManageTrainingSteps
 
     third_school = FactoryBot.create(:school, name: "Test School 3", slug: "111113-test-school-3", urn: "111113")
     create :school_cohort, :cip, school: third_school, cohort: cohort
+  end
+
+  def given_there_is_a_school_that_has_chosen_design_our_own_for_2021
+    @cohort = create(:cohort, start_year: 2021)
+    @school = create(:school, name: "Design Our Own Programme School")
+    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "design_our_own")
+  end
+
+  def given_there_is_a_school_that_has_chosen_no_ect_for_2021
+    @cohort = create(:cohort, start_year: 2021)
+    @school = create(:school, name: "No ECT Programme School")
+    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "no_early_career_teachers")
+  end
+
+  def given_i_am_on_roles_page
+    expect(page).to have_selector("h1", text: "Check what each person needs to do in the early career teacher training programme")
+    expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
+  end
+
+  # And_steps
+
+  def and_i_am_signed_in_as_an_induction_coordinator
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort.school])
+    privacy_policy = create(:privacy_policy)
+    privacy_policy.accept!(@induction_coordinator_profile.user)
+    sign_in_as @induction_coordinator_profile.user
+    set_participant_data
+    set_updated_participant_data
   end
 
   def and_i_have_added_an_ect
@@ -90,6 +120,7 @@ module ManageTrainingSteps
     @details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
   end
 
+<<<<<<< HEAD
   def then_i_am_on_schools_page
     visit "/schools"
   end
@@ -173,6 +204,17 @@ module ManageTrainingSteps
     set_updated_participant_data
   end
 
+  def and_i_have_added_ects_and_mentors
+    and_i_am_signed_in_as_an_induction_coordinator
+    and_i_have_added_an_eligible_ect
+    and_i_have_added_an_ineligible_ect
+    and_i_have_added_an_eligible_mentor
+    and_i_have_added_an_ineligible_mentor
+    and_i_have_added_an_ero_mentor
+    and_i_have_added_an_ect_contacted_for_info
+    and_i_have_added_an_ect_whose_details_are_being_checked
+  end
+
   def and_i_am_signed_in_as_an_induction_coordinator_for_multiple_schools
     induction_coordinator = User.find_by(email: "school-leader@example.com")
     sign_in_as induction_coordinator
@@ -195,7 +237,129 @@ module ManageTrainingSteps
     click_on "Confirm"
   end
 
-  def then_i_should_see_the_fip_induction_dashboard
+  # When_steps
+
+  def when_i_click_on_back
+    click_on("Back")
+  end
+
+  def when_i_click_on_confirm
+    click_on("Confirm")
+  end
+
+  def when_i_click_on_continue
+    click_on("Continue")
+  end
+
+  def when_i_click_on_change
+    click_on("Change")
+  end
+
+  def when_i_click_on_add
+    click_on("Add")
+  end
+
+  def when_i_click_confirm_and_add
+    click_on("Confirm and add")
+  end
+
+  def when_i_click_on_view_details
+    click_on("View details")
+  end
+
+  def when_i_click_on_add_ect
+    click_on("Add a new ECT")
+  end
+
+  def when_i_click_on_add_mentor
+    click_on("Add a new mentor")
+  end
+
+  def when_i_click_on_add_myself_as_mentor
+    click_on("Add yourself as a mentor")
+  end
+
+  def when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    click_on("Add your early career teacher and mentor details")
+  end
+
+  def when_i_click_on_add_a_new_ect_or_mentor_link
+    click_on("Add a new ECT or mentor")
+  end
+
+  def when_i_click_on_check_what_each_role_needs_to_do
+    click_on("Check what each role needs to do")
+  end
+
+  def when_i_click_on_sign_up
+    click_on("Sign up")
+  end
+
+  def when_i_click_on_confirm_and_add
+    click_on("Confirm and add")
+  end
+
+  def when_i_click_on_change_name
+    click_on("Change name", visible: false)
+  end
+
+  def when_i_click_on_change_email
+    click_on("Change email", visible: false)
+  end
+
+  def when_i_click_on_change_mentor
+    click_on("Change mentor", visible: false)
+  end
+
+  def when_i_choose_a_mentor
+    choose(@participant_profile_mentor.user.full_name.to_s, allow_label_click: true)
+  end
+
+  def when_i_add_ect_or_mentor_name
+    fill_in "Full_name", with: @participant_data[:full_name]
+  end
+
+  def when_i_add_ect_or_mentor_email
+    fill_in "Email", with: @participant_data[:email]
+  end
+
+  def when_i_add_ect_or_mentor_email_that_already_exists
+    fill_in "Email", with: @participant_profile_ect.user.email
+  end
+
+  def when_i_choose_assign_mentor_later
+    choose("Assign mentor later", allow_label_click: true)
+  end
+
+  def when_i_add_ect_or_mentor_updated_name
+    fill_in "Full_name", with: @updated_participant_data[:full_name]
+  end
+
+  def when_i_add_ect_or_mentor_updated_email
+    fill_in "Email", with: @updated_participant_data[:email]
+  end
+
+  def when_i_choose_materials
+    choose("CIP Programme 1", allow_label_click: true)
+  end
+
+  def when_i_visit_manage_training_dashboard
+    visit schools_dashboard_path(@school)
+  end
+
+  # Then_steps
+
+  def then_i_am_taken_to_roles_page
+    expect(page).to have_selector("h1", text: "Check what each person needs to do in the early career teacher training programme")
+    expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
+  end
+
+  def then_i_am_taken_to_add_mentor_page
+    expect(page).to have_selector("h1", text: "Who will mentor")
+    expect(page).to have_text("You can tell us later if you’re not sure")
+  end
+
+  def then_i_am_taken_to_fip_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Training provider")
     expect(page).to have_text(@school_cohort.lead_provider.name)
@@ -203,17 +367,9 @@ module ManageTrainingSteps
     expect(page).to have_text(@school_cohort.delivery_partner.name)
   end
 
-  def then_i_should_see_the_cip_induction_dashboard
+  def then_i_am_taken_to_cip_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).not_to have_text("Programme materials")
-  end
-
-  def when_i_click_add_your_early_career_teacher_and_mentor_details
-    click_on("Add your early career teacher and mentor details")
-  end
-
-  def when_i_click_on_add_a_new_ect_or_mentor_link
-    click_on("Add a new ECT or mentor")
   end
 
   def then_i_am_taken_to_your_ect_and_mentors_page
@@ -223,34 +379,9 @@ module ManageTrainingSteps
     expect(page).to have_text("Add yourself as a mentor")
   end
 
-  def when_i_select_add_ect
-    click_on("Add a new ECT")
-  end
-
-  def when_i_select_add_mentor
-    click_on("Add a new mentor")
-  end
-
-  def when_i_select_add_myself_as_mentor
-    click_on("Add yourself as a mentor")
-  end
-
   def then_i_am_taken_to_are_you_sure_page
     expect(page).to have_selector("h1", text: "Are you sure you want to add yourself as a mentor?")
     expect(page).to have_text("The induction tutor and mentor roles are separate")
-  end
-
-  def when_i_click_on_check_what_each_role_needs_to_do
-    click_on("Check what each role needs to do")
-  end
-
-  def when_i_am_taken_to_roles_page
-    expect(page).to have_selector("h1", text: "Check what each person needs to do in the early career teacher training programme")
-    expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
-  end
-
-  def and_select_continue
-    click_on("Continue")
   end
 
   def then_i_am_taken_to_add_ect_name_page
@@ -259,10 +390,6 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_add_mentor_name_page
     expect(page).to have_selector("h1", text: "What’s the full name of this mentor?")
-  end
-
-  def when_i_add_ect_or_mentor_name
-    fill_in "Full_name", with: @participant_data[:full_name]
   end
 
   def then_i_am_taken_to_add_new_ect_or_mentor_page
@@ -274,83 +401,31 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s email address?")
   end
 
-  def when_i_add_ect_or_mentor_email
-    fill_in "Email", with: @participant_data[:email]
-  end
-
-  def when_i_add_ect_or_mentor_email_that_already_exists
-    fill_in "Email", with: @participant_profile_ect.user.email
-  end
-
-  def when_i_select_change
-    click_on("Change")
-  end
-
   def then_i_am_taken_to_change_how_you_run_programme_page
     expect(page).to have_selector("h1", text: "Change how you run your programme")
     expect(page).to have_text("Check the other options available for your school if this changes")
   end
 
-  def when_i_select_change_name
-    click_on("Change name", visible: false)
-  end
-
-  def when_i_select_change_email
-    click_on("Change email", visible: false)
-  end
-
-  def when_i_select_change_mentor
-    click_on("Change mentor", visible: false)
-  end
-
-  def when_i_select_assign_mentor_later
-    choose("Assign mentor later", allow_label_click: true)
-  end
-
-  def then_i_can_view_assign_mentor_later_status
+  def then_i_am_taken_to_check_details_page
     expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text("Add later")
   end
 
-  def then_i_can_view_mentor_name
-    expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text(@participant_profile_mentor.user.full_name.to_s)
+  def then_i_am_taken_to_ect_confirmation_page
+    expect(page).to have_selector("h1", text: "#{@participant_data[:full_name]} has been added as an ECT")
+    expect(page).to have_text("What happens next")
   end
 
-  def when_i_add_ect_or_mentor_updated_name
-    fill_in "Full_name", with: @updated_participant_data[:full_name]
+  def then_i_am_taken_to_mentor_confirmation_page
+    expect(page).to have_selector("h1", text: "#{@participant_data[:full_name]} has been added as a mentor")
+    expect(page).to have_text("What happens next")
   end
 
-  def when_i_add_ect_or_mentor_updated_email
-    fill_in "Email", with: @updated_participant_data[:email]
+  def then_i_am_taken_to_yourself_as_mentor_confirmation_page
+    expect(page).to have_selector("h1", text: "You've been added as a mentor")
   end
 
   def then_i_am_taken_to_add_ect_or_mentor_updated_email_page
     expect(page).to have_selector("h1", text: "What’s #{@updated_participant_data[:full_name]}’s email address?")
-  end
-
-  def then_i_can_view_updated_name
-    expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text((@updated_participant_data[:full_name]).to_s)
-  end
-
-  def then_i_can_view_updated_email
-    expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text((@updated_participant_data[:email]).to_s)
-  end
-
-  def and_then_return_to_dashboard
-    visit schools_dashboard_path(@school)
-  end
-
-  def then_i_can_view_the_added_materials
-    expect(page).to have_selector("h1", text: "Manage your training")
-    expect(page).to have_text("Materials")
-    expect(page).to have_text(@cip.name)
-  end
-
-  def when_i_click_on_view_details
-    click_on("View details")
   end
 
   def then_i_am_taken_to_fip_programme_choice_info_page
@@ -365,83 +440,62 @@ module ManageTrainingSteps
     expect(page).to have_text("You’re not expecting any early career teachers this year")
   end
 
-  def then_i_should_see_the_fip_induction_dashboard_without_partnership_details
-    expect(page).to have_selector("h1", text: "Manage your training")
-    expect(page).not_to have_text("Delivery partner")
-  end
-
-  def when_i_click_on_sign_up
-    click_on("Sign up")
-  end
-
   def then_i_am_taken_to_sign_up_to_training_provider_page
     expect(page).to have_selector("h1", text: "Signing up with a training provider")
     expect(page).to have_text("How you can sign up with a training provider")
-  end
-
-  def when_i_click_on_add_materials
-    click_on("Add")
-    click_on("Continue")
   end
 
   def then_i_am_taken_to_course_choice_page
     expect(page).to have_text("Which training materials do you want this cohort to use?")
   end
 
-  def when_i_select_materials
-    choose("CIP Programme 1", allow_label_click: true)
-  end
-
-  def and_i_am_taken_to_course_confirmed_page
-    click_on("Continue")
-  end
-
-  def then_i_should_see_the_design_our_own_induction_dashboard
+  def then_i_can_view_the_design_our_own_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Design and deliver your own programme")
   end
 
-  def then_i_should_see_the_no_ect_induction_dashboard
+  def then_i_can_view_the_no_ect_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("No early career teachers for this cohort")
   end
 
-  def when_i_select_view_details
-    click_on("View details")
-  end
-
-  def and_click_continue
-    click_on("Continue")
-  end
-
-  def and_select_back
-    click_on("Back")
-  end
-
-  def when_i_select_confirm_and_add
-    click_on("Confirm and add")
-  end
-
-  def and_select_confirm
-    click_on("Confirm")
-  end
-
-  def then_i_am_taken_to_check_details_page
+  def then_i_can_view_assign_mentor_later_status
     expect(page).to have_selector("h1", text: "Check your answers")
+    expect(page).to have_text("Add later")
   end
 
-  def then_i_should_be_taken_to_ect_confirmation_page
-    expect(page).to have_selector("h1", text: "#{@participant_data[:full_name]} has been added as an ECT")
-    expect(page).to have_text("What happens next")
+  def then_i_can_view_the_add_your_ect_and_mentor_link
+    expect(page).to have_text("Add your early career teacher and mentor details")
   end
 
-  def then_i_should_be_taken_to_mentor_confirmation_page
-    expect(page).to have_selector("h1", text: "#{@participant_data[:full_name]} has been added as a mentor")
-    expect(page).to have_text("What happens next")
+  def then_i_can_view_the_view_your_ect_and_mentor_link
+    expect(page).to have_text("View your early career teacher and mentor details")
   end
 
-  def then_i_am_taken_to_yourself_as_mentor_confirmation_page
-    expect(page).to have_selector("h1", text: "You've been added as a mentor")
+  def then_i_can_view_mentor_name
+    expect(page).to have_selector("h1", text: "Check your answers")
+    expect(page).to have_text(@participant_profile_mentor.user.full_name.to_s)
+  end
+
+  def then_i_can_view_updated_name
+    expect(page).to have_selector("h1", text: "Check your answers")
+    expect(page).to have_text((@updated_participant_data[:full_name]).to_s)
+  end
+
+  def then_i_can_view_updated_email
+    expect(page).to have_selector("h1", text: "Check your answers")
+    expect(page).to have_text((@updated_participant_data[:email]).to_s)
+  end
+
+  def then_i_can_view_the_added_materials
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).to have_text("Materials")
+    expect(page).to have_text(@cip.name)
+  end
+
+  def then_i_can_view_the_fip_induction_dashboard_without_partnership_details
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).not_to have_text("Delivery partner")
   end
 
   def then_i_receive_a_missing_name_error_message
@@ -452,9 +506,24 @@ module ManageTrainingSteps
     expect(page).to have_text("Enter an email address")
   end
 
-  def then_i_will_see_email_already_taken_error_message
+  def then_i_receive_an_email_already_taken_error_message
     expect(page).to have_text("This email has already been added")
   end
+
+  def then_i_should_see_the_program_and_click_to_change_it(program_label:)
+    expect(page).to have_text(program_label)
+    click_on "Change induction programme choice"
+  end
+
+  def then_i_should_see_the_fip_induction_dashboard
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).to have_text("Training provider")
+    expect(page).to have_text(@school_cohort.lead_provider.name)
+    expect(page).to have_text("Delivery partner")
+    expect(page).to have_text(@school_cohort.delivery_partner.name)
+  end
+
+  # Set_steps
 
   def set_participant_data
     @participant_data = {

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -69,6 +69,24 @@ module ManageTrainingSteps
     expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
   end
 
+  def given_i_am_on_the_cip_induction_dashboard
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).not_to have_text("Programme materials")
+  end
+
+  def given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).not_to have_text("Delivery partner")
+  end
+
+  def given_i_am_taken_to_fip_induction_dashboard
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).to have_text("Training provider")
+    expect(page).to have_text(@school_cohort.lead_provider.name)
+    expect(page).to have_text("Delivery partner")
+    expect(page).to have_text(@school_cohort.delivery_partner.name)
+  end
+
   # And_steps
 
   def and_i_am_signed_in_as_an_induction_coordinator
@@ -81,46 +99,53 @@ module ManageTrainingSteps
   end
 
   def and_i_have_added_an_ect
-    @participant_profile_ect = create(:participant_profile, :ect, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort)
+    @ect = create(:participant_profile, :ect, user: create(:user, full_name: "Sally ECT"), school_cohort: @school_cohort)
   end
 
   def and_i_have_added_a_mentor
-    @participant_profile_mentor = create(:participant_profile, :mentor, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_cohort)
+    @mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_cohort)
   end
 
-  def and_i_have_added_an_eligible_ect
-    @eligible_ect = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: @school_cohort)
+  def and_i_have_added_an_eligible_ect_with_mentor
+    @eligible_ect_with_mentor = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible With-mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
   end
 
-  def and_i_have_added_an_ineligible_ect
-    @ineligible_ect = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: @school_cohort)
-    @ineligible_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "active_flags")
+  def and_i_have_added_an_eligible_ect_without_mentor
+    @eligible_ect_without_mentor = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible Without-mentor"), school_cohort: @school_cohort)
   end
 
   def and_i_have_added_an_eligible_mentor
-    @eligible_mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: @school_cohort)
+    @eligible_mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible Mentor"), school_cohort: @school_cohort)
+  end
+
+  def and_i_have_added_an_ineligible_ect_with_mentor
+    @ineligible_ect_with_mentor = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Ineligible With-mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
+    @ineligible_ect_with_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+  end
+
+  def and_i_have_added_an_ineligible_ect_without_mentor
+    @ineligible_ect_without_mentor = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Ineligible Without-mentor"), school_cohort: @school_cohort)
+    @ineligible_ect_without_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
   end
 
   def and_i_have_added_an_ineligible_mentor
-    @ineligible_mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: @school_cohort)
-    @ineligible_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "previous_induction")
+    @ineligible_mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Ineligible Mentor"), school_cohort: @school_cohort)
+    @ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
   end
 
   def and_i_have_added_an_ero_mentor
-    @ero_mentor = create(:participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, :mentor, school_cohort: @school_cohort)
-    @ero_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "previous_participation")
+    @ero_mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "ERO Mentor"), school_cohort: @school_cohort)
+    @ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
   end
 
-  def and_i_have_added_an_ect_contacted_for_info
-    @contacted_for_info_ect = create(:participant_profile, :ect, request_for_details_sent_at: 5.days.ago, school_cohort: @school_cohort)
+  def and_i_have_added_a_contacted_for_info_ect_with_mentor
+    @contacted_for_info_ect_with_mentor = create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, user: create(:user, full_name: "CFI With-mentor"), mentor_profile_id: @mentor.id, school_cohort: @school_cohort)
   end
 
-  def and_i_have_added_an_ect_whose_details_are_being_checked
-    @details_being_checked_ect = create(:participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, :ect, school_cohort: @school_cohort)
-    @details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+  def and_i_have_added_a_contacted_for_info_ect_without_mentor
+    @contacted_for_info_ect_without_mentor = create(:participant_profile, :ect, :email_bounced, request_for_details_sent_at: 5.days.ago, user: create(:user, full_name: "CFI Without-mentor"), school_cohort: @school_cohort)
   end
 
-<<<<<<< HEAD
   def then_i_am_on_schools_page
     visit "/schools"
   end
@@ -215,6 +240,10 @@ module ManageTrainingSteps
     and_i_have_added_an_ect_whose_details_are_being_checked
   end
 
+  def and_i_have_added_a_contacted_for_info_mentor
+    @contacted_for_info_mentor = create(:participant_profile, :mentor, :email_sent, request_for_details_sent_at: 5.days.ago, user: create(:user, full_name: "CFI Mentor"), school_cohort: @school_cohort)
+  end
+
   def and_i_am_signed_in_as_an_induction_coordinator_for_multiple_schools
     induction_coordinator = User.find_by(email: "school-leader@example.com")
     sign_in_as induction_coordinator
@@ -237,7 +266,26 @@ module ManageTrainingSteps
     click_on "Confirm"
   end
 
+  def and_i_have_added_a_details_being_checked_ect_with_mentor
+    @details_being_checked_ect_with_mentor = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
+    @details_being_checked_ect_with_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+  end
+
+  def and_i_have_added_a_details_being_checked_ect_without_mentor
+    @details_being_checked_ect_without_mentor = create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC Without-Mentor"), school_cohort: @school_cohort)
+    @details_being_checked_ect_without_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+  end
+
+  def and_i_have_added_a_details_being_checked_mentor
+    @details_being_checked_mentor = create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC Mentor"), school_cohort: @school_cohort)
+    @details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+  end
+
   # When_steps
+
+  def when_i_visit_manage_training_dashboard
+    visit schools_dashboard_path(@school)
+  end
 
   def when_i_click_on_back
     click_on("Back")
@@ -312,7 +360,7 @@ module ManageTrainingSteps
   end
 
   def when_i_choose_a_mentor
-    choose(@participant_profile_mentor.user.full_name.to_s, allow_label_click: true)
+    choose(@mentor.user.full_name.to_s, allow_label_click: true)
   end
 
   def when_i_add_ect_or_mentor_name
@@ -324,7 +372,7 @@ module ManageTrainingSteps
   end
 
   def when_i_add_ect_or_mentor_email_that_already_exists
-    fill_in "Email", with: @participant_profile_ect.user.email
+    fill_in "Email", with: @ect.user.email
   end
 
   def when_i_choose_assign_mentor_later
@@ -347,6 +395,57 @@ module ManageTrainingSteps
     visit schools_dashboard_path(@school)
   end
 
+  def when_i_click_on_details_within_eligible
+    within(".eligible") do
+      click_on("Details")
+    end
+  end
+
+  def when_i_click_on_check_within_eligible
+    within(".eligible") do
+      click_on("Check")
+    end
+  end
+
+  def when_i_click_on_check_within_ineligible
+    within(".ineligible") do
+      click_on("Check")
+    end
+  end
+
+  def when_i_click_on_check_within_checked
+    within(".checked") do
+      click_on("Check")
+    end
+  end
+
+  def when_i_click_on_details_within_checked
+    within(".checked") do
+      click_on("Details")
+    end
+  end
+
+  def when_i_click_on_details_within_details
+    within(".details") do
+      click_on("Details")
+    end
+  end
+
+  def when_i_click_on_check
+    click_on("Check")
+  end
+
+  def when_i_click_on_details
+    click_on("Details")
+  end
+
+  def when_i_navigate_to_participants_dashboard
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    when_i_click_on_continue
+    then_i_am_taken_to_your_ect_and_mentors_page
+  end
+
   # Then_steps
 
   def then_i_am_taken_to_roles_page
@@ -357,19 +456,6 @@ module ManageTrainingSteps
   def then_i_am_taken_to_add_mentor_page
     expect(page).to have_selector("h1", text: "Who will mentor")
     expect(page).to have_text("You can tell us later if you’re not sure")
-  end
-
-  def then_i_am_taken_to_fip_induction_dashboard
-    expect(page).to have_selector("h1", text: "Manage your training")
-    expect(page).to have_text("Training provider")
-    expect(page).to have_text(@school_cohort.lead_provider.name)
-    expect(page).to have_text("Delivery partner")
-    expect(page).to have_text(@school_cohort.delivery_partner.name)
-  end
-
-  def then_i_am_taken_to_cip_induction_dashboard
-    expect(page).to have_selector("h1", text: "Manage your training")
-    expect(page).not_to have_text("Programme materials")
   end
 
   def then_i_am_taken_to_your_ect_and_mentors_page
@@ -474,7 +560,7 @@ module ManageTrainingSteps
 
   def then_i_can_view_mentor_name
     expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text(@participant_profile_mentor.user.full_name.to_s)
+    expect(page).to have_text(@mentor.user.full_name.to_s)
   end
 
   def then_i_can_view_updated_name
@@ -491,11 +577,6 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Materials")
     expect(page).to have_text(@cip.name)
-  end
-
-  def then_i_can_view_the_fip_induction_dashboard_without_partnership_details
-    expect(page).to have_selector("h1", text: "Manage your training")
-    expect(page).not_to have_text("Delivery partner")
   end
 
   def then_i_receive_a_missing_name_error_message
@@ -515,7 +596,99 @@ module ManageTrainingSteps
     click_on "Change induction programme choice"
   end
 
-  def then_i_should_see_the_fip_induction_dashboard
+  def then_i_am_taken_to_view_details_page
+    expect(page).to have_text("Participant details")
+  end
+
+  def then_i_can_view_ineligible_participant_status
+    expect(page).to have_text("This person is not eligible for this programme.")
+  end
+
+  def then_i_can_view_eligible_fip_partnered_ect_status
+    expect(page).to have_text("We’ve confirmed this person is eligible for this programme. Your training provider will contact them directly.")
+  end
+
+  def then_i_can_view_eligible_fip_unpartnered_status
+    expect(page).to have_text("We’ve confirmed this person is eligible for this programme. Once you choose a training provider, they’ll contact this person directly.")
+  end
+
+  def then_i_can_view_contacted_for_info_status
+    expect(page).to have_text("We’ve asked this person to use our service to provide some information. We need this to check their eligibility with the Teaching Regulation Agency.")
+  end
+
+  def then_i_can_view_contacted_for_info_bounced_email_status
+    expect(page).to have_text("We could not send an email to this address. Please check it’s correct.")
+  end
+
+  def then_i_can_view_details_being_checked_status
+    expect(page).to have_text("Our checks show this person does not have qualified teacher status (QTS). Their status should be up to date if they completed their ITT in 2021.")
+  end
+
+  def then_i_can_view_details_being_checked_mentor_status
+    expect(page).to have_text("We’re checking this person’s details with the Teaching Regulation Agency. We’ll confirm if they’re eligible for this programme soon.")
+  end
+
+  def then_i_can_view_eligible_cip_status
+    expect(page).to have_text("We’ve confirmed this person is eligible for this programme. They have access to their materials.")
+  end
+
+  def then_i_am_taken_to_cip_induction_dashboard
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).not_to have_text("Programme materials")
+  end
+
+  def then_i_can_view_ineligible_participants
+    expect(page).to have_text("Not eligible for funded training")
+    expect(page).to have_text("We’ve checked these people's details and found they're not eligible for this programme.")
+  end
+
+  def then_the_action_required_is_none
+    expect(page).to have_text("None")
+  end
+
+  def then_the_action_required_is_assign_mentor
+    expect(page).to have_text("Assign mentor")
+  end
+
+  def then_the_action_required_is_check_email_address
+    expect(page).to have_text("Check email address")
+  end
+
+  def then_the_action_required_is_remind_them
+    expect(page).to have_text("Remind them")
+  end
+
+  def then_i_can_view_fip_unpartnered_eligible_participants
+    expect(page).to have_text("Eligible to start")
+    expect(page).to have_text("We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they'll contact your ECTs and mentors directly.")
+  end
+
+  def then_i_can_view_details_being_checked_participants
+    expect(page).to have_text("DfE checking eligibility")
+    expect(page).to have_text("We’re checking these people's details with the Teaching Regulation Agency. We'll confirm if they're eligible for this programme soon.")
+  end
+
+  def then_i_can_view_eligible_participants
+    expect(page).to have_text("Eligible to start")
+    expect(page).to have_text("We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.")
+  end
+
+  def then_i_can_view_cip_eligible_participants
+    expect(page).to have_text("Eligible to start")
+    expect(page).to have_text("We’ve confirmed these people are eligible for this programme. They have access to their materials.")
+  end
+
+  def then_i_can_view_contacted_for_info_participants
+    expect(page).to have_text("Contacted for information")
+    expect(page).to have_text("We need this to check their eligibility with the Teaching Regulation Agency.")
+  end
+
+  def then_i_can_view_the_fip_induction_dashboard_without_partnership_details
+    expect(page).to have_selector("h1", text: "Manage your training")
+    expect(page).not_to have_text("Delivery partner")
+  end
+
+  def then_i_am_taken_to_fip_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Training provider")
     expect(page).to have_text(@school_cohort.lead_provider.name)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -379,25 +379,25 @@ module ManageTrainingSteps
   end
 
   def when_i_click_on_details_within_eligible
-    within(".eligible") do
+    within("[data-test='eligible']") do
       click_on("Details")
     end
   end
 
   def when_i_click_on_check_within_eligible
-    within(".eligible") do
+    within("[data-test='eligible']") do
       click_on("Check")
     end
   end
 
   def when_i_click_on_check_within_ineligible
-    within(".ineligible") do
+    within("[data-test='ineligible']") do
       click_on("Check")
     end
   end
 
   def when_i_click_on_details_within_details
-    within(".details") do
+    within("[data-test='details']") do
       click_on("Details")
     end
   end
@@ -473,7 +473,7 @@ module ManageTrainingSteps
   end
 
   def then_i_am_taken_to_yourself_as_mentor_confirmation_page
-    expect(page).to have_selector("h1", text: "You've been added as a mentor")
+    expect(page).to have_selector("h1", text: "You’ve been added as a mentor")
   end
 
   def then_i_am_taken_to_add_ect_or_mentor_updated_email_page
@@ -595,7 +595,7 @@ module ManageTrainingSteps
   end
 
   def then_i_can_see_ero_status
-    expect(page).to have_text("This person is ready to mentor ECTs this year. Our checks show they're already receiving funded mentor training as part of the early roll-out of the early career framework (ECF) reforms.")
+    expect(page).to have_text("This person is ready to mentor ECTs this year. Our checks show they’re already receiving funded mentor training as part of the early roll-out of the early career framework (ECF) reforms.")
   end
 
   def then_i_am_taken_to_cip_induction_dashboard
@@ -605,7 +605,7 @@ module ManageTrainingSteps
 
   def then_i_can_view_ineligible_participants
     expect(page).to have_text("Not eligible for funded training")
-    expect(page).to have_text("We’ve checked these people's details and found they're not eligible for this programme.")
+    expect(page).to have_text("We’ve checked these people’s details and found they’re not eligible for this programme.")
   end
 
   def then_the_action_required_is_none
@@ -626,12 +626,12 @@ module ManageTrainingSteps
 
   def then_i_can_view_fip_unpartnered_eligible_participants
     expect(page).to have_text("Eligible to start")
-    expect(page).to have_text("We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they'll contact your ECTs and mentors directly.")
+    expect(page).to have_text("We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.")
   end
 
   def then_i_can_view_details_being_checked_participants
     expect(page).to have_text("DfE checking eligibility")
-    expect(page).to have_text("We’re checking these people's details with the Teaching Regulation Agency. We'll confirm if they're eligible for this programme soon.")
+    expect(page).to have_text("We’re checking these people’s details with the Teaching Regulation Agency. We’ll confirm if they’re eligible for this programme soon.")
   end
 
   def then_i_can_view_eligible_participants

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -278,10 +278,6 @@ module ManageTrainingSteps
 
   # When_steps
 
-  def when_i_visit_manage_training_dashboard
-    visit schools_dashboard_path(@school)
-  end
-
   def when_i_click_on_back
     click_on("Back")
   end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -598,6 +598,10 @@ module ManageTrainingSteps
     expect(page).to have_text("We’ve confirmed this person is eligible for this programme. They have access to their materials.")
   end
 
+  def then_i_can_see_ero_status
+    expect(page).to have_text("This person is ready to mentor ECTs this year. Our checks show they're already receiving funded mentor training as part of the early roll-out of the early career framework (ECF) reforms.")
+  end
+
   def then_i_am_taken_to_cip_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).not_to have_text("Programme materials")

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -64,11 +64,6 @@ module ManageTrainingSteps
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "no_early_career_teachers")
   end
 
-  def given_i_am_on_roles_page
-    expect(page).to have_selector("h1", text: "Check what each person needs to do in the early career teacher training programme")
-    expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
-  end
-
   def given_i_am_on_the_cip_induction_dashboard
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).not_to have_text("Programme materials")
@@ -331,20 +326,12 @@ module ManageTrainingSteps
     click_on("Add your early career teacher and mentor details")
   end
 
-  def when_i_click_on_add_a_new_ect_or_mentor_link
-    click_on("Add a new ECT or mentor")
-  end
-
   def when_i_click_on_check_what_each_role_needs_to_do
     click_on("Check what each role needs to do")
   end
 
   def when_i_click_on_sign_up
     click_on("Sign up")
-  end
-
-  def when_i_click_on_confirm_and_add
-    click_on("Confirm and add")
   end
 
   def when_i_click_on_change_name
@@ -413,18 +400,6 @@ module ManageTrainingSteps
     end
   end
 
-  def when_i_click_on_check_within_checked
-    within(".checked") do
-      click_on("Check")
-    end
-  end
-
-  def when_i_click_on_details_within_checked
-    within(".checked") do
-      click_on("Details")
-    end
-  end
-
   def when_i_click_on_details_within_details
     within(".details") do
       click_on("Details")
@@ -478,11 +453,6 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "What’s the full name of this mentor?")
   end
 
-  def then_i_am_taken_to_add_new_ect_or_mentor_page
-    expect(page).to have_text("Add your early career teachers and mentors")
-    expect(page).to have_text("We need to verify that your early career teachers")
-  end
-
   def then_i_am_taken_to_add_ect_or_mentor_email_page
     expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s email address?")
   end
@@ -520,10 +490,6 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_cip_programme_choice_info_page
     expect(page).to have_text("You’ve chosen to: deliver your own programme using DfE-accredited materials")
-  end
-
-  def then_i_am_taken_to_the_no_ect_training_info_page
-    expect(page).to have_text("You’re not expecting any early career teachers this year")
   end
 
   def then_i_am_taken_to_sign_up_to_training_provider_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -173,18 +173,6 @@ module ManageTrainingSteps
     expect(page).not_to have_text("Test School 3")
   end
 
-  def given_there_is_a_school_that_has_chosen_design_our_own_for_2021
-    @cohort = create(:cohort, start_year: 2021)
-    @school = create(:school, name: "Design Our Own Programme School")
-    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "design_our_own")
-  end
-
-  def given_there_is_a_school_that_has_chosen_no_ect_for_2021
-    @cohort = create(:cohort, start_year: 2021)
-    @school = create(:school, name: "No ECT Programme School")
-    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "no_early_career_teachers")
-  end
-
   def given_i_click_on_test_school_1
     click_on "Test School 1"
   end
@@ -213,15 +201,6 @@ module ManageTrainingSteps
   def and_i_should_see_school_2_data
     expect(page).to have_text("Test School 2")
     expect(page).not_to have_text("Test School 1")
-  end
-
-  def and_i_am_signed_in_as_an_induction_coordinator
-    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort.school])
-    privacy_policy = create(:privacy_policy)
-    privacy_policy.accept!(@induction_coordinator_profile.user)
-    sign_in_as @induction_coordinator_profile.user
-    set_participant_data
-    set_updated_participant_data
   end
 
   def and_i_have_added_ects_and_mentors
@@ -424,11 +403,6 @@ module ManageTrainingSteps
     expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
   end
 
-  def then_i_am_taken_to_add_mentor_page
-    expect(page).to have_selector("h1", text: "Who will mentor")
-    expect(page).to have_text("You can tell us later if you’re not sure")
-  end
-
   def then_i_am_taken_to_your_ect_and_mentors_page
     expect(page).to have_selector("h1", text: "Your ECTs and mentors")
     expect(page).to have_text("Add a new ECT")
@@ -551,11 +525,6 @@ module ManageTrainingSteps
 
   def then_i_receive_an_email_already_taken_error_message
     expect(page).to have_text("This email has already been added")
-  end
-
-  def then_i_should_see_the_program_and_click_to_change_it(program_label:)
-    expect(page).to have_text(program_label)
-    click_on "Change induction programme choice"
   end
 
   def then_i_am_taken_to_view_details_page

--- a/spec/services/set_participant_category_spec.rb
+++ b/spec/services/set_participant_category_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SetParticipantCategories do
+  describe "#run" do
+    subject(:service) { described_class }
+
+    before { FeatureFlag.activate(:induction_tutor_manage_participants) }
+
+    context "CIP cohorts" do
+      let(:school_cohort) { create(:school_cohort, :cip) }
+
+      let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
+      let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+
+      let(:cip_eligible_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect] }
+      let(:cip_ineligible_participants) { [] }
+      let(:cip_contacted_for_info_participants) { [contacted_for_info_ect] }
+      let(:cip_details_being_checked_participants) { [] }
+
+      before do
+        FeatureFlag.activate(:eligibility_notifications)
+
+        ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+        ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+
+        @participant_categories = service.call(school_cohort)
+      end
+
+      it "returns eligible, ineligible and details_being_checked participants in eligible category" do
+        expect(@participant_categories.eligible).to match_array(cip_eligible_participants)
+      end
+
+      it "does not return participants in ineligible category" do
+        expect(@participant_categories.ineligible).to match_array(cip_ineligible_participants)
+      end
+
+      it "returns contacted_for_info participants in contacted_for_info category" do
+        expect(@participant_categories.contacted_for_info).to match_array(cip_contacted_for_info_participants)
+      end
+
+      it "does not return participants in details_being_checked category" do
+        expect(@participant_categories.details_being_checked).to match_array(cip_details_being_checked_participants)
+      end
+    end
+
+    context "FIP cohorts with active eligibility_notifications feature flag" do
+      let(:school_cohort) { create(:school_cohort, :fip) }
+
+      let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
+      let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+
+      let(:fip_eligible_participants) { [eligible_ect, ero_mentor] }
+      let(:fip_ineligible_participants) { [ineligible_mentor] }
+      let(:fip_contacted_for_info_participants) { [contacted_for_info_ect] }
+      let(:fip_details_being_checked_participants) { [details_being_checked_ect] }
+
+      before do
+        FeatureFlag.activate(:eligibility_notifications)
+
+        ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+        ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+
+        @participant_categories = service.call(school_cohort)
+      end
+
+      it "returns eligible participants in eligible category" do
+        expect(@participant_categories.eligible).to match_array(fip_eligible_participants)
+      end
+
+      it "returns ineligible participants in ineligible category" do
+        expect(@participant_categories.ineligible).to match_array(fip_ineligible_participants)
+      end
+
+      it "returns contacted_for_info participants in contacted_for_info category" do
+        expect(@participant_categories.contacted_for_info).to match_array(fip_contacted_for_info_participants)
+      end
+
+      it "returns details_being_checked participants in details_being_checked category" do
+        expect(@participant_categories.details_being_checked).to match_array(fip_details_being_checked_participants)
+      end
+    end
+
+    context "FIP cohorts with inactive eligibility_notifications feature flag" do
+      let(:school_cohort) { create(:school_cohort, :fip) }
+
+      let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
+      let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+      let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+
+      let(:fip_eligible_participants) { [] }
+      let(:fip_ineligible_participants) { [] }
+      let(:fip_contacted_for_info_participants) { [contacted_for_info_ect] }
+      let(:fip_details_being_checked_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect] }
+
+      before do
+        FeatureFlag.deactivate(:eligibility_notifications)
+
+        ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+        ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+
+        @participant_categories = service.call(school_cohort)
+      end
+
+      it "does not return participants in eligible category" do
+        expect(@participant_categories.eligible).to match_array(fip_eligible_participants)
+      end
+
+      it "does not return participants in ineligible category" do
+        expect(@participant_categories.ineligible).to match_array(fip_ineligible_participants)
+      end
+
+      it "returns contacted_for_info participants in contacted_for_info category" do
+        expect(@participant_categories.contacted_for_info).to match_array(fip_contacted_for_info_participants)
+      end
+
+      it "returns details_being_checked, ineligible and eligible participants in details_being_checked category" do
+        expect(@participant_categories.details_being_checked).to match_array(fip_details_being_checked_participants)
+      end
+    end
+  end
+end

--- a/spec/services/set_participant_category_spec.rb
+++ b/spec/services/set_participant_category_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SetParticipantCategories do
 
     context "CIP cohorts" do
       let(:school_cohort) { create(:school_cohort, :cip) }
+      let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
 
       let(:cip_eligible_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect] }
       let(:cip_ineligible_participants) { [] }
@@ -27,7 +28,7 @@ RSpec.describe SetParticipantCategories do
         ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
         details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
-        @participant_categories = service.call(school_cohort)
+        @participant_categories = service.call(school_cohort, induction_coordinator.user)
       end
 
       it "returns eligible, ineligible and details_being_checked participants in eligible category" do
@@ -49,6 +50,7 @@ RSpec.describe SetParticipantCategories do
 
     context "FIP cohorts with active eligibility_notifications feature flag" do
       let(:school_cohort) { create(:school_cohort, :fip) }
+      let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
 
       let(:fip_eligible_participants) { [eligible_ect, ero_mentor] }
       let(:fip_ineligible_participants) { [ineligible_mentor] }
@@ -62,7 +64,7 @@ RSpec.describe SetParticipantCategories do
         ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
         details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
-        @participant_categories = service.call(school_cohort)
+        @participant_categories = service.call(school_cohort, induction_coordinator.user)
       end
 
       it "returns eligible participants in eligible category" do
@@ -84,6 +86,7 @@ RSpec.describe SetParticipantCategories do
 
     context "FIP cohorts with inactive eligibility_notifications feature flag" do
       let(:school_cohort) { create(:school_cohort, :fip) }
+      let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
 
       let(:fip_eligible_participants) { [] }
       let(:fip_ineligible_participants) { [] }
@@ -97,7 +100,7 @@ RSpec.describe SetParticipantCategories do
         ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
         details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
-        @participant_categories = service.call(school_cohort)
+        @participant_categories = service.call(school_cohort, induction_coordinator.user)
       end
 
       it "does not return participants in eligible category" do

--- a/spec/services/set_participant_category_spec.rb
+++ b/spec/services/set_participant_category_spec.rb
@@ -6,16 +6,14 @@ RSpec.describe SetParticipantCategories do
   describe "#run" do
     subject(:service) { described_class }
 
-    before { FeatureFlag.activate(:induction_tutor_manage_participants) }
+    let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
+    let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
 
     context "CIP cohorts" do
       let(:school_cohort) { create(:school_cohort, :cip) }
-
-      let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
-      let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
 
       let(:cip_eligible_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect] }
       let(:cip_ineligible_participants) { [] }
@@ -52,12 +50,6 @@ RSpec.describe SetParticipantCategories do
     context "FIP cohorts with active eligibility_notifications feature flag" do
       let(:school_cohort) { create(:school_cohort, :fip) }
 
-      let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
-      let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-
       let(:fip_eligible_participants) { [eligible_ect, ero_mentor] }
       let(:fip_ineligible_participants) { [ineligible_mentor] }
       let(:fip_contacted_for_info_participants) { [contacted_for_info_ect] }
@@ -92,12 +84,6 @@ RSpec.describe SetParticipantCategories do
 
     context "FIP cohorts with inactive eligibility_notifications feature flag" do
       let(:school_cohort) { create(:school_cohort, :fip) }
-
-      let!(:eligible_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:ineligible_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
-      let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
-      let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
 
       let(:fip_eligible_participants) { [] }
       let(:fip_ineligible_participants) { [] }

--- a/spec/support/shared_examples/participant_actions_support.rb
+++ b/spec/support/shared_examples/participant_actions_support.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a participant action service" do
-  context "when lead providers don't match" do
+  context "when lead providers don’t match" do
     it "raises a ParameterMissing error" do
       expect { described_class.call(params: given_params.merge({ cpd_lead_provider: another_lead_provider })) }.to raise_error(ActionController::ParameterMissing)
     end


### PR DESCRIPTION
## Ticket and context

Ticket: Sequel to [CPDRP-905](https://github.com/DFE-Digital/early-careers-framework/pull/1198) New participant dashboard

1. Refactoring of:  app/controllers/schools/participants_controller.rb (moving participant category logic into a `SetParticipantCategories` service allowing this to be more thoroughly tested

- Adding app/services/set_participant_categories.rb
- Adding spec/services/set_participant_category_spec.rb

2. Better implementation of Given, When, Then pattern in feature tests: 

- spec/features/schools/training_dashboard/manage_training_steps.rb (implementing Given, When, Then pattern)
- spec/features/schools/participants/add_participants_spec.rb 
- spec/features/schools/participants/update_participants_details_spec.rb
- spec/features/schools/training_dashboard/manage_cip_training_spec.rb
- spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
- spec/features/schools/training_dashboard/manage_fip_training_spec.rb
- spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb

3. Adding feature tests to cover updates added in CPDRP-905 (https://github.com/DFE-Digital/early-careers-framework/pull/1198) New participant dashboard

- spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
- spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
- spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb 

4. Updates to:
- app/views/schools/participants/index.html.erb (adding IDs) to facilitate testing

5. Two fixes:

- app/views/schools/participants/index.html.erb - Prevent mentors from seeing 'Assign mentor' in contacted_for_info category
- Adding `.uniq` to fip_flag_inactive_details_being_checked_participants method

6. More apostrophes