### PR TITLE
[CPDLP-1121] Nullify when training_status is withdrawn

### DIFF
--- a/app/serializers/api/v1/npq_participant_serializer.rb
+++ b/app/serializers/api/v1/npq_participant_serializer.rb
@@ -8,17 +8,39 @@ module Api
       include JSONAPI::Serializer
       include JSONAPI::Serializer::Instrumentation
 
+      class << self
+        def active_participant_attribute(attr, &blk)
+          attribute attr do |user, params|
+            unless NPQ::IsUserWithdrawn.new(user: user, cpd_lead_provider: params[:cpd_lead_provider]).call
+              blk.call(user)
+            end
+          end
+        end
+      end
+
       set_id :id
       set_type :'npq-participant'
 
-      attributes :participant_id, :email, :full_name
+      attribute :participant_id
+
+      active_participant_attribute :email, &:email
+
+      attribute :full_name
 
       attribute(:participant_id, &:id)
 
       attribute(:npq_courses) do |object, params|
-        object.npq_profiles
-          .filter { |profile| provider_matches(profile, params) }
-          .map { |npq_profile| npq_profile.npq_application.npq_course.identifier }
+        scope = object.npq_profiles
+        scope = scope.includes(npq_application: [:npq_course])
+
+        if params[:cpd_lead_provider]
+          scope = scope.joins(npq_application: { npq_lead_provider: [:cpd_lead_provider] })
+          scope = scope.where(npq_applications: { npq_lead_providers: { cpd_lead_provider: params[:cpd_lead_provider] } })
+        else
+          scope = ParticipantProfile::NPQ.none
+        end
+
+        scope.map { |npq_profile| npq_profile.npq_application.npq_course.identifier }
       end
 
       attribute(:teacher_reference_number) do |object|
@@ -27,10 +49,6 @@ module Api
 
       attribute(:updated_at) do |object|
         object.updated_at.rfc3339
-      end
-
-      def self.provider_matches(profile, params)
-        profile.npq_application&.npq_lead_provider&.cpd_lead_provider == params[:cpd_lead_provider]
       end
     end
   end

--- a/app/serializers/api/v1/participant_serializer.rb
+++ b/app/serializers/api/v1/participant_serializer.rb
@@ -11,7 +11,7 @@ module Api
       class << self
         def active_participant_attribute(attr, &blk)
           attribute attr do |profile, params|
-            if profile.active_record?
+            if !profile.withdrawn_record? && !profile.training_status_withdrawn?
               if blk.parameters.count == 1
                 blk.call(profile)
               else
@@ -52,11 +52,11 @@ module Api
         # profile.user.email
       end
 
-      active_participant_attribute :full_name do |profile|
+      attribute :full_name do |profile|
         profile.user.full_name
       end
 
-      active_participant_attribute :mentor_id do |profile, params|
+      attribute :mentor_id do |profile, params|
         if params[:mentor_ids].present?
           params[:mentor_ids][profile.id]
         elsif profile.ect?
@@ -64,37 +64,35 @@ module Api
         end
       end
 
-      active_participant_attribute :school_urn do |profile|
+      attribute :school_urn do |profile|
         profile.school.urn
       end
 
-      active_participant_attribute :participant_type, &:participant_type
+      attribute :participant_type
 
-      active_participant_attribute :cohort do |profile|
+      attribute :cohort do |profile|
         profile.cohort.start_year.to_s
       end
 
-      attribute :status, &:status
+      attribute :status
 
-      active_participant_attribute :teacher_reference_number do |profile|
+      attribute :teacher_reference_number do |profile|
         trn(profile)
       end
 
-      active_participant_attribute :teacher_reference_number_validated do |profile|
+      attribute :teacher_reference_number_validated do |profile|
         trn(profile).nil? ? nil : validated_trn(profile).present?
       end
 
-      active_participant_attribute :eligible_for_funding do |profile|
+      attribute :eligible_for_funding do |profile|
         eligible_for_funding?(profile)
       end
 
-      active_participant_attribute :pupil_premium_uplift, &:pupil_premium_uplift
+      attribute :pupil_premium_uplift
+      attribute :sparsity_uplift
+      attribute :training_status
 
-      active_participant_attribute :sparsity_uplift, &:sparsity_uplift
-
-      active_participant_attribute :training_status, &:training_status
-
-      active_participant_attribute :schedule_identifier do |profile|
+      attribute :schedule_identifier do |profile|
         profile.schedule&.schedule_identifier
       end
 

--- a/app/serializers/api/v2/npq_participant_serializer.rb
+++ b/app/serializers/api/v2/npq_participant_serializer.rb
@@ -8,10 +8,22 @@ module Api
       include JSONAPI::Serializer
       include JSONAPI::Serializer::Instrumentation
 
+      class << self
+        def active_participant_attribute(attr, &blk)
+          attribute attr do |user, params|
+            unless NPQ::IsUserWithdrawn.new(user: user, cpd_lead_provider: params[:cpd_lead_provider]).call
+              blk.call(user)
+            end
+          end
+        end
+      end
+
       set_id :id
       set_type :'npq-participant'
 
-      attributes :email, :full_name
+      active_participant_attribute :email, &:email
+
+      attribute :full_name
 
       attribute(:teacher_reference_number) do |object|
         object.teacher_profile&.trn

--- a/app/serializers/api/v2/participant_serializer.rb
+++ b/app/serializers/api/v2/participant_serializer.rb
@@ -11,7 +11,7 @@ module Api
       class << self
         def active_participant_attribute(attr, &blk)
           attribute attr do |profile, params|
-            if profile.active_record?
+            if !profile.withdrawn_record? && !profile.training_status_withdrawn?
               if blk.parameters.count == 1
                 blk.call(profile)
               else
@@ -52,11 +52,11 @@ module Api
         # profile.user.email
       end
 
-      active_participant_attribute :full_name do |profile|
+      attribute :full_name do |profile|
         profile.user.full_name
       end
 
-      active_participant_attribute :mentor_id do |profile, params|
+      attribute :mentor_id do |profile, params|
         if params[:mentor_ids].present?
           params[:mentor_ids][profile.id]
         elsif profile.ect?
@@ -64,37 +64,35 @@ module Api
         end
       end
 
-      active_participant_attribute :school_urn do |profile|
+      attribute :school_urn do |profile|
         profile.school.urn
       end
 
-      active_participant_attribute :participant_type, &:participant_type
+      attribute :participant_type
 
-      active_participant_attribute :cohort do |profile|
+      attribute :cohort do |profile|
         profile.cohort.start_year.to_s
       end
 
-      attribute :status, &:status
+      attribute :status
 
-      active_participant_attribute :teacher_reference_number do |profile|
+      attribute :teacher_reference_number do |profile|
         trn(profile)
       end
 
-      active_participant_attribute :teacher_reference_number_validated do |profile|
+      attribute :teacher_reference_number_validated do |profile|
         trn(profile).nil? ? nil : validated_trn(profile).present?
       end
 
-      active_participant_attribute :eligible_for_funding do |profile|
+      attribute :eligible_for_funding do |profile|
         eligible_for_funding?(profile)
       end
 
-      active_participant_attribute :pupil_premium_uplift, &:pupil_premium_uplift
+      attribute :pupil_premium_uplift
+      attribute :sparsity_uplift
+      attribute :training_status
 
-      active_participant_attribute :sparsity_uplift, &:sparsity_uplift
-
-      active_participant_attribute :training_status, &:training_status
-
-      active_participant_attribute :schedule_identifier do |profile|
+      attribute :schedule_identifier do |profile|
         profile.schedule&.schedule_identifier
       end
 

--- a/app/services/npq/is_user_withdrawn.rb
+++ b/app/services/npq/is_user_withdrawn.rb
@@ -17,7 +17,6 @@ module NPQ
 
     def active_npq_profiles
       scope = user.npq_profiles
-      scope = scope.includes(npq_application: [:npq_course])
       scope = scope.joins(npq_application: { npq_lead_provider: [:cpd_lead_provider] })
       scope = scope.where(npq_applications: { npq_lead_providers: { cpd_lead_provider: cpd_lead_provider } })
       scope = scope.where.not(training_status: "withdrawn")

--- a/app/services/npq/is_user_withdrawn.rb
+++ b/app/services/npq/is_user_withdrawn.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module NPQ
+  class IsUserWithdrawn
+    attr_reader :user, :cpd_lead_provider
+
+    def initialize(user:, cpd_lead_provider:)
+      @user = user
+      @cpd_lead_provider = cpd_lead_provider
+    end
+
+    def call
+      active_npq_profiles.none?
+    end
+
+  private
+
+    def active_npq_profiles
+      scope = user.npq_profiles
+      scope = scope.includes(npq_application: [:npq_course])
+      scope = scope.joins(npq_application: { npq_lead_provider: [:cpd_lead_provider] })
+      scope = scope.where(npq_applications: { npq_lead_providers: { cpd_lead_provider: cpd_lead_provider } })
+      scope = scope.where.not(training_status: "withdrawn")
+      scope.where.not(status: "withdrawn")
+    end
+  end
+end

--- a/spec/docs/v1/participants_spec.rb
+++ b/spec/docs/v1/participants_spec.rb
@@ -84,6 +84,7 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
         end
 
         schema({ "$ref": "#/components/schemas/ECFParticipantResponse" })
+
         run_test!
       end
     end

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -108,25 +108,14 @@ RSpec.describe "Participants API", type: :request do
 
         it "returns correct user types" do
           get "/api/v1/participants/ecf"
-          mentors = 0
-          ects = 0
-          withdrawn_participant_record = 0
 
-          parsed_response["data"].each do |user|
-            user_type = user["attributes"]["participant_type"]
-            status = user["attributes"]["status"]
-            if user_type == "mentor"
-              mentors += 1
-            elsif user_type == "ect"
-              ects += 1
-            elsif user_type.nil? && status == "withdrawn"
-              withdrawn_participant_record += 1
-            end
-          end
+          mentors = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "mentor" }
+          withdrawn = parsed_response["data"].count { |h| h["attributes"]["status"] == "withdrawn" }
+          ects = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "ect" }
 
           expect(mentors).to eql(1)
-          expect(ects).to eql(2)
-          expect(withdrawn_participant_record).to eql(1)
+          expect(ects).to eql(3)
+          expect(withdrawn).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -200,9 +189,9 @@ RSpec.describe "Participants API", type: :request do
           it "does not include personal information of the participant" do
             get "/api/v1/participants/ecf"
             matching_records = parsed_response["data"].select { |record| record["id"] == active_profile_with_other_provider.user.id }
-            expect(matching_records.first["attributes"]["full_name"]).to be_nil
+            expect(matching_records.first["attributes"]["full_name"]).to eql(active_profile_with_other_provider.user.full_name)
             expect(matching_records.first["attributes"]["email"]).to be_nil
-            expect(matching_records.first["attributes"]["teacher_reference_number"]).to be_nil
+            expect(matching_records.first["attributes"]["teacher_reference_number"]).to eql(active_profile_with_other_provider.teacher_profile.trn)
           end
         end
 
@@ -304,17 +293,17 @@ RSpec.describe "Participants API", type: :request do
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
           expect(withdrawn_record_row["email"]).to be_empty
-          expect(withdrawn_record_row["full_name"]).to be_empty
+          expect(withdrawn_record_row["full_name"]).to eql(withdrawn_ect_profile_record.user.full_name)
           expect(withdrawn_record_row["mentor_id"]).to be_empty
-          expect(withdrawn_record_row["school_urn"]).to be_empty
-          expect(withdrawn_record_row["participant_type"]).to be_empty
-          expect(withdrawn_record_row["cohort"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_empty
+          expect(withdrawn_record_row["school_urn"]).to eql(withdrawn_ect_profile_record.school.urn)
+          expect(withdrawn_record_row["participant_type"]).to eql(withdrawn_ect_profile_record.participant_type.to_s)
+          expect(withdrawn_record_row["cohort"]).to eql(withdrawn_ect_profile_record.cohort.start_year.to_s)
+          expect(withdrawn_record_row["teacher_reference_number"]).to eql(withdrawn_ect_profile_record.teacher_profile.trn)
+          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_present
           expect(withdrawn_record_row["eligible_for_funding"]).to be_empty
-          expect(withdrawn_record_row["pupil_premium_uplift"]).to be_empty
-          expect(withdrawn_record_row["sparsity_uplift"]).to be_empty
-          expect(withdrawn_record_row["training_status"]).to be_empty
+          expect(withdrawn_record_row["pupil_premium_uplift"]).to eql(withdrawn_ect_profile_record.pupil_premium_uplift.to_s)
+          expect(withdrawn_record_row["sparsity_uplift"]).to eql(withdrawn_ect_profile_record.sparsity_uplift.to_s)
+          expect(withdrawn_record_row["training_status"]).to eql(withdrawn_ect_profile_record.training_status)
         end
 
         it "ignores pagination parameters" do

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -78,25 +78,14 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
 
         it "returns correct user types" do
           get "/api/v1/participants"
-          mentors = 0
-          ects = 0
-          withdrawn_participant_record = 0
 
-          parsed_response["data"].each do |user|
-            user_type = user["attributes"]["participant_type"]
-            status = user["attributes"]["status"]
-            if user_type == "mentor"
-              mentors += 1
-            elsif user_type == "ect"
-              ects += 1
-            elsif user_type.nil? && status == "withdrawn"
-              withdrawn_participant_record += 1
-            end
-          end
+          mentors = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "mentor" }
+          withdrawn = parsed_response["data"].count { |h| h["attributes"]["status"] == "withdrawn" }
+          ects = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "ect" }
 
           expect(mentors).to eql(1)
-          expect(ects).to eql(2)
-          expect(withdrawn_participant_record).to eql(1)
+          expect(ects).to eql(3)
+          expect(withdrawn).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -230,17 +219,17 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
           expect(withdrawn_record_row["email"]).to be_empty
-          expect(withdrawn_record_row["full_name"]).to be_empty
+          expect(withdrawn_record_row["full_name"]).to eql(withdrawn_ect_profile_record.user.full_name)
           expect(withdrawn_record_row["mentor_id"]).to be_empty
-          expect(withdrawn_record_row["school_urn"]).to be_empty
-          expect(withdrawn_record_row["participant_type"]).to be_empty
-          expect(withdrawn_record_row["cohort"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_empty
+          expect(withdrawn_record_row["school_urn"]).to eql(withdrawn_ect_profile_record.school.urn)
+          expect(withdrawn_record_row["participant_type"]).to eql(withdrawn_ect_profile_record.participant_type.to_s)
+          expect(withdrawn_record_row["cohort"]).to eql(withdrawn_ect_profile_record.cohort.start_year.to_s)
+          expect(withdrawn_record_row["teacher_reference_number"]).to eql(withdrawn_ect_profile_record.teacher_profile.trn)
+          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_present
           expect(withdrawn_record_row["eligible_for_funding"]).to be_empty
-          expect(withdrawn_record_row["pupil_premium_uplift"]).to be_empty
-          expect(withdrawn_record_row["sparsity_uplift"]).to be_empty
-          expect(withdrawn_record_row["training_status"]).to be_empty
+          expect(withdrawn_record_row["pupil_premium_uplift"]).to eql(withdrawn_ect_profile_record.pupil_premium_uplift.to_s)
+          expect(withdrawn_record_row["sparsity_uplift"]).to eql(withdrawn_ect_profile_record.sparsity_uplift.to_s)
+          expect(withdrawn_record_row["training_status"]).to eql(withdrawn_ect_profile_record.training_status)
         end
 
         it "ignores pagination parameters" do

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -108,25 +108,14 @@ RSpec.describe "Participants API", type: :request do
 
         it "returns correct user types" do
           get "/api/v2/participants/ecf"
-          mentors = 0
-          ects = 0
-          withdrawn_participant_record = 0
 
-          parsed_response["data"].each do |user|
-            user_type = user["attributes"]["participant_type"]
-            status = user["attributes"]["status"]
-            if user_type == "mentor"
-              mentors += 1
-            elsif user_type == "ect"
-              ects += 1
-            elsif user_type.nil? && status == "withdrawn"
-              withdrawn_participant_record += 1
-            end
-          end
+          mentors = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "mentor" }
+          withdrawn = parsed_response["data"].count { |h| h["attributes"]["status"] == "withdrawn" }
+          ects = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "ect" }
 
           expect(mentors).to eql(1)
-          expect(ects).to eql(2)
-          expect(withdrawn_participant_record).to eql(1)
+          expect(ects).to eql(3)
+          expect(withdrawn).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -200,9 +189,9 @@ RSpec.describe "Participants API", type: :request do
           it "does not include personal information of the participant" do
             get "/api/v2/participants/ecf"
             matching_records = parsed_response["data"].select { |record| record["id"] == active_profile_with_other_provider.user.id }
-            expect(matching_records.first["attributes"]["full_name"]).to be_nil
+            expect(matching_records.first["attributes"]["full_name"]).to eql(active_profile_with_other_provider.user.full_name)
             expect(matching_records.first["attributes"]["email"]).to be_nil
-            expect(matching_records.first["attributes"]["teacher_reference_number"]).to be_nil
+            expect(matching_records.first["attributes"]["teacher_reference_number"]).to eql(active_profile_with_other_provider.teacher_profile.trn)
           end
         end
 
@@ -304,17 +293,17 @@ RSpec.describe "Participants API", type: :request do
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
           expect(withdrawn_record_row["email"]).to be_empty
-          expect(withdrawn_record_row["full_name"]).to be_empty
+          expect(withdrawn_record_row["full_name"]).to eql(withdrawn_ect_profile_record.user.full_name)
           expect(withdrawn_record_row["mentor_id"]).to be_empty
-          expect(withdrawn_record_row["school_urn"]).to be_empty
-          expect(withdrawn_record_row["participant_type"]).to be_empty
-          expect(withdrawn_record_row["cohort"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_empty
+          expect(withdrawn_record_row["school_urn"]).to eql(withdrawn_ect_profile_record.school.urn)
+          expect(withdrawn_record_row["participant_type"]).to eql(withdrawn_ect_profile_record.participant_type.to_s)
+          expect(withdrawn_record_row["cohort"]).to eql(withdrawn_ect_profile_record.cohort.start_year.to_s)
+          expect(withdrawn_record_row["teacher_reference_number"]).to eql(withdrawn_ect_profile_record.teacher_profile.trn)
+          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_present
           expect(withdrawn_record_row["eligible_for_funding"]).to be_empty
-          expect(withdrawn_record_row["pupil_premium_uplift"]).to be_empty
-          expect(withdrawn_record_row["sparsity_uplift"]).to be_empty
-          expect(withdrawn_record_row["training_status"]).to be_empty
+          expect(withdrawn_record_row["pupil_premium_uplift"]).to eql(withdrawn_ect_profile_record.pupil_premium_uplift.to_s)
+          expect(withdrawn_record_row["sparsity_uplift"]).to eql(withdrawn_ect_profile_record.sparsity_uplift.to_s)
+          expect(withdrawn_record_row["training_status"]).to eql(withdrawn_ect_profile_record.training_status)
         end
 
         it "ignores pagination parameters" do

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -78,25 +78,14 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
 
         it "returns correct user types" do
           get "/api/v2/participants"
-          mentors = 0
-          ects = 0
-          withdrawn_participant_record = 0
 
-          parsed_response["data"].each do |user|
-            user_type = user["attributes"]["participant_type"]
-            status = user["attributes"]["status"]
-            if user_type == "mentor"
-              mentors += 1
-            elsif user_type == "ect"
-              ects += 1
-            elsif user_type.nil? && status == "withdrawn"
-              withdrawn_participant_record += 1
-            end
-          end
+          mentors = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "mentor" }
+          withdrawn = parsed_response["data"].count { |h| h["attributes"]["status"] == "withdrawn" }
+          ects = parsed_response["data"].count { |h| h["attributes"]["participant_type"] == "ect" }
 
           expect(mentors).to eql(1)
-          expect(ects).to eql(2)
-          expect(withdrawn_participant_record).to eql(1)
+          expect(ects).to eql(3)
+          expect(withdrawn).to eql(1)
         end
 
         it "returns the right number of users per page" do
@@ -230,17 +219,17 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
           expect(withdrawn_record_row["email"]).to be_empty
-          expect(withdrawn_record_row["full_name"]).to be_empty
+          expect(withdrawn_record_row["full_name"]).to eql(withdrawn_ect_profile_record.user.full_name)
           expect(withdrawn_record_row["mentor_id"]).to be_empty
-          expect(withdrawn_record_row["school_urn"]).to be_empty
-          expect(withdrawn_record_row["participant_type"]).to be_empty
-          expect(withdrawn_record_row["cohort"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number"]).to be_empty
-          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_empty
+          expect(withdrawn_record_row["school_urn"]).to eql(withdrawn_ect_profile_record.school.urn)
+          expect(withdrawn_record_row["participant_type"]).to eql(withdrawn_ect_profile_record.participant_type.to_s)
+          expect(withdrawn_record_row["cohort"]).to eql(withdrawn_ect_profile_record.cohort.start_year.to_s)
+          expect(withdrawn_record_row["teacher_reference_number"]).to eql(withdrawn_ect_profile_record.teacher_profile.trn)
+          expect(withdrawn_record_row["teacher_reference_number_validated"]).to be_present
           expect(withdrawn_record_row["eligible_for_funding"]).to be_empty
-          expect(withdrawn_record_row["pupil_premium_uplift"]).to be_empty
-          expect(withdrawn_record_row["sparsity_uplift"]).to be_empty
-          expect(withdrawn_record_row["training_status"]).to be_empty
+          expect(withdrawn_record_row["pupil_premium_uplift"]).to eql(withdrawn_ect_profile_record.pupil_premium_uplift.to_s)
+          expect(withdrawn_record_row["sparsity_uplift"]).to eql(withdrawn_ect_profile_record.sparsity_uplift.to_s)
+          expect(withdrawn_record_row["training_status"]).to eql(withdrawn_ect_profile_record.training_status)
         end
 
         it "ignores pagination parameters" do

--- a/spec/serializers/api/v1/npq_participant_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq_participant_serializer_spec.rb
@@ -38,6 +38,39 @@ module Api
           result = NPQParticipantSerializer.new(participant).serializable_hash
           expect(result[:data][:attributes][:updated_at]).to eq participant.updated_at.rfc3339
         end
+
+        context "when training_status is withdrawn" do
+          let(:participant) { profile.user }
+          let(:profile) { create(:npq_participant_profile, training_status: "withdrawn") }
+          let(:npq_application) { profile.npq_application }
+          let(:cpd_lead_provider) { npq_application.npq_lead_provider.cpd_lead_provider }
+
+          subject { described_class.new(participant, params: { cpd_lead_provider: cpd_lead_provider }) }
+
+          it "nullifies email" do
+            expect(subject.serializable_hash.dig(:data, :attributes, :email)).to be_nil
+          end
+        end
+
+        context "when 2 NPQ profiles with same provider where 1 is withdrawn" do
+          let(:participant1) { profile1.user }
+          let(:profile1) { create(:npq_participant_profile, training_status: "withdrawn") }
+          let(:npq_application1) { profile1.npq_application }
+          let(:npq_lead_provider1) { npq_application1.npq_lead_provider }
+          let(:cpd_lead_provider1) { npq_lead_provider1.cpd_lead_provider }
+
+          let!(:profile2) { create(:npq_participant_profile, training_status: "active", teacher_profile: participant1.teacher_profile) }
+
+          before do
+            profile2.npq_application.update(npq_lead_provider: npq_lead_provider1)
+          end
+
+          subject { described_class.new(participant1, params: { cpd_lead_provider: cpd_lead_provider1 }) }
+
+          it "does not nullify email" do
+            expect(subject.serializable_hash.dig(:data, :attributes, :email)).to be_present
+          end
+        end
       end
     end
   end

--- a/spec/serializers/api/v1/participant_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_serializer_spec.rb
@@ -54,7 +54,7 @@ module Api
                   sparsity_uplift: mentor_profile.sparsity_uplift,
                   training_status: mentor_profile.training_status,
                   schedule_identifier: mentor_profile.schedule.schedule_identifier,
-                  updated_at: mentor_profile.updated_at.rfc3339,
+                  updated_at: mentor_profile.reload.updated_at.rfc3339,
                 },
               },
             }.to_json

--- a/spec/serializers/api/v2/ecf_user_serializer_spec.rb
+++ b/spec/serializers/api/v2/ecf_user_serializer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  module V2
+    RSpec.describe ECFUserSerializer do
+      let(:ect_profile) { create(:ect_participant_profile) }
+
+      describe "registration_completed" do
+        context "before validation started" do
+          it "returns false" do
+            expect(user_attributes(ect_profile.user)[:registration_completed]).to be false
+          end
+        end
+
+        context "when details were not matched" do
+          before do
+            create(:ecf_participant_validation_data, participant_profile: ect_profile)
+          end
+
+          it "returns true" do
+            expect(user_attributes(ect_profile.user)[:registration_completed]).to be true
+          end
+        end
+
+        context "when the details were matched" do
+          before do
+            create(:ecf_participant_validation_data, participant_profile: ect_profile)
+            eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
+            eligibility.matched_status!
+          end
+
+          it "returns true" do
+            expect(user_attributes(ect_profile.user)[:registration_completed]).to be true
+          end
+        end
+      end
+
+    private
+
+      def user_attributes(user)
+        described_class.new(user).serializable_hash[:data][:attributes]
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v2/participant_serializer_spec.rb
+++ b/spec/serializers/api/v2/participant_serializer_spec.rb
@@ -54,7 +54,7 @@ module Api
                   sparsity_uplift: mentor_profile.sparsity_uplift,
                   training_status: mentor_profile.training_status,
                   schedule_identifier: mentor_profile.schedule.schedule_identifier,
-                  updated_at: mentor_profile.updated_at.rfc3339,
+                  updated_at: mentor_profile.reload.updated_at.rfc3339,
                 },
               },
             }.to_json

--- a/spec/serializers/api/v2/participant_serializer_spec.rb
+++ b/spec/serializers/api/v2/participant_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 module Api
-  module V1
+  module V2
     RSpec.describe ParticipantSerializer do
       describe "serialization" do
         let(:mentor_profile) { create(:mentor_participant_profile) }

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1408,6 +1408,7 @@
           "email": {
             "description": "The email address registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -1418,9 +1419,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -1453,13 +1454,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -1471,13 +1470,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -1645,6 +1642,7 @@
           "email": {
             "description": "The email registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -1689,31 +1687,26 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
             "description": "Indicates whether this participant is eligible to receive DfE funded induction",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -1817,6 +1810,7 @@
           "email": {
             "description": "The email address registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -1827,9 +1821,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -1862,13 +1856,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -1880,13 +1872,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -2062,6 +2052,7 @@
           "email": {
             "description": "The email address registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -2072,9 +2063,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -2107,13 +2098,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -2125,13 +2114,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -2456,6 +2443,7 @@
           "email": {
             "description": "The email address registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -2466,9 +2454,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -2501,13 +2489,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -2519,13 +2505,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -3290,6 +3274,7 @@
           "email": {
             "description": "The email address registered for this NPQ participant",
             "type": "string",
+            "nullable": true,
             "example": "isabelle.macdonald2@some-school.example.com"
           },
           "teacher_reference_number": {

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -14,6 +14,7 @@ properties:
   email:
     description: "The email address registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of this ECF participant"
@@ -22,9 +23,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +51,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +64,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
@@ -27,6 +27,7 @@ properties:
   email:
     description: "The email registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of the ECF participant"
@@ -62,27 +63,22 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
     type: boolean
-    nullable: true
     example: true
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF Participant"

--- a/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -14,6 +14,7 @@ properties:
   email:
     description: "The email address registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of this ECF participant"
@@ -22,9 +23,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +51,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +64,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantResumeAttributesResponse.yml
@@ -14,6 +14,7 @@ properties:
   email:
     description: "The email address registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of this ECF participant"
@@ -22,9 +23,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +51,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +64,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
+++ b/swagger/v1/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
@@ -14,6 +14,7 @@ properties:
   email:
     description: "The email address registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of this ECF participant"
@@ -22,9 +23,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +51,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +64,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v1/component_schemas/NPQParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/NPQParticipantAttributes.yml
@@ -19,6 +19,7 @@ properties:
   email:
     description: "The email address registered for this NPQ participant"
     type: string
+    nullable: true
     example: "isabelle.macdonald2@some-school.example.com"
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -1462,6 +1462,7 @@
           "email": {
             "description": "The email address registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -1472,9 +1473,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -1507,13 +1508,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -1525,13 +1524,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -1743,31 +1740,26 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
             "description": "Indicates whether this participant is eligible to receive DfE funded induction",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -1881,9 +1873,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -1916,13 +1908,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -1934,13 +1924,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -2126,9 +2114,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -2161,13 +2149,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -2179,13 +2165,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -2510,6 +2494,7 @@
           "email": {
             "description": "The email address registered for this ECF participant",
             "type": "string",
+            "nullable": true,
             "example": "jane.smith@some-school.example.com"
           },
           "full_name": {
@@ -2520,9 +2505,9 @@
           "mentor_id": {
             "description": "The unique identifier of this ECF participants mentor",
             "type": "string",
+            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "school_urn": {
             "description": "The Unique Reference Number (URN) of the school that submitted this ECF participant",
@@ -2555,13 +2540,11 @@
           "teacher_reference_number": {
             "description": "The Teacher Reference Number (TRN) for this NPQ participant",
             "type": "string",
-            "nullable": true,
             "example": "1234567"
           },
           "teacher_reference_number_validated": {
             "description": "Indicates whether the Teacher Reference Number (TRN) has been validated",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "eligible_for_funding": {
@@ -2573,13 +2556,11 @@
           "pupil_premium_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to pupil premium",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "sparsity_uplift": {
             "description": "Indicates whether this participant qualifies for an uplift payment due to sparsity",
             "type": "boolean",
-            "nullable": true,
             "example": true
           },
           "training_status": {
@@ -3513,6 +3494,7 @@
           "email": {
             "description": "The email address registered for this NPQ participant",
             "type": "string",
+            "nullable": true,
             "example": "isabelle.macdonald2@some-school.example.com"
           },
           "teacher_reference_number": {

--- a/swagger/v2/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v2/component_schemas/ECFParticipantAttributes.yml
@@ -14,6 +14,7 @@ properties:
   email:
     description: "The email address registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of this ECF participant"
@@ -22,9 +23,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +51,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +64,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v2/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v2/component_schemas/ECFParticipantCsvRow.yml
@@ -62,27 +62,22 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
     type: boolean
-    nullable: true
     example: true
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF Participant"

--- a/swagger/v2/component_schemas/ECFParticipantDeferAttributesResponse.yml
+++ b/swagger/v2/component_schemas/ECFParticipantDeferAttributesResponse.yml
@@ -22,9 +22,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +50,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +63,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v2/component_schemas/ECFParticipantResumeAttributesResponse.yml
+++ b/swagger/v2/component_schemas/ECFParticipantResumeAttributesResponse.yml
@@ -22,9 +22,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +50,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +63,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v2/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
+++ b/swagger/v2/component_schemas/ECFParticipantWithdrawAttributesResponse.yml
@@ -14,6 +14,7 @@ properties:
   email:
     description: "The email address registered for this ECF participant"
     type: string
+    nullable: true
     example: "jane.smith@some-school.example.com"
   full_name:
     description: "The full name of this ECF participant"
@@ -22,9 +23,9 @@ properties:
   mentor_id:
     description: "The unique identifier of this ECF participants mentor"
     type: string
+    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
-    nullable: true
   school_urn:
     description: "The Unique Reference Number (URN) of the school that submitted this ECF participant"
     type: string
@@ -50,12 +51,10 @@ properties:
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"
     type: string
-    nullable: true
     example: "1234567"
   teacher_reference_number_validated:
     description: "Indicates whether the Teacher Reference Number (TRN) has been validated"
     type: boolean
-    nullable: true
     example: true
   eligible_for_funding:
     description: "Indicates whether this participant is eligible to receive DfE funded induction"
@@ -65,12 +64,10 @@ properties:
   pupil_premium_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to pupil premium"
     type: boolean
-    nullable: true
     example: true
   sparsity_uplift:
     description: "Indicates whether this participant qualifies for an uplift payment due to sparsity"
     type: boolean
-    nullable: true
     example: true
   training_status:
     description: "The training status of the ECF participant"

--- a/swagger/v2/component_schemas/NPQParticipantAttributes.yml
+++ b/swagger/v2/component_schemas/NPQParticipantAttributes.yml
@@ -13,6 +13,7 @@ properties:
   email:
     description: "The email address registered for this NPQ participant"
     type: string
+    nullable: true
     example: "isabelle.macdonald2@some-school.example.com"
   teacher_reference_number:
     description: "The Teacher Reference Number (TRN) for this NPQ participant"


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1121

- only email is now nullified
- all other fields are left intact
- this affects participant serializers
- this is so when provider withdraws they no see their details
 
## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Find an ECF user that is present via `/ecf/participants` endpoint
- Withdraw them either `status` or `training_status` set to `withdrawn`
- `email` should now be nullified via same api call
- Perform the same tests for CSV version
- Perform the same tests for NPQ + extra tests
- Additional feature for NPQ only. If you have 2 enrollments with the same provider, you must withdraw both enrollments in order for the email to be nullified

## External API changes

- Yes, to some degree. Some fields that could be previously nullified can no longer be nullified. Docs have been updated accordingly