### PR TITLE
Change of circumstances: Add mentor_profile to induction_record

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -6,6 +6,7 @@ class InductionRecord < ApplicationRecord
   belongs_to :induction_programme
   belongs_to :participant_profile, class_name: "ParticipantProfile::ECF"
   belongs_to :schedule, class_name: "Finance::Schedule"
+  belongs_to :mentor_profile, class_name: "ParticipantProfile::Mentor", optional: true
 
   has_one :school_cohort, through: :induction_programme
   has_one :user, through: :participant_profile

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -71,8 +71,10 @@ class ParticipantProfile < ApplicationRecord
     end
 
     def sync_status_with_induction_record
-      current_induction_record&.update!(induction_status: status) if saved_change_to_status?
-      current_induction_record&.update!(training_status: training_status) if saved_change_to_training_status?
+      induction_record = induction_records.latest
+      induction_record&.update!(induction_status: status) if saved_change_to_status?
+      induction_record&.update!(training_status: training_status) if saved_change_to_training_status?
+      induction_record&.update!(mentor_profile: mentor_profile) if saved_change_to_mentor_profile_id?
     end
   end
 end

--- a/db/migrate/20220322172748_add_mentor_to_induction_record.rb
+++ b/db/migrate/20220322172748_add_mentor_to_induction_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddMentorToInductionRecord < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :induction_records, :mentor_profile, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_18_104242) do
+ActiveRecord::Schema.define(version: 2022_03_22_172748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -366,7 +366,9 @@ ActiveRecord::Schema.define(version: 2022_03_18_104242) do
     t.string "training_status", default: "active", null: false
     t.uuid "preferred_identity_id"
     t.string "induction_status", default: "active", null: false
+    t.uuid "mentor_profile_id"
     t.index ["induction_programme_id"], name: "index_induction_records_on_induction_programme_id"
+    t.index ["mentor_profile_id"], name: "index_induction_records_on_mentor_profile_id"
     t.index ["participant_profile_id"], name: "index_induction_records_on_participant_profile_id"
     t.index ["preferred_identity_id"], name: "index_induction_records_on_preferred_identity_id"
     t.index ["schedule_id"], name: "index_induction_records_on_schedule_id"

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe InductionRecord, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:induction_programme) }
     it { is_expected.to belong_to(:participant_profile) }
+    it { is_expected.to belong_to(:schedule) }
+    it { is_expected.to belong_to(:preferred_identity).optional }
+    it { is_expected.to belong_to(:mentor_profile).optional }
   end
 
   describe "validations" do


### PR DESCRIPTION
## Ticket and context

Add `mentor_profile` to `InductionRecord` and keep in sync with changes to `ParticipantProfile`.
This will eventually enable us to separate the mentor profile from the participant profile and track an ECTs mentorship it via induction records instead. This will also allow us to show that a transferring ECT could have a mentor in their current school and also be assigned a different mentor in their new school.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
