### PR TITLE
CPDRP-850 Track major school changes

### DIFF
--- a/app/models/concerns/gias_types.rb
+++ b/app/models/concerns/gias_types.rb
@@ -8,9 +8,10 @@ module GiasTypes
   CIP_ONLY_TYPE_CODES = [10, 11, 30, 37].freeze
   CIP_ONLY_EXCEPT_WELSH_CODES = [10, 11, 37].freeze
 
+  OPEN_STATUS_CODES = ELIGIBLE_STATUS_CODES
+  CLOSED_STATUS_CODES = [2, 4].freeze
+
   MAJOR_CHANGE_ATTRIBUTES = %w[
-    administrative_district_code
-    administrative_district_name
     school_status_code
     school_status_name
     school_type_code
@@ -20,7 +21,7 @@ module GiasTypes
   ].freeze
 
   def open_status_code?(status_code)
-    ELIGIBLE_STATUS_CODES.include?(status_code)
+    OPEN_STATUS_CODES.include?(status_code)
   end
 
   def eligible_establishment_code?(establishment_type)

--- a/app/models/data_stage/school_change.rb
+++ b/app/models/data_stage/school_change.rb
@@ -7,7 +7,7 @@ module DataStage
     belongs_to :school, class_name: "DataStage::School",
                         foreign_key: :data_stage_school_id
 
-    scope :unhandled, -> { where(handled: false) }
+    scope :unprocessed, -> { where(handled: false) }
 
     enum status: {
       added: "added",

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -16,12 +16,13 @@ class School < ApplicationRecord
 
   has_many :school_local_authorities
   has_many :local_authorities, through: :school_local_authorities
-
   has_one :latest_school_authority, -> { latest }, class_name: "SchoolLocalAuthority"
   has_one :local_authority, through: :latest_school_authority
 
   has_many :school_local_authority_districts
   has_many :local_authority_districts, through: :school_local_authority_districts
+  has_one :latest_school_authority_district, -> { latest }, class_name: "SchoolLocalAuthorityDistrict"
+  has_one :local_authority_district, through: :latest_school_authority_district
 
   has_many :partnerships
   has_many :active_partnerships, -> { active }, class_name: "Partnership"
@@ -140,10 +141,6 @@ class School < ApplicationRecord
 
   def can_access_service?
     eligible? || cip_only?
-  end
-
-  def local_authority_district
-    school_local_authority_districts.latest.first&.local_authority_district
   end
 
   def pupil_premium_uplift?(start_year)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -8,6 +8,12 @@ class School < ApplicationRecord
 
   belongs_to :network, optional: true
 
+  has_many :school_links, dependent: :destroy
+  has_many :successor_links, -> { successor }, class_name: "SchoolLink"
+  has_many :predecessor_links, -> { predecessor }, class_name: "SchoolLink"
+  has_many :successor_schools, through: :successor_links, source: :link_school
+  has_many :predecessor_schools, through: :predecessor_links, source: :link_school
+
   has_many :school_local_authorities
   has_many :local_authorities, through: :school_local_authorities
 

--- a/app/models/school_link.rb
+++ b/app/models/school_link.rb
@@ -2,7 +2,9 @@
 
 class SchoolLink < ApplicationRecord
   belongs_to :school
-  belongs_to :link_school, class_name: "School"
+  has_one :link_school, class_name: "School",
+                        foreign_key: :urn,
+                        primary_key: :link_urn
 
   enum link_type: {
     predecessor: "predecessor",
@@ -11,8 +13,8 @@ class SchoolLink < ApplicationRecord
 
   enum link_reason: {
     simple: "simple",
-    merger: "merger",
-    split: "split",
+    school_merger: "school_merger",
+    school_split: "school_split",
     other: "other",
   }
 end

--- a/app/models/school_link.rb
+++ b/app/models/school_link.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class SchoolLink < ApplicationRecord
+  belongs_to :school
+  belongs_to :link_school, class_name: "School"
+
+  enum link_type: {
+    predecessor: "predecessor",
+    successor: "successor",
+  }
+
+  enum link_reason: {
+    simple: "simple",
+    merger: "merger",
+    split: "split",
+    other: "other",
+  }
+end

--- a/app/services/data_stage/process_school_changes.rb
+++ b/app/services/data_stage/process_school_changes.rb
@@ -77,9 +77,9 @@ module DataStage
           move_assets_from!(school: change.school.counterpart, successor: successor)
           change.school.counterpart.school_links.successor.simple.create!(link_urn: successor.urn)
           successor.school_links.predecessor.simple.create!(link_urn: change.school.urn)
+          change.school.create_or_sync_counterpart!
+          change.update!(handled: true)
         end
-        change.school.create_or_sync_counterpart!
-        change.update!(handled: true)
       end
     end
 

--- a/app/services/data_stage/process_school_changes.rb
+++ b/app/services/data_stage/process_school_changes.rb
@@ -97,7 +97,9 @@ module DataStage
       SchoolCohort.where(school: school).each do |school_cohort|
         school_cohort.update!(school: successor)
         school_cohort.ecf_participant_profiles.each do |profile|
-          RectifyParticipantSchool.call(participant_profile: profile, school: successor)
+          RectifyParticipantSchool.call(participant_profile: profile,
+                                        school: successor,
+                                        transfer_pupil_premium_and_sparsity: false)
         end
       end
 

--- a/app/services/data_stage/process_school_changes.rb
+++ b/app/services/data_stage/process_school_changes.rb
@@ -36,6 +36,7 @@ module DataStage
         unhandled_attrs.each do |attr|
           current_value = counterpart.send(attr)
           next if current_value.blank? || current_value == school.send(attr)
+
           has_unhandled_changes = true
           break
         end

--- a/app/services/data_stage/process_school_changes.rb
+++ b/app/services/data_stage/process_school_changes.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module DataStage
+  class ProcessSchoolChanges < ::BaseService
+    include GiasTypes
+
+    UNHANDLED_ATTRIBUTES = %w[
+      administrative_district_code
+      administrative_district_name
+      school_type_code
+      school_type_name
+      section_41_approved
+      ukprn
+    ].freeze
+
+    def call
+      DataStage::SchoolChange.includes(:school).unhandled.status_changed.find_each do |change|
+        next if has_unhandled_changes?(change)
+
+        if change.attribute_changes.key? "school_status_code"
+          handle_status_code_change(change)
+        end
+      end
+    end
+
+  private
+
+    def has_unhandled_changes?(school_change)
+      unhandled_attrs = (unhandled_attributes & change.attribute_changes.keys)
+      has_unhandled_changes = false
+
+      if unhandled_attrs.any?
+        counterpart = school_change.school.counterpart
+        unhandled_attrs.each do |attr|
+          next if counterpart.send(attr).blank?
+          has_unhandled_changes = true
+          break
+        end
+      end
+      has_unhandled_changes
+    end
+
+    def has_unhandled_attributes?(attributes)
+      (unhandled_attributes & attributes.keys).any?
+    end
+
+    def unhandled_attributes
+      MAJOR_CHANGE_ATTRIBUTES - %w[school_status_code school_status_name]
+    end
+
+    def handle_status_code_change(change)
+      from_code = change.school.school_status_code
+
+      if from_code.in? [1, 3]
+        # open status codes
+        open_school(change)
+      elsif from_code.in? [2, 4]
+        # closed statuses
+        close_school(change)
+      end
+    end
+
+    def open_school(change)
+      # simple opening/sync of school
+      ActiveRecord::Base.transaction do
+        change.school.create_or_sync_counterpart!
+        change.update!(handled: true)
+      end
+    end
+
+    def close_school(change)
+      # if the live school doesn't exist there is no need to create it just to mark it as closed
+      if change.school.counterpart.blank?
+        change.update!(handled: true)
+        return
+      end
+
+      last_link = change.school.school_links.find_by(link_type: "Successor")
+      if last_link.present?
+        ActiveRecord::Base.transaction do
+          successor = find_or_create_successor!(last_link.link_urn)
+          move_assets_from!(school: change.school.counterpart, successor: successor)
+          change.school.counterpart.school_links.successor.create!(link_school: successor)
+          successor.school_links.predecessor.create!(link_school: change.school.counterpart)
+          change.school.create_or_sync_counterpart!
+          change.update!(handled: true)
+        end
+      end
+    end
+
+    def find_or_create_successor!(urn)
+      school = DataStage::School.find_by!(urn: urn)
+      school.create_or_sync_counterpart!
+      school.counterpart
+    end
+
+    def move_assets_from!(school:, successor:)
+      # move everything to the new school
+      Partnership.active.where(school: school).each { |partnership| partnership.update!(school: successor) }
+      # TODO: What should we do here if the school already has a school_cohort (if anything)?
+      if successor.school_cohorts.empty?
+        SchoolCohort.where(school: school).each { |cohort| cohort.update!(school: successor) }
+      end
+
+      TeacherProfile.where(school: school).each { |profile| profile.update!(school: successor) }
+      InductionCoordinatorProfilesSchool.where(school: school).each { |profile| profile.update!(school: successor) }
+    end
+  end
+end

--- a/app/services/rectify_participant_school.rb
+++ b/app/services/rectify_participant_school.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
 class RectifyParticipantSchool < BaseService
-  attr_reader :participant_profile, :school
+  attr_reader :participant_profile, :school, :transfer_pupil_premium_and_sparsity
 
-  def initialize(participant_profile:, school:)
+  def initialize(participant_profile:, school:, transfer_pupil_premium_and_sparsity: true)
     @participant_profile = participant_profile
     @school = school
+    @transfer_pupil_premium_and_sparsity = transfer_pupil_premium_and_sparsity
   end
 
   # NOTE: Don't use this to move participants in cases where they have got a new job
   # and transferred to a different school. This is intended to fix issues with participants
-  # that have been added to the wrong school by mistake.
+  # that have been added to the wrong school by mistake or in a GIAS school closure/reopen
+  # scenario.
   def call
     cohort = participant_profile.school_cohort.cohort
     school_cohort = school.school_cohorts.find_by(cohort: cohort)
@@ -18,10 +20,16 @@ class RectifyParticipantSchool < BaseService
 
     ActiveRecord::Base.transaction do
       participant_profile.teacher_profile.update!(school: school)
-      participant_profile.update!(school_cohort: school_cohort,
-                                  sparsity_uplift: school.sparsity_uplift?(cohort.start_year),
-                                  pupil_premium_uplift: school.pupil_premium_uplift?(cohort.start_year))
+      attrs = {
+        school_cohort: school_cohort,
+      }
+
+      if transfer_pupil_premium_and_sparsity
+        attrs[:sparsity_uplift] = school.sparsity_uplift?(cohort.start_year)
+        attrs[:pupil_premium_uplift] = school.pupil_premium_uplift?(cohort.start_year)
+      end
+
+      participant_profile.update!(attrs)
     end
-    true
   end
 end

--- a/app/services/set_school_local_authority.rb
+++ b/app/services/set_school_local_authority.rb
@@ -8,7 +8,6 @@ class SetSchoolLocalAuthority < BaseService
         SchoolLocalAuthority.create!(school: school,
                                      local_authority: LocalAuthority.find_by(code: la_code),
                                      start_year: start_year)
-        update_pupil_premiums!
       end
     end
   end
@@ -21,17 +20,5 @@ private
     @school = school
     @la_code = la_code
     @start_year = start_year
-  end
-
-  def update_pupil_premiums!
-    # pupil premiums are added via an import process so if this school
-    # is new it may not have had any associated with it yet
-    unless school.partnerships.any?
-      uplift = school.pupil_premium_uplift?(start_year)
-
-      school.school_cohorts.for_year(start_year).first&.ecf_participant_profiles&.each do |profile|
-        profile.update!(pupil_premium_uplift: uplift)
-      end
-    end
   end
 end

--- a/app/services/set_school_local_authority.rb
+++ b/app/services/set_school_local_authority.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class SetSchoolLocalAuthority < BaseService
+  def call
+    if school.local_authority&.code != la_code
+      ActiveRecord::Base.transaction do
+        school.latest_school_authority&.update!(end_year: start_year)
+        SchoolLocalAuthority.create!(school: school,
+                                     local_authority: LocalAuthority.find_by(code: la_code),
+                                     start_year: start_year)
+        update_pupil_premiums!
+      end
+    end
+  end
+
+private
+
+  attr_reader :la_code, :school, :start_year
+
+  def initialize(school:, la_code:, start_year: Time.zone.now.year)
+    @school = school
+    @la_code = la_code
+    @start_year = start_year
+  end
+
+  def update_pupil_premiums!
+    # pupil premiums are added via an import process so if this school
+    # is new it may not have had any associated with it yet
+    unless school.partnerships.any?
+      uplift = school.pupil_premium_uplift?(start_year)
+
+      school.school_cohorts.for_year(start_year).first&.ecf_participant_profiles&.each do |profile|
+        profile.update!(pupil_premium_uplift: uplift)
+      end
+    end
+  end
+end

--- a/app/services/set_school_local_authority_district.rb
+++ b/app/services/set_school_local_authority_district.rb
@@ -7,9 +7,8 @@ class SetSchoolLocalAuthorityDistrict < BaseService
         school.latest_school_authority_district&.update!(end_year: start_year)
 
         SchoolLocalAuthorityDistrict.create!(school: school,
-                                             local_authority_district: la_district,
+                                             local_authority_district: LocalAuthorityDistrict.find_by(code: administrative_district_code),
                                              start_year: start_year)
-        update_participants_sparsity_flag!
       end
     end
   end
@@ -22,18 +21,5 @@ private
     @school = school
     @administrative_district_code = administrative_district_code || school.administrative_district_code
     @start_year = start_year
-  end
-
-  def update_participants_sparsity_flag!
-    unless school.partnerships.any?
-      lad_sparsity = la_district.sparse?(start_year)
-      school.school_cohorts.for_year(start_year).first&.ecf_participant_profiles&.each do |profile|
-        profile.update!(sparsity_uplift: lad_sparsity)
-      end
-    end
-  end
-
-  def la_district
-    @la_district ||= LocalAuthorityDistrict.find_by(code: administrative_district_code)
   end
 end

--- a/app/services/set_school_local_authority_district.rb
+++ b/app/services/set_school_local_authority_district.rb
@@ -4,7 +4,7 @@ class SetSchoolLocalAuthorityDistrict < BaseService
   def call
     if school.local_authority_district&.code != administrative_district_code
       ActiveRecord::Base.transaction do
-        school.school_local_authority_districts.latest.first&.update!(end_year: start_year)
+        school.latest_school_authority_district&.update!(end_year: start_year)
 
         SchoolLocalAuthorityDistrict.create!(school: school,
                                              local_authority_district: la_district,

--- a/app/services/set_school_local_authority_district.rb
+++ b/app/services/set_school_local_authority_district.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class SetSchoolLocalAuthorityDistrict < BaseService
+  def call
+    if school.local_authority_district&.code != administrative_district_code
+      ActiveRecord::Base.transaction do
+        school.school_local_authority_districts.latest.first&.update!(end_year: start_year)
+
+        SchoolLocalAuthorityDistrict.create!(school: school,
+                                             local_authority_district: la_district,
+                                             start_year: start_year)
+        update_participants_sparsity_flag!
+      end
+    end
+  end
+
+private
+
+  attr_reader :administrative_district_code, :school, :start_year
+
+  def initialize(school:, administrative_district_code: nil, start_year: Time.zone.now.year)
+    @school = school
+    @administrative_district_code = administrative_district_code || school.administrative_district_code
+    @start_year = start_year
+  end
+
+  def update_participants_sparsity_flag!
+    unless school.partnerships.any?
+      lad_sparsity = la_district.sparse?(start_year)
+      school.school_cohorts.for_year(start_year).first&.ecf_participant_profiles&.each do |profile|
+        profile.update!(sparsity_uplift: lad_sparsity)
+      end
+    end
+  end
+
+  def la_district
+    @la_district ||= LocalAuthorityDistrict.find_by(code: administrative_district_code)
+  end
+end

--- a/app/views/admin/gias/school_changes/show.html.erb
+++ b/app/views/admin/gias/school_changes/show.html.erb
@@ -12,7 +12,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @school.attributes.except("id", "created_at", "updated_at", "urn").each do |attribute_name, value| %>
+    <% @school.attributes.except("id", "created_at", "updated_at", "urn", "la_code").each do |attribute_name, value| %>
       <% current_value = @school.counterpart.read_attribute(attribute_name) %>
       <% if current_value != value && !(current_value.blank? && value.blank?) %>
         <tr class="govuk-table__row">

--- a/db/migrate/20211001135337_create_school_links.rb
+++ b/db/migrate/20211001135337_create_school_links.rb
@@ -4,7 +4,7 @@ class CreateSchoolLinks < ActiveRecord::Migration[6.1]
   def change
     create_table :school_links do |t|
       t.references :school
-      t.references :link_school, foreign_key: { to_table: 'schools' }
+      t.string :link_urn, null: false
       t.string :link_type, null: false
       t.string :link_reason, null: false, default: "simple"
       t.timestamps

--- a/db/migrate/20211001135337_create_school_links.rb
+++ b/db/migrate/20211001135337_create_school_links.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateSchoolLinks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :school_links do |t|
+      t.references :school
+      t.references :link_school, foreign_key: { to_table: 'schools' }
+      t.string :link_type, null: false
+      t.string :link_reason, null: false, default: "simple"
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -706,6 +706,17 @@ ActiveRecord::Schema.define(version: 2021_10_21_121416) do
     t.index ["school_id"], name: "index_school_cohorts_on_school_id"
   end
 
+  create_table "school_links", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "school_id", null: false
+    t.uuid "link_school_id", null: false
+    t.string "link_type", null: false
+    t.string "link_reason", default: "simple", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["link_school_id"], name: "index_school_links_on_link_school_id"
+    t.index ["school_id"], name: "index_school_links_on_school_id"
+  end
+
   create_table "school_local_authorities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id", null: false
     t.uuid "local_authority_id", null: false
@@ -868,6 +879,7 @@ ActiveRecord::Schema.define(version: 2021_10_21_121416) do
   add_foreign_key "school_cohorts", "cohorts"
   add_foreign_key "school_cohorts", "core_induction_programmes"
   add_foreign_key "school_cohorts", "schools"
+  add_foreign_key "school_links", "schools", column: "link_school_id"
   add_foreign_key "school_local_authorities", "local_authorities"
   add_foreign_key "school_local_authorities", "schools"
   add_foreign_key "school_local_authority_districts", "local_authority_districts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -708,12 +708,11 @@ ActiveRecord::Schema.define(version: 2021_10_21_121416) do
 
   create_table "school_links", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "school_id", null: false
-    t.uuid "link_school_id", null: false
+    t.string "link_urn", null: false
     t.string "link_type", null: false
     t.string "link_reason", default: "simple", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["link_school_id"], name: "index_school_links_on_link_school_id"
     t.index ["school_id"], name: "index_school_links_on_school_id"
   end
 
@@ -879,7 +878,6 @@ ActiveRecord::Schema.define(version: 2021_10_21_121416) do
   add_foreign_key "school_cohorts", "cohorts"
   add_foreign_key "school_cohorts", "core_induction_programmes"
   add_foreign_key "school_cohorts", "schools"
-  add_foreign_key "school_links", "schools", column: "link_school_id"
   add_foreign_key "school_local_authorities", "local_authorities"
   add_foreign_key "school_local_authorities", "schools"
   add_foreign_key "school_local_authority_districts", "local_authority_districts"

--- a/spec/models/data_stage/school_spec.rb
+++ b/spec/models/data_stage/school_spec.rb
@@ -66,18 +66,9 @@ RSpec.describe DataStage::School, type: :model do
         expect(counterpart_school.reload.local_authority_district).to eq local_authority_district
       end
 
-      it "updates the participant profiles with the sparsity uplift of the new district" do
+      it "does not update the participant profiles with the sparsity uplift of the new district" do
         school.create_or_sync_counterpart!
-        expect(participant.reload).not_to be_sparsity_uplift
-      end
-
-      context "when the school has a partnership" do
-        let!(:partnership) { create(:partnership, school: counterpart_school, cohort: cohort) }
-
-        it "does not update the participant profiles with the sparsity uplift of the new district" do
-          school.create_or_sync_counterpart!
-          expect(participant.reload).to be_sparsity_uplift
-        end
+        expect(participant.reload).to be_sparsity_uplift
       end
     end
   end

--- a/spec/models/data_stage/school_spec.rb
+++ b/spec/models/data_stage/school_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataStage::School, type: :model do
+  let(:local_authority) { create(:local_authority, code: "123") }
+  let(:local_authority_district) { create(:local_authority_district, code: "E12345678") }
+  subject(:school) { create(:staged_school, la_code: local_authority.code, administrative_district_code: local_authority_district.code) }
+
+  describe "#create_or_sync_counterpart!" do
+    it "creates the new School" do
+      expect {
+        school.create_or_sync_counterpart!
+      }.to change { School.count }.by(1)
+    end
+
+    it "synchronises the counterpart attributes" do
+      school.create_or_sync_counterpart!
+      synced_attrs = school.send(:attributes_to_sync)
+
+      expect(school.counterpart.attributes).to include(synced_attrs)
+    end
+
+    it "associates the counterpart with the local authority" do
+      school.create_or_sync_counterpart!
+      expect(school.counterpart.reload.local_authority).to eq local_authority
+    end
+
+    it "associates the counterpart with the local authority district" do
+      school.create_or_sync_counterpart!
+      expect(school.counterpart.reload.local_authority_district).to eq local_authority_district
+    end
+
+    context "when counterpart school exists" do
+      let(:current_year) { Time.zone.now.year }
+      let(:cohort) { create(:cohort, start_year: current_year) }
+      let(:old_local_authority) { create(:local_authority, code: "234") }
+      let(:old_local_authority_district) { create(:local_authority_district, :sparse, code: "E234") }
+      let!(:counterpart_school) { create(:school, urn: school.urn) }
+      let(:school_cohort) { create(:school_cohort, cohort: cohort, school: counterpart_school) }
+      let!(:participant) { create(:participant_profile, :ect, school_cohort: school_cohort, sparsity_uplift: true) }
+
+      before do
+        SchoolLocalAuthority.create!(school: counterpart_school,
+                                     local_authority: old_local_authority,
+                                     start_year: current_year)
+
+        SchoolLocalAuthorityDistrict.create!(school: counterpart_school,
+                                             local_authority_district: old_local_authority_district,
+                                             start_year: current_year)
+      end
+
+      it "does not create an additional school" do
+        expect {
+          school.create_or_sync_counterpart!
+        }.not_to change { School.count }
+      end
+
+      it "associates the counterpart with the new local authority" do
+        school.create_or_sync_counterpart!
+        expect(counterpart_school.reload.local_authority).to eq local_authority
+      end
+
+      it "associates the counterpart with the new local authority district" do
+        school.create_or_sync_counterpart!
+        expect(counterpart_school.reload.local_authority_district).to eq local_authority_district
+      end
+
+      it "updates the participant profiles with the sparsity uplift of the new district" do
+        school.create_or_sync_counterpart!
+        expect(participant.reload).not_to be_sparsity_uplift
+      end
+
+      context "when the school has a partnership" do
+        let!(:partnership) { create(:partnership, school: counterpart_school, cohort: cohort) }
+
+        it "does not update the participant profiles with the sparsity uplift of the new district" do
+          school.create_or_sync_counterpart!
+          expect(participant.reload).to be_sparsity_uplift
+        end
+      end
+    end
+  end
+end

--- a/spec/services/data_stage/process_school_changes_spec.rb
+++ b/spec/services/data_stage/process_school_changes_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataStage::ProcessSchoolChanges do
+  subject(:service) { described_class }
+  let(:local_authority) { create(:local_authority, code: 10) }
+  let(:local_authority_district) { create(:local_authority_district, code: "E123") }
+  let!(:staged_school) { create(:staged_school, urn: 20_001, name: "The Starship Children's Centre", la_code: local_authority.code, administrative_district_code: local_authority_district.code) }
+  let(:excluded_attrs) { %w[id created_at updated_at slug network_id domains la_code] }
+
+  describe ".call" do
+    context "when the change contains unhandled attributes" do
+      let!(:school_change) { create(:staged_school_change, :with_unhandled_changes, school: staged_school) }
+
+      context "when the live school does not exist" do
+        it "does not create the school" do
+          expect { service.call }.not_to change { ::School.count }
+        end
+      end
+
+      context "when the live school already exists" do
+        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 4, school_status_name: "Proposed to open") }
+
+        it "does not process any of the changes" do
+          service.call
+          expect(live_school.reload.school_status_code).to eq 4
+          expect(live_school.reload.school_status_name).to eq "proposed_to_open"
+        end
+      end
+
+      it "does not mark the change and handled" do
+        service.call
+        expect(school_change.reload).not_to be_handled
+      end
+    end
+
+    context "when a school status code changes from proposed to open to open" do
+      let!(:school_change) { create(:staged_school_change, :opening, school: staged_school) }
+
+      context "when the live school does not exist" do
+        it "creates a new school" do
+          expect { service.call }.to change { ::School.count }.by 1
+        end
+
+        it "populates the new school with the staged school attributes" do
+          service.call
+          live_school = ::School.find_by(urn: staged_school.urn)
+          live_attrs = live_school.attributes.except(*excluded_attrs)
+          staged_attrs = staged_school.attributes.except(*excluded_attrs)
+          expect(live_attrs).to eq staged_attrs
+        end
+
+        it "links the new school to the correct local authority and district" do
+          service.call
+          live_school = ::School.find_by(urn: staged_school.urn)
+          expect(live_school.local_authority).to eq local_authority
+          expect(live_school.local_authority_district).to eq local_authority_district
+        end
+      end
+
+      context "when the live school already exists" do
+        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 4, school_status_name: "Proposed to open") }
+
+        it "does not create a new school" do
+          expect { service.call }.not_to change { ::School.count }
+        end
+
+        it "updates the live school attributes from the staged school" do
+          service.call
+          live_attrs = live_school.reload.attributes.except(*excluded_attrs)
+          staged_attrs = staged_school.attributes.except(*excluded_attrs)
+          expect(live_attrs).to eq staged_attrs
+        end
+
+        context "when a predecessor school exists" do
+          let(:predecessor_school) { create(:school, urn: 10_001, name: "Starship Juniors School") }
+          let(:school_cohort) { create(:school_cohort, :fip, school: predecessor_school) }
+          let!(:induction_tutor) { create(:induction_coordinator_profile, schools: [predecessor_school]) }
+          let!(:participants) { create_list(:participant_profile, 2, :ecf, school_cohort: school_cohort) }
+          let!(:partnership) { create(:partnership, school: predecessor_school, cohort: school_cohort.cohort) }
+          let!(:school_link) { create(:staged_school_link, school: staged_school, link_urn: predecessor_school.urn) }
+
+          it "migrates the assets of the predecessor to the live school" do
+            service.call
+            expect(live_school.partnerships).to match_array [partnership]
+            expect(live_school.school_cohorts).to match_array [school_cohort]
+
+            participants.each do |participant|
+              expect(participant.reload.teacher_profile.school).to eq live_school
+            end
+
+            expect(induction_tutor.reload.schools).to match_array [live_school]
+          end
+        end
+      end
+
+      it "marks the change as handled" do
+        service.call
+        expect(school_change.reload).to be_handled
+      end
+    end
+
+    context "when a school status code changes to closed" do
+      let!(:school_change) { create(:staged_school_change, :closing, school: staged_school) }
+
+      context "when the live school does not exist" do
+        it "does not create a new school" do
+          expect { service.call }.not_to change { ::School.count }
+        end
+      end
+
+      context "when the live school already exists" do
+        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 3, school_status_name: "Open, but proposed to close") }
+
+        it "updates the live school attributes from the staged school" do
+          service.call
+          live_attrs = live_school.reload.attributes.except(*excluded_attrs)
+          staged_attrs = staged_school.attributes.except(*excluded_attrs)
+          expect(live_attrs).to eq staged_attrs
+        end
+      end
+
+      it "marks the change as handled" do
+        service.call
+        expect(school_change.reload).to be_handled
+      end
+    end
+  end
+end

--- a/spec/services/data_stage/process_school_changes_spec.rb
+++ b/spec/services/data_stage/process_school_changes_spec.rb
@@ -124,17 +124,6 @@ RSpec.describe DataStage::ProcessSchoolChanges do
         end
       end
 
-      context "when the live school already exists" do
-        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 3, school_status_name: "Open, but proposed to close") }
-
-        it "updates the live school attributes from the staged school" do
-          service.call
-          live_attrs = live_school.reload.attributes.except(*excluded_attrs)
-          staged_attrs = staged_school.attributes.except(*excluded_attrs)
-          expect(live_attrs).to eq staged_attrs
-        end
-      end
-
       context "when a successor school exists" do
         let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 3, school_status_name: "Open, but proposed to close") }
         let(:successor_school) { create(:school, urn: 10_001, name: "Starship Juniors School") }

--- a/spec/services/data_stage/process_school_changes_spec.rb
+++ b/spec/services/data_stage/process_school_changes_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DataStage::ProcessSchoolChanges do
   subject(:service) { described_class }
   let(:local_authority) { create(:local_authority, code: 10) }
   let(:local_authority_district) { create(:local_authority_district, code: "E123") }
-  let!(:staged_school) { create(:staged_school, urn: 20_001, name: "The Starship Children's Centre", la_code: local_authority.code, administrative_district_code: local_authority_district.code) }
+  let!(:staged_school) { create(:staged_school, urn: 20_001, name: "The Starship Children's Centre", la_code: local_authority.code, administrative_district_code: local_authority_district.code, ukprn: "987654321") }
   let(:excluded_attrs) { %w[id created_at updated_at slug network_id domains la_code] }
 
   describe ".call" do
@@ -14,28 +14,59 @@ RSpec.describe DataStage::ProcessSchoolChanges do
       let!(:school_change) { create(:staged_school_change, :with_unhandled_changes, school: staged_school) }
 
       context "when the live school does not exist" do
-        it "does not create the school" do
-          expect { service.call }.not_to change { ::School.count }
+        it "creates the school" do
+          expect { service.call }.to change { ::School.count }.by(1)
+        end
+
+        it "links the new school to the correct local authority and district" do
+          service.call
+          live_school = ::School.find_by(urn: staged_school.urn)
+          expect(live_school.local_authority).to eq local_authority
+          expect(live_school.local_authority_district).to eq local_authority_district
+        end
+
+        it "marks the change as handled" do
+          service.call
+          expect(school_change.reload).to be_handled
         end
       end
 
       context "when the live school already exists" do
-        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 4, school_status_name: "Proposed to open") }
+        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 4, school_status_name: "Proposed to open", ukprn: "12345678") }
 
         it "does not process any of the changes" do
           service.call
           expect(live_school.reload.school_status_code).to eq 4
           expect(live_school.reload.school_status_name).to eq "proposed_to_open"
         end
-      end
 
-      it "does not mark the change and handled" do
-        service.call
-        expect(school_change.reload).not_to be_handled
+        it "does not mark the change as handled" do
+          service.call
+          expect(school_change.reload).not_to be_handled
+        end
+
+        context "when the unhandled attributes are not set" do
+          before do
+            live_school.update!(ukprn: nil)
+            service.call
+            live_school.reload
+          end
+
+          it "syncs the changes to the live school" do
+            expect(live_school.school_status_code).to eq 1
+            expect(live_school.school_status_name).to eq "open"
+            expect(live_school.ukprn).to eq "987654321"
+          end
+
+          it "marks the change as handled" do
+            service.call
+            expect(school_change.reload).to be_handled
+          end
+        end
       end
     end
 
-    context "when a school status code changes from proposed to open to open" do
+    context "when a school status code changes to an open status" do
       let!(:school_change) { create(:staged_school_change, :opening, school: staged_school) }
 
       context "when the live school does not exist" do
@@ -72,27 +103,6 @@ RSpec.describe DataStage::ProcessSchoolChanges do
           staged_attrs = staged_school.attributes.except(*excluded_attrs)
           expect(live_attrs).to eq staged_attrs
         end
-
-        context "when a predecessor school exists" do
-          let(:predecessor_school) { create(:school, urn: 10_001, name: "Starship Juniors School") }
-          let(:school_cohort) { create(:school_cohort, :fip, school: predecessor_school) }
-          let!(:induction_tutor) { create(:induction_coordinator_profile, schools: [predecessor_school]) }
-          let!(:participants) { create_list(:participant_profile, 2, :ecf, school_cohort: school_cohort) }
-          let!(:partnership) { create(:partnership, school: predecessor_school, cohort: school_cohort.cohort) }
-          let!(:school_link) { create(:staged_school_link, school: staged_school, link_urn: predecessor_school.urn) }
-
-          it "migrates the assets of the predecessor to the live school" do
-            service.call
-            expect(live_school.partnerships).to match_array [partnership]
-            expect(live_school.school_cohorts).to match_array [school_cohort]
-
-            participants.each do |participant|
-              expect(participant.reload.teacher_profile.school).to eq live_school
-            end
-
-            expect(induction_tutor.reload.schools).to match_array [live_school]
-          end
-        end
       end
 
       it "marks the change as handled" do
@@ -103,9 +113,13 @@ RSpec.describe DataStage::ProcessSchoolChanges do
 
     context "when a school status code changes to closed" do
       let!(:school_change) { create(:staged_school_change, :closing, school: staged_school) }
+      before do
+        staged_school.update!(school_status_code: 2, school_status_name: "closed")
+      end
 
       context "when the live school does not exist" do
         it "does not create a new school" do
+          expect(staged_school.counterpart).to be_nil
           expect { service.call }.not_to change { ::School.count }
         end
       end
@@ -118,6 +132,38 @@ RSpec.describe DataStage::ProcessSchoolChanges do
           live_attrs = live_school.reload.attributes.except(*excluded_attrs)
           staged_attrs = staged_school.attributes.except(*excluded_attrs)
           expect(live_attrs).to eq staged_attrs
+        end
+      end
+
+      context "when a successor school exists" do
+        let!(:live_school) { create(:school, urn: 20_001, name: "The Starship Children's Centre", school_status_code: 3, school_status_name: "Open, but proposed to close") }
+        let(:successor_school) { create(:school, urn: 10_001, name: "Starship Juniors School") }
+        let!(:staged_successor_school) { create(:staged_school, urn: 10_001, name: "Starship Juniors School", la_code: local_authority.code, administrative_district_code: local_authority_district.code, ukprn: "22334455") }
+        let(:school_cohort) { create(:school_cohort, :fip, school: live_school) }
+        let!(:induction_tutor) { create(:induction_coordinator_profile, schools: [live_school]) }
+        let!(:participants) { create_list(:participant_profile, 2, :ecf, school_cohort: school_cohort) }
+        let!(:partnership) { create(:partnership, school: live_school, cohort: school_cohort.cohort) }
+        let!(:school_link) { create(:staged_school_link, :successor, school: staged_school, link_urn: successor_school.urn) }
+
+        it "migrates the assets of the school to the successor" do
+          service.call
+          successor_school.reload
+          expect(successor_school.partnerships).to match_array [partnership]
+          expect(successor_school.school_cohorts).to match_array [school_cohort]
+
+          participants.each do |participant|
+            expect(participant.reload.teacher_profile.school).to eq successor_school
+          end
+
+          expect(induction_tutor.reload.schools).to match_array [successor_school]
+        end
+
+        it "adds a successor school link" do
+          expect { service.call }.to change { SchoolLink.successor.count }.by(1)
+        end
+
+        it "adds a predecessor school link" do
+          expect { service.call }.to change { SchoolLink.predecessor.count }.by(1)
         end
       end
 

--- a/spec/services/rectify_participant_school_spec.rb
+++ b/spec/services/rectify_participant_school_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe RectifyParticipantSchool do
   let(:participant_profile) { create(:participant_profile, :ect) }
   let(:new_school) { create(:school, name: "Big Shiny School", urn: "123000") }
   let!(:school_cohort) { create(:school_cohort, cohort: participant_profile.school_cohort.cohort, school: new_school) }
+  let(:transfer_uplift) { true }
 
   describe ".call" do
     before do
-      service.call(participant_profile: participant_profile, school: new_school)
+      service.call(participant_profile: participant_profile, school: new_school, transfer_pupil_premium_and_sparsity: transfer_uplift)
       participant_profile.reload
     end
 
@@ -48,6 +49,19 @@ RSpec.describe RectifyParticipantSchool do
 
       it "clears the pupil premium uplift flag on the participant profile" do
         expect(participant_profile).not_to be_pupil_premium_uplift
+      end
+    end
+
+    context "when the transfer_pupil_premium_and_sparsity flag is false" do
+      let(:new_school) { create(:school, :pupil_premium_uplift, :sparsity_uplift, name: "Big Shiny School", urn: "123000") }
+      let(:transfer_uplift) { false }
+
+      it "does not change the pupil premium uplift flag on the participant profile" do
+        expect(participant_profile).not_to be_pupil_premium_uplift
+      end
+
+      it "does not change the sparsity uplift flag on the participant profile" do
+        expect(participant_profile).not_to be_sparsity_uplift
       end
     end
   end

--- a/spec/services/set_school_local_authority_district_spec.rb
+++ b/spec/services/set_school_local_authority_district_spec.rb
@@ -32,28 +32,6 @@ RSpec.describe SetSchoolLocalAuthorityDistrict do
       expect(school_district.local_authority_district).to eq local_authority_district
     end
 
-    it "updates sparsity uplift on the school's ECF participants" do
-      service.call(school: school,
-                   administrative_district_code: administrative_district_code,
-                   start_year: start_year)
-      participants.each do |participant|
-        expect(participant.reload).to be_sparsity_uplift
-      end
-    end
-
-    context "when a partnership exists" do
-      let!(:partnership) { create(:partnership, school: school) }
-
-      it "does not update sparsity uplift on the school's ECF participants" do
-        service.call(school: school,
-                     administrative_district_code: administrative_district_code,
-                     start_year: start_year)
-        participants.each do |participant|
-          expect(participant.reload).not_to be_sparsity_uplift
-        end
-      end
-    end
-
     context "when the local authority district is already linked" do
       before do
         SchoolLocalAuthorityDistrict.create!(school: school,

--- a/spec/services/set_school_local_authority_district_spec.rb
+++ b/spec/services/set_school_local_authority_district_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SetSchoolLocalAuthorityDistrict do
+  subject(:service) { described_class }
+  let(:cohort) { create(:cohort) }
+  let(:school) { create(:school, name: "Big Shiny School", urn: "123000") }
+  let(:school_cohort) { create(:school_cohort, cohort: cohort, school: school) }
+  let!(:participants) { create_list(:participant_profile, 2, :ecf, school_cohort: school_cohort) }
+  let(:administrative_district_code) { "E12345" }
+  let(:start_year) { cohort.start_year }
+  let!(:local_authority_district) { create(:local_authority_district, :sparse, code: administrative_district_code) }
+
+  describe ".call" do
+    it "creates a school local authority district association record" do
+      expect {
+        service.call(school: school,
+                     administrative_district_code: administrative_district_code,
+                     start_year: start_year)
+      }.to change { SchoolLocalAuthorityDistrict.count }.by(1)
+    end
+
+    it "creates an association starting from the start_year" do
+      service.call(school: school,
+                   administrative_district_code: administrative_district_code,
+                   start_year: start_year)
+
+      school_district = school.reload.school_local_authority_districts.latest.first
+      expect(school_district.start_year).to eq start_year
+      expect(school_district.end_year).to be_nil
+      expect(school_district.local_authority_district).to eq local_authority_district
+    end
+
+    it "updates sparsity uplift on the school's ECF participants" do
+      service.call(school: school,
+                   administrative_district_code: administrative_district_code,
+                   start_year: start_year)
+      participants.each do |participant|
+        expect(participant.reload).to be_sparsity_uplift
+      end
+    end
+
+    context "when a partnership exists" do
+      let!(:partnership) { create(:partnership, school: school) }
+
+      it "does not update sparsity uplift on the school's ECF participants" do
+        service.call(school: school,
+                     administrative_district_code: administrative_district_code,
+                     start_year: start_year)
+        participants.each do |participant|
+          expect(participant.reload).not_to be_sparsity_uplift
+        end
+      end
+    end
+
+    context "when the local authority district is already linked" do
+      before do
+        SchoolLocalAuthorityDistrict.create!(school: school,
+                                             local_authority_district: local_authority_district,
+                                             start_year: 2020)
+      end
+
+      it "does not add a new association record" do
+        expect {
+          service.call(school: school,
+                       administrative_district_code: administrative_district_code,
+                       start_year: start_year)
+        }.not_to change { SchoolLocalAuthorityDistrict.count }
+      end
+
+      it "does not set the end year on the existing association" do
+        service.call(school: school,
+                     administrative_district_code: administrative_district_code,
+                     start_year: start_year)
+        expect(school.reload.school_local_authority_districts.latest.first.end_year).to be_nil
+      end
+    end
+
+    context "when a school local authority record exists" do
+      let(:old_la_district) { create(:local_authority_district, code: "E321") }
+
+      before do
+        SchoolLocalAuthorityDistrict.create!(school: school, local_authority_district: old_la_district, start_year: 2020)
+      end
+
+      it "sets the end year of the existing record to the start_year param" do
+        old_school_la_district = school.school_local_authority_districts.latest.first
+        service.call(school: school,
+                     administrative_district_code: administrative_district_code,
+                     start_year: start_year)
+        expect(old_school_la_district.reload.end_year).to eq start_year
+      end
+    end
+
+    context "when no matching local authority district exists" do
+      let(:bad_la_district_code) { "E345" }
+
+      it "raises an exception" do
+        expect {
+          service.call(school: school, administrative_district_code: bad_la_district_code, start_year: start_year)
+        }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Local authority district must exist")
+      end
+    end
+  end
+end

--- a/spec/services/set_school_local_authority_spec.rb
+++ b/spec/services/set_school_local_authority_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SetSchoolLocalAuthority do
+  subject(:service) { described_class }
+  let(:school) { create(:school, name: "Big Shiny School", urn: "123000") }
+  let(:la_code) { "123" }
+  let(:start_year) { Time.zone.now.year }
+  let!(:local_authority) { create(:local_authority, code: la_code) }
+
+  describe ".call" do
+    it "creates a school local authority association record" do
+      expect {
+        service.call(school: school, la_code: la_code, start_year: start_year)
+      }.to change { SchoolLocalAuthority.count }.by(1)
+    end
+
+    it "creates an association starting from the start_year" do
+      service.call(school: school, la_code: la_code, start_year: start_year)
+      school.reload
+      expect(school.latest_school_authority.start_year).to eq start_year
+      expect(school.latest_school_authority.end_year).to be_nil
+      expect(school.latest_school_authority.local_authority).to eq local_authority
+    end
+
+    it "updates pupil premium uplift on ECF participants" do
+    end
+
+    context "when the local authority is already linked" do
+      before do
+        SchoolLocalAuthority.create!(school: school, local_authority: local_authority, start_year: 2020)
+      end
+
+      it "does not add a new association record" do
+        expect {
+          service.call(school: school, la_code: la_code, start_year: start_year)
+        }.not_to change { SchoolLocalAuthority.count }
+      end
+
+      it "does not set the end year on the existing association" do
+        service.call(school: school, la_code: la_code, start_year: start_year)
+        expect(school.reload.latest_school_authority.end_year).to be_nil
+      end
+    end
+
+    context "when a school local authority record exists" do
+      let(:old_local_authority) { create(:local_authority, code: "321") }
+
+      before do
+        SchoolLocalAuthority.create!(school: school, local_authority: old_local_authority, start_year: 2020)
+      end
+
+      it "sets the end year of the existing record to the start_year param" do
+        old_school_local_authority = school.latest_school_authority
+        service.call(school: school, la_code: la_code, start_year: start_year)
+        expect(old_school_local_authority.reload.end_year).to eq start_year
+      end
+    end
+
+    context "when no matching local authority exists" do
+      let(:bad_la_code) { "345" }
+
+      it "raises an exception" do
+        expect {
+          service.call(school: school, la_code: bad_la_code, start_year: start_year)
+        }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Local authority must exist")
+      end
+    end
+  end
+end

--- a/spec/services/set_school_local_authority_spec.rb
+++ b/spec/services/set_school_local_authority_spec.rb
@@ -24,9 +24,6 @@ RSpec.describe SetSchoolLocalAuthority do
       expect(school.latest_school_authority.local_authority).to eq local_authority
     end
 
-    it "updates pupil premium uplift on ECF participants" do
-    end
-
     context "when the local authority is already linked" do
       before do
         SchoolLocalAuthority.create!(school: school, local_authority: local_authority, start_year: 2020)


### PR DESCRIPTION
## Ticket and context

Automatically process the more straight-forward major changes to school data received from GIAS.

__Note:__ I've not added this to the `ImportGiasDataJob` as yet as I want to run it manually initially.

This will process `DataStage::SchoolChange` records created during the GIAS data import process.
It will attempt to handle school status changes (opening and closing) and migrate data to the successor school if present.  It does not attempt to handle more complex splits and merges that potentially need more interaction or communication with the schools.
When migrating a school it will add successor and predecessor links similar to the `DataStage::SchoolLink` links imported from GIAS so we can track what has happened. These are not currently surfaced in the UI.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
