### PR TITLE
Fix issue with jobs being picked up before transaction completes

### DIFF
--- a/app/services/partnerships/challenge.rb
+++ b/app/services/partnerships/challenge.rb
@@ -26,13 +26,13 @@ module Partnerships
           school_cohort.update!(induction_programme_choice: :no_early_career_teachers,
                                 opt_out_of_updates: true)
         end
+      end
 
-        partnership.lead_provider.users.each do |lead_provider_user|
-          LeadProviderMailer.partnership_challenged_email(
-            partnership: partnership,
-            user: lead_provider_user,
-          ).deliver_later
-        end
+      partnership.lead_provider.users.each do |lead_provider_user|
+        LeadProviderMailer.partnership_challenged_email(
+          partnership: partnership,
+          user: lead_provider_user,
+        ).deliver_later
       end
     end
 

--- a/spec/services/partnerships/challenge_spec.rb
+++ b/spec/services/partnerships/challenge_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Partnerships::Challenge do
       expect { subject.call }.to notify_all_lead_providers
     end
 
+    context "when an error occurs updating the partnership" do
+      before do
+        allow(partnership).to receive(:no_ects?).and_raise(ActiveRecord::StatementInvalid)
+      end
+
+      it "raises an error and does not schedule partnership challenged emails" do
+        expect { subject.call }.to raise_error ActiveRecord::StatementInvalid
+      end
+    end
+
     context "when the challenge reason is no ECTs this year" do
       let(:reason) { "no_ects" }
 


### PR DESCRIPTION
## Ticket and context

(Re-creating because of build issues in the previous PR)
Issue reported where the partnership challenge reason in the email has the text `translation missing: en.partnerships.challenge_reasons` which would indicate that the reason has not been set.
However the code to schedule the mailer is within the transaction block that updates the reason, and so it is thought that the mailer job is being picked up (in some cases, not all) before the transaction has been written to the db.

This moves the mail sending code outside the transaction block


## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
