### PR TITLE
[CPDLP-1066] Add NPQ school and provider to drill down page

### DIFF
--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -15,6 +15,16 @@
   <% end %>
 
   <% summary_list.row do |row| %>
+    <% row.key { "Lead provider" } %>
+    <% row.value { pp.npq_application&.npq_lead_provider&.name } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "School URN" } %>
+    <% row.value { pp.npq_application&.school_urn } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
     <% row.key { "Status" } %>
     <% row.value { pp.status } %>
   <% end %>

--- a/spec/views/finance/participants/show.html.erb_spec.rb
+++ b/spec/views/finance/participants/show.html.erb_spec.rb
@@ -21,13 +21,16 @@ RSpec.describe "finance/participants/show.html.erb" do
     let(:profile) { create(:npq_participant_profile) }
     let(:user) { profile.user }
 
-    it "renders schedule identifier and cohort" do
+    it "renders needed information" do
       assign :user, user
 
       render
 
       expect(rendered).to have_content("Schedule identifier#{profile.schedule.schedule_identifier}")
       expect(rendered).to have_content("Schedule cohort#{profile.schedule.cohort.start_year}")
+
+      expect(rendered).to have_content("Lead provider#{profile.npq_application.npq_lead_provider.name}")
+      expect(rendered).to have_content("School URN#{profile.npq_application.school_urn}")
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1066

- When viewing participant drill down pages in finance area
- When viewing an NPQ profile
- Added school URN and lead provider

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

- Login as a finance user
- View a user with an NPQ profile
- Should see school URN and lead provider

### How can someone see it it review app?

## External API changes

- None