### PR TITLE
Ignore Pundit::NotAuthorizedError exceptions in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -16,6 +16,8 @@ Sentry.init do |config|
     filter.filter(event.to_hash)
   end
 
+  config.excluded_exceptions += ["Pundit::NotAuthorizedError"]
+
   config.traces_sampler = lambda do |sampling_context|
     transaction_context = sampling_context[:transaction_context]
     op = transaction_context[:op]


### PR DESCRIPTION
## Ticket and context

Ignore `Pundit::NotAuthorizedError` exceptions in Sentry. I don't think that they are notable or exceptional — do we gain anything from having them in [Sentry](https://sentry.io/organizations/dfe-bat/issues/2735113167/?environment=production&project=5748989&query=is%3Aunresolved)?

