### PR TITLE
add release note for change of url in docs

### DIFF
--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,6 +9,13 @@ weight: 7
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l" id="8-3-2022">8th March 2022</h2>
+<p class="govuk-body-m">
+  <ul class="govuk-list govuk-list--bullet">
+    <li>In the documentation <code>/api-reference/reference.html</code> has been moved to <code>/api-reference/reference-v1.html</code></li>
+  </ul>
+</p>
+
 <h2 class="govuk-heading-l" id="12-1-2022">12th January 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- Add missing release note for change of URL in docs

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- visit docs in review app
- see release notes
- should see missing release note dated 8th March

## External API changes

- none