### PR TITLE
CPDLP-660 api docs can handle oneOf schemas

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -22,6 +22,7 @@ module GovukTechDocs
         @template_request_body = get_renderer("request_body.html.erb")
         @template_responses = get_renderer("responses.html.erb")
         @template_any_of = get_renderer("any_of.html.erb")
+        @template_one_of = get_renderer("one_of.html.erb")
         @template_curl_examples = get_renderer("curl_examples.html.erb")
       end
 
@@ -52,10 +53,12 @@ module GovukTechDocs
         properties = properties_for_schema(schema)
 
         if schema["anyOf"]
-          return @template_any_of.result(binding)
+          @template_any_of.result(binding)
+        elsif schema["oneOf"]
+          @template_one_of.result(binding)
+        else
+          @template_schema.result(binding)
         end
-
-        @template_schema.result(binding)
       end
 
       def schemas_from_path(text)
@@ -212,7 +215,7 @@ module GovukTechDocs
       end
 
       def get_schema_link(schema)
-        schema_name = get_schema_name schema.node_context.source_location.to_s
+        schema_name = get_schema_name(schema.node_context.source_location.to_s)
         unless schema_name.nil?
           id = "schema-#{schema_name.parameterize}"
           "<a href='\##{id}'>#{schema_name}</a>"

--- a/docs/lib/govuk_tech_docs/open_api/templates/one_of.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/one_of.html.erb
@@ -1,0 +1,11 @@
+<h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
+
+<p>
+  This schema must conform to one of the following schemas:
+</p>
+
+<ul>
+  <% schema["oneOf"].each do |schema| %>
+    <li><%= get_schema_link(schema) %></li>
+  <% end %>
+</ul>


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-660

- Prior to this change api docs could not handle `oneOf` schemas
- When displaying the referenced schemas it would be blank
- These are now populated and when clicked takes user to referenced schema

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

- https://ecf-review-pr-1426.london.cloudapps.digital/api-reference/reference.html#schema-participantdeclarationchoices
- This is a `oneOf` schema
- it should now correctly list and link of to referenced schemas

### How can someone see it it review app?

## External API changes

- there are no external api changes