### PR TITLE
Remove logstash from review apps

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -104,7 +104,7 @@ jobs:
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-dev:${{ github.event.pull_request.head.sha }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=${{ env.ENVIRONMENT }}/terraform.tfstate"
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{env.ENVIRONMENT}}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{env.ENVIRONMENT}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
 
       - name: comment on PR
         uses: unsplash/comment-on-pr@v1.3.0


### PR DESCRIPTION
We need to reduce our log output to logstash as we are hitting quotas. This PR disables logs draining to LogIt on review apps. You can enable it at any time by adding the `logstash-url` to your PR.

Review app pre-change: https://kibana.logit.io/s/51151c79-e17d-4407-be3a-01960f3f65ff/app/kibana#/discover?_g=()&_a=(columns:!(_source),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'cf.app:%22ecf-review-pr-1637%22'),sort:!())

This review app: https://kibana.logit.io/s/51151c79-e17d-4407-be3a-01960f3f65ff/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-60m,to:now))&_a=(columns:!(_source),filters:!(),index:'8ac115c0-aac1-11e8-88ea-0383c11b333a',interval:auto,query:(language:kuery,query:'cf.app:%22ecf-review-pr-1640%22'),sort:!())