### PR TITLE
[CPDLP-844] Change schedule with cohort

### DIFF
--- a/app/controllers/concerns/api/participant_actions.rb
+++ b/app/controllers/concerns/api/participant_actions.rb
@@ -25,7 +25,7 @@ module Api
     end
 
     def permitted_params
-      params.require(:data).permit(:type, attributes: %i[course_identifier reason schedule_identifier])
+      params.require(:data).permit(:type, attributes: %i[course_identifier reason schedule_identifier cohort])
     rescue ActionController::ParameterMissing => e
       if e.param == :data
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/services/participants/change_schedule/base.rb
+++ b/app/services/participants/change_schedule/base.rb
@@ -10,6 +10,7 @@ module Participants
       def initialize(params:)
         super(params: params)
         self.schedule_identifier = params[:schedule_identifier]
+        self.cohort = params[:cohort]
       end
     end
   end

--- a/app/services/participants/change_schedule/validate_and_change_schedule.rb
+++ b/app/services/participants/change_schedule/validate_and_change_schedule.rb
@@ -8,6 +8,7 @@ module Participants
 
       included do
         attr_accessor :schedule_identifier
+        attr_writer :cohort
 
         validates :schedule, presence: { message: I18n.t(:invalid_schedule) }
         validate :not_already_withdrawn
@@ -24,11 +25,21 @@ module Participants
 
     private
 
-      def schedule
-        alias_search_query = Finance::Schedule.where(identifier_alias: schedule_identifier)
+      def cohort_object
+        @cohort_object ||= if @cohort
+                             Cohort.find_by(start_year: @cohort)
+                           else
+                             Cohort.current
+                           end
+      end
 
-        Finance::Schedule
-          .where(schedule_identifier: schedule_identifier)
+      def schedule
+        return @schedule if @schedule
+
+        alias_search_query = Finance::Schedule.where(identifier_alias: schedule_identifier, cohort: cohort_object)
+
+        @schedule = Finance::Schedule
+          .where(schedule_identifier: schedule_identifier, cohort: cohort_object)
           .or(alias_search_query)
           .first
       end

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,6 +9,13 @@ weight: 6
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l" id="12-1-2022">12th January 2022</h2>
+<p class="govuk-body-m">
+  <ul class="govuk-list govuk-list--bullet">
+    <li><code>change-schedule</code> API endpoints now accept a <code>cohort</code> attribute in the request body. This defaults to <code>2021</code> if it is not specified.</li>
+  </ul>
+</p>
+
 <h2 class="govuk-heading-l" id="11-1-2022">11th January 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -12,7 +12,7 @@ weight: 6
 <h2 class="govuk-heading-l" id="12-1-2022">12th January 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">
-    <li><code>change-schedule</code> API endpoints now accept a <code>cohort</code> attribute in the request body. This defaults to <code>2021</code> if it is not specified.</li>
+    <li><code>change-schedule</code> API endpoints now accept a <code>cohort</code> attribute in the request body. This defaults to the current cohort if it is not specified.</li>
   </ul>
 </p>
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         end
       end
 
-      describe "JSON Participant Change Schedule" do
+      describe "/api/v1/participants/ID/change-schedule" do
         let(:parsed_response) { JSON.parse(response.body) }
 
         before do
@@ -281,6 +281,31 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
 
           expect(response).to be_successful
           expect(parsed_response.dig("data", "attributes", "schedule_identifier")).to eql("ecf-january-standard-2021")
+        end
+      end
+
+      describe "/api/v1/participants/ID/change-schedule with cohort" do
+        let(:parsed_response) { JSON.parse(response.body) }
+        let(:cohort_2022) { create(:cohort, start_year: "2022") }
+
+        let!(:schedule_2021) { create(:schedule, schedule_identifier: "ecf", name: "ECF 2021") }
+        let!(:schedule_2022) { create(:schedule, schedule_identifier: "ecf", name: "ECF 2022", cohort: cohort_2022) }
+
+        it "changes participant schedule" do
+          expect {
+            put "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule", params: {
+              data: {
+                attributes: {
+                  course_identifier: "ecf-induction",
+                  schedule_identifier: schedule_2022.schedule_identifier,
+                  cohort: "2022",
+                },
+              },
+            }
+          }.to change { early_career_teacher_profile.reload.schedule }.to(schedule_2022)
+
+          expect(response).to be_successful
+          expect(parsed_response.dig("data", "attributes", "schedule_identifier")).to eql(schedule_2022.schedule_identifier)
         end
       end
 

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1501,6 +1501,11 @@
               "ecf-mentor"
             ],
             "example": "ecf-induction"
+          },
+          "cohort": {
+            "description": "The start year of the cohort the the participant is enrolled in. Defaults to 2021 if not specified",
+            "type": "string",
+            "example": "2021"
           }
         },
         "required": [
@@ -1509,7 +1514,8 @@
         ],
         "example": {
           "schedule_identifier": "ecf-standard-january",
-          "course_identifier": "ecf-mentor"
+          "course_identifier": "ecf-mentor",
+          "cohort": "2021"
         }
       },
       "ECFParticipantChangeScheduleRequest": {
@@ -1543,7 +1549,8 @@
             "type": "participant-change-schedule",
             "attributes": {
               "schedule_identifier": "ecf-standard-january",
-              "course_identifier": "ecf-mentor"
+              "course_identifier": "ecf-mentor",
+              "cohort": "2021"
             }
           }
         }

--- a/swagger/v1/component_schemas/ECFParticipantChangeScheduleAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeScheduleAttributes.yml
@@ -16,9 +16,14 @@ properties:
       - ecf-induction
       - ecf-mentor
     example: ecf-induction
+  cohort:
+    description: "The start year of the cohort the the participant is enrolled in. Defaults to 2021 if not specified"
+    type: string
+    example: "2021"
 required:
   - schedule_identifier
   - course_identifier
 example:
   schedule_identifier: ecf-standard-january
   course_identifier: ecf-mentor
+  cohort: "2021"

--- a/swagger/v1/component_schemas/ECFParticipantChangeScheduleRequest.yml
+++ b/swagger/v1/component_schemas/ECFParticipantChangeScheduleRequest.yml
@@ -22,3 +22,4 @@ example:
     attributes:
       schedule_identifier: "ecf-standard-january"
       course_identifier: "ecf-mentor"
+      cohort: "2021"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-844

- `Schedule#schedule_identifier` are not unique
- Eg. `ecf-standard-january` may exist twice. one for cohort `2021` and one for `2022`
- Therefore providers can specify the cohort which affects which schedule is used
- If no cohort is specified it defaults to `Cohort.current` which at this moment in time is `2021` 
- Docs have been updated accordingly

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Docs can be found at https://ecf-review-pr-1619.london.cloudapps.digital/api-reference
- Not sure we have any `2022` schedule so you may have to add some first ensure it shares a `schedule_identifier` as a `2021` schedule otherwise won't be a very good test
- Hit the endpoint for a participant with a `2022` schedule, should be updated to the specified schedule

## External API changes

- Yes,  docs have been updated accordingly
- Release notes have also been udpated