### PR TITLE
Add now required statement to breakdown spec

### DIFF
--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Finance users payment breakdowns", :with_default_schedules, type:
 
   let!(:lead_provider)    { create(:lead_provider, name: "Test provider", id: "cffd2237-c368-4044-8451-68e4a4f73369") }
   let(:cpd_lead_provider) { lead_provider.cpd_lead_provider }
+  let!(:statement)        { create(:ecf_statement, cpd_lead_provider: cpd_lead_provider) }
   let!(:contract)         { create(:call_off_contract, lead_provider: lead_provider) }
   let(:school)            { create(:school) }
   let(:cohort)            { create(:cohort, :current) }


### PR DESCRIPTION
## Ticket and context

The payment breakdown now requires that there is a current statement for each lead provider. This PR creates a statement so that the test doesn't fail.