### PR TITLE
BUGFIX: ensure withdrawn profiles are always shown as such in API

### DIFF
--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -14,11 +14,11 @@ module Api
       def index
         respond_to do |format|
           format.json do
-            participant_hash = ParticipantSerializer.new(paginate(participants)).serializable_hash
+            participant_hash = ParticipantSerializer.new(paginate(participants), { params: { mentor_ids: mentor_ids } }).serializable_hash
             render json: participant_hash.to_json
           end
           format.csv do
-            participant_hash = ParticipantSerializer.new(participants).serializable_hash
+            participant_hash = ParticipantSerializer.new(participants, { params: { mentor_ids: mentor_ids } }).serializable_hash
             render body: to_csv(participant_hash)
           end
         end
@@ -28,7 +28,7 @@ module Api
 
       def serialized_response(profile)
         ParticipantSerializer
-          .new(profile.user)
+          .new(profile)
           .serializable_hash.to_json
       end
 
@@ -41,19 +41,41 @@ module Api
       end
 
       def participants
-        participants = lead_provider.ecf_participants
-                                    .distinct
-                                    .includes(
-                                      teacher_profile: {
-                                        current_ecf_profile: %i[cohort school ecf_participant_eligibility ecf_participant_validation_data participant_profile_state participant_profile_states schedule],
-                                        early_career_teacher_profile: :mentor,
-                                      },
-                                    )
-                                    .where(school_cohorts: { cohort_id: Cohort.current.id })
+        participant_profiles = ParticipantProfile::ECF.where(id: participant_profile_ids)
+                                                      .joins(:user)
+                                                      .includes(
+                                                        :user,
+                                                        :cohort,
+                                                        :school,
+                                                        :ecf_participant_eligibility,
+                                                        :ecf_participant_validation_data,
+                                                        :schedule,
+                                                        teacher_profile: { current_ect_profile: { mentor_profile: :user } },
+                                                      )
 
-        participants = participants.changed_since(updated_since) if updated_since.present?
+        if updated_since.present?
+          participant_profiles = participant_profiles.where(user: { updated_at: updated_since.. })
+                                                     .order("\"user\".updated_at, \"user\".id")
+        end
 
-        participants.order(:created_at)
+        participant_profiles.order("\"user\".created_at")
+      end
+
+      def participant_profile_ids
+        @participant_profile_ids ||= lead_provider.ecf_participant_profiles
+                                                  .select("DISTINCT ON (participant_profiles.teacher_profile_id) teacher_profile_id, participant_profiles.status, participant_profiles.id")
+                                                  .joins(:school_cohort)
+                                                  .where(school_cohort: { cohort_id: Cohort.current.id })
+                                                  .order(:teacher_profile_id, status: :asc)
+                                                  .map(&:id)
+      end
+
+      def mentor_ids
+        # I can't figure out a way to preload the mentor IDs with the other data here, since that would include two copies of the
+        # users table, and active_record picks the wrong one. This horrible hack is to keep the number of db queries sane by
+        # constructing a hash from profile ID to mentor ID in a single query
+        ect_profiles = ParticipantProfile::ECT.where(id: participant_profile_ids).includes(:mentor)
+        ect_profiles.map { |profile| [profile.id, profile.mentor&.id] }.to_h
       end
     end
   end

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       def serialized_response(profile)
         ParticipantSerializer
-          .new(profile.user)
+          .new(profile)
           .serializable_hash.to_json
       end
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -8,7 +8,7 @@ class LeadProvider < ApplicationRecord
   has_many :active_partnerships, -> { active }, class_name: "Partnership"
   has_many :schools, through: :active_partnerships
 
-  has_many :ecf_participant_profiles, through: :schools, class_name: "ParticipantProfile"
+  has_many :ecf_participant_profiles, through: :schools, class_name: "ParticipantProfile::ECF"
   has_many :ecf_participants, through: :ecf_participant_profiles, source: :user
   has_many :active_ecf_participant_profiles, through: :schools
   has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user

--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -9,6 +9,7 @@ class TeacherProfile < ApplicationRecord
 
   # TODO: Legacy associations, to be removed
   has_one :early_career_teacher_profile, -> { active_record }, class_name: "ParticipantProfile::ECT"
+  has_one :current_ect_profile, -> { active_record.includes(:school_cohort).where(school_cohort: { cohort: Cohort.current }) }, class_name: "ParticipantProfile::ECT"
   has_one :mentor_profile, -> { active_record }, class_name: "ParticipantProfile::Mentor"
 
   has_many :ecf_profiles, -> { active_record.includes(school_cohort: :cohort).joins(school_cohort: :cohort).order("cohort.start_year DESC") }, class_name: "ParticipantProfile::ECF"

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -8,94 +8,89 @@ class ParticipantSerializer
 
   class << self
     def active_participant_attribute(attr, &blk)
-      attribute attr do |user|
-        blk.call(user) if participant_active?(user)
+      attribute attr do |profile, params|
+        if profile.active_record?
+          if blk.parameters.count == 1
+            blk.call(profile)
+          else
+            blk.call(profile, params)
+          end
+        end
       end
     end
 
-    def participant_active?(user)
-      user.teacher_profile.current_ecf_profile&.active_record?
+    def trn(profile)
+      profile.teacher_profile.trn || profile.ecf_participant_validation_data&.trn
     end
 
-    def trn(user)
-      user.teacher_profile.trn || user.teacher_profile.current_ecf_profile.ecf_participant_validation_data&.trn
-    end
-
-    def validated_trn(user)
-      eligibility = user.teacher_profile.current_ecf_profile.ecf_participant_eligibility
+    def validated_trn(profile)
+      eligibility = profile.ecf_participant_eligibility
       eligibility.present? && !eligibility.different_trn_reason?
     end
 
-    def eligible_for_funding?(user)
-      ecf_participant_eligibility = user.teacher_profile.current_ecf_profile.ecf_participant_eligibility
+    def eligible_for_funding?(profile)
+      ecf_participant_eligibility = profile.ecf_participant_eligibility
       return if ecf_participant_eligibility.nil?
       return true if ecf_participant_eligibility.eligible_status?
       return false if ecf_participant_eligibility.ineligible_status?
     end
   end
 
-  set_id :id
-  active_participant_attribute :email, &:email
-
-  active_participant_attribute :full_name, &:full_name
-
-  active_participant_attribute :mentor_id do |user|
-    user.teacher_profile.early_career_teacher_profile&.mentor&.id
+  set_id :id do |profile|
+    profile.user.id
   end
 
-  active_participant_attribute :school_urn do |user|
-    user.teacher_profile.current_ecf_profile&.school&.urn
+  active_participant_attribute :email do |profile|
+    profile.user.email
   end
 
-  active_participant_attribute :participant_type do |user|
-    case user.teacher_profile.current_ecf_profile.type
-    when ParticipantProfile::ECT.name
-      :ect
-    when ParticipantProfile::Mentor.name
-      :mentor
+  active_participant_attribute :full_name do |profile|
+    profile.user.full_name
+  end
+
+  active_participant_attribute :mentor_id do |profile, params|
+    if params[:mentor_ids].present?
+      params[:mentor_ids][profile.id]
+    elsif profile.ect?
+      profile.mentor&.id
     end
   end
 
-  active_participant_attribute :cohort do |user|
-    user.teacher_profile.current_ecf_profile.cohort.start_year.to_s
+  active_participant_attribute :school_urn do |profile|
+    profile.school.urn
   end
 
-  attribute :status do |user|
-    user.teacher_profile.current_ecf_profile&.status || "withdrawn"
+  active_participant_attribute :participant_type, &:participant_type
+
+  active_participant_attribute :cohort do |profile|
+    profile.cohort.start_year.to_s
   end
 
-  active_participant_attribute :teacher_reference_number do |user|
-    trn(user)
+  attribute :status, &:status
+
+  active_participant_attribute :teacher_reference_number do |profile|
+    trn(profile)
   end
 
-  active_participant_attribute :teacher_reference_number_validated do |user|
-    trn(user).nil? ? nil : validated_trn(user).present?
+  active_participant_attribute :teacher_reference_number_validated do |profile|
+    trn(profile).nil? ? nil : validated_trn(profile).present?
   end
 
-  active_participant_attribute :eligible_for_funding do |user|
-    # TODO: we want to check eligibility without communicating it yet - except for sandbox
-    if Rails.env.sandbox? || FeatureFlag.active?(:eligibility_in_api)
-      eligible_for_funding?(user)
-    end
+  active_participant_attribute :eligible_for_funding do |profile|
+    eligible_for_funding?(profile)
   end
 
-  active_participant_attribute :pupil_premium_uplift do |user|
-    user.teacher_profile.current_ecf_profile&.pupil_premium_uplift
+  active_participant_attribute :pupil_premium_uplift, &:pupil_premium_uplift
+
+  active_participant_attribute :sparsity_uplift, &:sparsity_uplift
+
+  active_participant_attribute :training_status, &:training_status
+
+  active_participant_attribute :schedule_identifier do |profile|
+    profile.schedule&.schedule_identifier
   end
 
-  active_participant_attribute :sparsity_uplift do |user|
-    user.teacher_profile.current_ecf_profile&.sparsity_uplift
-  end
-
-  active_participant_attribute :training_status do |user|
-    user.teacher_profile.current_ecf_profile&.training_status || "active"
-  end
-
-  active_participant_attribute :schedule_identifier do |user|
-    user.teacher_profile.current_ecf_profile&.schedule&.schedule_identifier
-  end
-
-  attribute :updated_at do |user|
-    user.updated_at.rfc3339
+  attribute :updated_at do |profile|
+    profile.user.updated_at.rfc3339
   end
 end

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -188,6 +188,24 @@ RSpec.describe "Participants API", type: :request do
             end
           end
         end
+        context "when the participant is withdrawn with this lead provider but has another active profile not associated with the provider" do
+          let!(:active_profile_with_other_provider) { create(:participant_profile, :ect, teacher_profile: withdrawn_ect_profile_record.teacher_profile) }
+
+          it "shows the participant as withdrawn" do
+            get "/api/v1/participants/ecf"
+            matching_records = parsed_response["data"].select { |record| record["id"] == active_profile_with_other_provider.user.id }
+            expect(matching_records.size).to eql 1
+            expect(matching_records.first["attributes"]["status"]).to eql "withdrawn"
+          end
+
+          it "does not include personal information of the participant" do
+            get "/api/v1/participants/ecf"
+            matching_records = parsed_response["data"].select { |record| record["id"] == active_profile_with_other_provider.user.id }
+            expect(matching_records.first["attributes"]["full_name"]).to be_nil
+            expect(matching_records.first["attributes"]["email"]).to be_nil
+            expect(matching_records.first["attributes"]["teacher_reference_number"]).to be_nil
+          end
+        end
       end
 
       describe "CSV Index API" do

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -223,10 +223,10 @@ RSpec.describe "Participants API", type: :request do
           expect(ect_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(ect_row["teacher_reference_number"]).to eql ect.teacher_profile.trn
           expect(ect_row["teacher_reference_number_validated"]).to eql "false"
-          expect(mentor_row["eligible_for_funding"]).to be_empty
-          expect(mentor_row["pupil_premium_uplift"]).to eql "false"
-          expect(mentor_row["sparsity_uplift"]).to eql "false"
-          expect(mentor_row["training_status"]).to eql "active"
+          expect(ect_row["eligible_for_funding"]).to be_empty
+          expect(ect_row["pupil_premium_uplift"]).to eql "false"
+          expect(ect_row["sparsity_uplift"]).to eql "false"
+          expect(ect_row["training_status"]).to eql "active"
 
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe ParticipantSerializer do
       end
 
       it "outputs correctly formatted serialized Mentors" do
-        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":\"ecf-september-standard-2021\",\"updated_at\":\"#{mentor.updated_at.rfc3339}\"}}}"
-        expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
+        expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{mentor.email}\",\"full_name\":\"#{mentor.full_name}\",\"mentor_id\":null,\"school_urn\":\"#{mentor.mentor_profile.school.urn}\",\"participant_type\":\"mentor\",\"cohort\":\"#{mentor_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{mentor.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":\"ecf-september-standard-2021\",\"updated_at\":\"#{mentor.updated_at.rfc3339}\"}}}"
+        expect(ParticipantSerializer.new(mentor_profile).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
-        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":null,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":\"ecf-september-standard-2021\",\"updated_at\":\"#{ect.updated_at.rfc3339}\"}}}"
-        expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
+        expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":\"#{ect.email}\",\"full_name\":\"#{ect.full_name}\",\"mentor_id\":\"#{mentor.id}\",\"school_urn\":\"#{ect.early_career_teacher_profile.school.urn}\",\"participant_type\":\"ect\",\"cohort\":\"#{ect_cohort.start_year}\",\"status\":\"active\",\"teacher_reference_number\":\"#{ect.teacher_profile.trn}\",\"teacher_reference_number_validated\":true,\"eligible_for_funding\":true,\"pupil_premium_uplift\":false,\"sparsity_uplift\":false,\"training_status\":\"active\",\"schedule_identifier\":\"ecf-september-standard-2021\",\"updated_at\":\"#{ect.updated_at.rfc3339}\"}}}"
+        expect(ParticipantSerializer.new(ect_profile).serializable_hash.to_json).to eq expected_json_string
       end
     end
 
     context "when the participant record is withdrawn" do
-      let(:mentor) { create(:participant_profile, :mentor, :withdrawn_record).user }
-      let(:ect) { create(:participant_profile, :ect, :withdrawn_record, mentor_profile: mentor.mentor_profile).user }
+      let(:mentor_profile) { create(:participant_profile, :mentor, :withdrawn_record) }
+      let(:ect_profile) { create(:participant_profile, :ect, :withdrawn_record, mentor_profile: mentor.mentor_profile) }
 
       it "outputs correctly formatted serialized Mentors" do
         expected_json_string = "{\"data\":{\"id\":\"#{mentor.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"training_status\":null,\"schedule_identifier\":null,\"updated_at\":\"#{mentor.updated_at.rfc3339}\"}}}"
-        expect(ParticipantSerializer.new(mentor).serializable_hash.to_json).to eq expected_json_string
+        expect(ParticipantSerializer.new(mentor_profile).serializable_hash.to_json).to eq expected_json_string
       end
 
       it "outputs correctly formatted serialized ECTs" do
         expected_json_string = "{\"data\":{\"id\":\"#{ect.id}\",\"type\":\"participant\",\"attributes\":{\"email\":null,\"full_name\":null,\"mentor_id\":null,\"school_urn\":null,\"participant_type\":null,\"cohort\":null,\"status\":\"withdrawn\",\"teacher_reference_number\":null,\"teacher_reference_number_validated\":null,\"eligible_for_funding\":null,\"pupil_premium_uplift\":null,\"sparsity_uplift\":null,\"training_status\":null,\"schedule_identifier\":null,\"updated_at\":\"#{ect.updated_at.rfc3339}\"}}}"
-        expect(ParticipantSerializer.new(ect).serializable_hash.to_json).to eq expected_json_string
+        expect(ParticipantSerializer.new(ect_profile).serializable_hash.to_json).to eq expected_json_string
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe ParticipantSerializer do
         it "returns nil" do
           expect(ect_profile.ecf_participant_eligibility).to be_nil
 
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
         end
       end
@@ -62,7 +62,7 @@ RSpec.describe ParticipantSerializer do
         it "returns nil" do
           expect(ect_profile.ecf_participant_eligibility.status).to eql "manual_check"
 
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe ParticipantSerializer do
         it "returns nil" do
           expect(ect_profile.ecf_participant_eligibility.status).to eql "matched"
 
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
         end
       end
@@ -87,20 +87,11 @@ RSpec.describe ParticipantSerializer do
           eligibility.eligible_status!
         end
 
-        it "returns nil" do
+        it "returns true" do
           expect(ect_profile.ecf_participant_eligibility.status).to eql "eligible"
 
-          result = ParticipantSerializer.new(ect).serializable_hash
-          expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
-        end
-
-        context "when the feature flag is active", with_feature_flags: { eligibility_in_api: "active" } do
-          it "returns true" do
-            expect(ect_profile.ecf_participant_eligibility.status).to eql "eligible"
-
-            result = ParticipantSerializer.new(ect).serializable_hash
-            expect(result[:data][:attributes][:eligible_for_funding]).to be true
-          end
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
+          expect(result[:data][:attributes][:eligible_for_funding]).to be true
         end
       end
 
@@ -110,20 +101,11 @@ RSpec.describe ParticipantSerializer do
           eligibility.ineligible_status!
         end
 
-        it "returns nil" do
+        it "returns false" do
           expect(ect_profile.ecf_participant_eligibility.status).to eql "ineligible"
 
-          result = ParticipantSerializer.new(ect).serializable_hash
-          expect(result[:data][:attributes][:eligible_for_funding]).to be_nil
-        end
-
-        context "when the feature flag is active", with_feature_flags: { eligibility_in_api: "active" } do
-          it "returns false" do
-            expect(ect_profile.ecf_participant_eligibility.status).to eql "ineligible"
-
-            result = ParticipantSerializer.new(ect).serializable_hash
-            expect(result[:data][:attributes][:eligible_for_funding]).to be false
-          end
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
+          expect(result[:data][:attributes][:eligible_for_funding]).to be false
         end
       end
     end
@@ -131,7 +113,7 @@ RSpec.describe ParticipantSerializer do
     describe "teacher_reference_number" do
       context "when there is a trn on the teacher profile" do
         it "returns the correct TRN" do
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:teacher_reference_number]).to eql ect_profile.teacher_profile.trn
         end
       end
@@ -143,7 +125,7 @@ RSpec.describe ParticipantSerializer do
         let!(:validation_data) { create(:ecf_participant_validation_data, participant_profile: ect_profile) }
 
         it "returns the correct TRN" do
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:teacher_reference_number]).to eql validation_data.trn
         end
       end
@@ -154,7 +136,7 @@ RSpec.describe ParticipantSerializer do
         end
 
         it "returns nil" do
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:teacher_reference_number]).to be_nil
         end
       end
@@ -169,7 +151,7 @@ RSpec.describe ParticipantSerializer do
           end
 
           it "returns true" do
-            result = ParticipantSerializer.new(ect).serializable_hash
+            result = ParticipantSerializer.new(ect_profile).serializable_hash
             expect(result[:data][:attributes][:teacher_reference_number_validated]).to be true
           end
         end
@@ -181,7 +163,7 @@ RSpec.describe ParticipantSerializer do
           end
 
           it "returns true" do
-            result = ParticipantSerializer.new(ect).serializable_hash
+            result = ParticipantSerializer.new(ect_profile).serializable_hash
             expect(result[:data][:attributes][:teacher_reference_number_validated]).to be true
           end
         end
@@ -193,7 +175,7 @@ RSpec.describe ParticipantSerializer do
           end
 
           it "returns true" do
-            result = ParticipantSerializer.new(ect).serializable_hash
+            result = ParticipantSerializer.new(ect_profile).serializable_hash
             expect(result[:data][:attributes][:teacher_reference_number_validated]).to be true
           end
         end
@@ -205,14 +187,14 @@ RSpec.describe ParticipantSerializer do
           end
 
           it "returns false" do
-            result = ParticipantSerializer.new(ect).serializable_hash
+            result = ParticipantSerializer.new(ect_profile).serializable_hash
             expect(result[:data][:attributes][:teacher_reference_number_validated]).to be false
           end
         end
 
         context "when the participant has not started validation" do
           it "returns false" do
-            result = ParticipantSerializer.new(ect).serializable_hash
+            result = ParticipantSerializer.new(ect_profile).serializable_hash
             expect(result[:data][:attributes][:teacher_reference_number_validated]).to be false
           end
         end
@@ -225,7 +207,7 @@ RSpec.describe ParticipantSerializer do
         end
 
         it "returns false" do
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:teacher_reference_number_validated]).to be false
         end
       end
@@ -236,14 +218,14 @@ RSpec.describe ParticipantSerializer do
         end
 
         it "returns nil" do
-          result = ParticipantSerializer.new(ect).serializable_hash
+          result = ParticipantSerializer.new(ect_profile).serializable_hash
           expect(result[:data][:attributes][:teacher_reference_number_validated]).to be_nil
         end
       end
     end
 
     describe "pupil_premium_uplift" do
-      let(:result) { ParticipantSerializer.new(ect).serializable_hash }
+      let(:result) { ParticipantSerializer.new(ect_profile).serializable_hash }
 
       context "when participant belongs to a school" do
         context "eligible pupil premium uplift" do


### PR DESCRIPTION
Ensure that when a participant has an active profile not associated with the calling provider, the API response displays the correct withdrawn profile