### PR TITLE
[CST-316] temporary sit add ect/mentor content

### DIFF
--- a/app/controllers/schools/add_participants_controller.rb
+++ b/app/controllers/schools/add_participants_controller.rb
@@ -20,7 +20,7 @@ module Schools
         if add_participant_form.type == :self
           redirect_to action: :show, step: :yourself
         else
-          redirect_to action: :show, step: :name
+          redirect_to action: :show, step: :started
         end
       else
         redirect_to action: :show, step: form.next_step

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -13,6 +13,10 @@ module Schools
       next_step :confirm
     end
 
+    step :started do
+      next_step :name
+    end
+
     step :name do
       attribute :full_name
 

--- a/app/views/schools/add_participants/_ect_already_started.html.erb
+++ b/app/views/schools/add_participants/_ect_already_started.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Has this ECT already started their induction at another school?" %>
+
+<h1 class="govuk-heading-xl">Has this ECT already started their induction at another school?</h1>
+<p class="govuk-body">You can only add new ECTs to this service at the moment.</p>
+<p class="govuk-body govuk-!-font-weight-bold">Add an ECT who’s started their induction</p>
+<p class="govuk-body">If an ECT is transferring from another school where they’ve already started their induction, contact us for help:
+<%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>
+<p class="govuk-body govuk-!-font-weight-bold">Add an ECT who has not started their induction</p>

--- a/app/views/schools/add_participants/_mentor_already_started.html.erb
+++ b/app/views/schools/add_participants/_mentor_already_started.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Has this person already started mentoring ECTs at another school?" %>
+
+<h1 class="govuk-heading-xl">Has this person already started mentoring ECTs at another school?</h1>
+<p class="govuk-body">You can only add new mentors to this service at the moment.</p>
+<p class="govuk-body govuk-!-font-weight-bold">Add a mentor who’s already started mentoring ECTs</p>
+<p class="govuk-body">If a mentor is transferring from another school where they’ve already started mentoring ECTs, contact us for help:
+<%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>
+<p class="govuk-body govuk-!-font-weight-bold">Add a mentor who has not started mentoring ECTs</p>

--- a/app/views/schools/add_participants/_mentor_already_started.html.erb
+++ b/app/views/schools/add_participants/_mentor_already_started.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-xl">Has this person already started mentoring ECTs at another school?</h1>
 <p class="govuk-body">You can only add new mentors to this service at the moment.</p>
-<p class="govuk-body govuk-!-font-weight-bold">Add a mentor who’s already started mentoring ECTs</p>
+<p class="govuk-body govuk-!-font-weight-bold">Add a mentor who has already started mentoring ECTs</p>
 <p class="govuk-body">If a mentor is transferring from another school where they’ve already started mentoring ECTs, contact us for help:
 <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>
 <p class="govuk-body govuk-!-font-weight-bold">Add a mentor who has not started mentoring ECTs</p>

--- a/app/views/schools/add_participants/started.html.erb
+++ b/app/views/schools/add_participants/started.html.erb
@@ -1,0 +1,20 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+
+    <% if add_participant_form.type == :ect %>
+      <%= render partial: "ect_already_started" %>
+    <% else %>
+      <%= render partial: "mentor_already_started" %>
+    <% end %>
+
+    <p class="govuk-body">Continue using this service to add this person.</p>
+
+    <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/spec/features/schools/participants/add_participants_spec.rb
+++ b/spec/features/schools/participants/add_participants_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe "Add participants", js: true do
     then_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT and mentors"
 
     when_i_click_on_add_ect
+    then_i_am_taken_to_the_ect_already_started_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Has ECT already started"
+
     when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
     then_the_page_should_be_accessible
@@ -68,6 +72,10 @@ RSpec.describe "Add participants", js: true do
     then_i_am_taken_to_your_ect_and_mentors_page
 
     when_i_click_on_add_mentor
+    then_i_am_taken_to_the_mentor_already_started_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Has mentor already started"
+
     when_i_click_on_continue
     then_i_am_taken_to_add_mentor_name_page
     then_the_page_should_be_accessible

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe "Update participants details", js: true do
 
   scenario "Induction tutor can change ECT / mentor name from check details page" do
     when_i_click_on_add_ect
+    then_i_am_taken_to_the_ect_already_started_page
+
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
 
     when_i_add_ect_or_mentor_name
@@ -57,6 +60,9 @@ RSpec.describe "Update participants details", js: true do
 
   scenario "Induction tutor can change ECT / mentor email from check details page" do
     when_i_click_on_add_ect
+    then_i_am_taken_to_the_ect_already_started_page
+
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
 
     when_i_add_ect_or_mentor_name
@@ -89,6 +95,9 @@ RSpec.describe "Update participants details", js: true do
 
   scenario "Induction tutor can change ECT / mentor start_term from check details page" do
     when_i_click_on_add_ect
+    then_i_am_taken_to_the_ect_already_started_page
+
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
 
     when_i_add_ect_or_mentor_name
@@ -119,6 +128,8 @@ RSpec.describe "Update participants details", js: true do
 
   scenario "Induction tutor can change ECTs mentor from check details page" do
     when_i_click_on_add_ect
+    then_i_am_taken_to_the_ect_already_started_page
+
     when_i_click_on_continue
     then_i_am_taken_to_add_ect_name_page
 

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -483,6 +483,14 @@ module ManageTrainingSteps
     expect(page).to have_text("The induction tutor and mentor roles are separate")
   end
 
+  def then_i_am_taken_to_the_ect_already_started_page
+    expect(page).to have_selector("h1", text: "Has this ECT already started their induction at another school?")
+  end
+
+  def then_i_am_taken_to_the_mentor_already_started_page
+    expect(page).to have_selector("h1", text: "Has this person already started mentoring ECTs at another school?")
+  end
+
   def then_i_am_taken_to_add_ect_name_page
     expect(page).to have_selector("h1", text: "What’s the full name of this ECT?")
   end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -89,7 +89,7 @@ module ManageTrainingSteps
   # And_steps
 
   def and_i_am_signed_in_as_an_induction_coordinator
-    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort.school])
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort.school], user: create(:user, full_name: "Carl Coordinator"))
     privacy_policy = create(:privacy_policy)
     privacy_policy.accept!(@induction_coordinator_profile.user)
     sign_in_as @induction_coordinator_profile.user


### PR DESCRIPTION
## Ticket and context

Ticket:[316](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?selectedIssue=CST-316)

ECTs and mentors are now moving schools, but we do not have functionality to manage this in the service yet. This causes problems if the ppt’s new school adds them as a duplicate record. We need to let SITs at the new school know to contact support instead of adding them in to the service for their school.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Sign in as `cpd-test+tutor-10@example.com`
3. Go to the dashboard
4. Select `Add a new ECT` or `Add a new mentor`
5. It should be the first screen you see after this step. (Depending on whether you add an ECT or mentor, you'll get slightly different content on this screen. 
