### PR TITLE
Create one off rake task to update school_urns on participant_profile

### DIFF
--- a/lib/tasks/update_school_urns.rake
+++ b/lib/tasks/update_school_urns.rake
@@ -1,22 +1,24 @@
+# frozen_string_literal: true
+
 require "rake"
 
 namespace :update_school_urns do
   desc "Copy school_urn from NPQ Application to participant profile if missing from record"
   task one_off: :environment do
     PaperTrail.request.controller_info = {
-      reason: "CPDLP-843 - update-urn-if-missing-on-profile"
+      reason: "CPDLP-843 - update-urn-if-missing-on-profile",
     }
 
-    records_to_update = ParticipantProfile::NPQ.where(school_urn: nil).joins(:npq_application).where.not(npq_applications: {school_urn: nil})
-    puts "#{ records_to_update.count } records to update"
-    puts "#{ records_to_update.map(&:id) } records to update"
+    records_to_update = ParticipantProfile::NPQ.where(school_urn: nil).joins(:npq_application).where.not(npq_applications: { school_urn: nil })
+    puts "#{records_to_update.count} records to update"
+    puts "#{records_to_update.map(&:id)} records to update"
 
     records_to_update.find_each do |profile|
       profile.school_urn = profile.npq_application.school_urn
       profile.save!
     end
 
-    puts "#{ records_to_update.count } failed to update"
-    puts "#{ records_to_update.map(&:id)} failed to update"
+    puts "#{records_to_update.count} failed to update"
+    puts "#{records_to_update.map(&:id)} failed to update"
   end
 end

--- a/lib/tasks/update_school_urns.rake
+++ b/lib/tasks/update_school_urns.rake
@@ -1,0 +1,22 @@
+require "rake"
+
+namespace :update_school_urns do
+  desc "Copy school_urn from NPQ Application to participant profile if missing from record"
+  task one_off: :environment do
+    PaperTrail.request.controller_info = {
+      reason: "CPDLP-843 - update-urn-if-missing-on-profile"
+    }
+
+    records_to_update = ParticipantProfile::NPQ.where(school_urn: nil).joins(:npq_application).where.not(npq_applications: {school_urn: nil})
+    puts "#{ records_to_update.count } records to update"
+    puts "#{ records_to_update.map(&:id) } records to update"
+
+    records_to_update.find_each do |profile|
+      profile.school_urn = profile.npq_application.school_urn
+      profile.save!
+    end
+
+    puts "#{ records_to_update.count } failed to update"
+    puts "#{ records_to_update.map(&:id)} failed to update"
+  end
+end


### PR DESCRIPTION
## Ticket and context
Ticket: https://dfedigital.atlassian.net/browse/CPDLP-843

Following producing the NPQ assurances report, it was noticed that more than expected NPQ Participant Profiles had the School URN missing from their records, despite it being present on the NPQ Application. This was giving the false impression that these records might be international applicants.

On investigate it was discovered a code change between 21 June and 1 September likely cause this field to be missing.

This PR is a one off rake task - to be deleted after it is run on production.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
