### PR TITLE
CPDRP-1069: external links open new tab

### DIFF
--- a/app/views/accessibility_statements/show.html.erb
+++ b/app/views/accessibility_statements/show.html.erb
@@ -13,7 +13,12 @@
       <li>listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
     </ul>
     <p class="govuk-body">We have also made the service text as simple as possible to understand.</p>
-    <p class="govuk-body"><%= govuk_link_to 'AbilityNet (opens in a new tab)', "https://mcmw.abilitynet.org.uk/", target: :_blank %> has advice on making your device easier to use if you have an access need.</p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'AbilityNet (opens in a new tab)',
+          "https://mcmw.abilitynet.org.uk/",
+          target: :_blank,
+          rel: "noopener noreferrer" %> has advice on making your device easier to use if you have an access need.
+    </p>
 
     <h2 class="govuk-heading-l">How accessible this service is</h2>
     <p class="govuk-body">All parts of this service are fully accessible.</p>
@@ -23,17 +28,30 @@
     <p class="govuk-body">If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:</p>
     <p class="govuk-body">Email:<br>
     <%= render MailToSupportComponent.new %></p>
-    <p class="govuk-body"><%= govuk_link_to 'Read tips on contacting organisations about inaccessible websites (opens in a new tab)', "http://www.w3.org/WAI/users/inaccessible", target: :_blank %></p>
-
+    <p class="govuk-body">
+      <%= govuk_link_to 'Read tips on contacting organisations about inaccessible websites (opens in a new tab)',
+          "http://www.w3.org/WAI/users/inaccessible",
+          target: :_blank,
+          rel: "noopener noreferrer" %>
+    </p>
     <h2 class="govuk-heading-l">Enforcement procedure</h2>
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').</p>
-    <p class="govuk-body">If you are not happy with how we respond to your complaint, <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS) (opens in a new tab)', "https://www.equalityadvisoryservice.com/", target: :_blank %></p>
+    <p class="govuk-body">If you are not happy with how we respond to your complaint,
+      <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS) (opens in a new tab)',
+          "https://www.equalityadvisoryservice.com/",
+          target: :_blank,
+          rel: "noopener noreferrer" %>
+    </p>
 
     <h2 class="govuk-heading-l">Technical information about this service’s accessibility</h2>
     <p class="govuk-body">The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 
     <h2 class="govuk-heading-l">Compliance status</h2>
-    <p class="govuk-body">This service is fully compliant with the <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard (opens in a new tab).', "https://www.w3.org/TR/WCAG21/", target: :_blank  %>
+    <p class="govuk-body">This service is fully compliant with the
+      <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard (opens in a new tab).',
+          "https://www.w3.org/TR/WCAG21/",
+          target: :_blank,
+          rel: "noopener noreferrer"  %>
     <p class="govuk-body">There may be accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.</p>
 
     <h3 class="govuk-heading-m">Disproportionate burden</h3>

--- a/app/views/accessibility_statements/show.html.erb
+++ b/app/views/accessibility_statements/show.html.erb
@@ -13,7 +13,7 @@
       <li>listen to most of the service using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
     </ul>
     <p class="govuk-body">We have also made the service text as simple as possible to understand.</p>
-    <p class="govuk-body"><%= govuk_link_to 'AbilityNet', "https://mcmw.abilitynet.org.uk/" %> has advice on making your device easier to use if you have an access need.</p>
+    <p class="govuk-body"><%= govuk_link_to 'AbilityNet (opens in a new tab)', "https://mcmw.abilitynet.org.uk/", target: :_blank %> has advice on making your device easier to use if you have an access need.</p>
 
     <h2 class="govuk-heading-l">How accessible this service is</h2>
     <p class="govuk-body">All parts of this service are fully accessible.</p>
@@ -23,17 +23,17 @@
     <p class="govuk-body">If you find any problems not listed on this page or think we are not meeting accessibility requirements, contact us:</p>
     <p class="govuk-body">Email:<br>
     <%= render MailToSupportComponent.new %></p>
-    <p class="govuk-body"><%= govuk_link_to 'Read tips on contacting organisations about inaccessible websites', "http://www.w3.org/WAI/users/inaccessible" %></p>
+    <p class="govuk-body"><%= govuk_link_to 'Read tips on contacting organisations about inaccessible websites (opens in a new tab)', "http://www.w3.org/WAI/users/inaccessible", target: :_blank %></p>
 
     <h2 class="govuk-heading-l">Enforcement procedure</h2>
     <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations').</p>
-    <p class="govuk-body">If you are not happy with how we respond to your complaint, <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS)', "https://www.equalityadvisoryservice.com/" %></p>
+    <p class="govuk-body">If you are not happy with how we respond to your complaint, <%= govuk_link_to 'contact the Equality Advisory and Support Service (EASS) (opens in a new tab)', "https://www.equalityadvisoryservice.com/", target: :_blank %></p>
 
     <h2 class="govuk-heading-l">Technical information about this service’s accessibility</h2>
     <p class="govuk-body">The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 
     <h2 class="govuk-heading-l">Compliance status</h2>
-    <p class="govuk-body">This service is fully compliant with the <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard.', "https://www.w3.org/TR/WCAG21/" %>
+    <p class="govuk-body">This service is fully compliant with the <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1) AA standard (opens in a new tab).', "https://www.w3.org/TR/WCAG21/", target: :_blank  %>
     <p class="govuk-body">There may be accessibility issues we have not found yet. If you find any please contact us so we can continue to improve the services we provide.</p>
 
     <h3 class="govuk-heading-m">Disproportionate burden</h3>

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -22,7 +22,7 @@
   <li>If your organisation has provided us with your name and email address, we will create an account for you.</li>
   <li>We will send a notification to your email address that your account has been created. You can use this email address to sign in.</li>
   <li>You do not need a password. When you enter your email address, we send you an automatic email with a link to complete your sign in.</li>
-  <li>Sign in: <a href="https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in" class="govuk-link">https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in</a></li>
+  <li>Sign in: <a href="https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in" target="_blank" class="govuk-link">https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in</a></li>
   <li>When you have signed in, you will see this page (with your organisation’s name):</li>
 </ol>
 

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -22,7 +22,7 @@
   <li>If your organisation has provided us with your name and email address, we will create an account for you.</li>
   <li>We will send a notification to your email address that your account has been created. You can use this email address to sign in.</li>
   <li>You do not need a password. When you enter your email address, we send you an automatic email with a link to complete your sign in.</li>
-  <li>Sign in: <a href="https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in" target="_blank" class="govuk-link">https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in</a></li>
+  <li>Sign in: <a href="https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in" class="govuk-link">https://manage-training-for-early-career-teachers.education.gov.uk/users/sign_in</a></li>
   <li>When you have signed in, you will see this page (with your organisation’s name):</li>
 </ol>
 

--- a/app/views/nominations/request_nomination_invite/choose_location.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_location.html.erb
@@ -14,7 +14,7 @@
               label: { text: "What’s your school’s local authority?", tag: "h1", size: "l" },
               hint: -> { tag.span do
                 concat("This is the authority or council in your area. For example, Gloucestershire or Barnet. Not sure? ")
-                concat(govuk_link_to("Find your school on our register", "https://get-information-schools.service.gov.uk/"))
+                concat(govuk_link_to("Find your school on our register", "https://get-information-schools.service.gov.uk/", target: :_blank))
               end },
               options: { include_blank: true },
               class: ["js-location-select"]) %>

--- a/app/views/nominations/request_nomination_invite/choose_location.html.erb
+++ b/app/views/nominations/request_nomination_invite/choose_location.html.erb
@@ -14,7 +14,7 @@
               label: { text: "What’s your school’s local authority?", tag: "h1", size: "l" },
               hint: -> { tag.span do
                 concat("This is the authority or council in your area. For example, Gloucestershire or Barnet. Not sure? ")
-                concat(govuk_link_to("Find your school on our register", "https://get-information-schools.service.gov.uk/", target: :_blank))
+                concat(govuk_link_to("Find your school on our register (opens in a new tab)", "https://get-information-schools.service.gov.uk/", target: :_blank, rel: "noopener noreferrer"))
               end },
               options: { include_blank: true },
               class: ["js-location-select"]) %>

--- a/app/views/nominations/request_nomination_invite/limit_reached.html.erb
+++ b/app/views/nominations/request_nomination_invite/limit_reached.html.erb
@@ -6,7 +6,11 @@
     <p>You can try again later.</p>
 
     <h2 class="govuk-heading-m">If your school has not received this email</h2>
-    <p> <%= govuk_link_to "Sign in to DfE", "https://www.get-information-schools.service.gov.uk/", target: :_blank %> and make sure that your GIAS email address is up to date.
+    <p>
+      <%= govuk_link_to "Sign in to DfE (opens in a new tab)",
+          "https://www.get-information-schools.service.gov.uk/",
+          target: :_blank,
+          rel: "noopener noreferrer" %> and make sure that your GIAS email address is up to date.
     </p>
   </div>
 </div>

--- a/app/views/nominations/request_nomination_invite/limit_reached.html.erb
+++ b/app/views/nominations/request_nomination_invite/limit_reached.html.erb
@@ -6,7 +6,7 @@
     <p>You can try again later.</p>
 
     <h2 class="govuk-heading-m">If your school has not received this email</h2>
-    <p> <%= govuk_link_to "Sign in to DfE", "https://www.get-information-schools.service.gov.uk/" %> and make sure that your GIAS email address is up to date.
+    <p> <%= govuk_link_to "Sign in to DfE", "https://www.get-information-schools.service.gov.uk/", target: :_blank %> and make sure that your GIAS email address is up to date.
     </p>
   </div>
 </div>

--- a/app/views/nominations/request_nomination_invite/not_eligible.html.erb
+++ b/app/views/nominations/request_nomination_invite/not_eligible.html.erb
@@ -9,7 +9,7 @@
     <p class="govuk-body">It is only possible for teachers to serve statutory induction at certain institutions.</p>
     <p class="govuk-body">For more details about eligibility,
       <%= govuk_link_to(
-            "see our statutory guidance on inductions for early career teachers",
-            "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england") %>.</p>
+            "see our statutory guidance on inductions for early career teachers (opens in a new tab)",
+            "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england", target: :_blank) %>.</p>
   </div>
 </div>

--- a/app/views/nominations/request_nomination_invite/not_eligible.html.erb
+++ b/app/views/nominations/request_nomination_invite/not_eligible.html.erb
@@ -10,6 +10,9 @@
     <p class="govuk-body">For more details about eligibility,
       <%= govuk_link_to(
             "see our statutory guidance on inductions for early career teachers (opens in a new tab)",
-            "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england", target: :_blank) %>.</p>
+            "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england",
+            target: :_blank,
+            rel: "noopener noreferrer") %>.
+    </p>
   </div>
 </div>

--- a/app/views/participants/validations/change_your_details_with_tra.html.erb
+++ b/app/views/participants/validations/change_your_details_with_tra.html.erb
@@ -5,7 +5,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
-    <p class="govuk-body">Sign in to the <%= govuk_link_to "Teacher Self-Service Portal (opens in a new tab)", "https://teacherservices.education.gov.uk/SelfService/Login", target: :_blank %>.</p>
+    <p class="govuk-body">Sign in to the
+      <%= govuk_link_to "Teacher Self-Service Portal (opens in a new tab)", "https://teacherservices.education.gov.uk/SelfService/Login",
+          target: :_blank,
+          rel: "noopener noreferrer" %>.
+    </p>
     <p class="govuk-body">You’ll need to upload one of the following documents as evidence of your change of name:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>marriage: copy of your marriage certificate</li>

--- a/app/views/participants/validations/change_your_details_with_tra.html.erb
+++ b/app/views/participants/validations/change_your_details_with_tra.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
-    <p class="govuk-body">Sign in to the <%= govuk_link_to "Teacher Self-Service Portal", "https://teacherservices.education.gov.uk/SelfService/Login" %>.</p>
+    <p class="govuk-body">Sign in to the <%= govuk_link_to "Teacher Self-Service Portal (opens in a new tab)", "https://teacherservices.education.gov.uk/SelfService/Login", target: :_blank %>.</p>
     <p class="govuk-body">You’ll need to upload one of the following documents as evidence of your change of name:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>marriage: copy of your marriage certificate</li>

--- a/app/views/participants/validations/check_with_tra.html.erb
+++ b/app/views/participants/validations/check_with_tra.html.erb
@@ -6,6 +6,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
     <p class="govuk-body">If you’re not sure if you updated your name with the Teaching Regulation Agency, you can view your record.</p>
-    <p class="govuk-body"><%= govuk_link_to "Check your record using the Teacher Self-Service Portal (opens in a new tab)", "https://teacherservices.education.gov.uk/SelfService/Login", target: :_blank %></p>
+    <p class="govuk-body">
+      <%= govuk_link_to "Check your record using the Teacher Self-Service Portal (opens in a new tab)",
+          "https://teacherservices.education.gov.uk/SelfService/Login",
+          target: :_blank,
+          rel: "noopener noreferrer" %>
+    </p>
   </div>
 </div>

--- a/app/views/participants/validations/check_with_tra.html.erb
+++ b/app/views/participants/validations/check_with_tra.html.erb
@@ -6,6 +6,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
     <p class="govuk-body">If you’re not sure if you updated your name with the Teaching Regulation Agency, you can view your record.</p>
-    <p class="govuk-body"><%= govuk_link_to "Check your record using the Teacher Self-Service Portal", "https://teacherservices.education.gov.uk/SelfService/Login" %></p>
+    <p class="govuk-body"><%= govuk_link_to "Check your record using the Teacher Self-Service Portal (opens in a new tab)", "https://teacherservices.education.gov.uk/SelfService/Login", target: :_blank %></p>
   </div>
 </div>

--- a/app/views/participants/validations/get_a_trn.html.erb
+++ b/app/views/participants/validations/get_a_trn.html.erb
@@ -7,14 +7,14 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
     <h2 class="govuk-heading-m">Request a TRN reminder</h2>
-    <p class="govuk-body">If you have a TRN but cannot find it, <%= govuk_link_to "request a reminder", "https://www.gov.uk/guidance/request-a-reminder-for-a-teacher-reference-number-trn" %>.</p>
+    <p class="govuk-body">If you have a TRN but cannot find it, <%= govuk_link_to "request a reminder (opens in a new tab)", "https://www.gov.uk/guidance/request-a-reminder-for-a-teacher-reference-number-trn", target: :_blank %>.</p>
     <h2 class="govuk-heading-m">Get a new TRN number</h2>
     <p class="govuk-body">If you’ve never had a TRN, email the Teaching Regulation Agency at <%= govuk_mail_to "qts.enquiries@education.gov.uk", "qts.enquiries@education.gov.uk" %> to apply. They aim to reply within 5 working days.</p>
     <p class="govuk-body">You’ll need to provide some information and proof of ID to get a TRN.</p>
     <p class="govuk-body">Use the free Galaxkey secure email platform to make sure your identification documents are protected.</p>
 
     <h2 class="govuk-heading-s">Register to send a secure email</h2>
-    <p class="govuk-body">To send a secure email to the department, go to the Galaxkey site: <%= govuk_link_to "https://manager.galaxkey.com/services/registerme", "https://manager.galaxkey.com/services/registerme" %></p>
+    <p class="govuk-body">To send a secure email to the department, go to the Galaxkey site: <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)", "https://manager.galaxkey.com/services/registerme", target: :_blank %></p>
 
     <p class="govuk-body">Enter the email address that you want to sign up with, and complete the registration process.</p>
     <p class="govuk-body">You’ll get an email to activate your account once you complete this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.</p>
@@ -42,7 +42,7 @@
       </li>
     </ol>
     <p class="govuk-body">Follow the guidance on screen to make sure you send the correct file size.</p>
-    <p class="govuk-body">Find information about how the Teaching Regulation Agency processes your data on the <%= govuk_link_to "teacher self-service site", "https://www.gov.uk/guidance/teacher-self-service-portal" %>.</p>
+    <p class="govuk-body">Find information about how the Teaching Regulation Agency processes your data on the <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank %>.</p>
 
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk-body">The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.</p>

--- a/app/views/participants/validations/get_a_trn.html.erb
+++ b/app/views/participants/validations/get_a_trn.html.erb
@@ -7,14 +7,23 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= title %></h1>
     <h2 class="govuk-heading-m">Request a TRN reminder</h2>
-    <p class="govuk-body">If you have a TRN but cannot find it, <%= govuk_link_to "request a reminder (opens in a new tab)", "https://www.gov.uk/guidance/request-a-reminder-for-a-teacher-reference-number-trn", target: :_blank %>.</p>
+    <p class="govuk-body">If you have a TRN but cannot find it,
+    <%= govuk_link_to "request a reminder (opens in a new tab)",
+        "https://www.gov.uk/guidance/request-a-reminder-for-a-teacher-reference-number-trn",
+        target: :_blank,
+        rel: "noopener noreferrer" %>.</p>
     <h2 class="govuk-heading-m">Get a new TRN number</h2>
     <p class="govuk-body">If you’ve never had a TRN, email the Teaching Regulation Agency at <%= govuk_mail_to "qts.enquiries@education.gov.uk", "qts.enquiries@education.gov.uk" %> to apply. They aim to reply within 5 working days.</p>
     <p class="govuk-body">You’ll need to provide some information and proof of ID to get a TRN.</p>
     <p class="govuk-body">Use the free Galaxkey secure email platform to make sure your identification documents are protected.</p>
 
     <h2 class="govuk-heading-s">Register to send a secure email</h2>
-    <p class="govuk-body">To send a secure email to the department, go to the Galaxkey site: <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)", "https://manager.galaxkey.com/services/registerme", target: :_blank %></p>
+    <p class="govuk-body">To send a secure email to the department, go to the Galaxkey site:
+      <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)",
+          "https://manager.galaxkey.com/services/registerme",
+          target: :_blank,
+          rel: "noopener noreferrer" %>
+    </p>
 
     <p class="govuk-body">Enter the email address that you want to sign up with, and complete the registration process.</p>
     <p class="govuk-body">You’ll get an email to activate your account once you complete this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.</p>
@@ -42,7 +51,7 @@
       </li>
     </ol>
     <p class="govuk-body">Follow the guidance on screen to make sure you send the correct file size.</p>
-    <p class="govuk-body">Find information about how the Teaching Regulation Agency processes your data on the <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank %>.</p>
+    <p class="govuk-body">Find information about how the Teaching Regulation Agency processes your data on the <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank, rel: "noopener noreferrer" %>.</p>
 
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk-body">The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.</p>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -17,7 +17,7 @@
             legend: { text: "How do you want to run your training in #{@induction_choice_form.cohort.start_year} to #{@induction_choice_form.cohort.start_year + 1}?", size: "l", tag: "h1" },
             hint: -> { tag.p do
               concat("If you’re not sure which type of training to choose, check our guidance on the ")
-              concat(govuk_link_to("statutory changes and new training programmes.", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview"))
+              concat(govuk_link_to("statutory changes and new training programmes (opens in a new tab).", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview", target: :_blank))
               concat(content_tag(:br))
               concat(" You can also contact your ")
               unless @school.cip_only?

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -21,10 +21,10 @@
               concat(content_tag(:br))
               concat(" You can also contact your ")
               unless @school.cip_only?
-                concat(govuk_link_to("local teaching school hub", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub"))
+                concat(govuk_link_to("local teaching school hub (opens in a new tab)", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub", target: :_blank))
                 concat(" or ")
               end
-              concat(govuk_link_to("appropriate body", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework"))
+              concat(govuk_link_to("appropriate body (opens in a new tab)", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework", target: :_blank))
               concat(" for guidance.")
             end }
           ) %>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -17,14 +17,23 @@
             legend: { text: "How do you want to run your training in #{@induction_choice_form.cohort.start_year} to #{@induction_choice_form.cohort.start_year + 1}?", size: "l", tag: "h1" },
             hint: -> { tag.p do
               concat("If you’re not sure which type of training to choose, check our guidance on the ")
-              concat(govuk_link_to("statutory changes and new training programmes (opens in a new tab).", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview", target: :_blank))
+              concat(govuk_link_to("statutory changes and new training programmes (opens in a new tab).",
+                     "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+                     target: :_blank,
+                     rel: "noopener noreferrer"))
               concat(content_tag(:br))
               concat(" You can also contact your ")
               unless @school.cip_only?
-                concat(govuk_link_to("local teaching school hub (opens in a new tab)", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub", target: :_blank))
+                concat(govuk_link_to("local teaching school hub (opens in a new tab)",
+                       "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub",
+                       target: :_blank,
+                       rel: "noopener noreferrer"))
                 concat(" or ")
               end
-              concat(govuk_link_to("appropriate body (opens in a new tab)", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework", target: :_blank))
+              concat(govuk_link_to("appropriate body (opens in a new tab)",
+                     "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework",
+                     target: :_blank,
+                     rel: "noopener noreferrer"))
               concat(" for guidance.")
             end }
           ) %>

--- a/app/views/schools/choose_programme/success.html.erb
+++ b/app/views/schools/choose_programme/success.html.erb
@@ -71,7 +71,12 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>you do not need to use this service to set up your training programme</li>
-        <li>you'll need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL" target="_blank">training provider</a>, approved by the DfE</li>
+        <li>you'll need to make your own arrangements with a
+          <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL"
+             target="_blank"
+             rel="noopener noreferrer">training provider
+          </a>, approved by the DfE
+        </li>
         <li>if you change your mind about how you want to run your training, contact:
           <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
         </li>

--- a/app/views/schools/choose_programme/success.html.erb
+++ b/app/views/schools/choose_programme/success.html.erb
@@ -71,7 +71,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>you do not need to use this service to set up your training programme</li>
-        <li>you'll need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">training provider</a>, approved by the DfE</li>
+        <li>you'll need to make your own arrangements with a <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL" target="_blank">training provider</a>, approved by the DfE</li>
         <li>if you change your mind about how you want to run your training, contact:
           <a class="govuk-link" href="continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
         </li>

--- a/app/views/schools/cohorts/programme_choice.html.erb
+++ b/app/views/schools/cohorts/programme_choice.html.erb
@@ -40,8 +40,10 @@
       <p class="govuk-body">
       They will talk you through how to access this support for your early career teachers and mentors.
       Not sure? <%= govuk_link_to(
-        "Find your local Teaching School Hub (opens in a new tab)",
-        "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub", target: :_blank) %>.
+                    "Find your local Teaching School Hub (opens in a new tab)",
+                    "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub",
+                    target: :_blank,
+                    rel: "noopener noreferrer") %>.
       </p>
 
       <p class="govuk-body">

--- a/app/views/schools/cohorts/programme_choice.html.erb
+++ b/app/views/schools/cohorts/programme_choice.html.erb
@@ -40,8 +40,8 @@
       <p class="govuk-body">
       They will talk you through how to access this support for your early career teachers and mentors.
       Not sure? <%= govuk_link_to(
-        "Find your local Teaching School Hub",
-        "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub") %>.
+        "Find your local Teaching School Hub (opens in a new tab)",
+        "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub", target: :_blank) %>.
       </p>
 
       <p class="govuk-body">

--- a/app/views/schools/partnerships/_confirm_with_provider.html.erb
+++ b/app/views/schools/partnerships/_confirm_with_provider.html.erb
@@ -7,15 +7,15 @@
 
 <p>There are a few ways you can sign up with a training provider.</p>
 
-<p>The easiest way to sign up with a training provider is to contact your local <%= govuk_link_to "Teaching School Hub (TSH)", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub" %>. They can talk you through how to access this support for your early career teachers and mentors.</p>
+<p>The easiest way to sign up with a training provider is to contact your local <%= govuk_link_to "Teaching School Hub (TSH)", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub", target: :_blank %>. They can talk you through how to access this support for your early career teachers and mentors.</p>
 <p>You can also explore what our 6 providers have to offer and contact them directly:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><%= govuk_link_to "Ambition Institute", "https://www2.ambition.org.uk/l/330231/2021-02-24/4mvx6" %></li>
-  <li><%= govuk_link_to "Best Practice Network (home of Outstanding Leaders Partnership)", "https://bestpracticenet.co.uk/early-career-framework" %></li>
-  <li><%= govuk_link_to "Capita with lead academic partner the University of Birmingham", "https://www.capita.com/expertise/supporting-teachers-in-early-career" %></li>
-  <li><%= govuk_link_to "Education Development Trust", "https://www.educationdevelopmenttrust.com/ecf" %></li>
-  <li><%= govuk_link_to "Teach First", "https://www.teachfirst.org.uk/early-career-framework" %></li>
-  <li><%= govuk_link_to "UCL Institute of Education", "https://www.ucl.ac.uk/ioe-early-career-framework" %></li>
+  <li><%= govuk_link_to "Ambition Institute (opens in a new tab)", "https://www2.ambition.org.uk/l/330231/2021-02-24/4mvx6", target: :_blank %></li>
+  <li><%= govuk_link_to "Best Practice Network (home of Outstanding Leaders Partnership) (opens in a new tab)", "https://bestpracticenet.co.uk/early-career-framework", target: :_blank  %></li>
+  <li><%= govuk_link_to "Capita with lead academic partner the University of Birmingham (opens in a new tab)", "https://www.capita.com/expertise/supporting-teachers-in-early-career", target: :_blank  %></li>
+  <li><%= govuk_link_to "Education Development Trust (opens in a new tab)", "https://www.educationdevelopmenttrust.com/ecf", target: :_blank  %></li>
+  <li><%= govuk_link_to "Teach First (opens in a new tab)", "https://www.teachfirst.org.uk/early-career-framework", target: :_blank  %></li>
+  <li><%= govuk_link_to "UCL Institute of Education (opens in a new tab)", "https://www.ucl.ac.uk/ioe-early-career-framework", target: :_blank  %></li>
 </ul>
 
 <p>These training providers and their local partners will also be recruiting schools in the next few months, so you may hear from them.</p>

--- a/app/views/schools/partnerships/_confirm_with_provider.html.erb
+++ b/app/views/schools/partnerships/_confirm_with_provider.html.erb
@@ -7,15 +7,48 @@
 
 <p>There are a few ways you can sign up with a training provider.</p>
 
-<p>The easiest way to sign up with a training provider is to contact your local <%= govuk_link_to "Teaching School Hub (TSH)", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub", target: :_blank %>. They can talk you through how to access this support for your early career teachers and mentors.</p>
+<p>The easiest way to sign up with a training provider is to contact your local
+  <%= govuk_link_to "Teaching School Hub (TSH)", "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub",
+      target: :_blank,
+      rel: "noopener noreferrer" %>. They can talk you through how to access this support for your early career teachers and mentors.
+</p>
 <p>You can also explore what our 6 providers have to offer and contact them directly:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li><%= govuk_link_to "Ambition Institute (opens in a new tab)", "https://www2.ambition.org.uk/l/330231/2021-02-24/4mvx6", target: :_blank %></li>
-  <li><%= govuk_link_to "Best Practice Network (home of Outstanding Leaders Partnership) (opens in a new tab)", "https://bestpracticenet.co.uk/early-career-framework", target: :_blank  %></li>
-  <li><%= govuk_link_to "Capita with lead academic partner the University of Birmingham (opens in a new tab)", "https://www.capita.com/expertise/supporting-teachers-in-early-career", target: :_blank  %></li>
-  <li><%= govuk_link_to "Education Development Trust (opens in a new tab)", "https://www.educationdevelopmenttrust.com/ecf", target: :_blank  %></li>
-  <li><%= govuk_link_to "Teach First (opens in a new tab)", "https://www.teachfirst.org.uk/early-career-framework", target: :_blank  %></li>
-  <li><%= govuk_link_to "UCL Institute of Education (opens in a new tab)", "https://www.ucl.ac.uk/ioe-early-career-framework", target: :_blank  %></li>
+  <li>
+    <%= govuk_link_to "Ambition Institute (opens in a new tab)", "https://www2.ambition.org.uk/l/330231/2021-02-24/4mvx6",
+        target: :_blank,
+        rel: "noopener noreferrer" %>
+  </li>
+  <li>
+    <%= govuk_link_to "Best Practice Network (home of Outstanding Leaders Partnership) (opens in a new tab)",
+        "https://bestpracticenet.co.uk/early-career-framework",
+        target: :_blank,
+        rel: "noopener noreferrer" %>
+  </li>
+  <li>
+    <%= govuk_link_to "Capita with lead academic partner the University of Birmingham (opens in a new tab)",
+        "https://www.capita.com/expertise/supporting-teachers-in-early-career",
+        target: :_blank,
+        rel: "noopener noreferrer" %>
+  </li>
+  <li>
+    <%= govuk_link_to "Education Development Trust (opens in a new tab)",
+        "https://www.educationdevelopmenttrust.com/ecf",
+        target: :_blank,
+        rel: "noopener noreferrer" %>
+  </li>
+  <li>
+    <%= govuk_link_to "Teach First (opens in a new tab)",
+        "https://www.teachfirst.org.uk/early-career-framework",
+        target: :_blank,
+        rel: "noopener noreferrer" %>
+  </li>
+  <li>
+    <%= govuk_link_to "UCL Institute of Education (opens in a new tab)",
+        "https://www.ucl.ac.uk/ioe-early-career-framework",
+        target: :_blank,
+        rel: "noopener noreferrer" %>
+  </li>
 </ul>
 
 <p>These training providers and their local partners will also be recruiting schools in the next few months, so you may hear from them.</p>

--- a/app/views/shared/_diy_what_you_can_do_now_info.html.erb
+++ b/app/views/shared/_diy_what_you_can_do_now_info.html.erb
@@ -17,6 +17,9 @@
   <li>make sure your early career teacher has enough time off in their timetable to complete training</li>
   <li>make sure that your induction tutor and mentor have the time to carry out their roles</li>
 </ul>
-<p class="govuk-body">
-  See the <%= govuk_link_to "statutory induction guidance for early career teachers (opens in a new tab)", "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england", target: :_blank %> for details on time off, roles and responsibilities
+<p class="govuk-body">See the
+  <%= govuk_link_to "statutory induction guidance for early career teachers (opens in a new tab)",
+      "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england",
+      target: :_blank,
+      rel: "noopener noreferrer" %> for details on time off, roles and responsibilities
 </p>

--- a/app/views/shared/_diy_what_you_can_do_now_info.html.erb
+++ b/app/views/shared/_diy_what_you_can_do_now_info.html.erb
@@ -6,7 +6,7 @@
   You need to design training that covers all of these statements.
 </p>
 <p class="govuk-body">
-  You must also ask your appropriate body what evidence you need to supply to demonstrate that your programe is:
+  You must also ask your appropriate body what evidence you need to supply to demonstrate that your programme is:
   <ul class="govuk-list govuk-list--bullet">
     <li>based on the ECF</li>
     <li>meets the statutory requirements</li>
@@ -18,5 +18,5 @@
   <li>make sure that your induction tutor and mentor have the time to carry out their roles</li>
 </ul>
 <p class="govuk-body">
-  See the <%= govuk_link_to "statutory induction guidance for early career teachers", "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" %> for details on time off, roles and responsiblilites
+  See the <%= govuk_link_to "statutory induction guidance for early career teachers (opens in a new tab)", "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england", target: :_blank %> for details on time off, roles and responsibilities
 </p>

--- a/app/views/shared/_roles.html.erb
+++ b/app/views/shared/_roles.html.erb
@@ -13,17 +13,22 @@
 
     <p class="govuk-body">Teachers will need to do different things to prepare for and complete the early career teacher (ECT) training programme, depending on their role.</p>
 
-    <p class="govuk-body">You can <%= govuk_link_to "read the full list of responsibilities for each role in section 5 of the statutory guidance (opens in a new tab)",
-                                 "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england",
-                                 target: :_blank,
-                                 class: "govuk-link--no-visited-state" %>.</p>
+    <p class="govuk-body">You can
+      <%= govuk_link_to "read the full list of responsibilities for each role in section 5 of the statutory guidance (opens in a new tab)",
+          "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england",
+          target: :_blank,
+          rel: "noopener noreferrer",
+          class: "govuk-link--no-visited-state" %>.
+     </p>
 
     <h2 class="govuk-heading-m">Mentor</h2>
 
-    <p class="govuk-body">This new role has been introduced as part of the <%= govuk_link_to "early career framework (ECF) reforms (opens in a new tab)",
-                                                                          "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
-                                                                           target: :_blank
-                                                                           %>.</p>
+    <p class="govuk-body">This new role has been introduced as part of the
+      <%= govuk_link_to "early career framework (ECF) reforms (opens in a new tab)",
+          "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+          target: :_blank,
+          rel: "noopener noreferrer" %>.
+    </p>
 
     <p class="govuk-body">Mentor responsibilities include:</p>
 

--- a/app/views/shared/_roles.html.erb
+++ b/app/views/shared/_roles.html.erb
@@ -13,14 +13,17 @@
 
     <p class="govuk-body">Teachers will need to do different things to prepare for and complete the early career teacher (ECT) training programme, depending on their role.</p>
 
-    <p class="govuk-body">You can <%= govuk_link_to "read the full list of responsibilities for each role in section 5 of the statutory guidance",
+    <p class="govuk-body">You can <%= govuk_link_to "read the full list of responsibilities for each role in section 5 of the statutory guidance (opens in a new tab)",
                                  "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england",
+                                 target: :_blank,
                                  class: "govuk-link--no-visited-state" %>.</p>
 
     <h2 class="govuk-heading-m">Mentor</h2>
 
-    <p class="govuk-body">This new role has been introduced as part of the <%= govuk_link_to "early career framework (ECF) reforms",
-                                                                          "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %>.</p>
+    <p class="govuk-body">This new role has been introduced as part of the <%= govuk_link_to "early career framework (ECF) reforms (opens in a new tab)",
+                                                                          "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+                                                                           target: :_blank
+                                                                           %>.</p>
 
     <p class="govuk-body">Mentor responsibilities include:</p>
 
@@ -58,6 +61,6 @@
       <li>providing evidence that they have QTS and are eligible to start induction</li>
       <li>meeting with their induction tutor to discuss, agree and review priorities for their induction programme</li>
     </ul>
-    
+
   </div>
 </div>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -26,7 +26,12 @@
     <section class='govuk-aside'>
       <header class="govuk-aside__header">Related content</header>
       <ul class="govuk-list govuk-aside__links">
-        <li><%= govuk_link_to "Guidance on the ECF and choosing programmes (opens in a new tab)", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview", target: :_blank %></li>
+        <li>
+          <%= govuk_link_to "Guidance on the ECF and choosing programmes (opens in a new tab)",
+              "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+              target: :_blank,
+              rel: "noopener noreferrer" %>
+        </li>
         <li><%= govuk_link_to "Choose accredited study materials for your early career teachers (opens in a new tab)", page_path("core-materials-info") %></li>
       </ul>
     </section>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -26,8 +26,8 @@
     <section class='govuk-aside'>
       <header class="govuk-aside__header">Related content</header>
       <ul class="govuk-list govuk-aside__links">
-        <li><%= govuk_link_to "Guidance on the ECF and choosing programmes", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" %></li>
-        <li><%= govuk_link_to "Choose accredited study materials for your early career teachers", page_path("core-materials-info") %></li>
+        <li><%= govuk_link_to "Guidance on the ECF and choosing programmes (opens in a new tab)", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview", target: :_blank %></li>
+        <li><%= govuk_link_to "Choose accredited study materials for your early career teachers (opens in a new tab)", page_path("core-materials-info") %></li>
       </ul>
     </section>
   </div>

--- a/app/views/step_by_step/show.html.erb
+++ b/app/views/step_by_step/show.html.erb
@@ -6,14 +6,22 @@
 
     <p class="govuk-body">From September 2021, statutory induction for early career teachers (also known as NQTs) will
       change as part of the early career framework (ECF) reforms.
-      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview", target="_blank", class="govuk-link">Read
-        more about the reforms in our guidance (opens in a new tab)</a>.</p>
+      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+         target="_blank",
+         rel="noopener noreferrer",
+         class="govuk-link">Read more about the reforms in our guidance (opens in a new tab)
+      </a>.
+    </p>
     <p class="govuk-body">All early career teachers (ECTs) are now entitled to a funded 2-year induction programme. This
       includes structured training and support to help them get their teaching career off to the best possible
       start.</p>
     <p class="govuk-body">Your school still needs to
-      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body", target="_blank", class="govuk-link">have
-        an appropriate body in place (opens in a new tab)</a>.</p>
+      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body",
+         target="_blank",
+         rel="noopener noreferrer",
+         class="govuk-link">have an appropriate body in place (opens in a new tab)
+      </a>.
+    </p>
 
     <h2 class="govuk-heading-m">When to set up your school’s programme</h2>
     <p class="govuk-body">Any school that offers statutory induction needs to follow the steps below as soon as
@@ -88,16 +96,28 @@
               cannot begin their statutory induction until a training programme is in place.</p>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Option 1</h3>
             <p class="app-step-nav__paragraph">
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL", target="_blank", class="govuk-link">Use
-                a DfE-funded training provider (opens in a new tab)</a> - available for state-funded schools only</p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL",
+                 target="_blank",
+                 rel="noopener noreferrer",
+                 class="govuk-link">Use a DfE-funded training provider (opens in a new tab)
+              </a> - available for state-funded schools only
+            </p>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Option 2</h3>
             <p class="app-step-nav__paragraph">
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-delivering-their-own-training-using-dfe-accredited-materials-and-resources", target="_blank", class="govuk-link">Use
-                DfE-accredited materials to deliver your own programme (opens in a new tab)</a></p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-delivering-their-own-training-using-dfe-accredited-materials-and-resources",
+                 target="_blank",
+                 rel="noopener noreferrer",
+                 class="govuk-link">Use DfE-accredited materials to deliver your own programme (opens in a new tab)
+              </a>
+            </p>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Option 3</h3>
             <p class="app-step-nav__paragraph">
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction", target="_blank", class="govuk-link">Design
-                and deliver your own ECF-based programme (opens in a new tab)</a></p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction",
+                 target="_blank",
+                 rel="noopener noreferrer",
+                 class="govuk-link">Design and deliver your own ECF-based programme (opens in a new tab)
+              </a>
+            </p>
             <p class="app-step-nav__paragraph">If you choose option 3, you do not need to complete the steps listed
               below.</p>
           </div>
@@ -120,10 +140,19 @@
             <p class="app-step-nav__paragraph">If you choose to use a training provider, your induction tutor needs to select from the 6 available options as soon as possible.</p>
             <ol class="app-step-nav__list" data-length="2">
               <li class="app-step-nav__list-item js-list-item">
-                <a data-position="4.1" class="app-step-nav__link js-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL", target="_blank">Compare
-                  DfE-funded training providers (opens in a new tab)</a></li>
+                <a data-position="4.1" class="app-step-nav__link js-link"
+                   href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL",
+                   target="_blank",
+                   rel="noopener noreferrer">Compare DfE-funded training providers (opens in a new tab)
+                </a>
+              </li>
             </ol>
-            <p class="app-step-nav__paragraph">You can <%= govuk_link_to "contact your local teaching school hub (opens in a new tab)", "https://www.gov.uk/guidance/teaching-school-hubs", target: :_blank, class: "app-step-nav__link js-link" %> for guidance.</p>
+            <p class="app-step-nav__paragraph">You can
+              <%= govuk_link_to "contact your local teaching school hub (opens in a new tab)", "https://www.gov.uk/guidance/teaching-school-hubs",
+                  target: :_blank,
+                  rel: "noopener noreferrer",
+                  class: "app-step-nav__link js-link" %> for guidance.
+            </p>
             <p class="app-step-nav__paragraph">You must confirm your choice of training provider directly with the provider. You do not need to let the DfE know which provider you choose. They’ll contact us to let us know.</p>
           </div>
         </li>
@@ -144,8 +173,12 @@
               your induction tutor needs to select materials as soon as possible.</p>
             <ol class="app-step-nav__list" data-length="3">
               <li class="app-step-nav__list-item js-list-item">
-                <a data-position="4.1" class="app-step-nav__link js-link" href="https://www.early-career-framework.education.gov.uk/", target="_blank">Compare
-                  DfE-accredited materials (opens in a new tab)</a></li>
+                <a data-position="4.1" class="app-step-nav__link js-link"
+                   href="https://www.early-career-framework.education.gov.uk/",
+                   target="_blank",
+                   rel="noopener noreferrer">Compare DfE-accredited materials (opens in a new tab)
+                </a>
+              </li>
               <li class="app-step-nav__list-item js-list-item"><%= govuk_link_to "Tell us which materials you want to use", root_path, class: "app-step-nav__link js-link" %></li>
             </ol>
           </div>
@@ -208,8 +241,12 @@
               your own programme</h3>
             <p class="app-step-nav__paragraph">You need to plan and create your materials.</p>
             <p>
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body", target="_blank", class="govuk-link">Contact
-                your appropriate body (opens in a new tab)</a> to find out more about next steps.</p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body",
+                 target="_blank",
+                 rel="noopener noreferrer",
+                 class="govuk-link"> Contact your appropriate body (opens in a new tab)
+              </a>to find out more about next steps.
+            </p>
           </div>
         </li>
       </ol>

--- a/app/views/step_by_step/show.html.erb
+++ b/app/views/step_by_step/show.html.erb
@@ -6,14 +6,14 @@
 
     <p class="govuk-body">From September 2021, statutory induction for early career teachers (also known as NQTs) will
       change as part of the early career framework (ECF) reforms.
-      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview" class="govuk-link">Read
-        more about the reforms in our guidance</a>.</p>
+      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview", target="_blank", class="govuk-link">Read
+        more about the reforms in our guidance (opens in a new tab)</a>.</p>
     <p class="govuk-body">All early career teachers (ECTs) are now entitled to a funded 2-year induction programme. This
       includes structured training and support to help them get their teaching career off to the best possible
       start.</p>
     <p class="govuk-body">Your school still needs to
-      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body" class="govuk-link">have
-        an appropriate body in place</a>.</p>
+      <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body", target="_blank", class="govuk-link">have
+        an appropriate body in place (opens in a new tab)</a>.</p>
 
     <h2 class="govuk-heading-m">When to set up your school’s programme</h2>
     <p class="govuk-body">Any school that offers statutory induction needs to follow the steps below as soon as
@@ -88,16 +88,16 @@
               cannot begin their statutory induction until a training programme is in place.</p>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Option 1</h3>
             <p class="app-step-nav__paragraph">
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">Use
-                a DfE-funded training provider</a> - available for state-funded schools only</p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL", target="_blank", class="govuk-link">Use
+                a DfE-funded training provider (opens in a new tab)</a> - available for state-funded schools only</p>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Option 2</h3>
             <p class="app-step-nav__paragraph">
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-delivering-their-own-training-using-dfe-accredited-materials-and-resources">Use
-                DfE-accredited materials to deliver your own programme</a></p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-delivering-their-own-training-using-dfe-accredited-materials-and-resources", target="_blank", class="govuk-link">Use
+                DfE-accredited materials to deliver your own programme (opens in a new tab)</a></p>
             <h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Option 3</h3>
             <p class="app-step-nav__paragraph">
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction">Design
-                and deliver your own ECF-based programme</a></p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#schools-designing-and-delivering-their-own-ecf-based-induction", target="_blank", class="govuk-link">Design
+                and deliver your own ECF-based programme (opens in a new tab)</a></p>
             <p class="app-step-nav__paragraph">If you choose option 3, you do not need to complete the steps listed
               below.</p>
           </div>
@@ -120,10 +120,10 @@
             <p class="app-step-nav__paragraph">If you choose to use a training provider, your induction tutor needs to select from the 6 available options as soon as possible.</p>
             <ol class="app-step-nav__list" data-length="2">
               <li class="app-step-nav__list-item js-list-item">
-                <a data-position="4.1" class="app-step-nav__link js-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL">Compare
-                  DfE-funded training providers</a></li>
+                <a data-position="4.1" class="app-step-nav__link js-link" href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL", target="_blank">Compare
+                  DfE-funded training providers (opens in a new tab)</a></li>
             </ol>
-            <p class="app-step-nav__paragraph">You can <%= govuk_link_to "contact your local teaching school hub", "https://www.gov.uk/guidance/teaching-school-hubs", class: "app-step-nav__link js-link" %> for guidance.</p>
+            <p class="app-step-nav__paragraph">You can <%= govuk_link_to "contact your local teaching school hub (opens in a new tab)", "https://www.gov.uk/guidance/teaching-school-hubs", target: :_blank, class: "app-step-nav__link js-link" %> for guidance.</p>
             <p class="app-step-nav__paragraph">You must confirm your choice of training provider directly with the provider. You do not need to let the DfE know which provider you choose. They’ll contact us to let us know.</p>
           </div>
         </li>
@@ -144,8 +144,8 @@
               your induction tutor needs to select materials as soon as possible.</p>
             <ol class="app-step-nav__list" data-length="3">
               <li class="app-step-nav__list-item js-list-item">
-                <a data-position="4.1" class="app-step-nav__link js-link" href="https://www.early-career-framework.education.gov.uk/">Compare
-                  DfE-accredited materials </a></li>
+                <a data-position="4.1" class="app-step-nav__link js-link" href="https://www.early-career-framework.education.gov.uk/", target="_blank">Compare
+                  DfE-accredited materials (opens in a new tab)</a></li>
               <li class="app-step-nav__list-item js-list-item"><%= govuk_link_to "Tell us which materials you want to use", root_path, class: "app-step-nav__link js-link" %></li>
             </ol>
           </div>
@@ -208,8 +208,8 @@
               your own programme</h3>
             <p class="app-step-nav__paragraph">You need to plan and create your materials.</p>
             <p>
-              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body" class="govuk-link">Contact
-                your appropriate body</a> to find out more about next steps.</p>
+              <a href="https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#the-role-of-the-appropriate-body", target="_blank", class="govuk-link">Contact
+                your appropriate body (opens in a new tab)</a> to find out more about next steps.</p>
           </div>
         </li>
       </ol>

--- a/data/privacy_policy.html
+++ b/data/privacy_policy.html
@@ -187,7 +187,9 @@
   feedback you send us.
 </p>
 <p class="govuk-body">
-  <a class="govuk-link" href="https://www.zendesk.co.uk/company/agreements-and-terms/master-subscription-agreement//?cta=msa#confidentiality" target="_blank",>
+  <a class="govuk-link" href="https://www.zendesk.co.uk/company/agreements-and-terms/master-subscription-agreement//?cta=msa#confidentiality"
+     target="_blank"
+     rel="noopener noreferrer">
     Zendesk is currently our preferred customer service management system (opens in a new tab)
   </a>
   because it uses various safeguards to look after your data.
@@ -247,7 +249,9 @@
 </ul>
 <p class="govuk-body">
   You can find more information about how we handle personal data in our
-  <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" target="_blank">
+  <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter"
+     target="_blank"
+     rel="noopener noreferrer">
     personal information charter (opens in a new tab).
   </a>
 </p>
@@ -262,7 +266,9 @@
 </p>
 <p class="govuk-body">
   You can also use our contact form to
-  <a class="govuk-link" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen" target="_blank">
+  <a class="govuk-link" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen"
+     target="_blank"
+     rel="noopener noreferrer">
     get in touch with our Data Protection Officer (opens in a new tab).
   </a>
 </p>
@@ -273,7 +279,7 @@
 </p>
 <p class="govuk-body">
   For further information or to raise a concern, visit the
-  <a class="govuk-link" href="https://ico.org.uk/" target="_blank">
+  <a class="govuk-link" href="https://ico.org.uk/" target="_blank" rel="noopener noreferrer">
     Information Commissioner’s Office (ICO) (opens in a new tab).
   </a>
 </p>

--- a/data/privacy_policy.html
+++ b/data/privacy_policy.html
@@ -187,8 +187,8 @@
   feedback you send us.
 </p>
 <p class="govuk-body">
-  <a class="govuk-link" href="https://www.zendesk.co.uk/company/agreements-and-terms/master-subscription-agreement//?cta=msa#confidentiality">
-    Zendesk is currently our preferred customer service management system
+  <a class="govuk-link" href="https://www.zendesk.co.uk/company/agreements-and-terms/master-subscription-agreement//?cta=msa#confidentiality" target="_blank",>
+    Zendesk is currently our preferred customer service management system (opens in a new tab)
   </a>
   because it uses various safeguards to look after your data.
 </p>
@@ -247,8 +247,8 @@
 </ul>
 <p class="govuk-body">
   You can find more information about how we handle personal data in our
-  <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">
-    personal information charter.
+  <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" target="_blank">
+    personal information charter (opens in a new tab).
   </a>
 </p>
 
@@ -262,8 +262,8 @@
 </p>
 <p class="govuk-body">
   You can also use our contact form to
-  <a class="govuk-link" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen">
-    get in touch with our Data Protection Officer.
+  <a class="govuk-link" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen" target="_blank">
+    get in touch with our Data Protection Officer (opens in a new tab).
   </a>
 </p>
 <p class="govuk-body">
@@ -273,8 +273,8 @@
 </p>
 <p class="govuk-body">
   For further information or to raise a concern, visit the
-  <a class="govuk-link" href="https://ico.org.uk/">
-    Information Commissioner’s Office (ICO).
+  <a class="govuk-link" href="https://ico.org.uk/" target="_blank">
+    Information Commissioner’s Office (ICO) (opens in a new tab).
   </a>
 </p>
 


### PR DESCRIPTION
## Ticket and context

Ticket:[1069](https://dfedigital.atlassian.net/jira/software/projects/CPDRP/boards/102?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CPDRP-1069)

## Tech review

### Is there anything that the code reviewer should know?

I did a search for gov.uk, .com, .co.uk and .org. There's 4 links that go to the ECF page. I haven't done these, they'll need removing at some point. I'll create a ticket in the backlog for it. 

I also noticed `app/views/shared/_diy_what_you_can_do_now_info.html.erb` had a change, but couldn't see where it was being used. **Can it be deleted?**

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

