### PR TITLE
add employer as npq funding option

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -22,6 +22,7 @@ class NPQApplication < ApplicationRecord
     trust: "trust",
     self: "self",
     another: "another",
+    employer: "employer",
   }
 
   enum lead_provider_approval_status: {

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,7 +9,10 @@ weight: 6
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
-<h2 class="govuk-heading-l" id="29-09-2021">5th October 2021</h2>
+<h2 class="govuk-heading-l" id="25-10-2021">25th October 2021</h2>
+<p class="govuk-body-m">Add <code>employer</code> as possible option for NPQ <code>funding_choice</code>.</p>
+
+<h2 class="govuk-heading-l" id="05-10-2021">5th October 2021</h2>
 <p class="govuk-body-m">Update withdrawal and deferral reason codes.</p>
 
 <h2 class="govuk-heading-l" id="29-09-2021">29th September 2021</h2>

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -2055,7 +2055,8 @@
               "school",
               "trust",
               "self",
-              "another"
+              "another",
+              "employer"
             ]
           },
           "course_identifier": {

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -70,6 +70,7 @@ properties:
       - trust
       - self
       - another
+      - employer
   course_identifier:
     description: "The Unique Reference Number (URN) of the NPQ course this NPQ application relates to"
     type: string


### PR DESCRIPTION
## Ticket and context

Ticket: https://trello.com/c/vG0CILuF/578-build-journey-for-international-non-education-workers

- As part of the NPQ international journey `employer` will be added as a possible funding option

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

#### API

- Easiest option is probably locally run https://github.com/DFE-Digital/npq-registration/pull/203
- point `ECF_APP_BASE_URL` and `ECF_APP_BEARER_TOKEN` to the review app
- Run a through an international journey with `employer` as funding option
- Should see review app have new NPQ application with `employer` as `funding_choice`

#### Docs

- See updated docs at https://ecf-review-pr-1339.london.cloudapps.digital/api-docs/index.html
- also https://ecf-review-pr-1339.london.cloudapps.digital/api-reference/reference.html#schema-npqapplicationattributes
- release notes at https://ecf-review-pr-1339.london.cloudapps.digital/api-reference/release-notes.html#25-10-2021

## External API changes

- Yes this change has a direct impact
- release notes added
- docs updated
