### PR TITLE
[CPDLP-1081] tweak width of selects on statement selector

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,1 +1,9 @@
 plugin_gems: ['scss_lint-govuk']
+
+linters:
+  PlaceholderInExtend:
+    exclude:
+      - "app/webpacker/styles/components/statement_selector.scss"
+  BangFormat:
+    exclude:
+      - "app/webpacker/styles/components/statement_selector.scss"

--- a/app/components/finance/statements/statement_selector.html.erb
+++ b/app/components/finance/statements/statement_selector.html.erb
@@ -4,7 +4,8 @@
     :id,
     :name,
     label: { text: "View a different provider" },
-    options: { selected: current_statement.npq_lead_provider.id }
+    options: { selected: current_statement.npq_lead_provider.id },
+    form_group: { class: "govuk-form-group govuk-!-width-one-third" }
   %>
 
   <%= f.govuk_collection_select :statement,
@@ -12,7 +13,8 @@
     :id,
     :name,
     label: { text: "View a different statement" },
-    options: { selected: current_statement.name.parameterize }
+    options: { selected: current_statement.name.parameterize },
+    form_group: { class: "govuk-form-group govuk-!-width-one-third" }
   %>
 
   <%= f.govuk_submit "View", secondary: true %>

--- a/app/webpacker/styles/components/statement_selector.scss
+++ b/app/webpacker/styles/components/statement_selector.scss
@@ -7,6 +7,14 @@
     margin-bottom: 0;
   }
 
+  select {
+    @extend .govuk-\!-width-full; // hack as form builder does not seem to support injecting of classes where needed
+
+    @include govuk-media-query($until: tablet) {
+      margin-bottom: 15px;
+    }
+  }
+
   input[type=submit] {
     margin-bottom: 0;
     vertical-align: bottom;


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1081

- Tweak statement selector so each dropdown is one third
- Unfortunately small CSS hack required as can't seem to inject desired CSS classes via govuk form builder
- Increased spacing for mobile view

## Screenshots

![Screenshot 2022-03-03 at 17 17 56](https://user-images.githubusercontent.com/92580/156616843-96990e8f-fd62-41c5-9863-6f309ae0c34e.png)

![Screenshot 2022-03-03 at 17 18 38](https://user-images.githubusercontent.com/92580/156616958-e9ce32a2-e16e-4653-8bea-2b417908b6b6.png)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- https://ecf-review-pr-1782.london.cloudapps.digital/
- Login as finance user
- Find an NPQ statement
- Increased dropdowns to to thirds
- Mobile view has increased spacing

## External API changes

- None