### PR TITLE
CST-160: Notify SITs of participant withdrawal

### DIFF
--- a/app/jobs/participant_details_reminder_job.rb
+++ b/app/jobs/participant_details_reminder_job.rb
@@ -9,7 +9,7 @@ class ParticipantDetailsReminderJob < ApplicationJob
 
   def perform(profile_id:)
     profile = ParticipantProfile.find(profile_id)
-    return if !profile || profile.withdrawn_record? || profile.completed_validation_wizard?
+    return if !profile || profile.withdrawn_record? || profile.completed_validation_wizard? || profile.training_status_withdrawn?
 
     ActiveRecord::Base.transaction do
       ParticipantMailer.add_details_reminder(participant_profile: profile).deliver_later

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -27,6 +27,7 @@ class SchoolMailer < ApplicationMailer
   SIT_NEW_AMBITION_ECTS_AND_MENTORS_ADDED_TEMPLATE = "90d86c1b-2dca-4cca-9dcb-5940e7f28577"
   SIT_FIP_PARTICIPANT_VALIDATION_DEADLINE_REMINDER_TEMPLATE = "48f63205-a8d9-49a2-a76c-93d48ec9b23b"
   SCHOOL_PRETERM_REMINDER = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
+  PARTICIPANT_WITHDRAWN_BY_PROVIDER = "29f94916-8c3a-4c5a-9e33-bdf3f5d7249a"
 
   # This email is currently (30/09/2021) only used for manually sent chaser emails
   def remind_induction_coordinator_to_setup_cohort_email(induction_coordinator_profile:, school_name:, campaign: nil)
@@ -428,5 +429,27 @@ class SchoolMailer < ApplicationMailer
         nomination_link: nomination_email.nomination_url,
       },
     ).tag(:school_preterm_reminder).associate_with(school)
+  end
+
+  def fip_provider_has_withdrawn_a_participant(withdrawn_participant:, induction_coordinator:)
+    partnership = Partnership.find_by(school: withdrawn_participant.school, cohort: withdrawn_participant.cohort)
+
+    email = template_mail(
+      PARTICIPANT_WITHDRAWN_BY_PROVIDER,
+      to: induction_coordinator.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: induction_coordinator.user.full_name,
+        withdrawn_participant_name: withdrawn_participant.user.full_name,
+        school: withdrawn_participant.school.name,
+        delivery_partner: partnership.delivery_partner.name,
+        lead_provider: partnership.lead_provider.name,
+      },
+    )
+    email
+      .tag(:sit_fip_provider_has_withdrawn_a_participant)
+      .associate_with(induction_coordinator, as: :induction_coordinator)
+      .associate_with(withdrawn_participant, as: :participant_profile)
   end
 end

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -16,6 +16,11 @@ module Participants
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:withdrawn], reason: reason)
           user_profile.training_status_withdrawn!
+
+          unless user_profile.npq?
+            induction_coordinator = user_profile.school&.induction_coordinator_profiles&.first
+            SchoolMailer.fip_provider_has_withdrawn_a_participant(withdrawn_participant: user_profile, induction_coordinator: induction_coordinator).deliver_later
+          end
         end
         user_profile
       end

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -16,12 +16,13 @@ module Participants
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:withdrawn], reason: reason)
           user_profile.training_status_withdrawn!
-
-          unless user_profile.npq?
-            induction_coordinator = user_profile.school&.induction_coordinator_profiles&.first
-            SchoolMailer.fip_provider_has_withdrawn_a_participant(withdrawn_participant: user_profile, induction_coordinator: induction_coordinator).deliver_later
-          end
         end
+
+        unless user_profile.npq?
+          induction_coordinator = user_profile.school.induction_coordinator_profiles.first
+          SchoolMailer.fip_provider_has_withdrawn_a_participant(withdrawn_participant: user_profile, induction_coordinator: induction_coordinator).deliver_later
+        end
+
         user_profile
       end
     end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -186,4 +186,20 @@ RSpec.describe SchoolMailer, type: :mailer do
       expect(email.to).to eq([induction_coordinator_profile.user.email])
     end
   end
+
+  describe "sit_fip_provider_has_withdrawn_a_participant" do
+    let(:school_cohort) { create(:school_cohort, induction_programme_choice: "full_induction_programme") }
+    let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort: school_cohort, user: create(:user, email: "john.clemence@example.com")) }
+    let(:sit_profile) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
+
+    let(:email) do
+      SchoolMailer.fip_provider_has_withdrawn_a_participant(
+        withdrawn_participant: participant_profile,
+        induction_coordinator: sit_profile,
+      )
+
+      expect(email.from).to eq(["mail@example.com"])
+      expect(email.to).to eq([induction_coordinator_profile.user.email])
+    end
+  end
 end

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
     }
   end
 
-  it_behaves_like "a participant withdraw action service" do
+  it_behaves_like "a participant withdraw action service", with_notification: true do
     def given_params
       participant_params
     end

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Participants::Withdraw::Mentor do
     }
   end
 
-  it_behaves_like "a participant withdraw action service" do
+  it_behaves_like "a participant withdraw action service", with_notification: true do
     def given_params
       participant_params
     end

--- a/spec/services/participants/withdraw/npq_spec.rb
+++ b/spec/services/participants/withdraw/npq_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Participants::Withdraw::NPQ do
     }
   end
 
-  it_behaves_like "a participant withdraw action service" do
+  it_behaves_like "a participant withdraw action service", with_notification: false do
     def given_params
       participant_params
     end


### PR DESCRIPTION
## Ticket and context

Ticket: [160](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-160)

We need to notify SITs when their provider has withdrawn a participant. 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
