### PR TITLE
[CPDLP-1170] Actions affect induction records

### DIFF
--- a/app/services/participants/resume/validate_and_change_state.rb
+++ b/app/services/participants/resume/validate_and_change_state.rb
@@ -7,7 +7,9 @@ module Participants
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:active])
           user_profile.training_status_active!
+          relevant_induction_record.update!(training_status: "active") if relevant_induction_record
         end
+
         user_profile
       end
     end

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -16,6 +16,7 @@ module Participants
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:withdrawn], reason: reason)
           user_profile.training_status_withdrawn!
+          relevant_induction_record.update!(training_status: "withdrawn") if relevant_induction_record
         end
 
         unless user_profile.npq?

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
   let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
 
   let!(:induction_record) do
-    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+    ir = Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+    ir.update!(training_status: "deferred")
+    ir
   end
 
   let!(:partnership) do
@@ -38,6 +40,10 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
   describe "#call" do
     it "updates profile training_status to active" do
       expect { subject.call }.to change { profile.reload.training_status }.from("deferred").to("active")
+    end
+
+    it "updates induction_record training_status to active" do
+      expect { subject.call }.to change { induction_record.reload.training_status }.from("deferred").to("active")
     end
 
     it "creates a ParticipantProfileState" do

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
   let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
 
   let!(:induction_record) do
-    ir = Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
-    ir.update!(training_status: "deferred")
-    ir
+    Induction::Enrol
+      .call(participant_profile: profile, induction_programme: induction_programme)
+      .tap { |ir| ir.update!(training_status: "deferred") }
   end
 
   let!(:partnership) do

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Participants::Resume::Mentor do
   let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
 
   let!(:induction_record) do
-    ir = Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
-    ir.update!(training_status: "deferred")
-    ir
+    Induction::Enrol
+      .call(participant_profile: profile, induction_programme: induction_programme)
+      .tap { |ir| ir.update!(training_status: "deferred") }
   end
 
   let!(:partnership) do

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Participants::Resume::Mentor do
   let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
 
   let!(:induction_record) do
-    Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+    ir = Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
+    ir.update!(training_status: "deferred")
+    ir
   end
 
   let!(:partnership) do
@@ -37,6 +39,10 @@ RSpec.describe Participants::Resume::Mentor do
   describe "#call" do
     it "updates profile training_status to active" do
       expect { subject.call }.to change { profile.reload.training_status }.from("deferred").to("active")
+    end
+
+    it "updates induction_record training_status to active" do
+      expect { subject.call }.to change { induction_record.reload.training_status }.from("deferred").to("active")
     end
 
     it "creates a ParticipantProfileState" do

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
       expect { subject.call }.to change { profile.reload.training_status }.from("active").to("withdrawn")
     end
 
+    it "updates induction record training_status to withdrawn" do
+      expect { subject.call }.to change { induction_record.reload.training_status }.from("active").to("withdrawn")
+    end
+
     it "creates a ParticipantProfileState" do
       expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
     end

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Participants::Withdraw::Mentor do
       expect { subject.call }.to change { profile.reload.training_status }.from("active").to("withdrawn")
     end
 
+    it "updates induction record training_status to withdrawn" do
+      expect { subject.call }.to change { induction_record.reload.training_status }.from("active").to("withdrawn")
+    end
+
     it "creates a ParticipantProfileState" do
       expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
     end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1170

- Actions defer/resume/withdraw now affect induction records if one can be found

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- n/a

## External API changes

- None