### PR TITLE
BUGFIX: take account of timezones when checking for previous inductions

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -39,7 +39,7 @@ private
     return true if validation_data["induction"]["completion_date"].present?
     return false if validation_data["induction"]["start_date"].nil?
 
-    validation_data["induction"]["start_date"] < Date.new(Cohort.current.start_year, 9, 1)
+    validation_data["induction"]["start_date"] < ActiveSupport::TimeZone["London"].local(Cohort.current.start_year, 9, 1)
   end
 
   def check_first_name_only?

--- a/lib/full_dqt/client.rb
+++ b/lib/full_dqt/client.rb
@@ -34,7 +34,10 @@ module FullDqt
 
     def translate_hash(hash)
       hash.deep_transform_values do |value|
-        if value =~ /^\d{4}-\d{2}-\d{2}/
+        case value
+        when /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+          Time.zone.parse(value)
+        when /^\d{4}-\d{2}-\d{2}/
           Date.parse(value)
         else
           value

--- a/spec/lib/full_dqt/client_spec.rb
+++ b/spec/lib/full_dqt/client_spec.rb
@@ -136,14 +136,14 @@ RSpec.describe FullDqt::Client do
 
       record = subject.get_record(trn: trn, birthdate: birthdate)
 
-      expect(record["dob"]).to be_a(Date)
-      expect(record["qualified_teacher_status"]["qts_date"]).to be_a(Date)
-      expect(record["induction"]["start_date"]).to be_a(Date)
-      expect(record["induction"]["completion_date"]).to be_a(Date)
-      expect(record["initial_teacher_training"]["programme_start_date"]).to be_a(Date)
-      expect(record["initial_teacher_training"]["programme_end_date"]).to be_a(Date)
+      expect(record["dob"]).to be_an_instance_of(Date)
+      expect(record["qualified_teacher_status"]["qts_date"]).to be_an_instance_of(ActiveSupport::TimeWithZone)
+      expect(record["induction"]["start_date"]).to be_an_instance_of(ActiveSupport::TimeWithZone)
+      expect(record["induction"]["completion_date"]).to be_an_instance_of(ActiveSupport::TimeWithZone)
+      expect(record["initial_teacher_training"]["programme_start_date"]).to be_an_instance_of(ActiveSupport::TimeWithZone)
+      expect(record["initial_teacher_training"]["programme_end_date"]).to be_an_instance_of(ActiveSupport::TimeWithZone)
       expect(record["qualifications"][0]["date_awarded"]).to be_nil
-      expect(record["qualifications"][1]["date_awarded"]).to be_a(Date)
+      expect(record["qualifications"][1]["date_awarded"]).to be_an_instance_of(ActiveSupport::TimeWithZone)
     end
 
     context "when record does not exist" do

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe ParticipantValidationService do
       end
 
       context "when the participant has an induction start date in or after September this year" do
-        let(:induction_start_date) { Date.parse("2021-09-01T00:00:00Z") }
+        let(:induction_start_date) { Time.zone.parse("2021-09-01T00:00:00Z") }
         let(:induction_completion_date) { nil }
         let(:induction) do
           {
@@ -260,8 +260,26 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
+      context "when the participant has an induction start date is exactly on the threshold" do
+        let(:induction_start_date) { Time.zone.parse("2021-08-31T23:00:00Z") }
+        let(:induction_completion_date) { nil }
+        let(:induction) do
+          {
+            "start_date" => induction_start_date,
+            "completion_date" => induction_completion_date,
+            "status" => "Pass",
+            "state" => 0,
+            "state_name" => "Active",
+          }
+        end
+
+        it "returns false for previous induction and parses timezones correctly" do
+          expect(validation_result).to eql(build_validation_result(trn: trn, options: { previous_induction: false }))
+        end
+      end
+
       context "when the participant has an induction start date before September this year" do
-        let(:induction_start_date) { Date.parse("2021-08-31T22:59:59Z") }
+        let(:induction_start_date) { Time.zone.parse("2021-08-31T22:59:59Z") }
         let(:induction_completion_date) { nil }
         let(:induction) do
           {


### PR DESCRIPTION
2021-8-31T23:00:00Z should be eligible, but was not marked as such
previously