### PR TITLE
CPDLP-750 fix broken links in api docs

### DIFF
--- a/docs/source/_ecf_usage_participant_actions.html.erb
+++ b/docs/source/_ecf_usage_participant_actions.html.erb
@@ -14,7 +14,6 @@
 </p>
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-ecf-id-defer-put" class="govuk-link">defer ECF participant</a> endpoint.</p>
 
-
 <h2 id="notifying-of-resume" class="govuk-heading-l">Notifying that an ECF participant is resuming their course</h2>
 
 <p class="govuk-body-m">This functionality allows the provider to inform the DfE that a participant has resumed an ECF course.</p>
@@ -27,7 +26,6 @@
 </pre>
 <p class="govuk-body-m">This will return an <a href="/api-reference/reference#schema-ecfparticipantresponse" class="govuk-link">ECF participant record</a> with the updates to the record included.</p>
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-ecf-id-resume-put" class="govuk-link">resume ECF participant</a> endpoint.</p>
-
 
 <h2 id="notifying-of-schedule-change" class="govuk-heading-l">Notifying that an ECF participant is changing training schedule</h2>
 
@@ -150,7 +148,6 @@
     </tr>
   </tbody>
 </table>
-
 
 <h2 id="notifying-of-withdrawal" class="govuk-heading-l">Notifying that an ECF participant has withdrawn from their course</h2>
 

--- a/docs/source/_usage_participant_declarations.html.erb
+++ b/docs/source/_usage_participant_declarations.html.erb
@@ -4,14 +4,15 @@
 <h3 class="govuk-heading-m" id="provider-confirms-<%= programme %>-participant-has-started">1. Provider confirms an <%= programme %> participant has started</h3>
 <p class="govuk-body-m">Confirm an <%= programme %> participant has started their induction training before Milestone 1.</p>
 <p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
-<p class="govuk-body-m">With a <a href="/api-reference/reference#schema-participantdeclaration" class="govuk-link">request body containing an <%= programme %> participant declaration</a>.</p>
-<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-participantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
+
+<p class="govuk-body-m">With a <a href="/api-reference/reference#schema-ecfparticipantstarteddeclaration" class="govuk-link">request body containing an <%= programme %> participant declaration</a>.</p>
+<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-singleparticipantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
+
 <p class="govuk-body-m">This endpoint is idempotent - submitting exact copy of a request will return the same response body as submitting it the first time.</p>
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participant-declarations-post" class="govuk-link">confirm <%= programme %> participant declarations</a> endpoint.</p>
 
 <h3 class="govuk-heading-m" id="provider-records-<%= programme %>-participant-declaration-id">2. Provider records the <%= programme %> participant declaration ID</h3>
 <p class="govuk-body-m">Store the returned <%= programme %> participant declaration ID for future management tasks.</p>
-
 
 <h2 id="declaring-that-an-ecf-participant-has-retained-their-course" class="govuk-heading-l">Declaring that an <%= programme %> participant has been retained</h2>
 <p class="govuk-body-m">This scenario begins after it has been confirmed that an <%= programme %> participant has completed enough of their course to meet a milestone.</p>
@@ -20,13 +21,13 @@
 <p class="govuk-body-m">1. Confirm an <%= programme %> participant has been retained by the appropriate number of months for this retained event on their <%= programme %> course.</p>
 <p class="govuk-body-m">An explicit <code>retained-x</code> declaration is required to trigger output payments. You should declare this when a participant has reached a particular milestone in line with contractual reporting requirements.</p>
 <p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
-<p class="govuk-body-m">With a <a href="/api-reference/reference#schema-participantdeclaration" class="govuk-link">request body containing an <%= programme %> participant retained declaration</a>.</p>
-<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-participantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
+
+<p class="govuk-body-m">With a <a href="/api-reference/reference#schema-ecfparticipantretaineddeclaration" class="govuk-link">request body containing an <%= programme %> participant retained declaration</a>.</p>
+<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-singleparticipantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participant-declarations-post" class="govuk-link">confirm <%= programme %> participant declarations</a> endpoint.</p>
 
 <h3 class="govuk-heading-m" id="provider-records-<%= programme %>-participant-declaration-id-2">2. Provider records the <%= programme %> participant declaration ID</h3>
 <p class="govuk-body-m">Store the returned <%= programme %> participant declaration ID for future management tasks.</p>
-
 
 <h2 id="declaring-that-an-ecf-participant-has-completed-their-course" class="govuk-heading-l">Declaring that an <%= programme %> participant has completed their course</h2>
 <p class="govuk-body-m">This scenario begins after it has been confirmed that an <%= programme %> participant has completed their course.</p>
@@ -35,13 +36,13 @@
 <p class="govuk-body-m">Confirm an <%= programme %> participant has completed their <%= programme %> course.</p>
 <p class="govuk-body-m">An explicit <code>completed</code> declaration is required to trigger output payments. You should declare this when a participant has reached their final milestone and completed their <%= programme %> course.</p>
 <p class="govuk-body-m"><pre><code>POST /api/v1/participant-declarations</code></pre></p>
-<p class="govuk-body-m">With a <a href="/api-reference/reference#schema-participantdeclaration" class="govuk-link">request body containing an <%= programme %> participant completed declaration</a>.</p>
-<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-participantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
+
+<p class="govuk-body-m">With a <a href="/api-reference/reference#schema-ecfparticipantstarteddeclaration" class="govuk-link">request body containing an <%= programme %> participant completed declaration</a>.</p>
+<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-singleparticipantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participant-declarations-post" class="govuk-link">confirm <%= programme %> participant declarations</a> endpoint.</p>
 
 <h3 class="govuk-heading-m" id="provider-records-<%= programme %>-participant-declaration-id-3">2. Provider records the <%= programme %> participant declaration ID</h3>
 <p class="govuk-body-m">Store the returned <%= programme %> participant declaration ID for future management tasks.</p>
-
 
 <h2 id="listing-participant-declaration-submissions" class="govuk-heading-l">Listing participant declaration submissions</h2>
 <p class="govuk-body-m">This is how you see all the declarations you have made. This functionality allows the provider to check declaration submissions and identify any that are missing.</p>
@@ -51,13 +52,12 @@
 <p class="govuk-body-m">This section lets you review all of the declarations you have made.</p>
 <p class="govuk-body-m">All of your submitted declarations are listed.</p>
 <p class="govuk-body-m"><pre><code>GET /api/v1/participant-declarations</code></pre></p>
-<p class="govuk-body-m">This returns <a href="/api-reference/reference#multipleparticipantdeclarationresponse-object" class="govuk-link">participant declarations</a>.</p>
+<p class="govuk-body-m">This returns <a href="/api-reference/reference#schema-participantdeclarationresponse" class="govuk-link">participant declarations</a>.</p>
 
 <h3 class="govuk-heading-m" id="checking-a-single-previously-submitted-declaration">2. Checking a single previously submitted declaration</h3>
 <p class="govuk-body-m">This section lets you review a single declaration you have made</p>
 <p class="govuk-body-m"><pre><code>GET /api/v1/participant-declarations/{id}</code></pre></p>
-<p class="govuk-body-m">This returns a <a href="/api-reference/reference#singleparticipantdeclarationresponse-object" class="govuk-link">participant declaration</a>.</p>
-
+<p class="govuk-body-m">This returns a <a href="/api-reference/reference#schema-singleparticipantdeclarationresponse" class="govuk-link">participant declaration</a>.</p>
 
 <h2 id="removing-participant-declaration" class="govuk-heading-l">Removing a declaration submitted in error</h2>
 <p class="govuk-body-m">This operation allows the provider to void a participant declaration that has been previously submitted.</p>
@@ -66,5 +66,5 @@
 <h3 class="govuk-heading-m" id="provider-voids-a-declaration">1. Provider voids a declaration</h3>
 <p class="govuk-body-m">Submit the void to the following endpoint</p>
 <p class="govuk-body-m"><pre><code>PUT /api/v1/participant-declarations/{id}/void</code></pre></p>
-<p class="govuk-body-m">This will return a <a href="/api-reference/reference#singleparticipantdeclarationresponse-object" class="govuk-link">participant declaration record</a> with the updates to the record included.</p>
-<p class="govuk-body-m">See <a href="/api-reference/reference#put-api-v1-participant-declarations-id-void" class="govuk-link">void participant declaration</a> endpoint.</p>
+<p class="govuk-body-m">This will return a <a href="/api-reference/reference#schema-singleparticipantdeclarationresponse" class="govuk-link">participant declaration record</a> with the updates to the record included.</p>
+<p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participant-declarations-id-void-put" class="govuk-link">void participant declaration</a> endpoint.</p>

--- a/docs/source/ecf-usage.html.erb
+++ b/docs/source/ecf-usage.html.erb
@@ -35,7 +35,7 @@ weight: 2
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/participants/ecf</code></pre></p>
 
-<p class="govuk-body-m">This will return <a href="/api-reference/reference#multipleecfparticipantsresponse-object" class="govuk-link">multiple ECF participant records</a>.</p>
+<p class="govuk-body-m">This will return <a href="/api-reference/reference#schema-multipleecfparticipantsresponse" class="govuk-link">multiple ECF participant records</a>.</p>
 
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-ecf-get" class="govuk-link">retrieve multiple ECF participants</a> endpoint.</p>
 
@@ -56,7 +56,7 @@ weight: 2
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/participants/ecf?filter[updated_since]=2021-05-13T11:21:55Z</code></pre></p>
 
-<p class="govuk-body-m">This will return <a href="/api-reference/reference#multipleecfparticipantsresponse-object" class="govuk-link">multiple ECF participant records</a> with the updates to the record included.</p>
+<p class="govuk-body-m">This will return <a href="/api-reference/reference#schema-multipleecfparticipantsresponse" class="govuk-link">multiple ECF participant records</a> with the updates to the record included.</p>
 
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-ecf-get" class="govuk-link">retrieve multiple participants</a> endpoint.</p>
 

--- a/docs/source/npq-usage.html.erb
+++ b/docs/source/npq-usage.html.erb
@@ -53,7 +53,7 @@ weight: 3
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/npq-applications</code></pre></p>
 
-<p class="govuk-body-m">This will return <a href="/api-reference/reference#multiplenpqapplicationsresponse-object" class="govuk-link">multiple NPQ application records</a>.</p>
+<p class="govuk-body-m">This will return <a href="/api-reference/reference#schema-multiplenpqapplicationsresponse" class="govuk-link">multiple NPQ application records</a>.</p>
 
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-npq-applications-get" class="govuk-link">retrieve multiple NPQ applications</a> endpoint.</p>
 
@@ -63,7 +63,7 @@ weight: 3
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/npq-applications?filter[updated_since]=2021-05-13T11:21:55Z</code></pre></p>
 
-<p class="govuk-body-m">This will return <a href="/api-reference/reference#multiplenpqapplicationsresponse-object" class="govuk-link">multiple NPQ application records</a> with the updates to the record included.</p>
+<p class="govuk-body-m">This will return <a href="/api-reference/reference#schema-multiplenpqapplicationsresponse" class="govuk-link">multiple NPQ application records</a> with the updates to the record included.</p>
 
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-npq-applications-get" class="govuk-link">retrieve multiple NPQ applications</a> endpoint.</p>
 
@@ -123,7 +123,7 @@ weight: 3
 </p>
 
 <p class="govuk-body-m">
-  Where <code>{id}</code> is the <code>id</code> of the corresponding NPQ application. This returns an <a href="/api-reference/reference#npqapplicationresponse-object" class="govuk-link">NPQ application record</a>.
+  Where <code>{id}</code> is the <code>id</code> of the corresponding NPQ application. This returns an <a href="/api-reference/reference#schema-npqapplicationresponse" class="govuk-link">NPQ application record</a>.
 </p>
 
 <h3 id="reject-npq-application" class="govuk-heading-m">
@@ -145,7 +145,7 @@ weight: 3
 </p>
 
 <p class="govuk-body-m">
-  Where <code>{id}</code> is the <code>id</code> of the corresponding NPQ application. This returns an <a href="/api-reference/reference#npqapplicationresponse-object" class="govuk-link">NPQ application record</a>.
+  Where <code>{id}</code> is the <code>id</code> of the corresponding NPQ application. This returns an <a href="/api-reference/reference#schema-npqapplicationresponse" class="govuk-link">NPQ application record</a>.
 </p>
 
 <h3 id="handling-deferrals" class="govuk-heading-m">
@@ -189,7 +189,7 @@ weight: 3
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/participants/npq</code></pre></p>
 
-<p class="govuk-body-m">This will return <a href="/api-reference/reference#multiplenpqparticipantsresponse-object" class="govuk-link">multiple NPQ participant records</a>.</p>
+<p class="govuk-body-m">This will return <a href="/api-reference/reference#schema-multiplenpqparticipantsresponse" class="govuk-link">multiple NPQ participant records</a>.</p>
 
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-npq-get" class="govuk-link">retrieve multiple NPQ participants</a> endpoint.</p>
 
@@ -199,7 +199,7 @@ weight: 3
 
 <p class="govuk-body-m"><pre><code>GET /api/v1/participants/npq?filter[updated_since]=2021-05-13T11:21:55Z</code></pre></p>
 
-<p class="govuk-body-m">This will return <a href="/api-reference/reference#multiplenpqparticipantsresponse-object" class="govuk-link">multiple NPQ participant records</a> with the updates to the record included.</p>
+<p class="govuk-body-m">This will return <a href="/api-reference/reference#schema-multiplenpqparticipantsresponse" class="govuk-link">multiple NPQ participant records</a> with the updates to the record included.</p>
 
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-npq-get" class="govuk-link">retrieve multiple NPQ participants</a> endpoint.</p>
 


### PR DESCRIPTION
## Ticket and context

There are a number of broken links in the API docs, this PR fixes those.

Relates to ticket: https://dfedigital.atlassian.net/browse/CPDLP-750

## Tech review

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
