### PR TITLE
CPDLP-561 API doc improvements

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
@@ -18,22 +18,22 @@
         <tr>
           <td><%= property[0] %></td>
           <td><%= property[1].type %></td>
-          <td><%= property[1].required.present? %></td>
+          <td><%= schema.requires?(property[0]) %></td>
           <td>
             <%= markdown(property[1].description) %>
 
             <%=
-              schema = property[1]
+              nested_schema = property[1]
               # If property is an array, check the items property for a reference.
               if property[1].type == 'array'
-                schema = property[1]['items']
+                nested_schema = property[1]['items']
               end
-              schema_location = schema.node_context.source_location.to_s
+              schema_location = nested_schema.node_context.source_location.to_s
               # Only print a link if it's a referenced schema.
               if !schema_location.include?('/properties/')
-                "It conforms to #{get_schema_link(schema)} schema."
+                "It conforms to #{get_schema_link(nested_schema)} schema."
               elsif schema_location.end_with?("data")
-                "It conforms to #{get_schema_link_data(schema)} schema."
+                "It conforms to #{get_schema_link_data(nested_schema)} schema."
               end
             %>
 

--- a/docs/source/api-reference/stylesheets/screen.css.scss
+++ b/docs/source/api-reference/stylesheets/screen.css.scss
@@ -7,3 +7,11 @@
 .technical-documentation pre code {
   font-size: 14px;
 }
+
+@include govuk-media-query(desktop) {
+  .flexbox {
+    .app-pane__toc {
+      width: 400px;
+    }
+  }
+}


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?assignee=5e4e50b03df51b0c9374c1e4&selectedIssue=CPDLP-561

- The first trivial change is widening the sidenav so schema names and endpoints fit over one line in desktop view
- The second change is the fixing of the `required` for schema which was being incorrectly populated. A required field would end showing as `false` despite the swagger docs saying otherwise
- Although now obvious it may not seem it this is due to re-assignment of the variable `schema` which has profound consequences when `binding` with `erb` is also involved.

## Screenshots

![Screenshot 2021-11-08 at 16 33 22](https://user-images.githubusercontent.com/92580/140781111-b606881a-12a1-4c6e-9085-d354fb2d5007.png)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Compare with prod
- https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/reference.html#schema-ecfparticipantstarteddeclaration
- https://ecf-review-pr-1411.london.cloudapps.digital/api-reference/reference.html#schema-ecfparticipantstarteddeclaration
- Prod marks required fields as `false`, fixed in review app where they are marked as `true`

## External API changes

- There are no changes to the API itself