### PR TITLE
Skip creating review apps for the dependabot PRs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -5,13 +5,11 @@ on:
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'documentation/**'
-    branch-ignore:
-      - 'dependabot/**'
 
 jobs:
   deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
-
     steps:
       - uses: softprops/turnstyle@v1
         name: Check workflow concurrency
@@ -118,6 +116,7 @@ jobs:
           duplicate_msg_pattern: Created review app at*
 
   smoke-test:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     needs: [deploy]
     # Our rspec is deeply coupled with a database. I had a go at decoupling it for smoke tests, and gave up.


### PR DESCRIPTION
## Ticket and context

Ticket: N/A

We don't want to create review apps when dependabot creates PRs.

Changes:
- Seems the `branches` and `branches-ignore` filters check only the target branches, so I removed the `branch-ignore` filter
- Added an `if` statement in the jobs to not run when Dependabot is the PR author

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
