### PR TITLE
[CPDLP-827] add seeds for ecf-standard-april schedule

### DIFF
--- a/app/services/importers/seed_schedule.rb
+++ b/app/services/importers/seed_schedule.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Importers::SeedNPQSchedules
+class Importers::SeedSchedule
   attr_reader :path_to_csv, :klass
 
   def initialize(path_to_csv:, klass:)

--- a/db/seeds/schedules.rb
+++ b/db/seeds/schedules.rb
@@ -89,17 +89,22 @@ npq_leadership_november_2021.update!(cohort: cohort_2021)
   )
 end
 
-Importers::SeedNPQSchedules.new(
+Importers::SeedSchedule.new(
   path_to_csv: Rails.root.join("db/seeds/schedules/npq_specialist.csv"),
   klass: Finance::Schedule::NPQSpecialist,
 ).call
 
-Importers::SeedNPQSchedules.new(
+Importers::SeedSchedule.new(
   path_to_csv: Rails.root.join("db/seeds/schedules/npq_leadership.csv"),
   klass: Finance::Schedule::NPQLeadership,
 ).call
 
-Importers::SeedNPQSchedules.new(
+Importers::SeedSchedule.new(
   path_to_csv: Rails.root.join("db/seeds/schedules/npq_aso.csv"),
   klass: Finance::Schedule::NPQSupport,
+).call
+
+Importers::SeedSchedule.new(
+  path_to_csv: Rails.root.join("db/seeds/schedules/ecf_standard.csv"),
+  klass: Finance::Schedule::ECF,
 ).call

--- a/db/seeds/schedules/ecf_standard.csv
+++ b/db/seeds/schedules/ecf_standard.csv
@@ -1,0 +1,7 @@
+schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
+ecf-standard-april,ECF Standard April,2021,Output 1 - Participant Start,started,01/03/2022,30/04/2022,31/05/2022
+ecf-standard-april,ECF Standard April,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,30/09/2022,31/10/2022
+ecf-standard-april,ECF Standard April,2021,Output 3 - Retention Point 2,retained-2,01/11/2022,31/01/2023,28/02/2023
+ecf-standard-april,ECF Standard April,2021,Output 4 - Retention Point 3,retained-3,01/03/2023,30/04/2023,31/05/2023
+ecf-standard-april,ECF Standard April,2021,Output 5 - Retention Point 4,retained-4,01/06/2023,31/10/2023,30/11/2023
+ecf-standard-april,ECF Standard April,2021,Output 6 - Participant Completion,completed,01/12/2023,31/01/2024,28/02/2024

--- a/docs/source/_ecf_usage_participant_actions.html.erb
+++ b/docs/source/_ecf_usage_participant_actions.html.erb
@@ -41,14 +41,18 @@
 <p class="govuk-body-m">See <a href="/api-reference/reference#api-v1-participants-id-change-schedule-put" class="govuk-link">change schedule of ECF participant</a> endpoint.</p>
 
 <h3 class="govuk-heading-m" id="notifying-of-schedule-change-standard-induction">Standard induction</h3>
+
 <p class="govuk-body-m">
   A usual 2 year induction covers 6 terms (3 in each academic year). The payment model for those following a standard
   induction is therefore equal to 1 milestone payment for each of the 6 terms you are supporting a participant.</p>
 <p class="govuk-body-m">We are allowing functionality for providers to switch participants onto the following standard schedules:</p>
+
 <ul class="govuk-list govuk-list--bullet">
   <li><code>ecf-standard-september</code></li>
   <li><code>ecf-standard-january</code></li>
+  <li><code>ecf-standard-april</code></li>
 </ul>
+
 <p class="govuk-body-m">
   Functionality to switch participants onto non-standard inductions will be available at a later date.
   For the time being, please switch participants onto either a September or January schedule based on their start date,
@@ -56,10 +60,12 @@
 </p>
 
 <h3 class="govuk-heading-s" id="notifying-of-schedule-change-standard-induction-september">Standard induction starting in September</h3>
+
 <p class="govuk-body-m">
   Participants should be tagged as <code>ecf-standard-september</code> if they are starting their course before the <b>31st October</b>
   regardless of whether they will be on a standard or non standard induction.
 </p>
+
 <table class="govuk-table">
   <thead  class="nhsuk-table__head">
     <tr class="govuk-table__row">
@@ -145,6 +151,54 @@
       <td class="govuk-table__cell">Output 6 – Participant Completion (20%)</td>
       <td class="govuk-table__cell">31st October 2023</td>
       <td class="govuk-table__cell">30th November 2023</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3 class="govuk-heading-s" id="notifying-of-schedule-change-standard-induction-april">Standard induction starting in April</h3>
+
+<p class="govuk-body-m">
+  Participants should be tagged as <code>ecf-standard-april</code> if they are starting their course in <b>April</b>
+</p>
+
+<table class="govuk-table">
+  <thead  class="nhsuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Retention Point</th>
+      <th scope="col" class="govuk-table__header">Milestone Date</th>
+      <th scope="col" class="govuk-table__header">Payment Made</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Output 1 - Participant Start (20%)</td>
+      <td class="govuk-table__cell">30th April 2022</td>
+      <td class="govuk-table__cell">31st May 2022</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Output 2 – Retention Point 1 (15%)</td>
+      <td class="govuk-table__cell">30th September 2022</td>
+      <td class="govuk-table__cell">31st October 2022</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Output 3 – Retention Point 2 (15%)</td>
+      <td class="govuk-table__cell">31st January 2023</td>
+      <td class="govuk-table__cell">28th February 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Output 4 – Retention Point 3 (15%)</td>
+      <td class="govuk-table__cell">30th April 2023</td>
+      <td class="govuk-table__cell">31st May 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Output 5 – Retention Point 4 (15%)</td>
+      <td class="govuk-table__cell">31st October 2023</td>
+      <td class="govuk-table__cell">30th November 2023</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">Output 6 – Participant Completion (20%)</td>
+      <td class="govuk-table__cell">31st January 2024</td>
+      <td class="govuk-table__cell">28th February 2024</td>
     </tr>
   </tbody>
 </table>

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,6 +9,13 @@ weight: 6
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l" id="7-1-2022">7th January 2022</h2>
+<p class="govuk-body-m">
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Added schedule with identifier <code>ecf-standard-april</code></li>
+  </ul>
+</p>
+
 <h2 class="govuk-heading-l" id="6-1-2022">6th January 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">

--- a/spec/models/finance/schedule_spec.rb
+++ b/spec/models/finance/schedule_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
       expect(subject.cohort.start_year).to eql 2021
     end
   end
+
+  it "seeds ecf-standard-april schedule and milestones" do
+    schedule = described_class.find_by(schedule_identifier: "ecf-standard-april")
+
+    expect(schedule).to be_present
+    expect(schedule.milestones.count).to eql(6)
+  end
 end
 
 RSpec.describe Finance::Schedule::NPQLeadership, type: :model do

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1398,7 +1398,8 @@
             "example": "ecf-standard-january",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april"
             ]
           },
           "updated_at": {
@@ -1438,7 +1439,8 @@
             "type": "string",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april"
             ],
             "example": "ecf-standard-september"
           },
@@ -1781,7 +1783,8 @@
             "example": "ecf-standard-january",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april"
             ]
           },
           "updated_at": {
@@ -2025,7 +2028,8 @@
             "example": "ecf-standard-january",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april"
             ]
           },
           "updated_at": {
@@ -2418,7 +2422,8 @@
             "example": "ecf-standard-january",
             "enum": [
               "ecf-standard-september",
-              "ecf-standard-january"
+              "ecf-standard-january",
+              "ecf-standard-april"
             ]
           },
           "updated_at": {

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -87,6 +87,7 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantChangeScheduleAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeScheduleAttributes.yml
@@ -7,6 +7,7 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
     example: ecf-standard-september
   course_identifier:
     description: "The type of course the participant is enrolled in"

--- a/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -87,6 +87,7 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
@@ -87,6 +87,7 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
@@ -87,6 +87,7 @@ properties:
     enum:
       - ecf-standard-september
       - ecf-standard-january
+      - ecf-standard-april
   updated_at:
     description: "The date the ECF participant was last updated"
     type: string


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-827

- Adds new schedule `ecf-standard-april`
- Updates docs accordingly
- Data will be populated post deployment

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- https://ecf-review-pr-1599.london.cloudapps.digital/api-reference/ecf-usage.html#notifying-of-schedule-change-standard-induction for the docs
- To see schedule
- start a rails console on the review app
- Should see schedule and milestone present in the database

## External API changes

- Yes, new schedule. docs and release notes are part of this PR