### PR TITLE
Disable papertrail during seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+PaperTrail.enabled = false
+
 seed_path = %w[db seeds]
 load Rails.root.join(*seed_path, "initial_seed.rb").to_s
 load Rails.root.join(*seed_path, "schedules.rb").to_s
@@ -18,3 +20,5 @@ if Rails.env.development? || Rails.env.deployed_development?
     FeatureFlag.activate(feature)
   end
 end
+
+PaperTrail.enabled = true


### PR DESCRIPTION
## Ticket and context

This isn't providing any benefit and we need to speed up the seeds as deployments are timing out to review apps

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
