### PR TITLE
[CST-271] add notes field to admin console

### DIFF
--- a/app/components/admin/participants/details/ect_pending.html.erb
+++ b/app/components/admin/participants/details/ect_pending.html.erb
@@ -40,12 +40,16 @@
       <td class="govuk-table__cell"><%= profile.cohort&.display_name || 'No cohort' %></td>
       <td class="govuk-table__cell"></td>
     </tr>
-    <% if profile.notes.present? %>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Notes</th>
-      <td class="govuk-table__cell"><%= profile.notes.html_safe %></td>
-      <td class="govuk-table__cell"></td>
+       <td class="govuk-table__cell"><%= profile.notes? ? simple_format(profile.notes, class: "govuk-body") : "No notes" %></td>
+
+       <td class="govuk-table__cell">
+         <%= govuk_link_to edit_admin_note_path(profile) do %>
+           <span><%= profile.notes.present? ? "Change notes" : "Add notes" %></span>
+         <% end %>
+       </td>
+
     </tr>
-    <% end %>
   </tbody>
 </table>

--- a/app/components/admin/participants/details/mentor_pending.html.erb
+++ b/app/components/admin/participants/details/mentor_pending.html.erb
@@ -35,12 +35,16 @@
       <td class="govuk-table__cell"><%= profile.cohort&.display_name || 'No cohort' %></td>
       <td class="govuk-table__cell"></td>
     </tr>
-    <% if profile.notes.present? %>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Notes</th>
-      <td class="govuk-table__cell"><%= profile.notes.html_safe %></td>
-      <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell"><%= profile.notes? ? simple_format(profile.notes, class: "govuk-body") : "No notes" %></td>
+
+        <td class="govuk-table__cell">
+          <%= govuk_link_to edit_admin_note_path(profile) do %>
+            <span><%= profile.notes.present? ? "Change notes" : "Add notes" %></span>
+          <% end %>
+        </td>
+
     </tr>
-    <% end %>
   </tbody>
 </table>

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  class NotesController < Admin::BaseController
+    skip_after_action :verify_authorized
+    skip_after_action :verify_policy_scoped
+
+    before_action :load_participant
+
+    def edit; end
+
+    def update
+      @participant_profile.assign_attributes(note_params)
+
+      if @participant_profile.save
+        redirect_to admin_participant_path
+      else
+        render action: "edit"
+      end
+    end
+
+  private
+
+    def load_participant
+      @participant_profile = ParticipantProfile.find(params[:id])
+      authorize @participant_profile, policy_class: @participant_profile.policy_class
+    end
+
+    def note_params
+      params.require(:participant_profile).permit(:notes)
+    end
+  end
+end

--- a/app/views/admin/notes/edit.html.erb
+++ b/app/views/admin/notes/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "Participant notes" %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: admin_participant_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+   <span class="govuk-caption-l"><%= @participant_profile.user.full_name %></span>
+    <%= form_for @participant_profile, as: :participant_profile, url: admin_note_path, method: :put do |f| %>
+
+      <%= f.govuk_text_area(
+            :notes,
+            value: @participant_profile.notes,
+            rows: 10,
+            width: "three-quarters",
+            label: { text: "Add notes", tag: "h1", size: "xl" },
+            hint: { text: "Give details about any changes made to this participant. Notes are for internal use only" }
+            )%>
+
+      <%= f.submit "Save", class: "govuk-button" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,7 @@ Rails.application.routes.draw do
         end
       end
     end
+    resources :notes, only: %i[edit update]
     resource :impersonate, only: %i[create destroy]
 
     namespace :gias do

--- a/spec/features/admin/notes/participant_note_spec.rb
+++ b/spec/features/admin/notes/participant_note_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../participants/participant_details_steps"
+
+RSpec.feature "Admin can add notes to a participants record in the admin console", js: true, rutabaga: false do
+  include ParticipantDetailsSteps
+  before do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_an_admin
+    and_i_have_added_an_ect
+    and_i_have_added_a_mentor
+    when_i_visit_admin_participants_dashboard
+    then_i_should_see_a_list_of_participants
+  end
+
+  scenario "Admin is adding a note on an ECTs profile" do
+    when_i_click_on_the_participants_name "Sally Teacher"
+    then_i_should_see_the_ects_details
+    and_the_page_should_have_no_notes
+
+    when_i_click_on_add_notes
+    then_i_should_be_on_the_edit_notes_page
+
+    when_i_add_notes_to_the_participants_record
+    click_on "Save"
+    then_i_should_see_the_ects_details
+    and_the_notes_that_have_been_added
+  end
+
+  scenario "Admin is adding a note on an Mentors profile" do
+    when_i_click_on_the_participants_name "Billy Mentor"
+    then_i_should_see_the_mentors_details
+    and_the_page_should_have_no_notes
+
+    when_i_click_on_add_notes
+    then_i_should_be_on_the_edit_notes_page
+
+    when_i_add_notes_to_the_participants_record
+    click_on "Save"
+    then_i_should_see_the_mentors_details
+    and_the_notes_that_have_been_added
+  end
+end

--- a/spec/features/admin/participants/participant_details_steps.rb
+++ b/spec/features/admin/participants/participant_details_steps.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module ParticipantDetailsSteps
+  include Capybara::DSL
+
+  # Given
+
+  def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    @cohort = create(:cohort, start_year: 2021)
+    @school = create(:school, name: "Fip School")
+    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+  end
+
+  # When
+
+  def when_i_visit_admin_participants_dashboard
+    visit admin_participants_path
+  end
+
+  def when_i_click_on_the_participants_name(name)
+    click_on name
+  end
+
+  def when_i_click_on_change_name
+    click_on("Change name", visible: false)
+  end
+
+  def when_i_click_on_change_email
+    click_on("Change email", visible: false)
+  end
+
+  def when_i_click_on_add_notes
+    click_on("Add notes")
+  end
+
+  def when_i_update_the_name_with(name)
+    fill_in "Full name", with: name
+  end
+
+  def when_i_update_the_email_with(email)
+    fill_in "Email address", with: email
+  end
+
+  def when_i_add_notes_to_the_participants_record
+    fill_in "notes", with: "The participants notes have been updated"
+  end
+
+  # Then
+
+  def then_i_should_be_on_the_edit_name_page
+    expect(page).to have_text("Change ECT’s name")
+  end
+
+  def then_i_should_be_on_the_edit_email_page
+    expect(page).to have_text("Change mentor’s email address")
+  end
+
+  def then_i_should_see_the_ects_details
+    expect(page).to have_text(@participant_profile_ect.user.full_name)
+    have_link "Change", href: edit_name_admin_participant_path(id: @participant_profile_ect.id)
+    have_link "Change", href: edit_email_admin_participant_path(id: @participant_profile_ect.id)
+  end
+
+  def then_i_should_see_the_mentors_details
+    expect(page).to have_text(@participant_profile_mentor.user.full_name)
+    have_link "Change", href: edit_name_admin_participant_path(id: @participant_profile_mentor.id)
+    have_link "Change", href: edit_email_admin_participant_path(id: @participant_profile_mentor.id)
+  end
+
+  def then_i_should_see_a_list_of_participants
+    expect(page).to have_text("Fip School")
+    expect(page).to have_text("Sally Teacher")
+  end
+
+  def then_i_should_be_in_the_admin_participants_dashboard
+    expect(page).to have_selector("h1", text: "Participants")
+  end
+
+  def then_i_should_be_on_the_edit_notes_page
+    expect(page).to have_selector("h1", text: "Add notes")
+  end
+
+  def then_the_participants_email_should_have_updated(email)
+    expect(page).to have_text(email)
+  end
+
+  def then_i_should_receive_a_missing_name_error_message
+    expect(page).to have_text("Enter a full name")
+  end
+
+  def then_i_should_receive_a_missing_email_error_message
+    expect(page).to have_text("Enter an email")
+  end
+
+  def then_i_should_receive_an_email_already_taken_error_message
+    expect(page).to have_text("This email address is already in use")
+  end
+
+  def then_i_should_receive_a_invalid_email_error_message
+    expect(page).to have_text("Enter an email address in the correct format, like name@example.com")
+  end
+
+  # And
+
+  def and_i_have_added_an_ect
+    @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com"), school_cohort: @school_cohort)
+  end
+
+  def and_i_have_added_a_mentor
+    @participant_profile_mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor", email: "billy-mentor@example.com"), school_cohort: @school_cohort)
+  end
+
+  def and_i_click_on_continue
+    click_on("Continue")
+  end
+
+  def and_admin_should_be_shown_a_success_message
+    expect(page).to have_selector ".govuk-notification-banner--success"
+  end
+
+  def and_the_page_should_have_the_updated_name(name)
+    expect(page).to have_text(name)
+  end
+
+  def and_the_page_should_have_no_notes
+    expect(page).to have_text("No notes")
+    expect(page).to have_text("Add notes")
+  end
+
+  def and_the_notes_that_have_been_added
+    expect(page).to have_text("The participants notes have been updated")
+  end
+end

--- a/spec/features/admin/participants/update_participants_details_spec.rb
+++ b/spec/features/admin/participants/update_participants_details_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+require_relative "./participant_details_steps"
+
 RSpec.feature "Admin should be able to update participants details", js: true, rutabaga: false do
+  include ParticipantDetailsSteps
+
   before do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_admin
@@ -54,114 +59,5 @@ RSpec.feature "Admin should be able to update participants details", js: true, r
 
     when_i_click_on_the_participants_name "Billy Mentor"
     then_the_participants_email_should_have_updated "billy@mentor-example.com"
-  end
-
-private
-
-  # Given
-
-  def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
-    @cohort = create(:cohort, start_year: 2021)
-    @school = create(:school, name: "Fip School")
-    @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
-  end
-
-  # When
-
-  def when_i_visit_admin_participants_dashboard
-    visit admin_participants_path
-  end
-
-  def when_i_click_on_the_participants_name(name)
-    click_on name
-  end
-
-  def when_i_click_on_change_name
-    click_on("Change name", visible: false)
-  end
-
-  def when_i_click_on_change_email
-    click_on("Change email", visible: false)
-  end
-
-  def when_i_update_the_name_with(name)
-    fill_in "Full name", with: name
-  end
-
-  def when_i_update_the_email_with(email)
-    fill_in "Email address", with: email
-  end
-
-  # Then
-
-  def then_i_should_be_on_the_edit_name_page
-    expect(page).to have_text("Change ECT’s name")
-  end
-
-  def then_i_should_be_on_the_edit_email_page
-    expect(page).to have_text("Change mentor’s email address")
-  end
-
-  def then_i_should_see_the_ects_details
-    expect(page).to have_text(@participant_profile_ect.user.full_name)
-    have_link "Change", href: edit_name_admin_participant_path(id: @participant_profile_ect.id)
-    have_link "Change", href: edit_email_admin_participant_path(id: @participant_profile_ect.id)
-  end
-
-  def then_i_should_see_the_mentors_details
-    expect(page).to have_text(@participant_profile_mentor.user.full_name)
-    have_link "Change", href: edit_name_admin_participant_path(id: @participant_profile_mentor.id)
-    have_link "Change", href: edit_email_admin_participant_path(id: @participant_profile_mentor.id)
-  end
-
-  def then_i_should_see_a_list_of_participants
-    expect(page).to have_text("Fip School")
-    expect(page).to have_text("Sally Teacher")
-  end
-
-  def then_i_should_be_in_the_admin_participants_dashboard
-    expect(page).to have_selector("h1", text: "Participants")
-  end
-
-  def then_the_participants_email_should_have_updated(email)
-    expect(page).to have_text(email)
-  end
-
-  def then_i_should_receive_a_missing_name_error_message
-    expect(page).to have_text("Enter a full name")
-  end
-
-  def then_i_should_receive_a_missing_email_error_message
-    expect(page).to have_text("Enter an email")
-  end
-
-  def then_i_should_receive_an_email_already_taken_error_message
-    expect(page).to have_text("This email address is already in use")
-  end
-
-  def then_i_should_receive_a_invalid_email_error_message
-    expect(page).to have_text("Enter an email address in the correct format, like name@example.com")
-  end
-
-  # And
-
-  def and_i_have_added_an_ect
-    @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com"), school_cohort: @school_cohort)
-  end
-
-  def and_i_have_added_a_mentor
-    @participant_profile_mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor", email: "billy-mentor@example.com"), school_cohort: @school_cohort)
-  end
-
-  def and_i_click_on_continue
-    click_on("Continue")
-  end
-
-  def and_admin_should_be_shown_a_success_message
-    expect(page).to have_selector ".govuk-notification-banner--success"
-  end
-
-  def and_the_page_should_have_the_updated_name(name)
-    expect(page).to have_text(name)
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: [271](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-271)

## Tech review
<img width="681" alt="Screenshot 2022-01-19 at 07 43 59" src="https://user-images.githubusercontent.com/69353998/150086300-eeebdf45-f352-43c0-b5af-5b97f0f085c0.png">
<img width="676" alt="Screenshot 2022-01-19 at 07 44 20" src="https://user-images.githubusercontent.com/69353998/150086341-d50df97c-6253-4f43-8110-76587c6e108d.png">
<img width="705" alt="Screenshot 2022-01-19 at 07 44 28" src="https://user-images.githubusercontent.com/69353998/150086362-c8d10c4a-4ad2-4858-bacc-5ac578e6f382.png">

[Prototype PR with screenshots](https://github.com/DFE-Digital/early-career-framework-register-prototype/pull/243)

### Is there anything that the code reviewer should know?



### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as `admin@example.com`
3. Go to participants dashboard, either for a school or the whole list
4. Select a ECT or Mentor
5. Add and save a note
6. Edit the note
