### PR TITLE
Fix API request job arg serialization

### DIFF
--- a/app/jobs/api_request_job.rb
+++ b/app/jobs/api_request_job.rb
@@ -5,6 +5,8 @@ class ApiRequestJob
   include ActionController::HttpAuthentication::Token
 
   def perform(request_data, response_data, status_code, created_at)
+    request_data = request_data.with_indifferent_access
+    response_data = response_data.with_indifferent_access
     request_headers = request_data.fetch(:headers, {})
     token = auth_token(request_headers.delete("HTTP_AUTHORIZATION"))
     cpd_lead_provider = token.is_a?(LeadProviderApiToken) ? token.owner : nil

--- a/app/middlewares/api_request_middleware.rb
+++ b/app/middlewares/api_request_middleware.rb
@@ -29,7 +29,7 @@ class ApiRequestMiddleware
 
     begin
       if trace_request?
-        ApiRequestJob.perform_async(request_data, response_data, status, Time.zone.now)
+        ApiRequestJob.perform_async(request_data.stringify_keys, response_data.stringify_keys, status, Time.zone.now.to_s)
       end
     rescue StandardError => e
       Rails.logger.warn e.message

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,6 @@ Rails.application.configure do
   config.cache_classes = false
 
   config.middleware.use TimeTraveler
-  config.middleware.use ApiRequestMiddleware
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
This warning was being spat out every time an ApiRequestJob was created:

```
WARN: Job arguments to ApiRequestJob do not serialize to JSON safely. This will raise an error in
Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today
by calling `Sidekiq.strict_args!` during Sidekiq initialization.
```

The documentation advises against using symbolised keys in hashes as they will be turned into string keys when reserialized from json.

It turns out this was a good warning as we are accessing these hashes using symbols in the job itself, leading to a bunch of nils. Example of the last api request created:
```
ApiRequest id: "ffffcfd6-d8eb-4db6-ace7-c43a80ffb3d7", request_path: nil, status_code: 200, request_headers: {}, request_body: nil, response_body: {}, request_method: nil, response_headers: nil, cpd_lead_provider_id: nil, user_description: nil, created_at: "2022-01-23 00:15:21.000000000 +0000", updated_at: "2022-01-23 00:15:21.170203000 +0000"
```

This has probably been broken since the sidekiq migration a couple of months ago. The tests didn't pick this up because they don't save the args to redis, so there was no json serialization/de-serialization to occur.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
