### PR TITLE
Remove dependent destroy from ParticipantProfile::NPQ/NPQApplication

### DIFF
--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -6,7 +6,7 @@ class ParticipantProfile < ApplicationRecord
     belongs_to :school, optional: true
     belongs_to :npq_course, optional: true
 
-    has_one :npq_application, foreign_key: :id, dependent: :destroy
+    has_one :npq_application, foreign_key: :id
 
     self.validation_steps = %i[identity decision].freeze
 


### PR DESCRIPTION
When we need to manually reject applications that have been accepted in error, we want to delete the profile but not the application.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
