### PR TITLE
Prevent further npq couse accepts

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -13,7 +13,6 @@ module Api
     rescue_from ActiveRecord::RecordNotUnique, with: :bad_request_response
     rescue_from ActiveRecord::RecordInvalid, with: :invalid_transition
     rescue_from Api::Errors::InvalidTransitionError, with: :invalid_transition
-    rescue_from Api::Errors::NPQApplicationAlreadyAcceptedError, with: :invalid_transition
 
     def append_info_to_payload(payload)
       super

--- a/app/controllers/api/errors/npq_application_already_accepted_error.rb
+++ b/app/controllers/api/errors/npq_application_already_accepted_error.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Api
-  module Errors
-    class NPQApplicationAlreadyAcceptedError < StandardError; end
-  end
-end

--- a/app/services/api/error_factory.rb
+++ b/app/services/api/error_factory.rb
@@ -11,7 +11,7 @@ module Api
     def call
       model.errors.map do |e|
         {
-          title: "#{model.class.human_attribute_name(e.attribute)} is #{e.type.to_s.humanize.downcase}",
+          title: "#{model.class.human_attribute_name(e.attribute)} #{e.type.to_s.humanize.downcase}",
           detail: e.message,
         }
       end

--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -44,8 +44,8 @@ module NPQ
 
     def other_applications
       @other_applications ||= NPQApplication.where(user_id: user.id)
-                                               .where(npq_course: npq_course)
-                                               .where.not(id: npq_application.id)
+                                            .where(npq_course: npq_course)
+                                            .where.not(id: npq_application.id)
     end
 
     def create_profile

--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -15,7 +15,10 @@ module NPQ
     end
 
     def call
-      raise Api::Errors::NPQApplicationAlreadyAcceptedError, I18n.t(:npq_application_already_accepted) if npq_application.accepted?
+      if npq_application.accepted?
+        npq_application.errors.add(:lead_provider_approval_status, :has_already_been_accepted)
+        return false
+      end
 
       if has_other_accepted_applications_with_same_course?
         npq_application.errors.add(:lead_provider_approval_status, :has_another_accepted_application)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,34 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
   currency: "£"
   event_types:
@@ -261,6 +230,10 @@ en:
             estimated_teacher_count:
               <<: *defaults
               blank: "enter your expected number of teachers"
+        npq_application:
+          attributes:
+            lead_provider_approval_status:
+              has_another_accepted_application: The participant already has an accepted application for this course
   page_titles:
     lead_providers:
       guidance:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,6 @@ en:
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
   declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"
   invalid_data_structure: correct json data structure required. See API docs for reference
-  npq_application_already_accepted: This NPQ application has already been accepted
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults
     not_a_number: *default_message
@@ -234,6 +233,7 @@ en:
           attributes:
             lead_provider_approval_status:
               has_another_accepted_application: The participant already has an accepted application for this course
+              has_already_been_accepted: This NPQ application has already been accepted
   page_titles:
     lead_providers:
       guidance:

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "NPQ Applications API", type: :request do
   let(:bearer_token) { "Bearer #{token}" }
   let(:parsed_response) { JSON.parse(response.body) }
   let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
+  let(:another_npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
 
   describe "GET /api/v1/npq-applications" do
     let(:other_npq_lead_provider) { create(:npq_lead_provider) }
@@ -228,7 +229,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
         expect(parsed_response["errors"][0].key?("title")).to be_truthy
         expect(parsed_response["errors"][0].key?("detail")).to be_truthy
-        expect(parsed_response["errors"][0]["title"]).to eql("Status is invalid")
+        expect(parsed_response["errors"][0]["title"]).to eql("Status invalid")
         expect(parsed_response["errors"][0]["detail"]).to eql("Once accepted an application cannot change state")
       end
     end
@@ -257,7 +258,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
     context "when participant has applied for multiple NPQs" do
       let!(:other_npq_application) { create(:npq_application, npq_course: npq_course, npq_lead_provider: npq_lead_provider, user: user) }
-      let!(:other_accepted_npq_application) { create(:npq_application, npq_course: npq_course, npq_lead_provider: npq_lead_provider, user: user, lead_provider_approval_status: "accepted") }
+      let!(:other_accepted_npq_application) { create(:npq_application, npq_course: another_npq_course, npq_lead_provider: npq_lead_provider, user: user, lead_provider_approval_status: "accepted") }
 
       it "rejects all pending NPQs on same course" do
         post "/api/v1/npq-applications/#{default_npq_application.id}/accept"
@@ -287,7 +288,7 @@ RSpec.describe "NPQ Applications API", type: :request do
 
         expect(parsed_response["errors"][0].key?("title")).to be_truthy
         expect(parsed_response["errors"][0].key?("detail")).to be_truthy
-        expect(parsed_response["errors"][0]["title"]).to eql("Status is invalid")
+        expect(parsed_response["errors"][0]["title"]).to eql("Status invalid")
         expect(parsed_response["errors"][0]["detail"]).to eql("Once rejected an application cannot change state")
       end
     end

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -163,20 +163,27 @@ RSpec.describe NPQ::Accept do
     end
 
     context "after approving an existing NPQApplication record" do
+      let(:new_trn) { (trn.to_i + 1).to_s }
+
       before do
         npq_application.save!
         subject.call
+        npq_application.update!(teacher_reference_number: new_trn)
       end
 
-      let(:new_trn) { (trn.to_i + 1).to_s }
-
       it "does not create neither teacher nor participant profile" do
-        npq_application.update!(teacher_reference_number: new_trn)
-
         expect { subject.call }
-          .to raise_error(Api::Errors::NPQApplicationAlreadyAcceptedError, "This NPQ application has already been accepted")
-          .and change(TeacherProfile, :count).by(0)
+          .to change(TeacherProfile, :count).by(0)
           .and change(ParticipantProfile::NPQ, :count).by(0)
+      end
+
+      it "returns false" do
+        expect(subject.call).to eql(false)
+      end
+
+      it "adds errors to object" do
+        subject.call
+        expect(npq_application.errors).to be_present
       end
     end
   end

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -186,5 +186,18 @@ RSpec.describe NPQ::Accept do
         expect(npq_application.errors).to be_present
       end
     end
+
+    context "when application has already been rejected" do
+      before do
+        npq_application.lead_provider_approval_status = "rejected"
+        npq_application.save!
+      end
+
+      it "cannot then be accepted" do
+        expect {
+          subject.call
+        }.not_to change { npq_application.reload.lead_provider_approval_status }
+      end
+    end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://trello.com/c/prKZvbBl/647-ensure-a-second-course-cannot-be-accepted-it-was-created-after-the-original-accept-reject

- I have rolled a few changes into one so it may be easier to review each commit independently
- The first is to ensure that we prevent providers from accepting multiple NPQ applications for the same course. Whether this be with one provider or across multiple providers
- This will likely need to change in the future if they wish to apply again for the same course but this can be handled at a later date
- The second change is refactoring out `NPQApplicationAlreadyAcceptedError` in favour of simple control flow. I believe this to be an improvement over raising an exception part way thru the code for it to be handle somewhere else. This keeps things a bit more localised 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Create an NPQ application via console or hookup to the NPQ app
- accept this application
```sh
curl -X POST -H "Authorization: Bearer TOKEN" https://https://ecf-review-pr-1377.london.cloudapps.digital/api/v1/npq-applications/NPQ_APPLICATION_ID/accept
```
- Create another NPQ application for the same user. Ensure it is for the same course. The provider can be same or another provider feel free to check both
- attempt to accept the second application
```sh
curl -X POST -H "Authorization: Bearer TOKEN" https://https://ecf-review-pr-1377.london.cloudapps.digital/api/v1/npq-applications/SECOND_NPQ_APPLICATION_ID/accept
```
- should not get accepted
- response should be
```json
{"errors":[{"title":"Status has another accepted application","detail":"The participant already has an accepted application for this course"}]}
```

## External API changes

- There are no direct changes to the API will affect its behaviour. I believe this does not need to be documented