### PR TITLE
[CPDLP-1159] nullification based off induction record

### DIFF
--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -11,7 +11,7 @@ module Api
       class << self
         def active_participant_attribute(attr, &blk)
           attribute attr do |induction_record, params|
-            if !induction_record.participant_profile.withdrawn_record? && !induction_record.participant_profile.training_status_withdrawn?
+            unless induction_record.training_status_withdrawn?
               if blk.parameters.count == 1
                 blk.call(induction_record)
               else


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1159

- Base nullification off the induction record not the profile

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Setup api key with private access on 2 providers
- Move a profile from one lead provider to another
- or create relevant induction records
- hit test endpoint as old provider should see nullified email
- hit test endpoint as new provider should not see nullified email

## External API changes

- None