### PR TITLE
[CPDLP-962] Can void not last declaration

### DIFF
--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -12,7 +12,6 @@ class VoidParticipantDeclaration
     # TODO: these should be moved to activemodel validations
     # and not controller level exceptions
     raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_already_voided) if declaration.voided?
-    raise Api::Errors::InvalidTransitionError, I18n.t(:void_last_declaration_only) if latest_declaration != declaration
     raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_not_voidable) unless declaration.voidable?
 
     declaration.make_voided!
@@ -24,9 +23,5 @@ private
 
   def declaration
     @declaration ||= ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(id)
-  end
-
-  def latest_declaration
-    @latest_declaration ||= declaration.participant_profile.participant_declarations.order(declaration_date: :desc).first
   end
 end

--- a/app/views/finance/ecf/declarations/voided.html.erb
+++ b/app/views/finance/ecf/declarations/voided.html.erb
@@ -15,6 +15,7 @@
           <% row.cell(header: true, text: "Declaration ID") %>
           <% row.cell(header: true, text: "Participant ID") %>
           <% row.cell(header: true, text: "Type") %>
+          <% row.cell(header: true, text: "Course") %>
         <% end %>
       <% end %>
 
@@ -24,6 +25,7 @@
             <% row.cell(text: declaration.id) %>
             <% row.cell(text: declaration.user.id) %>
             <% row.cell(text: declaration.declaration_type) %>
+            <% row.cell(text: declaration.course_identifier) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/finance/npq/statements/voided.html.erb
+++ b/app/views/finance/npq/statements/voided.html.erb
@@ -15,6 +15,7 @@
           <% row.cell(header: true, text: "Declaration ID") %>
           <% row.cell(header: true, text: "Participant ID") %>
           <% row.cell(header: true, text: "Type") %>
+          <% row.cell(header: true, text: "Course") %>
         <% end %>
       <% end %>
 
@@ -24,6 +25,7 @@
             <% row.cell(text: declaration.id) %>
             <% row.cell(text: declaration.user.id) %>
             <% row.cell(text: declaration.declaration_type) %>
+            <% row.cell(text: declaration.course_identifier) %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,6 @@ en:
   declaration_on_incorrect_state: "The declaration on withdrawn or deferred participant can not be accepted"
   declaration_already_voided: "Declaration is already voided"
   declaration_not_voidable: "Declaration not voidable"
-  void_last_declaration_only: "Can only void last declaration"
   schedule_missing: "The participant does not have a schedule"
   declaration_before_milestone_start: "The property '#/declaration_date' can not be before milestone start"
   declaration_after_milestone_cutoff: "The property '#/declaration_date' can not be after milestone end"

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -49,35 +49,6 @@ RSpec.describe VoidParticipantDeclaration do
       }.to raise_error ActiveRecord::RecordNotFound
     end
 
-    context "when there are other declarations" do
-      let(:old_declaration) do
-        create(
-          :participant_declaration,
-          :submitted,
-          declaration_date: start_date + 1.day,
-          course_identifier: "ecf-induction",
-          declaration_type: "started",
-          cpd_lead_provider: cpd_lead_provider,
-          participant_profile: profile,
-        )
-      end
-
-      before do
-        declaration
-      end
-
-      it "only voids the last declaration" do
-        expect {
-          described_class.new(cpd_lead_provider: cpd_lead_provider, id: old_declaration.id).call
-        }.to raise_error Api::Errors::InvalidTransitionError
-
-        expect(old_declaration.reload).not_to be_voided
-
-        subject.call
-        expect(declaration.reload).to be_voided
-      end
-    end
-
     context "when declaration is payable" do
       let(:declaration) do
         create(


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-962

- Previously limiting voids to last declaration only may have made sense
- However now this does not seem a reasonable constraint to have
- So has been removed

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- For a given statement in play
- Assign some payable declarations to it if there aren't any
- Note the value of the statement
- Should be able to void a payable declaration via the api
- Value of statement should drop
- When viewing the statement at the bottom should be able to click through to the declaration(s) that have been voided

## External API changes

- Nothing that needs documenting