### PR TITLE
Change of Circumstances: prevent challenging partnerships from admin interface

### DIFF
--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -21,10 +21,6 @@
       <%= school_cohort.lead_provider&.name %>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <% if school_cohort.lead_provider.present? %>
-        <%= govuk_link_to "Change", new_admin_school_challenge_partnership_path(id: school_cohort.cohort.start_year) %>
-        <span class="govuk-visually-hidden"> partnership</span>
-      <% end %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/spec/features/admin/schools/challenging_partnerships_spec.rb
+++ b/spec/features/admin/schools/challenging_partnerships_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
-  scenario "Admin challenges school partnership" do
+  # feature removed while the new journeys are developed
+  xscenario "Admin challenges school partnership" do
     given_there_is_a_partnered_school
     and_i_am_signed_in_as_an_admin
     when_i_visit the_school_cohorts_page


### PR DESCRIPTION
## Ticket and context

Currently it is possible to challenge a partnership from the admin interface. If we do that it "withdraws" the partnership leaving the `InductionProgramme` and `InductionRecord`s enrolled in that FIP without a provider.  New journeys to enable schools to change programme or change provider are in the pipeline, so we're removing the option to do this from the admin interface until those journeys are understood/designed/built.


## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
