### PR TITLE
[CPDLP-1159] Multiple profiles or induction records

### DIFF
--- a/app/controllers/api/v1/test_ecf_participants_controller.rb
+++ b/app/controllers/api/v1/test_ecf_participants_controller.rb
@@ -37,22 +37,8 @@ module Api
       end
 
       def induction_records
-        scope = default_scope
-
-        if updated_since.present?
-          scope = scope
-            .where(users: { updated_at: updated_since.. })
-            .order("users.updated_at, users.id")
-        end
-
-        scope.order("users.created_at")
-      end
-
-      def default_scope
-        @default_scope ||= InductionRecord
-          .joins(induction_programme: { partnership: :lead_provider })
-          .joins(participant_profile: %i[user participant_identity])
-          .where(partnerships: { lead_provider: lead_provider })
+        scope = InductionRecord
+          .where(id: induction_record_ids)
           .includes(participant_profile: %i[
             participant_identity
             user
@@ -64,6 +50,29 @@ module Api
             teacher_profile
             mentor
           ])
+
+        if updated_since.present?
+          scope = scope
+            .where(users: { updated_at: updated_since.. })
+            .order("users.updated_at, users.id")
+        end
+
+        scope.order("users.created_at")
+      end
+
+      # this query deals with the following scenario
+      # given one profile with 2 induction records
+      # we only want to return the latest induction record
+      def induction_record_ids
+        query = InductionRecord
+          .joins(induction_programme: { partnership: :lead_provider })
+          .joins(participant_profile: %i[user participant_identity])
+          .select("DISTINCT ON (participant_profiles.id) participant_profile_id, induction_records.id")
+          .where(induction_programme: { partnerships: { lead_provider: lead_provider } })
+          .order("participant_profiles.id", start_date: :desc)
+          .to_sql
+
+        ActiveRecord::Base.connection.query_values("SELECT id FROM (#{query}) AS inner_query")
       end
     end
   end

--- a/app/controllers/api/v1/test_ecf_participants_controller.rb
+++ b/app/controllers/api/v1/test_ecf_participants_controller.rb
@@ -39,16 +39,16 @@ module Api
       def induction_records
         scope = InductionRecord
           .where(id: induction_record_ids_with_deduped_profiles)
-          .includes(participant_profile: %i[
-            participant_identity
-            user
-            cohort
-            school
-            ecf_participant_eligibility
-            ecf_participant_validation_data
-            schedule
-            teacher_profile
-            mentor
+          .includes(participant_profile: [
+            :participant_identity,
+            :user,
+            :cohort,
+            :school,
+            :ecf_participant_eligibility,
+            :ecf_participant_validation_data,
+            :schedule,
+            :teacher_profile,
+            { mentor_profile: [:mentor] },
           ])
 
         if updated_since.present?

--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -108,9 +108,7 @@ module Api
         induction_record.participant_profile.sparsity_uplift
       end
 
-      attribute :training_status do |induction_record|
-        induction_record.training_status
-      end
+      attribute :training_status, &:training_status
 
       attribute :schedule_identifier do |induction_record|
         induction_record.schedule&.schedule_identifier

--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -60,11 +60,7 @@ module Api
 
       attribute :mentor_id do |induction_record|
         if induction_record.participant_profile.ect?
-          # Quirk: test does not seem to pass with the following
-          # induction_record.participant_profile.mentor&.id
-          # so have to go the long way around
-          # not had time to determine why
-          induction_record.participant_profile&.mentor_profile&.user&.id
+          induction_record.participant_profile.mentor&.id
         end
       end
 

--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -60,7 +60,11 @@ module Api
 
       attribute :mentor_id do |induction_record|
         if induction_record.participant_profile.ect?
-          induction_record.participant_profile.mentor&.id
+          # Quirk: test does not seem to pass with the following
+          # induction_record.participant_profile.mentor&.id
+          # so have to go the long way around
+          # not had time to determine why
+          induction_record.participant_profile&.mentor_profile&.user&.id
         end
       end
 
@@ -105,7 +109,7 @@ module Api
       end
 
       attribute :training_status do |induction_record|
-        induction_record.participant_profile.training_status
+        induction_record.training_status
       end
 
       attribute :schedule_identifier do |induction_record|

--- a/spec/requests/api/v1/test_ecf_participants_spec.rb
+++ b/spec/requests/api/v1/test_ecf_participants_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Participants API", type: :request do
   let(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile) }
   let(:profile) { create(:ect_participant_profile, mentor_profile: mentor_profile) }
   let(:user) { profile.user }
+  let(:teacher_profile) { profile.teacher_profile }
   let(:identity) { profile.participant_identity }
 
   let(:mentor) { create(:user, :mentor) }
@@ -45,6 +46,7 @@ RSpec.describe "Participants API", type: :request do
 
         it "returns all users" do
           get "/api/v1/test_ecf_participants"
+
           expect(parsed_response["data"].size).to eql(1)
         end
 
@@ -110,7 +112,14 @@ RSpec.describe "Participants API", type: :request do
         end
 
         context "multiple profiles" do
-          it "only uses the active one"
+          let!(:induction_record2) { create(:induction_record, induction_programme: induction_programme, participant_profile: profile2) }
+          let(:profile2) { create(:ect_participant_profile, teacher_profile: teacher_profile) }
+
+          it "returns one" do
+            get "/api/v1/test_ecf_participants"
+
+            expect(parsed_response["data"].size).to eql(1)
+          end
         end
       end
     end

--- a/spec/requests/api/v1/test_ecf_participants_spec.rb
+++ b/spec/requests/api/v1/test_ecf_participants_spec.rb
@@ -72,6 +72,46 @@ RSpec.describe "Participants API", type: :request do
         end
 
         context "when there is no mentor"
+
+        context "one profile with 2 induction records" do
+          let(:profile) do
+            create(
+              :ect_participant_profile,
+              mentor_profile: mentor_profile,
+              training_status: "deferred", # something different as should use InductionRecord#training_status
+            )
+          end
+
+          let(:induction_record) do
+            create(
+              :induction_record,
+              induction_programme: induction_programme,
+              participant_profile: profile,
+              training_status: "withdrawn",
+            )
+          end
+
+          let!(:induction_record2) do
+            create(
+              :induction_record,
+              induction_programme: induction_programme,
+              participant_profile: profile,
+              start_date: 1.week.ago,
+              training_status: "active",
+            )
+          end
+
+          it "returns only the most recent induction record" do
+            get "/api/v1/test_ecf_participants"
+
+            expect(parsed_response["data"].size).to eql(1)
+            expect(parsed_response["data"][0]["attributes"]["training_status"]).to eql("active")
+          end
+        end
+
+        context "multiple profiles" do
+          it "only uses the active one"
+        end
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1159

- Handle scenario where a profile could have multiple induction records
- Crudely handles scenario where a user has more than one profile
- For the above point I feel the implementation is not perfect and buggy
- In order to rid of the bugs we need to fundamentally address de-dupe problems, these workarounds can only get us so far

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Will be tested on prod behind auth wall

## External API changes

- None