### PR TITLE
Remove cron:schedule from web app start command

### DIFF
--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -68,7 +68,7 @@ variable paas_web_app_memory {
 }
 
 variable paas_web_app_start_command {
-  default = "bundle exec rake cf:on_first_instance db:migrate cron:schedule && rails s"
+  default = "bundle exec rake cf:on_first_instance db:migrate && rails s"
 }
 
 variable paas_worker_app_deployment_strategy {


### PR DESCRIPTION
We don't use this any more. This wasn't caught in review env as it has a custom web app command

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
