### PR TITLE
Seed db in parallel on review apps to prevent slow seeds from breaking

### DIFF
--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -3,18 +3,29 @@
 namespace :db do
   desc "Remove all database content, then seed it. Only for dev environments."
   task safe_reset: :environment do
-    if Rails.env.development? || Rails.env.deployed_development? || Rails.env.sandbox?
+    if Rails.env.development? || Rails.env.deployed_development?
+      Rake::Task["db:safe_wipe"].invoke
+      Rake::Task["db:seed"].invoke
+      puts "Re-seeded the database!"
+    else
+      puts "You should think twice before recreating staging or production database!"
+      puts "Fire off Rails console and copy the code from this task if you really have to."
+      puts "Make sure you know what you are doing and maybe do a back-up first."
+    end
+  end
+
+  desc "Remove all database content. Only for dev environments."
+  task safe_wipe: :environment do
+    if Rails.env.development? || Rails.env.deployed_development?
       connection = ActiveRecord::Base.connection
       tables = connection
-                   .execute("SELECT * FROM pg_catalog.pg_tables;")
-                   .filter { |row| row["schemaname"].include?("public") }
-                   .map { |row| row["tablename"] }
+                 .execute("SELECT * FROM pg_catalog.pg_tables;")
+                 .filter { |row| row["schemaname"].include?("public") }
+                 .map { |row| row["tablename"] }
       tables.delete "schema_migrations"
       tables.delete "spatial_ref_sys"
       tables.delete "features"
       tables.each { |table| connection.execute("TRUNCATE #{table} CASCADE;") }
-      Rake::Task["db:seed"].invoke
-      puts "Re-seeded the database!"
     else
       puts "You should think twice before recreating staging or production database!"
       puts "Fire off Rails console and copy the code from this task if you really have to."

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -11,5 +11,5 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_wipe redis:flushall && (bundle exec rake cf:on_first_instance db:seed &) && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
 paas_redis_service_plan = "tiny-6_x"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,5 +10,5 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_wipe redis:flushall && (bundle exec rake cf:on_first_instance db:seed &) && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
 paas_redis_service_plan = "micro-6_x"


### PR DESCRIPTION
deployments

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
