### PR TITLE
DEDUPING: Move npq applications from user to participant identity part 2

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -32,7 +32,7 @@ module Api
       end
 
       def accept
-        npq_application = npq_lead_provider.npq_applications.includes(:user, :participant_identity, :npq_course).find(params[:id])
+        npq_application = npq_lead_provider.npq_applications.includes(:participant_identity, :npq_course).find(params[:id])
         if NPQ::Accept.call(npq_application: npq_application)
           render json: NPQApplicationSerializer.new(npq_application).serializable_hash
         else
@@ -47,7 +47,7 @@ module Api
       end
 
       def query_scope
-        scope = npq_lead_provider.npq_applications.includes(:user, :participant_identity, :npq_course)
+        scope = npq_lead_provider.npq_applications.includes(:participant_identity, :npq_course)
         scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
         scope
       end

--- a/app/jobs/create_new_fake_sandbox_data_job.rb
+++ b/app/jobs/create_new_fake_sandbox_data_job.rb
@@ -27,6 +27,7 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
       10.times do
         name = Faker::Name.name
         user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
+        identity = Identity::Create.call(user: user, origin: :npq)
         NPQApplication.create!(
           active_alert: "",
           date_of_birth: Date.new(1990, 1, 1),
@@ -39,7 +40,7 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
           teacher_reference_number_verified: true,
           npq_course: NPQCourse.all.sample,
           npq_lead_provider: npq_lead_provider,
-          user: user,
+          participant_identity: identity,
         )
       end
     end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -3,7 +3,7 @@
 class NPQApplication < ApplicationRecord
   has_paper_trail only: %i[user_id npq_lead_provider_id npq_course_id created_at updated_at lead_provider_approval_status]
 
-  self.ignored_columns = ["user_id"]
+  self.ignored_columns = %w[user_id]
 
   has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id, touch: true
   belongs_to :participant_identity
@@ -38,9 +38,7 @@ class NPQApplication < ApplicationRecord
   validate :validate_rejected_status_cannot_change
   validate :validate_accepted_status_cannot_change
 
-  def user
-    participant_identity.user
-  end
+  delegate :user, to: :participant_identity
 
   def validate_rejected_status_cannot_change
     if lead_provider_approval_status_changed?(from: "rejected")

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -7,8 +7,6 @@ class NPQApplication < ApplicationRecord
 
   has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id, touch: true
   belongs_to :participant_identity
-  # has_one :user, through: :participant_identity
-  # belongs_to :user
   belongs_to :npq_lead_provider
   belongs_to :npq_course
 

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -3,9 +3,12 @@
 class NPQApplication < ApplicationRecord
   has_paper_trail only: %i[user_id npq_lead_provider_id npq_course_id created_at updated_at lead_provider_approval_status]
 
+  self.ignored_columns = ["user_id"]
+
   has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id, touch: true
-  belongs_to :user
-  belongs_to :participant_identity, optional: true
+  belongs_to :participant_identity
+  # has_one :user, through: :participant_identity
+  # belongs_to :user
   belongs_to :npq_lead_provider
   belongs_to :npq_course
 
@@ -34,6 +37,10 @@ class NPQApplication < ApplicationRecord
 
   validate :validate_rejected_status_cannot_change
   validate :validate_accepted_status_cannot_change
+
+  def user
+    participant_identity.user
+  end
 
   def validate_rejected_status_cannot_change
     if lead_provider_approval_status_changed?(from: "rejected")

--- a/app/policies/participant_profile/ecf_policy.rb
+++ b/app/policies/participant_profile/ecf_policy.rb
@@ -10,7 +10,7 @@ class ParticipantProfile::ECFPolicy < ParticipantProfilePolicy
 
   def update?
     return true if admin?
-    return false if record.user.npq_applications?
+    return false if record.user.npq_applications.any?
     return false if record.completed_validation_wizard?
     return false if record.participant_declarations.any?
 

--- a/app/serializers/npq_application_csv_serializer.rb
+++ b/app/serializers/npq_application_csv_serializer.rb
@@ -45,9 +45,9 @@ private
   def to_row(record)
     [
       record.id,
-      participant_id(record),
-      full_name(record),
-      email(record),
+      record.participant_identity.external_identifier,
+      record.participant_identity.user.full_name,
+      record.participant_identity.email,
       true,
       record.teacher_reference_number,
       record.teacher_reference_number_verified,
@@ -61,26 +61,5 @@ private
       record.created_at.rfc3339,
       record.updated_at.rfc3339,
     ]
-  end
-
-  def participant_id(record)
-    # NOTE: only until identity data populated
-    record.user_id
-    # then change to this
-    # record.participant_identity.external_identifier
-  end
-
-  def full_name(record)
-    # NOTE: only until identity data populated
-    record.user.full_name
-    # then change to this
-    # record.participant_identity.user.full_name
-  end
-
-  def email(record)
-    # NOTE: only until identity data populated
-    record.user.email
-    # then change to this
-    # record.participant_identity.email
   end
 end

--- a/app/serializers/npq_application_serializer.rb
+++ b/app/serializers/npq_application_serializer.rb
@@ -22,27 +22,18 @@ class NPQApplicationSerializer
              :created_at,
              :updated_at
 
-  # NOTE: only until identity data populated
-  attribute(:participant_id, &:user_id)
-  # then change to this
-  # attribute(:participant_id) do |object|
-  #   object.participant_identity.external_identifier
-  # end
+  attribute(:participant_id) do |object|
+    object.participant_identity.external_identifier
+  end
 
   attribute(:teacher_reference_number_validated, &:teacher_reference_number_verified)
 
   attribute(:full_name) do |object|
-    # NOTE: only until identity data populated
-    object.user.full_name
-    # then change to this
-    # object.participant_identity.user.full_name
+    object.participant_identity.user.full_name
   end
 
   attribute(:email) do |object|
-    # NOTE: only until identity data populated
-    object.user.email
-    # then change to this
-    # object.participant_identity.email
+    object.participant_identity.email
   end
 
   attribute(:email_validated) do

--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -35,31 +35,19 @@ module NPQ
   private
 
     def has_other_accepted_applications_with_same_course?
-      # TODO: use this until identity populated
-      NPQApplication.where(user_id: user.id)
+      NPQApplication.joins(:participant_identity)
+        .where(participant_identity: { user_id: user.id })
         .where(npq_course: npq_course)
         .where(lead_provider_approval_status: "accepted")
         .where.not(id: npq_application.id)
         .exists?
-      # then change to this
-      # NPQApplication.joins(:participant_identity)
-      #   .where(participant_identity: { user_id: user.id })
-      #   .where(npq_course: npq_course)
-      #   .where(lead_provider_approval_status: "accepted")
-      #   .where.not(id: npq_application.id)
-      #   .exists?
     end
 
     def other_applications
-      # TODO: use this until identity populated
-      @other_applications ||= NPQApplication.where(user_id: user.id)
+      @other_applications ||= NPQApplication.joins(:participant_identity)
+                                            .where(participant_identity: { user_id: user.id })
                                             .where(npq_course: npq_course)
                                             .where.not(id: npq_application.id)
-      # then change to this
-      # @other_applications ||= NPQApplication.joins(:participant_identity)
-      #                                       .where(participant_identity: { user_id: user.id })
-      #                                       .where(npq_course: npq_course)
-      #                                       .where.not(id: npq_application.id)
     end
 
     def create_profile
@@ -70,10 +58,7 @@ module NPQ
         teacher_profile: teacher_profile,
         school_urn: npq_application.school_urn,
         school_ukprn: npq_application.school_ukprn,
-        # NOTE: use until identity populated
-        participant_identity: Identity::Create.call(user: user, origin: :npq),
-        # then change to this
-        # participant_identity: npq_application.participant_identity,
+        participant_identity: npq_application.participant_identity,
       ) do |participant_profile|
         ParticipantProfileState.find_or_create_by!(participant_profile: participant_profile)
       end
@@ -84,10 +69,7 @@ module NPQ
     end
 
     def user
-      # NOTE: use until identity populated
-      @user ||= npq_application.user
-      # then change to this
-      # @user ||= npq_application.participant_identity.user
+      @user ||= npq_application.participant_identity.user
     end
 
     def npq_course

--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -34,10 +34,9 @@ module NPQ
     attr_accessor :npq_application_params, :npq_course_id, :npq_lead_provider_id, :user_id
 
     def npq_application_attributes
-      npq_application_params.merge(
+      npq_application_params.except(:user_id).merge(
         npq_course: npq_course,
         npq_lead_provider: npq_lead_provider,
-        user: user,
         participant_identity: participant_identity,
       )
     end

--- a/db/migrate/20220107190116_add_foreign_key_on_npq_application_to_participant_identity.rb
+++ b/db/migrate/20220107190116_add_foreign_key_on_npq_application_to_participant_identity.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddForeignKeyOnNPQApplicationToParticipantIdentity < ActiveRecord::Migration[6.1]
+  def up
+    add_foreign_key :npq_applications, :participant_identities, null: false, validate: false
+  end
+
+  # for some reason rollback fails to revert a "change" unless split into up and down
+  def down
+    remove_foreign_key :npq_applications, :participant_identities
+  end
+end

--- a/db/migrate/20220108165316_remove_user_reference_from_npq_applications.rb
+++ b/db/migrate/20220108165316_remove_user_reference_from_npq_applications.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RemoveUserReferenceFromNPQApplications < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured { remove_reference :npq_applications, :user, null: true, foreign_key: true, type: :uuid }
+  end
+
+  def down
+    add_reference :npq_applications, :user, null: true
+    execute <<~SQL
+      UPDATE npq_applications
+      SET user_id = (
+        SELECT user_id
+        FROM participant_identities
+        WHERE participant_identities.id = npq_applications.participant_identity_id
+      );
+    SQL
+    add_foreign_key :npq_applications, :users, null: false, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_06_111301) do
+ActiveRecord::Schema.define(version: 2022_01_08_165316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -428,7 +428,6 @@ ActiveRecord::Schema.define(version: 2022_01_06_111301) do
   end
 
   create_table "npq_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "user_id", null: false
     t.uuid "npq_lead_provider_id", null: false
     t.uuid "npq_course_id", null: false
     t.date "date_of_birth"
@@ -448,7 +447,6 @@ ActiveRecord::Schema.define(version: 2022_01_06_111301) do
     t.index ["npq_course_id"], name: "index_npq_applications_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_applications_on_npq_lead_provider_id"
     t.index ["participant_identity_id"], name: "index_npq_applications_on_participant_identity_id"
-    t.index ["user_id"], name: "index_npq_applications_on_user_id"
   end
 
   create_table "npq_contracts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -856,7 +854,7 @@ ActiveRecord::Schema.define(version: 2022_01_06_111301) do
   add_foreign_key "nomination_emails", "schools"
   add_foreign_key "npq_applications", "npq_courses"
   add_foreign_key "npq_applications", "npq_lead_providers"
-  add_foreign_key "npq_applications", "users"
+  add_foreign_key "npq_applications", "participant_identities"
   add_foreign_key "npq_lead_providers", "cpd_lead_providers"
   add_foreign_key "participant_bands", "call_off_contracts"
   add_foreign_key "participant_declaration_attempts", "participant_declarations"

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -193,6 +193,7 @@ module ValidTestDataGenerator
     def create_participant(school:)
       name = Faker::Name.name
       user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
+      identity = Identity::Create.call(user: user, origin: :npq)
 
       npq_application = NPQApplication.create!(
         active_alert: "",
@@ -206,7 +207,7 @@ module ValidTestDataGenerator
         teacher_reference_number_verified: true,
         npq_course: NPQCourse.all.sample,
         npq_lead_provider: lead_provider,
-        user: user,
+        participant_identity: identity,
       )
 
       return if [true, false].sample

--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -47,7 +47,7 @@ Timecop.freeze(Date.parse("19/09/2019")) do
   FactoryBot.create(:npq_leadership_schedule)
   FactoryBot.create(:npq_specialist_schedule)
   npq_application = FactoryBot.create :npq_application,
-                                      participant_identity: Identity::Create.call(user:  npq_user, origin: :npq),
+                                      participant_identity: Identity::Create.call(user: npq_user, origin: :npq),
                                       date_of_birth: Date.parse("10/12/1982"),
                                       nino: "NI123456",
                                       teacher_reference_number: "9780824",

--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -47,7 +47,7 @@ Timecop.freeze(Date.parse("19/09/2019")) do
   FactoryBot.create(:npq_leadership_schedule)
   FactoryBot.create(:npq_specialist_schedule)
   npq_application = FactoryBot.create :npq_application,
-                                      user: npq_user,
+                                      participant_identity: Identity::Create.call(user:  npq_user, origin: :npq),
                                       date_of_birth: Date.parse("10/12/1982"),
                                       nino: "NI123456",
                                       teacher_reference_number: "9780824",

--- a/spec/docs/npq_participants_spec.rb
+++ b/spec/docs/npq_participants_spec.rb
@@ -79,7 +79,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
     before do
       Participants::Defer::NPQ.call(
         params: {
-          participant_id: npq_application.user_id,
+          participant_id: npq_application.participant_identity.external_identifier,
           reason: Participants::Defer::NPQ.reasons.sample,
           course_identifier: npq_application.npq_course.identifier,
           cpd_lead_provider: cpd_lead_provider,
@@ -120,7 +120,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
                 }
 
       response "200", "The NPQ participant being withdrawn" do
-        let(:id) { npq_application.user_id }
+        let(:id) { npq_application.participant_identity.external_identifier }
         let(:attributes) do
           {
             reason: Participants::Withdraw::NPQ.reasons.sample,
@@ -142,7 +142,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
       end
 
       response "422", "Unprocessable entity" do
-        let(:id) { npq_application.user_id }
+        let(:id) { npq_application.participant_identity.external_identifier }
         let(:attributes) do
           {
             reason: Participants::Withdraw::NPQ.reasons.sample,

--- a/spec/factories/npq_application.rb
+++ b/spec/factories/npq_application.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :npq_application do
-    user
+    participant_identity
     npq_course
     npq_lead_provider
 

--- a/spec/factories/participant_identity.rb
+++ b/spec/factories/participant_identity.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     end
 
     initialize_with do
-      ParticipantIdentity.find_or_create_by!(email: email) do |identity|
+      ParticipantIdentity.find_or_initialize_by(email: email) do |identity|
         identity.user = user
         identity.external_identifier = user.id
       end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     factory :npq_participant_profile, class: "ParticipantProfile::NPQ" do
-      npq_application { association :npq_application, user: teacher_profile.user, school_urn: rand(100_000..999_999) }
+      npq_application { association :npq_application, participant_identity: participant_identity, school_urn: rand(100_000..999_999) }
       schedule do |participant_profile|
         if Finance::Schedule::NPQLeadership::IDENTIFIERS.include?(participant_profile.npq_application.npq_course.identifier)
           Finance::Schedule::NPQLeadership.default || create(:npq_leadership_schedule)

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules do
 private
 
   def create_accepted_application(user, npq_course, npq_lead_provider)
-    identity = Identity::Create.call(user: user, origin: :npq)
+    Identity::Create.call(user: user, origin: :npq)
     npq_application = NPQ::BuildApplication.call(
       npq_application_params: attributes_for(:npq_application),
       npq_course_id: npq_course.id,

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -42,6 +42,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules do
 private
 
   def create_accepted_application(user, npq_course, npq_lead_provider)
+    identity = Identity::Create.call(user: user, origin: :npq)
     npq_application = NPQ::BuildApplication.call(
       npq_application_params: attributes_for(:npq_application),
       npq_course_id: npq_course.id,
@@ -59,7 +60,7 @@ private
     Timecop.freeze(stamp) do
       RecordDeclarations::Started::NPQ.call(
         params: {
-          participant_id: npq_application.user.id,
+          participant_id: npq_application.participant_identity.external_identifier,
           course_identifier: npq_application.npq_course.identifier,
           declaration_date: stamp.rfc3339,
           cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider,

--- a/spec/policies/participant_profile/ecf_policy_spec.rb
+++ b/spec/policies/participant_profile/ecf_policy_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
 
     context "with an NPQ application" do
       before do
-        create(:npq_application, user: participant_profile.user)
+        create(:npq_application, participant_identity: participant_profile.participant_identity)
       end
 
       it { is_expected.to permit_action(:withdraw_record) }
@@ -160,7 +160,7 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
 
     context "with an NPQ application" do
       before do
-        create(:npq_application, user: participant_profile.user)
+        create(:npq_application, participant_identity: participant_profile.participant_identity)
       end
 
       it { is_expected.to permit_action(:withdraw_record) }

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -258,8 +258,9 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
     end
 
     context "when participant has applied for multiple NPQs" do
-      let!(:other_npq_application) { create(:npq_application, npq_course: npq_course, npq_lead_provider: npq_lead_provider, user: user) }
-      let!(:other_accepted_npq_application) { create(:npq_application, npq_course: another_npq_course, npq_lead_provider: npq_lead_provider, user: user, lead_provider_approval_status: "accepted") }
+      let(:identity) { create(:participant_identity, user: user) }
+      let!(:other_npq_application) { create(:npq_application, npq_course: npq_course, npq_lead_provider: npq_lead_provider, participant_identity: identity) }
+      let!(:other_accepted_npq_application) { create(:npq_application, npq_course: another_npq_course, npq_lead_provider: npq_lead_provider, participant_identity: identity, lead_provider_approval_status: "accepted") }
 
       it "rejects all pending NPQs on same course" do
         post "/api/v1/npq-applications/#{default_npq_application.id}/accept"

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe "NPQ Participants API", type: :request do
           get "/api/v1/participants/npq"
 
           user = User.find(parsed_response["data"][0]["id"])
-          # expect(parsed_response["data"][0]["id"]).to be_in(NPQApplication.pluck(:user_id))
           expect(parsed_response["data"][0]["id"]).to be_in(ParticipantIdentity.joins(:npq_applications).pluck(:user_id))
           teacher_profile = user.teacher_profile
 

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe "NPQ Participants API", type: :request do
           get "/api/v1/participants/npq"
 
           user = User.find(parsed_response["data"][0]["id"])
-          expect(parsed_response["data"][0]["id"]).to be_in(NPQApplication.pluck(:user_id))
+          # expect(parsed_response["data"][0]["id"]).to be_in(NPQApplication.pluck(:user_id))
+          expect(parsed_response["data"][0]["id"]).to be_in(ParticipantIdentity.joins(:npq_applications).pluck(:user_id))
           teacher_profile = user.teacher_profile
 
           expect(parsed_response["data"][0]["attributes"]["email"]).to eql(user.email)

--- a/spec/serializers/npq_participant_serializer_spec.rb
+++ b/spec/serializers/npq_participant_serializer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe NPQParticipantSerializer do
     describe "multiple providers" do
       let!(:schedule) { create(:npq_leadership_schedule) }
       let!(:participant) { create(:user) }
+      let!(:identity) { create(:participant_identity, user: participant) }
 
       let(:cpd_provider_one) { create(:cpd_lead_provider) }
       let(:cpd_provider_two) { create(:cpd_lead_provider) }
@@ -17,8 +18,8 @@ RSpec.describe NPQParticipantSerializer do
       let(:course_one) { create(:npq_course, identifier: "npq-headship") }
       let(:course_two) { create(:npq_course, identifier: "npq-senior-leadership") }
 
-      let!(:application_one) { create(:npq_application, :accepted, npq_lead_provider: provider_one, npq_course: course_one, user: participant) }
-      let!(:application_two) { create(:npq_application, :accepted, npq_lead_provider: provider_two, npq_course: course_two, user: participant) }
+      let!(:application_one) { create(:npq_application, :accepted, npq_lead_provider: provider_one, npq_course: course_one, participant_identity: identity) }
+      let!(:application_two) { create(:npq_application, :accepted, npq_lead_provider: provider_two, npq_course: course_two, participant_identity: identity) }
 
       it "does not leak course info when given a provider param" do
         result = NPQParticipantSerializer.new(participant, params: { cpd_lead_provider: provider_one.cpd_lead_provider }).serializable_hash

--- a/spec/services/admin/change_induction_choice_service_spec.rb
+++ b/spec/services/admin/change_induction_choice_service_spec.rb
@@ -173,8 +173,6 @@ RSpec.describe Admin::ChangeInductionService do
           service.change_induction_provision(:core_induction_programme)
           expect(school.participants_for(cohort).map(&:id)).to match_array participant_ids
 
-          # expect { service.change_induction_provision(:core_induction_programme) }
-          #   .not_to change { school.participants_for(cohort).map(&:id) }
           expect(participant_profiles.each(&:reload)).to all be_active_record
         end
       end

--- a/spec/services/admin/change_induction_choice_service_spec.rb
+++ b/spec/services/admin/change_induction_choice_service_spec.rb
@@ -169,8 +169,12 @@ RSpec.describe Admin::ChangeInductionService do
         end
 
         it "does not change participants when changing to CIP" do
-          expect { service.change_induction_provision(:core_induction_programme) }
-            .not_to change { school.participants_for(cohort).map(&:id) }
+          participant_ids = school.participants_for(cohort).map(&:id)
+          service.change_induction_provision(:core_induction_programme)
+          expect(school.participants_for(cohort).map(&:id)).to match_array participant_ids
+
+          # expect { service.change_induction_provision(:core_induction_programme) }
+          #   .not_to change { school.participants_for(cohort).map(&:id) }
           expect(participant_profiles.each(&:reload)).to all be_active_record
         end
       end

--- a/spec/services/create_induction_tutor_spec.rb
+++ b/spec/services/create_induction_tutor_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe CreateInductionTutor do
       end
 
       context "when the induction coordinator applied for npq" do
-        let!(:npq_application) { create(:npq_application, user: existing_profile.user) }
+        let(:identity) { create(:participant_identity, user: existing_profile.user) }
+        let!(:npq_application) { create(:npq_application, participant_identity: identity) }
 
         it "retains the user but deletes the induction coordinator profile" do
           expect(school.induction_coordinator_profiles.first).to eq(existing_profile)

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -12,13 +12,14 @@ RSpec.describe NPQ::Accept do
   describe "#call" do
     let(:trn) { rand(1_000_000..9_999_999).to_s }
     let(:user) { create(:user) }
+    let(:identity) { create(:participant_identity, user: user) }
     let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
     let(:npq_lead_provider) { create(:npq_lead_provider) }
 
     let(:npq_application) do
       NPQApplication.new(
         teacher_reference_number: trn,
-        user: user,
+        participant_identity: identity,
         npq_course: npq_course,
         npq_lead_provider: npq_lead_provider,
         school_urn: "123456",
@@ -32,7 +33,7 @@ RSpec.describe NPQ::Accept do
       let(:other_npq_application) do
         NPQApplication.new(
           teacher_reference_number: trn,
-          user: user,
+          participant_identity: identity,
           npq_course: npq_course,
           npq_lead_provider: other_npq_lead_provider,
           school_urn: "123456",
@@ -58,7 +59,7 @@ RSpec.describe NPQ::Accept do
       let(:other_npq_application) do
         NPQApplication.create!(
           teacher_reference_number: trn,
-          user: user,
+          participant_identity: identity,
           npq_course: npq_course,
           npq_lead_provider: other_npq_lead_provider,
           school_urn: "123456",
@@ -89,7 +90,7 @@ RSpec.describe NPQ::Accept do
       let(:other_npq_application) do
         NPQApplication.new(
           teacher_reference_number: trn,
-          user: user,
+          participant_identity: identity,
           npq_course: other_npq_course,
           npq_lead_provider: other_npq_lead_provider,
           school_urn: "123456",
@@ -138,7 +139,7 @@ RSpec.describe NPQ::Accept do
           NPQApplication.new(
             teacher_reference_number: trn,
             teacher_reference_number_verified: true,
-            user: user,
+            participant_identity: identity,
             npq_course: npq_course,
             npq_lead_provider: npq_lead_provider,
           )

--- a/spec/services/npq/build_application_spec.rb
+++ b/spec/services/npq/build_application_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe NPQ::BuildApplication do
           npq_application_params.merge(
             npq_course_id: npq_course.id,
             npq_lead_provider_id: npq_lead_provider.id,
-            user_id: user.id,
           ),
         )
     end

--- a/spec/support/shared_examples/participant_actions_resume_support.rb
+++ b/spec/support/shared_examples/participant_actions_resume_support.rb
@@ -81,7 +81,7 @@ RSpec.shared_examples "JSON Participant resume documentation" do |url, request_s
                 }
 
       response "200", "The #{humanised_description} being resumed" do
-        let(:id) { participant.user_id }
+        let(:id) { participant.participant_identity.external_identifier }
 
         let(:params) do
           {


### PR DESCRIPTION
## Ticket and context

Ticket:

Part 2 of #1579. Now that has been merged and deployed and we have added `ParticipantIdentity` records to all of the existing `NPQApplication`s we can add a foreign key and use the participant_identity to allow us to move a user's npq_applications with `ParticipantProfile`s when users are de-duplicated.  This ensures we can still expose the original IDs in the API endpoints and that the applications remain with the appropriate user and profiles.


## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
