### PR TITLE
Finance::Statement is now an ActiveRecord thing

### DIFF
--- a/app/controllers/finance/ecf/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/ecf/payment_breakdowns_controller.rb
@@ -6,28 +6,36 @@ module Finance
       def show
         @ecf_lead_provider = lead_provider_scope.find(params[:id])
 
-        @statement = Finance::Statement::ECF.find_by_name("current")
+        @statement = Finance::Statement::ECF.new(
+          name: "November 2021",
+          cpd_lead_provider: @ecf_lead_provider.cpd_lead_provider,
+          deadline_date: Date.new(2021, 11, 30),
+          payment_date: Date.new(2021, 11, 30),
+        )
 
         @breakdown = Finance::ECF::CalculationOrchestrator.call(
           aggregator: ParticipantEligibleAggregator,
           cpd_lead_provider: @ecf_lead_provider.cpd_lead_provider,
           contract: @ecf_lead_provider.call_off_contract,
           event_type: :started,
-          interval: @statement.interval,
         )
       end
 
       def payable
         @ecf_lead_provider = lead_provider_scope.find(params[:id])
 
-        @statement = Finance::Statement::ECF.find_by_name("payable")
+        @statement = Finance::Statement::ECF.new(
+          name: "January 2022",
+          cpd_lead_provider: @ecf_lead_provider.cpd_lead_provider,
+          deadline_date: Date.new(2022, 1, 31),
+          payment_date: Date.new(2022, 2, 28),
+        )
 
         @breakdown = Finance::ECF::CalculationOrchestrator.call(
           aggregator: ParticipantPayableAggregator,
           cpd_lead_provider: @ecf_lead_provider.cpd_lead_provider,
           contract: @ecf_lead_provider.call_off_contract,
           event_type: :started,
-          interval: @statement.interval,
         )
 
         render :show

--- a/app/controllers/finance/ecf/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/ecf/payment_breakdowns_controller.rb
@@ -42,8 +42,8 @@ module Finance
       def payable_aggregator
         statement = @statement
         Class.new(ParticipantPayableAggregator) do
-          define_singleton_method(:call) do |cpd_lead_provider = nil, interval = nil, recorder = ParticipantDeclaration::ECF.where(statement: statement), event_type = :started|
-            new(cpd_lead_provider: cpd_lead_provider[:cpd_lead_provider], recorder: recorder).call(event_type: event_type, interval: interval)
+          define_singleton_method(:call) do |cpd_lead_provider:, interval:, recorder: ParticipantDeclaration::ECF.where(statement: statement), event_type: :started|
+            new(cpd_lead_provider: cpd_lead_provider, recorder: recorder).call(event_type: event_type, interval: interval)
           end
         end
       end
@@ -51,8 +51,8 @@ module Finance
       def eligible_aggregator
         statement = @statement
         Class.new(ParticipantEligibleAggregator) do
-          define_singleton_method(:call) do |cpd_lead_provider = nil, interval = nil, recorder = ParticipantDeclaration::ECF.where(statement: statement), event_type = :started|
-            new(cpd_lead_provider: cpd_lead_provider[:cpd_lead_provider], recorder: recorder).call(event_type: event_type, interval: interval)
+          define_singleton_method(:call) do |cpd_lead_provider:, interval:, recorder: ParticipantDeclaration::ECF.where(statement: statement), event_type: :started|
+            new(cpd_lead_provider: cpd_lead_provider, recorder: recorder).call(event_type: event_type, interval: interval)
           end
         end
       end

--- a/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
+++ b/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
@@ -4,16 +4,32 @@ module Finance
   module NPQ
     class CoursePaymentBreakdownsController < BaseController
       def show
-        @statement         = Finance::Statement::NPQ.find_by_name(params[:statement_id])
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
+        @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
+
+        @statement = Finance::Statement::NPQ.find_by(
+          name: params[:statement_id],
+          cpd_lead_provider: @cpd_lead_provider,
+        )
+
         @npq_course        = NPQCourse.find_by!(identifier: params[:id])
         @breakdown         = Finance::NPQ::CalculationOrchestrator.call(
-          cpd_lead_provider: @npq_lead_provider.cpd_lead_provider,
+          cpd_lead_provider: @cpd_lead_provider,
           contract: @npq_lead_provider.npq_contracts.find_by!(course_identifier: params[:id]),
+          aggregator: aggregator_with_statement(statement: @statement),
         )
       end
 
     private
+
+      def aggregator_with_statement(statement:)
+        Class.new(Finance::NPQ::ParticipantEligibleAndPayableAggregator) do
+          define_singleton_method(:call) do |cpd_lead_provider: nil, interval: nil, recorder: ParticipantDeclaration::NPQ.where(statement: statement), event_type: :started, course_identifier: nil|
+            new(cpd_lead_provider: cpd_lead_provider, recorder: recorder, course_identifier: course_identifier)
+              .call(event_type: event_type, interval: interval)
+          end
+        end
+      end
 
       def lead_provider_scope
         policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
+++ b/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
@@ -8,7 +8,6 @@ module Finance
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @npq_course        = NPQCourse.find_by!(identifier: params[:id])
         @breakdown         = Finance::NPQ::CalculationOrchestrator.call(
-          interval: @statement.interval,
           cpd_lead_provider: @npq_lead_provider.cpd_lead_provider,
           contract: @npq_lead_provider.npq_contracts.find_by!(course_identifier: params[:id]),
         )

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -6,26 +6,34 @@ module Finance
   module NPQ
     class StatementsController < BaseController
       def show
-        @statement         = temporary_statements.find { |statement| statement.name == params[:id] }
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
-        @breakdowns        = Finance::NPQ::CalculationOverviewOrchestrator.call(
-          cpd_lead_provider: @npq_lead_provider.cpd_lead_provider,
+        @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
+
+        @statement = Finance::Statement::NPQ.find_by(
+          name: params[:id],
+          cpd_lead_provider: @cpd_lead_provider,
+        )
+
+        @breakdowns = Finance::NPQ::CalculationOverviewOrchestrator.call(
+          cpd_lead_provider: @cpd_lead_provider,
           event_type: :started,
+          aggregator: aggregator_with_statement(statement: @statement),
         )
       end
 
     private
 
-      def lead_provider_scope
-        policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)
+      def aggregator_with_statement(statement:)
+        Class.new(Finance::NPQ::ParticipantEligibleAndPayableAggregator) do
+          define_singleton_method(:call) do |cpd_lead_provider: nil, interval: nil, recorder: ParticipantDeclaration::NPQ.where(statement: statement), event_type: :started, course_identifier: nil|
+            new(cpd_lead_provider: cpd_lead_provider, recorder: recorder, course_identifier: course_identifier)
+              .call(event_type: event_type, interval: interval)
+          end
+        end
       end
 
-      helper_method :temporary_statements
-      def temporary_statements
-        [
-          { name: "December 2021", deadline_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31) },
-          { name: "January 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-        ].map { |hash| Finance::Statement::NPQ.new(hash) }
+      def lead_provider_scope
+        policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)
       end
     end
   end

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -6,12 +6,11 @@ module Finance
   module NPQ
     class StatementsController < BaseController
       def show
-        @statement         = Finance::Statement::NPQ.find_by_name(params[:id])
+        @statement         = temporary_statements.find { |statement| statement.name == params[:id] }
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @breakdowns        = Finance::NPQ::CalculationOverviewOrchestrator.call(
           cpd_lead_provider: @npq_lead_provider.cpd_lead_provider,
           event_type: :started,
-          interval: @statement.interval,
         )
       end
 
@@ -19,6 +18,14 @@ module Finance
 
       def lead_provider_scope
         policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)
+      end
+
+      helper_method :temporary_statements
+      def temporary_statements
+        [
+          { name: "December 2021", deadline_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31) },
+          { name: "January 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+        ].map { |hash| Finance::Statement::NPQ.new(hash) }
       end
     end
   end

--- a/app/controllers/finance/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/payment_breakdowns_controller.rb
@@ -33,7 +33,7 @@ module Finance
     def choose_provider_npq
       render "select_provider_npq" and return unless @choose_programme_form.valid?(:choose_provider)
 
-      redirect_to finance_npq_lead_provider_statement_path(lead_provider_id: @choose_programme_form.provider, id: "current")
+      redirect_to finance_npq_lead_provider_statement_path(lead_provider_id: @choose_programme_form.provider, id: "January 2022")
     end
 
   private

--- a/app/models/finance/statement/base.rb
+++ b/app/models/finance/statement/base.rb
@@ -1,27 +1,7 @@
 # frozen_string_literal: true
 
-class Finance::Statement::Base
-  def self.all
-    self::DATA.map do |hash|
-      new(
-        interval: hash[:interval],
-        name: hash[:name],
-        payment_date: hash[:payment_date],
-        deadline_date: hash[:interval].end.to_date,
-      )
-    end
-  end
+class Finance::Statement::Base < ApplicationRecord
+  self.table_name = "statements"
 
-  def self.find_by_name(name)
-    all.find { |i| i.name == name }
-  end
-
-  attr_reader :interval, :name, :payment_date, :deadline_date
-
-  def initialize(interval:, name:, payment_date:, deadline_date:)
-    @interval = interval
-    @name = name
-    @payment_date = payment_date
-    @deadline_date = deadline_date
-  end
+  belongs_to :cpd_lead_provider
 end

--- a/app/models/finance/statement/base.rb
+++ b/app/models/finance/statement/base.rb
@@ -4,4 +4,6 @@ class Finance::Statement::Base < ApplicationRecord
   self.table_name = "statements"
 
   belongs_to :cpd_lead_provider
+
+  has_many :participant_declarations
 end

--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -1,16 +1,4 @@
 # frozen_string_literal: true
 
 class Finance::Statement::ECF < Finance::Statement::Base
-  DATA = [
-    {
-      interval: Time.zone.parse("2021-09-01T00:00:00+01:00")..Time.zone.parse("2021-11-19T23:59:59+00:00"),
-      name: "payable",
-      payment_date: Date.new(2021, 11, 30),
-    },
-    {
-      interval: Time.zone.parse("2021-11-20T00:00:00+00:00")..Time.zone.parse("2022-01-31T23:59:59+00:00"),
-      name: "current",
-      payment_date: Date.new(2022, 2, 28),
-    },
-  ].freeze
 end

--- a/app/models/finance/statement/npq.rb
+++ b/app/models/finance/statement/npq.rb
@@ -1,16 +1,4 @@
 # frozen_string_literal: true
 
 class Finance::Statement::NPQ < Finance::Statement::Base
-  DATA = [
-    {
-      interval: Time.zone.parse("2021-09-01T00:00:00+01:00")..Time.zone.parse("2021-12-25T23:59:59+00:00"),
-      name: "payable",
-      payment_date: Date.new(2022, 1, 31),
-    },
-    {
-      interval: Time.zone.parse("2021-12-26T00:00:00+00:00")..Time.zone.parse("2022-06-25T23:59:59+00:00"),
-      name: "current",
-      payment_date: Date.new(2022, 3, 31),
-    },
-  ].freeze
 end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -6,6 +6,7 @@ class ParticipantDeclaration < ApplicationRecord
   belongs_to :user
   belongs_to :participant_profile
   belongs_to :superseded_by, class_name: "ParticipantDeclaration", optional: true
+  belongs_to :statement, optional: true, polymorphic: true
   has_many :supersedes, class_name: "ParticipantDeclaration", foreign_key: :superseded_by_id, inverse_of: :superseded_by
 
   enum state: {

--- a/app/services/finance/npq/calculation_orchestrator.rb
+++ b/app/services/finance/npq/calculation_orchestrator.rb
@@ -35,7 +35,7 @@ module Finance
           cpd_lead_provider: cpd_lead_provider,
           event_type: event_type,
           course_identifier: contract.course_identifier,
-          interval: interval,
+          interval: nil,
         )
       end
     end

--- a/app/services/finance/npq/calculation_overview_orchestrator.rb
+++ b/app/services/finance/npq/calculation_overview_orchestrator.rb
@@ -7,12 +7,13 @@ module Finance
     class CalculationOverviewOrchestrator
       class << self
         def call(
+          aggregator:,
           cpd_lead_provider:,
           calculation_orchestrator: ::Finance::NPQ::CalculationOrchestrator,
           event_type: :started,
           interval: nil
         )
-          new(cpd_lead_provider: cpd_lead_provider, calculation_orchestrator: calculation_orchestrator, interval: interval)
+          new(cpd_lead_provider: cpd_lead_provider, calculation_orchestrator: calculation_orchestrator, interval: interval, aggregator: aggregator)
             .call(event_type: event_type)
         end
       end
@@ -24,18 +25,20 @@ module Finance
             cpd_lead_provider: cpd_lead_provider,
             contract: contract,
             interval: interval,
+            aggregator: aggregator,
           )
         end
       end
 
     private
 
-      attr_accessor :cpd_lead_provider, :calculation_orchestrator, :interval
+      attr_accessor :cpd_lead_provider, :calculation_orchestrator, :interval, :aggregator
 
-      def initialize(cpd_lead_provider:, calculation_orchestrator:, interval:)
+      def initialize(cpd_lead_provider:, calculation_orchestrator:, interval:, aggregator:)
         self.cpd_lead_provider        = cpd_lead_provider
         self.calculation_orchestrator = calculation_orchestrator
         self.interval                 = interval
+        self.aggregator               = aggregator
       end
     end
   end

--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -48,7 +48,7 @@ private
   def npq_statements
     [
       { name: "December 2021", deadline_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31) },
-      { name: "January 2021", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+      { name: "January 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
     ].map { |hash| OpenStruct.new(hash) }
   end
 end

--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Importers::SeedStatements
+  def call
+    LeadProvider.includes(:cpd_lead_provider).each do |lead_provider|
+      cpd_lead_provider = lead_provider.cpd_lead_provider
+
+      ecf_statements.each do |statement_data|
+        statement = Finance::Statement::ECF.find_or_create_by!(
+          name: statement_data.name,
+          cpd_lead_provider: cpd_lead_provider,
+        )
+
+        statement.update!(
+          deadline_date: statement_data.deadline_date,
+          payment_date: statement_data.payment_date,
+        )
+      end
+    end
+
+    NPQLeadProvider.includes(:cpd_lead_provider).each do |npq_lead_provider|
+      cpd_lead_provider = npq_lead_provider.cpd_lead_provider
+
+      npq_statements.each do |statement_data|
+        statement = Finance::Statement::NPQ.find_or_create_by!(
+          name: statement_data.name,
+          cpd_lead_provider: cpd_lead_provider,
+        )
+
+        statement.update!(
+          deadline_date: statement_data.deadline_date,
+          payment_date: statement_data.payment_date,
+        )
+      end
+    end
+  end
+
+private
+
+  def ecf_statements
+    [
+      { name: "November 2021", deadline_date: Date.new(2021, 11, 30), payment_date: Date.new(2021, 11, 30) },
+      { name: "January 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+      { name: "February 2022", deadline_date: Date.new(2022, 2, 28), payment_date: Date.new(2022, 3, 31) },
+    ].map { |hash| OpenStruct.new(hash) }
+  end
+
+  def npq_statements
+    [
+      { name: "December 2021", deadline_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31) },
+      { name: "January 2021", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+    ].map { |hash| OpenStruct.new(hash) }
+  end
+end

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -4,8 +4,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <ul class="govuk-list">
-      <li><%= text_otherwise_link_to("Payable", finance_npq_lead_provider_statement_path(lead_provider_id: @npq_lead_provider, id: "payable"), params[:id] == "payable") %></li>
-      <li><%= text_otherwise_link_to("Current", finance_npq_lead_provider_statement_path(lead_provider_id: @npq_lead_provider, id: "current"), params[:id] == "current") %></li>
+      <% temporary_statements.each do |statement| %>
+        <li><%= text_otherwise_link_to(statement.name, finance_npq_lead_provider_statement_path(lead_provider_id: @npq_lead_provider, id: statement.name), params[:id] == statement.name) %></li>
+      <% end %>
     </ul>
   </div>
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <ul class="govuk-list">
-      <% temporary_statements.each do |statement| %>
+      <% Finance::Statement::NPQ.where(cpd_lead_provider: @cpd_lead_provider).each do |statement| %>
         <li><%= text_otherwise_link_to(statement.name, finance_npq_lead_provider_statement_path(lead_provider_id: @npq_lead_provider, id: statement.name), params[:id] == statement.name) %></li>
       <% end %>
     </ul>

--- a/db/migrate/20220124125023_create_statements.rb
+++ b/db/migrate/20220124125023_create_statements.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateStatements < ActiveRecord::Migration[6.1]
+  def change
+    create_table :statements do |t|
+      t.text :type, null: false
+      t.text :name, null: false
+      t.references :cpd_lead_provider
+      t.date :deadline_date
+      t.date :payment_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220125122219_add_statement_to_declarations.rb
+++ b/db/migrate/20220125122219_add_statement_to_declarations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddStatementToDeclarations < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_belongs_to :participant_declarations, :statement, polymorphic: true, index: { algorithm: :concurrently }, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_11_133250) do
+ActiveRecord::Schema.define(version: 2022_01_24_125023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -786,6 +786,17 @@ ActiveRecord::Schema.define(version: 2022_01_11_133250) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "statements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "type", null: false
+    t.text "name", null: false
+    t.uuid "cpd_lead_provider_id", null: false
+    t.date "deadline_date"
+    t.date "payment_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"
   end
 
   create_table "teacher_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_24_125023) do
+ActiveRecord::Schema.define(version: 2022_01_25_122219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -521,8 +521,11 @@ ActiveRecord::Schema.define(version: 2022_01_24_125023) do
     t.string "state", default: "submitted", null: false
     t.uuid "participant_profile_id"
     t.uuid "superseded_by_id"
+    t.string "statement_type"
+    t.uuid "statement_id"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
+    t.index ["statement_type", "statement_id"], name: "index_participant_declarations_on_statement"
     t.index ["superseded_by_id"], name: "superseded_by_index"
     t.index ["user_id"], name: "index_participant_declarations_on_user_id"
   end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -18,7 +18,13 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
       event_type: :started,
     )
   end
-  let(:statement) { Finance::Statement::NPQ.find_by_name("payable") }
+  let!(:statement) do
+    Finance::Statement::NPQ.create!(
+      name: "January 2022",
+      deadline_date: Date.new(2022, 1, 31),
+      cpd_lead_provider: cpd_lead_provider,
+    )
+  end
 
   scenario "see a payment breakdown per NPQ course and a payment breakdown of each individual NPQ courses for each provider" do
     given_i_am_logged_in_as_a_finance_user
@@ -27,7 +33,6 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     when_i_visit_the_payment_breakdown_page
     and_choose_to_see_npq_payment_breakdown
     and_i_select_an_npq_lead_provider
-    when_i_click "Payable"
     then_i_should_have_the_correct_payment_breakdown_per_npq_lead_provider
     then_i_should_see_the_courses_vat_and_total_payment
     and_the_page_should_be_accessible

--- a/spec/models/finance/statement/base_spec.rb
+++ b/spec/models/finance/statement/base_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::Statement::Base do
+  describe "associations" do
+    it "can fetch associated participant_declarations" do
+      subject.participant_declarations << build(:participant_declaration)
+      subject.participant_declarations.size == 1
+    end
+  end
+end

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe ParticipantDeclaration, type: :model do
     it { is_expected.to belong_to(:cpd_lead_provider) }
     it { is_expected.to belong_to(:participant_profile) }
     it { is_expected.to have_many(:declaration_states) }
+
+    it "can be associated with a Finance::Statement" do
+      statement = Finance::Statement::ECF.new
+      subject.statement = statement
+    end
   end
 
   describe "state transitions" do

--- a/spec/services/finance/npq/calculation_orchestrator_spec.rb
+++ b/spec/services/finance/npq/calculation_orchestrator_spec.rb
@@ -30,20 +30,19 @@ RSpec.describe Finance::NPQ::CalculationOrchestrator do
     }
   end
 
-  let(:interval) { Finance::Statement::ECF.all.first.interval }
-
   subject(:run_calculation) do
     described_class.call(
       cpd_lead_provider: cpd_lead_provider,
       contract: contract,
-      interval: interval,
+      interval: nil,
     )
   end
 
   context ".call" do
     context "normal operation" do
       before do
-        timestamp = interval.begin + 1.day
+        timestamp = Date.new(2021, 10, 30)
+
         travel_to(timestamp) do
           FactoryBot.with_options cpd_lead_provider: cpd_lead_provider, course_identifier: contract.course_identifier, declaration_date: timestamp, created_at: timestamp do |factory|
             factory.create_list(:npq_participant_declaration, 3, :eligible)

--- a/spec/services/importers/seed_statements_spec.rb
+++ b/spec/services/importers/seed_statements_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe Importers::SeedStatements do
+  let!(:cpd_lead_provider) do
+    create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider)
+  end
+
+  describe "#call" do
+    it "creates ECF statements idempotently" do
+      expect {
+        subject.call
+        subject.call
+      }.to change(Finance::Statement::ECF, :count).by(3)
+    end
+
+    it "creates NPQ statements idempotently" do
+      expect {
+        subject.call
+        subject.call
+      }.to change(Finance::Statement::NPQ, :count).by(2)
+    end
+  end
+end


### PR DESCRIPTION
- there is some temporary hardcoding of statements
- as when this commit is deployed expected ActiveRecord statements will
  not exist yet
- post deployment this data will be seeded and the temporary hard coded
  coded removed
- added a seeded mechanism for statements
- this mechanism uses static code but can easily be changed to take csv
- interval is no longer passed thru from the payment breakdowns
- the interval concept can now be removed but is not part of this commit

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
