### PR TITLE
replace Kaminari with Pagy for Suppliers admin

### DIFF
--- a/app/controllers/admin/suppliers/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers/suppliers_controller.rb
@@ -9,7 +9,7 @@ module Admin
         lead_providers = policy_scope(LeadProvider).sort_by(&:name)
         delivery_partners = policy_scope(DeliveryPartner).sort_by(&:name)
         sorted_suppliers = (lead_providers + delivery_partners)
-        @pagy, @suppliers = pagy_array(sorted_suppliers, page: params[:page], items: 2)
+        @pagy, @suppliers = pagy_array(sorted_suppliers, page: params[:page], items: 20)
         @page = @pagy.page
         @total_pages = @pagy.pages
       end

--- a/app/controllers/admin/suppliers/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers/suppliers_controller.rb
@@ -9,9 +9,12 @@ module Admin
         lead_providers = policy_scope(LeadProvider).sort_by(&:name)
         delivery_partners = policy_scope(DeliveryPartner).sort_by(&:name)
         sorted_suppliers = (lead_providers + delivery_partners)
-        @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(20)
+        @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(5)
         @page = @suppliers.current_page
         @total_pages = @suppliers.total_pages
+        @pagy, @suppliers2 = pagy_array(sorted_suppliers, page: params[:page], items: 5)
+        # @page = @pagy.page
+        # @total_pages = @pagy.pages
       end
     end
   end

--- a/app/controllers/admin/suppliers/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers/suppliers_controller.rb
@@ -9,12 +9,9 @@ module Admin
         lead_providers = policy_scope(LeadProvider).sort_by(&:name)
         delivery_partners = policy_scope(DeliveryPartner).sort_by(&:name)
         sorted_suppliers = (lead_providers + delivery_partners)
-        @suppliers = Kaminari.paginate_array(sorted_suppliers).page(params[:page]).per(5)
-        @page = @suppliers.current_page
-        @total_pages = @suppliers.total_pages
-        @pagy, @suppliers2 = pagy_array(sorted_suppliers, page: params[:page], items: 5)
-        # @page = @pagy.page
-        # @total_pages = @pagy.pages
+        @pagy, @suppliers = pagy_array(sorted_suppliers, page: params[:page], items: 2)
+        @page = @pagy.page
+        @total_pages = @pagy.pages
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+  include Pagy::Backend
 
   impersonates :user
   prepend CurrentUser

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include Pagy::Frontend
+
   def profile_dashboard_path(user)
     if user.admin?
       admin_schools_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "pagy"
 
 module ApplicationHelper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "pagy"
 
 module ApplicationHelper
   include Pagy::Frontend

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -3,13 +3,12 @@
 module PaginationHelper
   OUTER_WINDOW = 1
 
-  def govuk_paginate(scope, pagy=nil)
+  def govuk_paginate(scope, pagy = nil)
     if pagy
-      render partial: 'shared/paginator', locals: {pagy: pagy}
+      render partial: "shared/paginator", locals: { pagy: pagy }
     else
       paginate(scope, window: window(scope), outer_window: OUTER_WINDOW)
     end
-
   end
 
 private

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 module PaginationHelper
-  def govuk_paginate(scope)
-    paginate(scope, window: window(scope), outer_window: 1)
+  OUTER_WINDOW = 1
+
+  def govuk_paginate(scope, pagy=nil)
+    if pagy
+      pagy_nav(pagy, size: pagy_size(pagy))
+    else
+      paginate(scope, window: window(scope), outer_window: OUTER_WINDOW)
+    end
+
   end
 
 private
@@ -20,5 +27,25 @@ private
     else
       2
     end
+  end
+
+  def pagy_window(pagy)
+    case pagy.page
+    when 1
+      4
+    when 2
+      3
+    when pagy.pages
+      4
+    when pagy.pages - 1
+      3
+    else
+      2
+    end
+  end
+
+  def pagy_size(pagy)
+    window = pagy_window(pagy)
+    [OUTER_WINDOW, window, window, OUTER_WINDOW]
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -5,7 +5,7 @@ module PaginationHelper
 
   def govuk_paginate(scope, pagy=nil)
     if pagy
-      pagy_nav(pagy, size: pagy_size(pagy))
+      render partial: 'shared/paginator', locals: {pagy: pagy}
     else
       paginate(scope, window: window(scope), outer_window: OUTER_WINDOW)
     end

--- a/app/views/admin/suppliers/suppliers/index.html.erb
+++ b/app/views/admin/suppliers/suppliers/index.html.erb
@@ -22,3 +22,5 @@
   </tbody>
 </table>
 <%= govuk_paginate @suppliers %>
+<% # test %>
+<%== govuk_paginate @suppliers2, @pagy %>

--- a/app/views/admin/suppliers/suppliers/index.html.erb
+++ b/app/views/admin/suppliers/suppliers/index.html.erb
@@ -21,6 +21,4 @@
     <% end %>
   </tbody>
 </table>
-<%= govuk_paginate @suppliers %>
-<% # test %>
-<%== govuk_paginate @suppliers2, @pagy %>
+<%== govuk_paginate @suppliers, @pagy %>

--- a/app/views/shared/_paginator.html.erb
+++ b/app/views/shared/_paginator.html.erb
@@ -1,0 +1,23 @@
+<% link = pagy_link_proc(pagy) -%>
+<nav aria-label="pager" class="pagination ecf-pagination" role="navigation">
+  <% if pagy.prev -%>
+    <span class="ecf-page-link ecf-page-link__prev">
+      <%== link.call(pagy.prev, I18n.t('pagy.nav.prev'), 'aria-label="previous" class="govuk-link"') %>
+    </span>
+  <% end -%>
+
+  <% if pagy.pages > 1 %>
+    <% pagy.series.each do |item| -%>
+      <% if item.is_a?(Integer) -%>  <span class="page"><%== link.call(item, item, 'class="govuk-link"') %></span>
+      <% elsif item.is_a?(String) -%>  <span class="page current"><%= item %></span>
+      <% elsif item == :gap -%>  <span class="page gap"><%== I18n.t('pagy.nav.gap') %></span>
+      <% end -%>
+    <% end -%>
+  <% end %>
+
+  <% if pagy.next -%>
+    <span class="ecf-page-link ecf-page-link__next">
+      <%== link.call(pagy.next, I18n.t('pagy.nav.next'), 'aria-label="next" class="govuk-link"') %>
+    </span>
+  <% end -%>
+</nav>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pagy/extras/overflow"
+require "pagy/extras/array"
 
 # Return an empty page when page number too high (other options :last_page and :exception )
 Pagy::DEFAULT[:overflow] = :empty_page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,3 +331,9 @@ en:
       providers:
         show:
           title: "Banding tracker for %{provider_name}"
+
+  pagy:
+    nav:
+      prev: ← Previous
+      next: Next →
+      gap: ...


### PR DESCRIPTION
## Ticket and context

Ticket: CST-587

## Tech review

### Is there anything that the code reviewer should know?

This is a proposed approach to migrate away from Kaminari and use Pagy instead.
The pagination is widely used in the app so I propose to do it in a few PRs instead of a big one.

This implementation changes the govuk_paginate helper to handle both Kaminari and Pagy pagination.
This way the migration can be done without breaking the retro compatibility.