### PR TITLE
[CPDLP-1001] Validate declaration type for schedule

### DIFF
--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -6,7 +6,7 @@ module RecordDeclarations
   class Base
     include Participants::ProfileAttributes
     include AbstractInterface
-    implement_class_method :required_params, :valid_declaration_types
+    implement_class_method :required_params
     implement_instance_method :user_profile
 
     MultipleParticipantDeclarationDuplicate = Class.new(ArgumentError)
@@ -18,9 +18,9 @@ module RecordDeclarations
     validates :declaration_date, :declaration_type, presence: true
     validates :parsed_date, future_date: true, allow_blank: true
     validate :date_has_the_right_format
+    validate :validate_schedule_present
     validate :validate_milestone_exists
 
-    validates :declaration_type, inclusion: { in: :valid_declaration_types, message: I18n.t(:invalid_declaration_type) }
     delegate :schedule, :participant_declarations, to: :user_profile, allow_nil: true
 
     class << self
@@ -137,22 +137,20 @@ module RecordDeclarations
       raise ActionController::ParameterMissing, I18n.t(:declaration_on_incorrect_state) unless last_state&.state.nil? || last_state.active?
     end
 
-    def milestone
+    def validate_schedule_present
       unless schedule
-        raise ActionController::ParameterMissing, I18n.t(:schedule_missing)
+        errors.add(:schedule, I18n.t(:schedule_missing))
       end
+    end
 
-      schedule.milestones.find_by(declaration_type: declaration_type)
+    def milestone
+      schedule&.milestones&.find_by(declaration_type: declaration_type)
     end
 
     def validate_milestone_exists
       if milestone.blank?
         errors.add(:declaration_type, I18n.t(:mismatch_declaration_type_for_schedule))
       end
-    end
-
-    def valid_declaration_types
-      self.class.valid_declaration_types
     end
 
     def original_participant_declaration

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -18,6 +18,7 @@ module RecordDeclarations
     validates :declaration_date, :declaration_type, presence: true
     validates :parsed_date, future_date: true, allow_blank: true
     validate :date_has_the_right_format
+    validate :validate_milestone_exists
 
     validates :declaration_type, inclusion: { in: :valid_declaration_types, message: I18n.t(:invalid_declaration_type) }
     delegate :schedule, :participant_declarations, to: :user_profile, allow_nil: true
@@ -142,6 +143,12 @@ module RecordDeclarations
       end
 
       schedule.milestones.find_by(declaration_type: declaration_type)
+    end
+
+    def validate_milestone_exists
+      if milestone.blank?
+        errors.add(:declaration_type, I18n.t(:mismatch_declaration_type_for_schedule))
+      end
     end
 
     def valid_declaration_types

--- a/app/services/record_declarations/ecf.rb
+++ b/app/services/record_declarations/ecf.rb
@@ -4,13 +4,6 @@ module RecordDeclarations
   module ECF
     extend ActiveSupport::Concern
 
-    STARTED      = "started"
-    COMPLETED    = "completed"
-    RETAINED_ONE = "retained-1"
-    RETAINED_TWO = "retained-2"
-    RETAINED_THREE = "retained-3"
-    RETAINED_FOUR = "retained-4"
-
     included do
       extend ECFClassMethods
     end
@@ -18,10 +11,6 @@ module RecordDeclarations
     module ECFClassMethods
       def declaration_model
         ParticipantDeclaration::ECF
-      end
-
-      def valid_declaration_types
-        [STARTED, COMPLETED, RETAINED_ONE, RETAINED_TWO, RETAINED_THREE, RETAINED_FOUR]
       end
     end
   end

--- a/app/services/record_declarations/npq.rb
+++ b/app/services/record_declarations/npq.rb
@@ -4,20 +4,11 @@ module RecordDeclarations
   module NPQ
     extend ActiveSupport::Concern
 
-    STARTED      = "started"
-    COMPLETED    = "completed"
-    RETAINED_ONE = "retained-1"
-    RETAINED_TWO = "retained-2"
-
     included { extend NPQClassMethods }
 
     module NPQClassMethods
       def declaration_model
         ParticipantDeclaration::NPQ
-      end
-
-      def valid_declaration_types
-        [STARTED, COMPLETED, RETAINED_ONE, RETAINED_TWO]
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
   invalid_declaration_type: "The property '#/declaration_type' must be available for '#/course_identifier'"
   invalid_declaration_date: "The property '#/declaration_date' must be a valid RCF3339 date"
   future_declaration_date: "The property '#/declaration_date' can not declare a future date"
-  mismatch_declaration_type_for_schedule: "Declaration type does not exist for this schedule"
+  mismatch_declaration_type_for_schedule: "#/declaration_type does not exist for this schedule"
   missing_declaration_type: "The property '#/declaration_type' must be present"
   missing_evidence_held: "The property '#/evidence_held' must be present"
   missing_lead_provider: "The lead provider must be present"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
   invalid_declaration_type: "The property '#/declaration_type' must be available for '#/course_identifier'"
   invalid_declaration_date: "The property '#/declaration_date' must be a valid RCF3339 date"
   future_declaration_date: "The property '#/declaration_date' can not declare a future date"
+  mismatch_declaration_type_for_schedule: "Declaration type does not exist for this schedule"
   missing_declaration_type: "The property '#/declaration_type' must be present"
   missing_evidence_held: "The property '#/evidence_held' must be present"
   missing_lead_provider: "The lead provider must be present"

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -80,7 +80,7 @@ module ValidTestDataGenerator
             course_identifier: "ecf-induction",
             declaration_date: (profile.schedule.milestones.first.start_date + 1.day).rfc3339,
             cpd_lead_provider: profile.school_cohort.lead_provider.cpd_lead_provider,
-            declaration_type: RecordDeclarations::ECF::STARTED,
+            declaration_type: "started",
           },
         )
 
@@ -101,7 +101,7 @@ module ValidTestDataGenerator
             course_identifier: "ecf-induction",
             declaration_date: (profile.schedule.milestones.second.start_date + 1.day).rfc3339,
             cpd_lead_provider: profile.school_cohort.lead_provider.cpd_lead_provider,
-            declaration_type: RecordDeclarations::ECF::RETAINED_ONE,
+            declaration_type: "retained-1",
             evidence_held: "other",
           },
         )
@@ -119,7 +119,7 @@ module ValidTestDataGenerator
             course_identifier: "ecf-mentor",
             declaration_date: (profile.schedule.milestones.first.start_date + 1.day).rfc3339,
             cpd_lead_provider: profile.school_cohort.lead_provider.cpd_lead_provider,
-            declaration_type: RecordDeclarations::ECF::STARTED,
+            declaration_type: "started",
           },
         )
 
@@ -140,7 +140,7 @@ module ValidTestDataGenerator
             course_identifier: "ecf-mentor",
             declaration_date: (profile.schedule.milestones.second.start_date + 1.day).rfc3339,
             cpd_lead_provider: profile.school_cohort.lead_provider.cpd_lead_provider,
-            declaration_type: RecordDeclarations::ECF::RETAINED_ONE,
+            declaration_type: "retained-1",
             evidence_held: "other",
           },
         )
@@ -332,7 +332,7 @@ module ValidTestDataGenerator
           course_identifier: npq_application.npq_course.identifier,
           declaration_date: (npq_application.profile.schedule.milestones.first.start_date + 1.day).rfc3339,
           cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider,
-          declaration_type: RecordDeclarations::NPQ::STARTED,
+          declaration_type: "started",
         },
       )
     end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -78,7 +78,7 @@ private
           course_identifier: npq_application.npq_course.identifier,
           declaration_date: timestamp.rfc3339,
           cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider,
-          declaration_type: RecordDeclarations::NPQ::STARTED,
+          declaration_type: "started",
         },
       )
     end

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -101,7 +101,7 @@ private
           declaration_date: (participant.schedule.milestones.first.start_date + 1.day).rfc3339,
           created_at: participant.schedule.milestones.first.start_date + 1.day,
           cpd_lead_provider: lead_provider.cpd_lead_provider,
-          declaration_type: RecordDeclarations::ECF::STARTED,
+          declaration_type: "started",
           evidence_held: "other",
         },
       )
@@ -124,7 +124,7 @@ private
           declaration_date: (participant.schedule.milestones.second.start_date + 1.day).rfc3339,
           created_at: participant.schedule.milestones.second.start_date + 1.day,
           cpd_lead_provider: lead_provider.cpd_lead_provider,
-          declaration_type: RecordDeclarations::ECF::RETAINED_ONE,
+          declaration_type: "retained-1",
           evidence_held: "other",
         },
       )
@@ -147,7 +147,7 @@ private
           declaration_date: (participant.schedule.milestones.second.start_date + 1.day).rfc3339,
           created_at: participant.schedule.milestones.second.start_date + 1.day,
           cpd_lead_provider: lead_provider.cpd_lead_provider,
-          declaration_type: RecordDeclarations::ECF::RETAINED_ONE,
+          declaration_type: "retained-1",
           evidence_held: "other",
         },
       )
@@ -170,7 +170,7 @@ private
           declaration_date: (participant.schedule.milestones.second.start_date + 1.day).rfc3339,
           created_at: participant.schedule.milestones.second.start_date + 1.day,
           cpd_lead_provider: lead_provider.cpd_lead_provider,
-          declaration_type: RecordDeclarations::ECF::RETAINED_ONE,
+          declaration_type: "retained-1",
           evidence_held: "other",
         },
       )

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         missing_attribute = valid_params.except(:participant_id)
         post "/api/v1/participant-declarations", params: build_params(missing_attribute)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t("activemodel.errors.models.record_declarations/base.attributes.participant_id.blank") }] }.to_json)
+        expect(JSON.parse(response.body)["errors"]).to include({ title: "Bad or missing parameters", detail: I18n.t("activemodel.errors.models.record_declarations/base.attributes.participant_id.blank") }.stringify_keys)
       end
 
       it "ignores an unpermitted parameter" do
@@ -184,7 +184,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         invalid_participant_for_course_type = valid_params.merge({ course_identifier: "ecf-mentor" })
         post "/api/v1/participant-declarations", params: build_params(invalid_participant_for_course_type)
         expect(response.status).to eq 422
-        expect(response.body).to eq({ errors: [{ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }] }.to_json)
+        expect(JSON.parse(response.body)["errors"]).to include({ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }.stringify_keys)
       end
 
       it "returns 422 when there are multiple errors" do

--- a/spec/services/record_declarations/base_spec.rb
+++ b/spec/services/record_declarations/base_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe RecordDeclarations::Base do
       end
 
       it "returns an error" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing, /Declaration type does not exist for this schedule/)
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing, /#\/declaration_type does not exist for this schedule/)
       end
     end
   end

--- a/spec/services/record_declarations/base_spec.rb
+++ b/spec/services/record_declarations/base_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RecordDeclarations::Base do
     end
   end
 
-  context "when milestone has null milestone_date" do
+  describe "#call" do
     let(:klass) do
       Class.new(described_class) do
         def self.valid_declaration_types
@@ -120,6 +120,7 @@ RSpec.describe RecordDeclarations::Base do
         end
       end
     end
+
     subject do
       klass.new(
         params: {
@@ -132,12 +133,36 @@ RSpec.describe RecordDeclarations::Base do
       )
     end
 
-    before do
-      Finance::Milestone.find_by(declaration_type: "started").update!(milestone_date: nil)
+    context "when milestone has null milestone_date" do
+      before do
+        Finance::Milestone.find_by(declaration_type: "started").update!(milestone_date: nil)
+      end
+
+      it "does not have errors on milestone_date" do
+        expect { subject.call }.not_to raise_error
+      end
     end
 
-    it "does not have errors on milestone_date" do
-      expect { subject.call }.not_to raise_error
+    context "when declaration_type does not exist for the schedule" do
+      before do
+        ect_participant_profile.schedule.milestones.find_by(declaration_type: "retained-4").destroy
+      end
+
+      subject do
+        klass.new(
+          params: {
+            course_identifier: "ecf-induction",
+            cpd_lead_provider: cpd_lead_provider,
+            declaration_date: 10.days.ago.iso8601,
+            declaration_type: "retained-4",
+            participant_id: user.id,
+          },
+        )
+      end
+
+      it "returns an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing, /Declaration type does not exist for this schedule/)
+      end
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1001

- It was assumed `declaration_type` is tied to the the groupings ECF/NPQ
- However this is not quite the case and can be gathered from the schedule they are on
- Remove the hardcoded declaration type from `RecordDeclarations` as we now want to delegate this to the schedule
- Therefore we can now validate the incoming `declaration_type` against the current schedule

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Attempt to submit a `retained-7` declaration for any participant as this milestones does not exist
- Should see a relevant validation error message returned
- Another test is to find/create a participant on one of the `npq-specialist` schedules
- Attempt to send a `retained-2` declaration which does not exist
- Should see a relevant validation error message returned

## External API changes

- Nothing that needs to be documented