### PR TITLE
CST-201 Update original identity record after email change on User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   has_many :npq_applications
 
   before_validation :strip_whitespace
+  after_update :sync_email_address_with_identity
 
   validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, notify_email: true
@@ -139,5 +140,11 @@ private
   def strip_whitespace
     full_name&.squish!
     email&.squish!
+  end
+
+  def sync_email_address_with_identity
+    if saved_change_to_email?
+      participant_identities.original.first&.update!(email: email)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe User, type: :model do
           end
 
           it "updates the email on the original participant identity" do
-            user.update!(email: "mary.jones@example.com")
             expect(user.participant_identities.first.email).to eq("mary.jones@example.com")
           end
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,6 +75,49 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "after_update" do
+    context "when the email changes" do
+      let(:user) { create(:user, email: "mary.lewis@example.com") }
+
+      context "when there are no identity records for the user" do
+        it "does not generate an error" do
+          expect {
+            user.update!(email: "mary.jones@example.com")
+          }.not_to raise_error
+        end
+      end
+
+      context "when the user is a participant" do
+        let(:teacher_profile) { create(:teacher_profile, user: user) }
+        let!(:mentor_profile) { create(:mentor_participant_profile, teacher_profile: teacher_profile) }
+
+        context "when an original participant identity exists" do
+          before do
+            user.update!(email: "mary.jones@example.com")
+          end
+
+          it "updates the email on the original participant identity" do
+            user.update!(email: "mary.jones@example.com")
+            expect(user.participant_identities.first.email).to eq("mary.jones@example.com")
+          end
+        end
+
+        context "when there are transferred identity records" do
+          let(:identity2) { create(:participant_identity, :npq, email: "mary.e.jones@example.com") }
+
+          before do
+            identity2.update!(user: user)
+            user.update!(email: "mary.jones@example.com")
+          end
+
+          it "does not update the email on the transferred records" do
+            expect(identity2.email).to eq("mary.e.jones@example.com")
+          end
+        end
+      end
+    end
+  end
+
   describe "#admin?" do
     it "is expected to be true when the user has an admin profile" do
       user = create(:user, :admin)


### PR DESCRIPTION
## Ticket and context

[Ticket:](https://dfedigital.atlassian.net/browse/CST-201)

Keep the `ParticipantIdentity.email` in sync with the `User.email` for original identity records (where `external_identifier == user_id`) when a user's email address is updated.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
