### PR TITLE
BUGFIX: Fix scope query to handle where no eligibility record exists

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -17,7 +17,7 @@ class ParticipantProfile::ECF < ParticipantProfile
                                        .or(joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible, reason: :previous_participation }))
   }
   scope :contacted_for_info, -> { where.missing(:ecf_participant_validation_data) }
-  scope :details_being_checked, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :manual_check }) }
+  scope :details_being_checked, -> { joins(:ecf_participant_validation_data).left_joins(:ecf_participant_eligibility).where("ecf_participant_eligibilities.id IS NULL OR ecf_participant_eligibilities.status = 'manual_check'") }
 
   def completed_validation_wizard?
     ecf_participant_eligibility.present? || ecf_participant_validation_data.present?

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -81,4 +81,19 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       end
     end
   end
+
+  describe "details_being_checked" do
+    let!(:validation_data) { create(:ecf_participant_validation_data, participant_profile: profile) }
+    context "when the details have not been matched" do
+      it "returns the profile" do
+        expect(ParticipantProfile::ECF.details_being_checked).to match_array([profile])
+      end
+    end
+    context "when the eligibility is manual check" do
+      let!(:eligibility) { create(:ecf_participant_eligibility, :manual_check, participant_profile: profile) }
+      it "returns the profile" do
+        expect(ParticipantProfile::ECF.details_being_checked).to match_array([profile])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Ticket and context

Fix issue where if a participant is unmatched (we couldn't find their details during validation so did not create a `ECFParticipantEligibility` record) they disappear from the participants view for the SIT.  A support admin has a different view and can see the participant.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
