### PR TITLE
CPDRP-1038: Allow replacing a SIT who was previously a mentor

### DIFF
--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -55,7 +55,7 @@ private
 
     if existing_induction_coordinator.induction_coordinator_profile.schools.count > 1
       existing_induction_coordinator.induction_coordinator_profile.schools.delete(school)
-    elsif existing_induction_coordinator.mentor? || existing_induction_coordinator.npq_registered?
+    elsif existing_induction_coordinator.teacher_profile.present? || existing_induction_coordinator.npq_registered?
       existing_induction_coordinator.induction_coordinator_profile.destroy!
     else
       existing_induction_coordinator.destroy!

--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe CreateInductionTutor do
         end
       end
 
+      context "when the induction coordinator was previously a mentor" do
+        let!(:mentor_profile) { create(:participant_profile, :mentor, user: existing_profile.user, school: school, status: "withdrawn") }
+
+        it "retains the user but deletes the induction coordinator profile" do
+          expect(school.induction_coordinator_profiles.first).to eq(existing_profile)
+
+          CreateInductionTutor.call(school: school, email: email, full_name: name)
+
+          user = User.find_by(email: email)
+          expect(school.reload.induction_coordinator_profiles.first).to eq(user.induction_coordinator_profile)
+          expect(InductionCoordinatorProfile.exists?(existing_profile.id)).to be false
+          expect(User.exists?(existing_user.id)).to be true
+          expect(ParticipantProfile::Mentor.exists?(mentor_profile.id)).to be true
+        end
+      end
+
       context "when the induction coordinator is also an npq" do
         let!(:npq_profile) { create(:participant_profile, :npq, user: existing_profile.user, school: school) }
 


### PR DESCRIPTION
## Ticket and context

Ticket: CPDRP-1038
Sentry: https://sentry.io/organizations/dfe-bat/issues/2734624887/activity/?project=5748989&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox

This induction tutor has a withdrawn mentor profile, which has validation data on it
