### PR TITLE
Ingore the destroy CI workflow for dependabot PRs

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   destroy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Ticket and context

Ticket: N/A

#1835 added a check in the create review app workflow to skip review apps for dependabot PRs, but missed to also add it in the destroy workflow which now fails every time a dependabot PRs is closed.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
