### PR TITLE
CST-107: As a SIT I want to change my schools SIT

### DIFF
--- a/app/controllers/schools/change_sit_controller.rb
+++ b/app/controllers/schools/change_sit_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Schools
+  class ChangeSitController < ::Schools::BaseController
+    skip_after_action :verify_authorized, :verify_policy_scoped
+    before_action :set_form
+    skip_before_action :ensure_school_user, only: :success
+    skip_before_action :authenticate_user!, only: :success
+
+    helper_method :has_multiple_schools?
+
+    def name; end
+
+    def set_name
+      unless @induction_tutor_form.valid?(:full_name)
+        return render :name
+      end
+
+      store_form
+      redirect_to action: :email
+    end
+
+    def email; end
+
+    def set_email
+      unless @induction_tutor_form.valid?(:email)
+        return render :email
+      end
+
+      store_form
+      redirect_to action: :check_details
+    end
+
+    def check_details; end
+
+    def confirm; end
+
+    def save
+      CreateInductionTutor.call(
+        school: @induction_tutor_form.school,
+        email: @induction_tutor_form.email,
+        full_name: @induction_tutor_form.full_name,
+      )
+      redirect_to action: :success
+    end
+
+    def success
+      session.delete(:induction_tutor_form)
+      sign_out unless current_user&.schools&.any?
+    end
+
+  private
+
+    def has_multiple_schools?
+      current_user.schools.count > 1
+    end
+
+    def form_params
+      return if params[:nominate_induction_tutor_form].blank?
+
+      params.require(:nominate_induction_tutor_form).permit(:full_name, :email)
+    end
+
+    def set_form
+      @induction_tutor_form = NominateInductionTutorForm.new(session[:induction_tutor_form])
+      @induction_tutor_form.school_id ||= active_school.id
+      @induction_tutor_form.assign_attributes(form_params) if form_params.present?
+    end
+
+    def store_form
+      session[:induction_tutor_form] = @induction_tutor_form.serializable_hash
+    end
+  end
+end

--- a/app/views/layouts/school_cohort.html.erb
+++ b/app/views/layouts/school_cohort.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: 'layouts/width_container' do %>
   <%= render SchoolRecruitedTransitionComponent.new(school_cohort: @school_cohort) if @school_cohort %>
-    <% if current_user.induction_coordinator_and_mentor? && !current_user.mentor_profile.completed_validation_wizard? %>
+    <% if current_user&.induction_coordinator_and_mentor? && !current_user&.mentor_profile&.completed_validation_wizard? %>
       <%= render GovukComponent::NotificationBannerComponent.new(title_text: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
         banner.heading(
           text: "You need to add information about yourself as a mentor.",

--- a/app/views/schools/change_sit/check_details.html.erb
+++ b/app/views/schools/change_sit/check_details.html.erb
@@ -1,0 +1,39 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :email}) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @induction_tutor_form.school.name %></span>
+    <h1 class="govuk-heading-xl">Check your answers</h1>
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Name
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <div><%= @induction_tutor_form.full_name %></div>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to({ action: :name }) do %>
+            Change <span class="govuk-visually-hidden">name</span>
+          <% end %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Email address
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <div><%= @induction_tutor_form.email %></div>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to({ action: :email }) do %>
+            Change <span class="govuk-visually-hidden">email</span>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+
+    <%= govuk_button_link_to "Accept and continue", {action: :confirm} %>
+  </div>
+</div>

--- a/app/views/schools/change_sit/confirm.html.erb
+++ b/app/views/schools/change_sit/confirm.html.erb
@@ -9,7 +9,7 @@
       <h1 class="govuk-heading-xl">Are you sure you want to replace the induction tutor for your school?</h1>
     <% end %>
     <p class="govuk-body">You can only assign one induction tutor to use this service for your school.</p>
-    <p class="govuk-body"><%= current_user.full_name %>  will no longer be able to:</p>
+    <p class="govuk-body">You will no longer be able to:</p>
     <ul class="govuk-list--bullet">
       <% unless has_multiple_schools? %>
        <li>sign in to this service</li>

--- a/app/views/schools/change_sit/confirm.html.erb
+++ b/app/views/schools/change_sit/confirm.html.erb
@@ -1,0 +1,27 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :check_details}) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @induction_tutor_form.school.name %></span>
+    <% if has_multiple_schools? %>
+      <h1 class="govuk-heading-xl">Are you sure you want to replace the induction tutor for <%= @induction_tutor_form.school.name %></h1>
+    <% else %>
+      <h1 class="govuk-heading-xl">Are you sure you want to replace the induction tutor for your school?</h1>
+    <% end %>
+    <p class="govuk-body">You can only assign one induction tutor to use this service for your school.</p>
+    <p class="govuk-body"><%= current_user.full_name %>  will no longer be able to:</p>
+    <ul class="govuk-list--bullet">
+      <% unless has_multiple_schools? %>
+       <li>sign in to this service</li>
+      <% end %>
+      <li>manage how your school runs your ECT training programme</li>
+      <li>add information about ECTs and mentors</li>
+      <li>tell us if things change at your school, for example if ECTs join or not</li>
+      <li>get notifications about the training programme and this service</li>
+    </ul>
+
+    <%= govuk_warning_text text: "You’ll be signed out of this service. You will not be able to sign in as #{current_user.email}" %>
+
+    <%= govuk_button_to "Confirm and replace", { action: :save } %>
+  </div>
+</div>

--- a/app/views/schools/change_sit/email.html.erb
+++ b/app/views/schools/change_sit/email.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action: :name }) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@induction_tutor_form, url: email_schools_change_sit_path, method: :post) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field(:email,
+                             label: -> {
+                               tag.span(@induction_tutor_form.school.name, class: "govuk-caption-xl") +
+                                 tag.h1("What’s #{@induction_tutor_form.full_name}’s email address?", class: "govuk-heading-xl")
+                             },
+                             hint: { text: "We'll use this address to contact them with more information" })
+      %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/schools/change_sit/name.html.erb
+++ b/app/views/schools/change_sit/name.html.erb
@@ -1,0 +1,16 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: schools_dashboard_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@induction_tutor_form, url: name_schools_change_sit_path, method: :post) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field(:full_name,
+                             label: -> {
+                               tag.span(@induction_tutor_form.school.name, class: "govuk-caption-xl") +
+                               tag.h1("What’s the full name of the new induction tutor?", class: "govuk-heading-xl") },
+          ) %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/schools/change_sit/success.html.erb
+++ b/app/views/schools/change_sit/success.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_panel title_text: "Your school's induction tutor has been changed", text: nil, classes: "govuk-!-margin-bottom-8" %>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk-body">We'll email <%= @induction_tutor_form.full_name %> and let them know that you nominated
+      them.</p>
+    <p class="govuk-body">They can now use this service to:</p>
+    <ul class="govuk-list--bullet">
+      <li>manage how your school runs your ECT training programme</li>
+      <li>add information about your ECTs and mentors</li>
+      <li>tell us if things change at your school, for example if ECTs join or not</li>
+    </ul>
+    <p class="govuk-body">This person is now our contact for ECT training at your school.</p>
+  </div>
+</div>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -30,6 +30,14 @@
           <dd class="govuk-summary-list__actions"></dd>
         </div>
         <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Induction tutor</dt>
+          <dd class="govuk-summary-list__value"><%= @school.induction_coordinators.first.full_name %></dd>
+          <dd class="govuk-summary-list__actions"><%= govuk_link_to name_schools_change_sit_path do %>
+              Change <span class="govuk-visually-hidden">Induction tutor</span>
+            <% end %>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Programme</dt>
           <dd class="govuk-summary-list__value"><%= t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes]) %></dd>
           <dd class="govuk-summary-list__actions">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,6 +391,17 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      resource :change_sit, only: [], controller: "change_sit", path: "change-sit" do
+        get :name
+        post :name, action: :set_name
+        get :email
+        post :email, action: :set_email
+        get :check_details, path: "check-details"
+        get :confirm
+        post :confirm, action: :save
+        get :success
+      end
     end
   end
 

--- a/spec/features/nominations/nominate_induction_tutor_steps.rb
+++ b/spec/features/nominations/nominate_induction_tutor_steps.rb
@@ -31,12 +31,12 @@ module NominateInductionTutorSteps
   end
 
   def when_i_fill_in_the_sits_name
-    set_participant_data
+    set_induction_tutor_data
     fill_in "nominate_induction_tutor_form[full_name]", with: @sit_data[:full_name]
   end
 
   def when_i_fill_in_the_sits_email
-    set_participant_data
+    set_induction_tutor_data
     fill_in "nominate_induction_tutor_form[email]", with: @sit_data[:email]
   end
 
@@ -130,7 +130,7 @@ module NominateInductionTutorSteps
     expect(page).to have_selector("h1", text: "The email address is being used by another school")
   end
 
-  def set_participant_data
+  def set_induction_tutor_data
     @sit_data = {
       full_name: "John Doe",
       email: "johndoe@example.com",

--- a/spec/features/schools/change_sit/change_sit_spec.rb
+++ b/spec/features/schools/change_sit/change_sit_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../nominations/nominate_induction_tutor_steps"
+
+RSpec.describe "Change a school induction tutor (SIT) as a SIT", js: true do
+  include NominateInductionTutorSteps
+
+  scenario "a SIT with one school assigns their school to a new SIT" do
+    given_there_is_a_school_and_an_induction_coordinator
+    and_i_am_signed_in_as_an_induction_coordinator
+
+    click_on "Change"
+    then_i_should_be_on_the_change_sit_name_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "SIT adds new SITs name"
+
+    click_on "Continue"
+    then_i_should_receive_a_full_name_error_message
+
+    when_i_fill_in_the_sits_name
+    click_on "Continue"
+    then_i_should_be_on_the_change_sit_email_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "SIT adds new SITs email"
+
+    click_on "Continue"
+    then_i_should_receive_a_blank_email_error_message
+
+    when_i_input_an_invalid_email_format
+    click_on "Continue"
+    then_i_should_receive_an_invalid_email_error_message
+
+    when_i_fill_in_the_sits_email
+    click_on "Continue"
+    then_i_should_be_on_the_check_details_page
+
+    click_on "Accept and continue"
+    then_i_should_be_on_confirm_sit_change_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Confirm new SIT details"
+
+    click_on "Confirm and replace"
+    then_i_should_be_on_the_nominate_sit_success_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "Replace SIT completed"
+
+    visit "/schools"
+    then_i_should_have_been_signed_out_of_the_service
+  end
+
+  scenario "a SIT with multiple schools assigns their school to a new SIT" do
+    given_there_are_multiple_schools_with_the_same_induction_coordinator
+    and_i_am_signed_in_as_an_induction_coordinator
+
+    click_on "Test School 1"
+    click_on "Change"
+    then_i_should_be_on_the_change_sit_name_page
+
+    when_i_fill_in_the_sits_name
+    click_on "Continue"
+    then_i_should_be_on_the_nominations_email_page
+
+    when_i_fill_in_the_sits_email
+    click_on "Continue"
+    then_i_should_be_on_the_check_details_page
+
+    click_on "Accept and continue"
+    then_i_should_be_on_confirm_sit_change_page
+
+    click_on "Confirm and replace"
+    then_i_should_be_on_the_nominate_sit_success_page
+
+    visit "/schools"
+    then_i_should_not_see_the_school_that_has_changed_sit
+  end
+
+private
+
+  # given
+
+  def given_there_is_a_school_and_an_induction_coordinator
+    @cohort = create(:cohort, :current)
+    @school = create(:school, name: "Fip School")
+    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+
+    create_partnership(@school)
+    create_induction_tutor(@school)
+  end
+
+  def given_there_are_multiple_schools_with_the_same_induction_coordinator
+    first_school = create(:school, name: "Test School 1", slug: "111111-test-school-1", urn: "111111")
+    second_school = create(:school, name: "Test School 2", slug: "111112-test-school-2", urn: "111112")
+
+    @cohort = create(:cohort, :current)
+    @school_cohort = create(:school_cohort, :cip, school: first_school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+
+    create_partnership(first_school)
+    create_induction_tutor(first_school, second_school)
+  end
+
+  # then
+
+  def then_i_should_be_on_the_change_sit_name_page
+    expect(page).to have_selector("label", text: "What’s the full name of the new induction tutor?")
+  end
+
+  def then_i_should_be_on_the_change_sit_email_page
+    expect(page).to have_selector("label", text: "What’s #{@sit_data[:full_name]}’s email address?")
+  end
+
+  def then_i_should_be_on_the_nominate_sit_success_page
+    expect(page).to have_selector("h1", text: "Your school's induction tutor has been changed")
+    expect(page).to have_selector("h2", text: "What happens next")
+    expect(page).to have_text("We'll email #{@sit_data[:full_name]} and let them know that you nominated them.")
+  end
+
+  def then_i_should_be_on_confirm_sit_change_page
+    expect(page).to have_selector("h1", text: "Are you sure you want to replace the induction tutor")
+    expect(page).to have_text("You can only assign one induction tutor to use this service for your school.")
+    expect(page).to have_text("#{@induction_coordinator_profile.user.full_name} will no longer be able to")
+  end
+
+  def then_i_should_have_been_signed_out_of_the_service
+    expect(page).to have_selector("h1", text: "Sign in")
+    expect(page).to have_text("How to access this service")
+    expect(current_path).to eq("/users/sign_in")
+  end
+
+  def then_i_should_not_see_the_school_that_has_changed_sit
+    expect(page).not_to have_text("Test School 1")
+    expect(page).to have_text("Test School 2")
+  end
+
+  # and
+
+  def and_i_am_signed_in_as_an_induction_coordinator
+    privacy_policy = create(:privacy_policy)
+    privacy_policy.accept!(@induction_coordinator_profile.user)
+    sign_in_as @induction_coordinator_profile.user
+    set_induction_tutor_data
+  end
+
+  def create_induction_tutor(*schools)
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: schools)
+  end
+
+  def create_partnership(school)
+    @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
+    @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
+    create(:partnership, school: school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort)
+  end
+end

--- a/spec/features/schools/change_sit/change_sit_spec.rb
+++ b/spec/features/schools/change_sit/change_sit_spec.rb
@@ -118,7 +118,7 @@ private
   def then_i_should_be_on_confirm_sit_change_page
     expect(page).to have_selector("h1", text: "Are you sure you want to replace the induction tutor")
     expect(page).to have_text("You can only assign one induction tutor to use this service for your school.")
-    expect(page).to have_text("#{@induction_coordinator_profile.user.full_name} will no longer be able to")
+    expect(page).to have_text("You will no longer be able to")
   end
 
   def then_i_should_have_been_signed_out_of_the_service

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Manage No ECT training", js: true do
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "No ECT dashboard"
 
-    when_i_click_on_change
+    when_i_click_on_change_programme
     then_i_am_taken_to_change_how_you_run_programme_page
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "No ECT training info"

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -319,6 +319,10 @@ module ManageTrainingSteps
     click_on("Change")
   end
 
+  def when_i_click_on_change_programme
+    click_on("Change induction programme choice", visible: false)
+  end
+
   def when_i_click_on_add
     click_on("Add")
   end

--- a/spec/requests/schools/change_sit_spec.rb
+++ b/spec/requests/schools/change_sit_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Schools::ChangeSit", type: :request do
+  let(:user) { create(:user, :induction_coordinator) }
+  let(:school) { user.induction_coordinator_profile.schools.first }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /schools/:slug/change-sit/name" do
+    it "renders the name template" do
+      get "/schools/#{school.slug}/change-sit/name"
+
+      expect(response).to render_template "schools/change_sit/name"
+    end
+  end
+
+  describe "POST /schools/:slug/change-sit/name" do
+    it "rejects an empty name" do
+      post "/schools/#{school.slug}/change-sit/name", params: { induction_tutor_form: { name: "" } }
+
+      expect(response).to render_template "schools/change_sit/name"
+      expect(response.body).to include "Enter a full name"
+    end
+  end
+
+  describe "GET /schools/:slug/change-sit/email" do
+    it "renders the email template" do
+      get "/schools/#{school.slug}/change-sit/email"
+      expect(response).to render_template "schools/change_sit/email"
+    end
+  end
+
+  describe "POST /schools/:slug/change-sit/email" do
+    it "rejects an empty email" do
+      post "/schools/#{school.slug}/change-sit/email", params: { induction_tutor_form: { email: "" } }
+
+      expect(response).to render_template "schools/change_sit/email"
+      expect(response.body).to include "Enter an email"
+    end
+  end
+
+  describe "GET /schools/:slug/change-sit/check-details" do
+    it "renders the check details template" do
+      get "/schools/#{school.slug}/change-sit/check-details"
+      expect(response).to render_template "schools/change_sit/check_details"
+    end
+  end
+
+  describe "GET /schools/:slug/change-sit/confirm" do
+    it "renders the confirm template" do
+      get "/schools/#{school.slug}/change-sit/confirm"
+      expect(response).to render_template "schools/change_sit/confirm"
+    end
+  end
+
+  describe "POST /schools/:slug/change-sit/confirm" do
+    let(:new_name) { Faker::Name.name }
+    let(:new_email) { Faker::Internet.email }
+
+    before do
+      set_session(:induction_tutor_form, {
+        school_id: school.id,
+        full_name: new_name,
+        email: new_email,
+      })
+    end
+
+    it "Creates a new user with the correct details" do
+      post "/schools/#{school.slug}/change-sit/confirm"
+
+      created_user = User.order(:created_at).last
+      expect(created_user.full_name).to eq new_name
+      expect(created_user.email).to eq new_email
+    end
+
+    it "assigns the school to the new user" do
+      post "/schools/#{school.slug}/change-sit/confirm"
+
+      created_user = User.order(:created_at).last
+      expect(created_user.schools).to include school
+    end
+
+    it "deletes the current user" do
+      post "/schools/#{school.slug}/change-sit/confirm"
+
+      expect(User.where(id: user.id)).to be_empty
+    end
+
+    context "when the acting user has multiple schools" do
+      let(:other_school) { create(:school) }
+      before do
+        user.induction_coordinator_profile.schools << other_school
+      end
+
+      it "removes the school from the acting user" do
+        post "/schools/#{school.slug}/change-sit/confirm"
+
+        expect(user.schools).not_to include school
+      end
+
+      it "adds the school to the new user" do
+        post "/schools/#{school.slug}/change-sit/confirm"
+
+        created_user = User.order(:created_at).last
+        expect(created_user.schools).to include school
+      end
+
+      it "does not delete the acting user" do
+        post "/schools/#{school.slug}/change-sit/confirm"
+
+        expect(User.where(id: user.id)).not_to be_empty
+      end
+
+      it "redirects to the success page" do
+        post "/schools/#{school.slug}/change-sit/confirm"
+
+        expect(response).to redirect_to "/schools/#{school.slug}/change-sit/success"
+      end
+    end
+  end
+
+  describe "GET /schools/:slug/change-sit/success" do
+    before do
+      let(:new_name) { Faker::Name.name }
+      let(:new_email) { Faker::Internet.email }
+
+      before do
+        set_session(:induction_tutor_form, {
+          school_id: school.id,
+          full_name: new_name,
+          email: new_email,
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
[107](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-107)

As a school induction tutor I want to change my schools induction tutor. 

For copies of the designs see [991](https://dfedigital.atlassian.net/browse/CPDRP-991)

In ticket 107 James has provided slightly tweaked versions for SITs with multiple schools. 
[multiple school confirm](https://docs.google.com/document/d/1XTxeskRhYEJ8lFauU_QzEKFrEP4WwQg8DXQJ9zFLrqo/edit#)
[multiple school success](https://docs.google.com/document/d/1hxCUh9Yx4rJa8_mF_XCGZg8c8t658QVXHQE1w_wVQRA/edit#heading=h.wcavz2duxplu)

**How to check:**

Go to [the PR app](https://ecf-review-pr-1556.london.cloudapps.digital/)
Sign in as `cpd-test+tutor-10@example.com` - they have multiple schools
Select either school. 
Select change
Full names and email address have to match our records. 
Full name: `InductionTutor User`
Email: `school-leader@example.com`

Complete the remaining steps and if you login as `school-leader@example.com`, they should be assigned as a SIT to example school. 

Repeat the steps above to show the journey for a SIT with one school. 
