### PR TITLE
[CPDLP-746] Fix swagger descriptions of NPQ endpoints

### DIFF
--- a/spec/support/shared_examples/attribute_lookups.rb
+++ b/spec/support/shared_examples/attribute_lookups.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+TAG_TO_OPERATION_ID = {
+  "NPQ Participant" => :npq_participant,
+  "ECF Participant" => :participant,
+}.freeze
+
+TAG_TO_HUMANISED_DESCRIPTION = {
+  "NPQ Participant" => "NPQ participant",
+  "ECF Participant" => "ECF participant",
+}.freeze

--- a/spec/support/shared_examples/participant_actions_defer_support.rb
+++ b/spec/support/shared_examples/participant_actions_defer_support.rb
@@ -51,9 +51,12 @@ RSpec.shared_examples "JSON Participant Deferral endpoint" do |serialiser_type|
 end
 
 RSpec.shared_examples "JSON Participant Deferral documentation" do |url, request_schema_ref, response_schema_ref, tag|
+  humanised_description = TAG_TO_HUMANISED_DESCRIPTION[tag]
+  operation_id = TAG_TO_OPERATION_ID[tag]
+
   path url do
-    put "Notify that an ECF participant is taking a break from their course" do
-      operationId :participant
+    put "Notify that an #{humanised_description} is taking a break from their course" do
+      operationId operation_id
       tags tag
       security [bearerAuth: []]
       consumes "application/json"
@@ -82,7 +85,7 @@ RSpec.shared_examples "JSON Participant Deferral documentation" do |url, request
                   "$ref": request_schema_ref,
                 }
 
-      response "200", "The ECF participant being deferred" do
+      response "200", "The #{humanised_description} being deferred" do
         let(:id) { participant.user.id }
 
         let(:params) do

--- a/spec/support/shared_examples/participant_actions_resume_support.rb
+++ b/spec/support/shared_examples/participant_actions_resume_support.rb
@@ -46,9 +46,12 @@ RSpec.shared_examples "JSON Participant Resume endpoint" do |serialiser_type|
 end
 
 RSpec.shared_examples "JSON Participant resume documentation" do |url, request_schema_ref, response_schema_ref, tag|
+  humanised_description = TAG_TO_HUMANISED_DESCRIPTION[tag]
+  operation_id = TAG_TO_OPERATION_ID[tag]
+
   path url do
-    put "Notify that a participant is resuming their course" do
-      operationId :participant
+    put "Notify that an #{humanised_description} is resuming their course" do
+      operationId operation_id
       tags tag
       security [bearerAuth: []]
       consumes "application/json"
@@ -77,7 +80,7 @@ RSpec.shared_examples "JSON Participant resume documentation" do |url, request_s
                   "$ref": request_schema_ref,
                 }
 
-      response "200", "The participant being resumed" do
+      response "200", "The #{humanised_description} being resumed" do
         let(:id) { participant.user_id }
 
         let(:params) do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -318,8 +318,8 @@
     },
     "/api/v1/participants/npq/{id}/defer": {
       "put": {
-        "summary": "Notify that an ECF participant is taking a break from their course",
-        "operationId": "participant",
+        "summary": "Notify that an NPQ participant is taking a break from their course",
+        "operationId": "npq_participant",
         "tags": [
           "NPQ Participant"
         ],
@@ -353,7 +353,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The ECF participant being deferred",
+            "description": "The NPQ participant being deferred",
             "content": {
               "application/json": {
                 "schema": {
@@ -367,8 +367,8 @@
     },
     "/api/v1/participants/npq/{id}/resume": {
       "put": {
-        "summary": "Notify that a participant is resuming their course",
-        "operationId": "participant",
+        "summary": "Notify that an NPQ participant is resuming their course",
+        "operationId": "npq_participant",
         "tags": [
           "NPQ Participant"
         ],
@@ -402,7 +402,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The participant being resumed",
+            "description": "The NPQ participant being resumed",
             "content": {
               "application/json": {
                 "schema": {
@@ -916,7 +916,7 @@
     },
     "/api/v1/participants/ecf/{id}/resume": {
       "put": {
-        "summary": "Notify that a participant is resuming their course",
+        "summary": "Notify that an ECF participant is resuming their course",
         "operationId": "participant",
         "tags": [
           "ECF Participant"
@@ -951,7 +951,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The participant being resumed",
+            "description": "The ECF participant being resumed",
             "content": {
               "application/json": {
                 "schema": {
@@ -1063,7 +1063,7 @@
     },
     "/api/v1/participants/{id}/resume": {
       "put": {
-        "summary": "Notify that a participant is resuming their course",
+        "summary": "Notify that an ECF participant is resuming their course",
         "operationId": "participant",
         "tags": [
           "ECF Participant"
@@ -1098,7 +1098,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The participant being resumed",
+            "description": "The ECF participant being resumed",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-746

Some endpoints using shared examples had ECF participant hard coded. This was effecting the description of the endpoint and the operationId

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
