### PR TITLE
[CPDLP-890] finance users can see schedules and milestones

### DIFF
--- a/app/controllers/finance/schedules_controller.rb
+++ b/app/controllers/finance/schedules_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Finance
+  class SchedulesController < BaseController
+    def index
+      @schedules = Finance::Schedule.includes(:cohort, :milestones).order(:schedule_identifier)
+    end
+
+    def show
+      @schedule = Finance::Schedule.includes(:cohort, :milestones).find(params[:id])
+    end
+  end
+end

--- a/app/views/finance/landing_page/show.html.erb
+++ b/app/views/finance/landing_page/show.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Manage CPD contracts</h1>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Payment Breakdown", finance_payment_breakdowns_url %></h2>
@@ -8,17 +9,25 @@
       </div>
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Contract Summary", "#" %></h2>
-        <p>View all current contract details  </p>
+        <p>View all current contract details</p>
       </div>
     </div>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Provider dashboard", "#" %></h2>
-        <p>Overview of all course providers </p>
+        <p>Overview of all course providers</p>
       </div>
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Programme dashboard", "#" %></h2>
         <p>Overview of all programme participants</p>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <h2 class="govuk-heading-m"><%= govuk_link_to "Schedules", finance_schedules_path %></h2>
+        <p>Overview of all schedules</p>
       </div>
     </div>
   </div>

--- a/app/views/finance/schedules/index.html.erb
+++ b/app/views/finance/schedules/index.html.erb
@@ -1,0 +1,29 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_landing_page_path) %>
+
+<h1 class="govuk-heading-xl">Schedules</h1>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Identifier</th>
+      <th scope="col" class="govuk-table__header">Cohort</th>
+      <th scope="col" class="govuk-table__header">Milestones</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @schedules.each do |schedule| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">
+          <%= govuk_link_to schedule.schedule_identifier, finance_schedule_path(schedule) %>
+        </th>
+        <td class="govuk-table__cell">
+          <%= schedule.cohort.start_year %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= schedule.milestones.size %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/finance/schedules/show.html.erb
+++ b/app/views/finance/schedules/show.html.erb
@@ -1,0 +1,43 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_schedules_path) %>
+
+<span class="govuk-caption-xl"><%= @schedule.cohort.start_year %></span>
+<h1 class="govuk-heading-xl"><%= @schedule.schedule_identifier %></h1>
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--l">Milestones</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Declaration type</th>
+      <th scope="col" class="govuk-table__header">Start date</th>
+      <th scope="col" class="govuk-table__header">Milestone date</th>
+      <th scope="col" class="govuk-table__header">Payment date</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @schedule.milestones.each do |milestone| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">
+          <%= milestone.name %>
+        </th>
+
+        <td class="govuk-table__cell">
+          <%= milestone.declaration_type %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= milestone.start_date %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= milestone.milestone_date %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= milestone.payment_date %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/finance/schedules/show.html.erb
+++ b/app/views/finance/schedules/show.html.erb
@@ -27,15 +27,15 @@
         </td>
 
         <td class="govuk-table__cell">
-          <%= milestone.start_date %>
+          <%= milestone.start_date&.to_s(:govuk) %>
         </td>
 
         <td class="govuk-table__cell">
-          <%= milestone.milestone_date %>
+          <%= milestone.milestone_date&.to_s(:govuk) %>
         </td>
 
         <td class="govuk-table__cell">
-          <%= milestone.payment_date %>
+          <%= milestone.payment_date&.to_s(:govuk) %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -291,6 +291,8 @@ Rails.application.routes.draw do
       post "/choose-provider-npq", to: "payment_breakdowns#choose_provider_npq", as: :choose_provider_npq
     end
 
+    resources :schedules, only: %i[index show]
+
     namespace :ecf do
       resources :payment_breakdowns, only: %i[show] do
         member do

--- a/spec/features/finance/schedules_spec.rb
+++ b/spec/features/finance/schedules_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Finance users payment breakdowns", type: :feature do
+  fscenario "viewing a schedule" do
+    given_i_am_logged_in_as_a_finance_user
+    and_there_is_a_schedule
+    when_i_click("Schedules")
+    then_i_see("Schedules")
+    and_see_table_with_schedule(@schedule)
+
+    when_i_click(@schedule.schedule_identifier)
+    then_i_see("Milestones")
+    and_see_table_of_milestones_for_schedule(@schedule)
+  end
+
+  def and_there_is_a_schedule
+    @schedule = create(:ecf_schedule)
+  end
+
+  def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def and_see_table_with_schedule(schedule)
+    within("table") do
+      expect(page).to have_content(schedule.schedule_identifier)
+    end
+  end
+
+  def and_see_table_of_milestones_for_schedule(schedule)
+    within("table") do
+      schedule.milestones.each do |milestone|
+        expect(page).to have_content(milestone.name)
+      end
+    end
+  end
+end

--- a/spec/features/finance/schedules_spec.rb
+++ b/spec/features/finance/schedules_spec.rb
@@ -3,33 +3,35 @@
 require "rails_helper"
 
 RSpec.feature "Finance users payment breakdowns", type: :feature do
-  fscenario "viewing a schedule" do
+  let(:schedule) { create(:ecf_schedule) }
+
+  scenario "viewing a schedule" do
     given_i_am_logged_in_as_a_finance_user
     and_there_is_a_schedule
     when_i_click("Schedules")
     then_i_see("Schedules")
-    and_see_table_with_schedule(@schedule)
+    and_see_table_with_schedule
 
-    when_i_click(@schedule.schedule_identifier)
+    when_i_click(schedule.schedule_identifier)
     then_i_see("Milestones")
-    and_see_table_of_milestones_for_schedule(@schedule)
+    and_see_table_of_milestones_for_schedule
   end
 
   def and_there_is_a_schedule
-    @schedule = create(:ecf_schedule)
+    schedule
   end
 
   def then_i_see(string)
     expect(page).to have_content(string)
   end
 
-  def and_see_table_with_schedule(schedule)
+  def and_see_table_with_schedule
     within("table") do
       expect(page).to have_content(schedule.schedule_identifier)
     end
   end
 
-  def and_see_table_of_milestones_for_schedule(schedule)
+  def and_see_table_of_milestones_for_schedule
     within("table") do
       schedule.milestones.each do |milestone|
         expect(page).to have_content(milestone.name)


### PR DESCRIPTION
## Ticket and context

Ticket: Related to but not really https://dfedigital.atlassian.net/browse/CPDLP-890

- Add schedules to finance area so finance users can see schedules
- This should allow non dev users to visualise schedules that have been persisted

Landing page
![Screenshot 2022-01-13 at 16 52 46](https://user-images.githubusercontent.com/92580/149373694-5b315427-4bf8-4518-8f93-108e8a55d22d.png)

Schedules index
![Screenshot 2022-01-13 at 16 54 45](https://user-images.githubusercontent.com/92580/149374024-b9ad97fd-67f8-4b01-8975-1fe5bcb9e720.png)

Schedules show
![Screenshot 2022-01-13 at 16 55 22](https://user-images.githubusercontent.com/92580/149374127-22d0f08f-3d37-4f34-b7db-4a49988cfc06.png)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Visit https://ecf-review-pr-1625.london.cloudapps.digital/finance
- Login as a finance user
- Click `Schedules`
- Should see all persisted schedules
- Click on a schedule
- Should see milestones for the schedule

## External API changes

- None