### PR TITLE
Add text content in the registration journey

### DIFF
--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -10,6 +10,11 @@
       <%= f.govuk_radio_buttons_fieldset :start_term,
           legend: { text: add_participant_form.start_term_legend, tag: 'h1', size: 'xl' } do %>
 
+        <div class="govuk-inset-text">
+          You’ll be able to add Autumn 2022 starters from May.
+          We’ll email schools as soon as the new term is added.
+        </div>
+
         <% ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS.each do |term| %>
           <%= f.govuk_radio_button :start_term, term, label: { text: term.humanize } %>
         <% end %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -13,6 +13,9 @@
       to <%= govuk_link_to "explain their role", roles_schools_cohort_path(info: true), class: "govuk-link--no-visited-state" %> and
       what they need to do next.</p>
 
+    <h2 class="govuk-heading-m">ECTs and mentors starting in the next academic year</h2>
+    <p>You’ll be able to add Autumn 2022 starters from May. We’ll email schools as soon as the new term is added.</p>
+
     <div class="govuk-inset-text">
       <ul class="govuk-list">
         <li><%= govuk_link_to "Add a new ECT", add_schools_participants_path(cohort_id: @school_cohort.cohort.start_year, type: :ect), class: "govuk-link--no-visited-state" %></li>


### PR DESCRIPTION
## Ticket and context

Ticket: [CST-447](https://dfedigital.atlassian.net/browse/CST-447)

We need to let people know adding ECTs/mentors for next year is not yet available and that emails will be sent out once it is.

## Tech review

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

