### PR TITLE
Change of Circumstances: Add job to enrol school cohorts

### DIFF
--- a/app/jobs/enrol_school_cohorts_job.rb
+++ b/app/jobs/enrol_school_cohorts_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class EnrolSchoolCohortsJob < ApplicationJob
+  def perform
+    SchoolCohort
+      .where(induction_programme_choice: InductionProgramme.training_programmes.keys)
+      .left_joins(:induction_programmes)
+      .where(induction_programmes: { id: nil })
+      .find_each do |sc|
+        choice = sc.induction_programme_choice
+        programme = InductionProgramme.new(school_cohort: sc,
+                                           training_programme: choice)
+        case choice
+        when "full_induction_programme"
+          programme.partnership = sc.school.partnerships.active.where(cohort: sc.cohort).first
+        when "core_induction_programme"
+          programme.core_induction_programme = sc.core_induction_programme
+        end
+        programme.save!
+
+        sc.ecf_participant_profiles.each do |profile|
+          induction_record = Induction::Enrol.call(participant_profile: profile, induction_programme: programme)
+          induction_record.update!(induction_status: profile.status,
+                                   training_status: profile.training_status,
+                                   mentor_profile_id: profile.mentor_profile_id)
+        end
+        sc.update!(default_induction_programme: programme)
+
+        Rails.logger.info "Added #{choice} to #{sc.school.urn}"
+      end
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -22,3 +22,7 @@ check_no_induction_participants:
   cron: "0 7 * * 1"
   class: "CheckParticipantsInductionJob"
   queue: default
+enrol_school_cohorts:
+  cron: "0 3 * * *"
+  class: "EnrolSchoolCohortsJob"
+  queue: default

--- a/spec/jobs/enrol_school_cohorts_job_spec.rb
+++ b/spec/jobs/enrol_school_cohorts_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EnrolSchoolCohortsJob do
+  describe "#perform" do
+    let(:school_cohort) { create(:school_cohort, :fip) }
+    let!(:ect) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:job_run) { described_class.new.perform }
+
+    context "when there is no induction programme" do
+      it "should add an induction programme" do
+        expect { job_run }.to change { school_cohort.induction_programmes.count }.by 1
+      end
+
+      it "should set the default induction programme" do
+        job_run
+        expect(school_cohort.reload.default_induction_programme).to be_present
+        expect(school_cohort.default_induction_programme).to eq school_cohort.induction_programmes.first
+      end
+
+      it "should enrol participants into the induction programme" do
+        job_run
+        ect.reload
+        school_cohort.reload
+        expect(ect.current_induction_programme).to eq school_cohort.default_induction_programme
+      end
+
+      context "when programme is a FIP" do
+        let!(:partnership) { create(:partnership, school: school_cohort.school, cohort: school_cohort.cohort) }
+        it "adds the partnership to the programme" do
+          job_run
+          school_cohort.reload
+          expect(school_cohort.default_induction_programme.partnership).to eq partnership
+        end
+      end
+
+      context "when programme is a CIP" do
+        let(:school_cohort) { create(:school_cohort, :cip) }
+
+        it "adds the cip materials provider to the programme" do
+          job_run
+          school_cohort.reload
+          expect(school_cohort.default_induction_programme.core_induction_programme).to eq school_cohort.core_induction_programme
+        end
+      end
+    end
+
+    context "when there is an existing induction programme" do
+      before do
+        Induction::SetCohortInductionProgramme.call(school_cohort: school_cohort,
+                                                    programme_choice: "full_induction_programme")
+      end
+
+      it "does not add an induction programme" do
+        expect { job_run }.not_to change { school_cohort.induction_programmes.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Probably only a temporary need, this job tries to ensure that any school cohort change that we've missed gets an induction programme, and the participants enrolled into that programme.

e.g. a school takes on an ECT and adds/changes their school_cohort

I've set this to run at 3am every day.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
