### PR TITLE
[CPDLP-997] Can persist value of an ECF statement

### DIFF
--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Finance::Statement < ApplicationRecord
+  include FinanceHelper
+
   self.table_name = "statements"
 
   belongs_to :cpd_lead_provider

--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -1,4 +1,21 @@
 # frozen_string_literal: true
 
 class Finance::Statement::ECF < Finance::Statement
+  def cache_original_value!
+    breakdown_started = orchestrator.call(event_type: :started)
+    breakdown_retained_1 = orchestrator.call(event_type: :retained_1)
+    value = total_payment_combined(breakdown_started, breakdown_retained_1)
+
+    update!(original_value: value)
+  end
+
+private
+
+  def orchestrator
+    Finance::ECF::CalculationOrchestrator.new(
+      aggregator: Finance::ECF::ParticipantAggregator,
+      contract: cpd_lead_provider.lead_provider.call_off_contract,
+      statement: self,
+    )
+  end
 end

--- a/db/migrate/20220208121107_add_cached_value_to_statements.rb
+++ b/db/migrate/20220208121107_add_cached_value_to_statements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCachedValueToStatements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :statements, :original_value, :decimal, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_133656) do
+ActiveRecord::Schema.define(version: 2022_02_08_121107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -826,6 +826,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_133656) do
     t.date "payment_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.decimal "original_value"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"
   end
 

--- a/spec/models/finance/statement/ecf_spec.rb
+++ b/spec/models/finance/statement/ecf_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::Statement::ECF do
+  describe "#cache_original_value!" do
+    let(:call_off_contract) { create(:call_off_contract) }
+    let(:ecf_lead_provider) { create(:lead_provider, call_off_contract: call_off_contract) }
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider: ecf_lead_provider) }
+
+    subject { create(:ecf_statement, cpd_lead_provider: cpd_lead_provider) }
+
+    it "persists value of statement" do
+      subject.cache_original_value!
+      expect(subject.reload.original_value).to be_within(1).of(22_287.89)
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-997

- We want to be able to persist the value of a statement against the record
- This is need as we will soon be introducing the ability to void payable declarations
- This would affect the value of a "frozen" statement. Therefore wish to store this value
- One can also the store the value of NPQ statement but by hand
- I have not added the automatic caching of NPQ statements as feel the code is still somewhat fluid and it would be counter-product to do this whereas adding it by hand would probably be more time productive

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- ssh into a rails console
- find a `Finance::Statement::ECF`
- call `#cache_original_value!`
- see `original_value` persisted against the statement

## External API changes

- None