### PR TITLE
remove the daemons gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,6 @@ gem "httpclient", "~> 2.8", ">= 2.8.3"
 gem "rubyzip", "~> 2.3", ">= 2.3.0"
 gem "savon", "~> 2.12", ">= 2.12.1"
 
-# Database based asynchronous priority queue system
-gem "daemons"
-
 # Strong migration checker for database migrations
 gem "strong_migrations"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,6 @@ GEM
     crass (1.0.6)
     cypress-on-rails (1.12.1)
       rack
-    daemons (1.4.1)
     database_cleaner-active_record (2.0.1)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
@@ -608,7 +607,6 @@ DEPENDENCIES
   canonical-rails (>= 0.2.13)
   capybara (>= 3.35.3)
   cypress-on-rails (~> 1.12)
-  daemons
   database_cleaner-active_record
   devise (>= 4.8.0)
   discard (~> 1.2, >= 1.2.0)

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
-require 'delayed/command'
-Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- this gem is no longer needed
- it was previously used to run delayed job as a process
- delayed job has been removed for some time
- sidekiq is used now and does not require this gem

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- The worker doesn't run on reviews so probably can't be tested
- Might be able to scale up workers and ensure they still work

## External API changes

- none