### PR TITLE
Fix sidekiq-cron deprecation warning

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,5 +24,7 @@ end
 
 # Sidekiq Cron
 if Sidekiq.server?
-  Sidekiq::Cron::Job.load_from_hash(YAML.load_file(Rails.root.join("config/sidekiq_cron_schedule.yml")))
+  Rails.application.config.after_initialize do
+    Sidekiq::Cron::Job.load_from_hash(YAML.load_file(Rails.root.join("config/sidekiq_cron_schedule.yml")))
+  end
 end


### PR DESCRIPTION
On running `bundle exec sidekiq`, I see the following deprecation warning:

```
2021-12-14T11:06:08.148Z pid=6620 tid=rc INFO: Booting Sidekiq 6.3.1 with redis options {}
2021-12-14T11:06:08.161Z pid=6620 tid=rc INFO: Cron Jobs - add job with name: session_trim
2021-12-14T11:06:08.172Z pid=6620 tid=rc INFO: Cron Jobs - add job with name: create_new_fake_sandbox_data
2021-12-14T11:06:08.180Z pid=6620 tid=rc INFO: Cron Jobs - add job with name: stream_big_query_participant_declarations
2021-12-14T11:06:08.188Z pid=6620 tid=rc INFO: Cron Jobs - add job with name: import_gias_data
2021-12-14T11:06:08.195Z pid=6620 tid=rc INFO: Cron Jobs - add job with name: school_analytics
2021-12-14T11:06:09.143Z pid=6620 tid=rc WARN: DEPRECATION WARNING: Initialization autoloaded the constants ApplicationJob, SessionTrimJob, CreateNewFakeSandboxDataJob, StreamBigQueryParticipantDeclarationsJob, ImportGiasDataJob, and SchoolAnalyticsJob.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ApplicationJob, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
 (called from <top (required)> at /mnt/c/Users/ethmil/Work/DFE/tmp/early-careers-framework/config/environment.rb:7)
```

 I'm using the solution from https://github.com/ondrejbartas/sidekiq-cron/issues/249#issuecomment-577492567, since we don't need to do this again on reload