### PR TITLE
Percy Fix - Add name to prevent a new random one being created

### DIFF
--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -32,7 +32,7 @@ module ManageTrainingSteps
   end
 
   def and_i_have_added_an_ect
-    @participant_profile_ect = create(:participant_profile, :ect, school_cohort: @school_cohort)
+    @participant_profile_ect = create(:participant_profile, :ect, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort)
   end
 
   def and_i_have_added_a_mentor


### PR DESCRIPTION
Without specifying a name, a new one is being created each time, the likely cause of Percy finding a new view (with a new name)

<img width="833" alt="Screenshot 2021-10-20 at 17 54 06" src="https://user-images.githubusercontent.com/11489752/138137217-e18c1c33-8fc8-4ee8-9d31-c2dbbcf44e0b.png">

## Ticket and context

Ticket: Relates to [CPDRP-905 - New participant dashboard ](https://github.com/DFE-Digital/early-careers-framework/pull/1198/files)
