### PR TITLE
Pin version of comment-on-pr

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -107,7 +107,7 @@ jobs:
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{env.ENVIRONMENT}}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@master
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -170,7 +170,7 @@ jobs:
         run: bundle exec rspec spec/smoke_tests/*_spec.rb --tag smoke_test
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@master
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The builds started failing with a weird error coming from this package when it tries to comment that a review app has been deployed. Attempt to go back to the previous version rather than master

https://github.com/unsplash/comment-on-pr/issues/51

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
