### PR TITLE
CPDLP-794 change seeds for NPQ schedules

### DIFF
--- a/db/seeds/schedules/npq_leadership.csv
+++ b/db/seeds/schedules/npq_leadership.csv
@@ -4,7 +4,7 @@ npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 – Retention Point 1,
 npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
 npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023
 ,,,,,,
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,01/01/2022,25/02/2022,25/03/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 – Retention Point 2,retained-2,26/09/2022,25/04/2023,25/05/2023
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 – Participant Completion,completed,26/04/2023,22/12/2023,25/01/2024

--- a/db/seeds/schedules/npq_leadership.csv
+++ b/db/seeds/schedules/npq_leadership.csv
@@ -1,30 +1,10 @@
 schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-npq-sl-november,NPQSL November,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-sl-november,NPQSL November,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-sl-november,NPQSL November,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
-npq-sl-november,NPQSL November,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023
 ,,,,,,
-npq-h-november,NPQH November,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-h-november,NPQH November,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-h-november,NPQH November,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
-npq-h-november,NPQH November,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023
-,,,,,,
-npq-el-november,NPQEL November,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-el-november,NPQEL November,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-el-november,NPQEL November,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
-npq-el-november,NPQEL November,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023
-,,,,,,
-npq-sl-february,NPQSL February,2021,Output 1 - Participant Start,started,01/01/2022,25/02/2022,25/03/2022
-npq-sl-february,NPQSL February,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
-npq-sl-february,NPQSL February,2021,Output 3 – Retention Point 2,retained-2,26/09/2022,25/04/2023,25/05/2023
-npq-sl-february,NPQSL February,2021,Output 4 – Participant Completion,completed,26/04/2023,22/12/2023,25/01/2024
-,,,,,,
-npq-h-february,NPQH February,2021,Output 1 - Participant Start,started,01/01/2022,25/02/2022,25/03/2022
-npq-h-february,NPQH February,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
-npq-h-february,NPQH February,2021,Output 3 – Retention Point 2,retained-2,26/09/2022,25/04/2023,25/05/2023
-npq-h-february,NPQH February,2021,Output 4 – Participant Completion,completed,26/04/2023,22/12/2023,25/01/2024
-,,,,,,
-npq-el-february,NPQEL February,2021,Output 1 - Participant Start,started,01/01/2022,25/02/2022,25/03/2022
-npq-el-february,NPQEL February,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
-npq-el-february,NPQEL February,2021,Output 3 – Retention Point 2,retained-2,26/09/2022,25/04/2023,25/05/2023
-npq-el-february,NPQEL February,2021,Output 4 – Participant Completion,completed,26/04/2023,22/12/2023,25/01/2024
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 – Retention Point 2,retained-2,26/06/2022,25/11/2022,25/12/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 – Participant Completion,completed,26/11/2022,25/08/2023,25/09/2023

--- a/db/seeds/schedules/npq_specialist.csv
+++ b/db/seeds/schedules/npq_specialist.csv
@@ -3,6 +3,6 @@ npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,st
 npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
 npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023
 ,,,,,,
-npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,01/11/2021,25/02/2022,25/03/2022
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 – Participant Completion,completed,26/09/2022,25/05/2023,25/06/2023

--- a/db/seeds/schedules/npq_specialist.csv
+++ b/db/seeds/schedules/npq_specialist.csv
@@ -1,24 +1,8 @@
 schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
-npq-ltd-november,NPQLTD November,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-ltd-november,NPQLTD November,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-ltd-november,NPQLTD November,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023
+npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
+npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
+npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023
 ,,,,,,
-npq-lt-november,NPQLT November,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-lt-november,NPQLT November,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-lt-november,NPQLT November,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023
-,,,,,,
-npq-lbc-november,NPQLBC November,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
-npq-lbc-november,NPQLBC November,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
-npq-lbc-november,NPQLBC November,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023
-,,,,,,
-npq-ltd-february,NPQLTD February,2021,Output 1 - Participant Start,started,01/11/2021,25/02/2022,25/03/2022
-npq-ltd-february,NPQLTD February,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
-npq-ltd-february,NPQLTD February,2021,Output 3 – Participant Completion,completed,26/09/2022,25/05/2023,25/06/2023
-,,,,,,
-npq-lt-february,NPQLT February,2021,Output 1 - Participant Start,started,01/11/2021,25/02/2022,25/03/2022
-npq-lt-february,NPQLT February,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
-npq-lt-february,NPQLT February,2021,Output 3 – Participant Completion,completed,26/09/2022,25/05/2023,25/06/2023
-,,,,,,
-npq-lbc-february,NPLBC February,2021,Output 1 - Participant Start,started,01/11/2021,25/02/2022,25/03/2022
-npq-lbc-february,NPLBC February,2021,Output 2 – Retention Point 1,retained-1,26/02/2022,25/09/2022,25/10/2022
-npq-lbc-february,NPLBC February,2021,Output 3 – Participant Completion,completed,26/09/2022,25/05/2023,25/06/2023
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,01/11/2021,25/12/2021,25/01/2022
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 – Retention Point 1,retained-1,26/12/2021,25/06/2022,25/07/2022
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 – Participant Completion,completed,26/06/2022,25/02/2023,25/03/2023

--- a/spec/models/finance/schedule_spec.rb
+++ b/spec/models/finance/schedule_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Finance::Schedule::NPQLeadership, type: :model do
   end
 
   it "seeds from csv" do
-    schedule = described_class.find_by(schedule_identifier: "npq-sl-february")
+    schedule = described_class.find_by(schedule_identifier: "npq-leadership-spring")
     expect(schedule).to be_present
     expect(schedule.milestones.count).to eql(4)
   end
@@ -46,7 +46,7 @@ RSpec.describe Finance::Schedule::NPQSpecialist, type: :model do
   end
 
   it "seeds from csv" do
-    schedule = described_class.find_by(schedule_identifier: "npq-lbc-february")
+    schedule = described_class.find_by(schedule_identifier: "npq-specialist-spring")
     expect(schedule).to be_present
     expect(schedule.milestones.count).to eql(3)
   end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-794

- There has been a change in the desired schedule identifiers
- Any existing seeded data added by the old fixtures will be removed after this has been shipped
- This seed data will also be applied to prod after it has been shipped
- The default will not be changed until after the data has been made available

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- `cf ssh ecf-review-pr-1574`
- start a rails console
- confirm seeded schedules are present
- e.g. `Finance::Schedule::NPQSupport.all`

## External API changes

- No external changes yet