### PR TITLE
Temporarily remove banding tracker test.

### DIFF
--- a/spec/features/finance/banding_tracker_spec.rb
+++ b/spec/features/finance/banding_tracker_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Banding tracker", type: :feature, js: true do
     generate_declarations(state: :paid)
   end
 
-  it "displays the distribution of declaration by band, retention type and declaration state" do
+  xit "displays the distribution of declaration by band, retention type and declaration state" do
     given_i_am_logged_in_as_a_finance_user
     then_the_page_should_be_accessible
 


### PR DESCRIPTION
It's seems to be taking over an hour to run under some conditions.
It something on CI is making it not run correctly.
My hunch is that it maybe related to running the tests in parallel but not
having enough connection in the pool or connection timing out.
This will need a bit more investigation but as of now we don't have the
exact (with the seed nuber use to run the tests)
command that run by CI to reproduce this

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
