### PR TITLE
BigQuery should accept rows that don't match schema

### DIFF
--- a/app/jobs/stream_big_query_participant_declarations_job.rb
+++ b/app/jobs/stream_big_query_participant_declarations_job.rb
@@ -18,7 +18,7 @@ class StreamBigQueryParticipantDeclarationsJob < ApplicationJob
             "cpd_lead_provider_name" => participant_declaration.cpd_lead_provider.name,
           )
         end
-        table.insert(rows) if rows.any?
+        table.insert(rows, ignore_unknown: true) if rows.any?
       end
   end
 end

--- a/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
+++ b/spec/jobs/stream_big_query_participant_declarations_job_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe StreamBigQueryParticipantDeclarationsJob do
         streamable_declaration.attributes.merge(
           "cpd_lead_provider_name" => cpd_lead_provider.name,
         ),
-      ])
+      ], { ignore_unknown: true })
     end
 
     it "doesn't attempt to stream when there are no updates" do


### PR DESCRIPTION
## Ticket and context

Sometimes we might change the schema on declarations but forget to update the BigQuery schema. Previously this would fail the BigQuery participant stream silently because we push _all_ attributes on that model. 

This change accepts rows that contain values that do not match the schema. The unknown values are ignored.