### PR TITLE
Remove ValidationRetryJob from cron schedule

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -14,10 +14,6 @@ import_gias_data:
   cron: "0 6 * * *"
   class: "ImportGiasDataJob"
   queue: default
-validation_retry:
-  cron: "15 3 * * *"
-  class: "ValidationRetryJob"
-  queue: default
 school_analytics:
   cron: "10 * * * *"
   class: "SchoolAnalyticsJob"


### PR DESCRIPTION
This was removed in https://github.com/DFE-Digital/early-careers-framework/pull/1343 so we can safely unschedule it.