### PR TITLE
[CPDLP-1043] API v2 NPQ enrollments CSV endpoint

### DIFF
--- a/app/controllers/api/v2/npq_enrollments_controller.rb
+++ b/app/controllers/api/v2/npq_enrollments_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class NPQEnrollmentsController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include ApiPagination
+      include ApiFilter
+
+      def index
+        respond_to do |format|
+          format.csv do
+            render body: csv_response
+          end
+        end
+      end
+
+    private
+
+      def npq_profiles
+        @npq_profiles ||= ParticipantProfile::NPQ
+          .joins(:npq_application)
+          .includes(:user, :npq_course, :npq_application, schedule: [:cohort])
+          .where(npq_application: { npq_lead_provider: npq_lead_provider })
+          .order(updated_at: :asc)
+
+        @npq_profiles = @npq_profiles.where("participant_profiles.updated_at > ?", updated_since) if updated_since.present?
+
+        @npq_profiles
+      end
+
+      def csv_response
+        @csv_response ||= NPQEnrollmentsCsvSerializer.new(scope: npq_profiles).call
+      end
+
+      def npq_lead_provider
+        current_api_token.cpd_lead_provider.npq_lead_provider
+      end
+
+      def access_scope
+        LeadProviderApiToken.joins(cpd_lead_provider: [:npq_lead_provider])
+      end
+    end
+  end
+end

--- a/app/serializers/api/v2/npq_enrollments_csv_serializer.rb
+++ b/app/serializers/api/v2/npq_enrollments_csv_serializer.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class NPQEnrollmentsCsvSerializer
+      attr_reader :scope
+
+      def initialize(scope:)
+        @scope = scope
+      end
+
+      def call
+        CSV.generate do |csv|
+          csv << headers
+
+          scope.each do |object|
+            row = [
+              object.user.id,
+              object.npq_course.identifier,
+              object.schedule.schedule_identifier,
+              object.schedule.cohort.start_year.to_s,
+              object.npq_application.id,
+              object.npq_application.eligible_for_funding,
+              object.training_status,
+              object.school_urn,
+            ]
+
+            csv << row
+          end
+        end
+      end
+
+    private
+
+      def headers
+        %w[
+          participant_id
+          course_identifier
+          schedule_identifier
+          cohort
+          npq_application_id
+          eligible_for_funding
+          training_status
+          school_urn
+        ]
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       resources :npq_participants, only: %i[index], path: "participants/npq" do
         concerns :participant_actions
       end
+      resources :npq_enrollments, only: %i[index], path: "npq-enrollments"
       resources :users, only: %i[index create]
       resources :ecf_users, only: %i[index create], path: "ecf-users"
       resources :participant_validation, only: %i[create], path: "participant-validation"

--- a/spec/docs/v2/npq_enrollments_spec.rb
+++ b/spec/docs/v2/npq_enrollments_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_spec.json" do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
+  let(:npq_lead_provider) { create(:npq_lead_provider) }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+  let(:Authorization) { "Bearer #{token}" }
+
+  let!(:npq_application) { create(:npq_application, :accepted, npq_lead_provider: npq_lead_provider) }
+
+  path "/api/v2/npq-enrollments.csv" do
+    get "Retrieve multiple NPQ enrollments" do
+      operationId :npq_enrollments
+      tags "NPQ enrollments"
+      security [bearerAuth: []]
+
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/ListFilter",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine NPQ participants to return.",
+                example: { updated_since: "2020-11-13T11:21:55Z" }
+
+      response "200", "A list of NPQ enrollments" do
+        schema({ "$ref": "#/components/schemas/MultipleNPQEnrollmentsCsvResponse" }, content_type: "text/csv")
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/npq_enrollments_spec.rb
+++ b/spec/requests/api/v2/npq_enrollments_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe "NPQ Enrollments API", type: :request do
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:npq_lead_provider) { create(:npq_lead_provider) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider: npq_lead_provider) }
+
+  before { default_headers[:Authorization] = bearer_token }
+
+  let(:expected_headers) do
+    %w[
+      participant_id
+      course_identifier
+      schedule_identifier
+      cohort
+      npq_application_id
+      eligible_for_funding
+      training_status
+      school_urn
+    ]
+  end
+
+  describe "GET /api/v2/npq-enrollments.csv" do
+    context "when authorized" do
+      context "when there is no data" do
+        it "returns csv headers and no rows" do
+          get "/api/v2/npq-enrollments.csv"
+
+          expect(response.status).to eql(200)
+
+          rows = CSV.parse(response.body)
+
+          expect(rows.size).to eql(1)
+          expect(rows[0]).to eql(expected_headers)
+        end
+      end
+
+      context "when there is data" do
+        let!(:npq_application) { create(:npq_application, npq_lead_provider: npq_lead_provider) }
+        let!(:npq_profile) { create(:npq_participant_profile, npq_application: npq_application) }
+
+        it "returns headers" do
+          get "/api/v2/npq-enrollments.csv"
+          rows = CSV.parse(response.body)
+          expect(rows[0]).to eql(expected_headers)
+        end
+
+        it "returns correct data" do
+          get "/api/v2/npq-enrollments.csv"
+          rows = CSV.parse(response.body, headers: true)
+          expect(rows.size).to eql(1)
+          expect(rows[0].to_h.symbolize_keys).to eql(
+            participant_id: npq_profile.user.id,
+            course_identifier: npq_profile.npq_course.identifier,
+            schedule_identifier: npq_profile.schedule.schedule_identifier,
+            cohort: npq_profile.schedule.cohort.start_year.to_s,
+            npq_application_id: npq_profile.npq_application.id,
+            eligible_for_funding: npq_profile.npq_application.eligible_for_funding.to_s,
+            training_status: npq_profile.training_status,
+            school_urn: npq_profile.school_urn,
+          )
+        end
+
+        context "with updated_since filter" do
+          it "filters out results" do
+            get "/api/v2/npq-enrollments.csv?filter[updated_since]=2030-11-13T11:21:55Z"
+            rows = CSV.parse(response.body, headers: true)
+            expect(rows.size).to eql(0)
+          end
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v2/npq-enrollments.csv"
+        expect(response.status).to eql(401)
+      end
+    end
+  end
+end

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -247,6 +247,60 @@
         }
       }
     },
+    "/api/v2/npq-enrollments.csv": {
+      "get": {
+        "summary": "Retrieve multiple NPQ enrollments",
+        "operationId": "npq_enrollments",
+        "tags": [
+          "NPQ enrollments"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/ListFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine NPQ participants to return.",
+            "example": {
+              "updated_since": "2020-11-13T11:21:55Z"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of NPQ enrollments",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultipleNPQEnrollmentsCsvResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/participants/npq": {
       "get": {
         "summary": "Retrieve multiple NPQ participants",
@@ -2825,6 +2879,22 @@
           }
         }
       },
+      "MultipleNPQEnrollmentsCsvResponse": {
+        "description": "A list of NPQ enrollments in the Comma Separated Value (CSV) format",
+        "type": "string",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NPQEnrollmentCsvRow"
+            }
+          }
+        },
+        "example": "participant_id,course_identifier,schedule_identifier,cohort,npq_application_id,eligible_for_funding,training_status,school_urn\n9b57c3ad-b911-4427-a4cb-87949741a631,npq-headship,npq-leadership-spring,2021,a7aad9e4-13c6-401c-b4d8-e5ccd231624e,false,active,329229\n"
+      },
       "MultipleNPQParticipantsResponse": {
         "description": "A list of NPQ participants",
         "type": "object",
@@ -2842,14 +2912,20 @@
                 "id": "db3a7848-7308-4879-942a-c4a70ced400a",
                 "type": "npq-participant",
                 "attributes": {
-                  "participant_id": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
                   "full_name": "Isabelle MacDonald",
                   "email": "isabelle.macdonald2@some-school.example.com",
-                  "npq_courses": [
-                    "npq-leading-teaching"
-                  ],
                   "teacher_reference_number": "1234567",
-                  "updated_at": "2021-05-31T02:21:32.000Z"
+                  "updated_at": "2021-05-31T02:21:32.000Z",
+                  "npq_enrollments": [
+                    {
+                      "course_identifier": "npq-headship",
+                      "schedule_identifier": "npq-leadership-autumn",
+                      "cohort": "2021",
+                      "npq_application_id": "db3a7848-7308-4879-942a-c4a70ced400a",
+                      "eligible_for_funding": true,
+                      "training_status": "active"
+                    }
+                  ]
                 }
               }
             ]
@@ -3048,7 +3124,7 @@
             ]
           },
           "course_identifier": {
-            "description": "The Unique Reference Number (URN) of the NPQ course this NPQ application relates to",
+            "description": "The NPQ course this NPQ application relates to",
             "type": "string",
             "example": "npq-leading-teaching",
             "enum": [
@@ -3251,9 +3327,9 @@
             "type": "string",
             "example": "npq-senior-leadership",
             "enum": [
-              "npq-senior-leadership",
-              "npq-headship",
-              "npq-executive-leadership",
+              "npq-leading-teaching",
+              "npq-leading-behaviour-culture",
+              "npq-leading-teaching-development",
               "npq-senior-leadership",
               "npq-headship",
               "npq-executive-leadership",
@@ -3300,6 +3376,94 @@
               "deferred",
               "withdrawn"
             ]
+          },
+          "school_urn": {
+            "description": "The URN of the school when the application was made, if any",
+            "nullable": true,
+            "type": "string",
+            "example": "123456"
+          }
+        }
+      },
+      "NPQEnrollmentCsvRow": {
+        "description": "The details of an NPQ application",
+        "type": "object",
+        "required": [
+          "participant_id",
+          "course_identifier",
+          "schedule_identifier",
+          "cohort",
+          "npq_application_id",
+          "eligible_for_funding",
+          "training_status",
+          "school_urn"
+        ],
+        "properties": {
+          "participant_id": {
+            "description": "The unique identifier of this NPQ participant",
+            "type": "string",
+            "example": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
+            "format": "uuid"
+          },
+          "course_identifier": {
+            "description": "The NPQ course the participant is enrolled in",
+            "type": "string",
+            "example": "npq-leading-teaching",
+            "enum": [
+              "npq-leading-teaching",
+              "npq-leading-behaviour-culture",
+              "npq-leading-teaching-development",
+              "npq-senior-leadership",
+              "npq-headship",
+              "npq-executive-leadership",
+              "npq-additional-support-offer"
+            ]
+          },
+          "schedule_identifier": {
+            "description": "The schedule currently applied to this enrollment",
+            "type": "string",
+            "example": "npq-specialist-autumn",
+            "enum": [
+              "npq-specialist-autumn",
+              "npq-specialist-spring",
+              "npq-leadership-autumn",
+              "npq-leadership-spring",
+              "npq-aso-december",
+              "npq-aso-november",
+              "npq-aso-march",
+              "npq-aso-june"
+            ]
+          },
+          "cohort": {
+            "description": "The start year of the cohort the participant is enrolled in",
+            "type": "string",
+            "example": "2021"
+          },
+          "npq_application_id": {
+            "description": "The unique identifier of this NPQ application that was accepted to create this enrollment",
+            "type": "string",
+            "example": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
+            "format": "uuid"
+          },
+          "eligible_for_funding": {
+            "description": "Indicates whether this NPQ participant would be eligible for funding from the DfE",
+            "type": "boolean",
+            "example": true
+          },
+          "training_status": {
+            "description": "The training status of the ECF participant",
+            "type": "string",
+            "example": "active",
+            "enum": [
+              "active",
+              "deferred",
+              "withdrawn"
+            ]
+          },
+          "school_urn": {
+            "description": "The Unique Reference Number (URN) of the school where this NPQ participant is teaching",
+            "type": "string",
+            "example": "106286"
           }
         }
       },
@@ -3335,19 +3499,12 @@
         "description": "The data attributes associated with an NPQ participants",
         "type": "object",
         "required": [
-          "participant_id",
           "full_name",
           "email",
           "npq_enrollments",
           "updated_at"
         ],
         "properties": {
-          "participant_id": {
-            "description": "The unique identifier of this NPQ participant",
-            "type": "string",
-            "example": "7a8fef46-3c43-42c0-b3d5-1ba5904ba562",
-            "format": "uuid"
-          },
           "full_name": {
             "description": "The full name of this NPQ participant",
             "type": "string",

--- a/swagger/v2/component_schemas/MultipleNPQEnrollmentsCsvResponse.yml
+++ b/swagger/v2/component_schemas/MultipleNPQEnrollmentsCsvResponse.yml
@@ -1,0 +1,12 @@
+description: "A list of NPQ enrollments in the Comma Separated Value (CSV) format"
+type: string
+required:
+  - data
+properties:
+  data:
+    type: array
+    items:
+      $ref: "#/components/schemas/NPQEnrollmentCsvRow"
+example: |
+  participant_id,course_identifier,schedule_identifier,cohort,npq_application_id,eligible_for_funding,training_status,school_urn
+  9b57c3ad-b911-4427-a4cb-87949741a631,npq-headship,npq-leadership-spring,2021,a7aad9e4-13c6-401c-b4d8-e5ccd231624e,false,active,329229

--- a/swagger/v2/component_schemas/NPQEnrollmentCsvRow.yml
+++ b/swagger/v2/component_schemas/NPQEnrollmentCsvRow.yml
@@ -1,0 +1,67 @@
+description: "The details of an NPQ application"
+type: object
+required:
+  - participant_id
+  - course_identifier
+  - schedule_identifier
+  - cohort
+  - npq_application_id
+  - eligible_for_funding
+  - training_status
+  - school_urn
+properties:
+  participant_id:
+    description: "The unique identifier of this NPQ participant"
+    type: string
+    example: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
+    format: uuid
+  course_identifier:
+    description: "The NPQ course the participant is enrolled in"
+    type: string
+    example: npq-leading-teaching
+    enum:
+      - npq-leading-teaching
+      - npq-leading-behaviour-culture
+      - npq-leading-teaching-development
+      - npq-senior-leadership
+      - npq-headship
+      - npq-executive-leadership
+      - npq-additional-support-offer
+  schedule_identifier:
+    description: "The schedule currently applied to this enrollment"
+    type: string
+    example: "npq-specialist-autumn"
+    enum:
+      - npq-specialist-autumn
+      - npq-specialist-spring
+      - npq-leadership-autumn
+      - npq-leadership-spring
+      - npq-aso-december
+      - npq-aso-november
+      - npq-aso-march
+      - npq-aso-june
+  cohort:
+    description: "The start year of the cohort the participant is enrolled in"
+    type: string
+    example: "2021"
+  npq_application_id:
+    description: "The unique identifier of this NPQ application that was accepted to create this enrollment"
+    type: string
+    example: 7a8fef46-3c43-42c0-b3d5-1ba5904ba562
+    format: uuid
+  eligible_for_funding:
+    description: "Indicates whether this NPQ participant would be eligible for funding from the DfE"
+    type: "boolean"
+    example: true
+  training_status:
+    description: "The training status of the ECF participant"
+    type: string
+    example: active
+    enum:
+      - active
+      - deferred
+      - withdrawn
+  school_urn:
+    description: "The Unique Reference Number (URN) of the school where this NPQ participant is teaching"
+    type: string
+    example: "106286"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1043

- NOTE: Before merging ensure v2 api docs are removed
- Add new endpoint for v2 API to fetch NPQ enrollments via CSV format
- Update docs fro this new endpoint

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- docs available at https://ecf-review-pr-1809.london.cloudapps.digital/api-reference/reference-v2.html#api-v2-npq-enrollments-csv-get
- call the new endpoint
- should see relevant enrollments in csv format

## External API changes

- Yes for v2
- But v2 is not been exposed yet