### PR TITLE
Fix NPQ docs

### DIFF
--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -2813,36 +2813,15 @@
                   "email_validated": true,
                   "teacher_reference_number": "1234567",
                   "teacher_reference_number_validated": true,
+                  "works_in_school": true,
                   "school_urn": "106286",
                   "school_ukprn": "10079319",
                   "headteacher_status": "no",
                   "eligible_for_funding": true,
                   "funding_choice": "trust",
                   "course_identifier": "npq-leading-teaching",
-                  "works_in_school": false,
                   "employer_name": null,
                   "employment_role": null
-                }
-              },
-              {
-                "id": "7ac0dd38-fca6-48df-a901-6c8db2d3782d",
-                "type": "participant",
-                "attributes": {
-                  "participant_id": "9e479754-5d02-4943-a5ec-5c328a7484f1",
-                  "full_name": "John Smith",
-                  "email": "john.smit@other-school.example.com",
-                  "email_validated": true,
-                  "teacher_reference_number": "1234567",
-                  "teacher_reference_number_validated": true,
-                  "school_urn": null,
-                  "school_ukprn": null,
-                  "headteacher_status": "no",
-                  "eligible_for_funding": true,
-                  "funding_choice": "trust",
-                  "course_identifier": "npq-leading-teaching",
-                  "works_in_school": false,
-                  "employer_name": "Some Company Ltd",
-                  "employment_role": "Director"
                 }
               }
             ]
@@ -3015,6 +2994,23 @@
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
             "example": true
+          },
+          "works_in_school": {
+            "description": "Indicates whether the participant is currently employed by school",
+            "type": "boolean",
+            "example": true
+          },
+          "employer_name": {
+            "description": "The name of current employer of the participant if not currently employed by school",
+            "type": "string",
+            "nullable": true,
+            "example": "Some Company Ltd"
+          },
+          "employment_role": {
+            "description": "Participant's current role in the company they are employed in if not currently employed by school",
+            "type": "string",
+            "nullable": true,
+            "example": "Director"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school where this NPQ participant is employed",

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -48,11 +48,13 @@ properties:
     example: true
   employer_name:
     description: "The name of current employer of the participant if not currently employed by school"
-    type: ['null', string]
+    type: string
+    nullable: true
     example: "Some Company Ltd"
   employment_role:
     description: "Participant's current role in the company they are employed in if not currently employed by school"
-    type: ['null', string]
+    type: string
+    nullable: true
     example: "Director"
   school_urn:
     description: "The Unique Reference Number (URN) of the school where this NPQ participant is employed"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -2992,6 +2992,23 @@
             "type": "boolean",
             "example": true
           },
+          "works_in_school": {
+            "description": "Indicates whether the participant is currently employed by school",
+            "type": "boolean",
+            "example": true
+          },
+          "employer_name": {
+            "description": "The name of current employer of the participant if not currently employed by school",
+            "type": "string",
+            "nullable": true,
+            "example": "Some Company Ltd"
+          },
+          "employment_role": {
+            "description": "Participant's current role in the company they are employed in if not currently employed by school",
+            "type": "string",
+            "nullable": true,
+            "example": "Director"
+          },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school where this NPQ participant is employed",
             "type": "string",

--- a/swagger/v2/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQApplicationAttributes.yml
@@ -42,6 +42,20 @@ properties:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
     example: true
+  works_in_school:
+    description: "Indicates whether the participant is currently employed by school"
+    type: boolean
+    example: true
+  employer_name:
+    description: "The name of current employer of the participant if not currently employed by school"
+    type: string
+    nullable: true
+    example: "Some Company Ltd"
+  employment_role:
+    description: "Participant's current role in the company they are employed in if not currently employed by school"
+    type: string
+    nullable: true
+    example: "Director"
   school_urn:
     description: "The Unique Reference Number (URN) of the school where this NPQ participant is employed"
     type: string


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- The current open api spec is invalid
- Techdocs is therefore failing to generate documentation based on invalid spec

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- 

## External API changes

- None