### PR TITLE
CPDRP-1147: Restrict scope to school_cohort for participant categories

### DIFF
--- a/app/services/set_participant_categories.rb
+++ b/app/services/set_participant_categories.rb
@@ -39,7 +39,9 @@ private
   end
 
   def active_participant_profiles
-    ParticipantProfilePolicy::Scope.new(user, ParticipantProfile::ECF.active_record).resolve
+    ParticipantProfilePolicy::Scope.new(user, ParticipantProfile::ECF.active_record)
+      .resolve
+      .where(school_cohort: school_cohort)
   end
 
   def ineligible_participants

--- a/app/services/set_participant_categories.rb
+++ b/app/services/set_participant_categories.rb
@@ -39,9 +39,7 @@ private
   end
 
   def active_participant_profiles
-    ParticipantProfilePolicy::Scope.new(user, ParticipantProfile::ECF.active_record)
-      .resolve
-      .where(school_cohort: school_cohort)
+    ParticipantProfilePolicy::Scope.new(user, school_cohort.active_ecf_participant_profiles).resolve
   end
 
   def ineligible_participants


### PR DESCRIPTION
## Ticket and context

[Ticket:](https://dfedigital.atlassian.net/browse/CPDRP-1147)

MAT SIT reported that recently the participant list for any of her schools show _all_ the participants from _all_ of her schools, including NQT+1s.

## Tech review

I have added a where clause to the `SetParticipantCategories#active_participant_profiles` to limit the scope to the selected school cohort

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
