### PR TITLE
Factories that are used with Percy must be deterministic

### DIFF
--- a/spec/cypress/app_commands/scenarios/schools/multiple_schools.rb
+++ b/spec/cypress/app_commands/scenarios/schools/multiple_schools.rb
@@ -8,4 +8,4 @@ FactoryBot.create(:school_cohort, :cip, school: second_school, cohort: cohort)
 third_school = FactoryBot.create(:school, name: "Test School 3", slug: "111113-test-school-3", urn: "111113")
 FactoryBot.create(:school_cohort, :cip, school: third_school, cohort: cohort)
 
-FactoryBot.create(:user, :induction_coordinator, email: "school-leader@example.com", school_ids: [first_school.id, second_school.id])
+FactoryBot.create(:user, :induction_coordinator, name: "School Leader", email: "school-leader@example.com", school_ids: [first_school.id, second_school.id])

--- a/spec/cypress/support/step_definitions/common-navigation.js
+++ b/spec/cypress/support/step_definitions/common-navigation.js
@@ -6,7 +6,12 @@ Given("I am logged in as an {string}", (user) => cy.login(user));
 Given("I am logged in as an induction coordinator for created school", () => {
   cy.appEval("School.all.first").then((school) => {
     cy.appFactories([
-      ["create", "user", "induction_coordinator", { school_ids: [school.id] }],
+      [
+        "create",
+        "user",
+        "induction_coordinator",
+        { full_name: "SIT", email: "sit@example.com", school_ids: [school.id] },
+      ],
     ]).then(() => {
       cy.loginCreated("user");
     });

--- a/spec/features/schools/change_sit/change_sit_spec.rb
+++ b/spec/features/schools/change_sit/change_sit_spec.rb
@@ -142,7 +142,8 @@ private
   end
 
   def create_induction_tutor(*schools)
-    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: schools)
+    user = create(:user, full_name: "Induction Coordinator", email: "ic@example.com")
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: schools, user: user)
   end
 
   def create_partnership(school)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -46,7 +46,8 @@ module ManageTrainingSteps
     second_school = create :school, name: "Test School 2", slug: "111112-test-school-2", urn: "111112"
     create :school_cohort, :cip, school: second_school, cohort: cohort
 
-    create :user, :induction_coordinator, email: "school-leader@example.com", schools: [first_school, second_school]
+    user = create :user, full_name: "School Leader", email: "school-leader@example.com"
+    create :induction_coordinator_profile, user: user, schools: [first_school, second_school]
 
     third_school = FactoryBot.create(:school, name: "Test School 3", slug: "111113-test-school-3", urn: "111113")
     create :school_cohort, :cip, school: third_school, cohort: cohort


### PR DESCRIPTION
If Percy takes snapshots of information that are generated dynamically in factories then it will always alert to 'new' content when in fact it hasn't materially changed.

This PR fixes one such instance.