### PR TITLE
Remove extra sidekiq resources from review env

### DIFF
--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -13,7 +13,7 @@ paas_web_app_instances = 4
 paas_web_app_memory = 8192
 paas_worker_app_instances = 1
 paas_worker_app_memory = 4096
-paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=*:2 start && (bundle exec rake jobs:work &) && bundle exec sidekiq -C config/sidekiq.yml"
+paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=*:2 start && bundle exec rake jobs:work"
 paas_sidekiq_worker_app_instances = 4
 paas_sidekiq_worker_app_memory = 1024
 paas_sidekiq_worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -12,11 +12,3 @@ paas_web_app_instances = 1
 paas_web_app_memory = 1024
 paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
 paas_redis_service_plan = "micro-6_x"
-
-# Temporarily added for testing purposes, delete before merging
-paas_worker_app_instances = 1
-paas_worker_app_memory = 1024
-paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && bundle exec rake jobs:work"
-paas_sidekiq_worker_app_instances = 1
-paas_sidekiq_worker_app_memory = 1024
-paas_sidekiq_worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"


### PR DESCRIPTION
These were added for testing purposes and are just wasteful otherwise, should have been deleted before PR was merged

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
