### PR TITLE
[CPDLP-937] Add participant drilldown to finance area

### DIFF
--- a/app/controllers/finance/participants_controller.rb
+++ b/app/controllers/finance/participants_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Finance
+  class ParticipantsController < BaseController
+    def index
+      if params[:query]
+        @user = User.find_by(id: params[:query].strip)
+
+        if @user
+          redirect_to finance_participant_path(@user)
+        else
+          flash.now[:alert] = "No user found"
+        end
+      end
+    end
+
+    def show
+      @user = User.includes(:participant_profiles).find(params[:id])
+    end
+  end
+end

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -14,6 +14,10 @@ class ParticipantProfile < ApplicationRecord
       true
     end
 
+    def ecf?
+      false
+    end
+
     def approved?
       validation_decision(:decision).approved?
     end

--- a/app/views/finance/landing_page/show.html.erb
+++ b/app/views/finance/landing_page/show.html.erb
@@ -7,6 +7,7 @@
         <h2 class="govuk-heading-m"><%= govuk_link_to "Payment Breakdown", finance_payment_breakdowns_url %></h2>
         <p>Review upcoming payments to providers</p>
       </div>
+
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Contract Summary", "#" %></h2>
         <p>View all current contract details</p>
@@ -18,6 +19,7 @@
         <h2 class="govuk-heading-m"><%= govuk_link_to "Provider dashboard", "#" %></h2>
         <p>Overview of all course providers</p>
       </div>
+
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Programme dashboard", "#" %></h2>
         <p>Overview of all programme participants</p>
@@ -28,6 +30,11 @@
       <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m"><%= govuk_link_to "Schedules", finance_schedules_path %></h2>
         <p>Overview of all schedules</p>
+      </div>
+
+      <div class="govuk-grid-column-one-half">
+        <h2 class="govuk-heading-m"><%= govuk_link_to "Participant drilldown", finance_participants_path %></h2>
+        <p>See participants and their declarations</p>
       </div>
     </div>
   </div>

--- a/app/views/finance/participants/_declaration.html.erb
+++ b/app/views/finance/participants/_declaration.html.erb
@@ -1,0 +1,41 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.row do |row| %>
+    <% row.key { "Declaration type" } %>
+    <% row.value { declaration.declaration_type } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Declaration date" } %>
+    <% row.value { declaration.declaration_date.to_s(:govuk) } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Course identifier" } %>
+    <% row.value { declaration.course_identifier } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Evidence held" } %>
+    <% row.value { declaration.evidence_held } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Lead provider" } %>
+    <% row.value { declaration.cpd_lead_provider.name } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "State" } %>
+    <% row.value { declaration.state } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Created at" } %>
+    <% row.value { declaration.created_at.to_s(:govuk) } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Updated at" } %>
+    <% row.value { declaration.updated_at.to_s(:govuk) } %>
+  <% end %>
+<% end %>

--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -1,0 +1,47 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.row do |row| %>
+    <% row.key { "User ID / Participant ID" } %>
+    <% row.value { @user.id } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Profile ID" } %>
+    <% row.value { pp.id } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Lead provider" } %>
+    <% row.value { pp&.school_cohort&.school&.active_partnerships[0]&.lead_provider&.name } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "School URN" } %>
+    <% row.value { pp&.school_cohort&.school&.urn } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Status" } %>
+    <% row.value { pp.status } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Training status" } %>
+    <% row.value { pp.training_status } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Created at" } %>
+    <% row.value { pp.created_at.to_s(:govuk) } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Updated at" } %>
+    <% row.value { pp.updated_at.to_s(:govuk) } %>
+  <% end %>
+<% end %>
+
+<h4>Declarations</h4>
+
+<% pp.participant_declarations.each do |declaration| %>
+  <%= render partial: "finance/participants/declaration", locals: { declaration: declaration } %>
+<% end %>

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -1,0 +1,41 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.row do |row| %>
+    <% row.key { "application id" } %>
+    <% row.value { application.id } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Lead provider" } %>
+    <% row.value { application.npq_lead_provider.name } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Lead provider approval status" } %>
+    <% row.value { application.lead_provider_approval_status } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "NPQ course" } %>
+    <% row.value { application.npq_course.name } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "School URN" } %>
+    <% row.value { application.school_urn } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "School UKPRN" } %>
+    <% row.value { application.school_ukprn } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Created at" } %>
+    <% row.value { application.created_at.to_s(:govuk) } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Updated at" } %>
+    <% row.value { application.updated_at.to_s(:govuk) } %>
+  <% end %>
+<% end %>

--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -1,0 +1,42 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.row do |row| %>
+    <% row.key { "User ID / Participant ID" } %>
+    <% row.value { @user.id } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Profile ID" } %>
+    <% row.value { pp.id } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "NPQ course" } %>
+    <% row.value { pp.npq_course&.name } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Status" } %>
+    <% row.value { pp.status } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Training status" } %>
+    <% row.value { pp.training_status } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Created at" } %>
+    <% row.value { pp.created_at.to_s(:govuk) } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Updated at" } %>
+    <% row.value { pp.updated_at.to_s(:govuk) } %>
+  <% end %>
+<% end %>
+
+<h4>Declarations</h4>
+
+<% pp.participant_declarations.each do |declaration| %>
+  <%= render partial: "finance/participants/declaration", locals: { declaration: declaration } %>
+<% end %>

--- a/app/views/finance/participants/index.html.erb
+++ b/app/views/finance/participants/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_landing_page_path) %>
+
+<h1 class="govuk-heading-xl">Participants</h1>
+
+<%= render SearchBox.new(
+  query: params[:query],
+  title: "Search participants",
+  hint: "Enter the participant’s ID",
+) %>

--- a/app/views/finance/participants/show.html.erb
+++ b/app/views/finance/participants/show.html.erb
@@ -1,0 +1,49 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_participants_path) %>
+
+<h1 class="govuk-heading-xl">Participant</h1>
+
+<h2>Identities</h2>
+
+<% @user.participant_identities.each_with_index do |identity, i| %>
+  <h3><%= "Identity #{i + 1}" %></h3>
+
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        User ID / Participant ID
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= govuk_link_to identity.user_id, finance_participant_path(identity.user_id) %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        External ID
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= govuk_link_to identity.external_identifier, finance_participant_path(identity.external_identifier) %>
+      </dd>
+    </div>
+  </dl>
+<% end %>
+
+<h2>Profiles</h2>
+
+<% @user.participant_profiles.each do |pp| %>
+  <h3><%= pp.type %></h3>
+
+  <% if pp.ecf? %>
+    <%= render partial: "finance/participants/ecf_profile", locals: { pp: pp } %>
+  <% else %>
+    <%= render partial: "finance/participants/npq_profile", locals: { pp: pp } %>
+  <% end %>
+<% end %>
+
+<h2>NPQ applications</h2>
+
+<% @user.npq_applications.each_with_index do |application, i| %>
+  <h3><%= "NPQ application #{i + 1}" %></h3>
+
+  <%= render partial: "finance/participants/npq_application", locals: { application: application } %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -283,6 +283,8 @@ Rails.application.routes.draw do
   namespace :finance do
     resource :landing_page, only: :show, path: "manage-cpd-contracts", controller: "landing_page"
 
+    resources :participants, only: %i[index show]
+
     resource :payment_breakdowns, only: :show, path: "payment-breakdowns", controller: "payment_breakdowns" do
       get "/choose-programme", to: "payment_breakdowns#select_programme", as: :select_programme
       post "/choose-programme", to: "payment_breakdowns#choose_programme", as: :choose_programme

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
 
         participant_profile.npq_application ||= npq_application
         participant_profile.schedule = schedule
+        participant_profile.npq_course = npq_application.npq_course
       end
     end
 

--- a/spec/features/finance/participant_drilldown_spec.rb
+++ b/spec/features/finance/participant_drilldown_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Finance users participant drilldown", type: :feature do
+  let(:ect_user) { create(:user, :early_career_teacher) }
+  let(:ect_profile) { ect_user.early_career_teacher_profile }
+  let(:ect_declaration) { create(:ect_participant_declaration, user: ect_user, participant_profile: ect_profile) }
+
+  let(:npq_user) { create(:user, :npq) }
+  let(:npq_profile) { npq_user.npq_profiles[0] }
+  let(:npq_declaration) { create(:npq_participant_declaration, user: npq_user, participant_profile: npq_profile) }
+  let(:npq_application) { create(:npq_application, participant_identity: npq_identity) }
+  let(:npq_identity) { create(:participant_identity, :npq_origin, user: npq_user) }
+
+  scenario "viewing ECT user" do
+    given_i_am_logged_in_as_a_finance_user
+    and_an_ect_user_with_profile_and_declarations
+    when_i_visit_the_finance_homepage
+    and_i_click_on("Participant drilldown")
+    then_i_see("Search participants")
+
+    when_i_fill_in("query", with: ect_user.id)
+    and_i_click_on("Search")
+    then_i_see("ParticipantProfile::ECT")
+    and_i_see("Declaration type#{ect_declaration.declaration_type}")
+  end
+
+  def when_i_visit_the_finance_homepage
+    visit("/finance/manage-cpd-contracts")
+  end
+
+  def and_i_click_on(string)
+    page.click_on(string)
+  end
+
+  def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def and_i_see(string)
+    then_i_see(string)
+  end
+
+  def when_i_fill_in(selector, with:)
+    page.fill_in selector, with: with
+  end
+
+  def and_an_ect_user_with_profile_and_declarations
+    ect_user
+    ect_profile
+    ect_declaration
+  end
+
+  def and_an_npq_user_with_application_and_profile_and_declarations
+    npq_user
+    npq_profile
+    npq_identity
+    npq_declaration
+    npq_application
+  end
+
+  scenario "viewing NPQ user" do
+    given_i_am_logged_in_as_a_finance_user
+    and_an_npq_user_with_application_and_profile_and_declarations
+    when_i_visit_the_finance_homepage
+    and_i_click_on("Participant drilldown")
+    then_i_see("Search participants")
+
+    when_i_fill_in("query", with: npq_user.id)
+    and_i_click_on("Search")
+    then_i_see("Identity 1")
+    and_i_see("ParticipantProfile::NPQ")
+    and_i_see("Declaration type#{npq_declaration.declaration_type}")
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-937

- Adds participant drilldown to finance area
- Can search for a user based off `participant_id`
- Returns their identities, profiles, declarations and npq applications
- No real optimisation has happened with regard to DB queries but don't think it will cause an issue

## Screenshots

Entry point
![Screenshot 2022-01-31 at 12 38 37](https://user-images.githubusercontent.com/92580/151820626-25839c85-3189-4751-8a0c-6df25ed8dcb3.png)

Searching for a participant
![Screenshot 2022-01-31 at 12 38 29](https://user-images.githubusercontent.com/92580/151820650-b9a2b472-8c57-4a8f-aa34-a56635002ef9.png)

Viewing an ECT-esque profile
![Screenshot 2022-01-31 at 12 38 11](https://user-images.githubusercontent.com/92580/151820704-d5cdb8e4-1569-41cd-8a29-9f5a6188614c.png)

Viewing an NPQ-esque profile
![Screenshot 2022-01-31 at 12 37 47](https://user-images.githubusercontent.com/92580/151820783-7d18db6d-0de7-46ac-a5b8-febecd76f3c0.png)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- https://ecf-review-pr-1685.london.cloudapps.digital/finance
- Login as finance user
- Navigate to participants drilldown
- Search for participants with following ids below:
- `2282c10c-8d0f-41eb-ac85-b8137a618b08` mentor
- `031d81f7-5541-49ba-91f6-c510ef0cab57` ect
- `79416621-a08f-4e32-acd1-25f947013e6d` npq
- Should see their correct identities, profiles, declarations and applications

## External API changes

- None