### PR TITLE
Ignore pundit errors in sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -35,4 +35,8 @@ Sentry.init do |config|
       0.0 # We don't care about performance of other things
     end
   end
+
+  config.excluded_exceptions = Sentry::Configuration::IGNORE_DEFAULT + [
+    "Pundit::NotAuthorizedError",
+  ]
 end


### PR DESCRIPTION
We have this line in application.rb
```
config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
```
Which renders a 403 error page when a pundit error is unhandled. However we are still getting errors reported in sentry https://sentry.io/organizations/dfe-bat/issues/2734501640/?project=5748989&query=is%3Aunresolved

This is because the sentry middleware catches the error (and re-raises it) before action dispatch does in the middleware stack. Just ignore this exception in sentry as we know it is being handled.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
