### PR TITLE
DEDUPING: Add participant_identity reference to npq_application

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -32,7 +32,7 @@ module Api
       end
 
       def accept
-        npq_application = npq_lead_provider.npq_applications.includes(:user, :npq_course).find(params[:id])
+        npq_application = npq_lead_provider.npq_applications.includes(:user, :participant_identity, :npq_course).find(params[:id])
         if NPQ::Accept.call(npq_application: npq_application)
           render json: NPQApplicationSerializer.new(npq_application).serializable_hash
         else
@@ -47,7 +47,7 @@ module Api
       end
 
       def query_scope
-        scope = npq_lead_provider.npq_applications.includes(:user, :npq_course)
+        scope = npq_lead_provider.npq_applications.includes(:user, :participant_identity, :npq_course)
         scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
         scope
       end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -5,6 +5,7 @@ class NPQApplication < ApplicationRecord
 
   has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id, touch: true
   belongs_to :user
+  belongs_to :participant_identity, optional: true
   belongs_to :npq_lead_provider
   belongs_to :npq_course
 

--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -3,6 +3,7 @@
 class ParticipantIdentity < ApplicationRecord
   belongs_to :user
   has_many :participant_profiles
+  has_many :npq_applications
 
   validates :email, presence: true, uniqueness: true, notify_email: true
   validates :external_identifier, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   has_many :npq_profiles, through: :teacher_profile
   # end: TODO
 
+  # NOTE: remove once identity populated
   has_many :npq_applications
 
   before_validation :strip_whitespace
@@ -69,7 +70,14 @@ class User < ApplicationRecord
   end
 
   def npq_registered?
-    npq? || npq_applications.any?
+    npq? || npq_applications?
+  end
+
+  def npq_applications?
+    # NOTE: remove once identity populated
+    npq_applications.any?
+    # and replace with this
+    # participant_identities.any? { |identity| identity.npq_applications.any? }
   end
 
   def participant?

--- a/app/policies/participant_profile/ecf_policy.rb
+++ b/app/policies/participant_profile/ecf_policy.rb
@@ -10,7 +10,7 @@ class ParticipantProfile::ECFPolicy < ParticipantProfilePolicy
 
   def update?
     return true if admin?
-    return false if record.user.npq_applications.any?
+    return false if record.user.npq_applications?
     return false if record.completed_validation_wizard?
     return false if record.participant_declarations.any?
 

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -45,9 +45,9 @@ private
   def to_row(record)
     [
       record.id,
-      record.user_id,
-      record.user.full_name,
-      record.user.email,
+      participant_id(record),
+      full_name(record),
+      email(record),
       true,
       record.teacher_reference_number,
       record.teacher_reference_number_verified,
@@ -61,5 +61,26 @@ private
       record.created_at.rfc3339,
       record.updated_at.rfc3339,
     ]
+  end
+
+  def participant_id(record)
+    # NOTE: only until identity data populated
+    record.user_id
+    # then change to this
+    # record.participant_identity.external_identifier
+  end
+
+  def full_name(record)
+    # NOTE: only until identity data populated
+    record.user.full_name
+    # then change to this
+    # record.participant_identity.user.full_name
+  end
+
+  def email(record)
+    # NOTE: only until identity data populated
+    record.user.email
+    # then change to this
+    # record.participant_identity.email
   end
 end

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -22,15 +22,27 @@ class NPQApplicationSerializer
              :created_at,
              :updated_at
 
+  # NOTE: only until identity data populated
   attribute(:participant_id, &:user_id)
+  # then change to this
+  # attribute(:participant_id) do |object|
+  #   object.participant_identity.external_identifier
+  # end
+
   attribute(:teacher_reference_number_validated, &:teacher_reference_number_verified)
 
   attribute(:full_name) do |object|
+    # NOTE: only until identity data populated
     object.user.full_name
+    # then change to this
+    # object.participant_identity.user.full_name
   end
 
   attribute(:email) do |object|
+    # NOTE: only until identity data populated
     object.user.email
+    # then change to this
+    # object.participant_identity.email
   end
 
   attribute(:email_validated) do

--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -35,17 +35,31 @@ module NPQ
   private
 
     def has_other_accepted_applications_with_same_course?
+      # TODO: use this until identity populated
       NPQApplication.where(user_id: user.id)
         .where(npq_course: npq_course)
         .where(lead_provider_approval_status: "accepted")
         .where.not(id: npq_application.id)
         .exists?
+      # then change to this
+      # NPQApplication.joins(:participant_identity)
+      #   .where(participant_identity: { user_id: user.id })
+      #   .where(npq_course: npq_course)
+      #   .where(lead_provider_approval_status: "accepted")
+      #   .where.not(id: npq_application.id)
+      #   .exists?
     end
 
     def other_applications
+      # TODO: use this until identity populated
       @other_applications ||= NPQApplication.where(user_id: user.id)
                                             .where(npq_course: npq_course)
                                             .where.not(id: npq_application.id)
+      # then change to this
+      # @other_applications ||= NPQApplication.joins(:participant_identity)
+      #                                       .where(participant_identity: { user_id: user.id })
+      #                                       .where(npq_course: npq_course)
+      #                                       .where.not(id: npq_application.id)
     end
 
     def create_profile
@@ -56,7 +70,10 @@ module NPQ
         teacher_profile: teacher_profile,
         school_urn: npq_application.school_urn,
         school_ukprn: npq_application.school_ukprn,
+        # NOTE: use until identity populated
         participant_identity: Identity::Create.call(user: user, origin: :npq),
+        # then change to this
+        # participant_identity: npq_application.participant_identity,
       ) do |participant_profile|
         ParticipantProfileState.find_or_create_by!(participant_profile: participant_profile)
       end
@@ -67,7 +84,10 @@ module NPQ
     end
 
     def user
+      # NOTE: use until identity populated
       @user ||= npq_application.user
+      # then change to this
+      # @user ||= npq_application.participant_identity.user
     end
 
     def npq_course

--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -55,7 +55,7 @@ module NPQ
     end
 
     def participant_identity
-      Identity::Create.call(user: user, origin: :npq) unless user_id.blank?
+      Identity::Create.call(user: user, origin: :npq) if user_id.present?
     end
   end
 end

--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -38,6 +38,7 @@ module NPQ
         npq_course: npq_course,
         npq_lead_provider: npq_lead_provider,
         user: user,
+        participant_identity: participant_identity,
       )
     end
 
@@ -51,6 +52,10 @@ module NPQ
 
     def user
       Identity.find_user_by(id: user_id)
+    end
+
+    def participant_identity
+      Identity::Create.call(user: user, origin: :npq) unless user_id.blank?
     end
   end
 end

--- a/db/migrate/20220105132616_add_participant_identity_to_npq_applications.rb
+++ b/db/migrate/20220105132616_add_participant_identity_to_npq_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddParticipantIdentityToNPQApplications < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :npq_applications, :participant_identity, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -444,8 +444,10 @@ ActiveRecord::Schema.define(version: 2022_01_06_111301) do
     t.text "school_ukprn"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "participant_identity_id"
     t.index ["npq_course_id"], name: "index_npq_applications_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_applications_on_npq_lead_provider_id"
+    t.index ["participant_identity_id"], name: "index_npq_applications_on_participant_identity_id"
     t.index ["user_id"], name: "index_npq_applications_on_user_id"
   end
 
@@ -574,8 +576,8 @@ ActiveRecord::Schema.define(version: 2022_01_06_111301) do
     t.string "training_status", default: "active", null: false
     t.string "profile_duplicity", default: "single", null: false
     t.uuid "participant_identity_id"
-    t.string "start_term", default: "Autumn 2021", null: false
     t.string "notes"
+    t.string "start_term", default: "Autumn 2021", null: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/models/participant_identity_spec.rb
+++ b/spec/models/participant_identity_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ParticipantIdentity, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:participant_profiles) }
+  it { is_expected.to have_many(:npq_applications) }
   it {
     is_expected.to define_enum_for(:origin).with_values(
       ecf: "ecf",

--- a/spec/services/npq/build_application_spec.rb
+++ b/spec/services/npq/build_application_spec.rb
@@ -24,24 +24,42 @@ RSpec.describe NPQ::BuildApplication do
     }
   end
 
-  subject(:npq_application) do
-    described_class.call(
-      npq_application_params: npq_application_params,
-      npq_course_id: npq_course.id,
-      npq_lead_provider_id: npq_lead_provider.id,
-      user_id: user.id,
-    )
-  end
+  subject(:service) { described_class }
 
-  it "creates an application" do
-    expect(npq_application.save).to be true
-    expect(npq_application)
-      .to have_attributes(
-        npq_application_params.merge(
-          npq_course_id: npq_course.id,
-          npq_lead_provider_id: npq_lead_provider.id,
-          user_id: user.id,
-        ),
+  describe "call" do
+    let(:npq_application) do
+      service.call(
+        npq_application_params: npq_application_params,
+        npq_course_id: npq_course.id,
+        npq_lead_provider_id: npq_lead_provider.id,
+        user_id: user.id,
       )
+    end
+
+    it "creates an application" do
+      expect(npq_application.save).to be true
+      expect(npq_application)
+        .to have_attributes(
+          npq_application_params.merge(
+            npq_course_id: npq_course.id,
+            npq_lead_provider_id: npq_lead_provider.id,
+            user_id: user.id,
+          ),
+        )
+    end
+
+    it "adds a participant identity record" do
+      expect {
+        npq_application
+      }.to change { ParticipantIdentity.count }.by(1)
+    end
+
+    context "when the user already has an identity record" do
+      let!(:identity) { Identity::Create.call(user: user) }
+
+      it "sets the participant identity reference" do
+        expect(npq_application.participant_identity.user).to eq user
+      end
+    end
   end
 end


### PR DESCRIPTION
## Ticket and context

As part of of de-duping tasks, it was noticed that `npq_applications` are associated directly with a `User` which means that they can not be transparently transferred during an identity transfer.  If we move the association to the user's `ParticipantIdentity` instead then any `NPQApplication`s can be moved without exposing the de-duping detail to via the API endpoints.

This will need to happen in 2 parts. Most of this has been added with comments to remove old code and replaced with new code once `ParticipantIdentity` references have been added.

1. deploy this code
2. fix up data to add/use participant identity
3. uncomment code, add foreign key constraint to participant identity reference etc.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
