### PR TITLE
Ensuring that all API actions are recorded against the correct participant profile

### DIFF
--- a/app/services/participants/early_career_teacher.rb
+++ b/app/services/participants/early_career_teacher.rb
@@ -6,12 +6,14 @@ module Participants
     extend ActiveSupport::Concern
     included do
       extend EarlyCareerTeacherClassMethods
-      delegate :early_career_teacher_profile, to: :user, allow_nil: true
     end
 
-    def user_profile
-      early_career_teacher_profile
+    def early_career_teacher_profile
+      return unless participant_identity
+
+      @early_career_teacher_profile ||= participant_identity.participant_profiles.active_record.ects.first
     end
+    alias_method :user_profile, :early_career_teacher_profile
 
     module EarlyCareerTeacherClassMethods
       def valid_courses

--- a/app/services/participants/mentor.rb
+++ b/app/services/participants/mentor.rb
@@ -6,12 +6,14 @@ module Participants
     extend ActiveSupport::Concern
     included do
       extend MentorClassMethods
-      delegate :mentor_profile, to: :user, allow_nil: true
     end
 
-    def user_profile
-      mentor_profile
+    def mentor_profile
+      return unless participant_identity
+
+      @mentor_profile ||= participant_identity.participant_profiles.active_record.mentors.first
     end
+    alias_method :user_profile, :mentor_profile
 
     module MentorClassMethods
       def valid_courses

--- a/app/services/participants/npq.rb
+++ b/app/services/participants/npq.rb
@@ -6,7 +6,6 @@ module Participants
 
     included do
       delegate :npq_application, :participant_profile_state, to: :user_profile, allow_nil: true
-      delegate :npq?, :npq_profiles, to: :user, allow_nil: true
       extend NPQClassMethods
     end
 
@@ -15,11 +14,19 @@ module Participants
     end
 
     def participant?
-      npq?
+      user_profile.present?
     end
 
     def user_profile
-      npq_profiles&.active_record&.includes({ npq_application: [:npq_course] })&.where('npq_courses.identifier': course_identifier)&.first
+      return unless participant_identity
+
+      @user_profile ||= ParticipantProfile::NPQ
+        .includes(npq_application: :npq_course)
+        .where(participant_identity: participant_identity)
+        .npqs
+        .active_record
+        .where('npq_courses.identifier': course_identifier)
+        .first
     end
 
     module NPQClassMethods

--- a/app/services/participants/profile_attributes.rb
+++ b/app/services/participants/profile_attributes.rb
@@ -30,8 +30,12 @@ module Participants
 
   private
 
+    def participant_identity
+      @participant_identity ||= ParticipantIdentity.find_by(external_identifier: participant_id)
+    end
+
     def user
-      @user ||= Identity.find_user_by(id: participant_id)
+      @user ||= participant_identity&.user
     end
 
     def valid_courses


### PR DESCRIPTION
As most of the duplicate teacher profiles has been now merged together, we should be always using participant identifier to identify the profile providers are acting upon. The old logic was trying to find the profile by going identity => user => find_profile, which is not guaranteed to return the correct profile, as users can now have multiple profiles at the same time (this on it own is a result of my mistake during de-dup process and will be handled separately). For example -  `identity.user.early_career_teacher_profile`, as a `has_one` profile would return one of the profiles if two matching profiles are present. However, since providers use identifier we recorded on participant identity, we can actually find the correct profile from `identity` record with `identity.participant_profiles.ect.active_record.first`.