### PR TITLE
Fix 404 API responses being html

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,7 +4,6 @@ module Api
   class ApiController < ActionController::API
     include ActionController::MimeResponds
     before_action :remove_charset
-    rescue_from ActiveRecord::RecordNotFound, with: :not_found
     rescue_from ActionController::ParameterMissing, with: :missing_parameter_response
     rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response
     rescue_from ActionController::BadRequest, with: :bad_request_response
@@ -21,10 +20,6 @@ module Api
     end
 
   private
-
-    def not_found
-      head :not_found
-    end
 
     def remove_charset
       ActionDispatch::Response.default_charset = nil

--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -40,7 +40,7 @@ module Api
         if record.present?
           render json: ParticipantDeclarationSerializer.new(record).serializable_hash.to_json
         else
-          head :not_found
+          raise ActiveRecord::RecordNotFound
         end
       end
 

--- a/app/controllers/api/v1/participant_validation_controller.rb
+++ b/app/controllers/api/v1/participant_validation_controller.rb
@@ -17,7 +17,7 @@ module Api
         if record.present?
           render json: ParticipantValidationSerializer.new(OpenStruct.new(record)).serializable_hash.to_json
         else
-          head :not_found
+          raise ActiveRecord::RecordNotFound
         end
       end
 

--- a/spec/docs/participant_declarations_spec.rb
+++ b/spec/docs/participant_declarations_spec.rb
@@ -191,8 +191,10 @@ RSpec.describe "Participant Declarations", type: :request, swagger_doc: "v1/api_
         run_test!
       end
 
-      response "404", "Not found" do
+      response "404", "Not found", exceptions_app: true do
         let(:id) { "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }
+
+        schema({ "$ref": "#/components/schemas/NotFoundResponse" })
 
         run_test!
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,6 +105,19 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include Rails.application.routes.url_helpers
 
+  config.before(:each, exceptions_app: true) do
+    # Make the app behave how it does in non dev/test environments and use the
+    # ErrorsController via config.exceptions_app = routes in config/application.rb
+    method = Rails.application.method(:env_config)
+    expect(Rails.application).to receive(:env_config).with(no_args) do
+      method.call.merge(
+        "action_dispatch.show_exceptions" => true,
+        "action_dispatch.show_detailed_exceptions" => false,
+        "consider_all_requests_local" => false,
+      )
+    end
+  end
+
   config.before(:suite) do
     Webpacker.compile
   end

--- a/spec/requests/api/v1/error_spec.rb
+++ b/spec/requests/api/v1/error_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestController < Api::ApiController
+  def not_found_exception
+    raise ActiveRecord::RecordNotFound
+  end
+
+  def random_error
+    raise hell
+  end
+end
+
+RSpec.describe "API errors", type: :request, exceptions_app: true do
+  before do
+    Rails.application.routes.disable_clear_and_finalize = true # preserve original routes
+    Rails.application.routes.draw do
+      get "/not_found_exception", to: "test#not_found_exception"
+      get "/random_error", to: "test#random_error"
+    end
+  end
+
+  describe "404 errors" do
+    it "responds with a status code of 404 and a json response when a not found exception is thrown" do
+      headers = {
+        "ACCEPT" => "application/json",
+        "CONTENT_TYPE" => "application/json",
+      }
+
+      get "/not_found_exception", headers: headers
+      expect(response.status).to eq 404
+      expect(response.content_type).to include "application/vnd.api+json"
+      expect(JSON.parse(response.body)).to eq({
+        "error" => "Resource not Found",
+      })
+    end
+
+    it "responds with a status code of 404 and a json response when route is not found" do
+      headers = {
+        "ACCEPT" => "application/json",
+        "CONTENT_TYPE" => "application/json",
+      }
+
+      get "/jibberish", headers: headers
+      expect(response.status).to eq 404
+      expect(response.content_type).to include "application/vnd.api+json"
+      expect(JSON.parse(response.body)).to eq({
+        "error" => "Resource not Found",
+      })
+    end
+  end
+
+  describe "500 errors" do
+    it "responds with a status code of 500 and a json response when an unhandled exception is thrown" do
+      headers = {
+        "ACCEPT" => "application/json",
+        "CONTENT_TYPE" => "application/json",
+      }
+
+      get "/random_error", headers: headers
+      expect(response.status).to eq 500
+      expect(response.content_type).to include "application/vnd.api+json"
+      expect(JSON.parse(response.body)).to eq({
+        "error" => "Internal server error",
+      })
+    end
+  end
+end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
           expect(JSON.parse(response.body)).to eq(expected_response)
         end
 
-        it "returns 404 if participant declaration does not exist" do
+        it "returns 404 if participant declaration does not exist", exceptions_app: true do
           get "/api/v1/participant-declarations/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
           expect(response.status).to eq 404
         end

--- a/spec/requests/api/v1/participant_validation_spec.rb
+++ b/spec/requests/api/v1/participant_validation_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "participant validation api endpoint", type: :request do
       context "when no record is found for given teacher_reference_number" do
         let(:service_response) { nil }
 
-        it "returns a 404" do
+        it "returns a 404", exceptions_app: true do
           post "/api/v1/participant-validation", params: {
             trn: trn,
             full_name: full_name,

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -687,7 +687,14 @@
             }
           },
           "404": {
-            "description": "Not found"
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized",
@@ -3001,6 +3008,16 @@
                 "$ref": "#/components/schemas/NPQParticipantWithdraw"
               }
             }
+          }
+        }
+      },
+      "NotFoundResponse": {
+        "description": "The requested resource was not found",
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "Resource not found"
           }
         }
       },

--- a/swagger/v1/component_schemas/NotFoundResponse.yml
+++ b/swagger/v1/component_schemas/NotFoundResponse.yml
@@ -1,0 +1,6 @@
+description: "The requested resource was not found"
+type: object
+properties:
+  error:
+    type: string
+    example: "Resource not found"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-748

On some occasions we would return an empty body with text/html, other times json.

This changes the api controller to rely on the exceptions app - see config.exceptions_app = routes in application.rb and ErrorsController, for 404s and 500 errors.
It isn't so straightforward things like BadRequest as we catch a few questionable exceptions to return that, along with a custom error message.


## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
