### PR TITLE
Fix call to update analytics from ECT create service

### DIFF
--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -25,7 +25,7 @@ module EarlyCareerTeachers
             ParticipantDetailsReminderJob.schedule(profile)
           end
 
-          Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: @participant_profile)
+          Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: profile)
         end
       end
     end

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -161,5 +161,6 @@ RSpec.describe EarlyCareerTeachers::Create do
         mentor_profile_id: mentor_profile.id,
       )
     }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob)
+      .with(participant_profile: instance_of(ParticipantProfile::ECT))
   end
 end


### PR DESCRIPTION
Previously using `@participant_profile` which was nil, and the spec was just asserting that the job was called.

This call is inside a transaction, so if we can't update analytics then the whole thing gets rolled back.

On production after this is deployed, manually create a Analytics::UpsertECFParticipantProfileJob for all ParticipantProfile::ECTs created after 1pm (we only have one
error, so far)

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
