### PR TITLE
[CST-268] temporary guidance pages

### DIFF
--- a/app/components/content_list_component.html.erb
+++ b/app/components/content_list_component.html.erb
@@ -1,0 +1,15 @@
+<nav class="app-contents-list">
+<h2 class="app-contents-list--font-size-19"><%= heading %></h2>
+
+<ol class="app-contents-list--font-size-19 govuk-!-padding-0">
+  <% list.each do |content| %>
+    <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
+      <a class="app-contents-list__link govuk-link", href="<%= href_anchor(content) %>">
+        <%= content %>
+      </a>
+    </li>
+  <% end %>
+</ol>
+</nav>
+
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"

--- a/app/components/content_list_component.html.erb
+++ b/app/components/content_list_component.html.erb
@@ -4,7 +4,7 @@
 <ol class="app-contents-list--font-size-19 govuk-!-padding-0">
   <% list.each do |content| %>
     <li class="app-contents-list__list-item app-contents-list__list-item--dashed">
-      <a class="app-contents-list__link govuk-link", href="<%= href_anchor(content) %>">
+      <a class="app-contents-list__link govuk-link" href="<%= href_anchor(content) %>">
         <%= content %>
       </a>
     </li>

--- a/app/components/content_list_component.rb
+++ b/app/components/content_list_component.rb
@@ -7,7 +7,7 @@ class ContentListComponent < ViewComponent::Base
   end
 
   def href_anchor(section_heading)
-    "##{section_heading.gsub(' ', '-')}"
+    "##{section_heading.parameterize}"
   end
 
   attr_reader :heading, :list

--- a/app/components/content_list_component.rb
+++ b/app/components/content_list_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ContentListComponent < ViewComponent::Base
+  def initialize(heading:, list:)
+    @heading = heading
+    @list = list
+  end
+
+  def href_anchor(section_heading)
+    "##{section_heading.gsub(' ', '-')}"
+  end
+
+  attr_reader :heading, :list
+end

--- a/app/views/pages/ect_additional_information.html.erb
+++ b/app/views/pages/ect_additional_information.html.erb
@@ -48,7 +48,8 @@
     </p>
     <p>
       You should participate in your ECF-based training programme as fully as possible, but failing to complete it will
-      not mean you fail your induction. Completing the assignments in your training programme is one way to collect evidence that you meet the Teachers’ Standards.
+      not mean you fail your induction. Completing the assignments in your training programme is one way to collect evidence that you meet the
+      <%= govuk_link_to "Teachers’ Standards", "https://www.gov.uk/government/publications/teachers-standards" %>.
     </p>
     <p>
       Headteachers are responsible for making sure you’re assessed against the Teachers’ Standards as part of your progress reviews,
@@ -101,8 +102,19 @@
     <p>
       If you have any concerns about your induction or statutory entitlements (time off timetable and support from a mentor),
       speak to your induction tutor first. This is the person responsible for ECT induction at your school.
-      Your statutory entitlements include 10% off timetable in the first year and 5% in the second year of induction to undertake induction activities including training and mentoring,
-      a supportive dedicated mentor and high quality development materials based on the Early Career Framework.
+      Your statutory entitlements include:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        10% off timetable in the first year, and 5% off timetable in the second year to undertake activities including training and mentoring
+      </li>
+      <li>
+        a supportive,dedicated mentor
+      </li>
+      <li>
+        high-quality development materials based on the Early Career Framework.
+      </li>
+    </ul>
     </p>
     <p>
       If they’re unable to help you, speak to your appropriate body. They’re responsible for making sure ECTs receive their statutory entitlements,
@@ -125,7 +137,7 @@
 
     <ol class="govuk-list govuk-list--number">
       <li>
-        Visit our service: https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration
+        Visit our service: <%= govuk_link_to "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration", "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration" %>
       </li>
       <li>
         Sign in using the email address your school has registered for you. Be careful to enter it correctly with no spaces.
@@ -147,7 +159,7 @@
      <p>
       Your TRN is a unique ID that you can usually find on your payslip, teachers’ pension documents or teacher training records.
     <p>
-      It is usually 7 digits long, may include the letters ‘RP’ or a slash ‘/’ symbol, or could be called a QTS, GTC, DfE, DfES or DCSF number.
+      It’s usually 7 digits long, may include the letters ‘RP’ or a slash ‘/’ symbol, or could be called a QTS, GTC, DfE, DfES or DCSF number.
     </p>
 
     <h3 class="govuk-heading-m">What happens next</h3>
@@ -156,6 +168,13 @@
     </p>
     <p>
       You can then start or continue your training programme.
+    </p>
+
+    <h3 class="govuk-heading-m">How to give feedback</h3>
+    <p>
+      The DfE and training providers are committed to maximising the impact of the ECF reforms. We welcome any feedback on the programmes,
+      including ECT engagement. You can share this directly with your training provider, or email the DfE:
+      <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>.
     </p>
   </div>
 </div>

--- a/app/views/pages/ect_additional_information.html.erb
+++ b/app/views/pages/ect_additional_information.html.erb
@@ -40,7 +40,7 @@
                                               "How do I register with the DfE’s service?"
                                               ]) %>
 
-    <section id="Is-the-ECF-an-assessment-tool,-and-can-I-fail-my-training?">
+    <section id="is-the-ecf-an-assessment-tool-and-can-i-fail-my-training">
       <h2 class="govuk-heading-l">Is the ECF an assessment tool, and can I fail my training?</h2>
     </section>
     <p>
@@ -55,7 +55,7 @@
       and in 2 formal assessments that will take place during your induction. This assessment is separate to the ECF programme itself.
     </p>
 
-    <section id="Do-I-have-to-complete-ECF-based-training-on-top-of-another-induction-programme?">
+    <section id="do-i-have-to-complete-ecf-based-training-on-top-of-another-induction-programme">
       <h2 class="govuk-heading-l">Do I have to complete ECF-based training on top of another induction programme?</h1>
     </section>
     <p>
@@ -70,7 +70,7 @@
       policies and practices (e.g. on safeguarding). This additional training does not replace your entitlement to the ECF-based programme.
     </p>
 
-    <section id="Do-I-need-to-collect-evidence-during-my-ECF-based-training?">
+    <section id="do-i-need-to-collect-evidence-during-my-ecf-based-training">
       <h2 class="govuk-heading-l">Do I need to collect evidence during my ECF-based training?</h2>
     </section>
     <p>
@@ -81,19 +81,19 @@
       This should only consist of existing documents, for example lesson plans or feedback from observations. There’s no need for you to create anything new for a formal assessment.
     </p>
 
-    <section id="What-happens-if-I-start-mid-term,-work-part-time,-or-I’m-serving-a-reduced-induction?">
+    <section id="what-happens-if-i-start-mid-term-work-part-time-or-i-m-serving-a-reduced-induction">
       <h2 class="govuk-heading-l">What happens if I start mid-term, work part-time, or I’m serving a reduced induction?</h2>
     </section>
     <p>
       You can start your induction at any time. Your school can choose from
-      <%= govuk_link_to "a number of options", "school-leader-additional-information#Can-we-register-an-ECT-with-a-training-provider-if-they-start-mid-term,-or-work-part-time?" %>
+      <%= govuk_link_to "a number of options", "school-leader-additional-information#Can-we-register-an-ect-with-a-training-provider-if-they-start-mid-term-or-work-part-time" %>
        to make sure your ECF-based training fits your own circumstances.
     <p>
       If you’re serving a reduced induction period, there’s no expectation that you should cover the full depth of the ECF.
       Your headteacher will work with your induction tutor, appropriate body and training provider (where relevant) to ensure that training and support is appropriate for you.
     </p>
 
-    <section id="What-should-I-do-if-I-have-difficulties-with-my-induction-programme?">
+    <section id="what-should-i-do-if-i-have-difficulties-with-my-induction-programme">
       <h2 class="govuk-heading-l">What should I do if I have difficulties with my induction programme?</h2>
     </section>
     <p>
@@ -109,7 +109,7 @@
       and are fairly and consistently assessed. Your school should provide you with contact details for the right person to speak to.
     <p>
 
-    <section id="How-do-I-register-with-the-DfE’s-service?">
+    <section id="how-do-i-register-with-the-dfe-s-service">
       <h2 class="govuk-heading-l">How do I register with the DfE’s service?</h2>
     </section>
     <p>

--- a/app/views/pages/ect_additional_information.html.erb
+++ b/app/views/pages/ect_additional_information.html.erb
@@ -1,0 +1,161 @@
+<% content_for :title, "ECF induction and training: additional information for early career teachers" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">ECF induction and training: additional information for early career teachers</h1>
+    <p>
+      This guidance is for early career teachers (ECTs). It answers some common questions about your 2-year induction programme,
+      which is based on the early career framework (ECF).
+    </p>
+    <p>
+      Find out how to register for your school’s ECF-based training programme, what happens during your induction, and how to get help.
+    </p>
+    <p>You can also read:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <%= govuk_link_to "guidance for school leaders, including the different roles involved in your induction",
+            "school-leader-additional-information"
+            %>
+      </li>
+      <li>
+        <%= govuk_link_to "guidance for mentors",
+            "mentor-additional-information"
+            %>
+      </li>
+      <li>
+        <%= govuk_link_to "ECF reforms: overview",
+            "https://www.gov.uk/government/publications/early-career-framework-reforms-overview"
+            %>
+      </li>
+    </ul>
+
+    <%= render ContentListComponent.new(heading: "Contents",
+                                        list: [
+                                              "Is the ECF an assessment tool, and can I fail my training?",
+                                              "Do I have to complete ECF-based training on top of another induction programme?",
+                                              "Do I need to collect evidence during my ECF-based training?",
+                                              "What happens if I start mid-term, work part-time, or I’m serving a reduced induction?",
+                                              "What should I do if I have difficulties with my induction programme?",
+                                              "How do I register with the DfE’s service?"
+                                              ]) %>
+
+    <section id="Is-the-ECF-an-assessment-tool,-and-can-I-fail-my-training?">
+      <h2 class="govuk-heading-l">Is the ECF an assessment tool, and can I fail my training?</h2>
+    </section>
+    <p>
+      No, you cannot fail your ECF training - the ECF is a package of support, not an assessment tool for teachers.
+    </p>
+    <p>
+      You should participate in your ECF-based training programme as fully as possible, but failing to complete it will
+      not mean you fail your induction. Completing the assignments in your training programme is one way to collect evidence that you meet the Teachers’ Standards.
+    </p>
+    <p>
+      Headteachers are responsible for making sure you’re assessed against the Teachers’ Standards as part of your progress reviews,
+      and in 2 formal assessments that will take place during your induction. This assessment is separate to the ECF programme itself.
+    </p>
+
+    <section id="Do-I-have-to-complete-ECF-based-training-on-top-of-another-induction-programme?">
+      <h2 class="govuk-heading-l">Do I have to complete ECF-based training on top of another induction programme?</h1>
+    </section>
+    <p>
+      No - the new ECF-based training is not an additional programme. It’s a central part of ECT induction at your school.
+    </p>
+    <p>
+      All ECTs are now entitled to a funded 2-year induction programme. This includes structured training and support to
+      help you get your teaching career off to the best possible start.
+    </p>
+    <p>
+      Your school may choose to offer you extra training and support to meet essential specific needs, reflecting local
+      policies and practices (e.g. on safeguarding). This additional training does not replace your entitlement to the ECF-based programme.
+    </p>
+
+    <section id="Do-I-need-to-collect-evidence-during-my-ECF-based-training?">
+      <h2 class="govuk-heading-l">Do I need to collect evidence during my ECF-based training?</h2>
+    </section>
+    <p>
+      You do not need to collect evidence based on the ECF itself.
+    </p>
+    <p>
+      Your induction tutor may ask you to provide evidence of meeting the Teachers’ Standards during your formal assessments.
+      This should only consist of existing documents, for example lesson plans or feedback from observations. There’s no need for you to create anything new for a formal assessment.
+    </p>
+
+    <section id="What-happens-if-I-start-mid-term,-work-part-time,-or-I’m-serving-a-reduced-induction?">
+      <h2 class="govuk-heading-l">What happens if I start mid-term, work part-time, or I’m serving a reduced induction?</h2>
+    </section>
+    <p>
+      You can start your induction at any time. Your school can choose from
+      <%= govuk_link_to "a number of options", "school-leader-additional-information#Can-we-register-an-ECT-with-a-training-provider-if-they-start-mid-term,-or-work-part-time?" %>
+       to make sure your ECF-based training fits your own circumstances.
+    <p>
+      If you’re serving a reduced induction period, there’s no expectation that you should cover the full depth of the ECF.
+      Your headteacher will work with your induction tutor, appropriate body and training provider (where relevant) to ensure that training and support is appropriate for you.
+    </p>
+
+    <section id="What-should-I-do-if-I-have-difficulties-with-my-induction-programme?">
+      <h2 class="govuk-heading-l">What should I do if I have difficulties with my induction programme?</h2>
+    </section>
+    <p>
+      If you’re struggling to engage with your training, ask your induction tutor for guidance. If your school is using a training provider, you can speak to them too.
+    <p>
+      If you have any concerns about your induction or statutory entitlements (time off timetable and support from a mentor),
+      speak to your induction tutor first. This is the person responsible for ECT induction at your school.
+      Your statutory entitlements include 10% off timetable in the first year and 5% in the second year of induction to undertake induction activities including training and mentoring,
+      a supportive dedicated mentor and high quality development materials based on the Early Career Framework.
+    </p>
+    <p>
+      If they’re unable to help you, speak to your appropriate body. They’re responsible for making sure ECTs receive their statutory entitlements,
+      and are fairly and consistently assessed. Your school should provide you with contact details for the right person to speak to.
+    <p>
+
+    <section id="How-do-I-register-with-the-DfE’s-service?">
+      <h2 class="govuk-heading-l">How do I register with the DfE’s service?</h2>
+    </section>
+    <p>
+      When your school’s induction tutor tells DfE you’ll be training with them, you’ll get an email asking you to register with the DfE.
+    <p>
+      This is a DfE-funded programme, so we need to confirm everyone who takes part is eligible. We do this by checking your details in the Teaching Regulation Agency records.
+    </p>
+    <p>
+      You’ll use our online service to provide us with your information. We need this in addition to any details you’ve given to a training provider. It should only take 5 minutes.
+    <p>
+
+    <h3 class="govuk-heading-m">How to give us your information</h3>
+
+    <ol class="govuk-list govuk-list--number">
+      <li>
+        Visit our service: https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration
+      </li>
+      <li>
+        Sign in using the email address your school has registered for you. Be careful to enter it correctly with no spaces.
+      </li>
+      <li>
+       If you do not receive an email from the DfE when you sign in, check your spam or junk folder.
+      </li>
+      <li>
+        Once you’re signed in you’ll be asked to enter your:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>date of birth</li>
+          <li>teacher reference number (TRN) or National Insurance number</li>
+        <ul>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-m">How to find your TRN</h3>
+     <p>
+      Your TRN is a unique ID that you can usually find on your payslip, teachers’ pension documents or teacher training records.
+    <p>
+      It is usually 7 digits long, may include the letters ‘RP’ or a slash ‘/’ symbol, or could be called a QTS, GTC, DfE, DfES or DCSF number.
+    </p>
+
+    <h3 class="govuk-heading-m">What happens next</h3>
+    <p>
+      We’ll check your details with the Teaching Regulation Agency to confirm your eligibility for funding.
+    </p>
+    <p>
+      You can then start or continue your training programme.
+    </p>
+  </div>
+</div>

--- a/app/views/pages/mentor_additional_information.html.erb
+++ b/app/views/pages/mentor_additional_information.html.erb
@@ -1,0 +1,234 @@
+<% content_for :title, "ECF induction and training: additional information for mentors" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">ECF induction and training: additional information for early career mentors</h1>
+    <p>
+      This guidance is for people who mentor early career teachers (ECTs) during their 2-year induction.
+      It answers some common questions about how the ECF-based training programme works, how to support ECTs, and how to get help.
+    </p>
+    <p>You can also read:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <%= govuk_link_to "guidance for ECTs",
+            "pages/ect_additional_information"
+            %>
+      </li>
+      <li>
+        <%= govuk_link_to "guidance for school leaders",
+            "pages/school_leader_additional_information"
+            %>
+      </li>
+      <li>
+        <%= govuk_link_to "ECF reforms: overview",
+            "https://www.gov.uk/government/publications/early-career-framework-reforms-overview"
+            %>
+      </li>
+    </ul>
+
+    <%= render ContentListComponent.new(heading: "Contents",
+                                        list: [
+                                                "How should I support ECTs?",
+                                                "Do I need to collect any evidence during the ECF-based training?",
+                                                "Can ECTs fail their training?",
+                                                "Do ECTs have to complete ECF-based training on top of another induction programme?",
+                                                "What should I do if an ECT has concerns or difficulties?",
+                                                "What should I do if I have concerns about mentoring?",
+                                                "Can I continue training as a mentor if my ECT withdraws from the programme?",
+                                                "How do I register with the DfE’s service?"
+                                               ]) %>
+
+    <section id="How-should-I-support-ECTs?">
+      <h2 class="govuk-heading-l">How should I support ECTs?</h2>
+    </section>
+    <p>As a mentor, your role is to support the ECT through their 2-year induction programme.</p>
+    <p>Your responsibilities will include:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+       working with your school to make sure ECTs receive a high-quality induction programme
+      </li>
+      <li>
+        meeting regularly with the ECTs to provide support and feedback
+      </li>
+      <li>
+        providing or arranging mentoring and coaching around specific phases and subject areas
+      </li>
+      <li>
+        taking prompt, appropriate action if an ECT is having difficulties
+      </li>
+    </ul>
+    <p>You’ll receive training on how to do this if your school selects to work with a training provider.</p>
+
+    <section id="Do-I-need-to-collect-any-evidence-during-the-ECF-based-training?">
+      <h2 class="govuk-heading-l">Do I need to collect any evidence during the ECF-based training?</h2>
+    </section>
+    <p>
+      The ECF is not an assessment tool, so you do not have to collect data on your ECT’s performance.
+    </p>
+    <p>
+      Your school’s headteacher and induction tutor will be responsible for assessing ECTs against the Teachers’ Standards.
+      Our <%= govuk_link_to "guidance for ECTs", "ect_additional_information" %> explains what evidence they may be asked
+      for to demonstrate their performance against those standards.
+    </p>
+    <p>
+      The mentor role is separate to assessment, and should focus on supporting the ECT through their 2-year induction programme.
+    </p>
+
+    <section id="Can-ECTs-fail-their-training?">
+      <h2 class="govuk-heading-l">Can ECTs fail their training?</h2>
+    </section>
+    <p>
+      No - ECTs should participate in their ECF-based training programme as fully as possible, but failing to complete it will
+      not mean they fail their induction. Completing the training programme will help them to develop the knowledge and skills they need to meet the Teachers’ Standards.
+    </p>
+    <p>
+      Headteachers are responsible for making sure ECTs are assessed against the Teachers’ Standards as part of their progress reviews,
+      and in 2 formal assessments that will take place during the induction. This assessment is separate to the ECF programme itself.
+    </p>
+    <section id="Do-ECTs-have-to-complete-ECF-based-training-on-top-of-another-induction-programme?">
+      <h2 class="govuk-heading-l">Do ECTs have to complete ECF-based training on top of another induction programme?</h2>
+    </section>
+    <p>
+      No - the new ECF-based training is not an additional programme. It’s a central part of ECT induction at your school.
+    </p>
+    <p>
+      All ECTs are now entitled to a funded 2-year induction programme. This includes structured training and support to
+      help them get their teaching career off to the best possible start.
+    </p>
+    <p>
+      Your school may choose to offer your ECTs extra training and support to meet essential specific needs, reflecting local policies
+      and practices (e.g. on safeguarding). This additional training does not replace their entitlement to the ECF-based programme however.
+    </p>
+
+    <section id="How-should-an-ECT’s-teaching-be-observed?">
+      <h2 class="govuk-heading-l">How should an ECT’s teaching be observed?</h2>
+    </section>
+    <p>
+      Each ECT’s teaching should be observed at regular intervals throughout their induction period. This is to make sure a fair
+      and effective assessment of the ECT’s teaching practice, conduct and efficiency can be made against the Teachers’ Standards.
+    </p>
+    <p>
+      Your induction tutor can be the observer, or they can select another suitable person from inside or outside of your school. Speak to your induction tutor to find out more.
+    </p>
+    <p>
+      If your school uses a training provider to deliver the programme, they may indicate when observations should happen as part of the training.
+      These observations are for development purposes only and should not be used for formal assessment.
+    </p>
+
+    <section id="What-should-I-do-if-an-ECT-has-concerns-or-difficulties?">
+      <h2 class="govuk-heading-l">What should I do if an ECT has concerns or difficulties?</h2>
+    </section>
+    <p>
+      They should speak to their induction tutor first, as this is the person responsible for ECT induction at your school.
+    </p>
+    <p>
+      If they’re unable to help, the ECT should speak to your school’s appropriate body. They’re responsible for making sure ECTs receive their statutory entitlements,
+      and are fairly and consistently assessed. Your school should provide ECTs with contact details for the right person to speak to.
+    </p>
+
+    <section id="What-should-I-do-if-I-have-concerns-about-mentoring?">
+      <h2 class="govuk-heading-l">What should I do if I have concerns about mentoring?</h2>
+    </section>
+    <p>
+      Contact your school leaders if you have concerns about:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+       your time off timetable
+      </li>
+      <li>
+        your entitlements set out in the
+        <%= govuk_link_to "statutory guidance", "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" %>
+      </li>
+    </ul>
+
+    <section id="Can-I-continue-training-as-a-mentor-if-my-ECT-withdraws-from-the-programme?">
+      <h2 class="govuk-heading-l">Can I continue training as a mentor if my ECT withdraws from the programme?</h2>
+    </section>
+    <p>
+      Yes. If you were assigned an ECT at the start of the programme, you can continue training so you are ready to work with other ECTs.
+    </p>
+
+    <section id="How-do-I-register-with-the-DfE’s-service?">
+      <h2 class="govuk-heading-l">How do I register with the DfE’s service?</h2>
+    </section>
+    <p>
+      When your school’s induction tutor tells DfE you’ll be mentoring, you’ll get an email asking you to register with the DfE.
+    </p>
+    <p>
+      This is a DfE-funded programme, so we need to confirm everyone who takes part is eligible. We do this by checking your details in the Teaching Regulation Agency records.
+    </p>
+    <p>
+      You’ll use our online service to provide us with your information. We need this in addition to any details you’ve given to a training provider. It should only take 5 minutes.
+    </p>
+
+    <h3 class="govuk-heading-m">How to give us your information</h3>
+    <ol class="govuk-list govuk-list--number">
+      <li>
+       Visit our service: <%= govuk_link_to "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration", "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration" %>
+      </li>
+      <li>
+        Sign in using the email address your school has registered for you. Be careful to enter it correctly with no spaces.
+      </li>
+      <li>
+        If you do not receive an email from the DfE when you sign in, check your spam or junk folder.
+      </li>
+      <li>
+        Once you’re signed in you’ll be asked to enter your:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>full name</li>
+          <li>date of birth</li>
+          <li>teacher reference number (TRN) or National Insurance number</li>
+        <ul>
+      </li>
+    </ol>
+
+    <h3 class="govuk-heading-m">How to find your TRN</h3>
+    <p>
+      Your TRN is a unique Id that:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+       is usually 7 digits long, for example ‘4567814’
+      </li>
+      <li>
+        may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’
+      </li>
+      <li>
+        may also be called a QTS, GTC, DfE, DfES or DCSF number
+      </li>
+    </ul>
+    <p>
+      You’ll have a TRN if you hold, or are working towards qualified teacher status (QTS) in England.
+     </p>
+    <p>
+      You can usually find it on your payslip, teachers’ pension documents or teacher training records.
+    </p>
+
+    <h3 class="govuk-heading-m">If you’re a mentor without a TRN</h3>
+    <p>
+      You must <%= govuk_link_to "apply for a TRN", "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration/trn-guidance" %>
+      before you can use DFE’s service. You need a TRN to receive funded training and materials.
+    </p>
+
+    <h3 class="govuk-heading-m">How to give feedback</h3>
+    <p>
+      The DfE and training providers are committed to maximising the impact of the ECF reforms. We welcome any feedback on the programmes,
+      including ECT engagement. You can share this directly with your training provider, or email the DfE:
+      <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>.
+    </p>
+  </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/views/pages/mentor_additional_information.html.erb
+++ b/app/views/pages/mentor_additional_information.html.erb
@@ -29,17 +29,18 @@
 
     <%= render ContentListComponent.new(heading: "Contents",
                                         list: [
-                                                "How should I support ECTs?",
+                                                "How should I support ECT's?",
                                                 "Do I need to collect any evidence during the ECF-based training?",
                                                 "Can ECTs fail their training?",
                                                 "Do ECTs have to complete ECF-based training on top of another induction programme?",
+                                                "How should an ECT's teaching be observed?",
                                                 "What should I do if an ECT has concerns or difficulties?",
                                                 "What should I do if I have concerns about mentoring?",
                                                 "Can I continue training as a mentor if my ECT withdraws from the programme?",
                                                 "How do I register with the DfE’s service?"
                                                ]) %>
 
-    <section id="How-should-I-support-ECTs?">
+    <section id="how-should-i-support-ect-s">
       <h2 class="govuk-heading-l">How should I support ECTs?</h2>
     </section>
     <p>As a mentor, your role is to support the ECT through their 2-year induction programme.</p>
@@ -60,7 +61,7 @@
     </ul>
     <p>You’ll receive training on how to do this if your school selects to work with a training provider.</p>
 
-    <section id="Do-I-need-to-collect-any-evidence-during-the-ECF-based-training?">
+    <section id="do-i-need-to-collect-any-evidence-during-the-ecf-based-training">
       <h2 class="govuk-heading-l">Do I need to collect any evidence during the ECF-based training?</h2>
     </section>
     <p>
@@ -75,7 +76,7 @@
       The mentor role is separate to assessment, and should focus on supporting the ECT through their 2-year induction programme.
     </p>
 
-    <section id="Can-ECTs-fail-their-training?">
+    <section id="can-ects-fail-their-training">
       <h2 class="govuk-heading-l">Can ECTs fail their training?</h2>
     </section>
     <p>
@@ -86,7 +87,7 @@
       Headteachers are responsible for making sure ECTs are assessed against the Teachers’ Standards as part of their progress reviews,
       and in 2 formal assessments that will take place during the induction. This assessment is separate to the ECF programme itself.
     </p>
-    <section id="Do-ECTs-have-to-complete-ECF-based-training-on-top-of-another-induction-programme?">
+    <section id="do-ects-have-to-complete-ecf-based-training-on-top-of-another-induction-programme">
       <h2 class="govuk-heading-l">Do ECTs have to complete ECF-based training on top of another induction programme?</h2>
     </section>
     <p>
@@ -101,7 +102,7 @@
       and practices (e.g. on safeguarding). This additional training does not replace their entitlement to the ECF-based programme however.
     </p>
 
-    <section id="How-should-an-ECT’s-teaching-be-observed?">
+    <section id="how-should-an-ect-s-teaching-be-observed">
       <h2 class="govuk-heading-l">How should an ECT’s teaching be observed?</h2>
     </section>
     <p>
@@ -116,7 +117,7 @@
       These observations are for development purposes only and should not be used for formal assessment.
     </p>
 
-    <section id="What-should-I-do-if-an-ECT-has-concerns-or-difficulties?">
+    <section id="what-should-i-do-if-an-ect-has-concerns-or-difficulties">
       <h2 class="govuk-heading-l">What should I do if an ECT has concerns or difficulties?</h2>
     </section>
     <p>
@@ -127,7 +128,7 @@
       and are fairly and consistently assessed. Your school should provide ECTs with contact details for the right person to speak to.
     </p>
 
-    <section id="What-should-I-do-if-I-have-concerns-about-mentoring?">
+    <section id="what-should-i-do-if-i-have-concerns-about-mentoring">
       <h2 class="govuk-heading-l">What should I do if I have concerns about mentoring?</h2>
     </section>
     <p>
@@ -143,14 +144,14 @@
       </li>
     </ul>
 
-    <section id="Can-I-continue-training-as-a-mentor-if-my-ECT-withdraws-from-the-programme?">
+    <section id="can-i-continue-training-as-a-mentor-if-my-ect-withdraws-from-the-programme">
       <h2 class="govuk-heading-l">Can I continue training as a mentor if my ECT withdraws from the programme?</h2>
     </section>
     <p>
       Yes. If you were assigned an ECT at the start of the programme, you can continue training so you are ready to work with other ECTs.
     </p>
 
-    <section id="How-do-I-register-with-the-DfE’s-service?">
+    <section id="how-do-i-register-with-the-dfe-s-service">
       <h2 class="govuk-heading-l">How do I register with the DfE’s service?</h2>
     </section>
     <p>

--- a/app/views/pages/mentor_additional_information.html.erb
+++ b/app/views/pages/mentor_additional_information.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">ECF induction and training: additional information for early career mentors</h1>
+    <h1 class="govuk-heading-xl">ECF induction and training: additional information for mentors</h1>
     <p>
       This guidance is for people who mentor early career teachers (ECTs) during their 2-year induction.
       It answers some common questions about how the ECF-based training programme works, how to support ECTs, and how to get help.
@@ -29,11 +29,11 @@
 
     <%= render ContentListComponent.new(heading: "Contents",
                                         list: [
-                                                "How should I support ECT's?",
+                                                "How should I support ECT’s?",
                                                 "Do I need to collect any evidence during the ECF-based training?",
                                                 "Can ECTs fail their training?",
                                                 "Do ECTs have to complete ECF-based training on top of another induction programme?",
-                                                "How should an ECT's teaching be observed?",
+                                                "How should an ECT’s teaching be observed?",
                                                 "What should I do if an ECT has concerns or difficulties?",
                                                 "What should I do if I have concerns about mentoring?",
                                                 "Can I continue training as a mentor if my ECT withdraws from the programme?",
@@ -81,7 +81,8 @@
     </section>
     <p>
       No - ECTs should participate in their ECF-based training programme as fully as possible, but failing to complete it will
-      not mean they fail their induction. Completing the training programme will help them to develop the knowledge and skills they need to meet the Teachers’ Standards.
+      not mean they fail their induction. Completing the training programme will help them to develop the knowledge and skills they need to meet the
+      <%= govuk_link_to "Teachers’ Standards", "https://www.gov.uk/government/publications/teachers-standards" %>.
     </p>
     <p>
       Headteachers are responsible for making sure ECTs are assessed against the Teachers’ Standards as part of their progress reviews,
@@ -99,7 +100,7 @@
     </p>
     <p>
       Your school may choose to offer your ECTs extra training and support to meet essential specific needs, reflecting local policies
-      and practices (e.g. on safeguarding). This additional training does not replace their entitlement to the ECF-based programme however.
+      and practices (on safeguarding, for example). This additional training does not replace their entitlement to the ECF-based programme however.
     </p>
 
     <section id="how-should-an-ect-s-teaching-be-observed">
@@ -148,7 +149,7 @@
       <h2 class="govuk-heading-l">Can I continue training as a mentor if my ECT withdraws from the programme?</h2>
     </section>
     <p>
-      Yes. If you were assigned an ECT at the start of the programme, you can continue training so you are ready to work with other ECTs.
+      Yes. If you were assigned an ECT at the start of the programme, you can continue training so you’re ready to work with other ECTs.
     </p>
 
     <section id="how-do-i-register-with-the-dfe-s-service">
@@ -209,8 +210,16 @@
 
     <h3 class="govuk-heading-m">If you’re a mentor without a TRN</h3>
     <p>
-      You must <%= govuk_link_to "apply for a TRN", "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration/trn-guidance" %>
+      You must <%= govuk_link_to "apply for a TRN", "https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration/get-a-trn" %>
       before you can use DFE’s service. You need a TRN to receive funded training and materials.
+    </p>
+
+    <h3 class="govuk-heading-m">What happens next</h3>
+    <p>
+      We’ll check your details with the Teaching Regulation Agency to confirm your eligibility for funding.
+    </p>
+    <p>
+      You can then start or continue your training programme.
     </p>
 
     <h3 class="govuk-heading-m">How to give feedback</h3>

--- a/app/views/pages/mentor_additional_information.html.erb
+++ b/app/views/pages/mentor_additional_information.html.erb
@@ -12,12 +12,12 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <%= govuk_link_to "guidance for ECTs",
-            "pages/ect_additional_information"
+            "ect-additional-information"
             %>
       </li>
       <li>
         <%= govuk_link_to "guidance for school leaders",
-            "pages/school_leader_additional_information"
+            "school-leader-additional-information"
             %>
       </li>
       <li>
@@ -68,7 +68,7 @@
     </p>
     <p>
       Your school’s headteacher and induction tutor will be responsible for assessing ECTs against the Teachers’ Standards.
-      Our <%= govuk_link_to "guidance for ECTs", "ect_additional_information" %> explains what evidence they may be asked
+      Our <%= govuk_link_to "guidance for ECTs", "ect-additional-information" %> explains what evidence they may be asked
       for to demonstrate their performance against those standards.
     </p>
     <p>

--- a/app/views/pages/school_leader_additional_information.html.erb
+++ b/app/views/pages/school_leader_additional_information.html.erb
@@ -1,0 +1,473 @@
+<% content_for :title, "ECF induction and training: additional information for school leaders" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">ECF induction and training: additional information for school leaders</h1>
+    <p>
+      This guidance is for school leaders and induction tutors. It answers some common questions about how to set up and
+      run your school’s early career teacher (ECT) induction training programme, based on the
+      <%= govuk_link_to "early career framework (ECF)", "https://www.gov.uk/government/publications/early-career-framework" %>.
+    </p>
+    <p>
+      You can also view:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        <%= govuk_link_to "guidance for ECTs",
+            "ect_additional_information"
+            %>
+      </li>
+      <li>
+        <%= govuk_link_to "guidance for mentors",
+            "mentor_additional_information"
+            %>
+      </li>
+      <li>
+        <%= govuk_link_to "ECF reforms: overview",
+            "https://www.gov.uk/government/publications/early-career-framework-reforms-overview"
+            %>
+      </li>
+    </ul>
+
+    <%= render ContentListComponent.new(heading: "Contents",
+                                        list: [
+                                            "What are the responsibilities of each role and organisation?",
+                                            "Is the ECF an assessment tool?",
+                                            "Do ECTs have to complete ECF-based training on top of another induction programme?",
+                                            "Can we register an ECT with a training provider if they start mid-term or work part-time?",
+                                            "What happens if an ECT has concerns or difficulties?",
+                                            "Who should observe an ECT’s teaching practice?",
+                                            "How should we choose and support mentors?",
+                                            "Why does DfE need personal information from ECTs and mentors?",
+                                            "Do I need to tell the DfE which training provider we’re using?",
+                                            "How does funding for training work?",
+                                            "What support is available for teachers who complete induction in autumn 2021 or spring 2022?",
+                                            "When and why do we need to use the DfE’s service?"
+                                            ]) %>
+
+    <section id="What-are-the-responsibilities-of-each-role-and-organisation?">
+      <h2 class="govuk-heading-l">What are the responsibilities of each role and organisation?</h2>
+    </section>
+    <section id="What’s-the-role-of-the-DfE-funded-provider?">
+      <h3 class="govuk-heading-m">What’s the role of the DfE-funded provider?</h3>
+    </section>
+    <h4 class="govuk-heading-s">Lead providers</h4>
+    <p>
+      Schools can choose from one of 6 DfE-funded training providers. These organisations are known as ‘lead providers’.
+    </p>
+
+    <h4 class="govuk-heading-s">Delivery partners</h4>
+    <p>
+      Lead providers work with ‘delivery partners’ to deliver their training programmes to ECTs and mentors across the country.
+      These partners include teaching school hubs, universities and other organisations.
+    </p>
+    <p>
+      The materials used in each programme have been accredited by DfE and quality assured by the Education Endowment Foundation.
+    </p>
+
+    <h3 class="govuk-heading-m">What’s the role of the appropriate body?</h3>
+    <p>
+      Your school must appoint an appropriate body and record all ECT inductions with them. This is a separate step from choosing a training provider, even if that training provider also acts as the appropriate body.
+    </p>
+    <p>
+      Appropriate bodies quality assure statutory teacher induction. They will:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>check ECTs are receiving their statutory induction entitlements</li>
+      <li>check that ECT assessment procedures are fair and appropriate</li>
+      <li>register your ECT’s induction with the Teaching Regulation Agency (TRA)</li>
+    </ul>
+    <p>
+      If your school is delivering its own induction programme, your appropriate body will check that it’s based on the ECF.
+      This process is known as ‘fidelity checking’. Schools using a funded training provider will not need to have these checks.
+    </p>
+    <p>
+      Find <%= govuk_link_to "information for local and national appropriate bodies here", "https://www.gov.uk/government/publications/statutory-teacher-induction-appropriate-bodies/find-an-appropriate-body" %>.
+    </p>
+    <p>
+      Read more about the <%= govuk_link_to "and responsibilities of appropriate bodies", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework" %>.
+    </p>
+
+    <h3 class="govuk-heading-m">What’s Ofsted’s role in the quality assurance of the training?</h2>
+    <p>
+      Ofsted will inspect the DfE-funded training providers known as lead providers. Inspection will focus on the quality of
+      professional development and training, and the leadership and management of the lead provider. These reports may help you
+      decide which provider-led programme you want to use for ECTs in your school.
+    </p>
+    <p>
+      Ofsted will visit a sample of the lead providers’ delivery partners, and talk to a sample of ECTs, mentors and trainers
+      (where applicable). They will not be inspected or judged themselves however.
+    </p>
+    <p>
+      Ofsted will not inspect induction programmes at schools that are delivering their own induction programme using DfE-accredited materials,
+      or their own ECF-based design.
+    </p>
+
+    <h3 class="govuk-heading-m">What do induction tutors and mentors need to do? </h3>
+    <h4 class="govuk-heading-s">Induction tutors</h4>
+    <p>
+      The induction tutor will provide regular monitoring and support, and coordinate assessments of ECTs. They’ll review each
+      ECT’s progress against the <%= govuk_link_to "Teachers’ Standards", "https://www.gov.uk/government/publications/teachers-standards" %>.
+    </p>
+    <p>
+      The induction tutor is a separate role to that of the mentor.
+    </p>
+    <p>
+      Your school can currently only select one induction tutor. They’ll have access to the DfE service, and be our point of contact.
+    </p>
+    <p>
+      Your induction tutor should:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>hold qualified teaching status (QTS)</li>
+      <li>have the skills and knowledge needed to assess your ECT’s progress against the Teachers’ Standards</li>
+      <li>carry out regular progress reviews</li>
+      <li>undertake 2 formal assessment meetings with each ECT during the course of the induction period, one midway through induction and one at the end</li>
+      <li>be able to recognise when early action is needed if an ECT is experiencing difficulties</li>
+    </ul>
+
+    <h4 class="govuk-heading-s">Mentors</h4>
+    <p>
+      ECTs are expected to receive support through regular one-to-one sessions with a dedicated mentor.
+    </p>
+    <p>
+      The mentor role is focused on supporting the ECT through their 2-year programme. Mentors at schools using a DfE-funded provider will receive comprehensive training on how to deliver this support.
+    </p>
+    <p>
+      Read about the <%= govuk_link_to "different tasks and responsibilities for ECTs, mentors and induction tutors",
+                         "https://manage-training-for-early-career-teachers.education.gov.uk/pages/what-each-person-does" %>.
+    </p>
+    <section id="Is-the-ECF-an-assessment-tool?" %>
+      <h2 class="govuk-heading-l">Is the ECF an assessment tool?</h2>
+    </section>
+    <p>
+      No - the ECF is a package of support, not an assessment tool for teachers.
+    </p>
+    <p>
+      ECTs will follow an ECF-based training programme, but they cannot fail it. Completing assignments as part of their
+      training programme is one way for ECTs to collect evidence that they meet the Teachers’ Standards
+    </p>
+    <p>
+      Headteachers are responsible for ensuring ECT’s continue to be assessed against the Teachers’ Standards as part of
+      their progress reviews, and during 2 formal assessments as part of their induction.
+    </p>
+
+    <h3 class="govuk-heading-m">If an ECT does not complete assignments from their training provider, will they fail their induction?</h3>
+    <p>
+      The ECF is not and should not be used as an assessment tool. ECTs should participate as fully as possible in order to develop their practice, but failing to complete the ECF programme will not mean they fail their induction. Your training provider may have specific requirements for engagement however (see the ‘What happens if an ECT does not fully engage with their provider-led training?’ section below).
+    </p>
+    <p>
+      Your school should arrange 2 formal assessment points: one midway through induction and one at the end. Each ECT’s
+      performance should be assessed against the Teachers’ Standards.
+    </p>
+    <p>
+      Assessments should be supported by regular reviews to monitor progress. These should take place in terms without a formal assessment.
+    </p>
+    <section id="Do-ECTs-have-to-complete-ECF-based-training-on-top-of-another-induction-programme?" %>
+      <h2 class="govuk-heading-l">Do ECTs have to complete ECF-based training on top of another induction programme?</h2>
+    </section>
+    <p>
+      All ECTs are now entitled to a funded 2-year induction programme. This includes structured training and support to
+      help them get their teaching career off to the best possible start.
+    </p>
+    <p>
+      The new ECF-based training is not an additional programme. It should be embedded as a central part of each ECT’s induction at your school.
+    </p>
+    <p>
+      Your school may choose to offer your ECTs extra training and support to meet essential specific needs, reflecting local
+      policies and practices (e.g. on safeguarding). This additional training does not replace their entitlement to the ECF-based programme however.
+    </p>
+    <section id="Can-we-register-an-ECT-with-a-training-provider-if-they-start-mid-term,-or-work-part-time?" %>
+      <h2 class="govuk-heading-l">Can we register an ECT with a training provider if they start mid-term, or work part-time?</h2>
+    </section>
+    <p>
+      Yes - all training providers have a policy in place for these circumstances, so speak to them for more information.
+      Your appropriate body can also advise your school of the options available in your area.
+    </p>
+
+    <h3 class="govuk-heading-m">If an ECT is serving a reduced induction, do they need to cover the full ECF?</h3>
+    <p>
+      There’s no expectation that an ECT serving a reduced induction period should cover the full depth of the ECF.
+    </p>
+    <p>
+      Headteachers should work with induction tutors, appropriate bodies and training providers (where relevant) to ensure
+      the training and support is appropriate for each individual.
+    </p>
+    <p>
+      Your appropriate body will decide if an ECT can serve a reduced induction period. See
+      <%= govuk_link_to "section 3 of the statutory guidance", "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" %>
+      for more information.
+    </p>
+    <section id="What-happens-if-an-ECT-has-concerns-or-difficulties?">
+      <h2 class="govuk-heading-l">What happens if an ECT has concerns or difficulties?</h2>
+    </section>
+    <p>
+      If an ECT has any concerns about their induction or statutory entitlements, they should speak to:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>their induction tutor in the first instance, then</li>
+      <li>raise the matter directly with their appropriate body if the induction tutor cannot resolve it</li>
+    </ul>
+    <p>
+      You must let your ECTs know who their appropriate body is at the start of induction, and provide contact details for a named person they can raise issues with.
+    </p>
+
+    <h3 class="govuk-heading-m">What happens if an ECT does not fully engage with their provider-led training?</h2>
+    <p>
+      The Early Career Framework reforms are designed to support early career teachers to succeed at the start of their careers by helping them to support their pupils to achieve their full potential.It is therefore important that ECTs engage with the training and receive their statutory entitlement to an ECF-based induction.
+    </p>
+    <p>
+      If an ECT is unable to participate sufficiently, they can be withdrawn from the programme by your training provider. If that happens, your school will be responsible for signing up with another provider or delivering an ECF-based induction directly which would need to be ‘fidelity checked’ by your appropriate body to ensure it is based on the ECF.
+    </p>
+    <p>
+      The DfE and training providers are committed to maximising the impact of the ECF reforms. We welcome any feedback on the programmes, including ECT engagement. You can share this directly with your training provider, or email the DfE: continuing-professional-development@digital.education.gov.uk.
+    </p>
+
+    <section id="Who-should-observe-an-ECT’s-teaching-practice?" %>
+      <h2 class="govuk-heading-l">Who should observe an ECT’s teaching practice?</h2>
+    </section>
+    <p>
+      Your induction tutor can be the observer, or you can select another suitable person from inside or outside of your school.
+    </p>
+    <p>
+      Each ECT’s teaching should be observed at regular intervals throughout their induction period. This is to make sure
+      a fair and effective assessment of the ECT’s teaching practice, conduct and efficiency can be made against the Teachers’ Standards.
+    </p>
+    <p>
+      If you use a training provider to deliver your programme, they may indicate when observations should happen as part
+      of the training programme. These observations are for development purposes only and should not be used for formal assessment.
+    </p>
+
+    <section id="How-should-we-choose-and-support-mentors?">
+      <h2 class="govuk-heading-l">How should we choose and support mentors?</h2>
+    </section>
+    <h3 class="govuk-heading-m">What happens if our school does not have a teacher with QTS available to act as a mentor?</h3>
+    <p>
+      Mentors should hold QTS or QTLS. In exceptional circumstances your headteacher may identify another member of staff
+      with the necessary skills and knowledge to work successfully in the role. If this happens:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your headteacher should discuss it with your appropriate body</li>
+      <li>your school should make sure the person has enough time to carry out the role effectively</li>
+      <li>the mentor will need to apply for a teacher reference number (TRN) so they can register with the DfE for relevant funding and access to materials</li>
+    </ul>
+    <p>
+      Find out about the different <%= govuk_link_to "tasks and responsibilities for mentors",
+      "https://manage-training-for-early-career-teachers.education.gov.uk/pages/what-each-person-does" %>
+      in our guidance.
+    </p>
+
+    <h3 class="govuk-heading-m">Should mentors have dedicated time off timetable to take part in this programme?</h3>
+    <p>
+      Mentoring is a very important part of the ECT induction process. Your headteacher and appropriate body must check that
+      mentors have adequate time during normal teaching hours to hold mentoring sessions with their ECTs on a regular basis.
+    </p>
+    <p>
+      Training providers will have minimum requirements for engagement to make sure mentors receive the full benefit of their
+      programme, allowing them to provide support to their early career teachers and set them up for a successful and fulfilling career in teaching.
+    </p>
+    <p>
+      Find out <%= govuk_link_to "how backfill payments for mentors will be made", "#How-will-backfill-payments-for-mentors-be-made?" %>.
+    </p>
+
+    <h3 class="govuk-heading-m">Do all mentors need to attend training, or can some attend and pass information to colleagues?</h3>
+    <p>
+      If your school has chosen to use a DfE-funded training provider, each mentor is expected to take part. Your school will receive
+      <%= govuk_link_to "additional funding to backfill each mentor’s training time", "#How-will-backfill-payments-for-mentors-be-made?" %>.
+    </p>
+
+    <h3 class="govuk-heading-m">What happens if a mentor has concerns or difficulties regarding mentoring?</h3>
+    <p>
+      Mentors should speak to their school leaders if they have any concerns. Your school should notify your appropriate body
+      if a mentor does not have enough time to carry out their role effectively.
+    </p>
+
+    <h3 class="govuk-heading-m">Can a mentor continue training if an ECT withdraws from the programme?</h3>
+    <p>
+      Yes. If mentors were assigned an ECT at the start of the programme, they can continue training so they are ready to work with other ECTs.
+    </p>
+
+    <section id="Why-does-DfE-need-personal-information-from-ECTs-and-mentors?">
+      <h2 class="govuk-heading-l">Why does DfE need personal information from ECTs and mentors?</h2>
+    </section>
+    <p>
+      After your school’s induction tutor registers your ECTs and mentors with the DfE’s service, we’ll:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>send each ECT and mentor an email to the address you provide (so it’s important to make sure it’s an active email account)</li>
+      <li>ask them to sign in to our service and tell us their teacher reference number (TRN) or National Insurance number, name, and date of birth</li>
+    </ul>
+    <p>
+      We use this information to check their eligibility for funded training and access to materials.
+    </p>
+    <p>
+      If participants do not provide this information to us directly, your school’s provider may not be able to continue training them.
+      If this happens, your school may have to deliver an alternative ECF-based induction.
+    </p>
+    <p>
+      Read our step-by-step guidance on <%= govuk_link_to "how to set up your programme using the DfE service", "https://manage-training-for-early-career-teachers.education.gov.uk/how-to-set-up-your-programme" %>.
+    </p>
+
+    <section id="Do-I-need-to-tell-the-DfE-which-training-provider-we’re-using?">
+      <h2 class="govuk-heading-l">Do I need to tell the DfE which training provider we’re using?</h2>
+    </section>
+    <p>
+      No, you do not need to register your training provider in the DfE’s service. Your provider needs to report this directly to the DfE.
+    </p>
+    <p>
+      When a provider confirms they’re delivering training for your school, you’ll see their name when you sign in to the DfE service.
+    </p>
+    <p>
+      If you cannot see the training provider’s name in your account, ask them to confirm the partnership with their lead provider so DfE has the correct information.
+    </p>
+
+    <section id="How-does-funding-for-training-work?">
+      <h2 class="govuk-heading-l">How does funding for training work?</h2>
+    </section>
+    <p>
+      Year 1 funding is already included in the National Funding Formula, which schools will continue to receive.
+    </p>
+    <p>
+      Information on
+      <%= govuk_link_to "year 2 funding, and time off timetable funding for mentors",
+                        "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#funding-for-national-roll-out" %>
+      is available in our ECF overview guidance.
+    </p>
+
+    <h3 class="govuk-heading-m">Which schools are eligible for funded training?</h3>
+    <p>
+      State-funded schools can choose to work with one of
+      <%= govuk_link_to "6 training providers", "#What’s-the-role-of-the-DfE-funded-provider?" %> that are accredited and funded by the DfE.
+    </p>
+    <p>
+      All maintained and non-maintained special schools and independent schools that receive Section 41 funding can access a funded provider-led programme too.
+    </p>
+    <p>
+      Schools that are not state funded can arrange and fund a provider-led programme. This is subject solely to the agreement of the lead provider and the institution.
+    </p>
+
+    <h3 class="govuk-heading-m">How much funding for year 1 induction is included in the national funding formula?</h3>
+    <p>
+      Schools receive their core funding through the
+      <%= govuk_link_to "dedicated schools grant (DSG)", "https://www.gov.uk/government/publications/dedicated-schools-grant-dsg-2021-to-2022" %>,
+      which is calculated using the <%= govuk_link_to "national funding formula (NFF)", "https://www.gov.uk/government/publications/guide-to-national-funding-formula/guide-to-national-funding-formula" %>.
+      The NFF allocates funding primarily based on the characteristics of schools and their pupils.
+    </p>
+    <p>
+      Schools initially received funding for time off timetable through the ‘standards fund’. Funding is now incorporated into the
+      core schools funding that they receive through the DSG. Schools are expected to meet the cost of the 10% release time for ECTs as part of their core funding.
+    </p>
+    <p>
+      The NFF does not ‘earmark’ any funding that schools should spend on ECTs or NQTs. It’s up to headteachers to manage the funding they receive.
+    </p>
+
+    <h3 class="govuk-heading-m">What happens to funding if an ECT leaves after one year? Can they transfer their induction?</h3>
+    <p>
+      If an ECT leaves during year 2 of induction, part funding will be calculated based on the
+      <%= govuk_link_to "School Workforce Census", "https://www.gov.uk/guidance/school-workforce-census" %> returns.
+    </p>
+    <p>
+      Year 1 funding is already included in the NFF, so schools will continue to receive this as normal.
+    </p>
+    <p>
+      If an ECT is training with a funded provider and moves school, they should continue their existing programme where possible.
+      If this is not possible, the training providers at both schools should work together to make arrangements to accommodate the ECT.
+    </p>
+    <p>
+      We’ll confirm how funding will be allocated for ECTs and mentors when ECTs move school partway through the year in due course.
+    </p>
+    <section id="How-will-backfill-payments-for-mentors-be-made?">
+      <h3 class="govuk-heading-m">How will backfill payments for mentors be made?</h3>
+    </section>
+    <p>
+      State schools running statutory induction will receive a single payment for their ECTs and mentors in their induction’s second summer.
+      Schools will receive funding to cover time off timetable for ECTs and mentors in the second year of induction. This will be paid directly to schools.
+    </p>
+    <p>
+      If your school is using a DfE-funded training provider, there’s additional funding to backfill mentor training time. This will also be paid directly to schools.
+    </p>
+    <p>
+      Schools will be paid grant funded backfill payments:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>to cover 36 hours per mentor over 2 years, from 2021 to 2022</li>
+      <li>in arrears, based on school workforce census data collections over the period (the same way the 5% time off timetable for ECTs is paid)</li>
+    </ul>
+    <p>
+      Data will be collected through the school workforce census to minimise the administrative burden for schools.
+      The funding amount is calculated by taking the average salary of mentors and ECTs by region.
+    </p>
+
+    <h3 class="govuk-heading-m">Is year 2 funding proportionate for part-time teachers?</h3>
+    <p>
+      Yes, part-time ECTs will be paid proportionately. For example, schools with an ECT who works 0.5 full-time equivalent (FTE) would receive:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>half the funding when the ECT completes 50% of their induction (after 2 years)</li>
+      <li>the full funding amount by the time they complete their induction (after 4 years)</li>
+    </ul>
+
+    <h3 class="govuk-heading-m">What happens to funding when an ECT is on parental leave?</h3>
+    <p>
+      ECTs will be able to continue their induction when they return from parental leave. Schools will receive proportionate
+      funding for the time ECTs are taking part in their induction. Funding will be based on school workforce census data collections over the period.
+    </p>
+
+   <h3 class="govuk-heading-m">How does funding work for ECTs undertaking a reduced induction?</h3>
+   <p>
+     ECTs undertaking a reduced induction will be funded proportionately. They’ll be identified using school workforce census data collections over the period.
+   </p>
+
+   <section id="What-support-is-available-for-teachers-who-complete-induction-in-autumn-2021-or-spring-2022?">
+     <h2 class="govuk-heading-l">What support is available for teachers who complete induction in autumn 2021 or spring 2022?</h2>
+   </section>
+   <p>
+     DfE is offering additional support to NQTs whose induction was impacted by coronavirus (COVID-19).
+     NQTs are eligible for time off timetable funding and access to ECF induction training materials if they:
+   </p>
+   <ul class="govuk-list govuk-list--bullet">
+     <li>completed their induction in the 2020 to 2021 academic year, or</li>
+     <li>had started but not yet completed their induction by 1 September 2021</li>
+   </ul>
+     <p>They’ll be identified using school workforce census data collections over the period.</p>
+
+   <section id="When-and-why-do-we-need-to-use-the-DfE’s-service?">
+     <h2 class="govuk-heading-l">When and why do we need to use the DfE’s service?</h2>
+   </section>
+   <p>
+     The <%= govuk_link_to "Manage training for early career teachers service", "https://manage-training-for-early-career-teachers.education.gov.uk" %>
+     is the place to tell DfE:
+   </p>
+   <ul class="govuk-list govuk-list--bullet">
+     <li>who your school nominates as your induction tutor (they’ll be our single point of contact)</li>
+     <li>if you want to use a DfE-funded training provider, accredited materials, or design your own programme based on the ECF</li>
+     <li>if you need to make changes to either of these things</li>
+   </ul>
+   <p>
+     If your school chooses to use a DfE-funded training provider or accredited materials, your induction tutor must also use the service to tell us:
+   </p>
+   <ul class="govuk-list govuk-list--bullet">
+     <li>the full name and email address of any ECT starting training in the term ahead</li>
+     <li>the full name and email address of any mentors who’ll be working with them</li>
+   </ul>
+   <p>
+     We need to know this to arrange relevant funding and access to materials.
+   </p>
+   <p>
+     You can add ECTs at any time, but they’ll only become eligible for funded training once they have qualified teacher status (QTS).
+   </p>
+   <p>
+     You must tell DfE this information directly so that our records are up to date. This is in addition to any information you give to your appropriate body, teaching school hub or training provider.
+   </p>
+   <p>
+     Read our <%= govuk_link_to "step-by-step guidance for schools", "https://manage-training-for-early-career-teachers.education.gov.uk/how-to-set-up-your-programme" %>
+      to find out more.
+   </p>
+  </div>
+</div>
+
+
+
+
+

--- a/app/views/pages/school_leader_additional_information.html.erb
+++ b/app/views/pages/school_leader_additional_information.html.erb
@@ -15,12 +15,12 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>
         <%= govuk_link_to "guidance for ECTs",
-            "ect_additional_information"
+            "ect-additional-information"
             %>
       </li>
       <li>
         <%= govuk_link_to "guidance for mentors",
-            "mentor_additional_information"
+            "mentor-additional-information"
             %>
       </li>
       <li>

--- a/app/views/pages/school_leader_additional_information.html.erb
+++ b/app/views/pages/school_leader_additional_information.html.erb
@@ -39,19 +39,18 @@
                                             "What happens if an ECT has concerns or difficulties?",
                                             "Who should observe an ECT’s teaching practice?",
                                             "How should we choose and support mentors?",
-                                            "Why does DfE need personal information from ECTs and mentors?",
+                                            "Why does DfE need personal information from ECT’s and mentors?",
                                             "Do I need to tell the DfE which training provider we’re using?",
                                             "How does funding for training work?",
                                             "What support is available for teachers who complete induction in autumn 2021 or spring 2022?",
                                             "When and why do we need to use the DfE’s service?"
                                             ]) %>
 
-    <section id="What-are-the-responsibilities-of-each-role-and-organisation?">
+    <section id="what-are-the-responsibilities-of-each-role-and-organisation">
       <h2 class="govuk-heading-l">What are the responsibilities of each role and organisation?</h2>
     </section>
-    <section id="What’s-the-role-of-the-DfE-funded-provider?">
-      <h3 class="govuk-heading-m">What’s the role of the DfE-funded provider?</h3>
-    </section>
+
+    <h3 class="govuk-heading-m">What’s the role of the DfE-funded provider?</h3>
     <h4 class="govuk-heading-s">Lead providers</h4>
     <p>
       Schools can choose from one of 6 DfE-funded training providers. These organisations are known as ‘lead providers’.
@@ -89,7 +88,7 @@
       Read more about the <%= govuk_link_to "and responsibilities of appropriate bodies", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework" %>.
     </p>
 
-    <h3 class="govuk-heading-m">What’s Ofsted’s role in the quality assurance of the training?</h2>
+    <h3 class="govuk-heading-m">What’s Ofsted’s role in the quality assurance of the training?</h3>
     <p>
       Ofsted will inspect the DfE-funded training providers known as lead providers. Inspection will focus on the quality of
       professional development and training, and the leadership and management of the lead provider. These reports may help you
@@ -138,7 +137,7 @@
       Read about the <%= govuk_link_to "different tasks and responsibilities for ECTs, mentors and induction tutors",
                          "https://manage-training-for-early-career-teachers.education.gov.uk/pages/what-each-person-does" %>.
     </p>
-    <section id="Is-the-ECF-an-assessment-tool?" %>
+    <section id="is-the-ecf-an-assessment-tool" %>
       <h2 class="govuk-heading-l">Is the ECF an assessment tool?</h2>
     </section>
     <p>
@@ -164,7 +163,8 @@
     <p>
       Assessments should be supported by regular reviews to monitor progress. These should take place in terms without a formal assessment.
     </p>
-    <section id="Do-ECTs-have-to-complete-ECF-based-training-on-top-of-another-induction-programme?" %>
+
+    <section id="do-ects-have-to-complete-ecf-based-training-on-top-of-another-induction-programme" %>
       <h2 class="govuk-heading-l">Do ECTs have to complete ECF-based training on top of another induction programme?</h2>
     </section>
     <p>
@@ -178,7 +178,7 @@
       Your school may choose to offer your ECTs extra training and support to meet essential specific needs, reflecting local
       policies and practices (e.g. on safeguarding). This additional training does not replace their entitlement to the ECF-based programme however.
     </p>
-    <section id="Can-we-register-an-ECT-with-a-training-provider-if-they-start-mid-term,-or-work-part-time?" %>
+    <section id="can-we-register-an-ect-with-a-training-provider-if-they-start-mid-term-or-work-part-time" %>
       <h2 class="govuk-heading-l">Can we register an ECT with a training provider if they start mid-term, or work part-time?</h2>
     </section>
     <p>
@@ -199,7 +199,8 @@
       <%= govuk_link_to "section 3 of the statutory guidance", "https://www.gov.uk/government/publications/induction-for-early-career-teachers-england" %>
       for more information.
     </p>
-    <section id="What-happens-if-an-ECT-has-concerns-or-difficulties?">
+
+    <section id="what-happens-if-an-ect-has-concerns-or-difficulties">
       <h2 class="govuk-heading-l">What happens if an ECT has concerns or difficulties?</h2>
     </section>
     <p>
@@ -224,7 +225,7 @@
       The DfE and training providers are committed to maximising the impact of the ECF reforms. We welcome any feedback on the programmes, including ECT engagement. You can share this directly with your training provider, or email the DfE: continuing-professional-development@digital.education.gov.uk.
     </p>
 
-    <section id="Who-should-observe-an-ECT’s-teaching-practice?" %>
+    <section id="who-should-observe-an-ect-s-teaching-practice" %>
       <h2 class="govuk-heading-l">Who should observe an ECT’s teaching practice?</h2>
     </section>
     <p>
@@ -239,7 +240,7 @@
       of the training programme. These observations are for development purposes only and should not be used for formal assessment.
     </p>
 
-    <section id="How-should-we-choose-and-support-mentors?">
+    <section id="how-should-we-choose-and-support-mentors">
       <h2 class="govuk-heading-l">How should we choose and support mentors?</h2>
     </section>
     <h3 class="govuk-heading-m">What happens if our school does not have a teacher with QTS available to act as a mentor?</h3>
@@ -288,7 +289,7 @@
       Yes. If mentors were assigned an ECT at the start of the programme, they can continue training so they are ready to work with other ECTs.
     </p>
 
-    <section id="Why-does-DfE-need-personal-information-from-ECTs-and-mentors?">
+    <section id="why-does-dfe-need-personal-information-from-ect-s-and-mentors">
       <h2 class="govuk-heading-l">Why does DfE need personal information from ECTs and mentors?</h2>
     </section>
     <p>
@@ -309,7 +310,7 @@
       Read our step-by-step guidance on <%= govuk_link_to "how to set up your programme using the DfE service", "https://manage-training-for-early-career-teachers.education.gov.uk/how-to-set-up-your-programme" %>.
     </p>
 
-    <section id="Do-I-need-to-tell-the-DfE-which-training-provider-we’re-using?">
+    <section id="do-i-need-to-tell-the-dfe-which-training-provider-we-re-using">
       <h2 class="govuk-heading-l">Do I need to tell the DfE which training provider we’re using?</h2>
     </section>
     <p>
@@ -322,7 +323,7 @@
       If you cannot see the training provider’s name in your account, ask them to confirm the partnership with their lead provider so DfE has the correct information.
     </p>
 
-    <section id="How-does-funding-for-training-work?">
+    <section id="how-does-funding-for-training-work">
       <h2 class="govuk-heading-l">How does funding for training work?</h2>
     </section>
     <p>
@@ -419,7 +420,7 @@
      ECTs undertaking a reduced induction will be funded proportionately. They’ll be identified using school workforce census data collections over the period.
    </p>
 
-   <section id="What-support-is-available-for-teachers-who-complete-induction-in-autumn-2021-or-spring-2022?">
+   <section id="what-support-is-available-for-teachers-who-complete-induction-in-autumn-2021-or-spring-2022">
      <h2 class="govuk-heading-l">What support is available for teachers who complete induction in autumn 2021 or spring 2022?</h2>
    </section>
    <p>
@@ -432,7 +433,7 @@
    </ul>
      <p>They’ll be identified using school workforce census data collections over the period.</p>
 
-   <section id="When-and-why-do-we-need-to-use-the-DfE’s-service?">
+   <section id="when-and-why-do-we-need-to-use-the-dfe-s-service">
      <h2 class="govuk-heading-l">When and why do we need to use the DfE’s service?</h2>
    </section>
    <p>

--- a/app/views/pages/school_leader_additional_information.html.erb
+++ b/app/views/pages/school_leader_additional_information.html.erb
@@ -53,7 +53,9 @@
     <h3 class="govuk-heading-m">What’s the role of the DfE-funded provider?</h3>
     <h4 class="govuk-heading-s">Lead providers</h4>
     <p>
-      Schools can choose from one of 6 DfE-funded training providers. These organisations are known as ‘lead providers’.
+      Schools can choose from one of
+      <%= govuk_link_to "6 DfE-funded training providers", "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview#FPL" %>.
+      These organisations are known as ‘lead providers’.
     </p>
 
     <h4 class="govuk-heading-s">Delivery partners</h4>
@@ -85,7 +87,7 @@
       Find <%= govuk_link_to "information for local and national appropriate bodies here", "https://www.gov.uk/government/publications/statutory-teacher-induction-appropriate-bodies/find-an-appropriate-body" %>.
     </p>
     <p>
-      Read more about the <%= govuk_link_to "and responsibilities of appropriate bodies", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework" %>.
+      Read more about the <%= govuk_link_to "role and responsibilities of appropriate bodies", "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework" %>.
     </p>
 
     <h3 class="govuk-heading-m">What’s Ofsted’s role in the quality assurance of the training?</h3>
@@ -145,7 +147,7 @@
     </p>
     <p>
       ECTs will follow an ECF-based training programme, but they cannot fail it. Completing assignments as part of their
-      training programme is one way for ECTs to collect evidence that they meet the Teachers’ Standards
+      training programme is one way for ECTs to collect evidence that they meet the Teachers’ Standards.
     </p>
     <p>
       Headteachers are responsible for ensuring ECT’s continue to be assessed against the Teachers’ Standards as part of
@@ -176,7 +178,7 @@
     </p>
     <p>
       Your school may choose to offer your ECTs extra training and support to meet essential specific needs, reflecting local
-      policies and practices (e.g. on safeguarding). This additional training does not replace their entitlement to the ECF-based programme however.
+      policies and practices (on safeguarding, for example). This additional training does not replace their entitlement to the ECF-based programme however.
     </p>
     <section id="can-we-register-an-ect-with-a-training-provider-if-they-start-mid-term-or-work-part-time" %>
       <h2 class="govuk-heading-l">Can we register an ECT with a training provider if they start mid-term, or work part-time?</h2>
@@ -216,13 +218,18 @@
 
     <h3 class="govuk-heading-m">What happens if an ECT does not fully engage with their provider-led training?</h2>
     <p>
-      The Early Career Framework reforms are designed to support early career teachers to succeed at the start of their careers by helping them to support their pupils to achieve their full potential.It is therefore important that ECTs engage with the training and receive their statutory entitlement to an ECF-based induction.
+      The ECF reforms are designed to support early career teachers to succeed at the start of their careers by helping
+      them to support their pupils to achieve their full potential. It’s therefore important that ECTs engage with the training and receive their statutory entitlement to an ECF-based induction.
     </p>
     <p>
-      If an ECT is unable to participate sufficiently, they can be withdrawn from the programme by your training provider. If that happens, your school will be responsible for signing up with another provider or delivering an ECF-based induction directly which would need to be ‘fidelity checked’ by your appropriate body to ensure it is based on the ECF.
+      If an ECT is unable to participate sufficiently, they can be withdrawn from the programme by your training provider.
+      If that happens, your school will be responsible for signing up with another provider or delivering an ECF-based induction directly
+      which would need to be ‘fidelity checked’ by your appropriate body to ensure it’s based on the ECF.
     </p>
     <p>
-      The DfE and training providers are committed to maximising the impact of the ECF reforms. We welcome any feedback on the programmes, including ECT engagement. You can share this directly with your training provider, or email the DfE: continuing-professional-development@digital.education.gov.uk.
+      The DfE and training providers are committed to maximising the impact of the ECF reforms. We welcome any feedback on the programmes,
+      including ECT engagement. You can share this directly with your training provider, or email the DfE:
+      <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>.
     </p>
 
     <section id="who-should-observe-an-ect-s-teaching-practice" %>
@@ -266,7 +273,7 @@
     </p>
     <p>
       Training providers will have minimum requirements for engagement to make sure mentors receive the full benefit of their
-      programme, allowing them to provide support to their early career teachers and set them up for a successful and fulfilling career in teaching.
+      programme, allowing them to provide support to their ECTs and set them up for a successful and fulfilling career in teaching.
     </p>
     <p>
       Find out <%= govuk_link_to "how backfill payments for mentors will be made", "#How-will-backfill-payments-for-mentors-be-made?" %>.
@@ -286,7 +293,7 @@
 
     <h3 class="govuk-heading-m">Can a mentor continue training if an ECT withdraws from the programme?</h3>
     <p>
-      Yes. If mentors were assigned an ECT at the start of the programme, they can continue training so they are ready to work with other ECTs.
+      Yes. If mentors were assigned an ECT at the start of the programme, they can continue training so they’re ready to work with other ECTs.
     </p>
 
     <section id="why-does-dfe-need-personal-information-from-ect-s-and-mentors">
@@ -424,7 +431,7 @@
      <h2 class="govuk-heading-l">What support is available for teachers who complete induction in autumn 2021 or spring 2022?</h2>
    </section>
    <p>
-     DfE is offering additional support to NQTs whose induction was impacted by coronavirus (COVID-19).
+     DfE is offering additional support to newly qualified teachers (NQTs) whose induction was impacted by coronavirus (COVID-19).
      NQTs are eligible for time off timetable funding and access to ECF induction training materials if they:
    </p>
    <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
## Ticket and context

Ticket:[268](https://dfedigital.atlassian.net/browse/CST-268)

We had the css for a contents list taken from [govuk publishing components](https://components.publishing.service.gov.uk/component-guide/contents_list). I've used similar styling to how they do but after speaking with Kate, we wanted the heading and bullets a bit bigger than they example. 

<img width="686" alt="Screenshot 2022-01-27 at 20 20 45" src="https://user-images.githubusercontent.com/69353998/151437412-eb5ad980-a616-4a21-b91d-4b5b13411745.png">


## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Go to `pages/ect_additional_information` , `pages/mentor_additional_information` and`pages/school_leader_additional_information`
