### PR TITLE
Revert "Display the commit subjects in the release notes"

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           git fetch --tags
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$(git log --first-parent --pretty='format: %s (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_ENV
+          echo "$(git log --first-parent --pretty='format: %b (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Post release notes on cpd-dev-alerts


### PR DESCRIPTION
This reverts commit c114717cd7f2883e4f46f4d8edd887d9ad27627e.

## Ticket and context

Ticket: N/A

The commit subjects are always merge messages from github, which are not that useful.