### PR TITLE
CPDLP-751 Update docs for participant action response examples

### DIFF
--- a/spec/docs/participants_ecf_spec.rb
+++ b/spec/docs/participants_ecf_spec.rb
@@ -108,7 +108,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
   it_behaves_like "JSON Participant resume documentation",
                   "/api/v1/participants/ecf/{id}/resume",
                   "#/components/schemas/ECFParticipantResumeRequest",
-                  "#/components/schemas/ECFParticipantResponse",
+                  "#/components/schemas/ECFParticipantResumeResponse",
                   "ECF Participant" do
     let(:participant) { mentor_profile }
     let(:attributes) { { course_identifier: "ecf-mentor" } }

--- a/spec/docs/participants_ecf_spec.rb
+++ b/spec/docs/participants_ecf_spec.rb
@@ -163,7 +163,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
           }
         end
 
-        schema({ "$ref": "#/components/schemas/ECFParticipantResponse" })
+        schema({ "$ref": "#/components/schemas/ECFParticipantWithdrawResponse" })
         run_test!
       end
     end

--- a/spec/docs/participants_ecf_spec.rb
+++ b/spec/docs/participants_ecf_spec.rb
@@ -94,7 +94,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
   it_behaves_like "JSON Participant Deferral documentation",
                   "/api/v1/participants/ecf/{id}/defer",
                   "#/components/schemas/ECFParticipantDeferRequest",
-                  "#/components/schemas/ECFParticipantResponse",
+                  "#/components/schemas/ECFParticipantDeferResponse",
                   "ECF Participant" do
     let(:participant) { mentor_profile }
     let(:attributes) do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -955,7 +955,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                  "$ref": "#/components/schemas/ECFParticipantResumeResponse"
                 }
               }
             }
@@ -1903,6 +1903,123 @@
           "course_identifier": "ecf-mentor"
         }
       },
+      "ECFParticipantResumeAttributesResponse": {
+        "description": "The data attributes associated with an ECF participant",
+        "type": "object",
+        "required": [
+          "email",
+          "full_name",
+          "school_urn",
+          "participant_type",
+          "cohort",
+          "status",
+          "training_status",
+          "schedule_identifier",
+          "updated_at"
+        ],
+        "properties": {
+          "email": {
+            "description": "The email address registered for this ECF participant",
+            "type": "string",
+            "example": "jane.smith@some-school.example.com"
+          },
+          "full_name": {
+            "description": "The full name of this ECF participant",
+            "type": "string",
+            "example": "Jane Smith"
+          },
+          "mentor_id": {
+            "description": "The unique identifier of this ECF participants mentor",
+            "type": "string",
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid",
+            "nullable": true
+          },
+          "school_urn": {
+            "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
+            "type": "string",
+            "example": "106286"
+          },
+          "participant_type": {
+            "description": "The type of ECF participant this record refers to",
+            "type": "string",
+            "example": "ect",
+            "enum": [
+              "ect",
+              "mentor"
+            ]
+          },
+          "cohort": {
+            "description": "Which cohort this ECF participant is associated with",
+            "type": "string",
+            "example": "2021"
+          },
+          "status": {
+            "description": "The status of this ECF participant record",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "withdrawn"
+            ]
+          },
+          "teacher_reference_number": {
+            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "type": "string",
+            "nullable": true,
+            "example": "1234567"
+          },
+          "teacher_reference_number_validated": {
+            "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "eligible_for_funding": {
+            "description": "Indicates whether this participant is eligible to receive DfE funded induction",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "pupil_premium_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "sparsity_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "training_status": {
+            "description": "The training status of the ECF participant",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "deferred",
+              "withdrawn"
+            ]
+          },
+          "schedule_identifier": {
+            "description": "The schedule of the ECF participant",
+            "type": "string",
+            "example": "ecf-january-standard-2021",
+            "enum": [
+              "ecf-september-standard-2021",
+              "ecf-january-standard-2021"
+            ]
+          },
+          "updated_at": {
+            "description": "The date the ECF participant was last updated",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:22:32.000Z"
+          }
+        }
+      },
       "ECFParticipantResumeRequest": {
         "description": "The resume request for a participant",
         "type": "object",
@@ -1927,6 +2044,43 @@
                 "$ref": "#/components/schemas/ECFParticipantResume"
               }
             }
+          }
+        }
+      },
+      "ECFParticipantResumeResponse": {
+        "description": "An ECF Participant",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ECFParticipantResumeResponseData"
+          }
+        }
+      },
+      "ECFParticipantResumeResponseData": {
+        "description": "The details of a participant",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the participant record",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "type": {
+            "description": "The data type",
+            "type": "string",
+            "example": "participant"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/ECFParticipantResumeAttributesResponse"
           }
         }
       },

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1004,7 +1004,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                  "$ref": "#/components/schemas/ECFParticipantWithdrawResponse"
                 }
               }
             }
@@ -2248,6 +2248,148 @@
           "course_identifier": "ecf-mentor"
         }
       },
+      "ECFParticipantWithdrawAttributesResponse": {
+        "description": "The data attributes associated with an ECF participant",
+        "type": "object",
+        "required": [
+          "email",
+          "full_name",
+          "school_urn",
+          "participant_type",
+          "cohort",
+          "status",
+          "training_status",
+          "schedule_identifier",
+          "updated_at"
+        ],
+        "properties": {
+          "email": {
+            "description": "The email address registered for this ECF participant",
+            "type": "string",
+            "example": "jane.smith@some-school.example.com"
+          },
+          "full_name": {
+            "description": "The full name of this ECF participant",
+            "type": "string",
+            "example": "Jane Smith"
+          },
+          "mentor_id": {
+            "description": "The unique identifier of this ECF participants mentor",
+            "type": "string",
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid",
+            "nullable": true
+          },
+          "school_urn": {
+            "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
+            "type": "string",
+            "example": "106286"
+          },
+          "participant_type": {
+            "description": "The type of ECF participant this record refers to",
+            "type": "string",
+            "example": "ect",
+            "enum": [
+              "ect",
+              "mentor"
+            ]
+          },
+          "cohort": {
+            "description": "Which cohort this ECF participant is associated with",
+            "type": "string",
+            "example": "2021"
+          },
+          "status": {
+            "description": "The status of this ECF participant record",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "withdrawn"
+            ]
+          },
+          "teacher_reference_number": {
+            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "type": "string",
+            "nullable": true,
+            "example": "1234567"
+          },
+          "teacher_reference_number_validated": {
+            "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "eligible_for_funding": {
+            "description": "Indicates whether this participant is eligible to receive DfE funded induction",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "pupil_premium_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "sparsity_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "training_status": {
+            "description": "The training status of the ECF participant",
+            "type": "string",
+            "example": "withdrawn",
+            "enum": [
+              "active",
+              "deferred",
+              "withdrawn"
+            ]
+          },
+          "schedule_identifier": {
+            "description": "The schedule of the ECF participant",
+            "type": "string",
+            "example": "ecf-january-standard-2021",
+            "enum": [
+              "ecf-september-standard-2021",
+              "ecf-january-standard-2021"
+            ]
+          },
+          "updated_at": {
+            "description": "The date the ECF participant was last updated",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:22:32.000Z"
+          }
+        }
+      },
+      "ECFParticipantWithdrawDataResponse": {
+        "description": "The details of a participant",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the participant record",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "type": {
+            "description": "The data type",
+            "type": "string",
+            "example": "participant"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/ECFParticipantWithdrawAttributesResponse"
+          }
+        }
+      },
       "ECFParticipantWithdrawRequest": {
         "description": "The withdrawal request for a participant",
         "type": "object",
@@ -2272,6 +2414,18 @@
                 "$ref": "#/components/schemas/ECFParticipantWithdraw"
               }
             }
+          }
+        }
+      },
+      "ECFParticipantWithdrawResponse": {
+        "description": "An ECF Participant",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ECFParticipantWithdrawDataResponse"
           }
         }
       },

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -906,7 +906,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                  "$ref": "#/components/schemas/ECFParticipantDeferResponse"
                 }
               }
             }
@@ -1668,6 +1668,123 @@
           "course_identifier": "ecf-mentor"
         }
       },
+      "ECFParticipantDeferAttributesResponse": {
+        "description": "The data attributes associated with an ECF participant",
+        "type": "object",
+        "required": [
+          "email",
+          "full_name",
+          "school_urn",
+          "participant_type",
+          "cohort",
+          "status",
+          "training_status",
+          "schedule_identifier",
+          "updated_at"
+        ],
+        "properties": {
+          "email": {
+            "description": "The email address registered for this ECF participant",
+            "type": "string",
+            "example": "jane.smith@some-school.example.com"
+          },
+          "full_name": {
+            "description": "The full name of this ECF participant",
+            "type": "string",
+            "example": "Jane Smith"
+          },
+          "mentor_id": {
+            "description": "The unique identifier of this ECF participants mentor",
+            "type": "string",
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid",
+            "nullable": true
+          },
+          "school_urn": {
+            "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
+            "type": "string",
+            "example": "106286"
+          },
+          "participant_type": {
+            "description": "The type of ECF participant this record refers to",
+            "type": "string",
+            "example": "ect",
+            "enum": [
+              "ect",
+              "mentor"
+            ]
+          },
+          "cohort": {
+            "description": "Which cohort this ECF participant is associated with",
+            "type": "string",
+            "example": "2021"
+          },
+          "status": {
+            "description": "The status of this ECF participant record",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "withdrawn"
+            ]
+          },
+          "teacher_reference_number": {
+            "description": "The Teacher Reference Number (TRN) for this NPQ participant",
+            "type": "string",
+            "nullable": true,
+            "example": "1234567"
+          },
+          "teacher_reference_number_validated": {
+            "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "eligible_for_funding": {
+            "description": "Indicates whether this participant is eligible to receive DfE funded induction",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "pupil_premium_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "sparsity_uplift": {
+            "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
+            "type": "boolean",
+            "nullable": true,
+            "example": true
+          },
+          "training_status": {
+            "description": "The training status of the ECF participant",
+            "type": "string",
+            "example": "deffered",
+            "enum": [
+              "active",
+              "deferred",
+              "withdrawn"
+            ]
+          },
+          "schedule_identifier": {
+            "description": "The schedule of the ECF participant",
+            "type": "string",
+            "example": "ecf-january-standard-2021",
+            "enum": [
+              "ecf-september-standard-2021",
+              "ecf-january-standard-2021"
+            ]
+          },
+          "updated_at": {
+            "description": "The date the ECF participant was last updated",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:22:32.000Z"
+          }
+        }
+      },
       "ECFParticipantDeferRequest": {
         "description": "The deferral request for a participant",
         "type": "object",
@@ -1692,6 +1809,43 @@
                 "$ref": "#/components/schemas/ECFParticipantDefer"
               }
             }
+          }
+        }
+      },
+      "ECFParticipantDeferResponse": {
+        "description": "An ECF Participant",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ECFParticipantDeferResponseData"
+          }
+        }
+      },
+      "ECFParticipantDeferResponseData": {
+        "description": "The details of a participant",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the participant record",
+            "type": "string",
+            "format": "uuid",
+            "example": "db3a7848-7308-4879-942a-c4a70ced400a"
+          },
+          "type": {
+            "description": "The data type",
+            "type": "string",
+            "example": "participant"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/ECFParticipantDeferAttributesResponse"
           }
         }
       },

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1761,7 +1761,7 @@
           "training_status": {
             "description": "The training status of the ECF participant",
             "type": "string",
-            "example": "deffered",
+            "example": "deferred",
             "enum": [
               "active",
               "deferred",

--- a/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -75,7 +75,7 @@ properties:
   training_status:
     description: "The training status of the ECF participant"
     type: string
-    example: deffered
+    example: deferred
     enum:
       - active
       - deferred

--- a/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -1,0 +1,94 @@
+description: "The data attributes associated with an ECF participant"
+type: object
+required:
+  - email
+  - full_name
+  - school_urn
+  - participant_type
+  - cohort
+  - status
+  - training_status
+  - schedule_identifier
+  - updated_at
+properties:
+  email:
+    description: "The email address registered for this ECF participant"
+    type: string
+    example: "jane.smith@some-school.example.com"
+  full_name:
+    description: "The full name of this ECF participant"
+    type: string
+    example: "Jane Smith"
+  mentor_id:
+    description: "The unique identifier of this ECF participants mentor"
+    type: string
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
+    nullable: true
+  school_urn:
+    description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
+    type: string
+    example: "106286"
+  participant_type:
+    description: "The type of ECF participant this record refers to"
+    type: string
+    example: ect
+    enum:
+      - ect
+      - mentor
+  cohort:
+    description: "Which cohort this ECF participant is associated with"
+    type: string
+    example: "2021"
+  status:
+    description: "The status of this ECF participant record"
+    type: string
+    example: active
+    enum:
+      - active
+      - withdrawn
+  teacher_reference_number:
+    description: "The Teacher Reference Number (TRN) for this NPQ participant"
+    type: string
+    nullable: true
+    example: "1234567"
+  teacher_reference_number_validated:
+    description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
+    type: boolean
+    nullable: true
+    example: true
+  eligible_for_funding:
+    description: "Indicates whether this participant is eligible to receive DfE funded induction"
+    type: boolean
+    nullable: true
+    example: true
+  pupil_premium_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
+    type: boolean
+    nullable: true
+    example: true
+  sparsity_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
+    type: boolean
+    nullable: true
+    example: true
+  training_status:
+    description: "The training status of the ECF participant"
+    type: string
+    example: deffered
+    enum:
+      - active
+      - deferred
+      - withdrawn
+  schedule_identifier:
+    description: "The schedule of the ECF participant"
+    type: string
+    example: ecf-january-standard-2021
+    enum:
+      - ecf-september-standard-2021
+      - ecf-january-standard-2021
+  updated_at:
+    description: "The date the ECF participant was last updated"
+    type: string
+    format: date-time
+    example: "2021-05-31T02:22:32.000Z"

--- a/swagger/v1/component_schemas/ECFParticipantDeferResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferResponse.yml
@@ -1,0 +1,7 @@
+description: "An ECF Participant"
+type: object
+required:
+  - data
+properties:
+  data:
+    $ref: "#/components/schemas/ECFParticipantDeferResponseData"

--- a/swagger/v1/component_schemas/ECFParticipantDeferResponseData.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferResponseData.yml
@@ -1,0 +1,18 @@
+description: "The details of a participant"
+type: object
+required:
+  - id
+  - type
+  - attributes
+properties:
+  id:
+    description: "The unique identifier of the participant record"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  type:
+    description: "The data type"
+    type: string
+    example: participant
+  attributes:
+    $ref: "#/components/schemas/ECFParticipantDeferAttributesResponse"

--- a/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
@@ -1,0 +1,94 @@
+description: "The data attributes associated with an ECF participant"
+type: object
+required:
+  - email
+  - full_name
+  - school_urn
+  - participant_type
+  - cohort
+  - status
+  - training_status
+  - schedule_identifier
+  - updated_at
+properties:
+  email:
+    description: "The email address registered for this ECF participant"
+    type: string
+    example: "jane.smith@some-school.example.com"
+  full_name:
+    description: "The full name of this ECF participant"
+    type: string
+    example: "Jane Smith"
+  mentor_id:
+    description: "The unique identifier of this ECF participants mentor"
+    type: string
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
+    nullable: true
+  school_urn:
+    description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
+    type: string
+    example: "106286"
+  participant_type:
+    description: "The type of ECF participant this record refers to"
+    type: string
+    example: ect
+    enum:
+      - ect
+      - mentor
+  cohort:
+    description: "Which cohort this ECF participant is associated with"
+    type: string
+    example: "2021"
+  status:
+    description: "The status of this ECF participant record"
+    type: string
+    example: active
+    enum:
+      - active
+      - withdrawn
+  teacher_reference_number:
+    description: "The Teacher Reference Number (TRN) for this NPQ participant"
+    type: string
+    nullable: true
+    example: "1234567"
+  teacher_reference_number_validated:
+    description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
+    type: boolean
+    nullable: true
+    example: true
+  eligible_for_funding:
+    description: "Indicates whether this participant is eligible to receive DfE funded induction"
+    type: boolean
+    nullable: true
+    example: true
+  pupil_premium_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
+    type: boolean
+    nullable: true
+    example: true
+  sparsity_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
+    type: boolean
+    nullable: true
+    example: true
+  training_status:
+    description: "The training status of the ECF participant"
+    type: string
+    example: active
+    enum:
+      - active
+      - deferred
+      - withdrawn
+  schedule_identifier:
+    description: "The schedule of the ECF participant"
+    type: string
+    example: ecf-january-standard-2021
+    enum:
+      - ecf-september-standard-2021
+      - ecf-january-standard-2021
+  updated_at:
+    description: "The date the ECF participant was last updated"
+    type: string
+    format: date-time
+    example: "2021-05-31T02:22:32.000Z"

--- a/swagger/v1/component_schemas/ECFParticipantResumeResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeResponse.yml
@@ -1,0 +1,7 @@
+description: "An ECF Participant"
+type: object
+required:
+  - data
+properties:
+  data:
+    $ref: "#/components/schemas/ECFParticipantResumeResponseData"

--- a/swagger/v1/component_schemas/ECFParticipantResumeResponseData.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeResponseData.yml
@@ -1,0 +1,18 @@
+description: "The details of a participant"
+type: object
+required:
+  - id
+  - type
+  - attributes
+properties:
+  id:
+    description: "The unique identifier of the participant record"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  type:
+    description: "The data type"
+    type: string
+    example: participant
+  attributes:
+    $ref: "#/components/schemas/ECFParticipantResumeAttributesResponse"

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
@@ -1,0 +1,94 @@
+description: "The data attributes associated with an ECF participant"
+type: object
+required:
+  - email
+  - full_name
+  - school_urn
+  - participant_type
+  - cohort
+  - status
+  - training_status
+  - schedule_identifier
+  - updated_at
+properties:
+  email:
+    description: "The email address registered for this ECF participant"
+    type: string
+    example: "jane.smith@some-school.example.com"
+  full_name:
+    description: "The full name of this ECF participant"
+    type: string
+    example: "Jane Smith"
+  mentor_id:
+    description: "The unique identifier of this ECF participants mentor"
+    type: string
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
+    nullable: true
+  school_urn:
+    description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
+    type: string
+    example: "106286"
+  participant_type:
+    description: "The type of ECF participant this record refers to"
+    type: string
+    example: ect
+    enum:
+      - ect
+      - mentor
+  cohort:
+    description: "Which cohort this ECF participant is associated with"
+    type: string
+    example: "2021"
+  status:
+    description: "The status of this ECF participant record"
+    type: string
+    example: active
+    enum:
+      - active
+      - withdrawn
+  teacher_reference_number:
+    description: "The Teacher Reference Number (TRN) for this NPQ participant"
+    type: string
+    nullable: true
+    example: "1234567"
+  teacher_reference_number_validated:
+    description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
+    type: boolean
+    nullable: true
+    example: true
+  eligible_for_funding:
+    description: "Indicates whether this participant is eligible to receive DfE funded induction"
+    type: boolean
+    nullable: true
+    example: true
+  pupil_premium_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
+    type: boolean
+    nullable: true
+    example: true
+  sparsity_uplift:
+    description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
+    type: boolean
+    nullable: true
+    example: true
+  training_status:
+    description: "The training status of the ECF participant"
+    type: string
+    example: withdrawn
+    enum:
+      - active
+      - deferred
+      - withdrawn
+  schedule_identifier:
+    description: "The schedule of the ECF participant"
+    type: string
+    example: ecf-january-standard-2021
+    enum:
+      - ecf-september-standard-2021
+      - ecf-january-standard-2021
+  updated_at:
+    description: "The date the ECF participant was last updated"
+    type: string
+    format: date-time
+    example: "2021-05-31T02:22:32.000Z"

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawDataResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawDataResponse.yml
@@ -1,0 +1,18 @@
+description: "The details of a participant"
+type: object
+required:
+  - id
+  - type
+  - attributes
+properties:
+  id:
+    description: "The unique identifier of the participant record"
+    type: string
+    format: uuid
+    example: db3a7848-7308-4879-942a-c4a70ced400a
+  type:
+    description: "The data type"
+    type: string
+    example: participant
+  attributes:
+    $ref: "#/components/schemas/ECFParticipantWithdrawAttributesResponse"

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawResponse.yml
@@ -1,0 +1,7 @@
+description: "An ECF Participant"
+type: object
+required:
+  - data
+properties:
+  data:
+    $ref: "#/components/schemas/ECFParticipantWithdrawDataResponse"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-751

- This change updates to docs to give specific examples responses for the ECF resume / defer / withdraw endpoints
- However in order to achieve this we must give new schemas which defines these examples despite all three responses fit under one schema

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- https://ecf-review-pr-1501.london.cloudapps.digital/api-reference/reference.html#api-v1-participants-ecf-id-defer-put-responses
- Example response shows correct training status `deferred`
- https://ecf-review-pr-1501.london.cloudapps.digital/api-reference/reference.html#api-v1-participants-ecf-id-resume-put-responses
- Example response shows correct training status `active`
- https://ecf-review-pr-1501.london.cloudapps.digital/api-reference/reference.html#api-v1-participants-ecf-id-withdraw-put-responses
- Example response shows correct training status `withdrawn`

## External API changes

- There are no external api changes