### PR TITLE
Split out web and worker crash alert rules

### DIFF
--- a/terraform/monitoring/config/production/alert.rules.yml
+++ b/terraform/monitoring/config/production/alert.rules.yml
@@ -70,10 +70,18 @@ groups:
   - name: Crashed-apps
     rules:
       - alert: AppsCrashed
-        expr: rate(crash{app=~"ecf-production"}[1m])*60 > 1
+        expr: rate(crash{app="ecf-production"}[1m])*60 > 1
         annotations:
           summary: Crashed Apps non-zero
           description: "ecf-production: At least 1 crashed app (current value: {{ $value }})"
+        labels:
+          environment: production
+          severity: high
+      - alert: AppsWorkerCrashed
+        expr: rate(crash{app="ecf-production-worker"}[1m])*60 > 1
+        annotations:
+          summary: Crashed Apps non-zero
+          description: "ecf-production-worker: At least 1 crashed app (current value: {{ $value }})"
         labels:
           environment: production
           severity: high

--- a/terraform/monitoring/config/staging/alert.rules.yml
+++ b/terraform/monitoring/config/staging/alert.rules.yml
@@ -70,10 +70,18 @@ groups:
   - name: Crashed-apps
     rules:
       - alert: AppsCrashed
-        expr: rate(crash{app=~"ecf-staging"}[1m])*60 > 1
+        expr: rate(crash{app="ecf-staging"}[1m])*60 > 1
         annotations:
           summary: Crashed Apps non-zero
           description: "ecf-staging: At least 1 crashed app (current value: {{ $value }})"
+        labels:
+          environment: staging
+          severity: medium
+      - alert: AppsWorkerCrashed
+        expr: rate(crash{app="ecf-staging-worker"}[1m])*60 > 1
+        annotations:
+          summary: Crashed Apps non-zero
+          description: "ecf-staging-worker: At least 1 crashed app (current value: {{ $value }})"
         labels:
           environment: staging
           severity: medium


### PR DESCRIPTION
## Ticket and context

We currently alert when any instance type crashes. This PR splits out web and worker crash alert rules so that we can better identify what type of instance has crashed.
