### PR TITLE
CPDLP-1125 Add test scenarios to ensure new LP can post declarations after transfer

### DIFF
--- a/app/services/induction/change_preferred_identity.rb
+++ b/app/services/induction/change_preferred_identity.rb
@@ -4,7 +4,7 @@ class Induction::ChangePreferredIdentity < BaseService
   def call
     # NOTE: this in not the place to change a programme or transfer a participant
     # This creates a new induction record to preserve the email address used
-    # at a point in time during indcution.
+    # at a point in time during induction.
     # We could just update the induction_record but we'd then lose that
     # ability to track it
     ActiveRecord::Base.transaction do

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -13,9 +13,9 @@ private
 
   attr_reader :participant_profile, :induction_programme, :start_date, :preferred_identity
 
-  # preferred_identity can be suppied if the participant_profile.participant_identity does not have
+  # preferred_identity can be supplied if the participant_profile.participant_identity does not have
   # the required email for the induction i.e. a participant transferring schools might have a new email
-  # address at their new school - really only useed for display in the UI
+  # address at their new school - really only used for display in the UI
   def initialize(participant_profile:, induction_programme:, start_date: nil, preferred_identity: nil)
     @participant_profile = participant_profile
     @induction_programme = induction_programme


### PR DESCRIPTION
## Ticket and context

Ticket: [1125](https://dfedigital.atlassian.net/browse/CPDLP-1125)

Updates to services/participants/ecf.rb `matches_lead_provider?` now allow LP after transfer to submit declarations - this PR adds test scenarios to demonstrate this. These tests will be extended in under separate tickets e.g. new LP not being able to post duplicate PR

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
