### PR TITLE
Change of Circumstances: Add relationship partnership

### DIFF
--- a/app/services/induction/create_relationship.rb
+++ b/app/services/induction/create_relationship.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This is related to Change of Circumstances / data model refactor
+# We need to be able to differentiate between Partnerships that have been added by a provider
+# and ones that have ben added by the school induction tutor as part of transferring in a participant
+# that is remaining on their current FIP induction.  Basically they are the same thing
+# but the business is calling the SIT added partnerships a "relationship" as a means to
+# differentiate them.
+class Induction::CreateRelationship < BaseService
+  def call
+    Partnership.create!(school: school_cohort.school,
+                        cohort: school_cohort.cohort,
+                        lead_provider: lead_provider,
+                        delivery_partner: delivery_partner,
+                        relationship: true)
+
+    # TODO: add notification to provider here if required
+  end
+
+private
+
+  attr_reader :school_cohort, :lead_provider, :delivery_partner
+
+  def initialize(school_cohort:, lead_provider:, delivery_partner: nil)
+    @school_cohort = school_cohort
+    @lead_provider = lead_provider
+    @delivery_partner = delivery_partner
+  end
+end

--- a/db/migrate/20220314120140_add_relationship_to_partnerships.rb
+++ b/db/migrate/20220314120140_add_relationship_to_partnerships.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRelationshipToPartnerships < ActiveRecord::Migration[6.1]
+  def change
+    add_column :partnerships, :relationship, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_24_164934) do
+ActiveRecord::Schema.define(version: 2022_03_14_120140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -663,6 +663,7 @@ ActiveRecord::Schema.define(version: 2022_02_24_164934) do
     t.datetime "challenge_deadline"
     t.boolean "pending", default: false, null: false
     t.uuid "report_id"
+    t.boolean "relationship", default: false, null: false
     t.index ["cohort_id"], name: "index_partnerships_on_cohort_id"
     t.index ["delivery_partner_id"], name: "index_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_partnerships_on_lead_provider_id"

--- a/spec/services/induction/create_relationship_spec.rb
+++ b/spec/services/induction/create_relationship_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::CreateRelationship do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:lead_provider) { create(:lead_provider) }
+    let(:delivery_partner) { create(:delivery_partner) }
+
+    subject(:service) { described_class }
+
+    it "adds a new Partnership record" do
+      expect {
+        service.call(school_cohort: school_cohort,
+                     lead_provider: lead_provider,
+                     delivery_partner: delivery_partner)
+      }.to change { school_cohort.school.partnerships.count }.by 1
+    end
+
+    it "sets the relationship flag on the Partnership" do
+      service.call(school_cohort: school_cohort,
+                   lead_provider: lead_provider,
+                   delivery_partner: delivery_partner)
+
+      expect(school_cohort.school.partnerships.last).to be_relationship
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

#### Context
As part of enabling transferring participants to continue their current FIP, we need to represent their `Partnership` with the new school.  The business is calling this a "relationship" to differentiate the two things. A relationship can be added by a SIT and doesn't need to originate from a provider. It is intended only for the transferring participant's use but otherwise it is the same as the current `Partnership`. It would not normally be challenged and would not be reused for wider use, but just to act as the glue between the school/providers and transferring participant's induction.


## Tech review

Adds a boolean `relationship` to `Partnership`
Adds a service to create a partnership with this flag set

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
