### PR TITLE
[CPDLP-1159] Test endpoint excludes NQT+1

### DIFF
--- a/app/controllers/api/v1/test_ecf_participants_controller.rb
+++ b/app/controllers/api/v1/test_ecf_participants_controller.rb
@@ -39,6 +39,8 @@ module Api
       def induction_records
         scope = InductionRecord
           .where(id: induction_record_ids_with_deduped_profiles)
+          .joins(participant_profile: { school_cohort: [:cohort] })
+          .where(participant_profile: { school_cohorts: { cohort: Cohort.current } })
           .includes(participant_profile: [
             :participant_identity,
             :user,

--- a/spec/requests/api/v1/test_ecf_participants_spec.rb
+++ b/spec/requests/api/v1/test_ecf_participants_spec.rb
@@ -75,6 +75,20 @@ RSpec.describe "Participants API", type: :request do
 
         context "when there is no mentor"
 
+        context "NQT+1" do
+          let(:cohort_2020) { create(:cohort, start_year: 2020) }
+
+          before do
+            profile.school_cohort.update!(cohort: cohort_2020)
+          end
+
+          it "does not include them" do
+            get "/api/v1/test_ecf_participants"
+
+            expect(parsed_response["data"].size).to be_zero
+          end
+        end
+
         context "one profile with 2 induction records" do
           let(:profile) do
             create(


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1159

- this is done by scoping to the current cohort
- how we deal with future cohorts is a future problem

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- this will be tested on prod behind an auth wall

## External API changes

- None