### PR TITLE
CPDLP-718 invert NPQ leadership and specialist courses

### DIFF
--- a/app/models/npq_course.rb
+++ b/app/models/npq_course.rb
@@ -3,13 +3,13 @@
 class NPQCourse < ApplicationRecord
   has_many :npq_applications
 
-  LEADERSHIP_IDENTIFIER = %w[
+  SPECIALIST_IDENTIFIER = %w[
     npq-leading-teaching
     npq-leading-behaviour-culture
     npq-leading-teaching-development
   ].freeze
 
-  SPECIALIST_IDENTIFIER = %w[
+  LEADERSHIP_IDENTIFIER = %w[
     npq-senior-leadership
     npq-headship
     npq-executive-leadership

--- a/spec/components/admin/participants/details_spec.rb
+++ b/spec/components/admin/participants/details_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
     let(:profile) { npq_application.profile }
 
     before do
-      create(:schedule, :npq_specialist)
+      create(:schedule, :npq_leadership)
       NPQ::Accept.new(npq_application: npq_application).call
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Admin::Participants::Details, type: :view_component do
     let(:profile) { npq_application.profile }
 
     before do
-      create(:schedule, :npq_specialist)
+      create(:schedule, :npq_leadership)
       NPQ::Accept.new(npq_application: npq_application).call
     end
 

--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -45,7 +45,7 @@ FactoryBot.create :participant_profile,
                   school_cohort: another_school_cohort,
                   created_at: Date.parse("29/12/2020")
 
-FactoryBot.create(:schedule, :npq_specialist)
+FactoryBot.create(:schedule, :npq_leadership)
 npq_course = FactoryBot.create(:npq_course, identifier: "npq-senior-leadership")
 npq_user = FactoryBot.create(:user, full_name: "Natalie Portman Quebec", email: "natalie.portman@quebec.ca")
 

--- a/spec/docs/npq_applications_spec.rb
+++ b/spec/docs/npq_applications_spec.rb
@@ -3,7 +3,7 @@
 require "swagger_helper"
 
 describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
-  let!(:default_schedule) { create(:schedule, :npq_specialist) }
+  let!(:default_schedule) { create(:schedule, :npq_leadership) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -29,5 +29,11 @@ FactoryBot.define do
       type { "Finance::Schedule::NPQSpecialist" }
       schedule_identifier { "npq-specialist-november-2021" }
     end
+
+    trait :npq_leadership do
+      name { "NPQ Leadership November 2021" }
+      type { "Finance::Schedule::NPQLeadership" }
+      schedule_identifier { "npq-leadership-november-2021" }
+    end
   end
 end

--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -29,7 +29,7 @@ module ParticipantDeclarationSteps
   end
 
   def given_an_npq_participant_has_been_entered_onto_the_dfe_service
-    create(:schedule, :npq_specialist)
+    create(:schedule, :npq_leadership)
     npq_lead_provider = create(:npq_lead_provider, cpd_lead_provider: @cpd_lead_provider)
     npq_course = create(:npq_course, identifier: "npq-senior-leadership")
     @npq_application = create(:npq_application, npq_lead_provider: npq_lead_provider, npq_course: npq_course)

--- a/spec/lib/importers/npq_manual_validation_spec.rb
+++ b/spec/lib/importers/npq_manual_validation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Importers::NPQManualValidation do
   let(:file) { Tempfile.new("test.csv") }
 
   before do
-    create(:schedule, :npq_specialist)
+    create(:schedule, :npq_leadership)
     NPQ::Accept.new(npq_application: npq_application).call
   end
 

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe "NPQ Applications API", type: :request do
-  let!(:default_schedule) { create(:schedule, :npq_specialist) }
+  let!(:default_schedule) { create(:schedule, :npq_leadership) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }

--- a/spec/serializers/npq_participant_serializer_spec.rb
+++ b/spec/serializers/npq_participant_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NPQParticipantSerializer do
     let(:participant) { create(:user) }
 
     describe "multiple providers" do
-      let!(:schedule) { create(:schedule, :npq_specialist) }
+      let!(:schedule) { create(:schedule, :npq_leadership) }
 
       let(:cpd_provider_one) { create(:cpd_lead_provider) }
       let(:cpd_provider_two) { create(:cpd_lead_provider) }

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe NPQ::Accept do
   before do
-    create(:schedule, :npq_specialist)
+    create(:schedule, :npq_leadership)
   end
 
   subject do
@@ -127,7 +127,7 @@ RSpec.describe NPQ::Accept do
 
         profile = user.teacher_profile.npq_profiles.first
 
-        expect(profile.schedule).to eql(Finance::Schedule::NPQSpecialist.default)
+        expect(profile.schedule).to eql(Finance::Schedule::NPQLeadership.default)
         expect(profile.npq_course).to eql(npq_application.npq_course)
         expect(profile.teacher_profile).to eql(user.teacher_profile)
         expect(profile.user).to eql(user)


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-718

- NPQ courses have been assigned the incorrect groupings and have been inverted
- This fixes it by inverting again
- There will need to be retrospective data changes to ensure NPQ applications/profiles are assigned to the correct schedule

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Find or create an NPQ application
- Accept this application
- Should now be assigned to correct schedule

## External API changes

- There are no external api changes