### PR TITLE
[CST-288] Don't resend manual check emails when the status doesn't change

### DIFF
--- a/app/jobs/check_participants_induction_job.rb
+++ b/app/jobs/check_participants_induction_job.rb
@@ -11,7 +11,7 @@ private
 
   def ects_with_no_induction_or_previous_induction
     ParticipantProfile::ECT.joins(:ecf_participant_eligibility).merge(
-      ECFParticipantEligibility.where(no_induction: true).or(ECFParticipantEligibility.where(previous_induction: true)),
+      ECFParticipantEligibility.where(reason: %w[no_induction previous_induction], manually_validated: false),
     )
   end
 end

--- a/app/services/store_participant_eligibility.rb
+++ b/app/services/store_participant_eligibility.rb
@@ -41,6 +41,7 @@ private
   def grab_current_eligibility_state
     @previous_status = @participant_eligibility.status
     @previous_reason = @participant_eligibility.reason
+    @new_eligibility_record = !@participant_eligibility.persisted?
   end
 
   def changed_to_ineligible?
@@ -51,8 +52,10 @@ private
     @participant_eligibility.eligible_status? && @previous_status != "eligible"
   end
 
+  # We need to check if the record is new because "manual_check" is the default value for newly
+  # created participant eligibilities
   def changed_to_manual_check?
-    @participant_eligibility.manual_check_status? && @previous_status != "ineligible"
+    @participant_eligibility.manual_check_status? && ((@previous_status != "manual_check") || @new_eligibility_record)
   end
 
   def changed_from_ineligible?

--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe StoreParticipantEligibility do
     end
 
     context "when manual check status is determined" do
-      it "sends the ect_no_induction_email when reason is no_induction" do
+      it "sends the ect_no_induction_email when reason is no_induction and there is no participant eligibility" do
         eligibility_options[:no_induction] = true
         expect {
           service.call(participant_profile: ect_profile, eligibility_options: eligibility_options)
@@ -83,6 +83,28 @@ RSpec.describe StoreParticipantEligibility do
               participant_profile: ect_profile,
             }],
           )
+      end
+
+      it "sends notifications if the previous state was ineligible" do
+        create(:ecf_participant_eligibility, :ineligible, participant_profile: ect_profile)
+        eligibility_options[:no_induction] = true
+        expect {
+          service.call(participant_profile: ect_profile, eligibility_options: eligibility_options)
+        }.to have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
+          .with(
+            args: [{
+              induction_tutor_email: induction_tutor.email,
+              participant_profile: ect_profile,
+            }],
+          )
+      end
+
+      it "doesn't send notifications if the previous state was manual check" do
+        create(:ecf_participant_eligibility, :manual_check, participant_profile: ect_profile)
+        eligibility_options[:no_induction] = true
+        expect {
+          service.call(participant_profile: ect_profile, eligibility_options: eligibility_options)
+        }.to_not have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
       end
     end
 


### PR DESCRIPTION
There is a job to recheck all no induction/previous induction participants on monday mornings. We don't want to keep resending emails about the participant
status when it doesn't change

## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CST-288

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
