### PR TITLE
Prevent using inactive records returned from dqt

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -59,7 +59,7 @@ private
 
     padded_trn = trn.rjust(7, "0")
     dqt_record = dqt_record(padded_trn, nino)
-    return if dqt_record.nil?
+    return if dqt_record.nil? || dqt_record["state_name"] != "Active"
 
     matches = 0
     trn_matches = padded_trn == dqt_record["trn"]

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe ParticipantValidationService do
     let(:induction_start_date) { Date.parse("2021-07-01T00:00:00Z") }
     let(:induction_completion_date) { Date.parse("2021-07-05T00:00:00Z") }
     let(:induction) { nil }
-    let(:dqt_record) { build_dqt_record(trn: trn, nino: nino, full_name: full_name, dob: dob, alert: alert, qts: qts, induction: induction) }
+    let(:inactive_record) { false }
+    let(:dqt_record) { build_dqt_record(trn: trn, nino: nino, full_name: full_name, dob: dob, alert: alert, qts: qts, induction: induction, inactive: inactive_record) }
     let(:dqt_records) { [dqt_record] }
 
     let(:validation_result) { ParticipantValidationService.validate(trn: trn, nino: nino, full_name: full_name, date_of_birth: dob) }
@@ -55,6 +56,14 @@ RSpec.describe ParticipantValidationService do
 
         it "returns nil" do
           expect(validation_result).to eql nil
+        end
+      end
+
+      context "when an inactive record is returned" do
+        let(:inactive_record) { true }
+
+        it "returns nil" do
+          expect(validation_result).to be_nil
         end
       end
 
@@ -316,15 +325,15 @@ RSpec.describe ParticipantValidationService do
     }.merge(options)
   end
 
-  def build_dqt_record(trn:, nino:, full_name:, dob:, alert:, qts:, induction:)
+  def build_dqt_record(trn:, nino:, full_name:, dob:, alert:, qts:, induction:, inactive: false)
     {
       "trn" => trn,
       "ni_number" => nino,
       "name" => full_name,
       "dob" => dob,
       "active_alert" => alert,
-      "state" => 0,
-      "state_name" => "Active",
+      "state" => (inactive ? 1 : 0),
+      "state_name" => (inactive ? "Inactive" : "Active"),
       "qualified_teacher_status" => qts,
       "induction" => induction,
       "initial_teacher_training" => {


### PR DESCRIPTION
## Ticket and context

It is possible that the DQT API returns "inactive" records and we are not checking for this.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
