### PR TITLE
CPDLP-771 Automate NPQ participant declarations transitioning to eligible

### DIFF
--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -26,5 +26,9 @@ class ParticipantProfile < ApplicationRecord
     def participant_type
       :npq
     end
+
+    def fundable?
+      npq_application&.eligible_for_funding
+    end
   end
 end

--- a/spec/services/record_participant_declaration_service_spec.rb
+++ b/spec/services/record_participant_declaration_service_spec.rb
@@ -17,6 +17,30 @@ RSpec.describe RecordParticipantDeclaration do
     it "creates a participant declaration" do
       expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1)
     end
+
+    context "when the npq application is eligible for funding" do
+      before do
+        npq_profile.npq_application.update!(eligible_for_funding: true)
+      end
+
+      it "creates the participant declaration in the eligible state" do
+        described_class.call(npq_params)
+        declaration = npq_profile.participant_declarations.first
+        expect(declaration.state).to eq "eligible"
+      end
+    end
+
+    context "when the npq application is not eligible for funding" do
+      before do
+        npq_profile.npq_application.update!(eligible_for_funding: false)
+      end
+
+      it "creates the participant declaration in the submitted state" do
+        described_class.call(npq_params)
+        declaration = npq_profile.participant_declarations.first
+        expect(declaration.state).to eq "submitted"
+      end
+    end
   end
 
   context "when sending event for an ect course" do


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-771

To my knowledge, there isn't a way to change the `eligible_for_funding` field on an npq application after it has been created, so we don't need to create a hook to update the declaration if that changes.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
