### PR TITLE
Fix STI autoloading for ParticipantProfile::NPQ

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -109,3 +109,6 @@ class ParticipantProfile < ApplicationRecord
     ParticipantProfilePolicy
   end
 end
+
+require "participant_profile/npq"
+require "participant_profile/ecf"

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -1,60 +1,62 @@
 # frozen_string_literal: true
 
-class ParticipantProfile::ECF < ParticipantProfile
-  self.ignored_columns = %i[school_id]
+class ParticipantProfile < ApplicationRecord
+  class ECF < ParticipantProfile
+    self.ignored_columns = %i[school_id]
 
-  belongs_to :school_cohort
-  belongs_to :core_induction_programme, optional: true
+    belongs_to :school_cohort
+    belongs_to :core_induction_programme, optional: true
 
-  has_one :school, through: :school_cohort
-  has_one :cohort, through: :school_cohort
-  has_one :ecf_participant_eligibility, foreign_key: :participant_profile_id
-  has_one :ecf_participant_validation_data, foreign_key: :participant_profile_id
+    has_one :school, through: :school_cohort
+    has_one :cohort, through: :school_cohort
+    has_one :ecf_participant_eligibility, foreign_key: :participant_profile_id
+    has_one :ecf_participant_validation_data, foreign_key: :participant_profile_id
 
-  scope :ineligible_status, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible }).where.not(ecf_participant_eligibility: { reason: :duplicate_profile }) }
-  scope :eligible_status, lambda {
-    joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :eligible })
-                                       .or(joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible, reason: %i[previous_participation duplicate_profile] }))
-  }
-  scope :current_cohort, -> { joins(:school_cohort).where(school_cohort: { cohort_id: Cohort.current.id }) }
-  scope :contacted_for_info, -> { where.missing(:ecf_participant_validation_data) }
-  scope :details_being_checked, -> { joins(:ecf_participant_validation_data).left_joins(:ecf_participant_eligibility).where("ecf_participant_eligibilities.id IS NULL OR ecf_participant_eligibilities.status = 'manual_check'") }
+    scope :ineligible_status, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible }).where.not(ecf_participant_eligibility: { reason: :duplicate_profile }) }
+    scope :eligible_status, lambda {
+      joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :eligible })
+        .or(joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible, reason: %i[previous_participation duplicate_profile] }))
+    }
+    scope :current_cohort, -> { joins(:school_cohort).where(school_cohort: { cohort_id: Cohort.current.id }) }
+    scope :contacted_for_info, -> { where.missing(:ecf_participant_validation_data) }
+    scope :details_being_checked, -> { joins(:ecf_participant_validation_data).left_joins(:ecf_participant_eligibility).where("ecf_participant_eligibilities.id IS NULL OR ecf_participant_eligibilities.status = 'manual_check'") }
 
-  enum profile_duplicity: {
-    single: "single",
-    primary: "primary",
-    secondary: "secondary",
-  }, _suffix: "profile"
+    enum profile_duplicity: {
+      single: "single",
+      primary: "primary",
+      secondary: "secondary",
+    }, _suffix: "profile"
 
-  after_save :update_analytics
+    after_save :update_analytics
 
-  def ecf?
-    true
-  end
+    def ecf?
+      true
+    end
 
-  def completed_validation_wizard?
-    ecf_participant_eligibility.present? || ecf_participant_validation_data.present?
-  end
+    def completed_validation_wizard?
+      ecf_participant_eligibility.present? || ecf_participant_validation_data.present?
+    end
 
-  def manual_check_needed?
-    ecf_participant_eligibility&.manual_check_status? ||
-      (ecf_participant_validation_data.present? && ecf_participant_eligibility.nil?)
-  end
+    def manual_check_needed?
+      ecf_participant_eligibility&.manual_check_status? ||
+        (ecf_participant_validation_data.present? && ecf_participant_eligibility.nil?)
+    end
 
-  def fundable?
-    ecf_participant_eligibility&.eligible_status?
-  end
+    def fundable?
+      ecf_participant_eligibility&.eligible_status?
+    end
 
-  def policy_class
-    ParticipantProfile::ECFPolicy
-  end
+    def policy_class
+      ParticipantProfile::ECFPolicy
+    end
 
-private
+  private
 
-  def update_analytics
-    Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if saved_change_to_training_status?
+    def update_analytics
+      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if saved_change_to_training_status?
+    end
   end
 end
 
-require_dependency "participant_profile/ect"
-require_dependency "participant_profile/mentor"
+require "participant_profile/ect"
+require "participant_profile/mentor"

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-class ParticipantProfile::NPQ < ParticipantProfile
-  self.ignored_columns = %i[mentor_profile_id school_cohort_id]
-  belongs_to :school, optional: true
-  belongs_to :npq_course, optional: true
+class ParticipantProfile < ApplicationRecord
+  class NPQ < ParticipantProfile
+    self.ignored_columns = %i[mentor_profile_id school_cohort_id]
+    belongs_to :school, optional: true
+    belongs_to :npq_course, optional: true
 
-  has_one :npq_application, foreign_key: :id, dependent: :destroy
+    has_one :npq_application, foreign_key: :id, dependent: :destroy
 
-  self.validation_steps = %i[identity decision].freeze
+    self.validation_steps = %i[identity decision].freeze
 
-  def npq?
-    true
-  end
+    def npq?
+      true
+    end
 
-  def approved?
-    validation_decision(:decision).approved?
-  end
+    def approved?
+      validation_decision(:decision).approved?
+    end
 
-  def rejected?
-    decision = validation_decision(:decision)
-    decision.persisted? && !decision.approved?
-  end
+    def rejected?
+      decision = validation_decision(:decision)
+      decision.persisted? && !decision.approved?
+    end
 
-  def participant_type
-    :npq
+    def participant_type
+      :npq
+    end
   end
 end


### PR DESCRIPTION
Previously we were getting a NameError: uninitialized constant #<Class:0x0000000104856e70>::NPQ when running the rails server in development mode and using the api endpoints

Explicitly require the descendants of ParticipantProfile to fix this, and format the files similarly to the other STI classes.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
