### PR TITLE
Remove rouge and govuk_markdown gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ gem "tzinfo-data"
 
 gem "govuk-components", "~> 3.0", ">= 3.0.3"
 gem "govuk_design_system_formbuilder", "~> 2.3.0b1"
-gem "govuk_markdown", "~> 1.0"
 gem "view_component", require: "view_component/engine"
 
 # Fetching from APIs
@@ -89,7 +88,6 @@ gem "jsonapi-serializer"
 gem "openapi3_parser", "~> 0.9.2"
 gem "open_api-rswag-api", "~> 0.1.0"
 gem "open_api-rswag-ui", "~> 0.1.0"
-gem "rouge"
 
 gem "ransack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,9 +242,6 @@ GEM
       activemodel (>= 5.2)
       activesupport (>= 5.2)
       deep_merge (~> 1.2.1)
-    govuk_markdown (1.0.0)
-      activesupport
-      redcarpet
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.1)
@@ -415,7 +412,6 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
     redis (4.6.0)
     regexp_parser (2.2.1)
     representable (3.1.1)
@@ -431,7 +427,6 @@ GEM
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
-    rouge (3.28.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-default_http_header (0.0.6)
@@ -647,7 +642,6 @@ DEPENDENCIES
   google-cloud-bigquery
   govuk-components (~> 3.0, >= 3.0.3)
   govuk_design_system_formbuilder (~> 2.3.0b1)
-  govuk_markdown (~> 1.0)
   httpclient (~> 2.8, >= 2.8.3)
   json-schema (>= 2.8.1)
   jsonapi-rspec
@@ -679,7 +673,6 @@ DEPENDENCIES
   rails (~> 6.1.5)
   rails-controller-testing (~> 1.0.5)
   ransack
-  rouge
   rspec-default_http_header (~> 0.0.6)
   rspec-rails (~> 5.1, >= 5.1.1)
   rubocop-govuk (>= 4.3)

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# source: https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/app/helpers/markdown_helper.rb
-
-module MarkdownHelper
-  def markdown_to_html(markdown)
-    GovukMarkdown.render(markdown.to_s).html_safe
-  end
-end


### PR DESCRIPTION
## Ticket and context

These gems and helpers are no longer used.