### PR TITLE
Fix for start_term form

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -58,7 +58,7 @@ class Schools::ParticipantsController < Schools::BaseController
   def edit_start_term; end
 
   def update_start_term
-    @profile.assign_attributes(params.require(:participant_profile_ect).permit(:start_term))
+    @profile.assign_attributes(params.require(:participant_profile).permit(:start_term))
 
     if @profile.save
       if @profile.ect?

--- a/app/views/schools/participants/edit_start_term.html.erb
+++ b/app/views/schools/participants/edit_start_term.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @profile, url: schools_participant_update_start_term_path, method: :put do |f| %>
+    <%= form_for :participant_profile, url: schools_participant_update_start_term_path, method: :put do |f| %>
       <%= f.govuk_radio_buttons_fieldset :start_term,
         legend: { text: I18n.t("schools.participants.change.start_term.#{@profile.participant_type}", full_name: @profile.user.full_name), tag: 'h1', size: 'xl' } do %>
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CST-263

Form was on the profile instance, which changes when a mentor is updated. This was clashing with strong params and made the update fail.
Features test the update but not when a mentor is involved, this because the forms are generic and not on the specific @profile instance. I've made the new form for `start_term` generic as well.