### PR TITLE
CST-285 Don't send any emails to users transitioning from eligible to exempt if they don't have declarations

### DIFF
--- a/app/services/store_participant_eligibility.rb
+++ b/app/services/store_participant_eligibility.rb
@@ -93,7 +93,7 @@ private
     if @participant_eligibility.reason.to_sym == :exempt_from_induction
       if participant_profile.participant_declarations.any? && @previous_status == "eligible"
         IneligibleParticipantMailer.ect_exempt_from_induction_email_to_ect_previously_eligible(participant_profile: participant_profile).deliver_later
-      else
+      elsif @previous_status != "eligible"
         IneligibleParticipantMailer.ect_exempt_from_induction_email_to_ect(participant_profile: participant_profile).deliver_later
       end
     end
@@ -107,6 +107,8 @@ private
       when :exempt_from_induction
         if participant_profile.participant_declarations.any? && @previous_status == "eligible"
           :ect_exempt_from_induction_email_previously_eligible
+        elsif @previous_status == "eligible"
+          nil
         else
           :ect_exempt_from_induction_email
         end

--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -214,6 +214,18 @@ RSpec.describe StoreParticipantEligibility do
                         }],
                       ).once
           end
+
+          it "doesn't send emails when the reason is exempt from induction, they were previously eligible but don't have declarations" do
+            create(:ecf_participant_eligibility, :eligible, participant_profile: ect_profile)
+            eligibility_options[:exempt_from_induction] = true
+            eligibility_options[:status] = :ineligible
+            eligibility_options[:reason] = :exempt_from_induction
+
+            expect {
+              service.call(participant_profile: ect_profile, eligibility_options: eligibility_options)
+            }.to not_have_enqueued_mail(IneligibleParticipantMailer, :ect_exempt_from_induction_email)
+              .and not_have_enqueued_mail(IneligibleParticipantMailer, :ect_exempt_from_induction_email_to_ect)
+          end
         end
 
         context "when participant is a Mentor" do


### PR DESCRIPTION

## Ticket and context

We don't want to send these emails to limit the impact on support

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
