### PR TITLE
CPDLP-506: Add explicit integration tests to show date validation for participant declarations

### DIFF
--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -127,6 +127,30 @@ module ParticipantDeclarationSteps
     expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started").count).to eq(1)
   end
 
+  def and_the_npq_declaration_date_is_early
+    @declaration_date = @npq_application.reload.profile.schedule.milestones.first.start_date - 1.day
+  end
+
+  def and_the_npq_declaration_date_is_late
+    @declaration_date = @npq_application.reload.profile.schedule.milestones.first.milestone_date + 1.day
+  end
+
+  def and_the_ect_declaration_date_is_early
+    @declaration_date = @ect_profile.schedule.milestones.first.start_date - 1.day
+  end
+
+  def and_the_ect_declaration_date_is_late
+    @declaration_date = @ect_profile.schedule.milestones.first.milestone_date + 1.day
+  end
+
+  def and_the_mentor_declaration_date_is_early
+    @declaration_date = @mentor_profile.schedule.milestones.first.start_date - 1.day
+  end
+
+  def and_the_mentor_declaration_date_is_late
+    @declaration_date = @mentor_profile.schedule.milestones.first.milestone_date + 1.day
+  end
+
   def then_the_declaration_made_is_invalid
     expect(@response["errors"]).not_to be_empty
   end

--- a/spec/features/participant-declarations/submit_participant_declarations_spec.rb
+++ b/spec/features/participant-declarations/submit_participant_declarations_spec.rb
@@ -34,6 +34,24 @@ RSpec.feature "Submit participant declarations", type: :feature do
     and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
   end
 
+  scenario "ECT participant details sent to provider, declaration sent using same unique ID, declaration_date too early" do
+    given_an_early_career_teacher_has_been_entered_onto_the_dfe_service
+    when_the_participant_details_are_passed_to_the_lead_provider
+    and_the_ect_declaration_date_is_early
+    and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
+    then_the_declaration_made_is_invalid
+    and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
+  end
+
+  scenario "ECT participant details sent to provider, declaration sent using same unique ID, declaration_date too late" do
+    given_an_early_career_teacher_has_been_entered_onto_the_dfe_service
+    when_the_participant_details_are_passed_to_the_lead_provider
+    and_the_ect_declaration_date_is_late
+    and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
+    then_the_declaration_made_is_invalid
+    and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
+  end
+
   scenario "Mentor details sent to provider, declaration sent using same unique ID, no errors in declaration" do
     given_an_ecf_mentor_has_been_entered_onto_the_dfe_service
     when_the_participant_details_are_passed_to_the_lead_provider
@@ -58,6 +76,24 @@ RSpec.feature "Submit participant declarations", type: :feature do
     and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
   end
 
+  scenario "Mentor participant details sent to provider, declaration sent using same unique ID, declaration_date too early" do
+    given_an_ecf_mentor_has_been_entered_onto_the_dfe_service
+    when_the_participant_details_are_passed_to_the_lead_provider
+    and_the_mentor_declaration_date_is_early
+    and_the_lead_provider_submits_a_declaration_for_the_mentor_using_their_id
+    then_the_declaration_made_is_invalid
+    and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
+  end
+
+  scenario "Mentor participant details sent to provider, declaration sent using same unique ID, declaration_date too late" do
+    given_an_ecf_mentor_has_been_entered_onto_the_dfe_service
+    when_the_participant_details_are_passed_to_the_lead_provider
+    and_the_mentor_declaration_date_is_late
+    and_the_lead_provider_submits_a_declaration_for_the_mentor_using_their_id
+    then_the_declaration_made_is_invalid
+    and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
+  end
+
   scenario "NPQ participant details sent to provider, declaration sent using same unique ID, no errors in declaration" do
     given_an_npq_participant_has_been_entered_onto_the_dfe_service
     when_the_npq_participant_details_are_passed_to_the_lead_provider
@@ -78,6 +114,24 @@ RSpec.feature "Submit participant declarations", type: :feature do
     given_an_npq_participant_has_been_entered_onto_the_dfe_service
     when_the_npq_participant_details_are_passed_to_the_lead_provider
     and_the_lead_provider_submits_a_declaration_without_participant_id
+    then_the_declaration_made_is_invalid
+    and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
+  end
+
+  scenario "NPQ participant details sent to provider, declaration sent using same unique ID, declaration_date too early" do
+    given_an_npq_participant_has_been_entered_onto_the_dfe_service
+    when_the_npq_participant_details_are_passed_to_the_lead_provider
+    and_the_npq_declaration_date_is_early
+    and_the_lead_provider_submits_a_declaration_for_the_npq_using_their_id
+    then_the_declaration_made_is_invalid
+    and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
+  end
+
+  scenario "NPQ participant details sent to provider, declaration sent using same unique ID, declaration_date too late" do
+    given_an_npq_participant_has_been_entered_onto_the_dfe_service
+    when_the_npq_participant_details_are_passed_to_the_lead_provider
+    and_the_npq_declaration_date_is_late
+    and_the_lead_provider_submits_a_declaration_for_the_npq_using_their_id
     then_the_declaration_made_is_invalid
     and_the_lead_provider_receives_a_response_to_confirm_that_the_declaration_has_a_validation_error
   end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-506

## Tech review

### Is there anything that the code reviewer should know?

We already have unit tests for the service that cover this. But as a neat little overkill, why not add some request specs that will check that too? 

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

## Product review

### How can someone see it it review app?
There are no changes in behaviour. If you really want to check that it works...
1. Get a token (`ambition-token` will work since this is a review app)
2. Get NPQ applications
3. Accept one of them
4. Try submitting a "started" declaration, using a declaration date before 1st of November (and a header that sets time to be in November)
5. Try submitting a "started" declaration, using declaration date after 25th of December (and a header that sets time to be in January)
6. 4 and 5 should fail.
