### PR TITLE
Enforce TRN requirement on participant validation service

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -55,6 +55,8 @@ private
   end
 
   def matching_record(trn:, nino:, full_name:, dob:)
+    return if trn.blank?
+
     padded_trn = trn.rjust(7, "0")
     dqt_record = dqt_record(padded_trn, nino)
     return if dqt_record.nil?

--- a/lib/full_dqt/client.rb
+++ b/lib/full_dqt/client.rb
@@ -11,7 +11,7 @@ module FullDqt
     end
 
     def get_record(trn:, birthdate:, nino: nil)
-      uri_for_record = uri(trn: padded_trn(trn), birthdate: birthdate, nino: nino)
+      uri_for_record = uri(trn: trn, birthdate: birthdate, nino: nino)
 
       request = Net::HTTP::Get.new(uri_for_record)
       request["Authorization"] = "Bearer #{token}"
@@ -27,10 +27,6 @@ module FullDqt
     end
 
   private
-
-    def padded_trn(trn)
-      trn.rjust(7, "0")
-    end
 
     def translate_hash(hash)
       hash.deep_transform_values do |value|

--- a/spec/lib/full_dqt/client_spec.rb
+++ b/spec/lib/full_dqt/client_spec.rb
@@ -165,18 +165,5 @@ RSpec.describe FullDqt::Client do
         expect(record["trn"]).to eql(trn)
       end
     end
-
-    context "trn is less than 7 characters" do
-      let(:trn) { "0001000" }
-      let(:short_trn) { "001000" }
-
-      it "pads the trn with zeros on the left" do
-        stub_api_request
-
-        record = subject.get_record(trn: short_trn, birthdate: birthdate)
-
-        expect(record["trn"]).to eql(trn)
-      end
-    end
   end
 end

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe ParticipantValidationService do
       ParticipantValidationService.validate(trn: trn, nino: nino, full_name: full_name, date_of_birth: dob)
     end
 
+    context "when no trn is provided" do
+      let(:trn) { nil }
+
+      it "returns nil" do
+        expect(validation_result).to be_nil
+      end
+    end
+
     context "given that it calls the API" do
       before do
         expect_any_instance_of(FullDqt::Client).to receive(:get_record).and_return(*dqt_records)


### PR DESCRIPTION
## Ticket and context

- Don't raise an [ambiguous](https://sentry.io/organizations/dfe-bat/issues/2699607064/?environment=production&project=5748989&query=is%3Aunresolved) exception if the TRN provided is nil.
- Remove duplicated padding method from DQT client. We already do this further up the chain.

If the review thinks it would be useful I'd be happy to report log when we receive nil TRNs. I don't think a nil TRN warrants an exception in this instance because it's expected.