### PR TITLE
Remove Grafana version pin

### DIFF
--- a/terraform/monitoring/resources.tf
+++ b/terraform/monitoring/resources.tf
@@ -13,5 +13,4 @@ module "prometheus_all" {
   grafana_admin_password = var.grafana_admin_password
   grafana_google_client_id = var.google_client_id
   grafana_google_client_secret = var.google_client_secret
-  grafana_runtime_version = "7.2.2"
 }


### PR DESCRIPTION
## Ticket and context

https://github.com/DFE-Digital/cf-monitoring/commit/0c104bab70659e769b464cd76fd6f97b27568668 and other commits are generated with a newer version of Grafana and this broke our instance. Instead, we can unpin from the version we were targeting and be on the latest and greatest.