### PR TITLE
Update analytics when any attribute on ECF profile changes

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -61,7 +61,6 @@ module Admin
     def destroy
       @participant_profile.withdrawn_record!
       @participant_profile.mentee_profiles.update_all(mentor_profile_id: nil) if @participant_profile.mentor?
-      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: @participant_profile)
 
       render :destroy_success
     end

--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -85,7 +85,6 @@ class Schools::ParticipantsController < Schools::BaseController
 
     if @mentor_form.valid?
       @profile.update!(mentor_profile: @mentor_form.mentor ? @mentor_form.mentor.mentor_profile : nil)
-      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: @profile)
 
       flash[:success] = { title: "Success", heading: "The mentor for this participant has been updated" }
       redirect_to schools_participant_path(id: @profile)
@@ -106,7 +105,6 @@ class Schools::ParticipantsController < Schools::BaseController
           sti_profile: current_user.induction_coordinator_profile,
         ).deliver_later
       end
-      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: @profile)
     end
 
     render :removed

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -55,7 +55,7 @@ class ParticipantProfile < ApplicationRecord
   private
 
     def update_analytics
-      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if saved_change_to_training_status?
+      Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: self) if saved_changes?
     end
   end
 end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -28,8 +28,6 @@ module EarlyCareerTeachers
             profile.update_column(:request_for_details_sent_at, Time.zone.now)
             ParticipantDetailsReminderJob.schedule(profile)
           end
-
-          Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: profile)
         end
       end
     end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -28,7 +28,6 @@ module Mentors
           ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later
           mentor_profile.update_column(:request_for_details_sent_at, Time.zone.now)
           ParticipantDetailsReminderJob.schedule(mentor_profile)
-          Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: mentor_profile)
         end
       end
     end

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ParticipantProfile, type: :model do
     expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
   end
 
-  it "updates analytics when training_status_changed?", :with_default_schedules do
+  it "updates analytics when any attributes changes", :with_default_schedules do
     profile = create(:ecf_participant_profile, training_status: :active)
     profile.training_status = :withdrawn
     expect {


### PR DESCRIPTION
## Ticket and context

We are having difficulty keeping the analytics table in sync because we are being specific about _which_ things should trigger an update. Instead of trying to find all the places that a profile might be updated we can just update the analytics table whenever _any_ field on an ECF profile gets updated.

One example is that we're not updating the table when a schedule is changed.

The risk here is that we increase the number of writes to that table significantly, but I think the benefit of having a correctly synced table outweighs that.

When this is merged and deployed we'll want to re-sync _all_ ECF profiles:

```ruby
ParticipantProfile::ECF.find_each do |participant_profile|
   Analytics::UpsertECFParticipantProfileJob.perform_later(participant_profile: participant_profile)
end