### PR TITLE
[CPDLP-959] Add schedule to finance participant drilldown

### DIFF
--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -30,6 +30,16 @@
   <% end %>
 
   <% summary_list.row do |row| %>
+    <% row.key { "Schedule identifier" } %>
+    <% row.value { pp.schedule&.schedule_identifier } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Schedule cohort" } %>
+    <% row.value { pp.schedule&.cohort&.start_year&.to_s } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
     <% row.key { "Created at" } %>
     <% row.value { pp.created_at.to_s(:govuk) } %>
   <% end %>

--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -25,6 +25,16 @@
   <% end %>
 
   <% summary_list.row do |row| %>
+    <% row.key { "Schedule identifier" } %>
+    <% row.value { pp.schedule&.schedule_identifier } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Schedule cohort" } %>
+    <% row.value { pp.schedule&.cohort&.start_year&.to_s } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
     <% row.key { "Created at" } %>
     <% row.value { pp.created_at.to_s(:govuk) } %>
   <% end %>

--- a/spec/views/finance/participants/show.html.erb_spec.rb
+++ b/spec/views/finance/participants/show.html.erb_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "finance/participants/show.html.erb" do
+  context "with ECF profile" do
+    let(:profile) { create(:ecf_participant_profile) }
+    let(:user) { profile.user }
+
+    it "renders schedule identifier and cohort" do
+      assign :user, user
+
+      render
+
+      expect(rendered).to have_content("Schedule identifier#{profile.schedule.schedule_identifier}")
+      expect(rendered).to have_content("Schedule cohort#{profile.schedule.cohort.start_year}")
+    end
+  end
+
+  context "with NPQ profile" do
+    let(:profile) { create(:npq_participant_profile) }
+    let(:user) { profile.user }
+
+    it "renders schedule identifier and cohort" do
+      assign :user, user
+
+      render
+
+      expect(rendered).to have_content("Schedule identifier#{profile.schedule.schedule_identifier}")
+      expect(rendered).to have_content("Schedule cohort#{profile.schedule.cohort.start_year}")
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-959

- Adds schedule when viewing a profile via participant drilldown in the finance area 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Login as a finance user
- Find a user in the participant drilldown area
- eg `2e2857b8-be3e-48ab-a718-32a7fded1cba`
- Should see their schedule assuming they have a profile 

## External API changes

- None