### PR TITLE
Convenience scopes

### DIFF
--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -5,6 +5,15 @@ class DeliveryPartner < DiscardableRecord
   has_many :lead_providers, through: :provider_relationships
   has_many :partnership_csv_uploads
 
+  has_many :partnerships
+  has_many :active_partnerships, -> { active }, class_name: "Partnership"
+  has_many :schools, through: :active_partnerships
+
+  has_many :ecf_participant_profiles, through: :schools, class_name: "ParticipantProfile"
+  has_many :ecf_participants, through: :ecf_participant_profiles, source: :user
+  has_many :active_ecf_participant_profiles, through: :schools
+  has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user
+
   has_paper_trail
 
   after_discard do

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -16,6 +16,7 @@ class ParticipantProfile::ECF < ParticipantProfile
     joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :eligible })
                                        .or(joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible, reason: :previous_participation }))
   }
+  scope :current_cohort, -> { joins(:school_cohort).where(school_cohort: { cohort_id: Cohort.current.id }) }
   scope :contacted_for_info, -> { where.missing(:ecf_participant_validation_data) }
   scope :details_being_checked, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :manual_check }) }
 

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -5,6 +5,22 @@ require "rails_helper"
 RSpec.describe ParticipantProfile::ECF, type: :model do
   let(:profile) { create(:participant_profile, :ecf) }
 
+  describe ":current_cohort" do
+    let!(:cohort_2020) { create(:cohort, start_year: 2020) }
+    let!(:current_cohort) { create(:cohort, :current) }
+    let!(:participant_2020) { create(:participant_profile, :ecf, school_cohort: create(:school_cohort, cohort: cohort_2020)) }
+    let!(:current_participant) { create(:participant_profile, :ecf, school_cohort: create(:school_cohort, cohort: current_cohort)) }
+
+    it "does not include 2020 participants" do
+      expect(ParticipantProfile::ECF.current_cohort).not_to include(participant_2020)
+    end
+
+    it "includes participants from the current cohort" do
+      expect(ParticipantProfile::ECF.current_cohort).to include(current_participant)
+      expect(ParticipantProfile::ECF.current_cohort.count).to eql 1
+    end
+  end
+
   describe "completed_validation_wizard?" do
     context "before any details have been entered" do
       it "returns false" do


### PR DESCRIPTION
Add a few scopes to models. current_cohort to make it easier to get the participant profiles we want (excluding NQT+1), and some to get the participants associated with a delivery partner
