### PR TITLE
[CPDLP-1040] Stop payable declarations reverting to eligible

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -81,7 +81,7 @@ class ParticipantDeclaration < ApplicationRecord
   scope :paid_npqs_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).npq }
   scope :paid_uplift_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).uplift }
 
-  after_create :create_initial_declaration_state
+  before_create :build_initial_declaration_state
 
   # TODO: Voiding paid should trigger clawbacks, but currently OOS
   def voidable?
@@ -131,8 +131,8 @@ class ParticipantDeclaration < ApplicationRecord
 
 private
 
-  def create_initial_declaration_state
-    declaration_states.create(state: state)
+  def build_initial_declaration_state
+    declaration_states.build(state: state)
   end
 end
 

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -81,6 +81,8 @@ class ParticipantDeclaration < ApplicationRecord
   scope :paid_npqs_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).npq }
   scope :paid_uplift_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).uplift }
 
+  after_create :create_initial_declaration_state
+
   # TODO: Voiding paid should trigger clawbacks, but currently OOS
   def voidable?
     !voided? && !paid?
@@ -125,6 +127,12 @@ class ParticipantDeclaration < ApplicationRecord
         course_identifier: course_identifier,
         superseded_by_id: nil,
       )
+  end
+
+private
+
+  def create_initial_declaration_state
+    declaration_states.create(state: state)
   end
 end
 

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -42,12 +42,11 @@ module RecordDeclarations
       raise ActiveRecord::RecordNotUnique, "Declaration with given participant ID already exists" if record_exists_with_different_declaration_date?
 
       ParticipantDeclaration.transaction do
-        DeclarationState.submitted!(participant_declaration)
-
         set_eligibility
 
         declaration_attempt.update!(participant_declaration: participant_declaration)
       end
+
       ParticipantDeclarationSerializer.new(participant_declaration).serializable_hash.to_json
     end
 
@@ -78,12 +77,8 @@ module RecordDeclarations
       ParticipantDeclarationAttempt.create!(declaration_parameters.except(:participant_profile))
     end
 
-    def find_or_create_record!
-      self.class.declaration_model.find_or_create_by!(declaration_parameters)
-    end
-
     def participant_declaration
-      @participant_declaration ||= find_or_create_record!
+      @participant_declaration ||= self.class.declaration_model.create!(declaration_parameters)
     end
 
     def declaration_parameters

--- a/spec/features/participant-declarations/block_participant_declaration_paid_twice_spec.rb
+++ b/spec/features/participant-declarations/block_participant_declaration_paid_twice_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Block participant declaration paid twice", type: :feature do
     then_the_declaration_made_is_valid
     and_schedule_change_is_submitted_for_this_participant
     and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
-    then_second_declaration_is_not_created
+    then_second_declaration_is_created
   end
 
   scenario "Declaration submitted for a changed lead provider" do

--- a/spec/features/participant-declarations/participant_declaration_steps.rb
+++ b/spec/features/participant-declarations/participant_declaration_steps.rb
@@ -123,8 +123,13 @@ module ParticipantDeclarationSteps
     partnership.destroy!
   end
 
+  def then_second_declaration_is_created
+    expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started", state: "submitted").count).to eq(1)
+    expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started", state: "ineligible").count).to eq(1)
+  end
+
   def then_second_declaration_is_not_created
-    expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started").count).to eq(1)
+    expect(ParticipantDeclaration.count).to eq(1)
   end
 
   def and_the_npq_declaration_date_is_early

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(ParticipantDeclaration.order(:created_at).last).to be_eligible
       end
 
-      it "does not create duplicate declarations with the same declaration date, but stores the duplicate declaration attempts" do
+      it "does create duplicate declarations with the same declaration date and stores the duplicate declaration attempts" do
         params = build_params(valid_params)
         post "/api/v1/participant-declarations", params: params
         original_id = parsed_response["id"]
 
         expect { post "/api/v1/participant-declarations", params: params }
-            .not_to change(ParticipantDeclaration, :count)
+            .to change(ParticipantDeclaration, :count).by(1)
         expect { post "/api/v1/participant-declarations", params: params }
             .to change(ParticipantDeclarationAttempt, :count).by(1)
 
@@ -74,7 +74,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(parsed_response["id"]).to eq(original_id)
       end
 
-      it "does not create duplicate declarations with different declaration date, but stores the duplicate declaration attempts" do
+      it "does create duplicate declarations with different declaration date and stores the duplicate declaration attempts" do
         params = build_params(valid_params)
 
         new_valid_params = valid_params
@@ -86,7 +86,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         original_id = parsed_response["id"]
 
         expect { post "/api/v1/participant-declarations", params: params }
-            .not_to change(ParticipantDeclaration, :count)
+            .to change(ParticipantDeclaration, :count).by(1)
         expect { post "/api/v1/participant-declarations", params: params_with_different_declaration_date }
             .to change(ParticipantDeclarationAttempt, :count).by(1)
 

--- a/spec/support/shared_examples/participant_declaration_support.rb
+++ b/spec/support/shared_examples/participant_declaration_support.rb
@@ -15,11 +15,11 @@ RSpec.shared_examples "a participant declaration service" do
     expect { described_class.call(params: given_params) }.to change { ParticipantDeclaration.count }.by(1)
   end
 
-  it "does not create exact duplicates" do
+  it "does create exact duplicates" do
     expect {
       described_class.call(params: given_params)
       described_class.call(params: given_params)
-    }.to change { ParticipantDeclaration.count }.by(1)
+    }.to change { ParticipantDeclaration.count }.by(2)
   end
 
   it "does not create close duplicates and throws an error" do


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1040

- This fixes a bug where by a provider could submit a declaration for an existing payable declaration causing it to revert back to eligible
- All incoming declarations now create a new record regardless if another similar one exists or not
- We now create a DeclarationState record when a ParticipantDeclation is created as an ActiveRecord callback

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Find a declaration in payable or paid state
- Submit the same declaration again as the provider
- NOTE: timestamps MUST be identical otherwise it will be considered as a different declaration and you get some kind of error which doesn't test this edge case
- It will create another declaration that is ineligible
- The original declaration will remain in original state of payable or paid

## External API changes

- Nothing that needs documenting