### PR TITLE
Fix param name in mailer call

### DIFF
--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -195,7 +195,7 @@ class ValidationBetaService
         next if sit_ids.include?(sit.id) || Email.associated_with(sit).tagged_with(:sit_new_ambition_participants_added).any?
 
         SchoolMailer.sit_new_ambition_ects_and_mentors_added_email(
-          induction_coordinator: sit,
+          induction_coordinator_profile: sit,
           school_name: user.school.name,
           sign_in_url: sign_in_url,
         ).deliver_later

--- a/spec/services/validation_beta_service_spec.rb
+++ b/spec/services/validation_beta_service_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe ValidationBetaService do
       expect(school.induction_coordinator_profiles).to include sit_profile
       validation_beta_service.send_sit_new_ambition_ects_and_mentors_added(path_to_csv: csv_file)
       expect(SchoolMailer).to delay_email_delivery_of(:sit_new_ambition_ects_and_mentors_added_email)
-                                .with(induction_coordinator: sit_profile,
+                                .with(induction_coordinator_profile: sit_profile,
                                       school_name: school.name,
                                       sign_in_url: "http://www.example.com/users/sign_in").once
     end


### PR DESCRIPTION
## Ticket and context

Fix problem with param name in mailer.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
