### PR TITLE
Allow lead providers to download their active partnerships

### DIFF
--- a/app/controllers/lead_providers/partnerships_controller.rb
+++ b/app/controllers/lead_providers/partnerships_controller.rb
@@ -11,5 +11,14 @@ module LeadProviders
       @selected_cohort = @partnership.cohort
       @delivery_partner = @partnership.delivery_partner
     end
+
+    def active
+      @schools = current_user.lead_provider.active_partnerships.includes(:school, :delivery_partner)
+      respond_to do |format|
+        format.csv do
+          render body: PartnershipCsvSerializer.new(@schools).call
+        end
+      end
+    end
   end
 end

--- a/app/serializers/partnership_csv_serializer.rb
+++ b/app/serializers/partnership_csv_serializer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class PartnershipCsvSerializer
+  attr_reader :scope
+
+  def initialize(scope)
+    @scope = scope
+  end
+
+  def call
+    CSV.generate do |csv|
+      csv << csv_headers
+
+      scope.each do |record|
+        csv << to_row(record)
+      end
+    end
+  end
+
+private
+
+  def csv_headers
+    %w[
+      urn
+      name
+      delivery_partner
+    ]
+  end
+
+  def to_row(record)
+    [
+      record.school.urn,
+      record.school.name,
+      record.delivery_partner&.name,
+    ]
+  end
+end

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -15,6 +15,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Your schools</h1>
     <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path %>
+    <%= govuk_button_link_to "Download schools for #{Cohort.current.display_name}", active_lead_providers_partnerships_path(format: :csv) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,11 @@ Rails.application.routes.draw do
     get "/api-docs/v1/api_spec.yml" => "openapi#api_docs", as: :api_docs
 
     resources :your_schools, path: "/your-schools", only: %i[index create]
-    resources :partnerships, only: %i[show]
+    resources :partnerships, only: %i[show] do
+      collection do
+        get :active
+      end
+    end
 
     namespace :report_schools, path: "report-schools" do
       get :start, to: "base#start"

--- a/spec/cypress/integration/lead_providers/YourSchools.feature
+++ b/spec/cypress/integration/lead_providers/YourSchools.feature
@@ -7,6 +7,8 @@ Feature: Your schools flow
 
   Scenario: Viewing my schools
     Then "page body" should contain "Your schools"
+    Then "page body" should contain "Confirm more schools"
+    Then "page body" should contain "Download schools for 2021"
     And the table should have 3 rows
     And "page body" should contain "Big School"
     And "page body" should contain "Middle School"

--- a/spec/requests/lead_providers/partnerships_spec.rb
+++ b/spec/requests/lead_providers/partnerships_spec.rb
@@ -31,4 +31,37 @@ RSpec.describe "Lead provider partnerships spec", type: :request do
       end
     end
   end
+
+  describe "GET /lead-providers/partnerships/active" do
+    let(:parsed_response) { CSV.parse(response.body, headers: true) }
+
+    let(:school) { create :school, name: "Active School" }
+    let(:delivery_partner) { create :delivery_partner, name: "Active Delivery Partner" }
+
+    let!(:partnership) { create :partnership, cohort: cohort, lead_provider: user.lead_provider, school: school, delivery_partner: delivery_partner }
+    let!(:inactive_partnership) { create :partnership, :challenged, cohort: cohort, lead_provider: user.lead_provider }
+
+    before do
+      get "/lead-providers/partnerships/active.csv"
+    end
+
+    it "returns the correct CSV content type header" do
+      expect(response.headers["Content-Type"]).to include("text/csv")
+    end
+
+    it "returns only active partnerships" do
+      expect(parsed_response.length).to eql 1
+    end
+
+    it "returns the correct headers" do
+      expect(parsed_response.headers).to match_array(%w[urn name delivery_partner])
+    end
+
+    it "returns the correct values" do
+      school_row = parsed_response.find { |row| row["urn"] == school.urn }
+
+      expect(school_row["name"]).to eq "Active School"
+      expect(school_row["delivery_partner"]).to eq "Active Delivery Partner"
+    end
+  end
 end


### PR DESCRIPTION
## Context

Internally we spent a significant amount of time every week compiling a report that contains each lead providers' active partnerships with schools. The process is very cumbersome because it is inferred from external analytics systems, despite having the data easily available within the service.

This PR adds a button to the lead provider area of the service. It allows them to self-serve and download their current active partnerships at any point.

The button link isn't ideal but we can improve it in a subsequent PR. I'd also expect to add an inactive/challenged partnerships export later as well.

Copying in @fofr here to cast his eyes over the new "Download schools for <cohort year>" link below.

![screencapture-localhost-3000-lead-providers-your-schools-2022-01-05-15_36_08](https://user-images.githubusercontent.com/31316/148244885-2adba46c-e32a-46c6-9336-c03e0644443e.png)

