### PR TITLE
CST-123 no trn mentors design changes

### DIFF
--- a/app/controllers/participants/start_registrations_controller.rb
+++ b/app/controllers/participants/start_registrations_controller.rb
@@ -3,5 +3,7 @@
 module Participants
   class StartRegistrationsController < ApplicationController
     def show; end
+
+    def trn_guidance; end
   end
 end

--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Participants
-  class ValidationsController < ApplicationController
+  class ValidationsController < BaseController
     include Multistep::Controller
 
     form Participants::ParticipantValidationForm, as: :validation_form

--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Participants
-  class ValidationsController < BaseController
+  class ValidationsController < ApplicationController
     include Multistep::Controller
 
     form Participants::ParticipantValidationForm, as: :validation_form
-
     setup_form do |form|
       form.participant_profile_id = current_user.teacher_profile.current_ecf_profile.id
+      form.complete_step(:check_trn_given, check_trn_given: true) unless current_user.mentor?
     end
 
     abandon_journey_path { { action: :already_completed } }

--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -36,6 +36,16 @@ module Participants
     attribute :dqt_response
     attribute :attempts, default: 0
 
+    step :check_trn_given, update: true do
+      attribute :check_trn_given, :boolean
+
+      validates :check_trn_given, inclusion: { in: [true, false], message: :blank }
+
+      next_step { check_trn_given ? :trn : :trn_guidance }
+    end
+
+    step :trn_guidance
+
     step :trn, update: true do
       attribute :trn, :string
       attribute :no_trn, :boolean, default: false

--- a/app/views/participants/start_registrations/show.html.erb
+++ b/app/views/participants/start_registrations/show.html.erb
@@ -9,12 +9,12 @@
       <li>mentors assigned to work with ECTs during their induction training</li>
      </ul>
 
-    <p class="govuk-body">We need to check your details on the Teaching Regulation Agency records. This is to make sure you qualify for this programme.</p>
+    <p class="govuk-body">We need to check your details on the Teaching Regulation Agency records. This is to make sure you’re eligible for this funded programme.</p>
 
     <p class="govuk-body">We’ll ask for your:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>teacher reference number(TRN)</li>
+      <li>teacher reference number (TRN)</li>
       <li>date of birth</li>
     </ul>
 

--- a/app/views/participants/start_registrations/show.html.erb
+++ b/app/views/participants/start_registrations/show.html.erb
@@ -1,15 +1,28 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Register for early career training and support</h1>
+    <h1 class="govuk-heading-xl">Register for DfE-funded early career teacher training</h1>
 
-    <p class="govuk-body">This service is for early career teachers and mentors who are about to begin their induction training programme.</p>
+    <p class="govuk-body">This service is for:</p>
+
+     <ul class="govuk-list govuk-list--bullet">
+      <li>early career teachers (ECTs) working, or due to start work, in England</li>
+      <li>mentors assigned to work with ECTs during their induction training</li>
+     </ul>
+
     <p class="govuk-body">We need to check your details on the Teaching Regulation Agency records. This is to make sure you qualify for this programme.</p>
-    <p class="govuk-body">You must only use this service if:</p>
+
+    <p class="govuk-body">We’ll ask for your:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>your school asked you to</li>
-      <li>you’re a teacher working (or due to start work) in England</li>
+      <li>teacher reference number(TRN)</li>
+      <li>date of birth</li>
     </ul>
+
+    <h2 class="govuk-heading-m">If you have a TRN but cannot find it</h2>
+    <p class="govuk-body">You can enter your National Insurance number instead. This will help us find and check your TRN.</p>
+
+    <h2 class="govuk-heading-m">If you’re a mentor without a TRN</h2>
+    <p class="govuk-body">You must <%= govuk_link_to "apply for a TRN", trn_guidance_participants_start_registrations_path %> before you can use this service. You need a TRN to receive funded training and materials.</p>
 
     <%= govuk_button_link_to "Continue", new_user_session_path %>
   </div>

--- a/app/views/participants/start_registrations/trn_guidance.html.erb
+++ b/app/views/participants/start_registrations/trn_guidance.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, "Get a Teacher Reference Number (TRN)" %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: participants_start_registrations_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <%= render partial: "shared/trn_guidance" %>
+
+  </div>
+</div>

--- a/app/views/participants/validations/check_trn_given.html.erb
+++ b/app/views/participants/validations/check_trn_given.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Have you been given a teacher reference number (TRN)?</h1>
+
+    <p class="govuk-body">You’ll have a TRN if you hold, or are working towards qualified teacher status (QTS) in England.</p>
+    <p class="govuk-body">You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
+
+    <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: { text: "" } do %>
+        <%= f.govuk_radio_button :check_trn_given, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :check_trn_given, false, label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/participants/validations/trn.html.erb
+++ b/app/views/participants/validations/trn.html.erb
@@ -10,7 +10,6 @@
       <li>may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’</li>
       <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
     </ul>
-    <p class="govuk-body">You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
 
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.hidden_field :no_trn, value: false %>
@@ -19,7 +18,7 @@
         width: "three-quarters",
         label: { text: "Teacher reference number (TRN)", class: "govuk-visually-hidden" }
       %>
-      <p class="govuk-body"><%= govuk_link_to "Register without a TRN", { action: :no_trn }, class: 'govuk-link--no-visit-state'  %></p>
+      <p class="govuk-body"><%= govuk_link_to "Cannot find your TRN?", { action: :no_trn }, class: 'govuk-link--no-visit-state'  %></p>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/participants/validations/trn_guidance.html.erb
+++ b/app/views/participants/validations/trn_guidance.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, "Get a Teacher Reference Number (TRN)" %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <%= render partial: "shared/trn_guidance" %>
+
+  </div>
+</div>

--- a/app/views/shared/_trn_guidance.html.erb
+++ b/app/views/shared/_trn_guidance.html.erb
@@ -1,0 +1,77 @@
+<h1 class="govuk-heading-xl">Get a Teacher Reference Number (TRN)</h1>
+
+<h2 class="govuk-heading-m">Why do I need this?</h2>
+
+<p class="govuk-body">
+  Mentors working with early career teachers (ECTs) need a <%= govuk_link_to "TRN (opens in a new tab)", "https://www.gov.uk/guidance/teacher-reference-number-trn", target: :_blank, rel: "noopener noreferrer" %>
+  to access DfE-funded training and materials. You do not need to be a teacher to get a TRN.
+</p>
+
+<h2 class="govuk-heading-m">How to request a TRN</h2>
+
+<p class="govuk-body">
+  You need to apply to the Teaching Regulation Agency. They'll need some information about you, as well as proof of ID.
+</p>
+
+<p class="govuk-body">
+  You can use a free email platform called Galaxkey to send your information securely.
+</p>
+
+<h2 class="govuk-heading-m">Register with Galaxkey to send your information securely</h2>
+
+<p class="govuk-body">
+  Visit the Galaxkey site:
+  <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)", "https://manager.galaxkey.com/services/registerme",  target: :_blank, rel: "noopener noreferrer" %>
+</p>
+
+<p class="govuk-body">
+  Enter the email address you want to sign up with and complete the registration process.
+</p>
+
+<p class="govuk-body">
+  You’ll get an email when your account is activated.
+</p>
+
+<h2 class="govuk-heading-m">How to send your ID documents</h2>
+
+<p class="govuk-body">Follow these steps to send your documents to the Teaching Regulation Agency through Galaxkey:</p>
+
+<ol class="govuk-list govuk-list--number">
+  <li>
+   Sign in to your Galaxkey account: <%= govuk_link_to "https://manager.galaxkey.com/Account/LogOn (opnes in a new tab)", "https://manager.galaxkey.com/Account/LogOn", target: :_blank, rel: "noopener noreferrer" %>
+  </li>
+  <li>Select ‘Compose’ to create a new secure email.</li>
+  <li>Enter ’qts.enquiries@education.gov.uk’ as the recipient.</li>
+  <li>Enter ‘Request a TRN for ECF induction training’ as the subject line.</li>
+  <li>
+    Provide your:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>full legal name</li>
+      <li>date of birth</li>
+      <li>email address</li>
+    </ul>
+  </li>
+  <li>Attach a scanned copy or photo of one of the following types of ID:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>passport</li>
+      <li>driving license (full or provisional)</li>
+      <li>certificate of residence</li>
+      <li>birth certificate</li>
+    </ul>
+  </li>
+</ol>
+
+<p class="govuk-body">Follow the guidance on screen to make sure you send the correct file size.</p>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p class="govuk-body">The Teaching Regulation Agency will use the information you send to create your TRN.</p>
+
+<p class="govuk-body">They aim to respond to valid email requests within 5 working days.</p>
+
+<p class="govuk-body">Your ID documents will be deleted once your request is processed.</p>
+
+<p class="govuk-body">
+  Find out how the Teaching Regulation Agency processes your data on the
+  <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank, rel: "noopener noreferrer" %>.
+</p>

--- a/config/locales/participants/validation_form.en.yml
+++ b/config/locales/participants/validation_form.en.yml
@@ -4,6 +4,8 @@ en:
       models:
         participants/participant_validation_form:
           attributes:
+            check_trn_given:
+              blank: Select an option
             trn:
               blank: Enter your teacher reference number
               too_short: Teacher reference number is at least %{count} digits long

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,7 +303,9 @@ Rails.application.routes.draw do
 
   namespace :participants do
     resource :no_access, only: :show, controller: "no_access"
-    resource :start_registrations, path: "/start-registration", only: :show
+    resource :start_registrations, path: "/start-registration", only: :show do
+      get "trn-guidance", action: :trn_guidance
+    end
 
     multistep_form :validation, Participants::ParticipantValidationForm, controller: :validations do
       get :no_trn, as: nil

--- a/spec/features/participants/starting_registration_spec.rb
+++ b/spec/features/participants/starting_registration_spec.rb
@@ -18,7 +18,7 @@ private
   end
 
   def then_i_should_see_the_registration_heading
-    expect(page).to have_selector("h1", text: "Register for early career training and support")
+    expect(page).to have_selector("h1", text: "Register for DfE-funded early career teacher training")
   end
 
   def and_i_should_see_a_continue_button

--- a/spec/features/participants/validation_spec.rb
+++ b/spec/features/participants/validation_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Participant validation journey", with_feature_flags: { eligibilit
 
   scenario "Mentor tries to validate but has no TRN" do
     sign_in_as mentor_participant_profile.user
-    expect(page).to have_current_path participants_validation_step_path(:check_trn_given.to_s.dasherize)
+    expect(page).to have_current_path participants_validation_step_path(:"check-trn-given")
     expect(page).to be_accessible
     page.percy_snapshot("Mentor validation journey: trn")
 
@@ -96,14 +96,14 @@ RSpec.feature "Participant validation journey", with_feature_flags: { eligibilit
     find(:label, text: "No").click
     click_on "Continue"
 
-    expect(page).to have_current_path participants_validation_step_path(:trn_guidance.to_s.dasherize)
+    expect(page).to have_current_path participants_validation_step_path(:"trn-guidance")
     expect(page).to be_accessible
     page.percy_snapshot("Mentor validation journey: trn guidance")
   end
 
   scenario "Mentor validates their details with trn" do
     sign_in_as mentor_participant_profile.user
-    expect(page).to have_current_path participants_validation_step_path(:check_trn_given.to_s.dasherize)
+    expect(page).to have_current_path participants_validation_step_path(:"check-trn-given")
 
     find(:label, text: "Yes").click
     click_on "Continue"

--- a/spec/features/participants/validation_spec.rb
+++ b/spec/features/participants/validation_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.feature "ECT participant validation journey", with_feature_flags: { eligibility_notifications: "active" }, type: :feature, js: true do
+RSpec.feature "Participant validation journey", with_feature_flags: { eligibility_notifications: "active" }, type: :feature, js: true do
   let(:school) { create :school, name: "Awesome school" }
   let(:school_cohort) { create :school_cohort, :fip, school: school }
-  let(:user) { create :user, full_name: "Lena zavroni" }
-  let(:teacher_profile) { create :teacher_profile, user: user }
-  let(:participant_profile) { create :ect_participant_profile, school_cohort: school_cohort, teacher_profile: teacher_profile }
+  let(:ect_user) { create :user, full_name: "Lena zavroni" }
+  let(:mentor_user) { create :user, full_name: "Spike Spiegel" }
+  let(:ect_teacher_profile) { create :teacher_profile, user: ect_user }
+  let(:mentor_teacher_profile) { create :teacher_profile, user: mentor_user }
+  let(:ect_participant_profile) { create :ect_participant_profile, school_cohort: school_cohort, teacher_profile: ect_teacher_profile }
+  let(:mentor_participant_profile) { create :mentor_participant_profile, school_cohort: school_cohort, teacher_profile: mentor_teacher_profile }
+
   before { set_dtq_validation_result nil }
 
-  scenario "Participant validates their details with trn" do
-    sign_in_as participant_profile.user
+  scenario "ECT validates their details with trn" do
+    sign_in_as ect_participant_profile.user
     expect(page).to have_current_path participants_validation_step_path(:trn)
     expect(page).to be_accessible
     page.percy_snapshot("Participant validation journey: trn")
@@ -66,7 +70,7 @@ RSpec.feature "ECT participant validation journey", with_feature_flags: { eligib
     expect(page).to be_accessible
 
     page.percy_snapshot("Participant validation journey: name")
-    expect(page.find_field("Your name").value).to eq participant_profile.user.full_name
+    expect(page.find_field("Your name").value).to eq ect_participant_profile.user.full_name
     fill_in "Your name", with: "Correct Name"
     click_on "Continue"
 
@@ -78,6 +82,66 @@ RSpec.feature "ECT participant validation journey", with_feature_flags: { eligib
     expect(page).to have_current_path participants_validation_step_path(:"manual-check")
     expect(page).to be_accessible
     page.percy_snapshot("Participant validation journey: manual check required")
+  end
+
+  scenario "Mentor tries to validate but has no TRN" do
+    sign_in_as mentor_participant_profile.user
+    expect(page).to have_current_path participants_validation_step_path(:check_trn_given.to_s.dasherize)
+    expect(page).to be_accessible
+    page.percy_snapshot("Mentor validation journey: trn")
+
+    click_on "Continue"
+    expect(page).to have_content "Select an option"
+
+    find(:label, text: "No").click
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:trn_guidance.to_s.dasherize)
+    expect(page).to be_accessible
+    page.percy_snapshot("Mentor validation journey: trn guidance")
+  end
+
+  scenario "Mentor validates their details with trn" do
+    sign_in_as mentor_participant_profile.user
+    expect(page).to have_current_path participants_validation_step_path(:check_trn_given.to_s.dasherize)
+
+    find(:label, text: "Yes").click
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:trn)
+
+    click_on "Continue"
+    expect(page).to have_content "Enter your teacher reference number"
+
+    fill_in "Teacher reference number (TRN)", with: "7654321"
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:dob)
+
+    fill_in "Day", with: "4"
+    fill_in "Month", with: "11"
+    fill_in "Year", with: "1991"
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:"no-match")
+    click_on "Add your National Insurance number"
+    expect(page).to have_current_path participants_validation_step_path(:nino)
+    click_on "Continue"
+
+    fill_in "National Insurance Number", with: "AB123456C"
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:"no-match")
+    click_on "Continue to confirm your name"
+
+    expect(page).to have_current_path participants_validation_step_path(:"name-changed")
+    find(:label, text: "Yes").click
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:"no-match")
+    click_on "Continue"
+
+    expect(page).to have_current_path participants_validation_step_path(:"manual-check")
   end
 
   def set_dtq_validation_result(result)

--- a/spec/requests/participants/validation_spec.rb
+++ b/spec/requests/participants/validation_spec.rb
@@ -3,24 +3,40 @@
 require "rails_helper"
 
 RSpec.describe "Participant validations", with_feature_flags: { eligibility_notifications: "active" }, type: :request do
-  before do
-    sign_in user
-  end
+  let!(:school_cohort) { create(:school_cohort) }
+  let!(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+  let!(:ect_user) { ect_profile.user }
+  let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+  let!(:mentor_user) { mentor_profile.user }
 
-  let(:school_cohort) { create(:school_cohort) }
-  let(:profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
-  let(:user) { profile.user }
+  describe "starting the journey" do
+    context "ECT is validating details" do
+      before do
+        sign_in ect_user
+      end
 
-  describe "starting the journey"
+      it "starts with :trn step" do
+        get participants_validation_path
+        expect(response).to redirect_to participants_validation_step_path(:trn)
+      end
+    end
 
-  it "starts with :trn step" do
-    get participants_validation_path
-    expect(response).to redirect_to participants_validation_step_path(:trn)
+    context "Mentor is validating details" do
+      before do
+        sign_in mentor_user
+      end
+
+      it "starts with :check_given_trn step" do
+        get participants_validation_path
+        expect(response).to redirect_to participants_validation_step_path(:check_trn_given.to_s.dasherize)
+      end
+    end
   end
 
   Participants::ParticipantValidationForm.steps.each_key do |step|
     describe "#{step} step" do
       before do
+        sign_in ect_user
         get participants_validation_path
         session_form = session[controller.class.session_key]
         session_form["dob"] = rand(20..30).years.ago + rand(1..355).days

--- a/spec/requests/participants/validation_spec.rb
+++ b/spec/requests/participants/validation_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Participant validations", with_feature_flags: { eligibility_noti
 
       it "starts with :check_given_trn step" do
         get participants_validation_path
-        expect(response).to redirect_to participants_validation_step_path(:check_trn_given.to_s.dasherize)
+        expect(response).to redirect_to participants_validation_step_path(:"check-trn-given")
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

Ticket: [123](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?selectedIssue=CST-123)

## Tech review

### Is there anything that the code reviewer should know?

A step did not already exist in the journey. If a mentor is trying to validate details then they should start at the check_trn_given step where as an ECT will skip this and go straight on to adding their trn. 

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login in as `fip-ect-eligible@example.com` and you should be asked to enter your trn as the first point.
3. Login as `fip-mentor-eligible@example.com` and you should be asked whether you've been given a TRN. 
4. For the trn guidance link on the start registrations go to `/participants/start-registration` and click the 'apply for a TRN' link