### PR TITLE
Fix for term editing

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -42,7 +42,7 @@ module Schools
 
       validates :start_term,
                 presence: { message: I18n.t("errors.start_term.blank") },
-                inclusion: { in: ParticipantProfile::START_TERM_OPTIONS }
+                inclusion: { in: ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS }
 
       next_step do
         if type == :ect && mentor_options.any?

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -42,7 +42,7 @@ module Schools
 
       validates :start_term,
                 presence: { message: I18n.t("errors.start_term.blank") },
-                inclusion: { in: :start_term_options }
+                inclusion: { in: ParticipantProfile::START_TERM_OPTIONS }
 
       next_step do
         if type == :ect && mentor_options.any?
@@ -88,10 +88,6 @@ module Schools
       return @mentor if defined? @mentor
 
       @mentor = (User.find(mentor_id) if mentor_id.present? && mentor_id != "later")
-    end
-
-    def start_term_options
-      @start_term_options ||= %w[spring_2022 summer_2022]
     end
 
     def email_already_taken?

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -49,6 +49,8 @@ class ParticipantProfile < ApplicationRecord
 
   self.ignored_columns = %w[user_id]
 
+  START_TERM_OPTIONS = %w[spring_2022 summer_2022].freeze
+
   def state
     participant_profile_state&.state
   end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -49,8 +49,6 @@ class ParticipantProfile < ApplicationRecord
 
   self.ignored_columns = %w[user_id]
 
-  START_TERM_OPTIONS = %w[spring_2022 summer_2022].freeze
-
   def state
     participant_profile_state&.state
   end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -4,6 +4,8 @@ class ParticipantProfile < ApplicationRecord
   class ECF < ParticipantProfile
     self.ignored_columns = %i[school_id]
 
+    CURRENT_START_TERM_OPTIONS = %w[spring_2022 summer_2022].freeze
+
     belongs_to :school_cohort
     belongs_to :core_induction_programme, optional: true
 

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_radio_buttons_fieldset :start_term,
           legend: { text: add_participant_form.start_term_legend, tag: 'h1', size: 'xl' } do %>
 
-        <% add_participant_form.start_term_options.each do |term| %>
+        <% ParticipantProfile::START_TERM_OPTIONS.each do |term| %>
           <%= f.govuk_radio_button :start_term, term, label: { text: term.humanize } %>
         <% end %>
       <% end %>

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_radio_buttons_fieldset :start_term,
           legend: { text: add_participant_form.start_term_legend, tag: 'h1', size: 'xl' } do %>
 
-        <% ParticipantProfile::START_TERM_OPTIONS.each do |term| %>
+        <% ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS.each do |term| %>
           <%= f.govuk_radio_button :start_term, term, label: { text: term.humanize } %>
         <% end %>
       <% end %>

--- a/app/views/schools/participants/edit_start_term.html.erb
+++ b/app/views/schools/participants/edit_start_term.html.erb
@@ -6,8 +6,8 @@
       <%= f.govuk_radio_buttons_fieldset :start_term,
         legend: { text: I18n.t("schools.participants.change.start_term.#{@profile.participant_type}", full_name: @profile.user.full_name), tag: 'h1', size: 'xl' } do %>
 
-        <% ParticipantProfile::START_TERM_OPTIONS.each do |term| %>
-          <%= f.govuk_radio_button :start_term, term, label: { text: ParticipantProfile.humanize_start_term(term) } %>
+        <% ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS.each do |term| %>
+          <%= f.govuk_radio_button :start_term, term, label: { text: term.humanize } %>
         <% end %>
       <% end %>
 

--- a/app/views/schools/participants/edit_start_term.html.erb
+++ b/app/views/schools/participants/edit_start_term.html.erb
@@ -6,8 +6,8 @@
       <%= f.govuk_radio_buttons_fieldset :start_term,
         legend: { text: I18n.t("schools.participants.change.start_term.#{@profile.participant_type}", full_name: @profile.user.full_name), tag: 'h1', size: 'xl' } do %>
 
-        <% ParticipantProfile.start_terms.each do |term_key, term_value| %>
-          <%= f.govuk_radio_button :start_term, term_key, label: { text: term_value } %>
+        <% ParticipantProfile::START_TERM_OPTIONS.each do |term| %>
+          <%= f.govuk_radio_button :start_term, term, label: { text: ParticipantProfile.humanize_start_term(term) } %>
         <% end %>
       <% end %>
 

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -87,6 +87,36 @@ RSpec.describe "Update participants details", js: true do
     then_i_can_view_updated_email
   end
 
+  scenario "Induction tutor can change ECT / mentor start_term from check details page" do
+    when_i_click_on_add_ect
+    then_i_am_taken_to_add_ect_name_page
+
+    when_i_add_ect_or_mentor_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_ect_or_mentor_email
+    when_i_click_on_continue
+    then_i_am_taken_to_choose_term_page_as_ect
+
+    when_i_choose_start_term
+    when_i_click_on_continue
+
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
+    then_i_am_taken_to_check_details_page
+
+    when_i_click_on_change_term
+    then_i_am_taken_to_choose_term_page_as_ect
+
+    when_i_add_ect_or_mentor_updated_term
+    when_i_click_on_continue
+    when_i_choose_assign_mentor_later
+    when_i_click_on_continue
+    then_i_am_taken_to_check_details_page
+    then_i_can_view_updated_term
+  end
+
   scenario "Induction tutor can change ECTs mentor from check details page" do
     when_i_click_on_add_ect
     when_i_click_on_continue

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -367,6 +367,10 @@ module ManageTrainingSteps
     click_on("Change mentor", visible: false)
   end
 
+  def when_i_click_on_change_term
+    click_on("Change term", visible: false)
+  end
+
   def when_i_choose_a_mentor
     choose(@participant_profile_mentor.user.full_name.to_s, allow_label_click: true)
   end
@@ -397,6 +401,10 @@ module ManageTrainingSteps
 
   def when_i_add_ect_or_mentor_updated_email
     fill_in "Email", with: @updated_participant_data[:email]
+  end
+
+  def when_i_add_ect_or_mentor_updated_term
+    choose(ParticipantProfile.humanize_start_term(@updated_participant_data[:start_term]), allow_label_click: true)
   end
 
   def when_i_choose_materials
@@ -577,6 +585,11 @@ module ManageTrainingSteps
     expect(page).to have_text((@updated_participant_data[:email]).to_s)
   end
 
+  def then_i_can_view_updated_term
+    expect(page).to have_selector("h1", text: "Check your answers")
+    expect(page).to have_text(ParticipantProfile.humanize_start_term(@updated_participant_data[:start_term]))
+  end
+
   def then_i_can_view_the_added_materials
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Materials")
@@ -723,6 +736,7 @@ module ManageTrainingSteps
     @updated_participant_data = {
       full_name: "Jane Teacher",
       email: "jane@school.com",
+      start_term: "spring_2022",
     }
   end
 end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -404,7 +404,7 @@ module ManageTrainingSteps
   end
 
   def when_i_add_ect_or_mentor_updated_term
-    choose(ParticipantProfile.humanize_start_term(@updated_participant_data[:start_term]), allow_label_click: true)
+    choose(@updated_participant_data[:start_term].humanize, allow_label_click: true)
   end
 
   def when_i_choose_materials
@@ -587,7 +587,7 @@ module ManageTrainingSteps
 
   def then_i_can_view_updated_term
     expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text(ParticipantProfile.humanize_start_term(@updated_participant_data[:start_term]))
+    expect(page).to have_text(@updated_participant_data[:start_term].humanize)
   end
 
   def then_i_can_view_the_added_materials

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -238,8 +238,8 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-start-term"
 
       expect(response).to render_template("schools/participants/edit_start_term")
-      ParticipantProfile::START_TERM_OPTIONS.each do |option|
-        expect(response.body).to include(CGI.escapeHTML(ParticipantProfile.humanize_start_term(option)))
+      ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS.each do |option|
+        expect(response.body).to include(CGI.escapeHTML(option.humanize))
       end
     end
 
@@ -248,7 +248,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-start-term", params: {
           participant_profile: { start_term: "summer_2022" },
         }
-      }.to change { ect_profile.reload.start_term_human }.to(ParticipantProfile.humanize_start_term(:summer_2022))
+      }.to change { ect_profile.reload.start_term.humanize }.to("Summer 2022")
     end
   end
 

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -233,6 +233,43 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
     end
   end
 
+  describe "GET /schools/:school_id/cohorts/:start_year/participants/:id/edit-term" do
+    it "renders the edit term template with the correct term for an ECT" do
+      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-start-term"
+
+      expect(response).to render_template("schools/participants/edit_start_term")
+      ParticipantProfile::START_TERM_OPTIONS.each do |option|
+        expect(response.body).to include(CGI.escapeHTML(ParticipantProfile.humanize_start_term(option)))
+      end
+    end
+
+    it "updates the term of a participant" do
+      expect {
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-start-term", params: {
+          participant_profile: { start_term: "summer_2022" },
+        }
+      }.to change { ect_profile.reload.start_term_human }.to(ParticipantProfile.humanize_start_term(:summer_2022))
+    end
+  end
+
+  describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-name" do
+    it "updates the name of an ECT" do
+      expect {
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-name", params: {
+          user: { full_name: "Joe Bloggs" },
+        }
+      }.to change { ect_user.reload.full_name }.to("Joe Bloggs")
+    end
+
+    it "updates the name of a mentor" do
+      expect {
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name", params: {
+          user: { full_name: "Sally Mentor" },
+        }
+      }.to change { mentor_user.reload.full_name }.to("Sally Mentor")
+    end
+  end
+
   describe "DELETE /schools/:school_id/cohorts/:start_year/participants/:id" do
     it "marks the participant as withdrawn" do
       expect { delete "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}" }


### PR DESCRIPTION
Had to move the start_term options back to ParticipantProfile.
These changes fix https://sentry.io/organizations/dfe-bat/issues/2942896307/?project=5748989&referrer=slack