### PR TITLE
Remove shared tests from declarations spec

### DIFF
--- a/spec/services/record_participant_declaration_spec.rb
+++ b/spec/services/record_participant_declaration_spec.rb
@@ -2,97 +2,205 @@
 
 require "rails_helper"
 
-require_relative "../shared/context/service_record_declaration_params"
-require_relative "../shared/context/lead_provider_profiles_and_courses"
-
 RSpec.describe RecordParticipantDeclaration do
-  include_context "lead provider profiles and courses"
-  include_context "service record declaration params"
-
-  before do
-    travel_to ect_profile.schedule.milestones.first.start_date + 4.days
-  end
-
   context "when sending event for an npq course" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+    let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+    let(:npq_application) { create(:npq_application, npq_lead_provider: npq_lead_provider) }
+    let(:profile) { create(:npq_participant_profile, npq_application: npq_application) }
+    let(:user) { profile.user }
+    let(:npq_course) { profile.npq_course }
+
+    let(:declaration_date) { profile.schedule.milestones.first.start_date + 3.days }
+
+    let(:params) do
+      {
+        participant_id: user.id,
+        declaration_date: declaration_date.rfc3339,
+        declaration_type: "started",
+        course_identifier: npq_course.identifier,
+        cpd_lead_provider: cpd_lead_provider,
+      }
+    end
+
     it "creates a participant declaration" do
-      expect { described_class.call(npq_params) }.to change { ParticipantDeclaration.count }.by(1)
+      expect { described_class.call(params) }.to change { ParticipantDeclaration.count }.by(1)
     end
 
     context "when the npq application is eligible for funding" do
       before do
-        npq_profile.npq_application.update!(eligible_for_funding: true)
+        profile.npq_application.update!(eligible_for_funding: true)
       end
 
       it "creates the participant declaration in the eligible state" do
-        described_class.call(npq_params)
-        declaration = npq_profile.participant_declarations.first
-        expect(declaration.state).to eq "eligible"
+        described_class.call(params)
+        declaration = profile.participant_declarations.first
+        expect(declaration.state).to eql("eligible")
       end
     end
 
     context "when the npq application is not eligible for funding" do
       before do
-        npq_profile.npq_application.update!(eligible_for_funding: false)
+        profile.npq_application.update!(eligible_for_funding: false)
       end
 
       it "creates the participant declaration in the submitted state" do
-        described_class.call(npq_params)
-        declaration = npq_profile.participant_declarations.first
-        expect(declaration.state).to eq "submitted"
+        described_class.call(params)
+        declaration = profile.participant_declarations.first
+        expect(declaration.state).to eql("submitted")
       end
     end
   end
 
   context "when sending event for an ect course" do
-    context "when lead providers don't match" do
-      it "raises a ParameterMissing error" do
-        expect { described_class.call(ect_params.merge(cpd_lead_provider: another_lead_provider)) }.to raise_error(ActionController::ParameterMissing)
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+    let(:lead_provider) { cpd_lead_provider.lead_provider }
+    let(:profile) { create(:ect_participant_profile) }
+    let(:user) { profile.user }
+    let(:school) { profile.school_cohort.school }
+    let(:cohort) { profile.school_cohort.cohort }
+    let!(:partnership) do
+      create(
+        :partnership,
+        school: school,
+        lead_provider: lead_provider,
+        cohort: cohort,
+      )
+    end
+
+    let(:declaration_date) { profile.schedule.milestones.first.start_date + 5.days }
+
+    let(:params) do
+      {
+        participant_id: user.id,
+        declaration_date: declaration_date.rfc3339,
+        declaration_type: "started",
+        course_identifier: "ecf-induction",
+        cpd_lead_provider: cpd_lead_provider,
+      }
+    end
+
+    before do
+      travel_to profile.schedule.milestones.first.start_date + 10.days
+    end
+
+    context "happy path" do
+      it "persists the declaration" do
+        expect {
+          described_class.call(params)
+        }.to change(ParticipantDeclaration::ECF, :count).by(1)
       end
     end
 
-    context "when valid user is an early_career_teacher" do
-      it "creates a participant and profile declaration" do
-        expect { described_class.call(ect_params) }.to change { ParticipantDeclaration.count }.by(1)
+    context "when a voided payable declaration exists" do
+      before do
+        profile.participant_declarations.create!(
+          cpd_lead_provider: cpd_lead_provider,
+          course_identifier: "ecf-induction",
+          user: user,
+          declaration_date: profile.schedule.milestones.first.start_date + 3.days,
+          declaration_type: "started",
+          state: "voided",
+        )
+      end
+
+      it "can re-submit the same declaration later" do
+        expect { described_class.call(params) }.to change { ParticipantDeclaration.count }.by(1)
+      end
+    end
+
+    context "when lead providers don't match" do
+      let(:other_cpd_lead_provider) { create(:cpd_lead_provider) }
+
+      let(:params) do
+        {
+          participant_id: user.id,
+          declaration_date: declaration_date.rfc3339,
+          declaration_type: "started",
+          course_identifier: "ecf-induction",
+          cpd_lead_provider: other_cpd_lead_provider,
+        }
+      end
+
+      it "raises a ParameterMissing error" do
+        expect {
+          described_class.call(params)
+        }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
+    context "when incorrect course given" do
+      let(:params) do
+        {
+          participant_id: user.id,
+          declaration_date: declaration_date.rfc3339,
+          declaration_type: "started",
+          course_identifier: "ecf-mentor",
+          cpd_lead_provider: cpd_lead_provider,
+        }
       end
 
       it "fails when course is for mentor" do
-        params = ect_params.merge({ course_identifier: "ecf-mentor" })
-        expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
+        expect {
+          described_class.call(params)
+        }.to raise_error(ActionController::ParameterMissing)
       end
     end
 
     context "when valid user is a mentor" do
-      it "creates a participant and profile declaration" do
-        expect { described_class.call(mentor_params) }.to change { ParticipantDeclaration.count }.by(1)
+      let(:profile) { create(:mentor_participant_profile) }
+
+      let(:params) do
+        {
+          participant_id: user.id,
+          declaration_date: declaration_date.rfc3339,
+          declaration_type: "started",
+          course_identifier: "ecf-mentor",
+          cpd_lead_provider: cpd_lead_provider,
+        }
       end
 
-      it "fails when course is for an early_career_teacher" do
-        params = mentor_params.merge({ course_identifier: "ecf-induction" })
-        expect { described_class.call(params) }.to raise_error(ActionController::ParameterMissing)
+      it "creates a participant and profile declaration" do
+        expect {
+          described_class.call(params)
+        }.to change { ParticipantDeclaration.count }.by(1)
+      end
+
+      context "when incorrect course given" do
+        let(:params) do
+          {
+            participant_id: user.id,
+            declaration_date: declaration_date.rfc3339,
+            declaration_type: "started",
+            course_identifier: "ecf-induction",
+            cpd_lead_provider: cpd_lead_provider,
+          }
+        end
+
+        it "fails when course is for an early_career_teacher" do
+          expect {
+            described_class.call(params)
+          }.to raise_error(ActionController::ParameterMissing)
+        end
       end
     end
 
     context "when user is not a participant" do
-      it "does not create a declaration record and raises ParameterMissing for an invalid user_id" do
-        expect { described_class.call(induction_coordinator_params) }.to raise_error(ActionController::ParameterMissing)
+      let(:params) do
+        {
+          participant_id: SecureRandom.uuid,
+          declaration_date: declaration_date.rfc3339,
+          declaration_type: "started",
+          course_identifier: "ecf-induction",
+          cpd_lead_provider: cpd_lead_provider,
+        }
       end
-    end
-  end
 
-  context "when a voided payable declaration exists" do
-    before do
-      ect_profile.participant_declarations.create!(
-        cpd_lead_provider: cpd_lead_provider,
-        course_identifier: "ecf-induction",
-        user: ect_profile.user,
-        declaration_date: ect_profile.schedule.milestones.first.start_date - 1.week,
-        declaration_type: "started",
-        state: "voided",
-      )
-    end
-
-    it "can re-submit the same declaration later" do
-      expect { described_class.call(ect_params) }.to change { ParticipantDeclaration.count }.by(1)
+      it "does not create a declaration record and raises ParameterMissing for an invalid user_id" do
+        expect {
+          described_class.call(params)
+        }.to raise_error(ActionController::ParameterMissing)
+      end
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- There seems to be a CI test failure around future declarations
- I've ripped out all the shared test setups from relevant file and re-implemented inline
- We want to rip out the shared tests at some point anyway so this is one step closer
- I highly recommend NOT having a global test setup that is called before a large number of different tests

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- n/a

## External API changes

- None