### PR TITLE
Additional pages content amends

### DIFF
--- a/app/views/pages/ect_additional_information.html.erb
+++ b/app/views/pages/ect_additional_information.html.erb
@@ -68,7 +68,7 @@
     </p>
     <p>
       Your school may choose to offer you extra training and support to meet essential specific needs, reflecting local
-      policies and practices (e.g. on safeguarding). This additional training does not replace your entitlement to the ECF-based programme.
+      policies and practices (on safeguarding, for example). This additional training does not replace your entitlement to the ECF-based programme.
     </p>
 
     <section id="do-i-need-to-collect-evidence-during-my-ecf-based-training">
@@ -87,7 +87,7 @@
     </section>
     <p>
       You can start your induction at any time. Your school can choose from
-      <%= govuk_link_to "a number of options", "school-leader-additional-information#Can-we-register-an-ect-with-a-training-provider-if-they-start-mid-term-or-work-part-time" %>
+      <%= govuk_link_to "a number of options", "school-leader-additional-information#can-we-register-an-ect-with-a-training-provider-if-they-start-mid-term-or-work-part-time" %>
        to make sure your ECF-based training fits your own circumstances.
     <p>
       If you’re serving a reduced induction period, there’s no expectation that you should cover the full depth of the ECF.
@@ -109,10 +109,10 @@
         10% off timetable in the first year, and 5% off timetable in the second year to undertake activities including training and mentoring
       </li>
       <li>
-        a supportive,dedicated mentor
+        a supportive, dedicated mentor
       </li>
       <li>
-        high-quality development materials based on the Early Career Framework.
+        high-quality development materials based on the early career framework
       </li>
     </ul>
     </p>

--- a/app/views/pages/mentor_additional_information.html.erb
+++ b/app/views/pages/mentor_additional_information.html.erb
@@ -68,7 +68,8 @@
       The ECF is not an assessment tool, so you do not have to collect data on your ECT’s performance.
     </p>
     <p>
-      Your school’s headteacher and induction tutor will be responsible for assessing ECTs against the Teachers’ Standards.
+      Your school’s headteacher and induction tutor will be responsible for assessing ECTs against the
+       <%= govuk_link_to "Teachers’ Standards" "https://www.gov.uk/government/publications/teachers-standards" %>.
       Our <%= govuk_link_to "guidance for ECTs", "ect-additional-information" %> explains what evidence they may be asked
       for to demonstrate their performance against those standards.
     </p>
@@ -81,8 +82,7 @@
     </section>
     <p>
       No - ECTs should participate in their ECF-based training programme as fully as possible, but failing to complete it will
-      not mean they fail their induction. Completing the training programme will help them to develop the knowledge and skills they need to meet the
-      <%= govuk_link_to "Teachers’ Standards", "https://www.gov.uk/government/publications/teachers-standards" %>.
+      not mean they fail their induction. Completing the training programme will help them to develop the knowledge and skills they need to meet the Teachers’ Standards.
     </p>
     <p>
       Headteachers are responsible for making sure ECTs are assessed against the Teachers’ Standards as part of their progress reviews,
@@ -188,7 +188,7 @@
 
     <h3 class="govuk-heading-m">How to find your TRN</h3>
     <p>
-      Your TRN is a unique Id that:
+      Your TRN is a unique ID that:
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>

--- a/app/views/pages/mentor_additional_information.html.erb
+++ b/app/views/pages/mentor_additional_information.html.erb
@@ -69,7 +69,7 @@
     </p>
     <p>
       Your school’s headteacher and induction tutor will be responsible for assessing ECTs against the
-       <%= govuk_link_to "Teachers’ Standards" "https://www.gov.uk/government/publications/teachers-standards" %>.
+       <%= govuk_link_to "Teachers’ Standards", "https://www.gov.uk/government/publications/teachers-standards" %>.
       Our <%= govuk_link_to "guidance for ECTs", "ect-additional-information" %> explains what evidence they may be asked
       for to demonstrate their performance against those standards.
     </p>

--- a/app/views/pages/school_leader_additional_information.html.erb
+++ b/app/views/pages/school_leader_additional_information.html.erb
@@ -50,7 +50,9 @@
       <h2 class="govuk-heading-l">What are the responsibilities of each role and organisation?</h2>
     </section>
 
-    <h3 class="govuk-heading-m">What’s the role of the DfE-funded provider?</h3>
+    <section id="what-s-the-role-of-the-dfe-funded-provider">
+      <h3 class="govuk-heading-m">What’s the role of the DfE-funded provider?</h3>
+    </section>
     <h4 class="govuk-heading-s">Lead providers</h4>
     <p>
       Schools can choose from one of
@@ -276,13 +278,13 @@
       programme, allowing them to provide support to their ECTs and set them up for a successful and fulfilling career in teaching.
     </p>
     <p>
-      Find out <%= govuk_link_to "how backfill payments for mentors will be made", "#How-will-backfill-payments-for-mentors-be-made?" %>.
+      Find out <%= govuk_link_to "how backfill payments for mentors will be made", "#how-will-backfill-payments-for-mentors-be-made" %>.
     </p>
 
     <h3 class="govuk-heading-m">Do all mentors need to attend training, or can some attend and pass information to colleagues?</h3>
     <p>
       If your school has chosen to use a DfE-funded training provider, each mentor is expected to take part. Your school will receive
-      <%= govuk_link_to "additional funding to backfill each mentor’s training time", "#How-will-backfill-payments-for-mentors-be-made?" %>.
+      <%= govuk_link_to "additional funding to backfill each mentor’s training time", "#how-will-backfill-payments-for-mentors-be-made" %>.
     </p>
 
     <h3 class="govuk-heading-m">What happens if a mentor has concerns or difficulties regarding mentoring?</h3>
@@ -346,7 +348,7 @@
     <h3 class="govuk-heading-m">Which schools are eligible for funded training?</h3>
     <p>
       State-funded schools can choose to work with one of
-      <%= govuk_link_to "6 training providers", "#What’s-the-role-of-the-DfE-funded-provider?" %> that are accredited and funded by the DfE.
+      <%= govuk_link_to "6 training providers", "#what-s-the-role-of-the-dfe-funded-provider" %> that are accredited and funded by the DfE.
     </p>
     <p>
       All maintained and non-maintained special schools and independent schools that receive Section 41 funding can access a funded provider-led programme too.
@@ -385,7 +387,7 @@
     <p>
       We’ll confirm how funding will be allocated for ECTs and mentors when ECTs move school partway through the year in due course.
     </p>
-    <section id="How-will-backfill-payments-for-mentors-be-made?">
+    <section id="how-will-backfill-payments-for-mentors-be-made">
       <h3 class="govuk-heading-m">How will backfill payments for mentors be made?</h3>
     </section>
     <p>


### PR DESCRIPTION
## Ticket and context

[316](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119/backlog?selectedIssue=CST-316&text=316)

Some content changes on the additional information pages have been picked up so this is just making those. Kate has made a note of them in the ticket comments.

Go to: 
`/pages/ect_additional_information`
`/pages/mentor_additional_information`
`/pages/school_leader_additional_information`