### PR TITLE
Don't attempt to stream BQ updates if there is no table

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ This procedure is used after a batch from manual validation has been complete. T
 ### Sentry
 We use [sentry.io](https://sentry.io/) for error tracking and performance monitoring. Ask a team member for access - this is done through digi-tools.
 ### Logit
-We use a [logit.io](https://logit.io/) ELK stack for log aggregation. This contains logs from all environments, and is useful for debugging failed deployments.
+We use a [logit.io](https://logit.io/) ELK stack for log aggregation. This contains logs from all environments except review apps, and is useful for debugging failed deployments.
 Ask a team member for access - this is done through digi-tools.
 ### Grafana
 We have a prometheus/grafana stack for metrics and alerting - [production metrics](https://grafana-cpd-monitoring-prod.london.cloudapps.digital/).

--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -6,7 +6,9 @@ class StreamBigQueryParticipantDeclarationsJob < ApplicationJob
   def perform
     bigquery = Google::Cloud::Bigquery.new
     dataset = bigquery.dataset "provider_declarations", skip_lookup: true
-    table = dataset.table "participant_declarations_#{Rails.env.downcase}", skip_lookup: true
+    table = dataset.table "participant_declarations_#{Rails.env.downcase}"
+
+    return if table.nil?
 
     rows = ParticipantDeclaration
       .where(updated_at: 1.hour.ago.beginning_of_hour..1.hour.ago.end_of_hour)

--- a/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
+++ b/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
@@ -51,5 +51,17 @@ RSpec.describe StreamBigQueryParticipantDeclarationsJob do
       described_class.perform_now
       expect(table).not_to have_received(:insert)
     end
+
+    context "where the BigQuery table does not exist" do
+      before do
+        allow(dataset).to receive(:table).and_return(nil)
+      end
+
+      it "doesn't attempt to stream" do
+        ParticipantDeclaration.update_all(updated_at: 0.5.hours.ago)
+        described_class.perform_now
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Ticket and context

This PR ensures that there is a relevant BigQuery table for the environment before attempting to stream declarations to it. It [stops this error](https://sentry.io/organizations/dfe-bat/issues/2949720212/?environment=deployed_development&project=5748989&query=is%3Aunresolved).