### PR TITLE
Don't create dependabot review apps

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -5,6 +5,8 @@ on:
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'documentation/**'
+    branch-ignore:
+      - 'dependabot/**'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Ticket and context

Don't create dependabot review apps — it fails by default because we don't want to expose our secrets to it.