### PR TITLE
[CPDLP-1091] Tweak ParticipantEligibleAndPayableAggregator

### DIFF
--- a/app/services/finance/npq/participant_eligible_and_payable_aggregator.rb
+++ b/app/services/finance/npq/participant_eligible_and_payable_aggregator.rb
@@ -26,6 +26,7 @@ module Finance
 
       def aggregate(aggregation_type:, event_type:)
         scope = recorder.public_send(self.class.aggregation_types[event_type][aggregation_type], cpd_lead_provider, course_identifier)
+        scope = scope.where(statement: nil)
         scope.count
       end
     end

--- a/spec/services/finance/npq/participant_eligible_and_payable_aggregator_spec.rb
+++ b/spec/services/finance/npq/participant_eligible_and_payable_aggregator_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::NPQ::ParticipantEligibleAndPayableAggregator do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider) }
+  let(:statement) { create(:npq_statement, cpd_lead_provider: cpd_lead_provider) }
+  let(:another_statement) { create(:npq_statement, cpd_lead_provider: cpd_lead_provider) }
+  let!(:declaration) { create(:npq_participant_declaration, statement: another_statement, state: "payable", cpd_lead_provider: cpd_lead_provider) }
+
+  subject do
+    described_class.new(statement: statement, course_identifier: declaration.course_identifier)
+  end
+
+  describe "#call" do
+    it "does not include assigned declarations" do
+      expect(subject.call[:all]).to be_zero
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1091

- aggregates on declarations not assigned to any statements
- as this aggregator operates on non frozen statements

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
 
- Sign in as a finance user
- Find a current statement ie has no declarations assigned to it
- View the course breakdown
- Submit/Create a `payable` declaration with correct provider and course on a previous frozen statement
- Should have zero affect on the statement

## External API changes

- None