### PR TITLE
Allow finance users to drilldown by NPQ application ID

### DIFF
--- a/app/controllers/finance/participants_controller.rb
+++ b/app/controllers/finance/participants_controller.rb
@@ -19,7 +19,8 @@ module Finance
   private
 
     def find_user_by_id_or_external_id
-      @user = Identity.find_user_by(id: params[:query] || params[:id])
+      query = params[:query] || params[:id]
+      @user = Identity.find_user_by(id: query) || NPQApplication.find_by(id: query)&.user
     end
   end
 end

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -1,16 +1,16 @@
 <%= govuk_summary_list do |summary_list| %>
   <% summary_list.row do |row| %>
-    <% row.key { "application id" } %>
-    <% row.value { application.id } %>
+    <% row.key { "Application ID" } %>
+    <% row.value { govuk_link_to application.id, finance_participant_path(application.id) } %>
   <% end %>
 
   <% summary_list.row do |row| %>
-    <% row.key { "Lead provider" } %>
+    <% row.key { "Lead Provider" } %>
     <% row.value { application.npq_lead_provider.name } %>
   <% end %>
 
   <% summary_list.row do |row| %>
-    <% row.key { "Lead provider approval status" } %>
+    <% row.key { "Lead Provider approval status" } %>
     <% row.value { application.lead_provider_approval_status } %>
   <% end %>
 

--- a/app/views/finance/participants/index.html.erb
+++ b/app/views/finance/participants/index.html.erb
@@ -5,5 +5,5 @@
 <%= render SearchBox.new(
   query: params[:query],
   title: "Search participants",
-  hint: "Enter the participant’s ID",
+  hint: "Enter a participant or application ID",
 ) %>

--- a/spec/features/finance/participant_drilldown_spec.rb
+++ b/spec/features/finance/participant_drilldown_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Finance users participant drilldown", type: :feature do
   let(:ect_user) { create(:user, :early_career_teacher) }
   let(:ect_profile) { ect_user.early_career_teacher_profile }
   let(:ect_declaration) { create(:ect_participant_declaration, user: ect_user, participant_profile: ect_profile) }
+  let(:ect_identity) { create :participant_identity, user: ect_user, external_identifier: SecureRandom.uuid }
 
   let(:npq_user) { create(:user, :npq) }
   let(:npq_profile) { npq_user.npq_profiles[0] }
@@ -24,6 +25,18 @@ RSpec.feature "Finance users participant drilldown", type: :feature do
     and_i_click_on("Search")
     then_i_see("ParticipantProfile::ECT")
     and_i_see("Declaration type#{ect_declaration.declaration_type}")
+  end
+
+  scenario "viewing ECT user by external identifier" do
+    given_i_am_logged_in_as_a_finance_user
+    and_an_ect_user_with_profile_and_declarations
+    when_i_visit_the_finance_homepage
+    and_i_click_on("Participant drilldown")
+    then_i_see("Search participants")
+
+    when_i_fill_in("query", with: ect_identity.external_identifier)
+    and_i_click_on("Search")
+    then_i_see(ect_user.id)
   end
 
   def when_i_visit_the_finance_homepage
@@ -68,6 +81,20 @@ RSpec.feature "Finance users participant drilldown", type: :feature do
     then_i_see("Search participants")
 
     when_i_fill_in("query", with: npq_user.id)
+    and_i_click_on("Search")
+    then_i_see("Identity 1")
+    and_i_see("ParticipantProfile::NPQ")
+    and_i_see("Declaration type#{npq_declaration.declaration_type}")
+  end
+
+  scenario "viewing NPQ user by application ID" do
+    given_i_am_logged_in_as_a_finance_user
+    and_an_npq_user_with_application_and_profile_and_declarations
+    when_i_visit_the_finance_homepage
+    and_i_click_on("Participant drilldown")
+    then_i_see("Search participants")
+
+    when_i_fill_in("query", with: npq_application.id)
     and_i_click_on("Search")
     then_i_see("Identity 1")
     and_i_see("ParticipantProfile::NPQ")


### PR DESCRIPTION
Allow finance users to drilldown by NPQ application ID

This area of the service is quickly becoming very useful — more than just the temporary page that it was initially. I'm going to pad out the testing of this area before merging this.