### PR TITLE
CPDRP-1079 move error messages

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -31,19 +31,19 @@ module Api
     end
 
     def missing_parameter_response(exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: "Bad or missing parameters", params: exception.param).call }, status: :unprocessable_entity
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:missing_parameters), params: exception.param).call }, status: :unprocessable_entity
     end
 
     def unpermitted_parameter_response(exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: "Unpermitted parameters", params: exception.params).call }, status: :unprocessable_entity
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:unpermitted_parameters), params: exception.params).call }, status: :unprocessable_entity
     end
 
     def bad_request_response(exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: "Bad request", params: exception.message).call }, status: :bad_request
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
     end
 
     def invalid_transition(exception)
-      render json: { errors: Api::ParamErrorFactory.new(error: "Invalid action", params: exception).call }, status: :unprocessable_entity
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:invalid_transition), params: exception).call }, status: :unprocessable_entity
     end
   end
 end

--- a/app/controllers/challenge_partnerships_controller.rb
+++ b/app/controllers/challenge_partnerships_controller.rb
@@ -29,14 +29,14 @@ private
     partnership_id = params[:partnership] || params.dig(:challenge_partnership_form, :partnership_id)
     if @token.present?
       notification_email = PartnershipNotificationEmail.find_by(token: @token)
-      raise ActionController::RoutingError, "Not Found" if notification_email.blank?
+      raise ActionController::RoutingError, I18n.t(:not_found) if notification_email.blank?
 
       @partnership = notification_email.partnership
     elsif partnership_id.present?
       @partnership = Partnership.find(partnership_id)
       authorize(@partnership, :update?)
     else
-      raise ActionController::RoutingError, "Not Found"
+      raise ActionController::RoutingError, I18n.t(:not_found)
     end
   end
 

--- a/app/controllers/concerns/api_filter.rb
+++ b/app/controllers/concerns/api_filter.rb
@@ -11,7 +11,7 @@ private
 
   def validate_filter_param
     unless filter.as_json.is_a?(Hash)
-      error_factory = Api::ParamErrorFactory.new(params: ["Filter must be a hash"], error: "Bad parameter")
+      error_factory = Api::ParamErrorFactory.new(params: ["Filter must be a hash"], error: I18n.t(:bad_parameter))
       render json: { errors: error_factory.call }, status: :bad_request
     end
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,7 +6,7 @@ class ErrorsController < ApplicationController
   def not_found
     respond_to do |format|
       format.html { render status: :not_found }
-      format.json { render json: { error: "Resource not found" }, status: :not_found }
+      format.json { render json: { error: I18n.t(:resource_not_found) }, status: :not_found }
       format.all { render status: :not_found, body: nil }
     end
   end
@@ -14,21 +14,21 @@ class ErrorsController < ApplicationController
   def internal_server_error
     respond_to do |format|
       format.html { render status: :internal_server_error }
-      format.json { render json: { error: "Internal server error" }, status: :internal_server_error }
+      format.json { render json: { error: I18n.t(:internal_server_error) }, status: :internal_server_error }
     end
   end
 
   def unprocessable_entity
     respond_to do |format|
       format.html { render status: :unprocessable_entity }
-      format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
+      format.json { render json: { error: I18n.t(:unprocessable_entity) }, status: :unprocessable_entity }
     end
   end
 
   def forbidden
     respond_to do |format|
       format.html { render status: :forbidden }
-      format.json { render json: { error: "Forbidden" }, status: :forbidden }
+      format.json { render json: { error: I18n.t(:forbidden) }, status: :forbidden }
     end
   end
 end

--- a/app/controllers/finance/base_controller.rb
+++ b/app/controllers/finance/base_controller.rb
@@ -10,7 +10,7 @@ module Finance
   private
 
     def ensure_finance
-      raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.finance?
+      raise Pundit::NotAuthorizedError, I18n.t(:forbidden) unless current_user.finance?
     end
   end
 end

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -36,45 +36,45 @@ private
   def migration_version
     ApplicationRecord.connection.migration_context.current_version
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 
   def delayed_jobs
     Delayed::Job.count
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 
   def jobs_with_errors
     Delayed::Job.where.not(last_error: nil).count
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 
   def failed_jobs
     Delayed::Job.where.not(failed_at: nil).count
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 
   def last_job_failure
     Delayed::Job.order(failed_at: :desc).first&.failed_at
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 
   def notify_incident
     status_response = HTTPClient.get(NOTIFY_STATUS_API)
-    return "Status request failed" unless status_response.status == 200
+    return I18n.t(:status_request_failed) unless status_response.status == 200
 
     JSON.parse(status_response.body)["status"]["indicator"]
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 
   def puma_stats
     JSON.parse(Puma.stats)
   rescue StandardError
-    "FAIL"
+    I18n.t(:fail)
   end
 end

--- a/app/controllers/lead_providers/base_controller.rb
+++ b/app/controllers/lead_providers/base_controller.rb
@@ -12,7 +12,7 @@ module LeadProviders
     def ensure_lead_provider
       return if current_user&.lead_provider?
 
-      raise Pundit::NotAuthorizedError, "Forbidden"
+      raise Pundit::NotAuthorizedError, I18n.t(:forbidden)
     end
   end
 end

--- a/app/controllers/lead_providers/report_schools/csv_controller.rb
+++ b/app/controllers/lead_providers/report_schools/csv_controller.rb
@@ -10,7 +10,7 @@ module LeadProviders
       def create
         if params[:partnership_csv_upload].blank?
           @partnership_csv_upload = PartnershipCsvUpload.new
-          @partnership_csv_upload.errors.add(:base, "Please select a CSV file to upload.")
+          @partnership_csv_upload.errors.add(:base, I18n.t("errors.select_file"))
           render :show and return
         end
 

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -14,7 +14,7 @@ class Schools::BaseController < ApplicationController
 private
 
   def ensure_school_user
-    raise Pundit::NotAuthorizedError, "Forbidden" unless current_user.induction_coordinator?
+    raise Pundit::NotAuthorizedError, I18n.t(:forbidden) unless current_user.induction_coordinator?
 
     authorize(active_school, :show?) if active_school.present?
   end

--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -5,7 +5,7 @@ class ChallengePartnershipForm
 
   attr_accessor :challenge_reason, :token, :school_name, :partnership_id
 
-  validates :challenge_reason, presence: { message: "Select a reason why you think this confirmation is incorrect" }
+  validates :challenge_reason, presence: { message: I18n.t("errors.challenge_reason.blank") }
 
   def challenge_reason_options
     %w[another_provider not_confirmed do_not_recognise no_ects mistake].map do |key|

--- a/app/forms/core_induction_programme_choice_form.rb
+++ b/app/forms/core_induction_programme_choice_form.rb
@@ -5,7 +5,7 @@ class CoreInductionProgrammeChoiceForm
 
   attr_accessor :core_induction_programme_id
 
-  validates :core_induction_programme_id, presence: { message: "Select the training materials you want to use" }
+  validates :core_induction_programme_id, presence: { message: I18n.t("errors.core_induction_programme.blank") }
 
   def programme_choices
     CoreInductionProgramme

--- a/app/forms/delivery_partner_form.rb
+++ b/app/forms/delivery_partner_form.rb
@@ -6,7 +6,7 @@ class DeliveryPartnerForm
 
   attr_accessor :name, :lead_provider_ids, :provider_relationship_hashes
 
-  validates :name, presence: { message: "Enter a name" }, on: %i[name update]
+  validates :name, presence: { message: I18n.t("errors.name.blank") }, on: %i[name update]
   validate :lead_providers_validation, on: %i[lead_providers update]
   validate :cohorts_validation, on: %i[cohorts update]
 
@@ -88,7 +88,7 @@ private
 
   def lead_providers_validation
     unless current_lead_provider_ids&.any?
-      errors.add(:lead_provider_ids, :blank, message: "Choose at least one")
+      errors.add(:lead_provider_ids, :blank, message: I18n.t("errors.cohorts.blank"))
     end
   end
 
@@ -96,7 +96,7 @@ private
     # Ensure all selected lead providers have at least one selected cohort
     # This is indicated by the presence of a provider relationship for that lead provider
     if (current_lead_provider_ids - chosen_provider_relationships_lead_provider_ids).any?
-      errors.add(:provider_relationship_hashes, :blank, message: "Choose at least one cohort for every lead provider")
+      errors.add(:provider_relationship_hashes, :blank, message: I18n.t("errors.lead_providers.blank"))
     end
   end
 end

--- a/app/forms/finance/choose_payment_breakdown_form.rb
+++ b/app/forms/finance/choose_payment_breakdown_form.rb
@@ -6,8 +6,8 @@ module Finance
 
     attr_accessor :programme, :provider
 
-    validates :programme, presence: { message: "Please select programme type" }, on: :choose_programme
-    validates :provider, presence: { message: "Please select a provider" }, on: :choose_provider
+    validates :programme, presence: { message: I18n.t("errors.programme.blank") }, on: :choose_programme
+    validates :provider, presence: { message: I18n.t("errors.provider.blank") }, on: :choose_provider
 
     def programme_choices
       [

--- a/app/forms/induction_choice_form.rb
+++ b/app/forms/induction_choice_form.rb
@@ -15,7 +15,7 @@ class InductionChoiceForm
     { programme_choice: nil }
   end
 
-  validates :programme_choice, presence: { message: "Select how you want to run your induction" }, inclusion: { in: PROGRAMME_OPTIONS }
+  validates :programme_choice, presence: { message: I18n.t("errors.programme_choice.blank") }, inclusion: { in: PROGRAMME_OPTIONS }
 
   def programme_choices(i18n_scope: "schools.induction_choice_form.options")
     options =

--- a/app/forms/lead_providers/report_schools_form.rb
+++ b/app/forms/lead_providers/report_schools_form.rb
@@ -12,7 +12,7 @@ module LeadProviders
     attribute :cohort_id
     attribute :lead_provider_id
 
-    validates :delivery_partner_id, presence: { message: "Choose a delivery partner" }, on: :delivery_partner
+    validates :delivery_partner_id, presence: { message: I18n.t("errors.delivery_partner.blank") }, on: :delivery_partner
 
     def save!
       ActiveRecord::Base.transaction do

--- a/app/forms/nominate_how_to_continue_form.rb
+++ b/app/forms/nominate_how_to_continue_form.rb
@@ -10,7 +10,7 @@ class NominateHowToContinueForm
     { how_to_continue: nil }
   end
 
-  validates :how_to_continue, presence: { message: "Tell us whether you expect to have any early career teachers this year" }
+  validates :how_to_continue, presence: { message: I18n.t("errors.how_to_continue.blank") }
 
   def choices
     [

--- a/app/forms/nomination_request_form.rb
+++ b/app/forms/nomination_request_form.rb
@@ -7,10 +7,10 @@ class NominationRequestForm
   attr_accessor :local_authority_id, :school_id
 
   validates :local_authority_id,
-            presence: { message: "The details you entered do not match any schools" },
+            presence: { message: I18n.t("errors.schools.blank") },
             on: %i[local_authority save]
   validates :school_id,
-            presence: { message: "The details you entered do not match any schools" },
+            presence: { message: I18n.t("errors.schools.blank") },
             on: %i[school save]
 
   def attributes

--- a/app/forms/participant_mentor_form.rb
+++ b/app/forms/participant_mentor_form.rb
@@ -5,7 +5,7 @@ class ParticipantMentorForm
 
   attr_accessor :mentor_id, :school_id, :user_id, :cohort_id
 
-  validates :mentor_id, presence: { message: "Choose one" }
+  validates :mentor_id, presence: { message: I18n.t("errors.mentor.blank") }
   validate :mentor_exists
 
   def mentor

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -17,7 +17,7 @@ module Schools
     step :name do
       attribute :full_name
 
-      validates :full_name, presence: { message: "Enter a full name" }
+      validates :full_name, presence: { message: I18n.t("errors.full_name.blank") }
 
       next_step :email
     end
@@ -26,7 +26,7 @@ module Schools
       attribute :email
 
       validates :email,
-                presence: { message: "Enter an email address" },
+                presence: { message: I18n.t("errors.email_address.blank") },
                 notify_email: { allow_blank: true }
 
       next_step do

--- a/app/forms/supplier_user_form.rb
+++ b/app/forms/supplier_user_form.rb
@@ -6,10 +6,10 @@ class SupplierUserForm
 
   attr_accessor :full_name, :email, :supplier
 
-  validates :supplier, presence: { message: "Select one" }, on: :supplier
-  validates :full_name, presence: { message: "Enter a name" }, on: :details
+  validates :supplier, presence: { message: I18n.t("errors.supplier.blank") }, on: :supplier
+  validates :full_name, presence: { message: I18n.t("errors.name.blank") }, on: :details
   validates :email,
-            presence: { message: "Enter email" },
+            presence: { message: I18n.t("errors.supplier_email.blank") },
             notify_email: true,
             on: :details
   validate :email_not_taken, on: :details
@@ -37,6 +37,6 @@ class SupplierUserForm
 private
 
   def email_not_taken
-    errors.add(:email, :unique, message: "There is already a user with this email address") if User.find_by(email: email)
+    errors.add(:email, :unique, message: I18n.t("errors.supplier_email.taken")) if User.find_by(email: email)
   end
 end

--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -6,10 +6,10 @@ class VoidParticipantDeclaration
   def call
     declaration = ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(id)
 
-    raise Api::Errors::InvalidTransitionError, "Declaration is already voided" if declaration.voided?
+    raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_already_voided) if declaration.voided?
 
     latest_declaration = declaration.participant_profile.participant_declarations.order(declaration_date: :desc).first
-    raise Api::Errors::InvalidTransitionError, "Can only void last declaration" if latest_declaration != declaration
+    raise Api::Errors::InvalidTransitionError, I18n.t(:void_last_declaration_only) if latest_declaration != declaration
 
     declaration.voided!
     ParticipantDeclarationSerializer.new(declaration).serializable_hash.to_json

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,21 @@ en:
     career_break: Career break
     passed_induction: Passed Induction
     other: "Other"
-  parameter_required: Parameter is required
+
+  # Errors
+  fail: "FAIL"
+  status_request_failed: "Status request failed"
+  forbidden: "Forbidden"
+  not_found: "Not Found"
+  resource_not_found: "Resource not Found"
+  unprocessable_entity: "Unprocessable entity"
+  internal_server_error: "Internal server error"
+  parameter_required: "Parameter is required"
+  missing_parameters: "Bad or missing parameters"
+  unpermitted_parameters: "Unpermitted parameters"
+  bad_request: "Bad request"
+  bad_parameter: "Bad parameter"
+  invalid_transition: "Invalid action"
   invalid_participant: "The property '#/participant_id' must be a valid Participant ID"
   invalid_identifier: "The property '#/course_identifier' must be an available course to '#/participant_id'"
   invalid_declaration_type: "The property '#/declaration_type' must be available for '#/course_identifier'"
@@ -35,6 +49,8 @@ en:
   schedule_invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
   withdrawn_participant: Cannot perform actions on a withdrawn participant
   declaration_on_incorrect_state: "The declaration on withdrawn or deferred participant can not be accepted"
+  declaration_already_voided: "Declaration is already voided"
+  void_last_declaration_only: "Can only void last declaration"
   schedule_missing: "The participant does not have a schedule"
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
   declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"
@@ -44,21 +60,18 @@ en:
     not_a_number: *default_message
     less_than: *default_message
     greater_than_or_equal_to: *default_message
-
-  manage_your_training:
-    induction_programmes:
-      full_induction_programme: "Use a training provider funded by the DfE"
-      core_induction_programme: "Use DfE-accredited materials"
-      design_our_own: "Design and deliver your own programme based on the Early Career Framework (ECF)"
-      school_funded_fip: "Use a training provider funded by your school"
-      no_early_career_teachers: "No early career teachers for this cohort"
-      not_yet_known: "Not yet decided"
-
   errors:
     email: &email_error_messages
       blank: "Enter an email"
       taken: "This email address is already in use"
       invalid: "Enter an email address in the correct format, like name@example.com"
+    supplier_email:
+      blank: "Enter email"
+      taken: "There is already a user with this email address"
+    email_address:
+      blank: "Enter an email address"
+    name:
+      blank: "Enter a name"
     full_name: &full_name_error_messages
       blank: "Enter a full name"
       does_not_match: "The name you entered does not match our records"
@@ -69,64 +82,57 @@ en:
       invalid: The property '#/participant_id' must have a valid UUID format
     cpd_lead_provider: &cpd_lead_provider_error_messages
       blank: The lead provider must be present
+    select_file: "Please select a CSV file to upload."
+    supplier:
+      blank: "Select one"
+    mentor:
+      blank: "Choose one"
+    how_to_continue:
+      blank: "Tell us whether you expect to have any early career teachers this year"
+    schools:
+      blank: "The details you entered do not match any schools"
+    programme_choice:
+      blank: "Select how you want to run your induction"
+    cohorts:
+      blank: "Choose at least one"
+    lead_providers:
+      blank: "Choose at least one cohort for every lead provider"
+    core_induction_programme:
+      blank: "Select the training materials you want to use"
+    challenge_reason:
+      blank: "Select a reason why you think this confirmation is incorrect"
+    delivery_partner:
+      blank: "Choose a delivery partner"
+    programme:
+      blank: "Please select programme type"
+    provider:
+      blank: "Please select a provider"
 
-  finance:
-    choose_programme: Choose programme scheme
-    show_contract: View contract information
-    provider: Provider
-    ects: Current ECTs
-    mentors: Current Mentors
-    participants: Current Participants
-    per_participant: Payment amount per person
-    payment_breakdown: Payment Breakdown
-    payment_type: Payment type
-    number_of_participants: Number of participants
-    payment_amount_for_period: Payment amount for period
-    payment: Payment
-    vat: VAT
-    total_payment: Total payment
-    fee_per_participant: Fee per participant
-    back_payment_participants: Back payment participants
-    participant_breakdown: Participant breakdown
-    current_milestone: Current milestone
-    total_paid: Total paid
-    total_not_paid: Total not paid
-    contract:
-      uplift_target: Uplift target
-      uplift_amount: Uplift amount
-      recuitment_target: Recruitment target
-      revised_target: Revised recruitment target (+2%)
-      set_up_fee: Set-up Fee
-      band: Band
-      bands:
-        min: Min
-        max: Max
-        floor: 0
-        ceiling: Unlimited
-    ecf:
-      bands:
-        "0": Band A
-        "1": Band B
-        "2": Band C
-        "3": New target
-      payment_breakdown: ECF Payment Breakdown
-      breakdown_summary:
-        submission_deadline: Submission deadline
-        total: Total
-
-    npq:
-      payment_breakdown: NPQ Payment Breakdown
-    service_fee:
-      caption: Service Fee
-    output_payment:
-      caption: Output Fee
-      band_d_info: Participants over the original band C target up to the new target.
-    uplift_fee:
-      caption: Uplift Fee
-    clawbacks:
-      caption: Clawbacks
-      per_participant: Clawback per participant
-
+  activerecord:
+    attributes:
+      npq_application:
+        lead_provider_approval_status: Status
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              <<: *email_error_messages
+            full_name:
+              <<: *full_name_error_messages
+        school_cohort_form:
+          attributes:
+            estimated_mentor_count:
+              blank: "Enter your expected number of mentors"
+              <<: *defaults
+            estimated_teacher_count:
+              <<: *defaults
+              blank: "enter your expected number of teachers"
+        npq_application:
+          attributes:
+            lead_provider_approval_status:
+              has_another_accepted_application: The participant already has an accepted application for this course
+              has_already_been_accepted: This NPQ application has already been accepted
 
   activemodel:
     errors:
@@ -183,7 +189,6 @@ en:
         participants/defer:
           reason:
             invalid: Cannot defer without a valid reason
-
         record_declarations/base:
           attributes:
             course_identifier:
@@ -209,31 +214,6 @@ en:
               blank: "Enter an email address for your teacher"
             core_induction_programme_id:
               blank: "Select the materials you want to use"
-  activerecord:
-    attributes:
-      npq_application:
-        lead_provider_approval_status: Status
-    errors:
-      models:
-        user:
-          attributes:
-            email:
-              <<: *email_error_messages
-            full_name:
-              <<: *full_name_error_messages
-        school_cohort_form:
-          attributes:
-            estimated_mentor_count:
-              blank: "Enter your expected number of mentors"
-              <<: *defaults
-            estimated_teacher_count:
-              <<: *defaults
-              blank: "enter your expected number of teachers"
-        npq_application:
-          attributes:
-            lead_provider_approval_status:
-              has_another_accepted_application: The participant already has an accepted application for this course
-              has_already_been_accepted: This NPQ application has already been accepted
   page_titles:
     lead_providers:
       guidance:
@@ -245,3 +225,68 @@ en:
         help: "Get help"
       content:
         partnership_guide: "Guide for providers to manage their schools on the ECF service"
+
+  manage_your_training:
+    induction_programmes:
+      full_induction_programme: "Use a training provider funded by the DfE"
+      core_induction_programme: "Use DfE-accredited materials"
+      design_our_own: "Design and deliver your own programme based on the Early Career Framework (ECF)"
+      school_funded_fip: "Use a training provider funded by your school"
+      no_early_career_teachers: "No early career teachers for this cohort"
+      not_yet_known: "Not yet decided"
+
+  finance:
+    choose_programme: Choose programme scheme
+    show_contract: View contract information
+    provider: Provider
+    ects: Current ECTs
+    mentors: Current Mentors
+    participants: Current Participants
+    per_participant: Payment amount per person
+    payment_breakdown: Payment Breakdown
+    payment_type: Payment type
+    number_of_participants: Number of participants
+    payment_amount_for_period: Payment amount for period
+    payment: Payment
+    vat: VAT
+    total_payment: Total payment
+    fee_per_participant: Fee per participant
+    back_payment_participants: Back payment participants
+    participant_breakdown: Participant breakdown
+    current_milestone: Current milestone
+    total_paid: Total paid
+    total_not_paid: Total not paid
+    contract:
+      uplift_target: Uplift target
+      uplift_amount: Uplift amount
+      recuitment_target: Recruitment target
+      revised_target: Revised recruitment target (+2%)
+      set_up_fee: Set-up Fee
+      band: Band
+      bands:
+        min: Min
+        max: Max
+        floor: 0
+        ceiling: Unlimited
+    ecf:
+      bands:
+        "0": Band A
+        "1": Band B
+        "2": Band C
+        "3": New target
+      payment_breakdown: ECF Payment Breakdown
+      breakdown_summary:
+        submission_deadline: Submission deadline
+        total: Total
+    npq:
+      payment_breakdown: NPQ Payment Breakdown
+    service_fee:
+      caption: Service Fee
+    output_payment:
+      caption: Output Fee
+      band_d_info: Participants over the original band C target up to the new target.
+    uplift_fee:
+      caption: Uplift Fee
+    clawbacks:
+      caption: Clawbacks
+      per_participant: Clawback per participant

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
               blank: "Enter an email address for your teacher"
             core_induction_programme_id:
               blank: "Select the materials you want to use"
+
   page_titles:
     lead_providers:
       guidance:


### PR DESCRIPTION
## Ticket and context

Goal - have all error messages in one place so that they can be easily accessed with minimal dev support, to avoid duplication and to tidy the project

Ticket: https://dfedigital.atlassian.net/browse/CPDRP-1079

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
