### PR TITLE
CPDLP-830 schedules can be given an alias identifier

### DIFF
--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -25,7 +25,12 @@ module Participants
     private
 
       def schedule
-        Finance::Schedule.find_by(schedule_identifier: schedule_identifier)
+        alias_search_query = Finance::Schedule.where(identifier_alias: schedule_identifier)
+
+        Finance::Schedule
+          .where(schedule_identifier: schedule_identifier)
+          .or(alias_search_query)
+          .first
       end
 
       def not_already_withdrawn

--- a/db/migrate/20220106111301_add_schedule_id_alias.rb
+++ b/db/migrate/20220106111301_add_schedule_id_alias.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScheduleIdAlias < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schedules, :identifier_alias, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_04_162036) do
+ActiveRecord::Schema.define(version: 2022_01_06_111301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -691,6 +691,7 @@ ActiveRecord::Schema.define(version: 2022_01_04_162036) do
     t.string "schedule_identifier"
     t.string "type", default: "Finance::Schedule::ECF"
     t.uuid "cohort_id"
+    t.text "identifier_alias"
     t.index ["cohort_id"], name: "index_schedules_on_cohort_id"
   end
 

--- a/spec/support/shared_examples/participant_actions_change_schedule_support.rb
+++ b/spec/support/shared_examples/participant_actions_change_schedule_support.rb
@@ -2,11 +2,28 @@
 
 RSpec.shared_examples "a participant change schedule action service" do
   it_behaves_like "a participant action service"
-  let!(:january_schedule) { create(:schedule, schedule_identifier: "ecf-january-standard-2021", name: "ECF January standard schedule 2021") }
+
+  let!(:january_schedule) do
+    create(
+      :schedule,
+      schedule_identifier: "ecf-january-standard-2021",
+      identifier_alias: "ecf-january-standard-2021-alias",
+      name: "ECF January standard schedule 2021",
+    )
+  end
 
   it "changes the schedule on user's profile" do
     expect {
       described_class.call(params: given_params)
+      user_profile.reload
+    }.to change(user_profile, :schedule).to(january_schedule)
+  end
+
+  it "succeeds when given alias of schedule identifier" do
+    params = given_params.merge({ schedule_identifier: "ecf-january-standard-2021-alias" })
+
+    expect {
+      described_class.call(params: params)
       user_profile.reload
     }.to change(user_profile, :schedule).to(january_schedule)
   end


### PR DESCRIPTION
## Ticket

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-830
- Also addresses: https://dfedigital.atlassian.net/browse/CPDLP-840

## Context

- schedules can be given an alias identifier
- this way a single schedule can be looked up via 2 identifiers
- giving lead providers backwards compatibility when changing schedules, when we change the schedule identifier
- once deployed on the relevant schedules i will:
  -  add the current identifiers as an alias eg `ecf-september-standard-2021`
  - then change the actual identifier to what they should be eg `ecf-september-standard-2021` => `ecf-standard-september`
 - I tried passing in empty string as identifier lookup and fails which is what we want

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- ssh into the box and start a rails app
- find an existing schedule and an alias to to it
- change a participants schedule to use this schedule based on the alias name you just added
- schedule should change to the one specified

## External API changes

- I haven't actually changed any data yet, once that has been done I will raise a PR to update the docs