### PR TITLE
Fix the release notes

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           git fetch --tags
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$(git log --first-parent --pretty='format: %b (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_ENV
+          echo "$(git log --first-parent --pretty='format: %s (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Post release notes on cpd-dev-alerts

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Set release notes
         run: |
+          git fetch --tags
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           echo "$(git log --first-parent --pretty='format: %b (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV


### PR DESCRIPTION
## Ticket and context

Ticket: N/A

On each staging release we get Slack notifications with empty release notes. It seems the git tags are not available to the CI step that sets the release notes, ending up comparing the same tag. 

This PR will:
- make the git tags available to the `Set release notes` step, which should fix the issue. 
- change the release notes to display the commit subjects instead of the commit body. Not all commits have a body, so this change avoids release notes with just the author name.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
