### PR TITLE
CST-283 Data Model changes - sync data model

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -15,4 +15,10 @@ class InductionRecord < ApplicationRecord
     transferred: "transferred",
     completed: "completed",
   }
+
+  enum training_status: {
+    active: "active",
+    deferred: "deferred",
+    withdrawn: "withdrawn",
+  }, _prefix: "training_status"
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -34,7 +34,7 @@ class ParticipantProfile < ApplicationRecord
 
     def current_induction_record
       now = Time.zone.now
-      induction_records.active.where("start_date < ? AND end_date IS NULL OR end_date > ?", now, now).first
+      induction_records.active.where("start_date <= ? AND end_date IS NULL OR end_date > ?", now, now).first
     end
 
     def ecf?
@@ -65,8 +65,8 @@ class ParticipantProfile < ApplicationRecord
     end
 
     def sync_status_with_induction_record
-      induction_records.active.first&.update!(status: status) if saved_change_to_status?
-      induction_records.active.first&.update!(training_status: training_status) if saved_change_to_training_status?
+      current_induction_record&.update!(status: status) if saved_change_to_status?
+      current_induction_record&.update!(training_status: training_status) if saved_change_to_training_status?
     end
   end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -30,6 +30,7 @@ class ParticipantProfile < ApplicationRecord
     }, _suffix: "profile"
 
     after_save :update_analytics
+    after_update :sync_status_with_induction_record
 
     def ecf?
       true
@@ -56,6 +57,10 @@ class ParticipantProfile < ApplicationRecord
 
     def update_analytics
       Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if saved_changes?
+    end
+
+    def sync_status_with_induction_record
+      induction_records.active.first&.update!(status: status) if saved_change_to_status?
     end
   end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -32,6 +32,11 @@ class ParticipantProfile < ApplicationRecord
     after_save :update_analytics
     after_update :sync_status_with_induction_record
 
+    def current_induction_record
+      now = Time.zone.now
+      induction_records.active.where("start_date < ? AND end_date IS NULL OR end_date > ?", now, now).first
+    end
+
     def ecf?
       true
     end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -66,6 +66,7 @@ class ParticipantProfile < ApplicationRecord
 
     def sync_status_with_induction_record
       induction_records.active.first&.update!(status: status) if saved_change_to_status?
+      induction_records.active.first&.update!(training_status: training_status) if saved_change_to_training_status?
     end
   end
 end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -33,7 +33,6 @@ module EarlyCareerTeachers
         ParticipantDetailsReminderJob.schedule(profile)
       end
 
-      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: profile)
       profile
     end
 

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -5,6 +5,7 @@ module EarlyCareerTeachers
     include SchoolCohortDelegator
 
     def call
+      profile = nil
       ActiveRecord::Base.transaction do
         # Retain the original name if the user already exists
         user = User.find_or_create_by!(email: email) do |ect|
@@ -12,24 +13,28 @@ module EarlyCareerTeachers
         end
         user.update!(full_name: full_name) unless user.participant_profiles&.active_record&.any? || user.npq_registered?
 
-        teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |profile|
-          profile.school = school_cohort.school
+        teacher_profile = TeacherProfile.find_or_create_by!(user: user) do |teacher|
+          teacher.school = school_cohort.school
         end
 
-        ParticipantProfile::ECT.create!({
+        profile = ParticipantProfile::ECT.create!({
           teacher_profile: teacher_profile,
           schedule: Finance::Schedule::ECF.default,
           participant_identity: Identity::Create.call(user: user),
-        }.merge(ect_attributes)) do |profile|
-          ParticipantProfileState.create!(participant_profile: profile)
+        }.merge(ect_attributes))
 
-          unless year_2020
-            ParticipantMailer.participant_added(participant_profile: profile).deliver_later
-            profile.update_column(:request_for_details_sent_at, Time.zone.now)
-            ParticipantDetailsReminderJob.schedule(profile)
-          end
-        end
+        ParticipantProfileState.create!(participant_profile: profile)
+        Induction::Enrol.call(participant_profile: profile) if school_cohort.default_induction_programme.present?
       end
+
+      unless year_2020
+        ParticipantMailer.participant_added(participant_profile: profile).deliver_later
+        profile.update_column(:request_for_details_sent_at, Time.zone.now)
+        ParticipantDetailsReminderJob.schedule(profile)
+      end
+
+      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: profile)
+      profile
     end
 
   private

--- a/app/services/induction/check_participant_records_are_synced.rb
+++ b/app/services/induction/check_participant_records_are_synced.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Induction::CheckParticipantRecordsAreSynced < BaseService
+  def call
+    participant_profiles.each do |profile|
+      next unless included_induction_programme?(profile)
+
+      check_induction_programme_change(profile)
+      check_status_is_correct(profile)
+    end
+  end
+
+private
+
+  attr_reader :participant_profiles
+
+  def initialize(participant_profiles:)
+    @participant_profiles = Array(participant_profiles)
+  end
+
+  def check_induction_programme_change(profile)
+    return if profile.induction_records.first.withdrawn?
+
+    if profile.current_induction_record.induction_programme != profile.school_cohort.default_induction_programme
+      Rails.logger.info "Programme has changed for #{profile.id}, expecting #{profile.school_cohort.default_induction_programme.id}
+            but got #{profile.current_induction_record.induction_programme.id}"
+    end
+  end
+
+  def check_status_is_correct(profile)
+    return if profile.induction_records.first.withdrawn?
+
+    if profile.current_induction_record&.status != profile.status
+      Rails.logger.info "Record status has changed for #{profile.id}, expecting #{profile.status}
+            but got #{profile.current_induction_record.status}"
+    end
+  end
+
+  def included_induction_programme?(profile)
+    profile.school_cohort.induction_programme_choice.in?(%w[full_induction_programme core_induction_programme design_our_own school_funded_fip])
+  end
+end

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -14,10 +14,14 @@ private
 
   attr_reader :participant_profile, :induction_programme, :start_date
 
-  def initialize(participant_profile:, induction_programme: nil, start_date: Time.zone.now)
+  def initialize(participant_profile:, induction_programme: nil, start_date: nil)
     @participant_profile = participant_profile
     @induction_programme = induction_programme || default_induction_programme
-    @start_date = start_date
+    @start_date = start_date || schedule_start_date
+  end
+
+  def schedule_start_date
+    participant_profile.schedule.milestones.first.start_date
   end
 
   def default_induction_programme

--- a/app/services/induction/transfer.rb
+++ b/app/services/induction/transfer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Induction::Transfer < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      participant_profiles.each do |participant_profile|
+        current_programme = participant_profile.current_induction_record&.induction_programme
+        if current_programme.present?
+          Induction::Withdraw.call(
+            participant_profile: participant_profile,
+            induction_programme: current_programme,
+            state: :transferred,
+            end_date: end_date,
+          )
+        end
+
+        Induction::Enrol.call(participant_profile: participant_profile,
+                              induction_programme: induction_programme,
+                              start_date: start_date)
+      end
+    end
+  end
+
+private
+
+  attr_reader :participant_profiles, :induction_programme, :start_date, :end_date
+
+  def initialize(participant_profiles:, end_date:, new_induction_programme:, start_date: Time.zone.now)
+    @participant_profiles = Array(participant_profiles)
+    @induction_programme = new_induction_programme
+    @start_date = start_date
+    @end_date = end_date
+  end
+end

--- a/app/services/induction/withdraw.rb
+++ b/app/services/induction/withdraw.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Induction::Withdraw < BaseService
+  def call
+    induction_programme.active_induction_records.find_by(participant_profile: participant_profile)&.update!(status: state, end_date: end_date)
+  end
+
+private
+
+  attr_reader :participant_profile, :induction_programme, :state, :end_date
+
+  def initialize(participant_profile:, induction_programme:, state:, end_date:)
+    @participant_profile = participant_profile
+    @induction_programme = induction_programme
+    @state = state
+    @end_date = end_date
+  end
+end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -33,7 +33,7 @@ module Mentors
       ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later
       mentor_profile.update_column(:request_for_details_sent_at, Time.zone.now)
       ParticipantDetailsReminderJob.schedule(mentor_profile)
-      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: mentor_profile)
+
       mentor_profile
     end
 

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -5,6 +5,7 @@ module Mentors
     include SchoolCohortDelegator
 
     def call
+      mentor_profile = nil
       ActiveRecord::Base.transaction do
         # NOTE: This will not update the full_name if the user has an active participant profile,
         # the scenario I am working on is enabling a NPQ user to be added as a mentor
@@ -19,17 +20,21 @@ module Mentors
           profile.school = school_cohort.school
         end
 
-        ParticipantProfile::Mentor.create!({
+        mentor_profile = ParticipantProfile::Mentor.create!({
           teacher_profile: teacher_profile,
           schedule: Finance::Schedule::ECF.default,
           participant_identity: Identity::Create.call(user: user),
-        }.merge(mentor_attributes)) do |mentor_profile|
-          ParticipantProfileState.create!(participant_profile: mentor_profile)
-          ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later
-          mentor_profile.update_column(:request_for_details_sent_at, Time.zone.now)
-          ParticipantDetailsReminderJob.schedule(mentor_profile)
-        end
+        }.merge(mentor_attributes))
+
+        ParticipantProfileState.create!(participant_profile: mentor_profile)
+        Induction::Enrol.call(participant_profile: mentor_profile) if school_cohort.default_induction_programme.present?
       end
+
+      ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later
+      mentor_profile.update_column(:request_for_details_sent_at, Time.zone.now)
+      ParticipantDetailsReminderJob.schedule(mentor_profile)
+      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: mentor_profile)
+      mentor_profile
     end
 
   private

--- a/db/migrate/20220214170448_add_training_status_to_induction_record.rb
+++ b/db/migrate/20220214170448_add_training_status_to_induction_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTrainingStatusToInductionRecord < ActiveRecord::Migration[6.1]
+  def change
+    add_column :induction_records, :training_status, :string, default: "active", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_121107) do
+ActiveRecord::Schema.define(version: 2022_02_14_170448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -361,6 +361,7 @@ ActiveRecord::Schema.define(version: 2022_02_08_121107) do
     t.datetime "end_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "training_status", default: "active", null: false
     t.index ["induction_programme_id"], name: "index_induction_records_on_induction_programme_id"
     t.index ["participant_profile_id"], name: "index_induction_records_on_participant_profile_id"
     t.index ["schedule_id"], name: "index_induction_records_on_schedule_id"

--- a/spec/factories/induction_record.rb
+++ b/spec/factories/induction_record.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :induction_record do
+    schedule { create(:ecf_schedule) }
     start_date { Date.new(2021, 1, 9) }
   end
 end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -42,6 +42,48 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     end
   end
 
+  describe "current_induction_record" do
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: profile.school_cohort) }
+
+    context "when no induction record exists" do
+      it "returns nil" do
+        expect(profile.current_induction_record).to be_nil
+      end
+    end
+
+    context "when an induction record exists but it is not at active status" do
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile, status: "completed") }
+
+      it "returns nil" do
+        expect(profile.current_induction_record).to be_nil
+      end
+    end
+
+    context "when an active induction record exists with an end_date in the past" do
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile, status: "active", end_date: 2.days.ago) }
+
+      it "returns nil" do
+        expect(profile.current_induction_record).to be_nil
+      end
+    end
+
+    context "when an active induction record exists with an end_date in the future" do
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile, status: "active", end_date: 2.days.from_now) }
+
+      it "returns the induction record" do
+        expect(profile.current_induction_record).to eq induction_record
+      end
+    end
+
+    context "when an active induction record exists with a start_date in the future" do
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile, status: "active", start_date: 2.days.from_now) }
+
+      it "returns nil" do
+        expect(profile.current_induction_record).to be_nil
+      end
+    end
+  end
+
   describe "completed_validation_wizard?" do
     context "before any details have been entered" do
       it "returns false" do

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -32,12 +32,28 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       end
     end
 
-    context "when the status is not changed" do
+    context "when the status has not changed" do
       before { induction_record.completed! }
 
       it "does not update the status" do
         profile.primary_profile!
         expect(induction_record.reload).to be_completed
+      end
+    end
+
+    context "when the training_status changes" do
+      it "updates the training_status on the active induction record" do
+        profile.training_status_withdrawn!
+        expect(induction_record.reload).to be_training_status_withdrawn
+      end
+    end
+
+    context "when the training_status has not changed" do
+      before { induction_record.training_status_deferred! }
+
+      it "does not update the training_status" do
+        profile.primary_profile!
+        expect(induction_record.reload).to be_training_status_deferred
       end
     end
   end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -21,6 +21,27 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     end
   end
 
+  describe "after_update" do
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: profile.school_cohort) }
+    let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile, status: "active") }
+
+    context "when the status changes" do
+      it "updates the status on the active induction record" do
+        profile.withdrawn_record!
+        expect(induction_record.reload).to be_withdrawn
+      end
+    end
+
+    context "when the status is not changed" do
+      before { induction_record.completed! }
+
+      it "does not update the status" do
+        profile.primary_profile!
+        expect(induction_record.reload).to be_completed
+      end
+    end
+  end
+
   describe "completed_validation_wizard?" do
     context "before any details have been entered" do
       it "returns false" do

--- a/spec/services/admin/change_induction_choice_service_spec.rb
+++ b/spec/services/admin/change_induction_choice_service_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Admin::ChangeInductionService do
 
         it "does not change participants when changing to FIP" do
           expect { service.change_induction_provision(:full_induction_programme) }
-            .not_to change { school.participants_for(cohort).map(&:id) }
+            .not_to change { school.participants_for(cohort).map(&:id).sort }
           expect(participant_profiles.each(&:reload)).to all be_active_record
         end
       end

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -56,6 +56,35 @@ RSpec.describe EarlyCareerTeachers::Create do
     }.to change { user.reload.full_name }
   end
 
+  context "when default induction programme is set on the school cohort" do
+    it "creates an induction record" do
+      induction_programme = create(:induction_programme, :fip, school_cohort: school_cohort)
+      school_cohort.update!(default_induction_programme: induction_programme)
+
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: user.full_name,
+          school_cohort: school_cohort,
+          mentor_profile_id: mentor_profile.id,
+        )
+      }.to change { InductionRecord.count }.by(1)
+    end
+  end
+
+  context "when there is no default induction programme set" do
+    it "does not create an induction record" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: user.full_name,
+          school_cohort: school_cohort,
+          mentor_profile_id: mentor_profile.id,
+        )
+      }.not_to change { InductionRecord.count }
+    end
+  end
+
   it "schedules participant_added email" do
     expect {
       described_class.call(

--- a/spec/services/induction/transfer_spec.rb
+++ b/spec/services/induction/transfer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::Transfer do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+    let(:new_induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+    let(:participant_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: participant_profile, status: :active) }
+    let(:start_date) { 5.days.from_now }
+    let(:end_date) { Time.zone.now }
+
+    subject(:service) { described_class }
+
+    it "updates the current induction record with status :transferred" do
+      service.call(participant_profiles: participant_profile, end_date: end_date, new_induction_programme: new_induction_programme, start_date: start_date)
+
+      expect(induction_record.reload).to be_transferred
+    end
+
+    it "updates the current induction record with the end date" do
+      service.call(participant_profiles: participant_profile, end_date: end_date, new_induction_programme: new_induction_programme, start_date: start_date)
+
+      expect(induction_record.reload.end_date).to eq end_date
+    end
+
+    it "adds a new induction record to the new programme for the participant" do
+      expect {
+        service.call(participant_profiles: participant_profile, end_date: end_date, new_induction_programme: new_induction_programme, start_date: start_date)
+      }.to change { new_induction_programme.induction_records.count }.by 1
+    end
+
+    it "sets the new induction record data correctly" do
+      service.call(participant_profiles: participant_profile, end_date: end_date, new_induction_programme: new_induction_programme, start_date: start_date)
+
+      expect(new_induction_programme.induction_records.first).to be_active
+      expect(new_induction_programme.induction_records.first.start_date).to eq start_date
+      expect(new_induction_programme.induction_records.first.participant_profile).to eq participant_profile
+    end
+  end
+end

--- a/spec/services/induction/transfer_spec.rb
+++ b/spec/services/induction/transfer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Induction::Transfer do
       service.call(participant_profiles: participant_profile, end_date: end_date, new_induction_programme: new_induction_programme, start_date: start_date)
 
       expect(new_induction_programme.induction_records.first).to be_active
-      expect(new_induction_programme.induction_records.first.start_date).to eq start_date
+      expect(new_induction_programme.induction_records.first.start_date).to be_within(1.second).of start_date
       expect(new_induction_programme.induction_records.first.participant_profile).to eq participant_profile
     end
   end

--- a/spec/services/induction/transfer_spec.rb
+++ b/spec/services/induction/transfer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Induction::Transfer do
     it "updates the current induction record with the end date" do
       service.call(participant_profiles: participant_profile, end_date: end_date, new_induction_programme: new_induction_programme, start_date: start_date)
 
-      expect(induction_record.reload.end_date).to eq end_date
+      expect(induction_record.reload.end_date).to be_within(1.second).of end_date
     end
 
     it "adds a new induction record to the new programme for the participant" do

--- a/spec/services/induction/withdraw_spec.rb
+++ b/spec/services/induction/withdraw_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::Withdraw do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+    let(:participant_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: participant_profile, status: :active) }
+
+    subject(:service) { described_class }
+
+    it "updates the induction record with the given status" do
+      service.call(participant_profile: participant_profile, induction_programme: induction_programme, state: :withdrawn, end_date: 2.days.from_now)
+      expect(induction_record.reload).to be_withdrawn
+    end
+
+    context "when the programme does not contain an active record for the participant" do
+      before do
+        induction_record.completed!
+      end
+
+      it "does not update the induction record" do
+        service.call(participant_profile: participant_profile,
+                     induction_programme: induction_programme,
+                     state: :withdrawn,
+                     end_date: 2.days.from_now)
+        expect(induction_record.reload).to be_completed
+      end
+    end
+  end
+end

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -65,6 +65,33 @@ RSpec.describe Mentors::Create, :with_default_schedules do
     }.to change { user.reload.full_name }
   end
 
+  context "when default induction programme is set on the school cohort" do
+    it "creates an induction record" do
+      induction_programme = create(:induction_programme, :fip, school_cohort: school_cohort)
+      school_cohort.update!(default_induction_programme: induction_programme)
+
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: user.full_name,
+          school_cohort: school_cohort,
+        )
+      }.to change { InductionRecord.count }.by(1)
+    end
+  end
+
+  context "when there is no default induction programme set" do
+    it "does not create an induction record" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: user.full_name,
+          school_cohort: school_cohort,
+        )
+      }.not_to change { InductionRecord.count }
+    end
+  end
+
   it "schedules participant_added email" do
     expect {
       described_class.call(


### PR DESCRIPTION
## Ticket and context

Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-283)

Adds services to aid changes to induction programmes
Adds `training_status` to `InductionRecord` to mirror the value from `ParticipantProfile`

Populate the new models and keep them up to date:
* enrols the participants into the default induction programme for their school cohort when a new ECT or Mentor is added.
* sync changes to `status` and `training_status` on `ParticipantProfile` to the associated `InductionRecord`
* added tooling to help check that participant records are in sync


## Tech review

### Is there anything that the code reviewer should know?

Once code is deployed the `training_status` value needs to be populated from the `ParticipantProfile`

```ruby
InductionRecord.includes(:participant_profile).find_each do |induction_record|
  induction_record.update!(training_status: induction_record.participant_profile.training_status)
end
```

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
