### PR TITLE
Show schema component examples in API docs

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
@@ -52,3 +52,14 @@
     </tbody>
   </table>
 <% end %>
+
+<% if schema.example.present? && schema.type == "object" %>
+  <h4 id="<%= id = 'schema-' + title + '-example'; id.parameterize %>">Example</h4>
+  <%
+    source = json_prettyprint(schema.example)
+    formatter = Rouge::Formatters::HTML.new
+    lexer = Rouge::Lexers::JSON.new
+    output = formatter.format(lexer.lex(source))
+  %>
+  <pre class="highlight"><code><%= output %></code></pre>
+<% end %>

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1482,7 +1482,8 @@
           "participant_type",
           "cohort",
           "status",
-          "training_status"
+          "training_status",
+          "updated_at"
         ],
         "properties": {
           "id": {
@@ -1582,6 +1583,12 @@
               "deferred",
               "withdrawn"
             ]
+          },
+          "updated_at": {
+            "description": "The date the ECF participant was last updated",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:22:32.000Z"
           }
         }
       },
@@ -1979,7 +1986,8 @@
                   "eligible_for_funding": true,
                   "pupil_premium_uplift": false,
                   "sparsity_uplift": true,
-                  "training_status": "active"
+                  "training_status": "active",
+                  "updated_at": "2021-05-31T02:22:32.000Z"
                 }
               },
               {
@@ -1997,7 +2005,8 @@
                   "eligible_for_funding": null,
                   "pupil_premium_uplift": true,
                   "sparsity_uplift": false,
-                  "training_status": "deferred"
+                  "training_status": "deferred",
+                  "updated_at": "2021-05-31T02:22:32.000Z"
                 }
               },
               {
@@ -2016,7 +2025,8 @@
                   "eligible_for_funding": null,
                   "pupil_premium_uplift": null,
                   "sparsity_uplift": null,
-                  "training_status": "withdrawn"
+                  "training_status": "withdrawn",
+                  "updated_at": "2021-05-31T02:22:32.000Z"
                 }
               }
             ]
@@ -2097,7 +2107,8 @@
                   "npq_courses": [
                     "npq-leading-teaching"
                   ],
-                  "teacher_reference_number": "1234567"
+                  "teacher_reference_number": "1234567",
+                  "updated_at": "2021-05-31T02:21:32.000Z"
                 }
               }
             ]
@@ -2118,7 +2129,7 @@
             }
           }
         },
-        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n"
+        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state,updated_at\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false,2021-05-31T02:22:32.000Z\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false,2021-05-31T02:22:32.000Z\n"
       },
       "MultipleParticipantDeclarationsResponse": {
         "description": "A list of participant declarations",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1245,7 +1245,14 @@
       "BadRequestResponse": {
         "description": "Bad Request",
         "type": "object",
-        "example": "Bad Request",
+        "example": {
+          "errors": [
+            {
+              "title": "Bad request",
+              "detail": "correct json data structure required. See API docs for reference"
+            }
+          ]
+        },
         "properties": {
           "bad_request": {
             "description": "An error message for bad request",
@@ -1452,6 +1459,15 @@
               }
             }
           }
+        },
+        "example": {
+          "data": {
+            "type": "participant-change-schedule",
+            "attributes": {
+              "schedule_identifier": "ecf-january-standard-2021",
+              "course_identifier": "ecf-mentor"
+            }
+          }
         }
       },
       "ECFParticipantCsvRow": {
@@ -1466,8 +1482,7 @@
           "participant_type",
           "cohort",
           "status",
-          "training_status",
-          "updated_at"
+          "training_status"
         ],
         "properties": {
           "id": {
@@ -1567,12 +1582,6 @@
               "deferred",
               "withdrawn"
             ]
-          },
-          "updated_at": {
-            "description": "The date the ECF participant was last updated",
-            "type": "string",
-            "format": "date-time",
-            "example": "2021-05-31T02:22:32.000Z"
           }
         }
       },
@@ -1939,7 +1948,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,updated_at\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false,deferred\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\",withdrawn,2021-05-31T02:22:32.000Z\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,updated_at\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,2021-05-31T02:22:32.000Z\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false,deferred,2021-05-31T02:22:32.000Z\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\",withdrawn\n"
       },
       "MultipleECFParticipantsResponse": {
         "description": "A list of ECF participants",
@@ -1970,8 +1979,7 @@
                   "eligible_for_funding": true,
                   "pupil_premium_uplift": false,
                   "sparsity_uplift": true,
-                  "training_status": "active",
-                  "updated_at": "2021-05-31T02:22:32.000Z"
+                  "training_status": "active"
                 }
               },
               {
@@ -1989,8 +1997,7 @@
                   "eligible_for_funding": null,
                   "pupil_premium_uplift": true,
                   "sparsity_uplift": false,
-                  "training_status": "deferred",
-                  "updated_at": "2021-05-31T02:22:32.000Z"
+                  "training_status": "deferred"
                 }
               },
               {
@@ -2009,8 +2016,7 @@
                   "eligible_for_funding": null,
                   "pupil_premium_uplift": null,
                   "sparsity_uplift": null,
-                  "training_status": "withdrawn",
-                  "updated_at": "2021-05-31T02:22:32.000Z"
+                  "training_status": "withdrawn"
                 }
               }
             ]
@@ -2091,8 +2097,7 @@
                   "npq_courses": [
                     "npq-leading-teaching"
                   ],
-                  "teacher_reference_number": "1234567",
-                  "updated_at": "2021-05-31T02:21:32.000Z"
+                  "teacher_reference_number": "1234567"
                 }
               }
             ]
@@ -2113,7 +2118,7 @@
             }
           }
         },
-        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state,updated_at\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false,2021-05-31T02:22:32.000Z\n"
+        "example": "id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state\nc88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false\n"
       },
       "MultipleParticipantDeclarationsResponse": {
         "description": "A list of participant declarations",

--- a/swagger/v1/component_schemas/BadRequestResponse.yml
+++ b/swagger/v1/component_schemas/BadRequestResponse.yml
@@ -1,6 +1,9 @@
 description: "Bad Request"
 type: object
-example: "Bad Request"
+example:
+  errors:
+    - title: Bad request
+      detail: correct json data structure required. See API docs for reference
 properties:
   bad_request:
     description: "An error message for bad request"

--- a/swagger/v1/component_schemas/ECFParticipantChangeScheduleRequest.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeScheduleRequest.yml
@@ -16,3 +16,9 @@ properties:
         example: participant-change-schedule
       attributes:
         $ref: "#/components/schemas/ECFParticipantChangeSchedule"
+example:
+  data:
+    type: "participant-change-schedule"
+    attributes:
+      schedule_identifier: "ecf-january-standard-2021"
+      course_identifier: "ecf-mentor"

--- a/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
@@ -10,6 +10,7 @@ required:
   - cohort
   - status
   - training_status
+  - updated_at
 properties:
   id:
     description: "The unique identifier of the ECF participant record"
@@ -90,3 +91,8 @@ properties:
       - active
       - deferred
       - withdrawn
+  updated_at:
+    description: "The date the ECF participant was last updated"
+    type: string
+    format: date-time
+    example: "2021-05-31T02:22:32.000Z"

--- a/swagger/v1/component_schemas/MultipleECFParticipantsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleECFParticipantsResponse.yml
@@ -24,6 +24,7 @@ properties:
           pupil_premium_uplift: false
           sparsity_uplift: true
           training_status: active
+          updated_at: "2021-05-31T02:22:32.000Z"
       - id: bb36d74a-68a7-47b6-86b6-1fd0d141c590
         type: participant
         attributes:
@@ -39,6 +40,7 @@ properties:
           pupil_premium_uplift: true
           sparsity_uplift: false
           training_status: deferred
+          updated_at: "2021-05-31T02:22:32.000Z"
       - id: eb475531-bf08-48ae-b0ef-c2ff5e5bdef0
         type: participant
         attributes:
@@ -55,3 +57,4 @@ properties:
           pupil_premium_uplift: null
           sparsity_uplift: null
           training_status: withdrawn
+          updated_at: "2021-05-31T02:22:32.000Z"

--- a/swagger/v1/component_schemas/MultipleNPQParticipantsResponse.yml
+++ b/swagger/v1/component_schemas/MultipleNPQParticipantsResponse.yml
@@ -16,3 +16,4 @@ properties:
           email: "isabelle.macdonald2@some-school.example.com"
           npq_courses: ["npq-leading-teaching"]
           teacher_reference_number: "1234567"
+          updated_at: "2021-05-31T02:21:32.000Z"

--- a/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleParticipantDeclarationsCsvResponse.yml
@@ -8,6 +8,6 @@ properties:
     items:
       $ref: "#/components/schemas/ParticipantDeclarationCsvRow"
 example: |
-  id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state
-  c88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false
-  31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false
+  id,participant_id,declaration_type,course_identifier,eligible_for_payment,declaration_date,voided,state,updated_at
+  c88eb9a9-773a-4f53-9716-121b981154d8,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false,2021-05-31T02:22:32.000Z
+  31a521ec-82c5-451c-aea3-426523f1facc,825f0a27-af62-43cb-8d80-fd1ec7599f62,started,ecf-induction,false,2021-08-26T15:38:52Z,false,2021-05-31T02:22:32.000Z


### PR DESCRIPTION
While looking into a query, I noticed that the API docs didn't include the same examples that the swagger docs did, making it really hard to figure out how to call some endpoints.

I've changes the docs templates to add the examples in where they are JSON. I've also updated a couple of examples. The docs are still inconsistent (and sometimes wrong) in a few places, but this should help