### PR TITLE
add rails console command to history

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ COPY --from=assets-precompile /app /app
 COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
 COPY --from=middleman /public/ /app/public/
 
+RUN echo "cd /app && /usr/local/bundle/bin/bundle exec rails c" > /root/.ash_history
+
 WORKDIR /app
 
 # Use this for development testing


### PR DESCRIPTION
## Ticket and context

Ticket: none

- I got bored of copying and pasting the various commands to fire up a rails console
- I've now added the needed command to the history 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- NOTE: I've actually tested this so unfortunately due to my testing it will have affected the history
```sh
cf target -s earlycareers-framework-dev
cf ssh ecf-review-pr-1433
````
- hit up arrow key
- hit enter
- should now be in a rails console

## External API changes

- there are no external api changes