### PR TITLE
[CPDLP-1091] fix NPQ course statements

### DIFF
--- a/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
+++ b/app/controllers/finance/npq/course_payment_breakdowns_controller.rb
@@ -27,13 +27,13 @@ module Finance
 
       def aggregator
         if @statement.past_deadline_date?
-          Finance::NPQ::ParticipantEligibleAndPayableAggregator.new(
+          ParticipantAggregator.new(
             statement: @statement,
             recorder: ParticipantDeclaration::NPQ.where.not(state: %w[voided]),
             course_identifier: params[:id],
           )
         else
-          ParticipantAggregator.new(
+          Finance::NPQ::ParticipantEligibleAndPayableAggregator.new(
             statement: @statement,
             recorder: ParticipantDeclaration::NPQ.where.not(state: %w[voided]),
             course_identifier: params[:id],


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1091

- this was due to inverted choice when selecting correct aggregator

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Sign in as a finance user
- Find a statement that already has declarations assigned to it
- View the course breakdown
- Submit an `eligible` declaration with correct provider and course
- Should have zero affect on the statement 

## External API changes

- None