### PR TITLE
CPDRP-1083: Add means to flag duplicate mentor profiles

### DIFF
--- a/app/components/participant_status_tag_component.rb
+++ b/app/components/participant_status_tag_component.rb
@@ -23,7 +23,7 @@ private
     return { text: "Not eligible: NQT+1", colour: "red" } if nqt_plus_one? && ineligible?
     return { text: "Not eligible: No QTS", colour: "red" } if participant_has_no_qts? && ineligible?
     return { text: "Eligible to start: ERO", colour: "green" } if ineligible? && mentor_was_in_early_rollout? && on_fip?
-    return { text: "Eligible to start", colour: "green" } if ineligible? && mentor_was_in_early_rollout?
+    return { text: "Eligible to start", colour: "green" } if ineligible? && (mentor_was_in_early_rollout? || mentor_with_duplicate_profile?)
     return { text: "Not eligible", colour: "red" } if ineligible?
     return { text: "Contacted for information", colour: "grey" } if latest_email&.delivered?
     return { text: "Check email address", colour: "grey" } if latest_email&.failed?
@@ -48,7 +48,13 @@ private
   def mentor_was_in_early_rollout?
     return unless profile.mentor?
 
-    profile.ecf_participant_eligibility.previous_participation_reason?
+    profile.ecf_participant_eligibility&.previous_participation_reason?
+  end
+
+  def mentor_with_duplicate_profile?
+    return unless profile.mentor?
+
+    profile.ecf_participant_eligibility&.duplicate_profile_reason?
   end
 
   def on_fip?

--- a/app/models/ecf_participant_eligibility.rb
+++ b/app/models/ecf_participant_eligibility.rb
@@ -19,8 +19,13 @@ class ECFParticipantEligibility < ApplicationRecord
     previous_induction: "previous_induction",
     no_qts: "no_qts",
     different_trn: "different_trn",
+    duplicate_profile: "duplicate_profile",
     none: "none",
   }, _suffix: true
+
+  def duplicate_profile?
+    participant_profile&.mentor? && participant_profile&.secondary_profile?
+  end
 
   def determine_status
     unless manually_validated?
@@ -34,6 +39,8 @@ class ECFParticipantEligibility < ApplicationRecord
                                    %i[manual_check no_qts]
                                  elsif different_trn?
                                    %i[manual_check different_trn]
+                                 elsif duplicate_profile?
+                                   %i[ineligible duplicate_profile]
                                  else
                                    %i[eligible none]
                                  end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -20,6 +20,12 @@ class ParticipantProfile::ECF < ParticipantProfile
   scope :contacted_for_info, -> { where.missing(:ecf_participant_validation_data) }
   scope :details_being_checked, -> { joins(:ecf_participant_validation_data).left_joins(:ecf_participant_eligibility).where("ecf_participant_eligibilities.id IS NULL OR ecf_participant_eligibilities.status = 'manual_check'") }
 
+  enum profile_duplicity: {
+    single: "single",
+    primary: "primary",
+    secondary: "secondary",
+  }, _suffix: "profile"
+
   def completed_validation_wizard?
     ecf_participant_eligibility.present? || ecf_participant_validation_data.present?
   end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -11,10 +11,10 @@ class ParticipantProfile::ECF < ParticipantProfile
   has_one :ecf_participant_eligibility, foreign_key: :participant_profile_id
   has_one :ecf_participant_validation_data, foreign_key: :participant_profile_id
 
-  scope :ineligible_status, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible }) }
+  scope :ineligible_status, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible }).where.not(ecf_participant_eligibility: { reason: :duplicate_profile }) }
   scope :eligible_status, lambda {
     joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :eligible })
-                                       .or(joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible, reason: :previous_participation }))
+                                       .or(joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible, reason: %i[previous_participation duplicate_profile] }))
   }
   scope :current_cohort, -> { joins(:school_cohort).where(school_cohort: { cohort_id: Cohort.current.id }) }
   scope :contacted_for_info, -> { where.missing(:ecf_participant_validation_data) }

--- a/db/migrate/20211118153946_add_profile_duplicity_to_participant_profiles.rb
+++ b/db/migrate/20211118153946_add_profile_duplicity_to_participant_profiles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProfileDuplicityToParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_profiles, :profile_duplicity, :string, null: false, default: "single"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_09_123940) do
+ActiveRecord::Schema.define(version: 2021_11_18_153946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -576,6 +576,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_123940) do
     t.text "school_ukprn"
     t.datetime "request_for_details_sent_at"
     t.string "training_status", default: "active", null: false
+    t.string "profile_duplicity", default: "single", null: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
 
     schedule
     teacher_profile
+    profile_duplicity { :single }
 
     transient do
       participant_type {}
@@ -92,6 +93,14 @@ FactoryBot.define do
       after(:create) do |profile, _evaluator|
         create :email, associated_with: profile, status: "permanent-failure", tags: [:request_for_details]
       end
+    end
+
+    trait :primary_profile do
+      profile_duplicity { :primary }
+    end
+
+    trait :secondary_profile do
+      profile_duplicity { :secondary }
     end
   end
 end

--- a/spec/models/ecf_participant_eligibility_spec.rb
+++ b/spec/models/ecf_participant_eligibility_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ECFParticipantEligibility, type: :model do
       previous_induction: "previous_induction",
       no_qts: "no_qts",
       different_trn: "different_trn",
+      duplicate_profile: "duplicate_profile",
       none: "none",
     ).backed_by_column_of_type(:string).with_suffix
   }

--- a/spec/services/set_participant_categories_spec.rb
+++ b/spec/services/set_participant_categories_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe SetParticipantCategories do
     let!(:primary_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, :primary_profile, school_cohort: school_cohort) }
     let!(:secondary_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, :secondary_profile, school_cohort: school_cohort) }
 
+    before do
+      [primary_mentor, secondary_mentor].each do |profile|
+        profile.ecf_participant_eligibility.determine_status
+        profile.ecf_participant_eligibility.save!
+      end
+    end
+
     context "SIT for multiple schools" do
       let(:school_cohorts) { create_list(:school_cohort, 3, :cip) }
       let(:school_cohort) { school_cohorts.first }

--- a/spec/services/set_participant_categories_spec.rb
+++ b/spec/services/set_participant_categories_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe SetParticipantCategories do
     let!(:contacted_for_info_ect) { create(:participant_profile, :ect, :email_sent, request_for_details_sent_at: 5.days.ago, school_cohort: school_cohort) }
     let!(:ero_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let!(:details_being_checked_ect) { create(:participant_profile, :ect, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let!(:primary_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, :primary_profile, school_cohort: school_cohort) }
+    let!(:secondary_mentor) { create(:participant_profile, :mentor, :ecf_participant_eligibility, :ecf_participant_validation_data, :secondary_profile, school_cohort: school_cohort) }
 
     context "SIT for multiple schools" do
       let(:school_cohorts) { create_list(:school_cohort, 3, :cip) }
@@ -26,7 +28,7 @@ RSpec.describe SetParticipantCategories do
 
       it "only returns participants for the selected school cohort" do
         participant_categories = service.call(school_cohort, induction_coordinator.user)
-        expect(participant_categories.eligible).to match_array [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect, @ects.first]
+        expect(participant_categories.eligible).to match_array [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect, primary_mentor, secondary_mentor, @ects.first]
         expect(participant_categories.eligible).not_to include(@ects[1], @ects[2])
       end
     end
@@ -35,7 +37,7 @@ RSpec.describe SetParticipantCategories do
       let(:school_cohort) { create(:school_cohort, :cip) }
       let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
 
-      let(:cip_eligible_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect] }
+      let(:cip_eligible_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect, primary_mentor, secondary_mentor] }
       let(:cip_ineligible_participants) { [] }
       let(:cip_contacted_for_info_participants) { [contacted_for_info_ect] }
       let(:cip_details_being_checked_participants) { [] }
@@ -71,7 +73,7 @@ RSpec.describe SetParticipantCategories do
       let(:school_cohort) { create(:school_cohort, :fip) }
       let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
 
-      let(:fip_eligible_participants) { [eligible_ect, ero_mentor] }
+      let(:fip_eligible_participants) { [eligible_ect, ero_mentor, primary_mentor, secondary_mentor] }
       let(:fip_ineligible_participants) { [ineligible_mentor] }
       let(:fip_contacted_for_info_participants) { [contacted_for_info_ect] }
       let(:fip_details_being_checked_participants) { [details_being_checked_ect] }
@@ -110,7 +112,7 @@ RSpec.describe SetParticipantCategories do
       let(:fip_eligible_participants) { [] }
       let(:fip_ineligible_participants) { [] }
       let(:fip_contacted_for_info_participants) { [contacted_for_info_ect] }
-      let(:fip_details_being_checked_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect] }
+      let(:fip_details_being_checked_participants) { [eligible_ect, ineligible_mentor, ero_mentor, details_being_checked_ect, primary_mentor, secondary_mentor] }
 
       before do
         FeatureFlag.deactivate(:eligibility_notifications)


### PR DESCRIPTION
## Ticket and context

[Ticket:](https://dfedigital.atlassian.net/browse/CPDRP-1083)

Hack so we can de-duplicate mentor profiles. This provides the means to mark duplicate mentor profiles as ineligible for funding but still appear as eligible for participation

Adds `duplicate_profile` as a `reason` on the `ECFParticipantEligibility` model

Adds `profile_duplicity` as an enum to the `ParticipantProfile::ECF` model. This can be:
* single - when no duplicates
* primary - when primary (eligible for funding) duplicate
* secondary - when (ineligible for funding) duplicate

This should allow us to manually identify and mark the duplicates as a stop gap. We still need to build the duplicate detection during validation and the changes to the success page at the end of validation.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
