### PR TITLE
CPDLP-672 Prevent voiding certain declarations

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -64,12 +64,17 @@ class ParticipantDeclaration < ApplicationRecord
   scope :paid_npqs_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).npq }
   scope :paid_uplift_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).uplift }
 
+  # TODO: Voiding paid should trigger clawbacks, but currently OOS
+  def voidable?
+    !voided? && !payable? && !paid?
+  end
+
   def make_submitted!
     DeclarationState.submitted!(self) if eligible?
   end
 
   def make_voided!
-    DeclarationState.voided!(self) unless voided? || payable? || paid? # TODO: Voiding paid should trigger clawbacks, but currently OOS
+    DeclarationState.voided!(self) if voidable?
   end
 
   def make_eligible!

--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -3,22 +3,30 @@
 class VoidParticipantDeclaration
   attr_accessor :cpd_lead_provider, :id
 
+  def initialize(cpd_lead_provider:, id:)
+    @cpd_lead_provider = cpd_lead_provider
+    @id = id
+  end
+
   def call
-    declaration = ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(id)
-
+    # TODO: these should be moved to activemodel validations
+    # and not controller level exceptions
     raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_already_voided) if declaration.voided?
-
-    latest_declaration = declaration.participant_profile.participant_declarations.order(declaration_date: :desc).first
     raise Api::Errors::InvalidTransitionError, I18n.t(:void_last_declaration_only) if latest_declaration != declaration
+    raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_not_voidable) unless declaration.voidable?
 
-    declaration.voided!
+    declaration.make_voided!
+
     ParticipantDeclarationSerializer.new(declaration).serializable_hash.to_json
   end
 
 private
 
-  def initialize(cpd_lead_provider:, id:)
-    @cpd_lead_provider = cpd_lead_provider
-    @id = id
+  def declaration
+    @declaration ||= ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(id)
+  end
+
+  def latest_declaration
+    @latest_declaration ||= declaration.participant_profile.participant_declarations.order(declaration_date: :desc).first
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
   withdrawn_participant: Cannot perform actions on a withdrawn participant
   declaration_on_incorrect_state: "The declaration on withdrawn or deferred participant can not be accepted"
   declaration_already_voided: "Declaration is already voided"
+  declaration_not_voidable: "Declaration not voidable"
   void_last_declaration_only: "Can only void last declaration"
   schedule_missing: "The participant does not have a schedule"
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
   let(:bearer_token) { "Bearer #{token}" }
 
-  describe "post" do
+  describe "POST /api/v1/participant-declarations" do
     let(:valid_params) do
       {
         participant_id: ect_profile.user.id,
@@ -414,7 +414,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
     end
   end
 
-  describe "#void" do
+  describe "PUT /api/v1/participant-declarations/:id/void" do
     before do
       default_headers[:Authorization] = bearer_token
       default_headers[:CONTENT_TYPE] = "application/json"
@@ -444,7 +444,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         }.not_to change { declaration.reload.state }
       end
 
-      it "returns a 400" do
+      it "returns a 422" do
         put "/api/v1/participant-declarations/#{declaration.id}/void"
         expect(response.status).to eql(422)
       end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
   include_context "lead provider profiles and courses"
   let(:parsed_response) { JSON.parse(response.body) }
 
-  describe "post" do
-    let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
-    let(:bearer_token) { "Bearer #{token}" }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+  let(:bearer_token) { "Bearer #{token}" }
 
+  describe "post" do
     let(:valid_params) do
       {
         participant_id: ect_profile.user.id,
@@ -411,6 +411,43 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
     it "ignores pagination parameters" do
       get "/api/v1/participant-declarations.csv", params: { page: { per_page: 1, page: 1 } }
       expect(parsed_response.length).to eql 2
+    end
+  end
+
+  describe "#void" do
+    before do
+      default_headers[:Authorization] = bearer_token
+      default_headers[:CONTENT_TYPE] = "application/json"
+    end
+
+    context "when declaration is submitted" do
+      let(:declaration) { create(:ect_participant_declaration, cpd_lead_provider: cpd_lead_provider) }
+
+      it "can be voided" do
+        expect {
+          put "/api/v1/participant-declarations/#{declaration.id}/void"
+        }.to change { declaration.reload.state }.from("submitted").to("voided")
+      end
+
+      it "returns a 200" do
+        put "/api/v1/participant-declarations/#{declaration.id}/void"
+        expect(response.status).to eql(200)
+      end
+    end
+
+    context "when declaration is payable" do
+      let(:declaration) { create(:ect_participant_declaration, :payable, cpd_lead_provider: cpd_lead_provider) }
+
+      it "cannot be voided" do
+        expect {
+          put "/api/v1/participant-declarations/#{declaration.id}/void"
+        }.not_to change { declaration.reload.state }
+      end
+
+      it "returns a 400" do
+        put "/api/v1/participant-declarations/#{declaration.id}/void"
+        expect(response.status).to eql(422)
+      end
     end
   end
 


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-672

- At API level prevent voided, payable and paid declarations from being voidable
- I have followed the crowd for the way the error is raised. However i feel raising exceptions for validation messages is not the way forward

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- still somewhat difficult given current state of dummy data

## External API changes

- Minor impact on API. I don't think it needs documenting at this moment in time