### PR TITLE
[CPDLP-1159] new test participants endpoint

### DIFF
--- a/app/controllers/api/v1/test_ecf_participants_controller.rb
+++ b/app/controllers/api/v1/test_ecf_participants_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Api
+  module V1
+    class TestECFParticipantsController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include ApiPagination
+      include ApiCsv
+      include ApiFilter
+      include Api::ParticipantActions
+
+      def index
+        respond_to do |format|
+          format.json do
+            participant_hash = ParticipantFromInductionRecordSerializer.new(paginate(induction_records)).serializable_hash
+            render json: participant_hash.to_json
+          end
+          format.csv do
+            participant_hash = ParticipantFromInductionRecordSerializer.new(induction_records).serializable_hash
+            render body: to_csv(participant_hash)
+          end
+        end
+      end
+
+    private
+
+      def access_scope
+        LeadProviderApiToken
+          .joins(cpd_lead_provider: [:lead_provider])
+          .where(private_api_access: true)
+      end
+
+      def lead_provider
+        current_user.lead_provider
+      end
+
+      def induction_records
+        scope = default_scope
+
+        if updated_since.present?
+          scope = scope
+            .where(users: { updated_at: updated_since.. })
+            .order("users.updated_at, users.id")
+        end
+
+        scope.order("users.created_at")
+      end
+
+      def default_scope
+        @default_scope ||= InductionRecord
+          .joins(induction_programme: { partnership: :lead_provider })
+          .joins(participant_profile: %i[user participant_identity])
+          .where(partnerships: { lead_provider: lead_provider })
+          .includes(participant_profile: %i[
+            participant_identity
+            user
+            cohort
+            school
+            ecf_participant_eligibility
+            ecf_participant_validation_data
+            schedule
+            teacher_profile
+            mentor
+          ])
+      end
+    end
+  end
+end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -14,6 +14,9 @@ class ParticipantProfile < ApplicationRecord
     has_one :ecf_participant_eligibility, foreign_key: :participant_profile_id
     has_one :ecf_participant_validation_data, foreign_key: :participant_profile_id
 
+    belongs_to :mentor_profile, -> { where(id: 0) }, class_name: "Mentor", optional: true
+    has_one :mentor, through: :mentor_profile, source: :user
+
     scope :ineligible_status, -> { joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :ineligible }).where.not(ecf_participant_eligibility: { reason: %i[previous_participation duplicate_profile] }) }
     scope :eligible_status, lambda {
       joins(:ecf_participant_eligibility).where(ecf_participant_eligibility: { status: :eligible })

--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "jsonapi/serializer/instrumentation"
+
+module Api
+  module V1
+    class ParticipantFromInductionRecordSerializer
+      include JSONAPI::Serializer
+      include JSONAPI::Serializer::Instrumentation
+
+      class << self
+        def active_participant_attribute(attr, &blk)
+          attribute attr do |induction_record, params|
+            if induction_record.participant_profile.active_record?
+              if blk.parameters.count == 1
+                blk.call(induction_record)
+              else
+                blk.call(induction_record, params)
+              end
+            end
+          end
+        end
+
+        def trn(profile)
+          profile.teacher_profile.trn || profile.ecf_participant_validation_data&.trn
+        end
+
+        def validated_trn(profile)
+          eligibility = profile.ecf_participant_eligibility
+          eligibility.present? && !eligibility.different_trn_reason?
+        end
+
+        def eligible_for_funding?(profile)
+          ecf_participant_eligibility = profile.ecf_participant_eligibility
+          return if ecf_participant_eligibility.nil?
+          return true if ecf_participant_eligibility.eligible_status?
+          return false if ecf_participant_eligibility.ineligible_status?
+        end
+      end
+
+      set_type :participant
+
+      set_id :id do |induction_record|
+        # NOTE: using this will retain the original ID exposed to provider
+        induction_record.participant_profile.participant_identity.external_identifier
+        # NOTE: use this instead to use new (de-duped) ID
+        # induction_record.participant_profile.user.id
+      end
+
+      active_participant_attribute :email do |induction_record|
+        # NOTE: using this will retain the original email exposed to provider
+        induction_record.participant_profile.participant_identity.email
+        # NOTE: use this instead to use new (de-duped) email
+        # induction_record.participant_profile.user.email
+      end
+
+      active_participant_attribute :full_name do |induction_record|
+        induction_record.participant_profile.user.full_name
+      end
+
+      active_participant_attribute :mentor_id do |induction_record|
+        if induction_record.participant_profile.ect?
+          induction_record.participant_profile.mentor&.id
+        end
+      end
+
+      active_participant_attribute :school_urn do |induction_record|
+        induction_record.participant_profile.school.urn
+      end
+
+      active_participant_attribute :participant_type do |induction_record|
+        induction_record.participant_profile.participant_type
+      end
+
+      active_participant_attribute :cohort do |induction_record|
+        induction_record.participant_profile.cohort.start_year.to_s
+      end
+
+      attribute :status do |induction_record|
+        induction_record.participant_profile.status
+      end
+
+      active_participant_attribute :teacher_reference_number do |induction_record|
+        trn(induction_record.participant_profile)
+      end
+
+      active_participant_attribute :teacher_reference_number_validated do |induction_record|
+        if trn(induction_record.participant_profile).nil?
+          nil
+        else
+          validated_trn(induction_record.participant_profile).present?
+        end
+      end
+
+      active_participant_attribute :eligible_for_funding do |induction_record|
+        eligible_for_funding?(induction_record.participant_profile)
+      end
+
+      active_participant_attribute :pupil_premium_uplift do |induction_record|
+        induction_record.participant_profile.pupil_premium_uplift
+      end
+
+      active_participant_attribute :sparsity_uplift do |induction_record|
+        induction_record.participant_profile.sparsity_uplift
+      end
+
+      active_participant_attribute :training_status do |induction_record|
+        induction_record.participant_profile.training_status
+      end
+
+      active_participant_attribute :schedule_identifier do |induction_record|
+        induction_record.schedule&.schedule_identifier
+      end
+
+      attribute :updated_at do |induction_record|
+        induction_record.participant_profile.user.updated_at.rfc3339
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       resources :ecf_participants, path: "participants/ecf", only: %i[index] do
         concerns :participant_actions
       end
+      resources :test_ecf_participants, only: %i[index]
       resources :participants, only: %i[index], controller: "ecf_participants"
       resources :participants, only: [] do
         concerns :participant_actions

--- a/spec/requests/api/v1/test_ecf_participants_spec.rb
+++ b/spec/requests/api/v1/test_ecf_participants_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe "Participants API", type: :request do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:cohort) { create(:cohort, :current) }
+
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider, private_api_access: true) }
+  let(:bearer_token) { "Bearer #{token}" }
+
+  before :each do
+    default_headers[:Authorization] = bearer_token
+  end
+
+  let(:partnership) { create(:partnership, lead_provider: lead_provider) }
+  let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+  let(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile) }
+  let(:profile) { create(:ect_participant_profile, mentor_profile: mentor_profile) }
+  let(:user) { profile.user }
+  let(:identity) { profile.participant_identity }
+
+  let(:mentor) { create(:user, :mentor) }
+  let(:mentor_profile) { mentor.mentor_profile }
+
+  before do
+    induction_record
+  end
+
+  describe "GET /api/v1/test_ecf_participants" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+      end
+
+      describe "JSON Index API" do
+        let(:parsed_response) { JSON.parse(response.body) }
+
+        it "returns correct jsonapi content type header" do
+          get "/api/v1/test_ecf_participants"
+          expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+        end
+
+        it "returns all users" do
+          get "/api/v1/test_ecf_participants"
+          expect(parsed_response["data"].size).to eql(1)
+        end
+
+        it "returns correct data" do
+          get "/api/v1/test_ecf_participants"
+
+          expect(parsed_response["data"][0]["id"]).to eql(user.id)
+          expect(parsed_response["data"][0]["type"]).to eql("participant")
+
+          expect(parsed_response["data"][0]["attributes"]["email"]).to eql(identity.email)
+          expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
+          expect(parsed_response["data"][0]["attributes"]["mentor_id"]).to eql(profile.mentor.id)
+          expect(parsed_response["data"][0]["attributes"]["school_urn"]).to eql(profile.school.urn)
+          expect(parsed_response["data"][0]["attributes"]["participant_type"]).to eql(profile.participant_type.to_s)
+          expect(parsed_response["data"][0]["attributes"]["cohort"]).to eql(profile.cohort.start_year.to_s)
+          expect(parsed_response["data"][0]["attributes"]["status"]).to eql(profile.status)
+          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number"]).to eql(profile.teacher_profile.trn)
+          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number_validated"]).to be_falsey
+          expect(parsed_response["data"][0]["attributes"]["eligible_for_funding"]).to be_nil
+          expect(parsed_response["data"][0]["attributes"]["pupil_premium_uplift"]).to eql(profile.pupil_premium_uplift)
+          expect(parsed_response["data"][0]["attributes"]["sparsity_uplift"]).to eql(profile.sparsity_uplift)
+          expect(parsed_response["data"][0]["attributes"]["training_status"]).to eql(profile.training_status)
+          expect(parsed_response["data"][0]["attributes"]["schedule_identifier"]).to eql(induction_record.schedule.schedule_identifier)
+          expect(parsed_response["data"][0]["attributes"]["updated_at"]).to eql(user.reload.updated_at.rfc3339)
+        end
+
+        context "when there is no mentor"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1159

- fetching of these participants hangs off induction records
- to run in parallel with current endpoint for testing
- requires privileged api key for access so not accessible to providers
- hopefully removed the need to fetch mentors in a different query then inject in as implemented in existing endpoint

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Will require quite some effort to setup data
- Setup all the required induction records
- Setup a privileged key
- hit the old ecf participants endpoint
- hit the new test endpoint
- data should the same or similar to the existing endpoint

## External API changes

- Nothing that is accessible to providers