### PR TITLE
CST-180 update participant in admin console

### DIFF
--- a/app/components/admin/participants/details/ect_pending.html.erb
+++ b/app/components/admin/participants/details/ect_pending.html.erb
@@ -5,26 +5,40 @@
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Full name</th>
       <td class="govuk-table__cell"><%= profile.user.full_name %></td>
+      <td class="govuk-table__cell">
+        <%= govuk_link_to edit_name_admin_participant_path(profile) do %>
+          Change <span class="govuk-visually-hidden">name</span>
+        <% end %>
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Email address</th>
       <td class="govuk-table__cell"><%= profile.user.email %></td>
+      <td class="govuk-table__cell">
+        <%= govuk_link_to edit_email_admin_participant_path(profile) do %>
+          Change <span class="govuk-visually-hidden">email</span>
+        <% end %>
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Participant type</th>
       <td class="govuk-table__cell"><%= t :ect, scope: "schools.participants.type" %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Mentor</th>
       <td class="govuk-table__cell"><%= profile.mentor&.full_name || 'Not yet assigned' %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">School</th>
       <td class="govuk-table__cell"><%= profile.school.name %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Cohort</th>
       <td class="govuk-table__cell"><%= profile.cohort&.display_name || 'No cohort' %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
   </tbody>
 </table>

--- a/app/components/admin/participants/details/mentor_pending.html.erb
+++ b/app/components/admin/participants/details/mentor_pending.html.erb
@@ -5,22 +5,35 @@
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Full name</th>
       <td class="govuk-table__cell"><%= profile.user.full_name %></td>
+      <td class="govuk-table__cell">
+        <%= govuk_link_to edit_name_admin_participant_path(profile) do %>
+          Change <span class="govuk-visually-hidden">name</span>
+        <% end %>
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Email address</th>
       <td class="govuk-table__cell"><%= profile.user.email %></td>
+      <td class="govuk-table__cell">
+        <%= govuk_link_to edit_email_admin_participant_path(profile) do %>
+          Change <span class="govuk-visually-hidden">email</span>
+        <% end %>
+      </td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Participant type</th>
       <td class="govuk-table__cell"><%= t :mentor, scope: "schools.participants.type" %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">School</th>
       <td class="govuk-table__cell"><%= profile.school.name %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Cohort</th>
       <td class="govuk-table__cell"><%= profile.cohort&.display_name || 'No cohort' %></td>
+      <td class="govuk-table__cell"></td>
     </tr>
   </tbody>
 </table>

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -23,6 +23,39 @@ module Admin
       end
     end
 
+    def edit_name; end
+
+    def update_name
+      if @participant_profile.user.update(params.require(:user).permit(:full_name))
+        if @participant_profile.ect?
+          set_success_message(heading: "The ECT’s name has been updated")
+        else
+          set_success_message(heading: "The mentor’s name has been updated")
+        end
+        redirect_to admin_participants_path
+      else
+        render "admin/participants/edit_name"
+      end
+    end
+
+    def edit_email; end
+
+    def update_email
+      user = @participant_profile.user
+      user.assign_attributes(params.require(:user).permit(:email))
+
+      if user.save
+        if @participant_profile.ect?
+          set_success_message(heading: "The ECT’s email address has been updated")
+        else
+          set_success_message(heading: "The mentor’s email address has been updated")
+        end
+        redirect_to admin_participants_path
+      else
+        render "admin/participants/edit_email"
+      end
+    end
+
     def remove; end
 
     def destroy
@@ -37,11 +70,7 @@ module Admin
 
     def load_participant
       @participant_profile = ParticipantProfile.find(params[:id])
-      if %w[remove destroy].include?(action_name)
-        authorize @participant_profile, :withdraw_record?
-      else
-        authorize @participant_profile
-      end
+      authorize @participant_profile, policy_class: @participant_profile.policy_class
     end
   end
 end

--- a/app/views/admin/participants/edit_email.html.erb
+++ b/app/views/admin/participants/edit_email.html.erb
@@ -1,0 +1,10 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(id: @participant_profile)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change <%= @participant_profile.ect? ? "ECT’s" : "mentor’s" %> email address</h1>
+    <%= form_for @participant_profile.user, url: update_email_admin_participant_path, method: :put do |f| %>
+      <%= f.govuk_text_field :email, label: { text: "Email address" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/edit_name.html.erb
+++ b/app/views/admin/participants/edit_name.html.erb
@@ -1,0 +1,10 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(id: @participant_profile)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change <%= @participant_profile.ect? ? "ECT’s" : "mentor’s" %> name</h1>
+    <%= form_for @participant_profile.user, url: update_name_admin_participant_path, method: :put do |f| %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -6,13 +6,13 @@
   <%= render ParticipantStatusTagComponent.new(profile: @participant_profile) %>
 </h1>
 
-<%= render Admin::Participants::Details.new(profile: @participant_profile) %>
-<%= render Admin::Participants::ValidationTasks.new(profile: @participant_profile) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render Admin::Participants::Details.new(profile: @participant_profile) %>
+    <%= render Admin::Participants::ValidationTasks.new(profile: @participant_profile) %>
 
-<% if @participant_profile.policy_class.new(current_user, @participant_profile).withdraw_record? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <% if @participant_profile.policy_class.new(current_user, @participant_profile).withdraw_record? %>
       <%= govuk_link_to "Delete participant", remove_admin_participant_path %>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,8 +187,11 @@ Rails.application.routes.draw do
 
     resources :participants, only: %i[show index destroy] do
       member do
+        get :edit_name, path: "edit-name"
+        put :update_name, path: "update-name"
+        get :edit_email, path: "edit-email"
+        put :update_email, path: "update-email"
         get :remove
-
         scope path: "validations", controller: "participants/validations" do
           get ":step", action: :show, as: :validation_step
           post ":step", action: :update

--- a/spec/features/admin/participants/update_participants_details_spec.rb
+++ b/spec/features/admin/participants/update_participants_details_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+RSpec.feature "Admin should be able to update participants details", js: true, rutabaga: false do
+  before do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_an_admin
+    and_i_have_added_an_ect
+    and_i_have_added_a_mentor
+    when_i_visit_admin_participants_dashboard
+    then_i_should_see_a_list_of_participants
+  end
+
+  scenario "Admin can edit a participants name" do
+    when_i_click_on_the_participants_name "Sally Teacher"
+    then_i_should_see_the_ects_details
+
+    when_i_click_on_change_name
+    then_i_should_be_on_the_edit_name_page
+
+    when_i_update_the_name_with ""
+    and_i_click_on_continue
+    then_i_should_receive_a_missing_name_error_message
+
+    when_i_update_the_name_with "Sandra Teacher"
+    and_i_click_on_continue
+    then_i_should_be_in_the_admin_participants_dashboard
+    and_admin_should_be_shown_a_success_message
+    and_the_page_should_have_the_updated_name "Sandra Teacher"
+  end
+
+  scenario "Admin can edit a participants email" do
+    when_i_click_on_the_participants_name "Billy Mentor"
+    then_i_should_see_the_mentors_details
+
+    when_i_click_on_change_email
+    then_i_should_be_on_the_edit_email_page
+
+    when_i_update_the_email_with "invalid@email"
+    and_i_click_on_continue
+    then_i_should_receive_a_invalid_email_error_message
+
+    when_i_update_the_email_with ""
+    and_i_click_on_continue
+    then_i_should_receive_a_missing_email_error_message
+
+    when_i_update_the_email_with @participant_profile_ect.user.email
+    and_i_click_on_continue
+    then_i_should_receive_an_email_already_taken_error_message
+
+    when_i_update_the_email_with "billy@mentor-example.com"
+    and_i_click_on_continue
+    then_i_should_be_in_the_admin_participants_dashboard
+    and_admin_should_be_shown_a_success_message
+
+    when_i_click_on_the_participants_name "Billy Mentor"
+    then_the_participants_email_should_have_updated "billy@mentor-example.com"
+  end
+
+private
+
+  # Given
+
+  def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    @cohort = create(:cohort, start_year: 2021)
+    @school = create(:school, name: "Fip School")
+    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+  end
+
+  # When
+
+  def when_i_visit_admin_participants_dashboard
+    visit admin_participants_path
+  end
+
+  def when_i_click_on_the_participants_name(name)
+    click_on name
+  end
+
+  # def when_i_click_to_change_the_participants_name
+  #   expect(page).to have_text(@participant_profile_ect.user.full_name)
+  # end
+
+  def when_i_click_on_change_name
+    click_on("Change name", visible: false)
+  end
+
+  def when_i_click_on_change_email
+    click_on("Change email", visible: false)
+  end
+
+  def when_i_update_the_name_with(name)
+    fill_in "Full name", with: name
+  end
+
+  def when_i_update_the_email_with(email)
+    fill_in "Email address", with: email
+  end
+
+  # Then
+
+  def then_i_should_be_on_the_edit_name_page
+    expect(page).to have_text("Change ECT’s name")
+  end
+
+  def then_i_should_be_on_the_edit_email_page
+    expect(page).to have_text("Change mentor’s email address")
+  end
+
+  def then_i_should_see_the_ects_details
+    expect(page).to have_text(@participant_profile_ect.user.full_name)
+    have_link "Change", href: edit_name_admin_participant_path(id: @participant_profile_ect.id)
+    have_link "Change", href: edit_email_admin_participant_path(id: @participant_profile_ect.id)
+  end
+
+  def then_i_should_see_the_mentors_details
+    expect(page).to have_text(@participant_profile_mentor.user.full_name)
+    have_link "Change", href: edit_name_admin_participant_path(id: @participant_profile_mentor.id)
+    have_link "Change", href: edit_email_admin_participant_path(id: @participant_profile_mentor.id)
+  end
+
+  def then_i_should_see_a_list_of_participants
+    expect(page).to have_text("Fip School")
+    expect(page).to have_text("Sally Teacher")
+  end
+
+  def then_i_should_be_in_the_admin_participants_dashboard
+    expect(page).to have_selector("h1", text: "Participants")
+  end
+
+  def then_the_participants_email_should_have_updated(email)
+    expect(page).to have_text(email)
+  end
+
+  def then_i_should_receive_a_missing_name_error_message
+    expect(page).to have_text("Enter a full name")
+  end
+
+  def then_i_should_receive_a_missing_email_error_message
+    expect(page).to have_text("Enter an email")
+  end
+
+  def then_i_should_receive_an_email_already_taken_error_message
+    expect(page).to have_text("This email address is already in use")
+  end
+
+  def then_i_should_receive_a_invalid_email_error_message
+    expect(page).to have_text("Enter an email address in the correct format, like name@example.com")
+  end
+
+  # And
+
+  def and_i_have_added_an_ect
+    @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort)
+  end
+
+  def and_i_have_added_a_mentor
+    @participant_profile_mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_cohort)
+  end
+
+  def and_i_click_on_continue
+    click_on("Continue")
+  end
+
+  def and_admin_should_be_shown_a_success_message
+    expect(page).to have_selector ".govuk-notification-banner--success"
+  end
+
+  def and_the_page_should_have_the_updated_name(name)
+    expect(page).to have_text(name)
+  end
+end

--- a/spec/features/admin/participants/update_participants_details_spec.rb
+++ b/spec/features/admin/participants/update_participants_details_spec.rb
@@ -76,10 +76,6 @@ private
     click_on name
   end
 
-  # def when_i_click_to_change_the_participants_name
-  #   expect(page).to have_text(@participant_profile_ect.user.full_name)
-  # end
-
   def when_i_click_on_change_name
     click_on("Change name", visible: false)
   end


### PR DESCRIPTION
## Ticket and context

Ticket: [180](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-180)

## Tech review

### Is there anything that the code reviewer should know?

This is to replace an admin having to impersonate a SIT, however this PR has not removed any of that functionality.

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as admin. 
3. Go to participants tab on the dashboard, select an ECT or Mentor
4. Have a go at editing their name or email. 
