### PR TITLE
[CPDLP-1025] Add NPQ statement selector

### DIFF
--- a/app/components/finance/statements/statement_selector.html.erb
+++ b/app/components/finance/statements/statement_selector.html.erb
@@ -1,0 +1,19 @@
+<%= form_with url: choose_npq_statement_finance_payment_breakdowns_path, class: "statement-selector" do |f| %>
+  <%= f.govuk_collection_select :npq_lead_provider,
+    npq_lead_providers,
+    :id,
+    :name,
+    label: { text: "View a different provider" },
+    options: { include_blank: "Select an option" }
+  %>
+
+  <%= f.govuk_collection_select :statement,
+    statements,
+    :id,
+    :name,
+    label: { text: "View a different statement" },
+    options: { include_blank: "Select an option" }
+  %>
+
+  <%= f.govuk_submit "View", secondary: true %>
+<% end %>

--- a/app/components/finance/statements/statement_selector.html.erb
+++ b/app/components/finance/statements/statement_selector.html.erb
@@ -12,7 +12,7 @@
     :id,
     :name,
     label: { text: "View a different statement" },
-    options: { selected: current_statement.identifier }
+    options: { selected: current_statement.name.parameterize }
   %>
 
   <%= f.govuk_submit "View", secondary: true %>

--- a/app/components/finance/statements/statement_selector.html.erb
+++ b/app/components/finance/statements/statement_selector.html.erb
@@ -4,7 +4,7 @@
     :id,
     :name,
     label: { text: "View a different provider" },
-    options: { include_blank: "Select an option" }
+    options: { selected: current_statement.npq_lead_provider.id }
   %>
 
   <%= f.govuk_collection_select :statement,
@@ -12,7 +12,7 @@
     :id,
     :name,
     label: { text: "View a different statement" },
-    options: { include_blank: "Select an option" }
+    options: { selected: current_statement.identifier }
   %>
 
   <%= f.govuk_submit "View", secondary: true %>

--- a/app/components/finance/statements/statement_selector.rb
+++ b/app/components/finance/statements/statement_selector.rb
@@ -3,6 +3,12 @@
 module Finance
   module Statements
     class StatementSelector < BaseComponent
+      attr_reader :current_statement
+
+      def initialize(current_statement:)
+        @current_statement = current_statement
+      end
+
       def npq_lead_providers
         NPQLeadProvider.all
       end

--- a/app/components/finance/statements/statement_selector.rb
+++ b/app/components/finance/statements/statement_selector.rb
@@ -10,13 +10,13 @@ module Finance
       end
 
       def npq_lead_providers
-        NPQLeadProvider.all
+        NPQLeadProvider.order(:name)
       end
 
       def statements
-        Finance::Statement::NPQ
-          .distinct(:name)
+        Finance::Statement::NPQ.order(:payment_date)
           .pluck(:name)
+          .uniq
           .map do |name|
             OpenStruct.new(
               id: name.downcase.gsub(" ", "-"),

--- a/app/components/finance/statements/statement_selector.rb
+++ b/app/components/finance/statements/statement_selector.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Finance
+  module Statements
+    class StatementSelector < BaseComponent
+      def npq_lead_providers
+        NPQLeadProvider.all
+      end
+
+      def statements
+        Finance::Statement::NPQ
+          .distinct(:name)
+          .pluck(:name)
+          .map do |name|
+            OpenStruct.new(
+              id: name.downcase.gsub(" ", "-"),
+              name: name,
+            )
+          end
+      end
+    end
+  end
+end

--- a/app/controllers/finance/ecf/declarations_controller.rb
+++ b/app/controllers/finance/ecf/declarations_controller.rb
@@ -6,8 +6,14 @@ module Finance
       def voided
         @ecf_lead_provider = LeadProvider.find(params[:payment_breakdown_id])
         @cpd_lead_provider = @ecf_lead_provider.cpd_lead_provider
-        @statement = @cpd_lead_provider.statements.find_by(name: params[:statement_id])
+        @statement = @cpd_lead_provider.statements.find_by(name: statement_id_to_name)
         @voided_declarations = @statement.participant_declarations.voided
+      end
+
+    private
+
+      def statement_id_to_name
+        params[:statement_id].humanize.gsub("-", " ")
       end
     end
   end

--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -11,7 +11,7 @@ module Finance
 
         @statements = @ecf_lead_provider.statements.upto_current.order(payment_date: :desc)
 
-        @statement = @ecf_lead_provider.statements.find(params[:id])
+        @statement = @ecf_lead_provider.statements.find_by(name: identifier_to_name)
 
         aggregator = ParticipantAggregator.new(
           statement: @statement,
@@ -29,6 +29,10 @@ module Finance
       end
 
     private
+
+      def identifier_to_name
+        params[:id].humanize.gsub("-", " ")
+      end
 
       def lead_provider_scope
         policy_scope(LeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
+++ b/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
@@ -7,7 +7,7 @@ module Finance
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
         @npq_course        = NPQCourse.find_by!(identifier: params[:id])
-        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find(params[:statement_id])
+        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: statement_id_to_name)
         @breakdown         = Finance::NPQ::CalculationOrchestrator.new(
           statement: @statement,
           contract: @npq_lead_provider.npq_contracts.find_by!(course_identifier: params[:id]),
@@ -16,6 +16,10 @@ module Finance
       end
 
     private
+
+      def statement_id_to_name
+        params[:statement_id].humanize.gsub("-", " ")
+      end
 
       def lead_provider_scope
         policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -8,7 +8,7 @@ module Finance
       def show
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
-        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find(params[:id])
+        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: identifier_to_name)
         @statements        = @npq_lead_provider.statements.upto_current.order(payment_date: :desc)
 
         @breakdowns = Finance::NPQ::CalculationOverviewOrchestrator.new(
@@ -20,11 +20,15 @@ module Finance
       def voided
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
-        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find(params[:id])
+        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: identifier_to_name)
         @voided_declarations = @statement.participant_declarations.voided
       end
 
     private
+
+      def identifier_to_name
+        params[:id].humanize.gsub("-", " ")
+      end
 
       def lead_provider_scope
         policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/payment_breakdowns_controller.rb
@@ -42,7 +42,7 @@ module Finance
       # TODO: remove when we have created the next statement
       statement ||= npq_lead_provider.statements.order(payment_date: :desc).first
 
-      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider, statement.identifier)
+      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider, statement)
     end
 
     def choose_npq_statement
@@ -50,7 +50,7 @@ module Finance
       statement_name = params[:statement].humanize.gsub("-", " ")
       statement = npq_lead_provider.statements.find_by(name: statement_name)
 
-      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider.id, statement.identifier)
+      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider.id, statement)
     end
 
   private

--- a/app/controllers/finance/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/payment_breakdowns_controller.rb
@@ -27,7 +27,7 @@ module Finance
 
       lead_provider = LeadProvider.find(@choose_programme_form.provider)
 
-      redirect_to finance_ecf_payment_breakdown_statement_path(lead_provider, lead_provider.current_statement)
+      redirect_to finance_ecf_payment_breakdown_statement_path(lead_provider, (lead_provider.current_statement || lead_provider.statements.latest))
     end
 
     def select_provider_npq; end

--- a/app/controllers/finance/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/payment_breakdowns_controller.rb
@@ -42,7 +42,15 @@ module Finance
       # TODO: remove when we have created the next statement
       statement ||= npq_lead_provider.statements.order(payment_date: :desc).first
 
-      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider, statement)
+      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider, statement.identifier)
+    end
+
+    def choose_npq_statement
+      npq_lead_provider = NPQLeadProvider.find(params[:npq_lead_provider])
+      statement_name = params[:statement].humanize.gsub("-", " ")
+      statement = npq_lead_provider.statements.find_by(name: statement_name)
+
+      redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider.id, statement.identifier)
     end
 
   private

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -20,6 +20,11 @@ class Finance::Statement < ApplicationRecord
   def current?
     payment_date > Time.current && deadline_date > Time.current
   end
+
+  def identifier
+    name.downcase.gsub(" ", "-")
+  end
 end
+
 require "finance/statement/ecf"
 require "finance/statement/npq"

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -22,7 +22,7 @@ class Finance::Statement < ApplicationRecord
     payment_date > Time.current && deadline_date > Time.current
   end
 
-  def identifier
+  def to_param
     name.downcase.gsub(" ", "-")
   end
 end

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -11,6 +11,7 @@ class Finance::Statement < ApplicationRecord
   scope :payable, -> { where("deadline_date < DATE(NOW()) AND payment_date >= DATE(NOW())") }
   scope :closed,  -> { where("payment_date < ?", Date.current) }
   scope :current, -> { where("deadline_date >= DATE(NOW())") }
+  scope :latest, -> { order(deadline_date: :asc).last }
   scope :upto_current, -> { payable.or(closed).or(current) }
 
   def past_deadline_date?

--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -40,15 +40,22 @@ private
   def ecf_statements
     [
       { name: "November 2021", deadline_date: Date.new(2021, 11, 30), payment_date: Date.new(2021, 11, 30) },
-      { name: "January 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
-      { name: "February 2022", deadline_date: Date.new(2022, 2, 28), payment_date: Date.new(2022, 3, 31) },
+      { name: "January 2022", deadline_date: Date.new(2021, 12, 31), payment_date: Date.new(2022, 1, 25) },
+      { name: "February 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 25) },
     ].map { |hash| OpenStruct.new(hash) }
   end
 
   def npq_statements
     [
-      { name: "December 2021", deadline_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 31) },
-      { name: "January 2022", deadline_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28) },
+      { name: "January 2022", deadline_date: Date.new(2021, 12, 25), payment_date: Date.new(2022, 1, 25) },
+      { name: "February 2022", deadline_date: Date.new(2022, 1, 25), payment_date: Date.new(2022, 2, 25) },
+      { name: "March 2022", deadline_date: Date.new(2022, 2, 25), payment_date: Date.new(2022, 3, 25) },
+      { name: "April 2022", deadline_date: Date.new(2022, 3, 25), payment_date: Date.new(2022, 4, 25) },
+      { name: "May 2022", deadline_date: Date.new(2022, 4, 25), payment_date: Date.new(2022, 5, 25) },
+      { name: "June 2022", deadline_date: Date.new(2022, 5, 25), payment_date: Date.new(2022, 6, 25) },
+      { name: "July 2022", deadline_date: Date.new(2022, 6, 25), payment_date: Date.new(2022, 7, 25) },
+      { name: "August 2022", deadline_date: Date.new(2022, 7, 25), payment_date: Date.new(2022, 8, 25) },
+      { name: "September 2022", deadline_date: Date.new(2022, 8, 25), payment_date: Date.new(2022, 9, 25) },
     ].map { |hash| OpenStruct.new(hash) }
   end
 end

--- a/app/views/finance/ecf/declarations/voided.html.erb
+++ b/app/views/finance/ecf/declarations/voided.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("finance.voided_declarations") %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: finance_ecf_payment_breakdown_statement_path(payment_breakdown_id: @ecf_lead_provider.id, id: @statement.name)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_ecf_payment_breakdown_statement_path(@ecf_lead_provider.id, @statement)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -35,7 +35,7 @@
     <% end %>
 
     <ul class="govuk-list">
-      <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_ecf_payment_breakdown_statement_declarations_path(payment_breakdown_id: @ecf_lead_provider.id, statement_id: @statement.name) %></li>
+      <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_ecf_payment_breakdown_statement_declarations_path(@ecf_lead_provider.id, @statement) %></li>
       <li><%= govuk_link_to t("finance.show_contract"), finance_ecf_contract_path(id: @ecf_lead_provider.id) %></li>
     </ul>
   </div>

--- a/app/views/finance/npq/course_payment_breakdowns/show.html.erb
+++ b/app/views/finance/npq/course_payment_breakdowns/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("finance.npq.payment_breakdown") %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider, @statement.identifier)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider, @statement)) %>
 
 <h1 class="govuk-heading-xl"><%= @cpd_lead_provider.name %></h1>
 <h2 class="govuk-heading-l"><%= @npq_course.name %></h2>

--- a/app/views/finance/npq/course_payment_breakdowns/show.html.erb
+++ b/app/views/finance/npq/course_payment_breakdowns/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("finance.npq.payment_breakdown") %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider, @statement)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider, @statement.identifier)) %>
 
 <h1 class="govuk-heading-xl"><%= @cpd_lead_provider.name %></h1>
 <h2 class="govuk-heading-l"><%= @npq_course.name %></h2>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -2,18 +2,12 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: select_provider_npq_finance_payment_breakdowns_path) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <ul class="govuk-list">
-      <% @statements.each do |statement| %>
-        <li><%= text_otherwise_link_to(statement_display_text(statement), finance_npq_lead_provider_statement_path(@npq_lead_provider, statement), statement == @statement) %></li>
-      <% end %>
-    </ul>
-  </div>
-
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
       <%= @breakdowns.dig(0, :breakdown_summary, :name) %>
     </h1>
+
+    <%= render Finance::Statements::StatementSelector.new  %>
 
     <p class="govuk-caption-m govuk-!-margin-0">Payment of</p>
     <h2 class="govuk-heading-xl govuk-!-margin-0"><%= number_to_pounds aggregated_payment(@breakdowns) + aggregated_vat(@breakdowns, @npq_lead_provider) %></h2>
@@ -39,6 +33,6 @@
 </div>
 
 <ul class="govuk-list">
-  <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement.id) %></li>
+  <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement.identifier) %></li>
   <li><%= govuk_link_to t("finance.show_contract"), finance_npq_contract_path(id: @npq_lead_provider.id) %></li>
 </ul>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -7,7 +7,7 @@
       <%= @breakdowns.dig(0, :breakdown_summary, :name) %>
     </h1>
 
-    <%= render Finance::Statements::StatementSelector.new  %>
+    <%= render Finance::Statements::StatementSelector.new(current_statement: @statement)  %>
 
     <p class="govuk-caption-m govuk-!-margin-0">Payment of</p>
     <h2 class="govuk-heading-xl govuk-!-margin-0"><%= number_to_pounds aggregated_payment(@breakdowns) + aggregated_vat(@breakdowns, @npq_lead_provider) %></h2>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -34,6 +34,6 @@
 </div>
 
 <ul class="govuk-list">
-  <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement.identifier) %></li>
+  <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement) %></li>
   <li><%= govuk_link_to t("finance.show_contract"), finance_npq_contract_path(id: @npq_lead_provider.id) %></li>
 </ul>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -3,9 +3,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">
-      <%= @breakdowns.dig(0, :breakdown_summary, :name) %>
-    </h1>
+    <h1 class="govuk-heading-xl">National professional qualifications (NPQs)</h1>
+
+    <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
+    <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 
     <%= render Finance::Statements::StatementSelector.new(current_statement: @statement)  %>
 

--- a/app/views/finance/npq/statements/voided.html.erb
+++ b/app/views/finance/npq/statements/voided.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("finance.voided_declarations") %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider.id, id: @statement.id)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider.id, id: @statement.identifier)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/finance/npq/statements/voided.html.erb
+++ b/app/views/finance/npq/statements/voided.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t("finance.voided_declarations") %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider.id, id: @statement.identifier)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_npq_lead_provider_statement_path(@npq_lead_provider.id, id: @statement)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -33,6 +33,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "aside";
 @import "vendor/nhs_tables";
 @import "table";
+@import "components/statement_selector";
 
 .govuk-tag {
   white-space: nowrap;

--- a/app/webpacker/styles/components/statement_selector.scss
+++ b/app/webpacker/styles/components/statement_selector.scss
@@ -1,0 +1,14 @@
+.statement-selector {
+  margin-bottom: 30px;
+
+  .govuk-form-group {
+    display: inline-block;
+    margin-right: 20px;
+    margin-bottom: 0;
+  }
+
+  input[type=submit] {
+    margin-bottom: 0;
+    vertical-align: bottom;
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,6 +286,10 @@ Rails.application.routes.draw do
       post "/choose-provider-ecf", to: "payment_breakdowns#choose_provider_ecf", as: :choose_provider_ecf
       get "/choose-provider-npq", to: "payment_breakdowns#select_provider_npq", as: :select_provider_npq
       post "/choose-provider-npq", to: "payment_breakdowns#choose_provider_npq", as: :choose_provider_npq
+
+      collection do
+        post :choose_npq_statement, path: "choose-npq-statement"
+      end
     end
 
     resources :schedules, only: %i[index show]

--- a/spec/components/finance/statements/statement_selector_spec.rb
+++ b/spec/components/finance/statements/statement_selector_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Finance::Statements::StatementSelector, type: :component do
 
   it "has dropdown with statements" do
     expect(rendered).to have_selector("select#statement-field")
-    expect(rendered).to have_selector("select#statement-field option[value='#{npq_statement.identifier}']", text: npq_statement.name)
+    expect(rendered).to have_selector("select#statement-field option[value='#{npq_statement.name.parameterize}']", text: npq_statement.name)
   end
 
   it "has submit button" do

--- a/spec/components/finance/statements/statement_selector_spec.rb
+++ b/spec/components/finance/statements/statement_selector_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 RSpec.describe Finance::Statements::StatementSelector, type: :component do
   let!(:npq_lead_provider) { create(:npq_lead_provider) }
   let!(:npq_statement) { create(:npq_statement) }
+  let!(:other_npq_statement) { create(:npq_statement) }
 
-  let(:rendered) { render_inline(described_class.new) }
+  let(:rendered) { render_inline(described_class.new(current_statement: npq_statement)) }
 
   it "has a form that PUTs to correct action" do
     expect(rendered).to have_selector("form[method=post][action='/finance/payment-breakdowns/choose-npq-statement']")
@@ -24,5 +25,13 @@ RSpec.describe Finance::Statements::StatementSelector, type: :component do
 
   it "has submit button" do
     expect(rendered).to have_selector("input[type=submit]")
+  end
+
+  it "defaults selected lead provider to current lead provider" do
+    expect(rendered).to have_selector("select#npq-lead-provider-field option[selected]", text: npq_statement.npq_lead_provider.name, visible: false)
+  end
+
+  it "defaults selected statement to current statement" do
+    expect(rendered).to have_selector("select#statement-field option[selected]", text: npq_statement.name, visible: false)
   end
 end

--- a/spec/components/finance/statements/statement_selector_spec.rb
+++ b/spec/components/finance/statements/statement_selector_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::Statements::StatementSelector, type: :component do
+  let!(:npq_lead_provider) { create(:npq_lead_provider) }
+  let!(:npq_statement) { create(:npq_statement) }
+
+  let(:rendered) { render_inline(described_class.new) }
+
+  it "has a form that PUTs to correct action" do
+    expect(rendered).to have_selector("form[method=post][action='/finance/payment-breakdowns/choose-npq-statement']")
+  end
+
+  it "has dropdown with NPQ lead providers" do
+    expect(rendered).to have_selector("select#npq-lead-provider-field")
+    expect(rendered).to have_selector("select#npq-lead-provider-field option[value='#{npq_lead_provider.id}']", text: npq_lead_provider.name)
+  end
+
+  it "has dropdown with statements" do
+    expect(rendered).to have_selector("select#statement-field")
+    expect(rendered).to have_selector("select#statement-field option[value='#{npq_statement.identifier}']", text: npq_statement.name)
+  end
+
+  it "has submit button" do
+    expect(rendered).to have_selector("input[type=submit]")
+  end
+end

--- a/spec/factories/finance/statement/npq.rb
+++ b/spec/factories/finance/statement/npq.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :npq_statement, class: "finance/statement/npq" do
-    name { "Statement of fact" }
-    cpd_lead_provider
+    sequence(:name) { |n| "NPQ statement #{n}" }
+    association :cpd_lead_provider, :with_npq_lead_provider
     deadline_date { 1.month.ago }
     payment_date { 2.days.from_now }
   end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -151,7 +151,7 @@ private
   end
 
   def then_i_should_have_the_correct_payment_breakdown_per_npq_lead_provider
-    within "main .govuk-grid-column-two-thirds table:nth-of-type(2)" do
+    within "main .govuk-grid-column-full table:nth-of-type(2)" do
       expect(page)
         .to have_css("tbody tr.govuk-table__row:nth-child(1) a[href='#{finance_npq_lead_provider_statement_course_path(npq_lead_provider, statement, id: npq_leading_teaching_contract.course_identifier)}']")
       expect(page)
@@ -162,7 +162,7 @@ private
   end
 
   def then_i_should_see_the_courses_vat_and_total_payment
-    within "main .govuk-grid-column-two-thirds table:nth-of-type(2)" do
+    within "main .govuk-grid-column-full table:nth-of-type(2)" do
       expect(page).to have_css("tr:nth-child(4) td:nth-child(1)", text: "VAT")
       expect(page).to have_css("tr:nth-child(4) td:nth-child(2)", text: number_to_pounds(aggregated_vat(breakdowns, npq_lead_provider)))
       expect(page).to have_css("tr:nth-child(5) td:nth-child(1)", text: "Total payment")

--- a/spec/services/importers/seed_statements_spec.rb
+++ b/spec/services/importers/seed_statements_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Importers::SeedStatements do
       expect {
         subject.call
         subject.call
-      }.to change(Finance::Statement::NPQ, :count).by(2)
+      }.to change(Finance::Statement::NPQ, :count).by(9)
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1025

- Add NPQ statement selector component
- Pre-selects values to whatever the current statement is
- LHS Nav is gone and now full width

## Screenhots

![Screenshot 2022-02-24 at 14 58 24](https://user-images.githubusercontent.com/92580/155549090-bb337bff-adc7-4924-afce-ff2dd4e9edb7.png)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Visit https://ecf-review-pr-1751.london.cloudapps.digital/
- Login as a finance user
- View an NPQ statement
- Should be able to switch to a different provider and/or statement without leaving the page

## External API changes

- None