### PR TITLE
CPDLP-773 Add spec for breakdown count and add seeds

### DIFF
--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -191,13 +191,15 @@ private
     (npq_contract.per_participant * npq_contract.output_payment_percentage) / (100 * npq_contract.number_of_payment_periods)
   end
 
-  def expected_output_fee_payment(npq_contract)
-    eligible_and_payable_participant_count = ParticipantDeclaration::NPQ
-        .eligible_or_payable_for_lead_provider_and_course(
-          npq_contract.npq_lead_provider.cpd_lead_provider, npq_contract.course_identifier
-        ).count
+  def eligible_and_payable_participant_count(npq_contract)
+    ParticipantDeclaration::NPQ
+      .eligible_or_payable_for_lead_provider_and_course(
+        npq_contract.npq_lead_provider.cpd_lead_provider, npq_contract.course_identifier
+      ).count
+  end
 
-    expected_per_participant_output_payment_portion(npq_contract) * eligible_and_payable_participant_count
+  def expected_output_fee_payment(npq_contract)
+    expected_per_participant_output_payment_portion(npq_contract) * eligible_and_payable_participant_count(npq_contract)
   end
 
   def then_i_should_see_correct_output_payment_breakdown(npq_contract)
@@ -210,6 +212,9 @@ private
 
       expect(page.find("td:nth-child(1)", text: "Output fee"))
         .to have_sibling("td", text: number_to_pounds(expected_output_fee_payment(npq_contract)))
+
+      expect(page.find("td:nth-child(1)", text: "Output fee"))
+        .to have_sibling("td", text: eligible_and_payable_participant_count(npq_contract))
     end
   end
 


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-773

The ticket is just to check that we are only using eligible declarations in the breakdown for NPQ output fee. The output fee page was showing N/A for the count, but this was fixed in a separate PR, so just a spec has been added to solidify this. Also added some seeds with eligible/submitted declarations for Ambition/npq-headship to make it easier to test the breakdown page.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
