### PR TITLE
Add show and update endpoints for npq applications

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -5,13 +5,32 @@ module Api
     class NPQProfilesController < Api::ApiController
       include ApiTokenAuthenticatable
 
+      def show
+        @npq_application = NPQApplication.find params[:id]
+        render json: NPQValidationDataSerializer.new(@npq_application).serializable_hash
+      end
+
       def create
-        if npq_application.save
+        @npq_application = build_npq_application
+
+        if @npq_application.save
           render status: :created,
                  content_type: "application/vnd.api+json",
-                 json: NPQValidationDataSerializer.new(npq_application).serializable_hash
+                 json: NPQValidationDataSerializer.new(@npq_application).serializable_hash
         else
-          render json: { errors: Api::ErrorFactory.new(model: npq_application).call }, status: :bad_request
+          render json: { errors: Api::ErrorFactory.new(model: @npq_application).call }, status: :bad_request
+        end
+      end
+
+      def update
+        @npq_application = NPQApplication.find params[:id]
+
+        if @npq_application.update(npq_application_update_params)
+          render status: :ok,
+                 content_type: "application/vnd.api+json",
+                 json: NPQValidationDataSerializer.new(@npq_application).serializable_hash
+        else
+          render json: { errors: Api::ErrorFactory.new(model: @npq_application).call }, status: :bad_request
         end
       end
 
@@ -21,8 +40,8 @@ module Api
         ApiToken.where(private_api_access: true)
       end
 
-      def npq_application
-        @npq_application ||= NPQ::BuildApplication.call(
+      def build_npq_application
+        NPQ::BuildApplication.call(
           npq_application_params: npq_application_params,
           npq_course_id: npq_course_id,
           npq_lead_provider_id: npq_lead_provider_id,
@@ -70,6 +89,12 @@ module Api
             :teacher_reference_number,
             :teacher_reference_number_verified,
           ).transform_keys! { |key| key == "national_insurance_number" ? "nino" : key }
+      end
+
+      def npq_application_update_params
+        params
+          .require(:data)
+          .permit(attributes: :eligible_for_funding)
       end
     end
   end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -36,6 +36,8 @@ class NPQApplication < ApplicationRecord
   validate :validate_rejected_status_cannot_change
   validate :validate_accepted_status_cannot_change
 
+  validates :eligible_for_funding_before_type_cast, inclusion: { in: [true, false, "true", "false"] }
+
   delegate :user, to: :participant_identity
 
   def validate_rejected_status_cannot_change

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :npq_profiles, only: [:create], path: "npq-profiles"
+      resources :npq_profiles, only: %i[show create update], path: "npq-profiles"
 
       namespace :data_studio, path: "data-studio" do
         get "/school-rollout", to: "school_rollout#index"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-852

There are some npq applications that have their `eligible_for_funding` status out of sync with npq-registration. This is because the eligibility criteria has changed after they were created in ecf. This PR adds the endpoints necessary for us to sync all the statuses by running a rake task from npq-registration

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
