### PR TITLE
[CPDLP-969] fix Importers::SeedSchedule bug

### DIFF
--- a/app/services/importers/seed_schedule.rb
+++ b/app/services/importers/seed_schedule.rb
@@ -16,10 +16,13 @@ class Importers::SeedSchedule
 
       cohort = Cohort.find_or_create_by!(start_year: row["schedule-cohort-year"])
 
-      schedule = klass.find_or_create_by!(
-        name: row["schedule-name"],
+      schedule = klass.find_or_initialize_by(
         schedule_identifier: row["schedule-identifier"],
         cohort: cohort,
+      )
+
+      schedule.update!(
+        name: row["schedule-name"],
       )
 
       milestone = Finance::Milestone.find_or_initialize_by(

--- a/spec/services/importers/seed_schedule_spec.rb
+++ b/spec/services/importers/seed_schedule_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::SeedSchedule do
+  describe "#call" do
+    context "when a schedule changes name" do
+      let(:csv) { Tempfile.new("data.csv") }
+      let(:path_to_csv) { csv.path }
+
+      subject do
+        described_class.new(path_to_csv: path_to_csv, klass: Finance::Schedule::ECF)
+      end
+
+      let!(:schedule) { create(:schedule, name: "foo extra", schedule_identifier: "foo") }
+
+      before do
+        csv.write "schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+        csv.write "\n"
+        csv.write "foo,just foo,2021,Output 1 - Participant Start,started,2021/09/01,2021/11/30,2021/11/30"
+        csv.close
+      end
+
+      it "does not create a new schedule" do
+        expect {
+          subject.call
+        }.not_to change(Finance::Schedule, :count)
+      end
+
+      it "updates the name of the existing schedule" do
+        expect {
+          subject.call
+        }.to change { schedule.reload.name }.from("foo extra").to("just foo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-969

- this class will no longer create new schedule if the name of a schedule is renamed
- instead simply update the name of the existing schedule
- a schedule is therefore now targeted by cohort and schedule-identifier

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- ssh into review app
- start a rails console
- get schedule count `Finance::Schedule.count`
- modify a schedule eg `/app/db/seeds/schedules/npq_specialist.csv`
- change a schedule name of a row
- import the schedule eg.

```
Importers::SeedSchedule.new(
  path_to_csv: Rails.root.join("db/seeds/schedules/npq_specialist.csv"),
  klass: Finance::Schedule::NPQSpecialist,
).call
```

- Schedule count `Finance::Schedule.count` should not change

## External API changes

- none