### PR TITLE
CPDLP-1113 NPQ breakdown post release changes

### DIFF
--- a/app/components/finance/npq/payment_overviews/contract_info.html.erb
+++ b/app/components/finance/npq/payment_overviews/contract_info.html.erb
@@ -1,0 +1,31 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">Contract Information</span>
+  </summary>
+  <div class="govuk-details__text">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">
+          <%= t("finance.contract.course_identifier") %>
+        </th>
+        <th class="govuk-table__header govuk-table__cell--numeric">
+          <%= t("finance.contract.recruitment_target") %>
+        </th>
+        <th class="govuk-table__header govuk-table__cell--numeric">
+          <%= t("finance.per_participant") %>
+        </th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <% @npq_contracts.each do |contract| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= contract.course_identifier %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= contract.recruitment_target %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_pounds contract.per_participant %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</details>

--- a/app/components/finance/npq/payment_overviews/contract_info.rb
+++ b/app/components/finance/npq/payment_overviews/contract_info.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Finance
+  module NPQ
+    module PaymentOverviews
+      class ContractInfo < BaseComponent
+        include FinanceHelper
+
+        def initialize(npq_contracts, npq_lead_provider)
+          @npq_contracts = npq_contracts
+          @npq_lead_provider = npq_lead_provider
+        end
+
+      private
+
+        attr_reader :npq_contracts, :npq_lead_provider
+      end
+    end
+  end
+end

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.html.erb
@@ -27,83 +27,61 @@
         </div>
       </div>
     </li>
-    <li>
-      <strong class="float govuk-body-s govuk-!-margin-bottom-0">
-        <%= t("finance.recruitment_target_total") %>
-      </strong>
-      <br>
-      <div class="number-group">
-        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-          <span><%= recruitment_target_total %></span>
-        </div>
-      </div>
-    </li>
   </ul>
   <ul class="second govuk-list govuk-!-margin-bottom-0">
     <li>
-      <strong class="float govuk-body-s govuk-!-margin-bottom-0"><%= t("finance.cohort") %></strong>
+      <strong class="float govuk-body-s govuk-!-margin-bottom-0"><%= t("finance.total_starts") %></strong>
       <div class="number-group">
         <div class="number-container govuk-!-padding-right-4">
           <div class="float tooltip">
             <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-              <span><%= t("finance.spring") %></span>
+              <span><%= total_starts %></span>
             </div>
           </div>
-        </div>
-      </div>
-    </li>
-    <li>
-      <strong class="float govuk-body-s govuk-!-margin-bottom-0"><%= t("finance.total_starts") %></strong>
-      <br>
-      <div class="number-group">
-        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-          <span><%= total_starts %></span>
         </div>
       </div>
     </li>
   </ul>
-  <ul class="third govuk-list govuk-!-margin-bottom-0">
+  <ul class="booster govuk-list govuk-!-margin-bottom-0">
     <li>
-      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.voided_declarations") %></strong>
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_retained") %></strong>
       <div class="number-group">
         <div class="number-container govuk-!-padding-right-4">
           <div class="float tooltip">
             <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-              <span><%= total_voided %></span>
+              <span><%= total_retained %></span>
             </div>
           </div>
-        </div>
-      </div>
-    </li>
-    <li>
-      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_retained") %></strong>
-      <br>
-      <div class="number-group">
-        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-          <span><%= total_retained %></span>
         </div>
       </div>
     </li>
   </ul>
   <ul class="fourth govuk-list govuk-!-margin-bottom-0">
     <li class="empty">
-      <strong class="govuk-body-s float govuk-!-margin-bottom-0"></strong>
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_completed") %></strong>
       <div class="number-group">
         <div class="number-container govuk-!-padding-right-4">
           <div class="float tooltip">
             <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-              <span></span>
+              <span><%= total_completed %></span>
             </div>
           </div>
         </div>
       </div>
     </li>
-    <li>
-      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_completed") %></strong>
-      <br>
+  </ul>
+  <ul class="fifth govuk-list govuk-!-margin-bottom-0">
+    <li class="empty">
+      <strong class="govuk-body-s float govuk-!-margin-bottom-0"><%= t("finance.total_voids") %></strong>
       <div class="number-group">
-        <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
-          <span><%= total_completed %></span>
+        <div class="number-container govuk-!-padding-right-4">
+          <div class="float tooltip">
+            <div class="float govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-0">
+              <span><%= total_voided %></span>
+              <br>
+              <p class="govuk-body-s"><%= govuk_link_to( t("finance.view") , voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement)) %></p>
+            </div>
+          </div>
         </div>
       </div>
     </li>

--- a/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_summary.rb
@@ -77,13 +77,13 @@ module Finance
         def statement_declarations
           if statement.current?
             ParticipantDeclaration::NPQ
-              .eligible_for_lead_provider(npq_lead_provider)
+              .for_lead_provider(npq_lead_provider)
+              .eligible
               .where(statement_id: nil)
           else
             statement
               .participant_declarations
               .paid_payable_or_eligible
-              .unique_id
           end
         end
 

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.html.erb
@@ -1,8 +1,7 @@
 <header class="app-application-card__header">
-  <% milestones.each do |milestone| %>
+  <% milestones.order(name: :asc).each do |milestone| %>
     <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewMilestoneSummary.new(milestone, total_participants_for(milestone)) %>
   <% end %>
-  <span class="govuk-body-s">Recruitment target<br><%= recruitment_target %></span>
-  <span class="govuk-body-s">Current trainees<br><%= current_trainees %></span>
-  <span class="govuk-body-s">Total not paid<br><%= total_not_paid %></span>
+  <span class="govuk-body-s"><%= t("finance.total_declarations") %><br><%= current_trainees %></span>
+  <span class="govuk-body-s"><%= t("finance.total_not_eligible_for_funding") %><br><%= total_not_paid %></span>
 </header>

--- a/app/controllers/finance/base_controller.rb
+++ b/app/controllers/finance/base_controller.rb
@@ -7,6 +7,8 @@ module Finance
     before_action :authenticate_user!
     before_action :ensure_finance
 
+    layout "finance"
+
   private
 
     def ensure_finance

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,6 +59,10 @@ module ApplicationHelper
     end
   end
 
+  def wide_container_view?
+    params[:controller].start_with?("finance")
+  end
+
 private
 
   def post_2020_ecf_participant?(user)

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -24,9 +24,7 @@
           <% end %>
         </div>
       </div>
-      <ul class="govuk-list">
-        <li><%= govuk_link_to t("finance.show_voided_declarations"), voided_finance_npq_lead_provider_statement_path(@npq_lead_provider.id, @statement) %></li>
-        <li><%= govuk_link_to t("finance.show_contract"), finance_npq_contract_path(id: @npq_lead_provider.id) %></li>
-      </ul>
+      <br>
+      <%= render Finance::NPQ::PaymentOverviews::ContractInfo.new(@npq_contracts, @npq_lead_provider) %>
     </div>
   </div>

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -101,28 +101,11 @@
 
     <%= yield(:nav_bar) %>
 
-    <div class="govuk-width-container">
-      <div class="govuk-phase-banner app-phase-banner--no-border govuk-!-display-none-print">
-        <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">
-            <% if Rails.env.production?  %>
-              Beta
-            <% elsif Rails.env.staging? %>
-              Staging
-            <% elsif Rails.env.sandbox? %>
-              Sandbox
-            <% else %>
-              Development
-            <% end %>
-          </strong>
-          <span class="govuk-phase-banner__text">
-            This is a new service – your
-            <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
-            will help us to improve it.
-          </span>
-        </p>
-      </div>
-    </div>
+    <% if wide_container_view? %>
+      <%= render "layouts/phase_banner_wide" %>
+    <% else %>
+      <%= render "layouts/phase_banner" %>
+    <% end %>
 
     <% if current_user != true_user %>
       <div class="govuk-width-container">
@@ -142,25 +125,10 @@
 
     <%= yield %>
 
-    <footer class="govuk-footer " role="contentinfo">
-      <div class="govuk-width-container">
-        <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <%= render 'layouts/support_links' %>
-            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-              />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
-          </div>
-          <div class="govuk-footer__meta-item">
-            <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-          </div>
-        </div>
-      </div>
-    </footer>
+    <% if wide_container_view? %>
+      <%= render "layouts/footer_wide" %>
+    <% else %>
+      <%= render "layouts/footer" %>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,20 @@
+<footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container govuk-width-container">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <%= render 'layouts/support_links' %>
+        <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+          />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
-<footer class="govuk-footer " role="contentinfo">
-  <div class="govuk-width-container govuk-width-container">
+<footer class="govuk-footer" role="contentinfo">
+  <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <%= render 'layouts/support_links' %>

--- a/app/views/layouts/_footer_wide.html.erb
+++ b/app/views/layouts/_footer_wide.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer " role="contentinfo">
+<footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container govuk-width-container__wide">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/app/views/layouts/_footer_wide.html.erb
+++ b/app/views/layouts/_footer_wide.html.erb
@@ -1,0 +1,20 @@
+<footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container govuk-width-container__wide">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <%= render 'layouts/support_links' %>
+        <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/layouts/_phase_banner.erb
+++ b/app/views/layouts/_phase_banner.erb
@@ -13,7 +13,7 @@
         <% end %>
       </strong>
       <span class="govuk-phase-banner__text">
-                This is a new service – your
+        This is a new service – your
         <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
         will help us to improve it.
       </span>

--- a/app/views/layouts/_phase_banner.erb
+++ b/app/views/layouts/_phase_banner.erb
@@ -1,0 +1,22 @@
+<div class="govuk-width-container">
+  <div class="govuk-phase-banner app-phase-banner--no-border govuk-!-display-none-print">
+    <p class="govuk-phase-banner__content">
+      <strong class="govuk-tag govuk-phase-banner__content__tag">
+        <% if Rails.env.production?  %>
+          Beta
+        <% elsif Rails.env.staging? %>
+          Staging
+        <% elsif Rails.env.sandbox? %>
+          Sandbox
+        <% else %>
+          Development
+        <% end %>
+      </strong>
+      <span class="govuk-phase-banner__text">
+                This is a new service – your
+        <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
+        will help us to improve it.
+      </span>
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/_phase_banner_wide.html.erb
+++ b/app/views/layouts/_phase_banner_wide.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       </strong>
       <span class="govuk-phase-banner__text">
-              This is a new service – your
+        This is a new service – your
         <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
         will help us to improve it.
       </span>

--- a/app/views/layouts/_phase_banner_wide.html.erb
+++ b/app/views/layouts/_phase_banner_wide.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-width-container govuk-width-container__wide">
+  <div class="govuk-phase-banner app-phase-banner--no-border govuk-!-display-none-print">
+    <p class="govuk-phase-banner__content">
+      <strong class="govuk-tag govuk-phase-banner__content__tag">
+        <% if Rails.env.production?  %>
+          Beta
+        <% elsif Rails.env.staging? %>
+          Staging
+        <% elsif Rails.env.sandbox? %>
+          Sandbox
+        <% else %>
+          Development
+        <% end %>
+      </strong>
+      <span class="govuk-phase-banner__text">
+              This is a new service – your
+        <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
+        will help us to improve it.
+      </span>
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/_width_container_wide.html.erb
+++ b/app/views/layouts/_width_container_wide.html.erb
@@ -1,0 +1,35 @@
+<%= render layout: "layouts/application" do %>
+  <div class="govuk-width-container govuk-width-container__wide">
+    <%= yield(:before_content) %>
+
+    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+      <% flash.each do |type, msg| %>
+        <% if type == "alert" %>
+          <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+            <h2 class="govuk-error-summary__title" id="error-summary-title">
+              <%= msg %>
+            </h2>
+          </div>
+        <% elsif type == "success" %>
+          <%= govuk_notification_banner(
+                title_text: msg[:title],
+                success: true,
+                html_attributes: { data: { test: "notification-banner" } }
+              ) do |banner| %>
+            <% banner.heading(text: msg[:heading]) %>
+            <% msg[:content] %>
+          <% end %>
+        <% else %>
+          <div class="govuk-success-summary" aria-labelledby="success-message" tabindex="-1" role="alert">
+            <div class="govuk-success-summary__title">
+              <h2 class="govuk-heading-m" id="success-message">
+                <%= msg %>
+              </h2>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+      <%= yield %>
+    </main>
+  </div>
+<% end %>

--- a/app/views/layouts/finance.html.erb
+++ b/app/views/layouts/finance.html.erb
@@ -1,0 +1,3 @@
+<%= render layout: 'layouts/width_container_wide' do %>
+  <%= yield %>
+<% end %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -51,3 +51,9 @@ $govuk-image-url-function: frontend-image-url;
 .bold-label {
   font-weight: 700;
 }
+
+.govuk-width-container__wide {
+  min-width: 1110px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/webpacker/styles/lead_providers/statements.scss
+++ b/app/webpacker/styles/lead_providers/statements.scss
@@ -5,9 +5,15 @@
   border: 1px #f3f2f1 solid;
   flex: 1 1 100%;
   margin-bottom: 0 !important;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr repeat(3, auto);
   grid-auto-flow: row;
   grid-row-gap: 1rem;
   grid-column-gap: 1rem;
+  @media (min-width: 40.625em) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(3, auto);
+  }
   @media (min-width: 68.75em) {
     display: flex;
     justify-content: space-between;
@@ -23,20 +29,13 @@
     }
   }
 
-  span {
-    float: right;
-  }
-
   ul {
     display: grid;
     grid-auto-flow: row;
     grid-gap: 0.5rem;
     padding: unset;
-    @media (min-width: 68.75em) {
-      grid-template-rows: repeat(2, 1fr);
-      grid-template-columns: 1fr;
-    }
   }
+
   li {
     @media (min-width: 40.0625em) {
       font-size: 1.1875rem;
@@ -52,14 +51,27 @@
   border: 1px #f3f2f1 solid;
   flex: 1 1 100%;
   margin-bottom: 0 !important;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(3, auto);
   grid-auto-flow: row;
   grid-row-gap: 1rem;
   grid-column-gap: 1rem;
+  @media (min-width: 40.625em) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(3, auto);
+  }
+  @media (min-width: 68.75em) {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr repeat(3, auto);
+  }
 }
 
 .app-application__card {
   margin-bottom: 10px;
   border-bottom: 1px solid black;
+  @media (min-width: 40.625em) {
+    margin-bottom: 10px;
+  }
 }
 
 .app-application-card__header {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,7 +246,10 @@ en:
     total_completed: Total completed
     total_retained: Total retained
     total_starts: Total starts
+    total_voids: Total voids
     total: Total
+    total_declarations: Total declarations
+    total_not_eligible_for_funding: Total not eligible for funding
     show_contract: View contract information
     show_voided_declarations: View voided declarations
     voided_declarations: Voided declarations
@@ -272,6 +275,7 @@ en:
     total_paid: Total paid
     total_not_paid: Total not paid
     number_of_declarations: Number of declarations
+    view: View
     contract:
       version: Contract reference
       per_participant: Per participant

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -38,10 +38,10 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named("Course overview per lead provider")
 
-    when_i_click_on("View voided declarations")
+    when_i_click_on_view_within_statement_summary
     then_i_see_voided_declarations
     when_i_click "Back"
-    when_i_click_on("View contract information")
+    when_i_click_on_view_contract
     then_i_see_contract_information
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named("Contract information per NPQ lead provider")
@@ -142,7 +142,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     within first(".app-application-card__header") do
       expect(page).to have_content("Started")
       expect(page).to have_content(total_participants_for(npq_specialist_schedule.milestones.first))
-      expect(page).to have_content("Current trainees")
+      expect(page).to have_content("Total declarations")
       expect(page).to have_content(current_trainees)
     end
   end
@@ -150,6 +150,12 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   def then_i_should_have_the_correct_payment_breakdown_per_npq_lead_provider
     within first(".app-application__card") do
       expect(page).to have_content("Started")
+    end
+  end
+
+  def when_i_click_on_view_within_statement_summary
+    within(".app-application__panel__summary") do
+      when_i_click_on("View")
     end
   end
 
@@ -176,13 +182,17 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def when_i_click_on(string)
-    click_on string
+    click_link_or_button string
+  end
+
+  def when_i_click_on_view_contract
+    find("span", text: "Contract Information").click
   end
 
   def then_i_see_contract_information
-    within first(".govuk-table") do
-      expect(page).to have_css("tr:nth-child(1) td:nth-child(1)", text: npq_course_leading_teaching.identifier)
-      expect(page).to have_css("tr:nth-child(1) td:nth-child(2)", text: npq_leading_teaching_contract.recruitment_target)
+    within first(".govuk-details__text") do
+      expect(page).to have_content(npq_course_leading_teaching.identifier)
+      expect(page).to have_content(npq_leading_teaching_contract.recruitment_target)
     end
   end
 

--- a/spec/features/finance/npq/view_contract_spec.rb
+++ b/spec/features/finance/npq/view_contract_spec.rb
@@ -48,28 +48,17 @@ RSpec.feature "NPQ view contract" do
   end
 
   def and_i_click_on_view_contract
-    click_on "View contract information"
+    find("span", text: "Contract Information").click
   end
 
   def then_i_see_contract_information_for_each_course
-    within "#main-content > table > tbody" do
-      within "tr:nth-child(1)" do
-        expect(page)
-          .to have_css("td:nth-child(1)", text: "npq-leading-teaching")
-        expect(page)
-          .to have_css("td:nth-child(2)", text: @npq_lt.recruitment_target)
-        expect(page)
-          .to have_css("td:nth-child(3)", text: number_to_pounds(@npq_lt.per_participant))
-      end
-
-      within "tr:nth-child(2)" do
-        expect(page)
-          .to have_css("td:nth-child(1)", text: "npq-leading-behaviour-culture")
-        expect(page)
-          .to have_css("td:nth-child(2)", text: @npq_lbc.recruitment_target)
-        expect(page)
-          .to have_css("td:nth-child(3)", text: number_to_pounds(@npq_lbc.per_participant))
-      end
+    within first(".govuk-details__text") do
+      expect(page).to have_content("npq-leading-teaching")
+      expect(page).to have_content(@npq_lt.recruitment_target)
+      expect(page).to have_content(number_to_pounds(@npq_lt.per_participant))
+      expect(page).to have_content("npq-leading-behaviour-culture")
+      expect(page).to have_content(@npq_lbc.recruitment_target)
+      expect(page).to have_content(number_to_pounds(@npq_lbc.per_participant))
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: [CPDLP-1113](https://dfedigital.atlassian.net/browse/CPDLP-1113)

**Changes include:**
1. Widening the container width for the finance area of the application (including banner at top of page and footer)
2. Copy updates as per CPDLP-1113
3. Make voided declarations accessible by link in summary (remove link from bottom of page)
4. Remove link to contract info and move info to bottom of payments summary
5. Remove unique scope on declarations in summary table - this was preventing numbers adding up correctly when a participant is doing more than one NPQ (on the statement)
6. Recruitment total removed from course breakdown table
7. Ordering of milestones 

## Tech review

### Is there anything that the code reviewer should know?

This is a follow up to CPDLP-1026 & 1027 which was deployed last week

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
8. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
