### PR TITLE
CST-111 Backfill identities

### DIFF
--- a/app/controllers/admin/schools/induction_coordinators_controller.rb
+++ b/app/controllers/admin/schools/induction_coordinators_controller.rb
@@ -75,7 +75,7 @@ module Admin
     end
 
     def school_using_this_email(email)
-      User.find_by(email: email).schools.first
+      Identity.find_user_by(email: email).schools.first
     end
 
     def render_email_used_page(email:, action_path:)

--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -41,10 +41,10 @@ module Api
       end
 
       def participants
-        # NOTE: use this until we backfill identities
         participant_profiles = ParticipantProfile::ECF.where(id: participant_profile_ids)
-                                                      .joins(:user)
+                                                      .joins(:participant_identity, :user)
                                                       .includes(
+                                                        :participant_identity,
                                                         :user,
                                                         :cohort,
                                                         :school,
@@ -53,19 +53,6 @@ module Api
                                                         :schedule,
                                                         teacher_profile: { current_ect_profile: { mentor_profile: :user } },
                                                       )
-        # NOTE: then switch to this query one identities have been backfilled
-        # participant_profiles = ParticipantProfile::ECF.where(id: participant_profile_ids)
-        #                                               .joins(:participant_identity, :user)
-        #                                               .includes(
-        #                                                 :participant_identity,
-        #                                                 :user,
-        #                                                 :cohort,
-        #                                                 :school,
-        #                                                 :ecf_participant_eligibility,
-        #                                                 :ecf_participant_validation_data,
-        #                                                 :schedule,
-        #                                                 teacher_profile: { current_ect_profile: { mentor_profile: :user } },
-        #                                               )
 
         if updated_since.present?
           participant_profiles = participant_profiles.where(user: { updated_at: updated_since.. })
@@ -93,25 +80,14 @@ module Api
         # this retrieves the list of ECF participant profiles for the LeadProvider, one per
         # teacher_profile (now participant_identity).
         # Withdrawn profiles are included unless there is also an active one.
-        # The DISTINCT ON clause chooses the first record after ordering by status.
-        #
-        # NOTE: use this query until identities have been backfilled
+        # The DISTINCT ON clause chooses the first record after ordering by status to do this.
         inner_query = lead_provider
           .ecf_participant_profiles
-          .select("DISTINCT ON (participant_profiles.teacher_profile_id) teacher_profile_id, participant_profiles.status, participant_profiles.id AS id")
+          .select("DISTINCT ON (participant_profiles.participant_identity_id) participant_identity_id, participant_profiles.status, participant_profiles.id AS id")
           .joins(:school_cohort)
           .where(school_cohort: { cohort_id: Cohort.current.id })
-          .order(:teacher_profile_id, status: :asc)
+          .order(:participant_identity_id, status: :asc)
           .to_sql
-
-        # NOTE: then switch to this query one identities have been backfilled
-        # inner_query = lead_provider
-        #   .ecf_participant_profiles
-        #   .select("DISTINCT ON (participant_profiles.participant_identity_id) participant_identity_id, participant_profiles.status, participant_profiles.id AS id")
-        #   .joins(:school_cohort)
-        #   .where(school_cohort: { cohort_id: Cohort.current.id })
-        #   .order(:participant_identity_id, status: :asc)
-        #   .to_sql
         ActiveRecord::Base.connection.query_values("SELECT id FROM (#{inner_query}) AS inner_query")
       end
     end

--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -57,7 +57,7 @@ module Api
                     })
 
         users = users.changed_since(updated_since) if updated_since.present?
-        users = users.joins(:participant_identities).where(participant_identities: { email: email}) if email.present?
+        users = users.joins(:participant_identities).where(participant_identities: { email: email }) if email.present?
 
         users
       end

--- a/app/controllers/api/v1/ecf_users_controller.rb
+++ b/app/controllers/api/v1/ecf_users_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def create
-        user = User.find_by(email: params[:data][:attributes][:email])
+        user = Identity.find_user_by(email: params[:data][:attributes][:email])
 
         if user.present?
           user.errors.add(:email, :taken)
@@ -57,7 +57,7 @@ module Api
                     })
 
         users = users.changed_since(updated_since) if updated_since.present?
-        users = users.where(email: email) if email.present?
+        users = users.joins(:participant_identities).where(participant_identities: { email: email}) if email.present?
 
         users
       end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def create
-        user = User.find_by(email: params[:data][:attributes][:email])
+        user = Identity.find_user_by(email: params[:data][:attributes][:email])
 
         if user.present?
           user.errors.add(:email, :taken)

--- a/app/controllers/schools/add_participants_controller.rb
+++ b/app/controllers/schools/add_participants_controller.rb
@@ -43,7 +43,7 @@ module Schools
     end
 
     def email_used_in_the_same_school?
-      User.find_by(email: add_participant_form.email).school == add_participant_form.school_cohort.school
+      Identity.find_user_by(email: add_participant_form.email).school == add_participant_form.school_cohort.school
     end
     helper_method :email_used_in_the_same_school?
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -81,7 +81,7 @@ private
     email = params.dig(:user, :email)
     return unless TEST_DOMAINS.any? { |domain| email.include?(domain) }
 
-    user = ParticipantIdentity.find_by(email: email)&.user || User.find_by(email: email) || return
+    user = Identity.find_user_by(email: email) || return
 
     sign_in(user, scope: :user)
     redirect_to profile_dashboard_path(user)

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -77,7 +77,8 @@ module Schools
     end
 
     def email_already_taken?
-      User.find_by(email: email)
+      ParticipantIdentity.find_by(email: email)
+        &.user
         &.teacher_profile
         &.participant_profiles
         &.active_record
@@ -107,7 +108,7 @@ module Schools
     end
 
     def current_user
-      @current_user ||= User.find_by(id: current_user_id)
+      @current_user ||= Identity.find_user_by(id: current_user_id)
     end
 
     def creators

--- a/app/forms/supplier_user_form.rb
+++ b/app/forms/supplier_user_form.rb
@@ -37,6 +37,6 @@ class SupplierUserForm
 private
 
   def email_not_taken
-    errors.add(:email, :unique, message: I18n.t("errors.supplier_email.taken")) if User.find_by(email: email)
+    errors.add(:email, :unique, message: I18n.t("errors.supplier_email.taken")) if Identity.find_user_by(email: email)
   end
 end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -6,7 +6,7 @@ class ParticipantProfile < ApplicationRecord
 
   belongs_to :schedule, class_name: "Finance::Schedule", touch: true
 
-  belongs_to :participant_identity, optional: true # optional just while this is set up
+  belongs_to :participant_identity
 
   has_one :user, through: :teacher_profile
 

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -38,16 +38,16 @@ class ParticipantSerializer
 
   set_id :id do |profile|
     # NOTE: using this will retain the original ID exposed to provider
-    # profile.participant_identity.external_identifier
+    profile.participant_identity.external_identifier
     # NOTE: use this instead to use new (de-duped) ID - (or before we've populated the identities)
-    profile.user.id
+    # profile.user.id
   end
 
   active_participant_attribute :email do |profile|
     # NOTE: using this will retain the original email exposed to provider
-    # profile.participant_identity.email
+    profile.participant_identity.email
     # NOTE: use this instead to use new (de-duped) email - (or before we've populated the identities)
-    profile.user.email
+    # profile.user.email
   end
 
   active_participant_attribute :full_name do |profile|

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -39,14 +39,14 @@ class ParticipantSerializer
   set_id :id do |profile|
     # NOTE: using this will retain the original ID exposed to provider
     profile.participant_identity.external_identifier
-    # NOTE: use this instead to use new (de-duped) ID - (or before we've populated the identities)
+    # NOTE: use this instead to use new (de-duped) ID
     # profile.user.id
   end
 
   active_participant_attribute :email do |profile|
     # NOTE: using this will retain the original email exposed to provider
     profile.participant_identity.email
-    # NOTE: use this instead to use new (de-duped) email - (or before we've populated the identities)
+    # NOTE: use this instead to use new (de-duped) email
     # profile.user.email
   end
 

--- a/app/services/create_induction_tutor.rb
+++ b/app/services/create_induction_tutor.rb
@@ -13,14 +13,14 @@ class CreateInductionTutor < BaseService
     ActiveRecord::Base.transaction do
       remove_existing_induction_coordinator
 
-      if (user = User.find_by(email: email))&.induction_coordinator?
+      user = Identity.find_user_by(email: email)
+
+      if user&.induction_coordinator?
         raise if user.full_name != full_name
 
         user.induction_coordinator_profile.schools << school
       else
-        user = User.find_or_create_by!(email: email) do |induction_tutor|
-          induction_tutor.full_name = full_name
-        end
+        user ||= User.create!(email: email, full_name: full_name)
         InductionCoordinatorProfile.create!(user: user, schools: [school])
       end
 

--- a/app/services/identity.rb
+++ b/app/services/identity.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Identity
+  def self.find_user_by(params = {})
+    if params.key?(:id)
+      id = params[:id]
+      ParticipantIdentity.find_by(external_identifier: id)&.user || User.find_by(id: id)
+    elsif params.key?(:email)
+      email = params[:email]
+      ParticipantIdentity.find_by(email: email)&.user || User.find_by(email: email)
+    else
+      User.find_by(params)
+    end
+  end
+end

--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -50,7 +50,7 @@ module NPQ
     end
 
     def user
-      User.find_by(id: user_id)
+      Identity.find_user_by(id: user_id)
     end
   end
 end

--- a/app/services/participants/profile_attributes.rb
+++ b/app/services/participants/profile_attributes.rb
@@ -29,7 +29,7 @@ module Participants
   private
 
     def user
-      @user ||= User.find_by(id: participant_id)
+      @user ||= Identity.find_user_by(id: participant_id)
     end
 
     def valid_courses

--- a/app/services/validation_beta_service.rb
+++ b/app/services/validation_beta_service.rb
@@ -234,7 +234,7 @@ class ValidationBetaService
       participant_email = row["email"]
       next if participant_email.blank?
 
-      user = User.find_by(email: row["email"])
+      user = Identity.find_user_by(email: participant_email)
       next if user.nil?
 
       sit = user&.school&.induction_coordinator_profiles&.first

--- a/db/migrate/20211213104559_add_foreign_key_on_participant_profile_to_participant_identity.rb
+++ b/db/migrate/20211213104559_add_foreign_key_on_participant_profile_to_participant_identity.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddForeignKeyOnParticipantProfileToParticipantIdentity < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :participant_profiles, :participant_identities, null: false, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_08_142919) do
+ActiveRecord::Schema.define(version: 2021_12_13_104559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -881,6 +881,7 @@ ActiveRecord::Schema.define(version: 2021_12_08_142919) do
   add_foreign_key "participant_profiles", "cohorts"
   add_foreign_key "participant_profiles", "core_induction_programmes"
   add_foreign_key "participant_profiles", "npq_courses"
+  add_foreign_key "participant_profiles", "participant_identities"
   add_foreign_key "participant_profiles", "participant_profiles", column: "mentor_profile_id"
   add_foreign_key "participant_profiles", "schedules"
   add_foreign_key "participant_profiles", "school_cohorts"

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -351,6 +351,7 @@ teacher_profile = TeacherProfile.find_or_create_by!(user: user)
 ParticipantProfile::ECT.find_or_create_by!(teacher_profile: teacher_profile) do |ect_profile|
   ect_profile.school_cohort = School.find_by(urn: "000103").school_cohorts.find_by(cohort: Cohort.current)
   ect_profile.schedule = Finance::Schedule::ECF.default
+  ect_profile.participant_identity = Identity::Create.call(user: user, origin: :ecf)
   ect_profile.training_status_withdrawn!
   ParticipantProfileState.find_or_create_by!(participant_profile: ect_profile)
 end

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -20,14 +20,7 @@ module Devise
         if params[:user].present?
           email = params.dig(:user, :email)
 
-          identity = ParticipantIdentity.find_by(email: email)
-          if identity.present?
-            confirmed_email = identity.email
-            user = identity.user
-          else
-            user = User.find_by(email: email)
-            confirmed_email = user&.email
-          end
+          user = Identity.find_user_by(email: email)
 
           token_expiry = 60.minutes.from_now
           result = user&.update(
@@ -42,7 +35,7 @@ module Devise
               **UTMService.email(:sign_in),
             )
 
-            UserMailer.sign_in_email(email: confirmed_email, full_name: user.full_name, url: url, token_expiry: token_expiry.localtime.to_s(:time)).deliver_later(queue: "priority_mailers")
+            UserMailer.sign_in_email(email: email.downcase, full_name: user.full_name, url: url, token_expiry: token_expiry.localtime.to_s(:time)).deliver_later(queue: "priority_mailers")
             raise LoginIncompleteError
           else
             raise EmailNotFoundError

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -100,7 +100,7 @@ module ManageTrainingSteps
   def and_i_have_added_an_ect
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
     teacher_profile = create(:teacher_profile, user: user)
-    @participant_profile_ect = create(:ect_participant_profile, teacher_profile: teacher_profile , school_cohort: @school_cohort)
+    @participant_profile_ect = create(:ect_participant_profile, teacher_profile: teacher_profile, school_cohort: @school_cohort)
   end
 
   def and_i_have_added_a_mentor

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -98,19 +98,27 @@ module ManageTrainingSteps
   end
 
   def and_i_have_added_an_ect
-    @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com"), school_cohort: @school_cohort)
+    user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
+    teacher_profile = create(:teacher_profile, user: user)
+    @participant_profile_ect = create(:ect_participant_profile, teacher_profile: teacher_profile , school_cohort: @school_cohort)
   end
 
   def and_i_have_added_a_mentor
-    @participant_profile_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Billy Mentor", email: "billy-mentor@example.com"), school_cohort: @school_cohort)
+    user = create(:user, full_name: "Billy Mentor", email: "billy-mentor@example.com")
+    teacher_profile = create(:teacher_profile, user: user)
+    @participant_profile_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, teacher_profile: teacher_profile, school_cohort: @school_cohort)
   end
 
   def and_i_have_added_an_eligible_ect_with_mentor
-    @eligible_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible With-mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
+    user = create(:user, full_name: "Eligible With-mentor")
+    teacher_profile = create(:teacher_profile, user: user)
+    @eligible_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, teacher_profile: teacher_profile, mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
   end
 
   def and_i_have_added_an_eligible_ect_without_mentor
-    @eligible_ect_without_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible Without-mentor"), school_cohort: @school_cohort)
+    user = create(:user, full_name: "Eligible Without-mentor")
+    teacher_profile = create(:teacher_profile, user: user)
+    @eligible_ect_without_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, teacher_profile: teacher_profile, school_cohort: @school_cohort)
   end
 
   def and_i_have_added_an_eligible_ect

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -35,18 +35,16 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when the email is in use by an ECT user" do
-      let!(:ect_profile) do
-        create(:ect_participant_profile, user: create(:user, email: "ray.clemence@example.com"))
-      end
+      let(:user) { create(:user, email: "ray.clemence@example.com") }
+      let(:teacher_profile) { create(:teacher_profile, user: user) }
+      let!(:ect_profile) { create(:ect_participant_profile, teacher_profile: teacher_profile) }
 
       it "returns true" do
         expect(form).to be_email_already_taken
       end
 
       context "when the ECT profile record is withdrawn" do
-        let!(:ect_profile) do
-          create(:ect_participant_profile, :withdrawn_record, user: create(:user, email: "ray.clemence@example.com"))
-        end
+        let!(:ect_profile) { create(:ect_participant_profile, :withdrawn_record, teacher_profile: teacher_profile) }
 
         it "returns false" do
           expect(form).not_to be_email_already_taken
@@ -55,18 +53,16 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when the email is in use by a Mentor" do
-      let!(:mentor_profile) do
-        create(:mentor_participant_profile, user: create(:user, email: "ray.clemence@example.com"))
-      end
+      let(:user) { create(:user, email: "ray.clemence@example.com") }
+      let(:teacher_profile) { create(:teacher_profile, user: user) }
+      let!(:mentor_profile) { create(:mentor_participant_profile, teacher_profile: teacher_profile) }
 
       it "returns true" do
         expect(form).to be_email_already_taken
       end
 
       context "when the mentor profile record is withdrawn" do
-        let!(:mentor_profile) do
-          create(:mentor_participant_profile, :withdrawn_record, user: create(:user, email: "ray.clemence@example.com"))
-        end
+        let!(:mentor_profile) { create(:mentor_participant_profile, :withdrawn_record, teacher_profile: teacher_profile) }
 
         it "returns false" do
           expect(form).not_to be_email_already_taken
@@ -75,10 +71,9 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when the email is in use by a NPQ registrant" do
-      before do
-        existing_user = create(:user, email: "ray.clemence@example.com")
-        create(:npq_participant_profile, user: existing_user)
-      end
+      let(:user) { create(:user, email: "ray.clemence@example.com") }
+      let(:teacher_profile) { create(:teacher_profile, user: user) }
+      let!(:npq_profile) { create(:npq_participant_profile, teacher_profile: teacher_profile) }
 
       it "returns false" do
         expect(form).not_to be_email_already_taken

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ParticipantProfile, type: :model do
   it { is_expected.to belong_to(:teacher_profile) }
-  it { is_expected.to belong_to(:participant_identity).optional }
+  it { is_expected.to belong_to(:participant_identity) }
   it { is_expected.to belong_to(:schedule) }
   it { is_expected.to have_one(:user).through(:teacher_profile) }
   it {

--- a/spec/services/identity_spec.rb
+++ b/spec/services/identity_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Identity do
+  describe ".find_user_by" do
+    context "when searching by email" do
+      let(:user) { create(:user, email: "fred@example.com") }
+      let!(:identity) { create(:participant_identity, user: user, email: "charlie@example.com") }
+
+      context "when a matching identity record exists" do
+        it "returns the associated user record" do
+          result = described_class.find_user_by(email: "charlie@example.com")
+          expect(result).to eq user
+        end
+      end
+
+      context "when a matching user record exists" do
+        it "returns the user record" do
+          result = described_class.find_user_by(email: "fred@example.com")
+          expect(result).to eq user
+        end
+      end
+
+      context "when a matching identity or user record is not found" do
+        it "returns nil" do
+          result = described_class.find_user_by(email: "arthur@example.com")
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    context "when searching by id" do
+      let(:user) { create(:user) }
+      let(:external_id) { SecureRandom.uuid }
+      let!(:identity) { create(:participant_identity, user: user, external_identifier: external_id) }
+
+      context "when a matching identity record exists" do
+        it "returns the associated user record" do
+          result = described_class.find_user_by(id: external_id)
+          expect(result).to eq user
+        end
+      end
+
+      context "when a matching user record exists" do
+        it "returns the user record" do
+          result = described_class.find_user_by(id: user.id)
+          expect(result).to eq user
+        end
+      end
+
+      context "when a matching identity or user record is not found" do
+        it "returns nil" do
+          result = described_class.find_user_by(id: SecureRandom.uuid)
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    context "when searching by other user attributes" do
+      let!(:user) { create(:user, full_name: "Chester Thompson") }
+
+      it "falls back to User.find_by" do
+        result = described_class.find_user_by(full_name: "Chester Thompson")
+        expect(result).to eq user
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-111)

Data has been backfilled in all the environments. This adds in functionality to use `ParticipantIdentity` for looking up `User` records by email or id.

Add a new `Identity.find_user_by` method to encapsulate the queries to smooth this transition.

Adds foreign key to `participant_profiles.participant_identity_id` and removes `optional` from `belongs_to :participant_identity` in `ParticipantProfile` model

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
