### PR TITLE
Changes to admins creating NQT+1s

### DIFF
--- a/app/controllers/admin/schools/cohort_2020_controller.rb
+++ b/app/controllers/admin/schools/cohort_2020_controller.rb
@@ -25,7 +25,12 @@ module Admin
         render :new and return unless @user.valid?
 
         if @user.early_career_teacher?
-          @user.errors.add(:base, "A user with this email address is currently participating as an ECT at school with urn #{@user.teacher_profile.current_ecf_profile.school.urn}")
+          if (ect_profile = @user.teacher_profile.current_ecf_profile)
+            @user.errors.add(:base, I18n.t(:admin_nqt_1_email_used_ect, urn: ect_profile.school.urn))
+          else
+            nqt_profile = @user.teacher_profile.early_career_teacher_profile
+            @user.errors.add(:base, I18n.t(:admin_nqt_1_email_used_nqt, urn: nqt_profile.school.urn))
+          end
           render :new and return
         end
 

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -10,7 +10,7 @@ module EarlyCareerTeachers
         user = User.find_or_create_by!(email: email) do |ect|
           ect.full_name = full_name
         end
-        user.update!(full_name: full_name) unless user.teacher_profile&.participant_profiles&.active_record&.any?
+        user.update!(full_name: full_name) unless user.participant_profiles&.active_record&.any? || user.npq_registered?
 
         teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
           profile.school = school_cohort.school

--- a/app/views/admin/schools/cohort2020/new.html.erb
+++ b/app/views/admin/schools/cohort2020/new.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Enter NQT+1 details</h1>
-    <%= form_with(model: @user, url: admin_school_cohort2020_path) do |f| %>
+    <%= form_with(model: @user, url: admin_school_cohort2020_path, method: :post) do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field(
             :full_name,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,8 @@ en:
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
   declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"
   invalid_data_structure: correct json data structure required. See API docs for reference
+  admin_nqt_1_email_used_ect: "A user with this email address is currently participating as an ECT at school with urn %{urn}"
+  admin_nqt_1_email_used_nqt: "A user with this email address is currently participating as an NQT+1 at school with urn %{urn}"
   estimate_participants_default_message: &default_message "Enter a number between 0 and 1000"
   estimate_participants_defaults: &defaults
     not_a_number: *default_message

--- a/spec/requests/admin/schools/cohort_2020_spec.rb
+++ b/spec/requests/admin/schools/cohort_2020_spec.rb
@@ -199,5 +199,22 @@ RSpec.describe "Admin::Schools::Cohort2020", type: :request do
         expect(User.find_by(email: email).full_name).to eql original_name
       end
     end
+
+    context "when there is an NQT+1 with that email" do
+      let!(:participant_profile) { create(:participant_profile, :ect, school_cohort: build(:school_cohort, cohort: cohort_2020)) }
+      let(:name) { participant_profile.user.full_name }
+      let(:email) { participant_profile.user.email }
+
+      it "shows an error message" do
+        expect(EarlyCareerTeachers::Create).not_to receive(:call)
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: name, email: email },
+        }
+
+        expect(response).to render_template("admin/schools/cohort2020/new")
+        expect(response.body).to include("A user with this email address is currently participating as an NQT+1")
+      end
+    end
   end
 end

--- a/spec/requests/admin/schools/cohort_2020_spec.rb
+++ b/spec/requests/admin/schools/cohort_2020_spec.rb
@@ -60,5 +60,144 @@ RSpec.describe "Admin::Schools::Cohort2020", type: :request do
         user: { full_name: name, email: email },
       }
     end
+
+    context "when there is an active ECT with that email" do
+      let!(:participant_profile) { create(:participant_profile, :ect) }
+      let(:name) { participant_profile.user.full_name }
+      let(:email) { participant_profile.user.email }
+
+      it "shows an error message" do
+        expect(EarlyCareerTeachers::Create).not_to receive(:call)
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: name, email: email },
+        }
+
+        expect(response).to render_template("admin/schools/cohort2020/new")
+        expect(response.body).to include("A user with this email address is currently participating as an ECT")
+      end
+    end
+
+    context "when there is an inactive ECT with that email" do
+      let!(:participant_profile) { create(:participant_profile, :ect, :withdrawn_record) }
+      let(:name) { participant_profile.user.full_name }
+      let(:email) { participant_profile.user.email }
+
+      it "adds an NQT+1 profile to the user" do
+        expect(EarlyCareerTeachers::Create).to receive(:call).with({
+          full_name: name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+          year_2020: true,
+        }).and_call_original
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: name, email: email },
+        }
+
+        expect(User.find_by(email: email).participant_profiles.count).to eql 2
+      end
+
+      it "changes the name on the user" do
+        other_name = "Other Name"
+
+        expect(EarlyCareerTeachers::Create).to receive(:call).with({
+          full_name: other_name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+          year_2020: true,
+        }).and_call_original
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: other_name, email: email },
+        }
+
+        expect(User.find_by(email: email).full_name).to eql other_name
+      end
+    end
+
+    context "when there is an active mentor with that email" do
+      let!(:participant_profile) { create(:participant_profile, :mentor) }
+      let(:name) { participant_profile.user.full_name }
+      let(:email) { participant_profile.user.email }
+
+      it "adds an NQT+1 profile to the user" do
+        expect(EarlyCareerTeachers::Create).to receive(:call).with({
+          full_name: name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+          year_2020: true,
+        }).and_call_original
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: name, email: email },
+        }
+
+        expect(User.find_by(email: email).participant_profiles.count).to eql 2
+      end
+
+      it "does not change the name on the user" do
+        original_name = name
+        other_name = "Other name"
+
+        expect(EarlyCareerTeachers::Create).to receive(:call).with({
+          full_name: other_name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+          year_2020: true,
+        }).and_call_original
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: other_name, email: email },
+        }
+
+        expect(User.find_by(email: email).full_name).to eql original_name
+      end
+    end
+
+    context "when there is an npq participant with that email" do
+      let!(:participant_profile) { create(:participant_profile, :npq) }
+      let(:name) { participant_profile.user.full_name }
+      let(:email) { participant_profile.user.email }
+
+      it "adds an NQT+1 profile to the user" do
+        expect(EarlyCareerTeachers::Create).to receive(:call).with({
+          full_name: name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+          year_2020: true,
+        }).and_call_original
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: name, email: email },
+        }
+
+        expect(User.find_by(email: email).participant_profiles.count).to eql 2
+      end
+
+      it "does not change the name on the user" do
+        original_name = name
+        other_name = "Other name"
+
+        expect(EarlyCareerTeachers::Create).to receive(:call).with({
+          full_name: other_name,
+          email: email,
+          school_cohort: school_cohort,
+          mentor_profile_id: nil,
+          year_2020: true,
+        }).and_call_original
+
+        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+          user: { full_name: other_name, email: email },
+        }
+
+        expect(User.find_by(email: email).full_name).to eql original_name
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow them to be creating using emails already in use
 - Not allowed for active ECTs
 - Allowed for other user types
 - Name should not be changed for active participants

