### PR TITLE
Fix failing spec after merge

### DIFF
--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -88,10 +88,8 @@ RSpec.describe StoreParticipantEligibility do
           service.call(participant_profile: ect_profile, eligibility_options: eligibility_options)
         }.to have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
           .with(
-            args: [{
-              induction_tutor_email: induction_tutor.email,
-              participant_profile: ect_profile,
-            }],
+            induction_tutor_email: induction_tutor.email,
+            participant_profile: ect_profile,
           )
       end
 


### PR DESCRIPTION
There was a version upgrade before this test was added, the interface for have_enqueued_mail now doesn't require the args key and you have to pass the
args directly.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
