### PR TITLE
Stream declarations to BigQuery in batches

### DIFF
--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -10,14 +10,15 @@ class StreamBigQueryParticipantDeclarationsJob < ApplicationJob
 
     return if table.nil?
 
-    rows = ParticipantDeclaration
+    ParticipantDeclaration
       .where(updated_at: 1.hour.ago.beginning_of_hour..1.hour.ago.end_of_hour)
-      .map do |participant_declaration|
-        participant_declaration.attributes.merge(
-          "cpd_lead_provider_name" => participant_declaration.cpd_lead_provider.name,
-        )
+      .find_in_batches do |declarations|
+        rows = declarations.map do |participant_declaration|
+          participant_declaration.attributes.merge(
+            "cpd_lead_provider_name" => participant_declaration.cpd_lead_provider.name,
+          )
+        end
+        table.insert(rows) if rows.any?
       end
-
-    table.insert(rows) if rows.any?
   end
 end


### PR DESCRIPTION
## Ticket and context

We stream declarations to BigQuery that were updated in the previous hour. If we were to update thousands of records in one go then the streamer would break as we would hit BQ limits. Instead we can rely on `find_in_batches` to stream an hours worth of declarations in batches. 