### PR TITLE
CST-287 Send no-induction emails when participant was previously eligible

### DIFF
--- a/app/services/store_participant_eligibility.rb
+++ b/app/services/store_participant_eligibility.rb
@@ -18,7 +18,7 @@ class StoreParticipantEligibility < BaseService
       send_ineligible_notification_emails
     end
 
-    if changed_to_manual_check? && doing_fip? && @previous_status != "eligible"
+    if changed_to_manual_check? && doing_fip?
       send_manual_check_notification_email
     end
 

--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -71,12 +71,12 @@ RSpec.describe StoreParticipantEligibility do
           )
       end
 
-      it "doesn't send any notifications if the previous state was eligible" do
+      it "sends notifications if the previous state was eligible" do
         create(:ecf_participant_eligibility, :eligible, participant_profile: ect_profile)
         eligibility_options[:no_induction] = true
         expect {
           service.call(participant_profile: ect_profile, eligibility_options: eligibility_options)
-        }.to_not have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
+        }.to have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
           .with(
             args: [{
               induction_tutor_email: induction_tutor.email,


### PR DESCRIPTION
We don't want to prevent this email from being sent when revalidating participants, we just want to prevent other ineligible emails being sent, for which there are specific emails for when the participant was previously eligible.

There was a different bug (now fixed) that was misevaluating these users as being exempt from induction, for which we have sent specific comms to tell them this was a mistake, so we don't need to re-run eligibility checks for these users.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
