### PR TITLE
Fixed  bug after succesful deduplication

### DIFF
--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -13,15 +13,28 @@ module CurrentUser
 
     @deduped_current_user = transferred_identity&.user || original
   end
+
+  def true_user
+    return @deduped_true_user if defined? @deduped_true_user
+
+    original = super
+    return if original.nil?
+
+    transferred_identity = ParticipantIdentity.transferred.find_by(external_identifier: original.id)
+
+    @deduped_true_user = transferred_identity&.user || original
+  end
   # rubocop:enable Naming/MemoizedInstanceVariableName
 
   def impersonate_user(user)
     super
     remove_instance_variable(:@deduped_current_user)
+    remove_instance_variable(:@deduped_true_user)
   end
 
   def stop_impersonating_user
     super
     remove_instance_variable(:@deduped_current_user)
+    remove_instance_variable(:@deduped_true_user)
   end
 end

--- a/spec/features/dedup/session_spec.rb
+++ b/spec/features/dedup/session_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Dedup: maintaining session after identity transfer", :js do
+  let(:original_user) { create(:ect_participant_profile).user }
+  let(:target_user) { create(:npq_participant_profile).user }
+
+  before do
+    Identity::Transfer.call(from_user: original_user, to_user: target_user)
+  end
+
+  it "silently switches current_user onto user to which we transferred identity" do
+    sign_in_as original_user
+    expect(page).to have_no_content "You are impersonating"
+  end
+end


### PR DESCRIPTION
https://teachercpdhelp.zendesk.com/agent/tickets/12103

When automated deduplication was implemented we were forced to use a "temporary" hack to swap the `current_user` with the user an actual `current_user` has been merged into. This hack unfortunately means that after the transfer, the `current_user` and `true_user` are different, which system interpretes as impersonification.

This "fixes" this by carrying the same hack for a `true_user`.