### PR TITLE
ECF participants API performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -159,6 +159,11 @@ group :development do
 
   # State machine diagrams - https://github.com/Katee/aasm-diagram
   gem "aasm-diagram"
+
+  # Profiling
+  gem "memory_profiler"
+  gem "rack-mini-profiler"
+  gem "stackprof"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
+    memory_profiler (1.0.0)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
@@ -365,6 +366,8 @@ GEM
     rack (2.2.3)
     rack-attack (6.5.0)
       rack (>= 1.0, < 3)
+    rack-mini-profiler (2.3.3)
+      rack (>= 1.2.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -532,6 +535,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.17)
     strong_migrations (0.7.8)
       activerecord (>= 5)
     terminal-table (3.0.2)
@@ -628,6 +632,7 @@ DEPENDENCIES
   lograge (>= 0.11.2)
   logstash-event
   mail-notify (>= 1.0.3)
+  memory_profiler
   multi_json
   open_api-rswag-api (>= 0.1.0)
   open_api-rswag-specs (>= 0.1.0)
@@ -644,6 +649,7 @@ DEPENDENCIES
   pundit
   pundit-matchers (~> 1.7.0)
   rack-attack (>= 6.5.0)
+  rack-mini-profiler
   rails (~> 6.1.4, >= 6.1.4.1)
   rails-controller-testing (>= 1.0.5)
   ransack
@@ -663,6 +669,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  stackprof
   strong_migrations
   terminal-table
   timecop

--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -74,8 +74,10 @@ module Api
         # I can't figure out a way to preload the mentor IDs with the other data here, since that would include two copies of the
         # users table, and active_record picks the wrong one. This horrible hack is to keep the number of db queries sane by
         # constructing a hash from profile ID to mentor ID in a single query
-        ect_profiles = ParticipantProfile::ECT.where(id: participant_profile_ids).includes(:mentor)
-        ect_profiles.map { |profile| [profile.id, profile.mentor&.id] }.to_h
+        ParticipantProfile::ECT.where(id: participant_profile_ids)
+                               .joins(:mentor)
+                               .pluck(:id, User.arel_table["id"])
+                               .to_h
       end
     end
   end


### PR DESCRIPTION
Rework creation of the mentor_ids hash to eliminate the map

Before and after flamegraphs, viewable with https://www.speedscope.app/
[flamegraphs.zip](https://github.com/DFE-Digital/early-careers-framework/files/7582967/flamegraphs.zip)

I've left the perf tools in, they're probably useful. Happy to remove if wanted though