### PR TITLE
[CPDLP-1091] fix toggle for NPQ aggregator which was inverted

### DIFF
--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -35,7 +35,11 @@ module Finance
       end
 
       def aggregator_for(statement)
-        statement.past_deadline_date? ? Finance::NPQ::ParticipantEligibleAndPayableAggregator : Finance::NPQ::ParticipantAggregator
+        if statement.past_deadline_date?
+          Finance::NPQ::ParticipantAggregator
+        else
+          Finance::NPQ::ParticipantEligibleAndPayableAggregator
+        end
       end
     end
   end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   let(:breakdowns) do
     Finance::NPQ::CalculationOverviewOrchestrator.new(
       statement: statement,
-      aggregator: Finance::NPQ::ParticipantEligibleAndPayableAggregator,
+      aggregator: Finance::NPQ::ParticipantAggregator,
     ).call(event_type: :started)
   end
   let!(:statement) do


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1091

- The selecting of correct aggregator for NPQ statement was inverted

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Maybe
- Sign in as a finance user
- Find a statement that already has declarations assigned to it
- Submit an `eligible` declaration with correct provider and course
- Should have zero affect on the statement 

## External API changes

- None