### PR TITLE
[CST-347]Re-add autumn_2021 to start term options

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -4,7 +4,7 @@ class ParticipantProfile < ApplicationRecord
   class ECF < ParticipantProfile
     self.ignored_columns = %i[school_id]
 
-    CURRENT_START_TERM_OPTIONS = %w[spring_2022 summer_2022].freeze
+    CURRENT_START_TERM_OPTIONS = %w[autumn_2021 spring_2022 summer_2022].freeze
 
     belongs_to :school_cohort
     belongs_to :core_induction_programme, optional: true


### PR DESCRIPTION
## Ticket and context

Ticket:[347](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?selectedIssue=CST-347)

We've had some support queries asking to choose Autumn 2021 as an option but we removed in [1580](https://github.com/DFE-Digital/early-careers-framework/pull/1580). Adding it back will allow users to select Autumn 2021 again