### PR TITLE
Fix ECF participants pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem "strong_migrations"
 gem "aasm"
 
 # Pagination for API
-gem "pagy", "~> 4.11"
+gem "pagy", "~> 5.10.1"
 
 # Json Schema for api validation
 gem "json-schema", ">= 2.8.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,8 +330,9 @@ GEM
       psych (~> 3.1)
     orm_adapter (0.5.0)
     os (1.1.4)
-    pagy (4.11.0)
-    paper_trail (12.3.0)
+    pagy (5.10.1)
+      activesupport
+    paper_trail (12.1.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.21.0)
@@ -637,7 +638,7 @@ DEPENDENCIES
   open_api-rswag-specs (>= 0.1.0)
   open_api-rswag-ui (>= 0.1.0)
   openapi3_parser (= 0.9.1)
-  pagy (~> 4.11)
+  pagy (~> 5.10.1)
   paper_trail
   parallel_tests
   percy-capybara

--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -51,7 +51,7 @@ module Api
                                                         :ecf_participant_eligibility,
                                                         :ecf_participant_validation_data,
                                                         :schedule,
-                                                        teacher_profile: { current_ect_profile: { mentor_profile: :user } },
+                                                        :teacher_profile,
                                                       )
 
         if updated_since.present?

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -3,4 +3,4 @@
 require "pagy/extras/overflow"
 
 # Return an empty page when page number too high (other options :last_page and :exception )
-Pagy::VARS[:overflow] = :empty_page
+Pagy::DEFAULT[:overflow] = :empty_page


### PR DESCRIPTION
## Ticket and context

We've observed some issues with pagination on the `/participants` endpoints where the some records were missing. This PR is a bit of a shot in the dark, but it seems to fix the issues:

- The issue is applicable only to the JSON endpoint. The CSV endpoint returns the correct data.
- It appears that there is an issue with our pagination: we aren’t seeing a final page of results where we’d expect to.
- Some empty records are being 'counted' by pagy which means the offsets are incorrect later.

We discovered that removing an unnecessary outer join resolves the issue, but we still don't know why. This PR also updates Pagy.

The main thing for reviewers to check is I'm not introducing N+1 queries in the serializer. My benchmarks suggest not:

```
with join:

=> #<Benchmark::Tms:0x00007fec60e38498 @label="", @real=0.16645600087940693, @cstime=0.0, @cutime=0.0, @stime=0.004386000000000001, @utime=0.1112080000000013, @total=0.1155940000000013>

without join:

=> #<Benchmark::Tms:0x00007febe584d4a0 @label="", @real=0.15284099988639355, @cstime=0.0, @cutime=0.0, @stime=0.0040640000000000676, @utime=0.09827399999999997, @total=0.10233800000000004>
```

I'll step this out slowly to production so that I can diff serializer responses on the sandbox.

🤷 