### PR TITLE
Remove unused school cohort code

### DIFF
--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -35,34 +35,12 @@ class SchoolCohort < ApplicationRecord
     end
   end
 
-  def training_provider_status
-    school.partnerships&.active&.exists?(cohort: cohort) ? "Done" : "To do"
-  end
-
   def lead_provider
     school.lead_provider(cohort.start_year)
   end
 
   def delivery_partner
     school.delivery_partner_for(cohort.start_year)
-  end
-
-  def add_participants_status
-    "To do"
-  end
-
-  def choose_training_materials_status
-    core_induction_programme_id ? "Done" : "To do"
-  end
-
-  def status
-    if core_induction_programme?
-      cip_status
-    elsif full_induction_programme?
-      fip_status
-    elsif not_yet_known?
-      "To do"
-    end
   end
 
   def school_chose_cip?
@@ -81,23 +59,5 @@ class SchoolCohort < ApplicationRecord
 
   def can_change_programme?
     induction_programme_choice.in? %w[design_our_own no_early_career_teachers school_funded_fip]
-  end
-
-private
-
-  def cip_status
-    if choose_training_materials_status == "Done" && add_participants_status == "Done"
-      "Done"
-    else
-      "To do"
-    end
-  end
-
-  def fip_status
-    if training_provider_status == "Done" && add_participants_status == "Done"
-      "Done"
-    else
-      "To do"
-    end
   end
 end

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -45,11 +45,6 @@ RSpec.describe SchoolCohort, type: :model do
     ).backed_by_column_of_type(:string)
   }
 
-  it { is_expected.to respond_to(:training_provider_status) }
-  it { is_expected.to respond_to(:add_participants_status) }
-  it { is_expected.to respond_to(:choose_training_materials_status) }
-  it { is_expected.to respond_to(:status) }
-
   describe ".for_year" do
     let(:school) { create(:school) }
     let(:cohort) { create(:cohort, start_year: 2020) }
@@ -61,79 +56,6 @@ RSpec.describe SchoolCohort, type: :model do
 
     it "returns the school cohort for the given year" do
       expect(school.school_cohorts.for_year(2020).first).to eq school_cohort
-    end
-  end
-
-  describe "#status" do
-    context "when core induction programme is selected" do
-      subject(:school_cohort) { create(:school_cohort, induction_programme_choice: "core_induction_programme") }
-      it "returns the result of #cip_status" do
-        expect(school_cohort.status).to eq school_cohort.send(:cip_status)
-      end
-    end
-
-    context "when full induction programme is selected" do
-      subject(:school_cohort) { create(:school_cohort, induction_programme_choice: "full_induction_programme") }
-      it "returns the result of #fip_status" do
-        expect(school_cohort.status).to eq school_cohort.send(:fip_status)
-      end
-    end
-
-    context "when a choice hasn't been made" do
-      subject(:school_cohort) { create(:school_cohort, induction_programme_choice: "not_yet_known") }
-      it "returns 'To do'" do
-        expect(school_cohort.status).to eq "To do"
-      end
-    end
-
-    context "when design our own programme is selected" do
-      subject(:school_cohort) { create(:school_cohort, induction_programme_choice: "design_our_own") }
-      it "returns nil" do
-        expect(school_cohort.status).to be_nil
-      end
-    end
-
-    context "when no early career teachers is selected" do
-      subject(:school_cohort) { create(:school_cohort, induction_programme_choice: "no_early_career_teachers") }
-      it "returns nil" do
-        expect(school_cohort.status).to be_nil
-      end
-    end
-  end
-
-  describe "#training_provider_status" do
-    subject(:school_cohort) { create(:school_cohort) }
-
-    it "returns 'To do' by default" do
-      expect(subject.training_provider_status).to eq "To do"
-    end
-
-    context "when school is in a partnership" do
-      let(:lead_provider) { create(:lead_provider) }
-      let(:delivery_partner) { create(:delivery_partner) }
-
-      before do
-        Partnership.create!(
-          cohort: school_cohort.cohort,
-          lead_provider: lead_provider,
-          school: school_cohort.school,
-          delivery_partner: delivery_partner,
-        )
-      end
-
-      it "returns 'Done' by default" do
-        expect(subject.training_provider_status).to eq "Done"
-      end
-
-      context "when the partnership has been challenged" do
-        before do
-          Partnership.find_by(school: school_cohort.school).update!(challenged_at: Time.zone.now, challenge_reason: "mistake")
-        end
-
-        it "returns 'To do'" do
-          expect(subject.training_provider_status).to eq "To do"
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Status was used in the old UI only

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
