### PR TITLE
CPDLP  1026 & 1027 - NPQ course breakdown

### DIFF
--- a/app/components/content_list_component.html.erb
+++ b/app/components/content_list_component.html.erb
@@ -12,4 +12,4 @@
 </ol>
 </nav>
 
-<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">

--- a/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="gov-table__row">
   <td scope="row" class="govuk-table__cell govuk-body-s">Output payment</td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"><%= 'XX' %></td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"></td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= trainees %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds payment_per_trainee %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds total %></td>
 </tr>

--- a/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
@@ -1,0 +1,6 @@
+<tr class="gov-table__row">
+  <td scope="row" class="govuk-table__cell govuk-body-s">Output payment</td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= 'XX' %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"></td>
+</tr>

--- a/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="gov-table__row">
   <td scope="row" class="govuk-table__cell govuk-body-s">Output payment</td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"><%= trainees %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= current_trainees %></td>
   <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds payment_per_trainee %></td>
   <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds total %></td>
 </tr>

--- a/app/components/finance/npq/payment_overviews/output_payment_row.rb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.rb
@@ -6,11 +6,12 @@ module Finance
       class OutputPaymentRow < BaseComponent
         include FinanceHelper
 
-        attr_accessor :output_payment, :contract
+        attr_accessor :output_payment, :contract, :statement
 
-        def initialize(output_payment, contract)
+        def initialize(output_payment, contract, statement)
           @output_payment = output_payment
           @contract = contract
+          @statement = statement
         end
 
         def total
@@ -21,8 +22,12 @@ module Finance
           output_payment[:per_participant]
         end
 
-        def trainees
-          contract.recruitment_target
+        def current_trainees
+          statement
+            .participant_declarations
+            .for_course_identifier(contract.course_identifier)
+            .unique_paid_payable_or_eligible
+            .count
         end
       end
     end

--- a/app/components/finance/npq/payment_overviews/output_payment_row.rb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class OutputPaymentRow < BaseComponent
+        include FinanceHelper
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/output_payment_row.rb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.rb
@@ -26,7 +26,8 @@ module Finance
           statement
             .participant_declarations
             .for_course_identifier(contract.course_identifier)
-            .unique_paid_payable_or_eligible
+            .paid_payable_or_eligible
+            .unique_id
             .count
         end
       end

--- a/app/components/finance/npq/payment_overviews/output_payment_row.rb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.rb
@@ -23,12 +23,20 @@ module Finance
         end
 
         def current_trainees
-          statement
-            .participant_declarations
-            .for_course_identifier(contract.course_identifier)
-            .paid_payable_or_eligible
-            .unique_id
-            .count
+          if statement.current?
+            ParticipantDeclaration::NPQ
+              .eligible_for_lead_provider(lead_provider)
+              .for_course_identifier(contract.course_identifier)
+              .where(statement_id: nil)
+              .count
+          else
+            statement
+              .participant_declarations
+              .for_course_identifier(contract.course_identifier)
+              .paid_payable_or_eligible
+              .unique_id
+              .count
+          end
         end
       end
     end

--- a/app/components/finance/npq/payment_overviews/output_payment_row.rb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.rb
@@ -6,12 +6,13 @@ module Finance
       class OutputPaymentRow < BaseComponent
         include FinanceHelper
 
-        attr_accessor :output_payment, :contract, :statement
+        attr_accessor :output_payment, :contract, :statement, :npq_lead_provider
 
-        def initialize(output_payment, contract, statement)
+        def initialize(output_payment, contract, statement, npq_lead_provider)
           @output_payment = output_payment
           @contract = contract
           @statement = statement
+          @npq_lead_provider = npq_lead_provider
         end
 
         def total
@@ -25,7 +26,7 @@ module Finance
         def current_trainees
           if statement.current?
             ParticipantDeclaration::NPQ
-              .eligible_for_lead_provider(lead_provider)
+              .eligible_for_lead_provider(npq_lead_provider)
               .for_course_identifier(contract.course_identifier)
               .where(statement_id: nil)
               .count

--- a/app/components/finance/npq/payment_overviews/output_payment_row.rb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.rb
@@ -5,6 +5,25 @@ module Finance
     module PaymentOverviews
       class OutputPaymentRow < BaseComponent
         include FinanceHelper
+
+        attr_accessor :output_payment, :contract
+
+        def initialize(output_payment, contract)
+          @output_payment = output_payment
+          @contract = contract
+        end
+
+        def total
+          output_payment[:subtotal]
+        end
+
+        def payment_per_trainee
+          output_payment[:per_participant]
+        end
+
+        def trainees
+          contract.recruitment_target
+        end
       end
     end
   end

--- a/app/components/finance/npq/payment_overviews/payment_overview_milestone_summary.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_milestone_summary.html.erb
@@ -1,0 +1,5 @@
+<span class="govuk-body-s">
+  <%= declaration_type %>
+  <br>
+  <%= total_participants %>
+</span>

--- a/app/components/finance/npq/payment_overviews/payment_overview_milestone_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_milestone_summary.rb
@@ -5,6 +5,7 @@ module Finance
     module PaymentOverviews
       class PaymentOverviewMilestoneSummary < BaseComponent
         attr_reader :total_participants
+
         def initialize(milestone, total_participants)
           self.milestone = milestone
           self.total_participants = total_participants
@@ -15,6 +16,7 @@ module Finance
         end
 
       private
+
         attr_accessor :milestone
         attr_writer :total_participants
       end

--- a/app/components/finance/npq/payment_overviews/payment_overview_milestone_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_milestone_summary.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class PaymentOverviewMilestoneSummary < BaseComponent
+        attr_reader :total_participants
+        def initialize(milestone, total_participants)
+          self.milestone = milestone
+          self.total_participants = total_participants
+        end
+
+        def declaration_type
+          milestone.declaration_type.titleize
+        end
+
+      private
+        attr_accessor :milestone
+        attr_writer :total_participants
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.html.erb
@@ -1,0 +1,111 @@
+<div class="app-application__panel__summary">
+  <div class="govuk-!-margin-right-4">
+    <h4 class="govuk-heading-l govuk-!-margin-bottom-2"><%= t("finance.total") %> <%= number_to_pounds(overall_total) %></h4>
+    <p class="govuk-body-s govuk-!-margin-bottom-2">
+      <%= t("finance.output_payment.label") %>
+      <span><%= number_to_pounds(total_output_payment) %></span>
+    </p>
+    <p class="govuk-body-s govuk-!-margin-bottom-2">
+      <%= t("finance.service_fee.caption") %>
+      <span><%= number_to_pounds(total_service_fees) %></span>
+    </p>
+    <p class="govuk-body-s govuk-!-margin-bottom-2">
+      <%= t("finance.vat") %>
+      <span><%= number_to_pounds(overall_vat) %></span>
+    </p>
+  </div>
+  <ul class="first govuk-list govuk-!-margin-bottom-0">
+    <li>
+      <strong class="float govuk-body-s govuk-!-margin-bottom-0"><%= t("finance.cut_off_date.caption") %></strong>
+      <div class="number-group">
+        <div class="number-container govuk-!-padding-right-4">
+          <div class="float tooltip">
+            <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+              <span><%= output_payment_cut_off_date.to_s(:govuk) %></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li>
+      <strong class="float govuk-body-s govuk-!-margin-bottom-0">
+        <%= t("finance.recruitment_target_total") %>
+      </strong>
+      <br>
+      <div class="number-group">
+        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+          <span><%= recruitment_target_total %></span>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <ul class="second govuk-list govuk-!-margin-bottom-0">
+    <li>
+      <strong class="float govuk-body-s govuk-!-margin-bottom-0"><%= t("finance.cohort") %></strong>
+      <div class="number-group">
+        <div class="number-container govuk-!-padding-right-4">
+          <div class="float tooltip">
+            <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+              <span><%= t("finance.spring") %></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li>
+      <strong class="float govuk-body-s govuk-!-margin-bottom-0"><%= t("finance.total_starts") %></strong>
+      <br>
+      <div class="number-group">
+        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+          <span><%= total_starts %></span>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <ul class="third govuk-list govuk-!-margin-bottom-0">
+    <li>
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.voided_declarations") %></strong>
+      <div class="number-group">
+        <div class="number-container govuk-!-padding-right-4">
+          <div class="float tooltip">
+            <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+              <span><%= total_voided %></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li>
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_retained") %></strong>
+      <br>
+      <div class="number-group">
+        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+          <span><%= total_retained %></span>
+        </div>
+      </div>
+    </li>
+  </ul>
+  <ul class="fourth govuk-list govuk-!-margin-bottom-0">
+    <li class="empty">
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"></strong>
+      <div class="number-group">
+        <div class="number-container govuk-!-padding-right-4">
+          <div class="float tooltip">
+            <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+              <span></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li>
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_completed") %></strong>
+      <br>
+      <div class="number-group">
+        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+          <span><%= total_completed %></span>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class PaymentOverviewSummary < BaseComponent
+        include FinanceHelper
+
+        def initialize(contracts, statement, npq_lead_provider)
+          @contracts = contracts
+          @statement = statement
+          @npq_lead_provider = npq_lead_provider
+        end
+
+      private
+
+        attr_accessor :statement, :contracts, :npq_lead_provider
+
+        def service_fees
+          service_fees = []
+          contracts.each do |contract|
+            next if contract.service_fee_percentage.zero?
+
+            service_fees << PaymentCalculator::NPQ::ServiceFees.call(contract: contract)
+          end
+          service_fees
+        end
+
+        def total_service_fees
+          service_fees.sum { |service_fee| service_fee[:monthly] }
+        end
+
+        def total_output_payment
+          output_payments.sum { |output_payment| output_payment[:subtotal] }
+        end
+
+        def total_payment
+          total_service_fees + total_output_payment
+        end
+
+        def overall_vat
+          total_payment * (npq_lead_provider.vat_chargeable ? 0.2 : 0.0)
+        end
+
+        def overall_total
+          total_payment + overall_vat
+        end
+
+        def output_payment_cut_off_date
+          statement.payment_date
+        end
+
+        def recruitment_target_total
+          contracts.sum { |contract| contract[:recruitment_target] }
+        end
+
+        def total_starts
+          statement_declarations.where(declaration_type: "started").unique_id.count
+        end
+
+        def total_voided
+          statement_declarations.where(declaration_type: "voided").unique_id.count
+        end
+
+        def total_retained
+          statement_declarations.where(declaration_type: %w[retained-1 retained-2]).unique_id.count
+        end
+
+        def total_completed
+          statement_declarations.where(declaration_type: "completed").unique_id.count
+        end
+
+        def output_payments
+          output_payments = []
+          contracts.each do |contract|
+            output_payments << PaymentCalculator::NPQ::OutputPayment.call(contract: contract, total_participants: statement_declarations.count)
+          end
+          output_payments
+        end
+
+        def statement_declarations
+          if statement.current?
+            ParticipantDeclaration::NPQ
+              .eligible_for_lead_provider(lead_provider)
+              .where(statement_id: nil)
+          else
+            statement
+              .participant_declarations
+              .paid_payable_or_eligible
+              .unique_id
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -73,7 +73,7 @@ module Finance
         def output_payments
           output_payments = []
           contracts.each do |contract|
-            output_payments << PaymentCalculator::NPQ::OutputPayment.call(contract: contract, total_participants: statement_declarations.count)
+            output_payments << PaymentCalculator::NPQ::OutputPayment.call(contract: contract, total_participants: statement_declarations_per_contract(contract))
           end
           output_payments
         end
@@ -88,6 +88,23 @@ module Finance
               .participant_declarations
               .paid_payable_or_eligible
               .unique_id
+          end
+        end
+
+        def statement_declarations_per_contract(contract)
+          if statement.current?
+            ParticipantDeclaration::NPQ
+              .eligible_for_lead_provider(npq_lead_provider)
+              .for_course_identifier(contract.course_identifier)
+              .where(statement_id: nil)
+              .count
+          else
+            statement
+              .participant_declarations
+              .for_course_identifier(contract.course_identifier)
+              .paid_payable_or_eligible
+              .unique_id
+              .count
           end
         end
 

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -55,19 +55,19 @@ module Finance
         end
 
         def total_starts
-          statement_declarations.where(declaration_type: "started").unique_id.count
+          statement_declarations.where(declaration_type: "started").count
         end
 
         def total_voided
-          voided_declarations
+          voided_declarations.count
         end
 
         def total_retained
-          statement_declarations.where(declaration_type: %w[retained-1 retained-2]).unique_id.count
+          statement_declarations.where(declaration_type: %w[retained-1 retained-2]).count
         end
 
         def total_completed
-          statement_declarations.where(declaration_type: "completed").unique_id.count
+          statement_declarations.where(declaration_type: "completed").count
         end
 
         def output_payments

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -81,7 +81,7 @@ module Finance
         def statement_declarations
           if statement.current?
             ParticipantDeclaration::NPQ
-              .eligible_for_lead_provider(lead_provider)
+              .eligible_for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
           else
             statement

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -59,7 +59,7 @@ module Finance
         end
 
         def total_voided
-          statement_declarations.where(declaration_type: "voided").unique_id.count
+          voided_declarations
         end
 
         def total_retained
@@ -87,6 +87,21 @@ module Finance
             statement
               .participant_declarations
               .paid_payable_or_eligible
+              .unique_id
+          end
+        end
+
+        def voided_declarations
+          if statement.current?
+            ParticipantDeclaration::NPQ
+              .for_lead_provider(npq_lead_provider)
+              .where(statement_id: nil)
+              .where(state: "voided")
+              .unique_id
+          else
+            statement
+              .participant_declarations
+              .where(state: "voided")
               .unique_id
           end
         end

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -71,11 +71,7 @@ module Finance
         end
 
         def output_payments
-          output_payments = []
-          contracts.each do |contract|
-            output_payments << PaymentCalculator::NPQ::OutputPayment.call(contract: contract, total_participants: statement_declarations_per_contract(contract))
-          end
-          output_payments
+          contracts.map { |contract| PaymentCalculator::NPQ::OutputPayment.call(contract: contract, total_participants: statement_declarations_per_contract(contract)) }
         end
 
         def statement_declarations

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
@@ -8,12 +8,8 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <tr class="gov-table__row">
-    <td scope="row" class="govuk-table__cell govuk-body-s">Output</td>
-    <td scope="row" class="govuk-table__cell govuk-body-s"></td>
-    <td scope="row" class="govuk-table__cell govuk-body-s"></td>
-    <td scope="row" class="govuk-table__cell govuk-body-s"></td>
-  </tr>
-  <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(service_fee, contract) %>
+  <%= render Finance::NPQ::PaymentOverviews::OutputPaymentRow.new(output_payments, contract) %>
+  <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(service_fees, contract) %>
   </tbody>
 </table>
+<%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTotal.new(service_fees, output_payments, lead_provider) %>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
@@ -12,4 +12,4 @@
   <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(service_fees, contract) %>
   </tbody>
 </table>
-<%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTotal.new(service_fees, output_payments, lead_provider) %>
+<%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTotal.new(service_fees, output_payments, npq_lead_provider) %>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
@@ -8,7 +8,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <%= render Finance::NPQ::PaymentOverviews::OutputPaymentRow.new(output_payments, contract, statement) %>
+  <%= render Finance::NPQ::PaymentOverviews::OutputPaymentRow.new(output_payments, contract, statement, npq_lead_provider) %>
   <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(service_fees, contract) %>
   </tbody>
 </table>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
@@ -14,6 +14,6 @@
     <td scope="row" class="govuk-table__cell govuk-body-s"></td>
     <td scope="row" class="govuk-table__cell govuk-body-s"></td>
   </tr>
-  <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(self) %>
+  <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(service_fee, contract) %>
   </tbody>
 </table>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
@@ -8,7 +8,7 @@
   </tr>
   </thead>
   <tbody class="govuk-table__body">
-  <%= render Finance::NPQ::PaymentOverviews::OutputPaymentRow.new(output_payments, contract) %>
+  <%= render Finance::NPQ::PaymentOverviews::OutputPaymentRow.new(output_payments, contract, statement) %>
   <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(service_fees, contract) %>
   </tbody>
 </table>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.html.erb
@@ -1,0 +1,19 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th scope="col" class="govuk-table__header govuk-body-s">Payment type</th>
+    <th scope="col" class="govuk-table__header govuk-body-s">Trainees</th>
+    <th scope="col" class="govuk-table__header govuk-body-s">Payment per trainee</th>
+    <th scope="col" class="govuk-table__header govuk-body-s">Total</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <tr class="gov-table__row">
+    <td scope="row" class="govuk-table__cell govuk-body-s">Output</td>
+    <td scope="row" class="govuk-table__cell govuk-body-s"></td>
+    <td scope="row" class="govuk-table__cell govuk-body-s"></td>
+    <td scope="row" class="govuk-table__cell govuk-body-s"></td>
+  </tr>
+  <%= render Finance::NPQ::PaymentOverviews::ServiceFeeRow.new(self) %>
+  </tbody>
+</table>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -23,8 +23,16 @@ module Finance
         def output_payments
           @output_payments ||= PaymentCalculator::NPQ::OutputPayment.call(
             contract: contract,
-            total_participants: statement.participant_declarations.paid_payable_or_eligible.unique_id.count,
+            total_participants: statement_declarations,
           )
+        end
+
+        def statement_declarations
+          if statement.current?
+            statement.participant_declarations.paid_payable_or_eligible.unique_id.count
+          else
+            statement.participant_declarations.where.not(state: "voided").unique_id.count
+          end
         end
       end
     end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -6,15 +6,15 @@ module Finance
       class PaymentOverviewTable < BaseComponent
         include FinanceHelper
 
-        def initialize(contract, statement, lead_provider)
+        def initialize(contract, statement, npq_lead_provider)
           @contract = contract
           @statement = statement
-          @lead_provider = lead_provider
+          @npq_lead_provider = npq_lead_provider
         end
 
       private
 
-        attr_accessor :statement, :contract, :lead_provider
+        attr_accessor :statement, :contract, :npq_lead_provider
 
         def service_fees
           @service_fees ||= PaymentCalculator::NPQ::ServiceFees.call(contract: contract)
@@ -30,7 +30,7 @@ module Finance
         def statement_declarations
           if statement.current?
             ParticipantDeclaration::NPQ
-              .eligible_for_lead_provider(lead_provider)
+              .eligible_for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
               .count
           else

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -31,7 +31,6 @@ module Finance
           if statement.current?
             ParticipantDeclaration::NPQ
               .eligible_for_lead_provider(lead_provider)
-              .for_course_identifier(contract.course_identifier)
               .where(statement_id: nil)
               .count
           else

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -29,9 +29,17 @@ module Finance
 
         def statement_declarations
           if statement.current?
-            statement.participant_declarations.paid_payable_or_eligible.unique_id.count
+            statement
+              .participant_declarations
+              .paid_payable_or_eligible
+              .unique_id
+              .count
           else
-            statement.participant_declarations.where.not(state: "voided").unique_id.count
+            ParticipantDeclaration::NPQ
+              .eligible_for_lead_provider(lead_provider)
+              .for_course_identifier(contract.course_identifier)
+              .where(statement_id: nil)
+              .count
           end
         end
       end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -31,12 +31,14 @@ module Finance
           if statement.current?
             ParticipantDeclaration::NPQ
               .eligible_for_lead_provider(npq_lead_provider)
+              .for_course_identifier(contract.course_identifier)
               .where(statement_id: nil)
               .count
           else
             statement
               .participant_declarations
               .paid_payable_or_eligible
+              .for_course_identifier(contract.course_identifier)
               .unique_id
               .count
           end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -23,7 +23,7 @@ module Finance
         def output_payments
           @output_payments ||= PaymentCalculator::NPQ::OutputPayment.call(
             contract: contract,
-            total_participants: statement.participant_declarations.unique_paid_payable_or_eligible.count,
+            total_participants: statement.participant_declarations.paid_payable_or_eligible.unique_id.count,
           )
         end
       end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -12,10 +12,6 @@ module Finance
           @lead_provider = lead_provider
         end
 
-        # def service_fee
-        #   { service_fee: service_fees }
-        # end
-
         def monthly_output_payments
           output_payments[:subtotal]
         end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -6,6 +6,8 @@ module Finance
       class PaymentOverviewTable < BaseComponent
         include FinanceHelper
 
+        attr_reader :contract
+
         def initialize(contract, statement)
           @contract = contract
           @statement = statement
@@ -21,7 +23,7 @@ module Finance
 
       private
 
-        attr_accessor :contract, :statement
+        attr_reader :statement
 
         def service_fees
           @service_fees ||= PaymentCalculator::NPQ::ServiceFees.call(contract: contract)
@@ -30,9 +32,7 @@ module Finance
         def output_fees
           @output_fees ||= PaymentCalculator::NPQ::OutputPayment.call(
             contract: contract,
-            total_participants: statement.participant_declarations
-              .for_course_identifier(contract.course_identifier)
-              .unique_paid_payable_or_eligible.count,
+            total_participants: statement.declarations.count,
           )
         end
       end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -6,33 +6,32 @@ module Finance
       class PaymentOverviewTable < BaseComponent
         include FinanceHelper
 
-        attr_reader :contract
-
-        def initialize(contract, statement)
+        def initialize(contract, statement, lead_provider)
           @contract = contract
           @statement = statement
+          @lead_provider = lead_provider
         end
 
-        def service_fee
-          { service_fee: service_fees }
-        end
+        # def service_fee
+        #   { service_fee: service_fees }
+        # end
 
-        def monthly_output_fees
-          output_fees[:subtotal]
+        def monthly_output_payments
+          output_payments[:subtotal]
         end
 
       private
 
-        attr_reader :statement
+        attr_accessor :statement, :contract, :lead_provider
 
         def service_fees
           @service_fees ||= PaymentCalculator::NPQ::ServiceFees.call(contract: contract)
         end
 
-        def output_fees
-          @output_fees ||= PaymentCalculator::NPQ::OutputPayment.call(
+        def output_payments
+          @output_payments ||= PaymentCalculator::NPQ::OutputPayment.call(
             contract: contract,
-            total_participants: statement.declarations.count,
+            total_participants: statement.participant_declarations.unique_paid_payable_or_eligible.count,
           )
         end
       end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class PaymentOverviewTable < BaseComponent
+        include FinanceHelper
+
+        def initialize(contract, statement)
+          @contract = contract
+          @statement = statement
+        end
+
+        def service_fee
+          { service_fee: service_fees }
+        end
+
+        def monthly_output_fees
+          output_fees[:subtotal]
+        end
+
+      private
+
+        attr_accessor :contract, :statement
+
+        def service_fees
+          @service_fees ||= PaymentCalculator::NPQ::ServiceFees.call(contract: contract)
+        end
+
+        def output_fees
+          @output_fees ||= PaymentCalculator::NPQ::OutputPayment.call(
+            contract: contract,
+            total_participants: statement.participant_declarations
+              .for_course_identifier(contract.course_identifier)
+              .unique_paid_payable_or_eligible.count,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -12,10 +12,6 @@ module Finance
           @lead_provider = lead_provider
         end
 
-        def monthly_output_payments
-          output_payments[:subtotal]
-        end
-
       private
 
         attr_accessor :statement, :contract, :lead_provider

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -29,16 +29,16 @@ module Finance
 
         def statement_declarations
           if statement.current?
-            statement
-              .participant_declarations
-              .paid_payable_or_eligible
-              .unique_id
-              .count
-          else
             ParticipantDeclaration::NPQ
               .eligible_for_lead_provider(lead_provider)
               .for_course_identifier(contract.course_identifier)
               .where(statement_id: nil)
+              .count
+          else
+            statement
+              .participant_declarations
+              .paid_payable_or_eligible
+              .unique_id
               .count
           end
         end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.html.erb
@@ -1,0 +1,8 @@
+<header class="app-application-card__header">
+  <% milestones.each do |milestone| %>
+    <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewMilestoneSummary.new(milestone, total_participants_for(milestone)) %>
+  <% end %>
+  <span class="govuk-body-s">Recruitment target<br><%= recruitment_target %></span>
+  <span class="govuk-body-s">Current trainees<br><%= current_trainees %></span>
+  <span class="govuk-body-s">Total not paid<br><%= total_not_paid %></span>
+</header>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class PaymentOverviewTableHeader < BaseComponent
+        def initialize(contract, statement)
+          self.contract = contract
+          self.statement = statement
+        end
+
+        def milestones
+          NPQCourse.schedule_for(course).milestones
+        end
+
+        delegate :recruitment_target, to: :contract
+
+        def current_trainees
+          statement
+            .participant_declarations
+            .for_course_identifier(contract.course_identifier)
+            .unique_paid_payable_or_eligible
+            .count
+        end
+
+        def total_not_paid
+          statement
+            .participant_declarations
+            .for_course_identifier(contract.course_identifier)
+            .ineligible.unique_id.count
+        end
+
+        def total_participants_for(milestone)
+          participant_per_declaration_type.fetch(milestone.declaration_type, 0)
+        end
+
+      private
+
+        attr_accessor :contract, :statement
+
+        def course
+          @course ||= NPQCourse.find_by!(identifier: contract.course_identifier)
+        end
+
+        def participant_per_declaration_type
+          @participant_per_declaration_type ||= statement.participant_declarations
+            .for_course_identifier(contract.course_identifier)
+            .group(:declaration_type)
+            .count
+        end
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -16,19 +16,37 @@ module Finance
         end
 
         def current_trainees
-          statement
-            .participant_declarations
-            .for_course_identifier(contract.course_identifier)
-            .paid_payable_or_eligible
-            .unique_id
-            .count
+          if statement.current?
+            ParticipantDeclaration::NPQ
+              .eligible_for_lead_provider(lead_provider)
+              .where(statement_id: nil)
+              .count
+          else
+            statement
+              .participant_declarations
+              .for_course_identifier(contract.course_identifier)
+              .paid_payable_or_eligible
+              .unique_id
+              .count
+          end
         end
 
         def total_not_paid
-          statement
-            .participant_declarations
-            .for_course_identifier(contract.course_identifier)
-            .ineligible.unique_id.count
+          if statement.current?
+            ParticipantDeclaration::NPQ
+              .for_lead_provider(lead_provider)
+              .where(statement_id: nil)
+              .ineligible
+              .unique_id
+              .count
+          else
+            statement
+              .participant_declarations
+              .for_course_identifier(contract.course_identifier)
+              .ineligible
+              .unique_id
+              .count
+          end
         end
 
         def total_participants_for(milestone)

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -19,7 +19,8 @@ module Finance
           statement
             .participant_declarations
             .for_course_identifier(contract.course_identifier)
-            .unique_paid_payable_or_eligible
+            .paid_payable_or_eligible
+            .unique_id
             .count
         end
 

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -65,7 +65,7 @@ module Finance
         def participant_per_declaration_type
           @participant_per_declaration_type ||= statement.participant_declarations
             .for_course_identifier(contract.course_identifier)
-            .where.not(state: :voided)
+            .paid_payable_or_eligible
             .group(:declaration_type)
             .count
         end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -6,9 +6,12 @@ module Finance
       class PaymentOverviewTableHeader < BaseComponent
         delegate :recruitment_target, to: :contract
 
-        def initialize(contract, statement)
+        attr_accessor :contract, :statement, :npq_lead_provider
+
+        def initialize(contract, statement, npq_lead_provider)
           self.contract = contract
           self.statement = statement
+          self.npq_lead_provider = npq_lead_provider
         end
 
         def milestones
@@ -18,7 +21,7 @@ module Finance
         def current_trainees
           if statement.current?
             ParticipantDeclaration::NPQ
-              .eligible_for_lead_provider(lead_provider)
+              .eligible_for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
               .count
           else
@@ -34,7 +37,7 @@ module Finance
         def total_not_paid
           if statement.current?
             ParticipantDeclaration::NPQ
-              .for_lead_provider(lead_provider)
+              .for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
               .ineligible
               .unique_id
@@ -54,8 +57,6 @@ module Finance
         end
 
       private
-
-        attr_accessor :contract, :statement
 
         def course
           @course ||= NPQCourse.find_by!(identifier: contract.course_identifier)

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -45,6 +45,7 @@ module Finance
         def participant_per_declaration_type
           @participant_per_declaration_type ||= statement.participant_declarations
             .for_course_identifier(contract.course_identifier)
+            .where.not(state: :voided)
             .group(:declaration_type)
             .count
         end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -21,14 +21,16 @@ module Finance
         def current_trainees
           if statement.current?
             ParticipantDeclaration::NPQ
-              .eligible_for_lead_provider(npq_lead_provider)
+              .for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
+              .where.not(state: "submitted")
+              .unique_id
               .count
           else
             statement
               .participant_declarations
               .for_course_identifier(contract.course_identifier)
-              .paid_payable_or_eligible
+              .where.not(state: "submitted")
               .unique_id
               .count
           end
@@ -39,14 +41,14 @@ module Finance
             ParticipantDeclaration::NPQ
               .for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
-              .ineligible
+              .where(state: %w[ineligible voided])
               .unique_id
               .count
           else
             statement
               .participant_declarations
               .for_course_identifier(contract.course_identifier)
-              .ineligible
+              .where(state: %w[ineligible voided])
               .unique_id
               .count
           end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -4,6 +4,8 @@ module Finance
   module NPQ
     module PaymentOverviews
       class PaymentOverviewTableHeader < BaseComponent
+        delegate :recruitment_target, to: :contract
+
         def initialize(contract, statement)
           self.contract = contract
           self.statement = statement
@@ -12,8 +14,6 @@ module Finance
         def milestones
           NPQCourse.schedule_for(course).milestones
         end
-
-        delegate :recruitment_target, to: :contract
 
         def current_trainees
           statement

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -23,6 +23,7 @@ module Finance
             ParticipantDeclaration::NPQ
               .for_lead_provider(npq_lead_provider)
               .where(statement_id: nil)
+              .for_course_identifier(contract.course_identifier)
               .where.not(state: "submitted")
               .unique_id
               .count

--- a/app/components/finance/npq/payment_overviews/payment_overview_total.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_total.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-table__row govuk-!-padding-bottom-1">
+  <div class="govuk-label--s govuk-table__header--numeric">
+    Course total
+    <br>
+    <%= number_to_pounds course_total %>
+  </div>
+</div>

--- a/app/components/finance/npq/payment_overviews/payment_overview_total.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_total.rb
@@ -17,15 +17,11 @@ module Finance
         attr_accessor :service_fees, :output_payments, :lead_provider
 
         def course_total
-          course_payment + total_vat(lead_provider)
+          course_payment
         end
 
         def course_payment
           monthly_service_fees + output_payment_subtotal
-        end
-
-        def total_vat(lead_provider)
-          course_payment * (lead_provider.vat_chargeable ? 0.2 : 0.0)
         end
 
         def monthly_service_fees

--- a/app/components/finance/npq/payment_overviews/payment_overview_total.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_total.rb
@@ -6,15 +6,15 @@ module Finance
       class PaymentOverviewTotal < BaseComponent
         include FinanceHelper
 
-        def initialize(service_fees, output_payments, lead_provider)
+        def initialize(service_fees, output_payments, npq_lead_provider)
           @service_fees = service_fees
           @output_payments = output_payments
-          @lead_provider = lead_provider
+          @npq_lead_provider = npq_lead_provider
         end
 
       private
 
-        attr_accessor :service_fees, :output_payments, :lead_provider
+        attr_accessor :service_fees, :output_payments, :npq_lead_provider
 
         def course_total
           course_payment

--- a/app/components/finance/npq/payment_overviews/payment_overview_total.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_total.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class PaymentOverviewTotal < BaseComponent
+        include FinanceHelper
+
+        def initialize(service_fees, output_payments, lead_provider)
+          @service_fees = service_fees
+          @output_payments = output_payments
+          @lead_provider = lead_provider
+        end
+
+      private
+
+        attr_accessor :service_fees, :output_payments, :lead_provider
+
+        def course_total
+          course_payment + total_vat(lead_provider)
+        end
+
+        def course_payment
+          monthly_service_fees + output_payment_subtotal
+        end
+
+        def total_vat(lead_provider)
+          course_payment * (lead_provider.vat_chargeable ? 0.2 : 0.0)
+        end
+
+        def monthly_service_fees
+          service_fees[:monthly]
+        end
+
+        def output_payment_subtotal
+          output_payments[:subtotal]
+        end
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/service_fee_row.html.erb
+++ b/app/components/finance/npq/payment_overviews/service_fee_row.html.erb
@@ -1,0 +1,6 @@
+<tr class="gov-table__row">
+  <td scope="row" class="govuk-table__cell govuk-body-s">Service fee</td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= 'XX' %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds service_fees[:service_fee][:per_participant] %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds service_fees[:service_fee][:monthly] %></td>
+</tr>

--- a/app/components/finance/npq/payment_overviews/service_fee_row.html.erb
+++ b/app/components/finance/npq/payment_overviews/service_fee_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="gov-table__row">
   <td scope="row" class="govuk-table__cell govuk-body-s">Service fee</td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"><%= 'XX' %></td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds service_fees[:service_fee][:per_participant] %></td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds service_fees[:service_fee][:monthly] %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= trainees %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds payment_per_trainee %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds total %></td>
 </tr>

--- a/app/components/finance/npq/payment_overviews/service_fee_row.rb
+++ b/app/components/finance/npq/payment_overviews/service_fee_row.rb
@@ -6,13 +6,26 @@ module Finance
       class ServiceFeeRow < BaseComponent
         include FinanceHelper
 
-        def initialize(service_fees)
+        def initialize(service_fees, contract)
           @service_fees = service_fees
+          @contract = contract
         end
 
+        def total
+          service_fees.dig(:service_fee, :monthly)
+        end
+
+        def payment_per_trainee
+          service_fees.dig(:service_fee, :per_participant)
+        end
+
+        def trainees
+          contract.recruitment_target
+        end
       private
 
-        attr_accessor :service_fees
+        attr_reader :service_fees, :contract
+
       end
     end
   end

--- a/app/components/finance/npq/payment_overviews/service_fee_row.rb
+++ b/app/components/finance/npq/payment_overviews/service_fee_row.rb
@@ -12,20 +12,20 @@ module Finance
         end
 
         def total
-          service_fees.dig(:service_fee, :monthly)
+          service_fees[:monthly]
         end
 
         def payment_per_trainee
-          service_fees.dig(:service_fee, :per_participant)
+          service_fees[:per_participant]
         end
 
         def trainees
           contract.recruitment_target
         end
+
       private
 
         attr_reader :service_fees, :contract
-
       end
     end
   end

--- a/app/components/finance/npq/payment_overviews/service_fee_row.rb
+++ b/app/components/finance/npq/payment_overviews/service_fee_row.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class ServiceFeeRow < BaseComponent
+        include FinanceHelper
+
+        def initialize(service_fees)
+          @service_fees = service_fees
+        end
+
+      private
+
+        attr_accessor :service_fees
+      end
+    end
+  end
+end

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -10,6 +10,7 @@ module Finance
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
         @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: identifier_to_name)
         @statements        = @npq_lead_provider.statements.upto_current.order(payment_date: :desc)
+        @npq_contracts = @npq_lead_provider.npq_contracts.order(course_identifier: :asc)
 
         @breakdowns = Finance::NPQ::CalculationOverviewOrchestrator.new(
           statement: @statement,

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -10,7 +10,7 @@ module Finance
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
         @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: identifier_to_name)
         @statements        = @npq_lead_provider.statements.upto_current.order(payment_date: :desc)
-        @npq_contracts = @npq_lead_provider.npq_contracts.order(course_identifier: :asc)
+        @npq_contracts     = @npq_lead_provider.npq_contracts.order(course_identifier: :asc)
 
         @breakdowns = Finance::NPQ::CalculationOverviewOrchestrator.new(
           statement: @statement,

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -25,18 +25,6 @@ class Finance::Statement < ApplicationRecord
   def to_param
     name.downcase.gsub(" ", "-")
   end
-
-  # def declarations
-  #   if current?
-  #     participant_declarations
-  #       .for_course_identifier(contract.course_identifier)
-  #       .unique_paid_payable_or_eligible.count
-  #   else
-  #     participant_declarations
-  #       .for_course_identifier(contract.course_identifier)
-  #       .where.not(status: "voided")
-  #   end
-  # end
 end
 
 require "finance/statement/ecf"

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -25,6 +25,18 @@ class Finance::Statement < ApplicationRecord
   def to_param
     name.downcase.gsub(" ", "-")
   end
+
+  def declarations
+    if current?
+      participant_declarations
+        .for_course_identifier(contract.course_identifier)
+        .unique_paid_payable_or_eligible.count
+    else
+      participant_declarations
+        .for_course_identifier(contract.course_identifier)
+        .where.not(status: "voided")
+    end
+  end
 end
 
 require "finance/statement/ecf"

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -26,17 +26,17 @@ class Finance::Statement < ApplicationRecord
     name.downcase.gsub(" ", "-")
   end
 
-  def declarations
-    if current?
-      participant_declarations
-        .for_course_identifier(contract.course_identifier)
-        .unique_paid_payable_or_eligible.count
-    else
-      participant_declarations
-        .for_course_identifier(contract.course_identifier)
-        .where.not(status: "voided")
-    end
-  end
+  # def declarations
+  #   if current?
+  #     participant_declarations
+  #       .for_course_identifier(contract.course_identifier)
+  #       .unique_paid_payable_or_eligible.count
+  #   else
+  #     participant_declarations
+  #       .for_course_identifier(contract.course_identifier)
+  #       .where.not(status: "voided")
+  #   end
+  # end
 end
 
 require "finance/statement/ecf"

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -39,6 +39,7 @@ class ParticipantDeclaration < ApplicationRecord
   scope :mentor, -> { where(participant_profile_id: ParticipantProfile::Mentor.select(:id)) }
   scope :npq, -> { where(participant_profile_id: ParticipantProfile::NPQ.select(:id)) }
 
+  scope :unique_paid_payable_or_eligible, -> { where(state: %w[eligible payable paid]).unique_id }
   scope :changeable, -> { where(state: %w[eligible submitted]) }
   scope :unique_id, -> { select(:user_id).distinct }
 

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -39,7 +39,7 @@ class ParticipantDeclaration < ApplicationRecord
   scope :mentor, -> { where(participant_profile_id: ParticipantProfile::Mentor.select(:id)) }
   scope :npq, -> { where(participant_profile_id: ParticipantProfile::NPQ.select(:id)) }
 
-  scope :unique_paid_payable_or_eligible, -> { where(state: %w[eligible payable paid]).unique_id }
+  scope :paid_payable_or_eligible, -> { where(state: %w[eligible payable paid]) }
   scope :changeable, -> { where(state: %w[eligible submitted]) }
   scope :unique_id, -> { select(:user_id).distinct }
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -16,7 +16,7 @@
           <% @npq_contracts.each do |npq_contract| %>
             <section class="app-application__card">
               <h2 class="govuk-heading-s"><%= t("#{ npq_contract.course_identifier }", scope: "npq_courses") %></h2>
-              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTableHeader.new(npq_contract, @statement) %>
+              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTableHeader.new(npq_contract, @statement, @npq_lead_provider) %>
               <span class="govuk-label--s govuk-visually-hidden">Payment details</span>
               <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(npq_contract, @statement, @npq_lead_provider) %>
             </section>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -11,39 +11,7 @@
               <h2 class="govuk-heading-s"><%= t("#{ npq_contract.course_identifier }", scope: "npq_courses") %></h2>
               <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTableHeader.new(npq_contract, @statement) %>
               <span class="govuk-label--s govuk-visually-hidden">Payment details</span>
-              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(npq_contract, @statement) %>
-<!--              <table class="govuk-table">-->
-<!--                <thead class="govuk-table__head">-->
-<!--                <tr class="govuk-table__row">-->
-<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Payment type</th>-->
-<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Trainees</th>-->
-<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Payment per trainee</th>-->
-<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Total</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody class="govuk-table__body">-->
-<!--                <tr class="gov-table__row">-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s">Output</td>-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
-<!--                </tr>-->
-<!--                <tr class="gov-table__row">-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s">Service Fee</td>-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
-<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
-<!--                </tr>-->
-                <%#= render Finance::NPQ::PaymentOverviews::ServiceFees.with_collection(@service_fees) %>
-<!--                </tbody>-->
-<!--              </table>-->
-              <div class="govuk-table__row govuk-!-padding-bottom-1">
-                <div class="govuk-label--s govuk-table__header--numeric">
-                  Course total
-                  <br>
-                  £1000.00
-                </div>
-              </div>
+              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(npq_contract, @statement, @npq_lead_provider) %>
             </section>
             <br>
           <% end %>

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -9,21 +9,7 @@
           <% @npq_contracts.each do |npq_contract| %>
             <section class="app-application__card">
               <h2 class="govuk-heading-s"><%= t("#{ npq_contract.course_identifier }", scope: "npq_courses") %></h2>
-              <header class="app-application-card__header">
-                <% NPQCourse.schedule_for(NPQCourse.find_by(identifier: npq_contract.course_identifier))
-                            .milestones.each do |milestone| %>
-                  <span class="govuk-body-s">
-                    <%= milestone.declaration_type.titleize %>
-                    <br>
-                    <%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier)
-                                  .for_declaration(milestone.declaration_type)
-                                  .count %>
-                  </span>
-                <% end %>
-                <span class="govuk-body-s">Recruitment target<br><%= npq_contract.recruitment_target %></span>
-                <span class="govuk-body-s">Current trainees<br><%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier).unique_paid_payable_or_eligible.count %></span>
-                <span class="govuk-body-s">Total not paid<br><%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier).ineligible.unique_id.count %></span>
-              </header>
+              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTableHeader.new(npq_contract, @statement) %>
               <span class="govuk-label--s govuk-visually-hidden">Payment details</span>
               <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(npq_contract, @statement) %>
 <!--              <table class="govuk-table">-->

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -1,35 +1,69 @@
 <% content_for :title, t("finance.npq.payment_breakdown") %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: select_provider_npq_finance_payment_breakdowns_path) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">National professional qualifications (NPQs)</h1>
-
-    <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
-    <h2 class="govuk-heading-l"><%= @statement.name %></h2>
-
     <%= render Finance::Statements::StatementSelector.new(current_statement: @statement)  %>
 
-    <p class="govuk-caption-m govuk-!-margin-0">Payment of</p>
-    <h2 class="govuk-heading-xl govuk-!-margin-0"><%= number_to_pounds aggregated_payment(@breakdowns) + aggregated_vat(@breakdowns, @npq_lead_provider) %></h2>
-    <p class="govuk-caption-m govuk-!-margin-top-0">On or after <%= @statement.payment_date.to_s(:govuk) %></p>
-
-    <%= render Finance::NPQ::PaymentOverviews::References.new(@statement) %>
-
-    <h2 class="govuk-heading-m"><%=t("finance.npq.payment_breakdown") %></h2>
-
-    <table class="govuk-table payment-breakdown-table">
-      <tbody>
-        <%= render Finance::NPQ::PaymentOverviews::PaymentCoursesRow.with_collection(@breakdowns, statement: @statement, npq_lead_provider: @npq_lead_provider) %>
-
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= t("finance.vat") %></td>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds aggregated_vat(@breakdowns, @npq_lead_provider) %></td>
-        </tr>
-
-        <%= render Finance::NPQ::PaymentOverviews::TotalPaymentCoursesRow.new(@breakdowns, statement: @statement, npq_lead_provider: @npq_lead_provider) %>
-      </tbody>
-    </table>
+    <div class="app-application__panel">
+      <div class="govuk-grid-column-full">
+        <div class="moj-filter-layout__content">
+          <% @npq_contracts.each do |npq_contract| %>
+            <section class="app-application__card">
+              <h2 class="govuk-heading-s"><%= t("#{ npq_contract.course_identifier }", scope: "npq_courses") %></h2>
+              <header class="app-application-card__header">
+                <% NPQCourse.schedule_for(NPQCourse.find_by(identifier: npq_contract.course_identifier))
+                            .milestones.each do |milestone| %>
+                  <span class="govuk-body-s">
+                    <%= milestone.declaration_type.titleize %>
+                    <br>
+                    <%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier)
+                                  .for_declaration(milestone.declaration_type)
+                                  .count %>
+                  </span>
+                <% end %>
+                <span class="govuk-body-s">Recruitment target<br><%= npq_contract.recruitment_target %></span>
+                <span class="govuk-body-s">Current trainees<br><%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier).unique_paid_payable_or_eligible.count %></span>
+                <span class="govuk-body-s">Total not paid<br><%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier).ineligible.unique_id.count %></span>
+              </header>
+              <span class="govuk-label--s govuk-visually-hidden">Payment details</span>
+              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(@npq_contracts.first, @statement) %>
+<!--              <table class="govuk-table">-->
+<!--                <thead class="govuk-table__head">-->
+<!--                <tr class="govuk-table__row">-->
+<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Payment type</th>-->
+<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Trainees</th>-->
+<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Payment per trainee</th>-->
+<!--                  <th scope="col" class="govuk-table__header govuk-body-s">Total</th>-->
+<!--                </tr>-->
+<!--                </thead>-->
+<!--                <tbody class="govuk-table__body">-->
+<!--                <tr class="gov-table__row">-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s">Output</td>-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
+<!--                </tr>-->
+<!--                <tr class="gov-table__row">-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s">Service Fee</td>-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
+<!--                  <td scope="row" class="govuk-table__cell govuk-body-s"></td>-->
+<!--                </tr>-->
+                <%#= render Finance::NPQ::PaymentOverviews::ServiceFees.with_collection(@service_fees) %>
+<!--                </tbody>-->
+<!--              </table>-->
+              <div class="govuk-table__row govuk-!-padding-bottom-1">
+                <div class="govuk-label--s govuk-table__header--numeric">
+                  Course total
+                  <br>
+                  £1000.00
+                </div>
+              </div>
+            </section>
+            <br>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -25,7 +25,7 @@
                 <span class="govuk-body-s">Total not paid<br><%= @statement.participant_declarations.for_course_identifier(npq_contract.course_identifier).ineligible.unique_id.count %></span>
               </header>
               <span class="govuk-label--s govuk-visually-hidden">Payment details</span>
-              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(@npq_contracts.first, @statement) %>
+              <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewTable.new(npq_contract, @statement) %>
 <!--              <table class="govuk-table">-->
 <!--                <thead class="govuk-table__head">-->
 <!--                <tr class="govuk-table__row">-->

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -1,10 +1,17 @@
 <% content_for :title, t("finance.npq.payment_breakdown") %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: select_provider_npq_finance_payment_breakdowns_path) %>
 
-    <%= render Finance::Statements::StatementSelector.new(current_statement: @statement)  %>
-
-    <div class="app-application__panel">
-      <div class="govuk-grid-column-full">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-xl">National professional qualifications (NPQs)</h1>
+      <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
+      <h2 class="govuk-heading-l"><%= @statement.name %></h2>
+      <%= render Finance::Statements::StatementSelector.new(current_statement: @statement) %>
+      <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewSummary.new(@npq_contracts, @statement, @npq_lead_provider) %>
+      <br>
+    </div>
+    <div class="govuk-grid-column-full">
+      <div class="app-application__panel">
         <div class="moj-filter-layout__content">
           <% @npq_contracts.each do |npq_contract| %>
             <section class="app-application__card">
@@ -17,11 +24,9 @@
           <% end %>
         </div>
       </div>
+      <ul class="govuk-list">
+        <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement) %></li>
+        <li><%= govuk_link_to t("finance.show_contract"), finance_npq_contract_path(id: @npq_lead_provider.id) %></li>
+      </ul>
     </div>
   </div>
-</div>
-
-<ul class="govuk-list">
-  <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement) %></li>
-  <li><%= govuk_link_to t("finance.show_contract"), finance_npq_contract_path(id: @npq_lead_provider.id) %></li>
-</ul>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -51,7 +51,3 @@ $govuk-image-url-function: frontend-image-url;
 .bold-label {
   font-weight: 700;
 }
-
-.govuk-width-container {
-  max-width: 1110px;
-}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -51,3 +51,7 @@ $govuk-image-url-function: frontend-image-url;
 .bold-label {
   font-weight: 700;
 }
+
+.govuk-width-container {
+  max-width: 1110px;
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -26,6 +26,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "lead_providers/code";
 @import "lead_providers/contents_list";
 @import "lead_providers/syntax_highlighting";
+@import "lead_providers/statements";
 @import "pagination";
 @import "subnav";
 @import "primary-nav";

--- a/app/webpacker/styles/lead_providers/statements.scss
+++ b/app/webpacker/styles/lead_providers/statements.scss
@@ -1,3 +1,50 @@
+.app-application__panel__summary {
+  display: grid;
+  padding: 20px;
+  background-color: #f8f8f8;
+  border: 1px #f3f2f1 solid;
+  flex: 1 1 100%;
+  margin-bottom: 0 !important;
+  grid-auto-flow: row;
+  grid-row-gap: 1rem;
+  grid-column-gap: 1rem;
+  @media (min-width: 68.75em) {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  div {
+    .float {
+      display: inline-block;
+      float: left;
+    }
+    .number-group {
+      display: block;
+    }
+  }
+
+  span {
+    float: right;
+  }
+
+  ul {
+    display: grid;
+    grid-auto-flow: row;
+    grid-gap: 0.5rem;
+    padding: unset;
+    @media (min-width: 68.75em) {
+      grid-template-rows: repeat(2, 1fr);
+      grid-template-columns: 1fr;
+    }
+  }
+  li {
+    @media (min-width: 40.0625em) {
+      font-size: 1.1875rem;
+      line-height: 1.31579;
+    }
+  }
+}
+
 .app-application__panel {
   display: grid;
   padding: 20px;
@@ -25,4 +72,3 @@
 .moj-filter-layout__content {
   overflow: hidden;
 }
-

--- a/app/webpacker/styles/lead_providers/statements.scss
+++ b/app/webpacker/styles/lead_providers/statements.scss
@@ -1,0 +1,28 @@
+.app-application__panel {
+  display: grid;
+  padding: 20px;
+  background-color: #f8f8f8;
+  border: 1px #f3f2f1 solid;
+  flex: 1 1 100%;
+  margin-bottom: 0 !important;
+  grid-auto-flow: row;
+  grid-row-gap: 1rem;
+  grid-column-gap: 1rem;
+}
+
+.app-application__card {
+  margin-bottom: 10px;
+  border-bottom: 1px solid black;
+}
+
+.app-application-card__header {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.moj-filter-layout__content {
+  overflow: hidden;
+}
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,14 @@ en:
       no_early_career_teachers: "No early career teachers for this cohort"
       not_yet_known: "Not yet decided"
 
+  npq_courses:
+    npq-leading-teaching: Leading Teaching development course breakdown
+    npq-leading-behaviour-culture: Leading Behaviour and Culture course breakdown
+    npq-leading-teaching-development: Leading Teacher Development course breakdown
+    npq-senior-leadership: Senior Leadership course breakdown
+    npq-headship: Headship course breakdown
+    npq-executive-leadership: Executive Leadership course breakdown
+    npq-additional-support-offer: Additional Support Offer course breakdown
   courses:
     npq:
       npq-leading-teaching: Leading Teaching

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,12 @@ en:
     submission_deadline: Submission deadline
     choose_programme: Choose programme scheme
     cohort: Cohort
+    spring: Spring 2022
+    recruitment_target_total: Recruitment target total
+    total_completed: Total completed
+    total_retained: Total retained
+    total_starts: Total starts
+    total: Total
     show_contract: View contract information
     show_voided_declarations: View voided declarations
     voided_declarations: Voided declarations
@@ -303,8 +309,11 @@ en:
     service_fees:
       caption: Service fees
     output_payment:
+      label: Output Payment
       caption: Output fee
       band_d_info: Participants over the original band C target up to the new target.
+    cut_off_date:
+      caption: Output payment cut off date
     uplift_fee:
       caption: Uplift fee
     clawbacks:

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -279,9 +279,9 @@ module ValidTestDataGenerator
       user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
       identity = Identity::Create.call(user: user, origin: :npq)
 
-      december_statement = Finance::Statement::NPQ.find_by(
+      january_statement = Finance::Statement::NPQ.find_by(
         cpd_lead_provider: lead_provider.cpd_lead_provider,
-        name: "December 2021",
+        name: "January 2022",
       )
 
       npq_application = NPQApplication.create!(
@@ -317,7 +317,7 @@ module ValidTestDataGenerator
       return if [true, false].sample
 
       participant_declaration.make_payable!
-      participant_declaration.update!(statement: december_statement)
+      participant_declaration.update!(statement: january_statement)
     end
 
     def accept_application(npq_application)
@@ -326,13 +326,13 @@ module ValidTestDataGenerator
     end
 
     def create_started_declarations(npq_application)
-      RecordDeclarations::Started::NPQ.call(
+      RecordDeclarations::Retained::NPQ.call(
         params: {
           participant_id: npq_application.user.id,
           course_identifier: npq_application.npq_course.identifier,
-          declaration_date: (npq_application.profile.schedule.milestones.first.start_date + 1.day).rfc3339,
+          declaration_date: (npq_application.profile.schedule.milestones.second.start_date + 1.day).rfc3339,
           cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider,
-          declaration_type: "started",
+          declaration_type: "retained-1",
         },
       )
     end

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -279,9 +279,9 @@ module ValidTestDataGenerator
       user = User.create!(full_name: name, email: Faker::Internet.email(name: name))
       identity = Identity::Create.call(user: user, origin: :npq)
 
-      january_statement = Finance::Statement::NPQ.find_by(
+      december_statement = Finance::Statement::NPQ.find_by(
         cpd_lead_provider: lead_provider.cpd_lead_provider,
-        name: "January 2022",
+        name: "December 2021",
       )
 
       npq_application = NPQApplication.create!(
@@ -317,7 +317,7 @@ module ValidTestDataGenerator
       return if [true, false].sample
 
       participant_declaration.make_payable!
-      participant_declaration.update!(statement: january_statement)
+      participant_declaration.update!(statement: december_statement)
     end
 
     def accept_application(npq_application)
@@ -326,13 +326,13 @@ module ValidTestDataGenerator
     end
 
     def create_started_declarations(npq_application)
-      RecordDeclarations::Retained::NPQ.call(
+      RecordDeclarations::Started::NPQ.call(
         params: {
           participant_id: npq_application.user.id,
           course_identifier: npq_application.npq_course.identifier,
-          declaration_date: (npq_application.profile.schedule.milestones.second.start_date + 1.day).rfc3339,
+          declaration_date: (npq_application.profile.schedule.milestones.first.start_date + 1.day).rfc3339,
           cpd_lead_provider: npq_application.npq_lead_provider.cpd_lead_provider,
-          declaration_type: "retained-1",
+          declaration_type: "started",
         },
       )
     end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -4,20 +4,17 @@ require "rails_helper"
 
 RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :feature, js: true do
   include FinanceHelper
-  let(:cpd_lead_provider)                         { create(:cpd_lead_provider, name: "Lead Provider") }
-  let(:npq_lead_provider)                         { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider, name: "NPQ Lead Provider") }
-  let(:npq_leading_teaching_contract)             { create(:npq_contract, :npq_leading_teaching, npq_lead_provider: npq_lead_provider) }
-  let(:npq_leading_behaviour_culture_contract)    { create(:npq_contract, :npq_leading_behaviour_culture, npq_lead_provider: npq_lead_provider) }
+  let(:npq_leadership_schedule) { create(:npq_leadership_schedule) }
+  let(:npq_specialist_schedule) { create(:npq_specialist_schedule) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, name: "Lead Provider") }
+  let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider, name: "NPQ Lead Provider") }
+  let(:npq_leading_teaching_contract) { create(:npq_contract, :npq_leading_teaching, npq_lead_provider: npq_lead_provider) }
+  let(:npq_leading_behaviour_culture_contract) { create(:npq_contract, :npq_leading_behaviour_culture, npq_lead_provider: npq_lead_provider) }
   let(:npq_leading_teaching_development_contract) { create(:npq_contract, :npq_leading_teaching_development, npq_lead_provider: npq_lead_provider) }
-  let(:npq_course_leading_teaching)               { create(:npq_course, identifier: npq_leading_teaching_contract.course_identifier, name: "Leading Teaching") }
-  let(:npq_course_leading_behaviour_culture)      { create(:npq_course, identifier: npq_leading_behaviour_culture_contract.course_identifier, name: "Leading Behaviour Culture") }
-  let(:npq_course_leading_teaching_development)   { create(:npq_course, identifier: npq_leading_teaching_development_contract.course_identifier, name: "Leading Teaching Development") }
-  let(:breakdowns) do
-    Finance::NPQ::CalculationOverviewOrchestrator.new(
-      statement: statement,
-      aggregator: Finance::NPQ::ParticipantAggregator,
-    ).call(event_type: :started)
-  end
+  let(:npq_course_leading_teaching) { create(:npq_course, identifier: npq_leading_teaching_contract.course_identifier, name: "Leading Teaching") }
+  let(:npq_course_leading_behaviour_culture) { create(:npq_course, identifier: npq_leading_behaviour_culture_contract.course_identifier, name: "Leading Behaviour Culture") }
+  let(:npq_course_leading_teaching_development) { create(:npq_course, identifier: npq_leading_teaching_development_contract.course_identifier, name: "Leading Teaching Development") }
+
   let!(:statement) do
     Finance::Statement::NPQ.create!(
       name: "January 2022",
@@ -27,61 +24,27 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     )
   end
 
-  def course_breakdown_for(npq_contract)
-    aggregator_class = if statement.participant_declarations.any?
-                         Finance::NPQ::ParticipantAggregator
-                       else
-                         Finance::NPQ::ParticipantEligibleAndPayableAggregator
-                       end
-
-    Finance::NPQ::CalculationOrchestrator.new(
-      statement: statement,
-      contract: npq_contract,
-      aggregator: aggregator_class.new(
-        statement: statement,
-        recorder: ParticipantDeclaration::NPQ.where.not(state: %w[voided]),
-        course_identifier: npq_contract.course_identifier,
-      ),
-    )
-  end
-
   scenario "see a payment breakdown per NPQ course and a payment breakdown of each individual NPQ courses for each provider" do
     given_i_am_logged_in_as_a_finance_user
-    and_there_is_npq_provider_with_contracts
     and_those_courses_have_submitted_declarations
     when_i_visit_the_payment_breakdown_page
     and_choose_to_see_npq_payment_breakdown
     and_i_select_an_npq_lead_provider
-    then_i_should_have_the_correct_payment_breakdown_per_npq_lead_provider
-    then_i_should_see_the_courses_vat_and_total_payment
-    and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Payment breakdown per NPQ lead provider")
 
-    [npq_leading_teaching_contract, npq_leading_behaviour_culture_contract, npq_leading_teaching_development_contract].each do |npq_contract|
-      when_i_click_on_contract(npq_contract)
-      then_i_should_see_correct_breakdown_summary(npq_contract)
-      then_i_should_see_correct_service_fee_payment_breakdown(npq_contract)
-      then_i_should_see_correct_output_payment_breakdown(npq_contract)
-      then_i_should_see_the_correct_vat_total(npq_contract)
-      then_i_should_see_the_correct_total(npq_contract)
-      when_i_click "Back"
-    end
+    then_i_should_see_correct_course_summary
+    then_i_should_see_correct_output_payment_breakdown
+    then_i_should_see_correct_service_fee_payment_breakdown
+    then_i_should_see_the_correct_total
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named("Course overview per lead provider")
 
     when_i_click_on("View voided declarations")
     then_i_see_voided_declarations
     when_i_click "Back"
-
-    when_i_click_on_contract(npq_leading_teaching_contract)
+    when_i_click_on("View contract information")
+    then_i_see_contract_information
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Payment breakdown per contract")
-  end
-
-private
-
-  def then_i_see_voided_declarations
-    first("table") do
-      expect(page).to have_css("tr", count: 4) # headers + (3 * 1) # 1 for each of the 3 courses
-    end
+    and_percy_should_be_sent_a_snapshot_named("Contract information per NPQ lead provider")
   end
 
   def create_accepted_application(user, npq_course, npq_lead_provider)
@@ -144,16 +107,21 @@ private
         .each(&:make_payable!)
     end
 
-    ParticipantDeclaration::NPQ.where(state: "voided", cpd_lead_provider: cpd_lead_provider).update_all(statement_id: statement.id) # voided payable
     ParticipantDeclaration::NPQ
-      .where(state: "payable", cpd_lead_provider: cpd_lead_provider)
+      .where(state: "voided", cpd_lead_provider: cpd_lead_provider)
+      .update_all(statement_id: statement.id) # voided payable
+    ParticipantDeclaration::NPQ
+      .where(state: %w[eligible payable], cpd_lead_provider: cpd_lead_provider)
       .update_all(statement_id: statement.id)
   end
 
-  def and_there_is_npq_provider_with_contracts
-    npq_leading_teaching_contract
-    npq_leading_behaviour_culture_contract
-    npq_leading_teaching_development_contract
+  def then_i_should_see_correct_output_payment_breakdown
+    within first(".app-application__card") do
+      expect(page).to have_css("tr:nth-child(1) td:nth-child(1)", text: "Output payment")
+      expect(page).to have_css("tr:nth-child(1) td:nth-child(2)", text: current_trainees)
+      expect(page).to have_css("tr:nth-child(1) td:nth-child(3)", text: number_to_pounds(payment_per_trainee))
+      expect(page).to have_css("tr:nth-child(1) td:nth-child(4)", text: number_to_pounds(total))
+    end
   end
 
   def when_i_visit_the_payment_breakdown_page
@@ -170,146 +138,103 @@ private
     click_on "Continue"
   end
 
+  def then_i_should_see_correct_course_summary
+    within first(".app-application-card__header") do
+      expect(page).to have_content("Started")
+      expect(page).to have_content(total_participants_for(npq_specialist_schedule.milestones.first))
+      expect(page).to have_content("Current trainees")
+      expect(page).to have_content(current_trainees)
+    end
+  end
+
   def then_i_should_have_the_correct_payment_breakdown_per_npq_lead_provider
-    within "main .govuk-grid-column-full table:nth-of-type(2)" do
-      expect(page)
-        .to have_css("tbody tr.govuk-table__row:nth-child(1) a[href='#{finance_npq_lead_provider_statement_course_path(npq_lead_provider, statement, id: npq_leading_teaching_contract.course_identifier)}']")
-      expect(page)
-        .to have_css("tbody tr.govuk-table__row:nth-child(2) a[href='#{finance_npq_lead_provider_statement_course_path(npq_lead_provider, statement, id: npq_leading_behaviour_culture_contract.course_identifier)}']")
-      expect(page)
-        .to have_css("tbody tr.govuk-table__row:nth-child(3) a[href='#{finance_npq_lead_provider_statement_course_path(npq_lead_provider, statement, id: npq_leading_teaching_development_contract.course_identifier)}']")
+    within first(".app-application__card") do
+      expect(page).to have_content("Started")
     end
   end
 
-  def then_i_should_see_the_courses_vat_and_total_payment
-    within "main .govuk-grid-column-full table:nth-of-type(2)" do
-      expect(page).to have_css("tr:nth-child(4) td:nth-child(1)", text: "VAT")
-      expect(page).to have_css("tr:nth-child(4) td:nth-child(2)", text: number_to_pounds(aggregated_vat(breakdowns, npq_lead_provider)))
-      expect(page).to have_css("tr:nth-child(5) td:nth-child(1)", text: "Total payment")
-      expect(page).to have_css("tr:nth-child(5) td:nth-child(2)", text: number_to_pounds(aggregated_payment(breakdowns) + aggregated_vat(breakdowns, npq_lead_provider)))
+  def then_i_see_voided_declarations
+    first("table") do
+      expect(page).to have_css("tr", count: 4) # headers + (3 * 1) # 1 for each of the 3 courses
     end
   end
 
-  def when_i_click_on_contract(npq_contract)
-    click_on I18n.t(npq_contract.course_identifier, scope: %i[courses npq])
+  def then_i_should_see_correct_service_fee_payment_breakdown
+    within first(".app-application__card") do
+      expect(page).to have_css("tr:nth-child(2) td:nth-child(1)", text: "Service fee")
+      expect(page).to have_css("tr:nth-child(2) td:nth-child(2)", text: npq_leading_behaviour_culture_contract.recruitment_target)
+      expect(page).to have_css("tr:nth-child(2) td:nth-child(3)", text: number_to_pounds(service_fee_payment_per_trainee))
+      expect(page).to have_css("tr:nth-child(2) td:nth-child(4)", text: number_to_pounds(service_fee_total))
+    end
+  end
+
+  def then_i_should_see_the_correct_total
+    within first(".app-application__card") do
+      expect(page).to have_content("Course total")
+      expect(page).to have_content(number_to_pounds(course_total))
+    end
   end
 
   def when_i_click_on(string)
     click_on string
   end
 
+  def then_i_see_contract_information
+    within first(".govuk-table") do
+      expect(page).to have_css("tr:nth-child(1) td:nth-child(1)", text: npq_course_leading_teaching.identifier)
+      expect(page).to have_css("tr:nth-child(1) td:nth-child(2)", text: npq_leading_teaching_contract.recruitment_target)
+    end
+  end
+
   def expected_service_fee_payment(npq_contract)
     npq_contract.recruitment_target * expected_service_fee_portion_per_participant(npq_contract)
   end
 
-  def expected_current_particpant_count(npq_contract)
-    ParticipantDeclaration::NPQ.neither_paid_nor_voided_lead_provider_and_course(npq_contract.npq_lead_provider, npq_contract.course_identifier).count
+  def participant_per_declaration_type
+    statement.participant_declarations.for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier).where.not(state: :voided).group(:declaration_type).count
   end
 
-  def expected_total_paid(npq_contract)
-    ParticipantDeclaration::NPQ
-      .eligible_or_payable_for_lead_provider_and_course(npq_contract.npq_lead_provider.cpd_lead_provider, npq_contract.course_identifier)
-      .count
+  def total_participants_for(milestone)
+    participant_per_declaration_type.fetch(milestone.declaration_type, 0)
   end
 
-  def then_i_should_see_correct_breakdown_summary(npq_contract)
-    expect(page).to have_css("h2.govuk-heading-l", text: NPQCourse.find_by!(identifier: npq_contract.course_identifier).name)
-
-    within("main .govuk-grid-column-two-thirds table:nth-of-type(1)") do
-      expect(page).to have_content("Submission deadline")
-      expect(page).to have_content(statement.deadline_date.to_s(:govuk))
-    end
-
-    within("main .govuk-grid-column-two-thirds table:nth-of-type(2)") do
-      expect(page).to have_content("Recruitment target")
-      expect(page).to have_content(npq_contract.recruitment_target)
-      expect(page).to have_content("Current participants")
-      expect(page).to have_content(
-        ParticipantDeclaration::NPQ
-          .where(cpd_lead_provider: npq_lead_provider.cpd_lead_provider)
-          .where(course_identifier: npq_contract.course_identifier)
-          .where(statement: statement)
-          .where(state: "payable")
-          .count,
-      )
-      expect(page).to have_content("Total paid")
-      expect(page).to have_content(
-        ParticipantDeclaration::NPQ
-          .where(cpd_lead_provider: npq_lead_provider.cpd_lead_provider)
-          .where(course_identifier: npq_contract.course_identifier)
-          .where(statement: statement)
-          .where(state: "payable")
-          .count,
-      )
-      expect(page).to have_content("Total not paid")
-      # TODO: to be implemented later
-    end
+  def current_trainees
+    statement.participant_declarations.for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier).unique_paid_payable_or_eligible.count
   end
 
-  def expected_service_fee_portion_per_participant(npq_contract)
-    npq_contract.per_participant * npq_contract.service_fee_percentage / (100 * npq_contract.service_fee_installments)
+  def total
+    output_payments[:subtotal]
   end
 
-  def expected_total_vat(npq_contract)
-    output_fees_calculator = output_fees_calculator_for(npq_contract)
-    (expected_service_fee_payment(npq_contract) + output_fees_calculator[:subtotal]) * 0.2
+  def payment_per_trainee
+    output_payments[:per_participant]
   end
 
-  def service_fees_calculator_for(npq_contract)
-    PaymentCalculator::NPQ::ServiceFees.call(contract: npq_contract)
+  def output_payments
+    PaymentCalculator::NPQ::OutputPayment.call(contract: npq_leading_behaviour_culture_contract, total_participants: statement.participant_declarations.unique_paid_payable_or_eligible.count)
   end
 
-  def output_fees_calculator_for(npq_contract)
-    course_breakdown = course_breakdown_for(npq_contract).call(event_type: :started)
-    PaymentCalculator::NPQ::OutputPayment.call(contract: npq_contract, total_participants: course_breakdown[:output_payments][:participants])
+  def service_fees
+    PaymentCalculator::NPQ::ServiceFees.call(contract: npq_leading_behaviour_culture_contract)
   end
 
-  def then_i_should_see_correct_service_fee_payment_breakdown(npq_contract)
-    within("main .govuk-grid-column-two-thirds table:nth-of-type(3)") do
-      service_fees_calculator = service_fees_calculator_for(npq_contract)
-      expect(page).to have_css("tr:nth-child(1) td:nth-child(1)", text: "Service fee")
-      expect(page).to have_css("tr:nth-child(1) td:nth-child(2)", text: number_to_pounds(service_fees_calculator[:per_participant]))
-      expect(page).to have_css("tr:nth-child(1) td:nth-child(3)", text: npq_contract.recruitment_target)
-      expect(page).to have_css("tr:nth-child(1) td:nth-child(4)", text: number_to_pounds(service_fees_calculator[:monthly]))
-    end
+  def service_fee_total
+    service_fees[:monthly]
   end
 
-  def expected_per_participant_output_payment_portion(npq_contract)
-    (npq_contract.per_participant * npq_contract.output_payment_percentage) / (100 * npq_contract.number_of_payment_periods)
+  def service_fee_payment_per_trainee
+    service_fees[:per_participant]
   end
 
-  def eligible_and_payable_participant_count(npq_contract)
-    ParticipantDeclaration::NPQ
-      .eligible_or_payable_for_lead_provider_and_course(npq_contract.npq_lead_provider.cpd_lead_provider, npq_contract.course_identifier).count
+  def course_total
+    course_payment + total_vat(npq_lead_provider)
   end
 
-  def then_i_should_see_correct_output_payment_breakdown(npq_contract)
-    within("main .govuk-grid-column-two-thirds table:nth-of-type(3)") do
-      course_breakdown = course_breakdown_for(npq_contract).call(event_type: :started)
-      output_fees_calculator = PaymentCalculator::NPQ::OutputPayment.call(contract: npq_contract, total_participants: course_breakdown[:output_payments][:participants])
-      expect(page).to have_css("tr:nth-child(2) td:nth-child(1)", text: "Output fee")
-      expect(page).to have_css("tr:nth-child(2) td:nth-child(2)", text: number_to_pounds(output_fees_calculator[:per_participant]))
-      expect(page).to have_css("tr:nth-child(2) td:nth-child(3)", text: output_fees_calculator[:participants])
-      expect(page).to have_css("tr:nth-child(2) td:nth-child(4)", text: number_to_pounds(output_fees_calculator[:subtotal]))
-    end
+  def course_payment
+    service_fee_total + total
   end
 
-  def then_i_should_see_the_correct_vat_total(npq_contract)
-    within("main .govuk-grid-column-two-thirds table:nth-of-type(3)") do
-      expect(page).to have_css("tr:nth-child(3) td:nth-child(1)", text: "VAT")
-      expect(page).to have_css("tr:nth-child(3) td:nth-child(4)", text: number_to_pounds(expected_total_vat(npq_contract)))
-    end
-  end
-
-  def then_i_should_see_the_correct_total(npq_contract)
-    within("main .govuk-grid-column-two-thirds table:nth-of-type(3)") do
-      expected_service_fee_payment = service_fees_calculator_for(npq_contract)[:monthly]
-      expected_output_fee_payment  = output_fees_calculator_for(npq_contract)[:subtotal]
-      expected_total_vat           = expected_total_vat(npq_contract)
-      expected_total               = expected_service_fee_payment + expected_output_fee_payment + expected_total_vat
-
-      expect(page).to have_css("tr:nth-child(4) td:nth-child(1)", text: "Total payment")
-      expect(page).to have_css("tr:nth-child(4) td:nth-child(4)", text: number_to_pounds(expected_total))
-    end
+  def total_vat(npq_lead_provider)
+    course_payment * (npq_lead_provider.vat_chargeable ? 0.2 : 0.0)
   end
 end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -199,7 +199,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def current_trainees
-    statement.participant_declarations.for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier).unique_paid_payable_or_eligible.count
+    statement.participant_declarations.for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier).paid_payable_or_eligible.unique_id.count
   end
 
   def total
@@ -211,7 +211,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def output_payments
-    PaymentCalculator::NPQ::OutputPayment.call(contract: npq_leading_behaviour_culture_contract, total_participants: statement.participant_declarations.unique_paid_payable_or_eligible.count)
+    PaymentCalculator::NPQ::OutputPayment.call(contract: npq_leading_behaviour_culture_contract, total_participants: statement.participant_declarations.paid_payable_or_eligible.unique_id.count)
   end
 
   def service_fees

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -227,14 +227,10 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def course_total
-    course_payment + total_vat(npq_lead_provider)
+    course_payment
   end
 
   def course_payment
     service_fee_total + total
-  end
-
-  def total_vat(npq_lead_provider)
-    course_payment * (npq_lead_provider.vat_chargeable ? 0.2 : 0.0)
   end
 end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -211,7 +211,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def output_payments
-    PaymentCalculator::NPQ::OutputPayment.call(contract: npq_leading_behaviour_culture_contract, total_participants: statement.participant_declarations.paid_payable_or_eligible.unique_id.count)
+    PaymentCalculator::NPQ::OutputPayment.call(contract: npq_leading_behaviour_culture_contract, total_participants: statement.participant_declarations.where(course_identifier: npq_leading_behaviour_culture_contract.course_identifier).paid_payable_or_eligible.unique_id.count)
   end
 
   def service_fees

--- a/spec/features/finance/npq/view_contract_spec.rb
+++ b/spec/features/finance/npq/view_contract_spec.rb
@@ -12,11 +12,15 @@ RSpec.feature "NPQ view contract" do
     and_choose_to_see_npq_payment_breakdown
     and_i_select_an_npq_lead_provider
     and_i_click_on_view_contract
-
     then_i_see_contract_information_for_each_course
   end
 
   def and_there_is_an_npq_lead_provider_with_contracts
+    @npq_leading_teaching = create(:npq_course, identifier: "npq-leading-teaching")
+    @npq_leading_behaviour_culture = create(:npq_course, identifier: "npq-leading-behaviour-culture")
+    @npq_schedule = create(:npq_leadership_schedule)
+    @npq_specialist_schedule = create(:npq_specialist_schedule)
+
     @npq_lt = create(:npq_contract, :npq_leading_teaching)
     @npq_lead_provider = @npq_lt.npq_lead_provider
     @npq_lbc = create(:npq_contract, :npq_leading_behaviour_culture, npq_lead_provider: @npq_lead_provider)


### PR DESCRIPTION
Includes both [1026 ](https://dfedigital.atlassian.net/browse/CPDLP-1026) and [1027](https://dfedigital.atlassian.net/browse/CPDLP-1027)

1026 - adds Statement Summary
1027 - adds course breakdowns

- This view is for internal users only
- Refer to prototype / tickets for details & acceptance criteria

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
