### PR TITLE
Only seed statements once

### DIFF
--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -64,3 +64,5 @@ end
 NPQLeadProvider.all.each do |lp|
   lp.update!(cpd_lead_provider: CpdLeadProvider.find_by(name: lp.name))
 end
+
+Importers::SeedStatements.new.call

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -7,7 +7,6 @@ module ValidTestDataGenerator
   class LeadProviderPopulater
     class << self
       def call(name:, total_schools: 10, participants_per_school: 50)
-        Importers::SeedStatements.new.call
         new(name: name).call(total_schools: total_schools, participants_per_school: participants_per_school)
       end
     end
@@ -244,7 +243,6 @@ module ValidTestDataGenerator
   class NPQLeadProviderPopulater
     class << self
       def call(name:, total_schools: 10, participants_per_school: 10)
-        Importers::SeedStatements.new.call
         new(name: name, participants_per_school: participants_per_school).call(total_schools: total_schools)
       end
     end


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- Our deployments involving seeding are timing out
- These are limited to 60 seconds and we are often over this limit causing a deployment to fail which it time costly
- This should reduce that time but only seeding statements once and not repeatedly

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Review app should be available otherwise the deploy failed

## External API changes

- None