### PR TITLE
Stop running delayed job in non-prod environments

### DIFF
--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -11,5 +11,5 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
 paas_redis_service_plan = "tiny-6_x"

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -10,5 +10,5 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && /app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=* start && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
 paas_redis_service_plan = "micro-6_x"

--- a/terraform/workspace-variables/sandbox.tfvars
+++ b/terraform/workspace-variables/sandbox.tfvars
@@ -11,8 +11,7 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 4
 paas_web_app_memory = 8192
-paas_worker_app_instances = 1
-paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=*:2 start && bundle exec rake jobs:work"
+paas_worker_app_instances = 0
 paas_sidekiq_worker_app_instances = 1
 paas_sidekiq_worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
 paas_sidekiq_worker_app_memory = 1024

--- a/terraform/workspace-variables/staging.tfvars
+++ b/terraform/workspace-variables/staging.tfvars
@@ -11,8 +11,7 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 4
 paas_web_app_memory = 8192
-paas_worker_app_instances = 1
-paas_worker_app_start_command = "/app/bin/delayed_job --pool=mailers --pool=priority_mailers --pool=*:2 start && bundle exec rake jobs:work"
+paas_worker_app_instances = 0
 paas_sidekiq_worker_app_instances = 1
 paas_sidekiq_worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.yml"
 paas_sidekiq_worker_app_memory = 1024


### PR DESCRIPTION
The databases on these environments are regularly reset, so there aren't any more delayed jobs hanging around. We don't need to run this any more. This should also stop the the dev/review boxes running out of memory and the OOM killer killing the sidekiq process.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
