### PR TITLE
Fix issues with manual validation importer

### DIFF
--- a/app/services/importers/ecf_manual_validation.rb
+++ b/app/services/importers/ecf_manual_validation.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-class Importers::ECFManualValidation
-  attr_reader :path_to_csv
-
-  def initialize(path_to_csv:)
-    @path_to_csv = path_to_csv
-  end
-
+class Importers::ECFManualValidation < BaseService
   def call
     check_headers
 
     rows.each do |row|
-      user = User.find(row["id"])
+      user = Identity.find_user_by(id: row["id"])
 
       if user.nil?
         puts "No profile found for #{row['id']}. Skipping"
@@ -25,7 +19,7 @@ class Importers::ECFManualValidation
       end
 
       Participants::ParticipantValidationForm.call(
-        participant_profile: participant_profile,
+        participant_profile,
         save_validation_data_without_match: false,
         data: {
           trn: row["trn"],
@@ -48,8 +42,14 @@ class Importers::ECFManualValidation
 
 private
 
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:)
+    @path_to_csv = path_to_csv
+  end
+
   def check_headers
-    unless rows.headers == %w[id name trn dob nino]
+    unless %w[id name trn dob nino].all? { |header| rows.headers.include?(header) }
       raise NameError, "Invalid headers"
     end
   end


### PR DESCRIPTION
## Ticket and context

The ECF manual validation importer has been broken for a long time, this fixes the issues.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
