### PR TITLE
[CPDLP-1128] Change schedule access scoped by induction record

### DIFF
--- a/app/services/participants/change_schedule/ecf.rb
+++ b/app/services/participants/change_schedule/ecf.rb
@@ -114,7 +114,7 @@ module Participants
       end
 
       def matches_lead_provider?
-        cpd_lead_provider == school_cohort&.lead_provider&.cpd_lead_provider
+        relevant_induction_record.present?
       end
     end
   end

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Participants API", type: :request do
   let(:lead_provider) { create(:lead_provider) }
   let(:cohort) { create(:cohort, :current) }
   let(:partnership) { create(:partnership, lead_provider: lead_provider, cohort: cohort) }
+  let(:induction_programme) { create(:induction_programme, partnership: partnership) }
   let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: cohort, induction_programme_choice: "full_induction_programme") }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
   let(:bearer_token) { "Bearer #{token}" }
@@ -318,7 +319,11 @@ RSpec.describe "Participants API", type: :request do
         end
       end
 
-      it_behaves_like "JSON Participant Change schedule endpoint"
+      it_behaves_like "JSON Participant Change schedule endpoint" do
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+      end
 
       describe "JSON Participant Withdrawal" do
         it_behaves_like "a participant withdraw action endpoint" do

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
     let(:lead_provider) { create(:lead_provider) }
     let(:cohort) { create(:cohort, :current) }
     let(:partnership) { create(:partnership, lead_provider: lead_provider, cohort: cohort) }
+    let(:induction_programme) { create(:induction_programme, partnership: partnership) }
     let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: cohort, induction_programme_choice: "full_induction_programme") }
     let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
@@ -249,7 +250,6 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
-          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
 
           let!(:induction_record) do
             Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
@@ -264,14 +264,17 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         end
       end
 
-      it_behaves_like "JSON Participant Change schedule endpoint"
+      it_behaves_like "JSON Participant Change schedule endpoint" do
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+      end
 
       it_behaves_like "JSON Participant Deferral endpoint", "participant" do
         let(:url)               { "/api/v1/participants/#{early_career_teacher_profile.user.id}/defer" }
         let(:withdrawal_url)    { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
-        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
         let!(:induction_record) do
           Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
         end
@@ -282,7 +285,6 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         let(:withdrawal_url)    { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
-        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
         let!(:induction_record) do
           Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
         end

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Participants API", type: :request do
   let(:lead_provider) { create(:lead_provider) }
   let(:cohort) { create(:cohort, :current) }
   let(:partnership) { create(:partnership, lead_provider: lead_provider, cohort: cohort) }
+  let(:induction_programme) { create(:induction_programme, partnership: partnership) }
   let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: cohort, induction_programme_choice: "full_induction_programme") }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
   let(:bearer_token) { "Bearer #{token}" }
@@ -318,13 +319,16 @@ RSpec.describe "Participants API", type: :request do
         end
       end
 
-      it_behaves_like "JSON Participant Change schedule endpoint"
+      it_behaves_like "JSON Participant Change schedule endpoint" do
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+      end
 
       describe "JSON Participant Withdrawal" do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
-          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
           let!(:induction_record) do
             Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
           end
@@ -343,7 +347,6 @@ RSpec.describe "Participants API", type: :request do
         let(:withdrawal_url)    { "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
-        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
         let!(:induction_record) do
           Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
         end
@@ -393,7 +396,6 @@ RSpec.describe "Participants API", type: :request do
     let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
     let(:withdrawal_url)    { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
     let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
-    let(:induction_programme) { create(:induction_programme, partnership: partnership) }
     let!(:induction_record) do
       Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
     end

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
     let(:lead_provider) { create(:lead_provider) }
     let(:cohort) { create(:cohort, :current) }
     let(:partnership) { create(:partnership, lead_provider: lead_provider, cohort: cohort) }
+    let(:induction_programme) { create(:induction_programme, partnership: partnership) }
     let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort: cohort, induction_programme_choice: "full_induction_programme") }
     let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: cpd_lead_provider) }
     let(:bearer_token) { "Bearer #{token}" }
@@ -248,7 +249,6 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         it_behaves_like "a participant withdraw action endpoint" do
           let(:url) { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
           let(:params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "moved-school" } } } }
-          let(:induction_programme) { create(:induction_programme, partnership: partnership) }
           let!(:induction_record) do
             Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
           end
@@ -262,14 +262,17 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         end
       end
 
-      it_behaves_like "JSON Participant Change schedule endpoint"
+      it_behaves_like "JSON Participant Change schedule endpoint" do
+        let!(:induction_record) do
+          Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
+        end
+      end
 
       it_behaves_like "JSON Participant Deferral endpoint", "participant" do
         let(:url)               { "/api/v2/participants/#{early_career_teacher_profile.user.id}/defer" }
         let(:withdrawal_url)    { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction", reason: "career-break" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
-        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
         let!(:induction_record) do
           Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
         end
@@ -280,7 +283,6 @@ RSpec.describe "Participants API", :with_default_schdules, type: :request do
         let(:withdrawal_url)    { "/api/v2/participants/#{early_career_teacher_profile.user.id}/withdraw" }
         let(:params)            { { data: { attributes: { course_identifier: "ecf-induction" } } } }
         let(:withdrawal_params) { { data: { attributes: { course_identifier: "ecf-induction", reason: "left-teaching-profession" } } } }
-        let(:induction_programme) { create(:induction_programme, partnership: partnership) }
         let!(:induction_record) do
           Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme: induction_programme)
         end

--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -129,6 +129,16 @@ RSpec.describe Participants::ChangeSchedule::EarlyCareerTeacher do
              course_identifier: "ecf-induction")
     end
 
+    let(:induction_programme) do
+      create(
+        :induction_programme,
+        :fip,
+        school_cohort: school_cohort,
+        partnership: partnership,
+      )
+    end
+    let!(:induction_record) { Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme) }
+
     subject do
       described_class.new(params: {
         schedule_identifier: schedule.schedule_identifier,


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1128

- Access to change schedule is now based off the induction record
- As previous check via `school_cohort` will soon be no longer supported

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Assuming induction records are present
- Change the schedule of a participant
- Induction record should be updated
- Delete association via `school_cohort`
- Change the schedule of a participant
- Induction record should be updated. This would previously have failed

## External API changes

- None