### PR TITLE
Remove evidence held from NPQ declaration docs

### DIFF
--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -2516,14 +2516,6 @@
               "npq-additional-support-offer"
             ],
             "example": "npq-headship"
-          },
-          "evidence_held": {
-            "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
-            "type": "string",
-            "enum": [
-              "yes"
-            ],
-            "example": "yes"
           }
         },
         "required": [

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -2522,15 +2522,13 @@
           "participant_id",
           "declaration_type",
           "declaration_date",
-          "course_identifier",
-          "evidence_held"
+          "course_identifier"
         ],
         "example": {
           "participant_id": "db3a7848-7308-4879-942a-c4a70ced400a",
           "declaration_type": "retained-1",
           "declaration_date": "2021-05-31T02:21:32.000Z",
-          "course_identifier": "npq-headship",
-          "evidence_held": "yes"
+          "course_identifier": "npq-headship"
         }
       },
       "NPQParticipantStartedDeclaration": {

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -36,10 +36,8 @@ required:
   - declaration_type
   - declaration_date
   - course_identifier
-  - evidence_held
 example:
   participant_id: db3a7848-7308-4879-942a-c4a70ced400a
   declaration_type: retained-1
   declaration_date: "2021-05-31T02:21:32.000Z"
   course_identifier: npq-headship
-  evidence_held: "yes"

--- a/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
+++ b/swagger/v1/component_schemas/NPQParticipantRetainedDeclaration.yml
@@ -31,12 +31,6 @@ properties:
       - npq-executive-leadership
       - npq-additional-support-offer
     example: npq-headship
-  evidence_held:
-    description: "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period"
-    type: string
-    enum:
-      - "yes"
-    example: "yes"
 required:
   - participant_id
   - declaration_type


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?assignee=5e4e50b03df51b0c9374c1e4&selectedIssue=CPDLP-555

- Update docs to remove `evidence_help` from NPQ declarations endpoint
- This is so it correctly reflects the state of the API

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- https://ecf-review-pr-1399.london.cloudapps.digital/api-reference/reference.html#schema-npqparticipantretaineddeclaration
- Should no longer reference `evidence_held` as client no longer needs to provide it

## External API changes

- No api changes but documentation has been updated to correctly reflect the state of the API