### PR TITLE
[CPDLP-825] - Change current NPQ payment breakdown

### DIFF
--- a/app/models/finance/statement/npq.rb
+++ b/app/models/finance/statement/npq.rb
@@ -8,7 +8,7 @@ class Finance::Statement::NPQ < Finance::Statement::Base
       payment_date: Date.new(2022, 1, 31),
     },
     {
-      interval: Time.zone.parse("2021-12-26T00:00:00+00:00")..Time.zone.parse("2022-06-01T23:59:59+00:00"),
+      interval: Time.zone.parse("2021-12-26T00:00:00+00:00")..Time.zone.parse("2022-06-25T23:59:59+00:00"),
       name: "current",
       payment_date: Date.new(2022, 3, 31),
     },


### PR DESCRIPTION
## Ticket and context

[Ticket:](https://dfedigital.atlassian.net/browse/CPDLP-825)


Changed it to the current milestone milestone_date
```ruby
f = Finance::Schedule.find_by(name: "NPQ Specialist November 2021")
f.milestones.order(milestone_date: :asc).where("milestone_date > ?", Date.today
).first.milestone_date # => Sat, 25 Jun 2022
```
