### PR TITLE
CPDLP-878 add schedule identifier to big query data

### DIFF
--- a/analytics_queries/participants.sql
+++ b/analytics_queries/participants.sql
@@ -13,6 +13,7 @@ SELECT u.id                                                    as participant_id
        pp.status                                               as status,
        pp.training_status                                      as training_status,
        s.name                                                  as schedule,
+       s.schedule_identifier                                   as schedule_identifier,
        tp.trn                                                  as trn,
        epvd.created_at                                         as trn_provided_at,
        (epe.status IN ('eligible', 'matched'))                 as trn_validated,

--- a/app/services/analytics/ecf_validation_service.rb
+++ b/app/services/analytics/ecf_validation_service.rb
@@ -23,6 +23,7 @@ module Analytics
         record.sparsity = participant_profile.sparsity_uplift
         record.pupil_premium = participant_profile.pupil_premium_uplift
         record.training_status = participant_profile.training_status
+        record.schedule_identifier = participant_profile.schedule&.schedule_identifier
 
         record.save!
       end

--- a/db/analytics_migrate/20220114163650_add_schedule_identifier_to_ecf_participant.rb
+++ b/db/analytics_migrate/20220114163650_add_schedule_identifier_to_ecf_participant.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScheduleIdentifierToECFParticipant < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ecf_participants, :schedule_identifier, :boolean, default: true
+  end
+end

--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_150638) do
+ActiveRecord::Schema.define(version: 2022_01_14_163650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2021_11_12_150638) do
     t.string "training_status"
     t.boolean "sparsity"
     t.boolean "pupil_premium"
+    t.boolean "schedule_identifier", default: true
     t.index ["participant_profile_id"], name: "index_ecf_participants_on_participant_profile_id"
   end
 


### PR DESCRIPTION
## Ticket and context
We currently pipe various data from the production database to BigQuery to enable the performance analysts to construct dashboards and reports in Google Data Studio.

Will Sandford has requested that schedule_identifier is added to the ECF Postgres tables and made available in BigQuery to support his analytics work.

This PR adds schedule_identifier to ecf_participants, participants.sql & ecf_validiation_service

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-878

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
