### PR TITLE
"Autumn 2021" removed from add participant journey

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -78,6 +78,10 @@ class Schools::ParticipantsController < Schools::BaseController
     else
       render "schools/participants/edit_start_term"
     end
+
+  rescue ActionController::ParameterMissing
+    flash[:warning] = I18n.t('errors.start_term.blank')
+    render "schools/participants/edit_start_term"
   end
 
   def edit_mentor; end

--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -63,12 +63,18 @@ class Schools::ParticipantsController < Schools::BaseController
 
   def email_used; end
 
-  def edit_start_term; end
+  def edit_start_term
+    @start_term_form = build_start_term_form
+    @start_term_form.start_term = @profile.start_term
+  end
 
   def update_start_term
-    @profile.assign_attributes(params.require(:participant_profile).permit(:start_term))
+    @start_term_form = build_start_term_form
+    unless @start_term_form.valid?
+      render "schools/participants/edit_start_term" and return
+    end
 
-    if @profile.save
+    if @profile.update(start_term: @start_term_form.start_term)
       if @profile.ect?
         set_success_message(heading: "The ECT's start term has been updated")
       else
@@ -78,10 +84,6 @@ class Schools::ParticipantsController < Schools::BaseController
     else
       render "schools/participants/edit_start_term"
     end
-
-  rescue ActionController::ParameterMissing
-    flash[:warning] = I18n.t("errors.start_term.blank")
-    render "schools/participants/edit_start_term"
   end
 
   def edit_mentor; end
@@ -147,5 +149,15 @@ private
 
   def email_used?
     User.where.not(id: @profile.user.id).where(email: @profile.user.email).any?
+  end
+
+  def start_term_form_params
+    params.require(:participant_start_term_form).permit(:start_term)
+  rescue ActionController::ParameterMissing
+    nil
+  end
+
+  def build_start_term_form
+    ParticipantStartTermForm.new(start_term_form_params)
   end
 end

--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -80,7 +80,7 @@ class Schools::ParticipantsController < Schools::BaseController
     end
 
   rescue ActionController::ParameterMissing
-    flash[:warning] = I18n.t('errors.start_term.blank')
+    flash[:warning] = I18n.t("errors.start_term.blank")
     render "schools/participants/edit_start_term"
   end
 

--- a/app/forms/participant_start_term_form.rb
+++ b/app/forms/participant_start_term_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ParticipantStartTermForm
   include ActiveModel::Model
 

--- a/app/forms/participant_start_term_form.rb
+++ b/app/forms/participant_start_term_form.rb
@@ -1,0 +1,9 @@
+class ParticipantStartTermForm
+  include ActiveModel::Model
+
+  attr_accessor :start_term
+
+  validates :start_term,
+            presence: { message: I18n.t("errors.start_term.blank") },
+            inclusion: { in: ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS }
+end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -4,7 +4,7 @@ class ParticipantProfile < ApplicationRecord
   class ECF < ParticipantProfile
     self.ignored_columns = %i[school_id]
 
-    CURRENT_START_TERM_OPTIONS = %w[autumn_2021 spring_2022 summer_2022].freeze
+    CURRENT_START_TERM_OPTIONS = %w[spring_2022 summer_2022].freeze
 
     belongs_to :school_cohort
     belongs_to :core_induction_programme, optional: true

--- a/app/views/schools/participants/edit_start_term.html.erb
+++ b/app/views/schools/participants/edit_start_term.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for :participant_profile, url: schools_participant_update_start_term_path, method: :put do |f| %>
+    <%= form_with model: @start_term_form, url: schools_participant_update_start_term_path, method: :put do |f| %>
       <%= f.govuk_radio_buttons_fieldset :start_term,
         legend: { text: I18n.t("schools.participants.change.start_term.#{@profile.participant_type}", full_name: @profile.user.full_name), tag: 'h1', size: 'xl' } do %>
 

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
     it "updates the term of a participant" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-start-term", params: {
-          participant_profile: { start_term: "summer_2022" },
+          participant_start_term_form: { start_term: "summer_2022" },
         }
       }.to change { ect_profile.reload.start_term.humanize }.to("Summer 2022")
     end


### PR DESCRIPTION
## Ticket and context

Ticket: CST-519

## Tech review

### Is there anything that the code reviewer should know?
The ticket includes a fix related to a bug found in the participant start term edit page where if no term was selected before hitting the submit button then an error was shown (missing parameter exception).
The code fixes the issue and show validation messages instead.

### Code quality checks
- [x] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
