### PR TITLE
Add importer for ECF manual validation data

### DIFF
--- a/app/services/importers/ecf_manual_validation.rb
+++ b/app/services/importers/ecf_manual_validation.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class Importers::ECFManualValidation
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:)
+    @path_to_csv = path_to_csv
+  end
+
+  def call
+    check_headers
+
+    rows.each do |row|
+      user = User.find(row["id"])
+
+      if user.nil?
+        puts "No profile found for #{row['id']}. Skipping"
+        next
+      end
+
+      participant_profile = user.teacher_profile.current_ecf_profile
+      if participant_profile.nil?
+        puts "No profile found for #{row['id']}. Skipping"
+        next
+      end
+
+      ValidateParticipant.call(
+        participant_profile: participant_profile,
+        validation_data: {
+          trn: row["trn"],
+          name: row["name"],
+          date_of_birth: Date.parse(row["dob"]),
+          national_insurance_number: row["nino"],
+        },
+        config: { check_first_name_only: true, save_validation_data_without_match: false },
+      )
+
+      if participant_profile.ecf_participant_eligibility.nil?
+        puts "No match found #{row['id']}"
+        next
+      end
+
+      unless participant_profile.ecf_participant_eligibility.eligible_status?
+        puts "#{participant_profile.ecf_participant_eligibility.reason} #{row['id']}"
+      end
+    end
+  end
+
+private
+
+  def check_headers
+    unless rows.headers == %w[id name trn dob nino]
+      raise NameError, "Invalid headers"
+    end
+  end
+
+  def rows
+    @rows ||= CSV.read(path_to_csv, headers: true)
+  end
+end


### PR DESCRIPTION
This is an adaptation of a script I've been using to deal with ECF manual validations. My process so far has been to generate a CSV for manual validation with `cf conduit ecf-postgres-production -- psql -c "\copy (SELECT u.id, u.email, pp.type, epvd.full_name, epvd.date_of_birth, epvd.trn, epvd.nino, epe.id IS NOT NULL AS identity_matched, epe.active_flags, epe.status, epe.reason FROM users u JOIN teacher_profiles tp on u.id = tp.user_id JOIN participant_profiles pp on tp.id = pp.teacher_profile_id and pp.type in ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor') and pp.status = 'active' JOIN ecf_participant_validation_data epvd on pp.id = epvd.participant_profile_id LEFT OUTER JOIN ecf_participant_eligibilities epe on pp.id = epe.participant_profile_id WHERE (epe.id IS NULL OR epe.status = 'manual_check')) to 'manual_validations.csv' csv header"`, remove the rows where the reason is no_qts, then pass to Brandon via the secure drive.

Once complete, I take his results, and feed them back to the service using this script.