### PR TITLE
Fix broken link to authentication info in api docs

### DIFF
--- a/docs/source/index.html.erb
+++ b/docs/source/index.html.erb
@@ -27,7 +27,7 @@ weight: 1
 
 <p class="govuk-body-m">Each token is associated with a single provider. It will grant access to participants for courses offered by that provider. You can get a token by writing to <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-link">continuing-professional-development@digital.education.gov.uk</a></p>
 
-<p class="govuk-body-m">For instructions on how to authenticate see the <a href="/api-reference/reference#authentication" class="govuk-link">API reference</a>.</p>
+<p class="govuk-body-m">For instructions on how to authenticate see the <a href="/api-reference/developing-on-the-api.html#authentication" class="govuk-link">API reference</a>.</p>
 
 <h3 class="govuk-heading-m" id="versioning">Versioning</h3>
 <p class="govuk-body-m">The version of the API is specified in the URL <code>/api/v{n}/</code>. For example: <code>/api/v1/</code>, <code>/api/v2/</code>, <code>/api/v3/</code>, ...</p>


### PR DESCRIPTION
I was just reading through to test another ticket and the first link on how to auth with the api was broken.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
