### PR TITLE
Remove dev errors alerting rule

### DIFF
--- a/terraform/monitoring/config/development/alert.rules.yml
+++ b/terraform/monitoring/config/development/alert.rules.yml
@@ -1,18 +1,4 @@
 groups:
-  - name: Request-rates
-    rules:
-      - alert: RequestsFailuresElevated
-        # Condition for alerting
-        expr: (sum(rate(requests{app="ecf-dev", status_range=~"0xx|4xx|5xx"}[10m]))) / (sum(rate(requests{app="ecf-dev"}[10m])) ) > 0.2
-        # Annotation - additional informational labels to store more information
-        annotations:
-          summary: High rate of failing requests
-          description: "ecf-dev: The proportion of failed HTTP requests in the past 5 min is above 10% (current value: {{ humanizePercentage $value }})"
-        # Labels - additional labels to be attached to the alert
-        labels:
-          environment: development
-          severity: low
-
   - name: CPU-usage
     rules:
       - alert: AppCPUHigh


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- dev gets very low traffic so if there is one error this alert will trigger causing noise

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- n/a

## External API changes

- None