### PR TITLE
Add reasons to papertrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ per participant service fee £398 (40%) >> monthly service fee £27k >> total se
 * "Output payments" are payments made based on the performance of the training provider (i.e. their output).
 * "Payment type" for start/retention_x/completion output payments.
 
+## Storing reasons in PaperTrail
+Sometimes, we need to make manual changes to data. The reason for this change may not be obvious to those looking in the future.
+We version changes using PaperTrail, and when making an unusual change, we can set a reason to help those reading the change history.
+
+To set a reason for an entire console session:
+
+`PaperTrail.request.controller_info = {reason: "some reason"}`
+
+To set a reason for a block:
+
+```
+PaperTrail.request(controller_info: {reason: "some reason"}) do
+  # do something
+end
+```
+
 ## Runbook
 
 ### Updating NPQ applications from manual validation

--- a/db/migrate/20211208100449_add_reason_to_versions.rb
+++ b/db/migrate/20211208100449_add_reason_to_versions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReasonToVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :versions, :reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_162431) do
+ActiveRecord::Schema.define(version: 2021_12_08_100449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -819,6 +819,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_162431) do
     t.json "object_changes"
     t.datetime "created_at"
     t.uuid "item_id", default: -> { "gen_random_uuid()" }, null: false
+    t.string "reason"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
Add a reason column to papertrail, for recording notes about changes made on the console
