### PR TITLE
Change default for start_term

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -111,7 +111,7 @@ module Schools
       if type == :self
         self.full_name = current_user.full_name
         self.email = current_user.email
-        self.start_term = "Autumn 2021" if start_term.nil?
+        self.start_term = "autumn_2021" if start_term.nil?
         self.participant_type = :mentor
       else
         self.participant_type = type

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -38,7 +38,7 @@ module EarlyCareerTeachers
 
     attr_reader :full_name, :email, :start_term, :school_cohort, :mentor_profile_id, :year_2020
 
-    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_term: "Autumn 2021", year_2020: false)
+    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_term: "autumn_2021", year_2020: false)
       @full_name = full_name
       @email = email
       @start_term = start_term

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -37,7 +37,7 @@ module Mentors
 
     attr_reader :full_name, :email, :start_term, :school_cohort
 
-    def initialize(full_name:, email:, school_cohort:, start_term: "Autumn 2021", **)
+    def initialize(full_name:, email:, school_cohort:, start_term: "autumn_2021", **)
       @full_name = full_name
       @email = email
       @start_term = start_term

--- a/db/migrate/20220207133656_change_default_start_term_on_participant_profile.rb
+++ b/db/migrate/20220207133656_change_default_start_term_on_participant_profile.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 class ChangeDefaultStartTermOnParticipantProfile < ActiveRecord::Migration[6.1]
-  def change
-    change_column_default :participant_profiles, :start_term, from: "Autumn 2021", to: "autumn_2021"
+  def up
+    change_column_default :participant_profiles, :start_term, "autumn_2021"
+
+    ParticipantProfile.where(start_term: "Autumn 2021").update_all(start_term: "autumn_2021")
+    ParticipantProfile.where(start_term: "Spring 2022").update_all(start_term: "spring_2022")
+    ParticipantProfile.where(start_term: "Summer 2022").update_all(start_term: "summer_2022")
+  end
+
+  def down
+    change_column_default :participant_profiles, :start_term, "Autumn 2021"
+
+    ParticipantProfile.where(start_term: "autumn_2021").update_all(start_term: "Autumn 2021")
+    ParticipantProfile.where(start_term: "spring_2022").update_all(start_term: "Spring 2022")
+    ParticipantProfile.where(start_term: "summer_2022").update_all(start_term: "Summer 2022")
   end
 end

--- a/db/migrate/20220207133656_change_default_start_term_on_participant_profile.rb
+++ b/db/migrate/20220207133656_change_default_start_term_on_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeDefaultStartTermOnParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :participant_profiles, :start_term, from: "Autumn 2021", to: "autumn_2021"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_11_133250) do
+ActiveRecord::Schema.define(version: 2022_02_07_133656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -578,8 +578,8 @@ ActiveRecord::Schema.define(version: 2022_01_11_133250) do
     t.string "training_status", default: "active", null: false
     t.string "profile_duplicity", default: "single", null: false
     t.uuid "participant_identity_id"
-    t.string "start_term", default: "Autumn 2021", null: false
     t.string "notes"
+    t.string "start_term", default: "autumn_2021", null: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
       form.type = form.type_options.sample
       form.full_name = Faker::Name.name
       form.email = Faker::Internet.email
-      form.start_term = "Autumn 2021"
+      form.start_term = "autumn_2021"
       form.mentor_id = (form.mentor_options.pluck(:id) + %w[later]).sample if form.type == :ect
 
       create :ecf_schedule


### PR DESCRIPTION
## Ticket and context

It was noticed that we are storing the `start_term` value on `ParticipantProfile` inconsistently in the database.
This PR moves the defaults to the underscore type of text eg `autumn_2021` instead of `Autumn 2021`.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
