### PR TITLE
[CPDLP-1128] Change schedule updates induction record

### DIFF
--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -3,4 +3,125 @@
 require "rails_helper"
 
 RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
+  describe "validations" do
+    context "when null schedule_identifier given" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+      let(:lead_provider) { cpd_lead_provider.lead_provider }
+      let(:user) { profile.user }
+      let(:profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+      let(:school_cohort) { create(:school_cohort) }
+      let(:school) { school_cohort.school }
+      let!(:partnership) { create(:partnership, school: school, lead_provider: lead_provider, cohort: school_cohort.cohort) }
+      let(:schedule) { create(:ecf_schedule) }
+
+      subject do
+        described_class.new(params: {
+          schedule_identifier: nil,
+          participant_id: user.id,
+          course_identifier: "ecf-induction",
+          cpd_lead_provider: cpd_lead_provider,
+        })
+      end
+
+      before do
+        create(:schedule, name: "Schedule with no alias")
+      end
+
+      it "should have an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
+    context "when changing to schedule suitable for the course" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+      let(:lead_provider) { cpd_lead_provider.lead_provider }
+      let(:user) { profile.user }
+      let(:profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+      let(:school_cohort) { create(:school_cohort) }
+      let(:school) { school_cohort.school }
+      let!(:partnership) { create(:partnership, school: school, lead_provider: lead_provider, cohort: school_cohort.cohort) }
+      let(:schedule) { create(:ecf_schedule) }
+
+      subject do
+        described_class.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: user.id,
+          course_identifier: "ecf-induction",
+          cpd_lead_provider: cpd_lead_provider,
+        })
+      end
+
+      it "should not have an error" do
+        expect { subject.call }.not_to raise_error
+      end
+    end
+
+    context "when changing to schedule not suitable for the course" do
+      let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+      let(:lead_provider) { cpd_lead_provider.lead_provider }
+      let(:user) { profile.user }
+      let(:profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+      let(:school_cohort) { create(:school_cohort) }
+      let(:school) { school_cohort.school }
+      let!(:partnership) { create(:partnership, school: school, lead_provider: lead_provider, cohort: school_cohort.cohort) }
+      let(:schedule) { create(:ecf_mentor_schedule) }
+
+      subject do
+        described_class.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: user.id,
+          course_identifier: "ecf-induction",
+          cpd_lead_provider: cpd_lead_provider,
+        })
+      end
+
+      it "should have an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+  end
+
+  describe "changing to a soft schedules with previous declarations" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+    let(:lead_provider) { cpd_lead_provider.lead_provider }
+    let(:user) { profile.user }
+    let(:profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:school_cohort) { create(:school_cohort) }
+    let(:cohort) { school_cohort.cohort }
+    let(:school) { school_cohort.school }
+    let!(:partnership) { create(:partnership, school: school, lead_provider: lead_provider, cohort: school_cohort.cohort) }
+    let(:schedule) { create(:ecf_mentor_schedule) }
+
+    let(:schedule) do
+      Finance::Schedule.create!(
+        cohort: cohort,
+        schedule_identifier: "soft-schedule",
+        name: "soft-schedule",
+      )
+    end
+
+    let!(:started_milestone) { create(:milestone, :started, :soft_milestone, schedule: schedule) }
+    let!(:declaration) do
+      create(:participant_declaration,
+             user: user,
+             participant_profile: profile,
+             course_identifier: "ecf-induction")
+    end
+
+    subject do
+      described_class.new(params: {
+        schedule_identifier: schedule.schedule_identifier,
+        participant_id: user.id,
+        course_identifier: "ecf-induction",
+        cpd_lead_provider: cpd_lead_provider,
+        cohort: schedule.cohort.start_year,
+      })
+    end
+
+    it "changes schedule" do
+      expect {
+        subject.call
+      }.to change { profile.reload.schedule.schedule_identifier }.from("ecf-standard-september").to("soft-schedule")
+    end
+  end
 end

--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -40,7 +40,24 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
       let(:school_cohort) { create(:school_cohort) }
       let(:school) { school_cohort.school }
       let!(:partnership) { create(:partnership, school: school, lead_provider: lead_provider, cohort: school_cohort.cohort) }
-      let(:schedule) { create(:ecf_schedule) }
+      let(:original_schedule) { profile.schedule }
+      let(:schedule) { create(:ecf_schedule, schedule_identifier: "new-schedule") }
+      let!(:induction_record) do
+        create(
+          :induction_record,
+          participant_profile: profile,
+          schedule: original_schedule,
+          induction_programme: induction_programme,
+        )
+      end
+      let(:induction_programme) do
+        create(
+          :induction_programme,
+          :fip,
+          school_cohort: school_cohort,
+          partnership: partnership,
+        )
+      end
 
       subject do
         described_class.new(params: {
@@ -53,6 +70,14 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
 
       it "should not have an error" do
         expect { subject.call }.not_to raise_error
+      end
+
+      it "updates the profile#schedule" do
+        expect { subject.call }.to change { profile.reload.schedule }.from(original_schedule).to(schedule)
+      end
+
+      it "updates induction_record#schedule" do
+        expect { subject.call }.to change { induction_record.reload.schedule }.from(original_schedule).to(schedule)
       end
     end
 

--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -118,11 +118,7 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
     let(:schedule) { create(:ecf_mentor_schedule) }
 
     let(:schedule) do
-      Finance::Schedule.create!(
-        cohort: cohort,
-        schedule_identifier: "soft-schedule",
-        name: "soft-schedule",
-      )
+      create(:schedule, cohort: cohort, schedule_identifier: "soft-schedule", name: "soft-schdule")
     end
 
     let!(:started_milestone) { create(:milestone, :started, :soft_milestone, schedule: schedule) }


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1128

- There is now a schedule fields on the induction record
- When a provider changes schedule we now also update the relevant induction record
- Once we swap over the schedule on the profile will become defunct
- However I am leaving the profile schedule present as there will be existing code that utilises it therefore maintain backwards compatibility

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- assuming you have a participant with an induction record otherwise no induction record will get updated
- change their schedule
- should also change the schedule on the induction record on top of the profile schedule
- NPQ should not be affected

## External API changes

- None