### PR TITLE
[CPDLP-829] New ECF change schedule endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,11 @@ Rails.application.routes.draw do
           put :change_schedule, path: "change-schedule"
         end
       end
+      resources :participants, path: "/participants/ecf", only: [] do
+        member do
+          put :change_schedule, path: "change-schedule"
+        end
+      end
       resources :participant_declarations, only: %i[create index show], path: "participant-declarations" do
         member do
           put :void

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,6 +9,13 @@ weight: 6
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l" id="11-1-2022">11th January 2022</h2>
+<p class="govuk-body-m">
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Added new API endpoint <code>/api/v1/participants/ecf/{participant_id}/change-schedule</code></li>
+  </ul>
+</p>
+
 <h2 class="govuk-heading-l" id="7-1-2022">7th January 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">

--- a/spec/docs/participants_spec.rb
+++ b/spec/docs/participants_spec.rb
@@ -93,6 +93,65 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
     end
   end
 
+  path "/api/v1/participants/ecf/{id}/change-schedule" do
+    put "Notify that an ECF participant is changing training schedule" do
+      operationId :participant
+      tags "ECF Participant"
+      security [bearerAuth: []]
+      consumes "application/json"
+
+      request_body content: {
+        "application/json": {
+          "schema": {
+            "$ref": "#/components/schemas/ECFParticipantChangeScheduleRequest",
+          },
+        },
+      }
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The ID of the participant"
+
+      parameter name: :params,
+                in: :body,
+                type: :object,
+                style: :deepObject,
+                required: true,
+                schema: {
+                  "$ref": "#/components/schemas/ECFParticipantChangeScheduleRequest",
+                }
+
+      response "200", "The ECF participant changing schedule" do
+        let(:id) { mentor_profile.user.id }
+        let(:attributes) do
+          {
+            schedule_identifier: "ecf-standard-january",
+            course_identifier: "ecf-mentor",
+          }
+        end
+
+        let(:params) do
+          {
+            "data": {
+              "type": "participant",
+              "attributes": attributes,
+            },
+          }
+        end
+
+        before do
+          create(:schedule, schedule_identifier: "ecf-standard-january", name: "ECF January standard 2021")
+        end
+
+        schema({ "$ref": "#/components/schemas/ECFParticipantResponse" })
+        run_test!
+      end
+    end
+  end
+
   path "/api/v1/participants/{id}/withdraw" do
     put "Notify that an ECF participant has withdrawn from their course" do
       operationId :participant

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/participants/{id}/defer
         /api/v1/participants/{id}/resume
         /api/v1/participants/{id}/change-schedule
+        /api/v1/participants/ecf/{id}/change-schedule
         /api/v1/participants/{id}/withdraw
       ]
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -284,6 +284,21 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         end
       end
 
+      describe "/api/v1/participants/ecf/ID/change-schedule" do
+        let(:parsed_response) { JSON.parse(response.body) }
+
+        before do
+          create(:schedule, schedule_identifier: "ecf-january-standard-2021", name: "ECF January standard 2021")
+        end
+
+        it "changes participant schedule" do
+          put "/api/v1/participants/ecf/#{early_career_teacher_profile.user.id}/change-schedule", params: { data: { attributes: { course_identifier: "ecf-induction", schedule_identifier: "ecf-january-standard-2021" } } }
+
+          expect(response).to be_successful
+          expect(parsed_response.dig("data", "attributes", "schedule_identifier")).to eql("ecf-january-standard-2021")
+        end
+      end
+
       it_behaves_like "JSON Participant Deferral endpoint", "participant" do
         let(:url)               { "/api/v1/participants/#{early_career_teacher_profile.user.id}/defer" }
         let(:withdrawal_url)    { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1166,6 +1166,55 @@
         }
       }
     },
+    "/api/v1/participants/ecf/{id}/change-schedule": {
+      "put": {
+        "summary": "Notify that an ECF participant is changing training schedule",
+        "operationId": "participant",
+        "tags": [
+          "ECF Participant"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ECFParticipantChangeScheduleRequest"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the participant",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The ECF participant changing schedule",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participants/{id}/withdraw": {
       "put": {
         "summary": "Notify that an ECF participant has withdrawn from their course",


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-829

- Adds extra endpoint `/api/vi/particicipants/ecf/ID/change-schedule`
- Does not differ from `/api/vi/particicipants/ID/change-schedule` endpoint but may do so in the fututre
- Updated docs accordingly

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Updated docs can be found at https://ecf-review-pr-1613.london.cloudapps.digital/api-reference
- Find a existing ECF user and change their schedule via new documented api endpoint

## External API changes

- Yes, API docs have been updated along with release notes