### PR TITLE
Change of Circumstances: Add induction_programme during school_cohort choice

### DIFF
--- a/app/controllers/schools/choose_programme_controller.rb
+++ b/app/controllers/schools/choose_programme_controller.rb
@@ -49,9 +49,9 @@ private
   end
 
   def save_school_choice!
-    school_cohort.induction_programme_choice = @induction_choice_form.programme_choice
-    school_cohort.opt_out_of_updates = @induction_choice_form.opt_out_choice_selected?
-    school_cohort.save!
+    Induction::SetCohortInductionProgramme.call(school_cohort: school_cohort,
+                                                programme_choice: @induction_choice_form.programme_choice,
+                                                opt_out_of_updates: @induction_choice_form.opt_out_choice_selected?)
   end
 
   def programme_choice_form_params

--- a/app/forms/schools/year2020_form.rb
+++ b/app/forms/schools/year2020_form.rb
@@ -76,9 +76,9 @@ module Schools
     def save!
       ActiveRecord::Base.transaction do
         school_cohort = SchoolCohort.find_or_initialize_by(school: school, cohort: cohort)
-        school_cohort.induction_programme_choice = "core_induction_programme"
-        school_cohort.core_induction_programme = core_induction_programme
-        school_cohort.save!
+        Induction::SetCohortInductionProgramme.call(school_cohort: school_cohort,
+                                                    programme_choice: "core_induction_programme",
+                                                    core_induction_programme: core_induction_programme)
 
         participants = get_participants.each do |participant|
           EarlyCareerTeachers::Create.call(

--- a/app/services/induction/set_cohort_induction_programme.rb
+++ b/app/services/induction/set_cohort_induction_programme.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Induction::SetCohortInductionProgramme < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      school_cohort.induction_programme_choice = programme_choice
+      school_cohort.opt_out_of_updates = opt_out_of_updates
+      # need to save this first if it hasn't been persisted
+      school_cohort.save! unless school_cohort.persisted?
+
+      programme = nil
+
+      if InductionProgramme.training_programmes.keys.include? programme_choice
+        # NOTE: we could move any participants in the old default programme (if present)
+        # over to the new one here but not sure that would always be required?
+        programme = InductionProgramme.create!(programme_attrs)
+      end
+
+      school_cohort.default_induction_programme = programme
+      school_cohort.save!
+    end
+  end
+
+private
+
+  attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme
+
+  def initialize(school_cohort:, programme_choice:, opt_out_of_updates: false, core_induction_programme: nil)
+    # NOTE: this is mainly called during addition of a school_cohort and the model may not
+    # be persisted as yet
+    @school_cohort = school_cohort
+    @programme_choice = programme_choice
+    @opt_out_of_updates = opt_out_of_updates
+    @core_induction_programme = core_induction_programme
+  end
+
+  def programme_attrs
+    attrs = {
+      training_programme: programme_choice,
+      school_cohort: school_cohort,
+    }
+
+    case programme_choice.to_s
+    when "full_induction_programme"
+      attrs[:partnership] = school_cohort.school.partnerships.where(cohort: school_cohort.cohort,
+                                                                    relationship: false).active.first
+    when "core_induction_programme"
+      attrs[:core_induction_programme] = core_induction_programme
+    end
+
+    attrs
+  end
+end

--- a/spec/services/induction/set_cohort_induction_programme_spec.rb
+++ b/spec/services/induction/set_cohort_induction_programme_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Induction::SetCohortInductionProgramme do
         expect(school_cohort.default_induction_programme).to be_core_induction_programme
       end
     end
-    
+
     context "when a CIP is chosen and the programme specified" do
       let(:cip) { create(:core_induction_programme) }
 

--- a/spec/services/induction/set_cohort_induction_programme_spec.rb
+++ b/spec/services/induction/set_cohort_induction_programme_spec.rb
@@ -63,5 +63,14 @@ RSpec.describe Induction::SetCohortInductionProgramme do
         expect(school_cohort.default_induction_programme).to be_core_induction_programme
       end
     end
+    
+    context "when a CIP is chosen and the programme specified" do
+      let(:cip) { create(:core_induction_programme) }
+
+      it "sets the core_induction_programme" do
+        service.call(school_cohort: school_cohort, programme_choice: "core_induction_programme", core_induction_programme: cip)
+        expect(school_cohort.default_induction_programme.core_induction_programme).to eq cip
+      end
+    end
   end
 end

--- a/spec/services/induction/set_cohort_induction_programme_spec.rb
+++ b/spec/services/induction/set_cohort_induction_programme_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::SetCohortInductionProgramme do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort, induction_programme_choice: "no_early_career_teachers", opt_out_of_updates: true }
+
+    subject(:service) { described_class }
+
+    it "sets the programme choice" do
+      service.call(school_cohort: school_cohort, programme_choice: "full_induction_programme")
+      expect(school_cohort).to be_full_induction_programme
+    end
+
+    it "sets the opt out flag correctly" do
+      service.call(school_cohort: school_cohort, programme_choice: "full_induction_programme")
+      expect(school_cohort).not_to be_opt_out_of_updates
+    end
+
+    it "creates a new induction programme" do
+      expect {
+        service.call(school_cohort: school_cohort, programme_choice: "full_induction_programme")
+      }.to change { InductionProgramme.count }.by 1
+    end
+
+    it "sets the default induction programme" do
+      service.call(school_cohort: school_cohort, programme_choice: "full_induction_programme")
+      expect(school_cohort.default_induction_programme).to be_full_induction_programme
+    end
+
+    context "when a non-training programme is chosen" do
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+
+      before do
+        school_cohort.update!(default_induction_programme: induction_programme, opt_out_of_updates: false)
+      end
+
+      it "does not add an induction programme" do
+        expect {
+          service.call(school_cohort: school_cohort, programme_choice: "no_early_career_teachers")
+        }.not_to change { InductionProgramme.count }
+      end
+
+      it "removes any default induction programme association" do
+        service.call(school_cohort: school_cohort, programme_choice: "no_early_career_teachers")
+        expect(school_cohort.default_induction_programme).to be_blank
+      end
+
+      it "sets the opt out flag correctly" do
+        service.call(school_cohort: school_cohort, programme_choice: "no_early_career_teachers", opt_out_of_updates: true)
+        expect(school_cohort).to be_opt_out_of_updates
+      end
+    end
+
+    context "when a default induction programme already exists" do
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+
+      before do
+        school_cohort.update!(default_induction_programme: induction_programme)
+      end
+
+      it "replaces the default induction programme" do
+        service.call(school_cohort: school_cohort, programme_choice: "core_induction_programme")
+        expect(school_cohort.default_induction_programme).to be_core_induction_programme
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ensure we create an `InductionProgramme` to represent the training programme choice made for the school cohort.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
