### PR TITLE
Add identity external identifier to analytics database

### DIFF
--- a/app/services/analytics/ecf_validation_service.rb
+++ b/app/services/analytics/ecf_validation_service.rb
@@ -8,6 +8,7 @@ module Analytics
 
         record = Analytics::ECFParticipant.find_or_initialize_by(participant_profile_id: participant_profile.id)
         record.user_id = participant_profile.user.id
+        record.external_id = participant_profile.participant_identity.external_identifier
         record.user_created_at = participant_profile.user.created_at
         record.trn_verified = trn_verified?(participant_profile)
         record.school_urn = participant_profile.school_cohort.school.urn

--- a/db/analytics_migrate/20220131150652_add_external_id_to_ecf_participant.rb
+++ b/db/analytics_migrate/20220131150652_add_external_id_to_ecf_participant.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExternalIdToECFParticipant < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ecf_participants, :external_id, :string
+  end
+end

--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_20_103423) do
+ActiveRecord::Schema.define(version: 2022_01_31_150652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_103423) do
     t.boolean "sparsity"
     t.boolean "pupil_premium"
     t.string "schedule_identifier"
+    t.string "external_id"
     t.index ["participant_profile_id"], name: "index_ecf_participants_on_participant_profile_id"
   end
 


### PR DESCRIPTION
## Ticket and context

This will allow people who consume the analytics database to determine whether a profile has been deduplicated. 

Post-deploy I'll need to re-insert all records so that they have this field.