### PR TITLE
Rename registered_identity to preferred_identity

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -17,7 +17,7 @@ class InductionRecord < ApplicationRecord
   # and to enable participants transferring between schools (where they might be added with
   # a different email address) to still appear correctly at their old and new schools
   # and still be able to access CIP materials while moving
-  belongs_to :registered_identity, class_name: "ParticipantIdentity", optional: true
+  belongs_to :preferred_identity, class_name: "ParticipantIdentity", optional: true
 
   validates :start_date, presence: true
 

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -24,7 +24,10 @@ module EarlyCareerTeachers
         }.merge(ect_attributes))
 
         ParticipantProfileState.create!(participant_profile: profile)
-        Induction::Enrol.call(participant_profile: profile) if school_cohort.default_induction_programme.present?
+        if school_cohort.default_induction_programme.present?
+          Induction::Enrol.call(participant_profile: profile,
+                                induction_programme: school_cohort.default_induction_programme)
+        end
       end
 
       unless year_2020

--- a/app/services/induction/change_preferred_identity.rb
+++ b/app/services/induction/change_preferred_identity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Induction::ChangeRegisteredIdentity < BaseService
+class Induction::ChangePreferredIdentity < BaseService
   def call
     # NOTE: this in not the place to change a programme or transfer a participant
     # This creates a new induction record to preserve the email address used
@@ -14,16 +14,16 @@ class Induction::ChangeRegisteredIdentity < BaseService
       Induction::Enrol.call(participant_profile: induction_record.participant_profile,
                             induction_programme: induction_record.induction_programme,
                             start_date: time_now,
-                            registered_identity: registered_identity)
+                            preferred_identity: preferred_identity)
     end
   end
 
 private
 
-  attr_reader :registered_identity, :induction_record
+  attr_reader :preferred_identity, :induction_record
 
-  def initialize(induction_record:, registered_identity:)
+  def initialize(induction_record:, preferred_identity:)
     @induction_record = induction_record
-    @registered_identity = registered_identity
+    @preferred_identity = preferred_identity
   end
 end

--- a/app/services/induction/change_programme.rb
+++ b/app/services/induction/change_programme.rb
@@ -8,7 +8,7 @@ class Induction::ChangeProgramme < BaseService
       Induction::Enrol.call(participant_profile: participant_profile,
                             induction_programme: new_induction_programme,
                             start_date: start_date,
-                            registered_identity: registered_identity)
+                            preferred_identity: preferred_identity)
     end
   end
 
@@ -31,7 +31,7 @@ private
     participant_profile.current_induction_record&.induction_programme
   end
 
-  def registered_identity
-    current_induction_record&.registered_identity || participant_profile.participant_identity
+  def preferred_identity
+    current_induction_record&.preferred_identity || participant_profile.participant_identity
   end
 end

--- a/app/services/induction/check_participant_records_are_synced.rb
+++ b/app/services/induction/check_participant_records_are_synced.rb
@@ -8,7 +8,7 @@ class Induction::CheckParticipantRecordsAreSynced < BaseService
       check_induction_programme_change(profile)
       check_status_is_correct(profile)
     end
-    check_registered_identity_is_set
+    check_preferred_identity_is_set
   end
 
 private
@@ -37,9 +37,9 @@ private
     end
   end
 
-  def check_registered_identity_is_set
+  def check_preferred_identity_is_set
     InductionRecord.joins(:participant_profile).find_each do |induction|
-      Rails.logger.info("Blank registered identity for #{induction.id}") if induction.registered_identity_id.nil?
+      Rails.logger.info("Blank preferred identity for #{induction.id}") if induction.preferred_identity_id.nil?
     end
   end
 

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -6,33 +6,24 @@ class Induction::Enrol < BaseService
                                                   start_date: start_date,
                                                   status: :active,
                                                   schedule: participant_profile.schedule,
-                                                  registered_identity: registered_identity)
+                                                  preferred_identity: preferred_identity)
   end
 
 private
 
-  attr_reader :participant_profile, :induction_programme, :start_date, :registered_identity
+  attr_reader :participant_profile, :induction_programme, :start_date, :preferred_identity
 
-  # registered_identity can be suppied if the participant_profile.participant_identity does not have
+  # preferred_identity can be suppied if the participant_profile.participant_identity does not have
   # the required email for the induction i.e. a participant transferring schools might have a new email
   # address at their new school - really only useed for display in the UI
-  def initialize(participant_profile:, induction_programme: nil, start_date: nil, registered_identity: nil)
+  def initialize(participant_profile:, induction_programme:, start_date: nil, preferred_identity: nil)
     @participant_profile = participant_profile
-    @induction_programme = induction_programme || default_induction_programme
+    @induction_programme = induction_programme
     @start_date = start_date || schedule_start_date
-    @registered_identity = registered_identity || participant_profile.participant_identity
+    @preferred_identity = preferred_identity || participant_profile.participant_identity
   end
 
   def schedule_start_date
     participant_profile.schedule.milestones.first.start_date
-  end
-
-  def default_induction_programme
-    # FIXME: we need to navigate to the school_cohort - currently there is a direct link
-    # but when that goes we'd need to either pass that in or use the teacher_profile
-    # assuming that is populated correctly or something else
-    # participant_profile.teacher_profile.school
-    #
-    participant_profile.school_cohort.default_induction_programme
   end
 end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -27,7 +27,11 @@ module Mentors
         }.merge(mentor_attributes))
 
         ParticipantProfileState.create!(participant_profile: mentor_profile)
-        Induction::Enrol.call(participant_profile: mentor_profile) if school_cohort.default_induction_programme.present?
+
+        if school_cohort.default_induction_programme.present?
+          Induction::Enrol.call(participant_profile: mentor_profile,
+                                induction_programme: school_cohort.default_induction_programme)
+        end
       end
 
       ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later

--- a/db/migrate/20220318104242_change_registered_identity_to_preferred_identity_on_induction_record.rb
+++ b/db/migrate/20220318104242_change_registered_identity_to_preferred_identity_on_induction_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ChangeRegisteredIdentityToPreferredIdentityOnInductionRecord < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      rename_column :induction_records, :registered_identity_id, :preferred_identity_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_14_120140) do
+ActiveRecord::Schema.define(version: 2022_03_18_104242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -364,11 +364,11 @@ ActiveRecord::Schema.define(version: 2022_03_14_120140) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "training_status", default: "active", null: false
-    t.uuid "registered_identity_id"
+    t.uuid "preferred_identity_id"
     t.string "induction_status", default: "active", null: false
     t.index ["induction_programme_id"], name: "index_induction_records_on_induction_programme_id"
     t.index ["participant_profile_id"], name: "index_induction_records_on_participant_profile_id"
-    t.index ["registered_identity_id"], name: "index_induction_records_on_registered_identity_id"
+    t.index ["preferred_identity_id"], name: "index_induction_records_on_preferred_identity_id"
     t.index ["schedule_id"], name: "index_induction_records_on_schedule_id"
     t.index ["status"], name: "index_induction_records_on_status"
   end
@@ -615,8 +615,8 @@ ActiveRecord::Schema.define(version: 2022_03_14_120140) do
     t.string "training_status", default: "active", null: false
     t.string "profile_duplicity", default: "single", null: false
     t.uuid "participant_identity_id"
-    t.string "start_term", default: "autumn_2021", null: false
     t.string "notes"
+    t.string "start_term", default: "autumn_2021", null: false
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"

--- a/spec/services/induction/change_preferred_identity_spec.rb
+++ b/spec/services/induction/change_preferred_identity_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Induction::ChangeRegisteredIdentity do
+RSpec.describe Induction::ChangePreferredIdentity do
   describe "#call" do
     let(:school_cohort) { create :school_cohort }
     let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
@@ -13,14 +13,14 @@ RSpec.describe Induction::ChangeRegisteredIdentity do
     it "adds a new induction record for the participant" do
       expect {
         service.call(induction_record: induction_record,
-                     registered_identity: new_identity)
+                     preferred_identity: new_identity)
       }.to change { induction_programme.induction_records.count }.by 1
     end
 
     describe "induction records" do
       before do
         service.call(induction_record: induction_record,
-                     registered_identity: new_identity)
+                     preferred_identity: new_identity)
       end
 
       it "updates the current induction record with status :changed" do
@@ -37,7 +37,7 @@ RSpec.describe Induction::ChangeRegisteredIdentity do
         expect(new_induction_record).to be_active_induction_status
         expect(new_induction_record.start_date).to be_within(1.second).of Time.zone.now
         expect(new_induction_record.participant_profile).to eq participant_profile
-        expect(new_induction_record.registered_identity).to eq new_identity
+        expect(new_induction_record.preferred_identity).to eq new_identity
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

Rename `registered_identity` to `preferred_identity` on `InductionRecord` to give it a more meaningful name.
Also make the `induction_record` param mandatory for the call to the `Induction::Enrol` service as we won't always be able to know the current school without more context.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
