### PR TITLE
[CPDLP-1170] InductionRecord#training_status updates via API

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -73,7 +73,6 @@ class ParticipantProfile < ApplicationRecord
     def sync_status_with_induction_record
       induction_record = induction_records.latest
       induction_record&.update!(induction_status: status) if saved_change_to_status?
-      induction_record&.update!(training_status: training_status) if saved_change_to_training_status?
       induction_record&.update!(mentor_profile: mentor_profile) if saved_change_to_mentor_profile_id?
     end
   end

--- a/app/services/participants/defer/validate_and_change_state.rb
+++ b/app/services/participants/defer/validate_and_change_state.rb
@@ -16,7 +16,10 @@ module Participants
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:deferred], reason: reason)
           user_profile.training_status_deferred!
+
+          relevant_induction_record.update!(training_status: "deferred") if relevant_induction_record
         end
+
         user_profile
       end
     end

--- a/app/services/participants/ecf.rb
+++ b/app/services/participants/ecf.rb
@@ -7,10 +7,21 @@ module Participants
     included do
       delegate :early_career_teacher?, :mentor_profile, :early_career_teacher_profile, :participant?, to: :user, allow_nil: true
       delegate :school_cohort, :participant_profile_state, to: :user_profile, allow_nil: true
+      delegate :lead_provider, to: :cpd_lead_provider
     end
 
     def matches_lead_provider?
-      cpd_lead_provider == school_cohort&.lead_provider&.cpd_lead_provider
+      relevant_induction_record.present?
+    end
+
+    def relevant_induction_record
+      @relevant_induction_record ||= InductionRecord
+        .joins(:participant_profile, induction_programme: { school_cohort: [:cohort], partnership: [:lead_provider] })
+        .where(participant_profile: user_profile)
+        .where(induction_programme: { partnerships: { lead_provider: lead_provider } })
+        .where(induction_programme: { school_cohorts: { cohort: Cohort.current } })
+        .order(start_date: :desc)
+        .first
     end
   end
 end

--- a/app/services/participants/npq.rb
+++ b/app/services/participants/npq.rb
@@ -29,6 +29,12 @@ module Participants
         .first
     end
 
+    # this is to appease the abused inheritance hierarchy
+    # as induction records are an ECF concept
+    def relevant_induction_record
+      nil
+    end
+
     module NPQClassMethods
       def valid_courses
         NPQCourse.identifiers

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -10,8 +10,10 @@ RSpec.feature "Finance users payment breakdowns", :with_default_schedules, type:
   let!(:statement)        { create(:ecf_statement, cpd_lead_provider: cpd_lead_provider) }
   let!(:contract)         { create(:call_off_contract, lead_provider: lead_provider) }
   let(:school)            { create(:school) }
-  let!(:school_cohort)    { create(:school_cohort, school: school, cohort: contract.cohort) }
-  let!(:partnership)      { create(:partnership, school: school_cohort.school, lead_provider: lead_provider, cohort: contract.cohort) }
+  let(:cohort)            { contract.cohort }
+  let!(:school_cohort)    { create(:school_cohort, school: school, cohort: cohort) }
+  let!(:partnership)      { create(:partnership, school: school_cohort.school, lead_provider: lead_provider, cohort: cohort) }
+  let(:induction_programme) { create(:induction_programme, partnership: partnership) }
   let(:nov_statement)     { Finance::Statement::ECF.find_by!(name: "November 2021", cpd_lead_provider: cpd_lead_provider) }
   let(:jan_statement)     { Finance::Statement::ECF.find_by!(name: "January 2022", cpd_lead_provider: cpd_lead_provider) }
   let(:voided_declarations) do
@@ -127,6 +129,8 @@ private
   end
 
   def create_start_declarations_nov(participant)
+    Induction::Enrol.call(participant_profile: participant, induction_programme: induction_programme)
+
     timestamp = participant.schedule.milestones.first.start_date + 1.day
     travel_to(timestamp) do
       serialized_started_declaration = RecordDeclarations::Started::EarlyCareerTeacher.call(
@@ -150,6 +154,8 @@ private
   end
 
   def create_voided_declarations_nov(participant)
+    Induction::Enrol.call(participant_profile: participant, induction_programme: induction_programme)
+
     timestamp = participant.schedule.milestones.first.start_date + 1.day
     travel_to(timestamp) do
       serialized_started_declaration = RecordDeclarations::Started::EarlyCareerTeacher.call(
@@ -175,6 +181,8 @@ private
   end
 
   def create_retained_declarations_nov(participant)
+    Induction::Enrol.call(participant_profile: participant, induction_programme: induction_programme)
+
     timestamp = participant.schedule.milestones.second.start_date + 1.day
     travel_to(timestamp) do
       serialized_started_declaration = RecordDeclarations::Retained::EarlyCareerTeacher.call(
@@ -198,6 +206,8 @@ private
   end
 
   def create_retained_declarations_jan_mentor(participant)
+    Induction::Enrol.call(participant_profile: participant, induction_programme: induction_programme)
+
     timestamp = participant.schedule.milestones.second.start_date + 1.day
     travel_to(timestamp) do
       serialized_started_declaration = RecordDeclarations::Retained::Mentor.call(
@@ -221,6 +231,8 @@ private
   end
 
   def create_retained_declarations_jan_ect(participant)
+    Induction::Enrol.call(participant_profile: participant, induction_programme: induction_programme)
+
     timestamp = participant.schedule.milestones.second.start_date + 1.day
     travel_to(timestamp) do
       serialized_started_declaration = RecordDeclarations::Retained::EarlyCareerTeacher.call(
@@ -243,6 +255,8 @@ private
   end
 
   def create_ineligible_declarations_jan(participant)
+    Induction::Enrol.call(participant_profile: participant, induction_programme: induction_programme)
+
     timestamp = participant.schedule.milestones.first.start_date + 1.day
     travel_to(timestamp) do
       serialized_started_declaration = RecordDeclarations::Started::EarlyCareerTeacher.call(

--- a/spec/features/participant_declarations/block_participant_declaration_paid_twice_spec.rb
+++ b/spec/features/participant_declarations/block_participant_declaration_paid_twice_spec.rb
@@ -27,6 +27,6 @@ RSpec.feature "Block participant declaration paid twice", type: :feature do
     then_the_declaration_made_is_valid
     and_lead_provider_changed_for_the_participant
     and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
-    then_second_declaration_is_not_created
+    then_second_declaration_is_created
   end
 end

--- a/spec/features/participant_declarations/participant_declaration_steps.rb
+++ b/spec/features/participant_declarations/participant_declaration_steps.rb
@@ -8,11 +8,15 @@ module ParticipantDeclarationSteps
     school_cohort = create(:school_cohort, cohort: cohort)
     @ect_profile = create(:ect_participant_profile, school_cohort: school_cohort)
     delivery_partner = create(:delivery_partner)
-    create(:partnership,
-           school: @ect_profile.school,
-           lead_provider: @cpd_lead_provider.lead_provider,
-           cohort: cohort,
-           delivery_partner: delivery_partner)
+    partnership = create(
+      :partnership,
+      school: @ect_profile.school,
+      lead_provider: @cpd_lead_provider.lead_provider,
+      cohort: cohort,
+      delivery_partner: delivery_partner,
+    )
+    induction_programme = create(:induction_programme, partnership: partnership)
+    Induction::Enrol.call(participant_profile: @ect_profile, induction_programme: induction_programme)
     @ect_id = @ect_profile.user.id
     @declaration_date = @ect_profile.schedule.milestones.first.start_date + 1.day
     @submission_date = @ect_profile.schedule.milestones.first.start_date + 2.days
@@ -24,6 +28,9 @@ module ParticipantDeclarationSteps
     partnership = create(:partnership, lead_provider: @lead_provider, cohort: cohort, school: school_cohort.school)
     @mentor_profile = create(:mentor_participant_profile, school: partnership.school, cohort: partnership.cohort)
     @mentor_id = @mentor_profile.user.id
+    induction_programme = create(:induction_programme, partnership: partnership)
+    Induction::Enrol.call(participant_profile: @mentor_profile, induction_programme: induction_programme)
+
     @declaration_date = @mentor_profile.schedule.milestones.first.start_date + 1.day
     @submission_date = @mentor_profile.schedule.milestones.first.start_date + 2.days
   end
@@ -114,13 +121,16 @@ module ParticipantDeclarationSteps
 
     delivery_partner = create(:delivery_partner)
 
-    create(:partnership,
-           school: @ect_profile.school,
-           lead_provider: @new_cpd_lead_provider.lead_provider,
-           cohort: partnership.cohort,
-           delivery_partner: delivery_partner)
+    new_partnership = create(
+      :partnership,
+      school: @ect_profile.school,
+      lead_provider: @new_cpd_lead_provider.lead_provider,
+      cohort: partnership.cohort,
+      delivery_partner: delivery_partner,
+    )
 
-    partnership.destroy!
+    new_induction_programme = create(:induction_programme, partnership: new_partnership)
+    Induction::Enrol.call(participant_profile: @ect_profile, induction_programme: new_induction_programme)
   end
 
   def then_second_declaration_is_created

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -270,9 +270,14 @@ RSpec.describe ParticipantDeclaration, type: :model do
       let(:declaration_date)  { (Finance::Schedule::ECF.default.milestones.first.milestone_date - 1.day).rfc3339 }
       let(:declaration_type)  { "started" }
 
+      let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+
       before do
-        create(:partnership, lead_provider: cpd_lead_provider.lead_provider, cohort: cohort, school: school)
+        Induction::Enrol.call(participant_profile: participant_profile, induction_programme: induction_programme)
+        Induction::Enrol.call(participant_profile: primary_participant_profile, induction_programme: induction_programme)
       end
+
+      let!(:partnership) { create(:partnership, lead_provider: cpd_lead_provider.lead_provider, cohort: cohort, school: school) }
 
       context "when declarations have been made for a teacher profile with the same trn" do
         subject(:record_started_declaration) do
@@ -339,6 +344,8 @@ RSpec.describe ParticipantDeclaration, type: :model do
               end
 
               before do
+                Induction::Enrol.call(participant_profile: another_duplicate_participant_profile, induction_programme: induction_programme)
+
                 RecordDeclarations::Started::EarlyCareerTeacher.call(
                   params: {
                     participant_id: another_duplicate_participant_profile.user_id,
@@ -372,6 +379,8 @@ RSpec.describe ParticipantDeclaration, type: :model do
 
           context "when declarations have been made for a different course" do
             before do
+              Induction::Enrol.call(participant_profile: mentor_participant_profile, induction_programme: induction_programme)
+
               RecordDeclarations::Started::Mentor.call(
                 params: {
                   participant_id: mentor_participant_profile.user_id,

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -41,13 +41,6 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       end
     end
 
-    context "when the training_status changes" do
-      it "updates the training_status on the active induction record" do
-        profile.training_status_withdrawn!
-        expect(induction_record.reload).to be_training_status_withdrawn
-      end
-    end
-
     context "when the training_status has not changed" do
       before { induction_record.training_status_deferred! }
 

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -324,6 +324,10 @@ RSpec.describe "Participants API", type: :request do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v1/participants/ecf/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
+          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+          let!(:induction_record) do
+            Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+          end
 
           it "changes the training status of a participant to withdrawn" do
             put url, params: params
@@ -339,6 +343,11 @@ RSpec.describe "Participants API", type: :request do
         let(:withdrawal_url)    { "/api/v1/participants/ecf/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+
         before do
           put "/api/v1/participants/ecf/#{early_career_teacher_profile.user.id}/defer",
               params: { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } }
@@ -384,5 +393,9 @@ RSpec.describe "Participants API", type: :request do
     let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
     let(:withdrawal_url)    { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
     let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+    let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+    let!(:induction_record) do
+      Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+    end
   end
 end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
              teacher_profile: ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record,
              school_cohort: school_cohort)
     end
+
     let!(:withdrawn_ect_profile_record) { create(:ect_participant_profile, :withdrawn_record, school_cohort: school_cohort) }
     let(:user) { create(:user) }
     let(:early_career_teacher_profile) { create(:ect_participant_profile, school_cohort: school_cohort, user: user) }
@@ -248,6 +249,11 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
+          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+
+          let!(:induction_record) do
+            Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+          end
 
           it "changes the training status of a participant to withdrawn" do
             put url, params: params
@@ -265,6 +271,10 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         let(:withdrawal_url)    { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
       end
 
       it_behaves_like "JSON Participant Resume endpoint", "participant" do
@@ -272,6 +282,10 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         let(:withdrawal_url)    { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
         before do
           put "/api/v1/participants/#{early_career_teacher_profile.user.id}/defer",
               params: { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } }

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -324,6 +324,10 @@ RSpec.describe "Participants API", type: :request do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
+          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+          let!(:induction_record) do
+            Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+          end
 
           it "changes the training status of a participant to withdrawn" do
             put url, params: params
@@ -339,6 +343,11 @@ RSpec.describe "Participants API", type: :request do
         let(:withdrawal_url)    { "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+
         before do
           put "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}/defer",
               params: { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } }
@@ -384,5 +393,9 @@ RSpec.describe "Participants API", type: :request do
     let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
     let(:withdrawal_url)    { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
     let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+    let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+    let!(:induction_record) do
+      Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+    end
   end
 end

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -248,6 +248,10 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
+          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+          let!(:induction_record) do
+            Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+          end
 
           it "changes the training status of a participant to withdrawn" do
             put url, params: params
@@ -265,6 +269,10 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         let(:withdrawal_url)    { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
       end
 
       it_behaves_like "JSON Participant Resume endpoint", "participant" do
@@ -272,6 +280,11 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         let(:withdrawal_url)    { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
+        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+
         before do
           put "/api/v2/participants/#{early_career_teacher_profile.user.id}/defer",
               params: { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } }

--- a/spec/services/participants/defer/early_career_teacher_spec.rb
+++ b/spec/services/participants/defer/early_career_teacher_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Participants::Defer::EarlyCareerTeacher do
   let(:user) { profile.user }
   let(:school) { profile.school_cohort.school }
   let(:cohort) { profile.school_cohort.cohort }
+  let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(
       :partnership,
@@ -36,6 +42,10 @@ RSpec.describe Participants::Defer::EarlyCareerTeacher do
 
     it "creates a ParticipantProfileState" do
       expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+    end
+
+    it "updates induction_record training_status" do
+      expect { subject.call }.to change { induction_record.reload.training_status }.from("active").to("deferred")
     end
 
     context "when already deferred" do

--- a/spec/services/participants/defer/mentor_spec.rb
+++ b/spec/services/participants/defer/mentor_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Participants::Defer::Mentor do
   let(:user) { profile.user }
   let(:school) { profile.school_cohort.school }
   let(:cohort) { profile.school_cohort.cohort }
+  let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(
       :partnership,
@@ -36,6 +42,10 @@ RSpec.describe Participants::Defer::Mentor do
 
     it "creates a ParticipantProfileState" do
       expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+    end
+
+    it "updates induction_record training_status" do
+      expect { subject.call }.to change { induction_record.reload.training_status }.from("active").to("deferred")
     end
 
     context "when already deferred" do

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
   let(:user) { profile.user }
   let(:school) { profile.school_cohort.school }
   let(:cohort) { profile.school_cohort.cohort }
+
+  let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(
       :partnership,

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Participants::Resume::Mentor do
   let(:user) { profile.user }
   let(:school) { profile.school_cohort.school }
   let(:cohort) { profile.school_cohort.cohort }
+  let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(
       :partnership,

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
   let(:user) { profile.user }
   let(:school) { profile.school_cohort.school }
   let(:cohort) { profile.school_cohort.cohort }
+  let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(
       :partnership,

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Participants::Withdraw::Mentor do
   let(:user) { profile.user }
   let(:school) { profile.school_cohort.school }
   let(:cohort) { profile.school_cohort.cohort }
+  let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(
       :partnership,

--- a/spec/services/record_declarations/base_spec.rb
+++ b/spec/services/record_declarations/base_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe RecordDeclarations::Base do
   let(:user)                    { create(:user) }
   let(:teacher_profile)         { create(:teacher_profile, user: user) }
   let!(:ect_participant_profile) { create(:ect_participant_profile, school_cohort: school_cohort, teacher_profile: teacher_profile) }
+  let!(:partnership) { create(:partnership, lead_provider: cpd_lead_provider.lead_provider, cohort: cohort, school: school) }
+
+  let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: ect_participant_profile, induction_programme: induction_programme)
+  end
+
   let(:params) do
     {
       participant_id: ect_participant_profile.user_id,
@@ -20,10 +28,6 @@ RSpec.describe RecordDeclarations::Base do
       declaration_date: declaration_date.rfc3339,
       declaration_type: declaration_type,
     }
-  end
-
-  before do
-    create(:partnership, lead_provider: cpd_lead_provider.lead_provider, cohort: cohort, school: school)
   end
 
   describe "#call" do
@@ -68,6 +72,7 @@ RSpec.describe RecordDeclarations::Base do
       let(:original_ect_participant_profile) do
         create(:ect_participant_profile, school_cohort: school_cohort).tap do |participant_profile|
           participant_profile.teacher_profile.update!(trn: ect_participant_profile.teacher_profile.trn)
+          Induction::Enrol.call(participant_profile: participant_profile, induction_programme: induction_programme)
         end
       end
 

--- a/spec/services/record_declarations/retained/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/retained/early_career_teacher_spec.rb
@@ -45,17 +45,4 @@ RSpec.describe RecordDeclarations::Retained::EarlyCareerTeacher do
       ect_profile
     end
   end
-
-  context "when user is for 2020 cohort" do
-    let!(:cohort_2020) { create(:cohort, start_year: 2020) }
-    let!(:school_cohort_2020) { create(:school_cohort, cohort: cohort_2020, school: ect_profile.school) }
-
-    before do
-      ect_profile.update!(school_cohort: school_cohort_2020)
-    end
-
-    it "raises a ParameterMissing error" do
-      expect { described_class.call(params: retained_ect_params) }.to raise_error(ActionController::ParameterMissing)
-    end
-  end
 end

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
     let!(:school_cohort_2020) { create(:school_cohort, cohort: cohort_2020, school: ect_profile.school) }
 
     before do
-      ect_profile.update!(school_cohort: school_cohort_2020)
+      induction_programme.update!(school_cohort: school_cohort_2020)
     end
 
     it "raises a ParameterMissing error" do

--- a/spec/services/record_participant_declaration_spec.rb
+++ b/spec/services/record_participant_declaration_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe RecordParticipantDeclaration do
     let(:user) { profile.user }
     let(:school) { profile.school_cohort.school }
     let(:cohort) { profile.school_cohort.cohort }
+
+    let(:induction_programme) { create(:induction_programme, partnership: partnership) }
+
+    let!(:induction_record) do
+      Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+    end
+
     let!(:partnership) do
       create(
         :partnership,

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -7,6 +7,7 @@ RSpec.shared_context "lead provider profiles and courses" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Unknown") }
   let!(:default_schedule) { Finance::Schedule::ECF.default }
+
   # ECF setup
   let(:ecf_lead_provider) { cpd_lead_provider.lead_provider }
   let!(:ect_profile) { create(:ect_participant_profile, schedule: default_schedule) }
@@ -14,12 +15,29 @@ RSpec.shared_context "lead provider profiles and courses" do
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:delivery_partner) { create(:delivery_partner) }
   let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }
+
+  let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+  end
+
+  let!(:mentor_induction_record) do
+    Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: induction_programme)
+  end
+
   let!(:partnership) do
     create(:partnership,
            school: ect_profile.school,
            lead_provider: cpd_lead_provider.lead_provider,
            cohort: ect_profile.cohort,
            delivery_partner: delivery_partner)
+  end
+
+  let(:induction_programme) { create(:induction_programme, partnership: partnership, school_cohort: school_cohort) }
+
+  let!(:induction_record) do
+    Induction::Enrol.call(participant_profile: ect_profile, induction_programme: induction_programme)
   end
 
   # NPQ setup

--- a/spec/support/shared_examples/participant_service_ect_support.rb
+++ b/spec/support/shared_examples/participant_service_ect_support.rb
@@ -17,7 +17,7 @@ RSpec.shared_examples "a participant service for ect" do
       let!(:school_cohort_2020) { create(:school_cohort, cohort: cohort_2020, school: user_profile.school) }
 
       before do
-        user_profile.update!(school_cohort: school_cohort_2020)
+        induction_programme.update!(school_cohort: school_cohort_2020)
       end
 
       it "raises a ParameterMissing error" do


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1170

- Lead providers deferring, resuming, withdrawn now affect induction records for `training_status`
- The AR callback for syncing `training_status` has been removed
- Seeds have been updated to support this. I will continue to admit the state of the seeds is appalling and needs a re-vamp

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Assuming induction records are setup
- As a lead provider defer/resume/withdraw a participant
- Relevant induction record should be updated

## External API changes

- None