### PR TITLE
CPDLP-1130 Exclude ineligible declarations

### DIFF
--- a/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
+++ b/app/components/finance/npq/payment_overviews/output_payment_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="gov-table__row">
   <td scope="row" class="govuk-table__cell govuk-body-s"><%= t("finance.output_payment.label") %></td>
-  <td scope="row" class="govuk-table__cell govuk-body-s"><%= total_declarations %></td>
+  <td scope="row" class="govuk-table__cell govuk-body-s"><%= total_declarations(npq_lead_provider, contract) %></td>
   <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds output_payment_per_participant %></td>
   <td scope="row" class="govuk-table__cell govuk-body-s"><%= number_to_pounds output_payment_subtotal %></td>
 </tr>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table.rb
@@ -23,7 +23,7 @@ module Finance
         def output_payment
           @output_payment ||= PaymentCalculator::NPQ::OutputPayment.call(
             contract: contract,
-            total_participants: total_declarations,
+            total_participants: total_declarations(npq_lead_provider, contract),
           )
         end
       end

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.html.erb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.html.erb
@@ -2,6 +2,6 @@
   <% milestones.order(name: :asc).each do |milestone| %>
     <%= render Finance::NPQ::PaymentOverviews::PaymentOverviewMilestoneSummary.new(milestone, total_participants_for(milestone)) %>
   <% end %>
-  <span class="govuk-body-s"><%= t("finance.total_declarations") %><br><%= total_declarations %></span>
+  <span class="govuk-body-s"><%= t("finance.total_declarations") %><br><%= total_declarations(npq_lead_provider, contract) %></span>
   <span class="govuk-body-s"><%= t("finance.total_not_eligible_for_funding") %><br><%= not_eligible_declarations %></span>
 </header>

--- a/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
+++ b/app/components/finance/npq/payment_overviews/payment_overview_table_header.rb
@@ -19,25 +19,6 @@ module Finance
           NPQCourse.schedule_for(course).milestones
         end
 
-        def total_declarations
-          if statement.current?
-            ParticipantDeclaration::NPQ
-              .for_lead_provider(npq_lead_provider)
-              .where(statement_id: nil)
-              .for_course_identifier(contract.course_identifier)
-              .where.not(state: "submitted")
-              .unique_id
-              .count
-          else
-            statement
-              .participant_declarations
-              .for_course_identifier(contract.course_identifier)
-              .where.not(state: "submitted")
-              .unique_id
-              .count
-          end
-        end
-
         def not_eligible_declarations
           if statement.current?
             ParticipantDeclaration::NPQ
@@ -57,7 +38,7 @@ module Finance
         end
 
         def total_participants_for(milestone)
-          participant_per_declaration_type.fetch(milestone.declaration_type, 0)
+          participants_per_declaration_type.fetch(milestone.declaration_type, 0)
         end
 
       private
@@ -66,8 +47,8 @@ module Finance
           @course ||= NPQCourse.find_by!(identifier: contract.course_identifier)
         end
 
-        def participant_per_declaration_type
-          @participant_per_declaration_type ||= statement.participant_declarations
+        def participants_per_declaration_type
+          @participants_per_declaration_type ||= statement.participant_declarations
             .for_course_identifier(contract.course_identifier)
             .paid_payable_or_eligible
             .group(:declaration_type)

--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -15,7 +15,7 @@ module Finance
 
         aggregator = ParticipantAggregator.new(
           statement: @statement,
-          recorder: ParticipantDeclaration::ECF.where.not(state: %w[voided]),
+          recorder: ParticipantDeclaration::ECF.where(state: %w[paid payable eligible]),
         )
 
         orchestrator = Finance::ECF::CalculationOrchestrator.new(

--- a/app/helpers/finance/npq_payments_helper.rb
+++ b/app/helpers/finance/npq_payments_helper.rb
@@ -22,7 +22,7 @@ module Finance
       output_payment[:per_participant]
     end
 
-    def total_declarations
+    def total_declarations(npq_lead_provider, contract)
       if statement.current?
         ParticipantDeclaration::NPQ
           .eligible_for_lead_provider(npq_lead_provider)

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -21,6 +21,18 @@ RSpec.feature "Finance users payment breakdowns", :with_default_schedules, type:
     participant_profiles.map { |participant| ECFParticipantEligibility.create!(participant_profile_id: participant.id).eligible_status! }
     participant_profiles.map { |participant| create_voided_declarations_nov(participant) }
   end
+  let(:participant_aggregator_nov) do
+    Finance::ECF::ParticipantAggregator.new(
+      statement: nov_statement,
+      recorder: ParticipantDeclaration::ECF.where(state: %w[paid payable eligible]),
+    )
+  end
+  let(:participant_aggregator_jan) do
+    Finance::ECF::ParticipantAggregator.new(
+      statement: jan_statement,
+      recorder: ParticipantDeclaration::ECF.where(state: %w[paid payable eligible]),
+    )
+  end
 
   before { Importers::SeedStatements.new.call }
 
@@ -89,6 +101,13 @@ private
     participant_profiles.map { |participant| create_retained_declarations_nov(participant) }
   end
 
+  def multiple_ineligible_declarations_are_submitted_jan_statement
+    participant_profiles = create_list(:ect_participant_profile, 3, school_cohort: school_cohort, cohort: cohort)
+    participant_profiles.map { |participant| ParticipantProfileState.create!(participant_profile: participant) }
+    participant_profiles.map { |participant| ECFParticipantEligibility.create!(participant_profile_id: participant.id).eligible_status! }
+    participant_profiles.map { |participant| create_ineligible_declarations_jan(participant) }
+  end
+
   def multiple_retained_declarations_are_submitted_jan_statement
     mentor_participant_profiles = create_list(:mentor_participant_profile, 5, school_cohort: school_cohort, cohort: cohort, sparsity_uplift: true)
     mentor_participant_profiles.map { |participant| ParticipantProfileState.create!(participant_profile: participant) }
@@ -104,6 +123,7 @@ private
     multiple_start_declarations_are_submitted_nov_statement
     multiple_retained_declarations_are_submitted_nov_statement
     multiple_retained_declarations_are_submitted_jan_statement
+    multiple_ineligible_declarations_are_submitted_jan_statement
   end
 
   def and_voided_payable_declarations_are_submitted
@@ -226,11 +246,34 @@ private
     end
   end
 
+  def create_ineligible_declarations_jan(participant)
+    timestamp = participant.schedule.milestones.first.start_date + 1.day
+    travel_to(timestamp) do
+      serialized_started_declaration = RecordDeclarations::Started::EarlyCareerTeacher.call(
+        params: {
+          participant_id: participant.user.id,
+          course_identifier: "ecf-induction",
+          declaration_date: (participant.schedule.milestones.first.start_date + 1.day).rfc3339,
+          created_at: participant.schedule.milestones.first.start_date + 1.day,
+          cpd_lead_provider: lead_provider.cpd_lead_provider,
+          declaration_type: "started",
+          evidence_held: "other",
+        },
+      )
+      declaration = ParticipantDeclaration.find(JSON.parse(serialized_started_declaration).dig("data", "id"))
+      declaration.update!(
+        state: "ineligible",
+        statement: jan_statement,
+      )
+      declaration
+    end
+  end
+
   def nov_retained_breakdowns_are_calculated
     @nov_retained_1 = Finance::ECF::CalculationOrchestrator.new(
       statement: nov_statement,
       contract: lead_provider.call_off_contract,
-      aggregator: Finance::ECF::ParticipantAggregator.new(statement: nov_statement),
+      aggregator: participant_aggregator_nov,
       calculator: PaymentCalculator::ECF::PaymentCalculation,
     ).call(event_type: :retained_1)
   end
@@ -239,7 +282,7 @@ private
     @nov_starts = Finance::ECF::CalculationOrchestrator.new(
       statement: nov_statement,
       contract: lead_provider.call_off_contract,
-      aggregator: Finance::ECF::ParticipantAggregator.new(statement: nov_statement),
+      aggregator: participant_aggregator_nov,
       calculator: PaymentCalculator::ECF::PaymentCalculation,
     ).call(event_type: :started)
   end
@@ -248,7 +291,7 @@ private
     @jan_starts = Finance::ECF::CalculationOrchestrator.new(
       statement: jan_statement,
       contract: lead_provider.call_off_contract,
-      aggregator: Finance::ECF::ParticipantAggregator.new(statement: jan_statement),
+      aggregator: participant_aggregator_jan,
       calculator: PaymentCalculator::ECF::PaymentCalculation,
     ).call(event_type: :started)
   end
@@ -257,7 +300,7 @@ private
     @jan_retained_1 = Finance::ECF::CalculationOrchestrator.new(
       statement: jan_statement,
       contract: lead_provider.call_off_contract,
-      aggregator: Finance::ECF::ParticipantAggregator.new(statement: jan_statement),
+      aggregator: participant_aggregator_jan,
       calculator: PaymentCalculator::ECF::PaymentCalculation,
     ).call(event_type: :retained_1)
   end


### PR DESCRIPTION
## Ticket and context

Ticket: [#1130](https://dfedigital.atlassian.net/browse/CPDLP-1130)

This ticket ensures that declarations with an ineligible status are excluded from the payment breakdown calculations

1. For NPQ, currently we only calculate the output fee and total payments based on [paid, payable & eligible]
declarations
2. This PR removes one instance where we were excluding specific states - instead we want to whitelist states
3. For ECF, instead of only excluding voided declarations we now whitelist [paid, payable & eligible] declarations. The specs for ECF needed to be updated to use the non-default aggregator so that we could whitelist the declaration statuses

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
