### PR TITLE
CPDLP-764 cohort on schedule

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Cohort < ApplicationRecord
+  has_many :schedules, class_name: "Finance::Schedule"
+
   def self.current
     # TODO: Register and Partner 262: Figure out how to update current year
     find_by(start_year: 2021)

--- a/app/models/finance/schedule.rb
+++ b/app/models/finance/schedule.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Finance::Schedule < ApplicationRecord
+  belongs_to :cohort
+
   has_many :milestones, -> { order(milestone_date: :asc) }
   has_many :participant_profiles
 end

--- a/db/migrate/20211202162431_add_cohort_to_schedule.rb
+++ b/db/migrate/20211202162431_add_cohort_to_schedule.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCohortToSchedule < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :schedules, :cohort, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_18_153946) do
+ActiveRecord::Schema.define(version: 2021_12_02_162431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -690,6 +690,8 @@ ActiveRecord::Schema.define(version: 2021_11_18_153946) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "schedule_identifier"
     t.string "type", default: "Finance::Schedule::ECF"
+    t.uuid "cohort_id"
+    t.index ["cohort_id"], name: "index_schedules_on_cohort_id"
   end
 
   create_table "school_cohorts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -877,6 +879,7 @@ ActiveRecord::Schema.define(version: 2021_11_18_153946) do
   add_foreign_key "provider_relationships", "delivery_partners"
   add_foreign_key "provider_relationships", "lead_providers"
   add_foreign_key "pupil_premiums", "schools"
+  add_foreign_key "schedules", "cohorts"
   add_foreign_key "school_cohorts", "cohorts"
   add_foreign_key "school_cohorts", "core_induction_programmes"
   add_foreign_key "school_cohorts", "schools"

--- a/db/seeds/schedules.rb
+++ b/db/seeds/schedules.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-ecf_september_standard_2021 = Finance::Schedule::ECF.find_or_create_by!(name: "ECF September standard 2021")
+cohort_2021 = Cohort.find_by!(start_year: 2021)
+
+ecf_september_standard_2021 = Finance::Schedule::ECF.find_or_create_by!(name: "ECF September standard 2021") do |s|
+  s.cohort = cohort_2021
+end
 ecf_september_standard_2021.update!(schedule_identifier: "ecf-september-standard-2021")
+ecf_september_standard_2021.update!(cohort: cohort_2021)
 [
   { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 11, 30), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
   { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
@@ -19,8 +24,11 @@ ecf_september_standard_2021.update!(schedule_identifier: "ecf-september-standard
   ).update!(declaration_type: hash[:declaration_type])
 end
 
-ecf_january_standard_2021 = Finance::Schedule::ECF.find_or_create_by!(name: "ECF January standard 2021")
+ecf_january_standard_2021 = Finance::Schedule::ECF.find_or_create_by!(name: "ECF January standard 2021") do |s|
+  s.cohort = cohort_2021
+end
 ecf_january_standard_2021.update!(schedule_identifier: "ecf-january-standard-2021")
+ecf_january_standard_2021.update!(cohort: cohort_2021)
 [
   { name: "Output 1 - Participant Start", start_date: Date.new(2022, 1, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "started" },
   { name: "Output 2 – Retention Point 1", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-1" },
@@ -38,7 +46,10 @@ ecf_january_standard_2021.update!(schedule_identifier: "ecf-january-standard-202
   ).update!(declaration_type: hash[:declaration_type])
 end
 
-npq_specialist_november_2021 = Finance::Schedule::NPQSpecialist.find_or_create_by!(name: "NPQ Specialist November 2021", schedule_identifier: "npq-specialist-november-2021")
+npq_specialist_november_2021 = Finance::Schedule::NPQSpecialist.find_or_create_by!(name: "NPQ Specialist November 2021", schedule_identifier: "npq-specialist-november-2021") do |s|
+  s.cohort = cohort_2021
+end
+npq_specialist_november_2021.update!(cohort: cohort_2021)
 [
   { name: "Output 1 - Participant Start", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31), declaration_type: "started" },
   { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 12, 26), milestone_date: Date.new(2022, 6, 25), payment_date: Date.new(2022, 7, 31), declaration_type: "retained-1" },
@@ -54,7 +65,10 @@ npq_specialist_november_2021 = Finance::Schedule::NPQSpecialist.find_or_create_b
   )
 end
 
-npq_leadership_november_2021 = Finance::Schedule::NPQLeadership.find_or_create_by!(name: "NPQ Leadership November 2021", schedule_identifier: "npq-leadership-november-2021")
+npq_leadership_november_2021 = Finance::Schedule::NPQLeadership.find_or_create_by!(name: "NPQ Leadership November 2021", schedule_identifier: "npq-leadership-november-2021") do |s|
+  s.cohort = cohort_2021
+end
+npq_leadership_november_2021.update!(cohort: cohort_2021)
 [
   { name: "Output 1 - Participant Start", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31), declaration_type: "started" },
   { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 12, 26), milestone_date: Date.new(2022, 6, 25), payment_date: Date.new(2022, 7, 31), declaration_type: "retained-1" },

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -21,6 +21,8 @@ FactoryBot.define do
       end
     end
 
+    cohort { Cohort.find_or_create_by(start_year: 2021) }
+
     factory :ecf_schedule, class: "Finance::Schedule::ECF", parent: :schedule do
       name { "ECF September standard 2021" }
       schedule_identifier { "ecf-september-standard-2021" }

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
       end
     end
 
-    cohort { Cohort.find_or_create_by(start_year: 2021) }
+    cohort { Cohort.find_or_create_by!(start_year: 2021) }
 
     factory :ecf_schedule, class: "Finance::Schedule::ECF", parent: :schedule do
       name { "ECF September standard 2021" }

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -3,6 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Cohort, type: :model do
+  describe "#schedules" do
+    subject { described_class.create!(start_year: 3000) }
+
+    let!(:schedule) { create(:ecf_schedule, cohort: subject) }
+
+    it "returns associated scheules" do
+      expect(subject.schedules).to include(schedule)
+    end
+  end
+
   it "can be created" do
     expect {
       Cohort.create(start_year: 2021)

--- a/spec/models/finance/schedule_spec.rb
+++ b/spec/models/finance/schedule_spec.rb
@@ -9,39 +9,48 @@ end
 
 RSpec.describe Finance::Schedule::ECF, type: :model do
   before do
-    seed_path = %w[db seeds]
-    load Rails.root.join(*seed_path, "schedules.rb").to_s
+    load Rails.root.join("db/seeds/initial_seed.rb").to_s
+    load Rails.root.join("db/seeds/schedules.rb").to_s
   end
+
+  subject { described_class.default }
 
   describe "default" do
     it "returns ECF September standard 2021 schedule" do
-      expect(described_class.default.name).to eq "ECF September standard 2021"
+      expect(subject.name).to eq "ECF September standard 2021"
+      expect(subject.cohort.start_year).to eq 2021
     end
   end
 end
 
 RSpec.describe Finance::Schedule::NPQLeadership, type: :model do
   before do
-    seed_path = %w[db seeds]
-    load Rails.root.join(*seed_path, "schedules.rb").to_s
+    load Rails.root.join("db/seeds/initial_seed.rb").to_s
+    load Rails.root.join("db/seeds/schedules.rb").to_s
   end
+
+  subject { described_class.default }
 
   describe "default" do
     it "returns ECF September standard 2021 schedule" do
-      expect(described_class.default.name).to eq "NPQ Leadership November 2021"
+      expect(subject.name).to eq "NPQ Leadership November 2021"
+      expect(subject.cohort.start_year).to eq 2021
     end
   end
 end
 
 RSpec.describe Finance::Schedule::NPQSpecialist, type: :model do
   before do
-    seed_path = %w[db seeds]
-    load Rails.root.join(*seed_path, "schedules.rb").to_s
+    load Rails.root.join("db/seeds/initial_seed.rb").to_s
+    load Rails.root.join("db/seeds/schedules.rb").to_s
   end
+
+  subject { described_class.default }
 
   describe "default" do
     it "returns ECF September standard 2021 schedule" do
-      expect(described_class.default.name).to eq "NPQ Specialist November 2021"
+      expect(subject.name).to eq "NPQ Specialist November 2021"
+      expect(subject.cohort.start_year).to eq 2021
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-764

- Previously a schedule was not directly associated with a cohort
- This was implied through the name of the schedule
- This adds the association between schedules and cohorts
- The  schedule name can now therefore be free from containing the cohort year
- This change at the moment is somewhat superficial as this association is not utilised but will pave the way for future changes
- After this is deployed i will ensure all environments contain this extra data

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- `cf ssh ecf-review-pr-1508`
- start rails console
- `pp Finance::Schedule.all`
- all schedules should belong to a cohort

## External API changes

- There are no external api changes