### PR TITLE
CPDLP-508 Add schema validation which logs results

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -11,6 +11,9 @@ module Api
 
       def create
         params = HashWithIndifferentAccess.new({ cpd_lead_provider: cpd_lead_provider }).merge(permitted_params["attributes"] || {})
+
+        log_schema_validation_results
+
         render json: RecordParticipantDeclaration.call(params)
       end
 
@@ -74,6 +77,19 @@ module Api
         else
           raise
         end
+      end
+
+      def log_schema_validation_results
+        errors = SchemaValidator.call(raw_event: request.raw_post)
+
+        if errors.blank?
+          Rails.logger.info "Passed schema validation"
+        else
+          Rails.logger.info "Failed schema validation for #{request.raw_post}"
+          Rails.logger.info errors
+        end
+      rescue StandardError => e
+        Rails.logger.info "Error on schema validation, #{e}"
       end
     end
   end

--- a/app/services/schema_validator.rb
+++ b/app/services/schema_validator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "json_schema/validation"
+
+class SchemaValidator
+  CACHED_SCHEMAS = JSON.parse(File.read(Rails.root.join("swagger/v1/api_spec.json")))["components"]["schemas"]
+
+  attr_accessor :raw_event
+
+  class << self
+    def call(raw_event:)
+      new(raw_event: raw_event).call
+    end
+  end
+
+  def call
+    validate_schema!
+  end
+
+private
+
+  def initialize(raw_event:)
+    @raw_event = raw_event
+  end
+
+  def schema
+    # TODO: need to pull in correct schema depending on request
+    hash = YAML.safe_load(File.read(Rails.root.join("swagger/v1/component_schemas/ParticipantDeclaration.yml")))
+
+    hash["components"] = {}
+    hash["components"]["schemas"] = {}
+    hash["components"]["schemas"] = CACHED_SCHEMAS
+
+    hash
+  end
+
+  def validate_schema!
+    JSON::Validator.fully_validate(schema, raw_event)
+  end
+end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1589,6 +1589,7 @@
       "ECFParticipantRetainedDeclaration": {
         "description": "An ECF retained participant declaration",
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "participant_id": {
             "description": "The unique id of the participant",
@@ -1651,6 +1652,7 @@
       "ECFParticipantStartedDeclaration": {
         "description": "An ECF started and completed participant declaration",
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "participant_id": {
             "description": "The unique id of the participant",
@@ -2478,6 +2480,7 @@
       "NPQParticipantRetainedDeclaration": {
         "description": "An NPQ retained participant declaration",
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "participant_id": {
             "description": "The unique id of the participant",
@@ -2541,6 +2544,7 @@
       "NPQParticipantStartedDeclaration": {
         "description": "An NPQ started and completed participant declaration",
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "participant_id": {
             "description": "The unique id of the participant",

--- a/swagger/v1/component_schemas/ECFParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/ECFParticipantRetainedDeclaration.yml
@@ -1,5 +1,6 @@
 description: "An ECF retained participant declaration"
 type: object
+additionalProperties: false
 properties:
   participant_id:
     description: "The unique id of the participant"

--- a/swagger/v1/component_schemas/ECFParticipantStartedDeclaration.yml
+++ b/swagger/v1/component_schemas/ECFParticipantStartedDeclaration.yml
@@ -1,5 +1,6 @@
 description: "An ECF started and completed participant declaration"
 type: object
+additionalProperties: false
 properties:
   participant_id:
     description: "The unique id of the participant"

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -1,5 +1,6 @@
 description: "An NPQ retained participant declaration"
 type: object
+additionalProperties: false
 properties:
   participant_id:
     description: "The unique id of the participant"

--- a/swagger/v1/component_schemas/NPQParticipantStartedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantStartedDeclaration.yml
@@ -1,5 +1,6 @@
 description: "An NPQ started and completed participant declaration"
 type: object
+additionalProperties: false
 properties:
   participant_id:
     description: "The unique id of the participant"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-508

- This reintroduces schema validations for one particular set of endpoints, participant declarations
- From conversations I have had there is hesitance to make failing schema validations prevent api calls from being made 
- Therefore the outcome of this is to log the data instead
- From the logging we should be able to determine the ratio of api calls between passing and failing schema validation
- Also if something did fail validation, what that payload looks like and why it failed. this way we can either fix our end or ask api users to change their calls to conform
- The previous version of the schema validation used handcrafted json schemas to validate against. This change uses the swagger open api 3.0.1 spec which is close to being a json schema. My understanding is we may need to use open api 3.1 in order to have a fully valid json schema. But from my testing it seems to be working

## Future changes

- Analysis of logs to determine failure/success rate to leading changes to api and/or informing api users to change
- Change these validations checks into a blocking calls and return errors to client
- Remove handcrafted json schemas and associated code

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

- Changes have been made in this area but there is nothing that directly impacts api users that needs to be documented