### PR TITLE
Fix login sentry error

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -74,7 +74,7 @@ private
   end
 
   def login_token_expired?
-    Time.zone.now > @user.login_token_valid_until
+    @user.login_token_valid_until.blank? || Time.zone.now > @user.login_token_valid_until
   end
 
   def mock_login

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -165,6 +165,19 @@ RSpec.describe "Users::Sessions", type: :request do
       end
     end
 
+    context "when no token is provided" do
+      before do
+        user.update!(login_token_valid_until: nil)
+        user.update!(login_token: nil)
+      end
+
+      it "redirects to link invalid" do
+        get "/users/confirm_sign_in"
+
+        expect(response).to redirect_to "/users/link-invalid"
+      end
+    end
+
     context "when already signed in" do
       before { sign_in user }
 


### PR DESCRIPTION
Some people are hitting the /confirm-sign-in page directly and it is causing a 500 error
https://sentry.io/organizations/dfe-bat/issues/2735066106/?project=5748989&query=is%3Aunresolved
Presumably through a bookmark or browser autocomplete

This is because it finds one of the many users with no login token, and checks their (nil) token expiry. To solve this, just treat the user as if their token is expired if one isn't provided - redirect them to the link-invalid page to sign in again.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
