### PR TITLE
Add missing error summary to participant pages

### DIFF
--- a/app/views/participants/validations/check_trn_given.html.erb
+++ b/app/views/participants/validations/check_trn_given.html.erb
@@ -3,7 +3,7 @@
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: { text: "Have you been given a teacher reference number (TRN)?", tag: 'h1', size: 'l' } do %>
+      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: { text: "Have you been given a teacher reference number (TRN)?", tag: 'h1', size: 'xl' } do %>
         <p class="govuk-body">You’ll have a TRN if you hold, or are working towards qualified teacher status (QTS) in England.</p>
         <p class="govuk-body">You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
 

--- a/app/views/participants/validations/check_trn_given.html.erb
+++ b/app/views/participants/validations/check_trn_given.html.erb
@@ -1,15 +1,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Have you been given a teacher reference number (TRN)?</h1>
-
-    <p class="govuk-body">You’ll have a TRN if you hold, or are working towards qualified teacher status (QTS) in England.</p>
-    <p class="govuk-body">You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
-
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: nil do %>
-        <%= f.govuk_radio_button :check_trn_given, true, label: { text: "Yes" } %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :check_trn_given, inline: true, legend: { text: "Have you been given a teacher reference number (TRN)?", tag: 'h1', size: 'l' } do %>
+        <p class="govuk-body">You’ll have a TRN if you hold, or are working towards qualified teacher status (QTS) in England.</p>
+        <p class="govuk-body">You can usually find it on your payslip, teachers’ pension documents, or teacher training records.</p>
+
+        <%= f.govuk_radio_button :check_trn_given, true, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :check_trn_given, false, label: { text: "No" } %>
       <% end %>
+
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/participants/validations/dob.html.erb
+++ b/app/views/participants/validations/dob.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_date_field :dob,
         date_of_birth: true,
         width: "three-quarters",
-        legend: { text: title, tag: 'h1', size: 'l' },
+        legend: { text: title, tag: 'h1', size: 'xl' },
         hint: { text: "For example 14 7 1990"}
       %>
 

--- a/app/views/participants/validations/dob.html.erb
+++ b/app/views/participants/validations/dob.html.erb
@@ -4,14 +4,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_error_summary  %>
+
       <%= f.govuk_date_field :dob,
         date_of_birth: true,
         width: "three-quarters",
-        legend: { text: "Your date of birth", class: "govuk-visually-hidden" },
+        legend: { text: title, tag: 'h1', size: 'l' },
         hint: { text: "For example 14 7 1990"}
       %>
+
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/participants/validations/name.html.erb
+++ b/app/views/participants/validations/name.html.erb
@@ -6,7 +6,7 @@
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :full_name, label: { text: "What was your full name when you started your initial teacher training?", tag: 'h1', size: 'l' }, class: %w[govuk-!-width-two-thirds] %>
+      <%= f.govuk_text_field :full_name, label: { text: "What was your full name when you started your initial teacher training?", tag: 'h1', size: 'xl' }, class: %w[govuk-!-width-two-thirds] %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/participants/validations/name.html.erb
+++ b/app/views/participants/validations/name.html.erb
@@ -3,9 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">What was your full name when you started your initial teacher training?</h1>
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
-      <%= f.govuk_text_field :full_name, label: { text: "Your name", class: "govuk-visually-hidden" }, class: %w[govuk-!-width-two-thirds] %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :full_name, label: { text: "What was your full name when you started your initial teacher training?", tag: 'h1', size: 'l' }, class: %w[govuk-!-width-two-thirds] %>
+
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/participants/validations/name_changed.html.erb
+++ b/app/views/participants/validations/name_changed.html.erb
@@ -3,18 +3,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Is this the name you used when you started your initial teacher training (ITT)?</h1>
-    <div class="govuk-inset-text">
-      <p>
-        <span class="govuk-!-font-weight-bold">Name:</span>
-        <%= validation_form.participant_profile.user.full_name %>
-      </p>
-    </div>
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Is this the name you used when you started your initial teacher training (ITT)?</h1>
+      <div class="govuk-inset-text">
+        <p>
+          <span class="govuk-!-font-weight-bold">Name:</span>
+          <%= validation_form.participant_profile.user.full_name %>
+        </p>
+      </div>
+
       <%= f.govuk_radio_buttons_fieldset :name_changed, inline: true, legend: nil, hint: { text: "Answer ‘no’ if your last name has changed, or you used a different version of your first name." } do %>
-        <%= f.govuk_radio_button :name_changed, false, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :name_changed, false, label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :name_changed, true, label: { text: "No" } %>
       <% end %>
+
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/participants/validations/nino.html.erb
+++ b/app/views/participants/validations/nino.html.erb
@@ -4,13 +4,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_error_summary  %>
+
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
       <%= f.govuk_text_field :nino,
         width: "three-quarters",
         label: { text: "National Insurance Number", class: "govuk-visually-hidden" },
         hint: { text: "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."}
       %>
+
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/participants/validations/trn.html.erb
+++ b/app/views/participants/validations/trn.html.erb
@@ -3,22 +3,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= title %></h1>
-    <p class="govuk-body">This unique ID is:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>usually 7 digits long, for example ‘4567814’</li>
-      <li>may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’</li>
-      <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
-    </ul>
-
     <%= form_for validation_form, url: { action: :update }, method: :patch do |f| %>
-      <%= f.hidden_field :no_trn, value: false %>
+      <%= f.govuk_error_summary  %>
 
+      <%= f.hidden_field :no_trn, value: false %>
       <%= f.govuk_text_field :trn,
         width: "three-quarters",
-        label: { text: "Teacher reference number (TRN)", class: "govuk-visually-hidden" }
+        label: { text: "Teacher reference number (TRN)", class: "govuk-visually-hidden" },
+        hint: -> do
       %>
+        <h1 class="govuk-heading-xl"><%= title %></h1>
+        <p class="govuk-body">This unique ID is:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>usually 7 digits long, for example ‘4567814’</li>
+          <li>may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’</li>
+          <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
+        </ul>
+      <% end %>
+
       <p class="govuk-body"><%= govuk_link_to "Cannot find your TRN?", { action: :no_trn }, class: 'govuk-link--no-visit-state'  %></p>
+
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/schools/add_participants/choose_mentor.html.erb
+++ b/app/views/schools/add_participants/choose_mentor.html.erb
@@ -2,13 +2,15 @@
 
 <% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
 
-<span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
 
 <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.hidden_field :mentor_id, value: '' %>
   <%= f.govuk_radio_buttons_fieldset :mentor_id,
     legend: { text: "Who will mentor #{add_participant_form.full_name}?", tag: 'h1', size: 'xl' },
-    hint: { text: "You can tell us later if you’re not sure." } do %>
+    hint: { text: "You can tell us later if you’re not sure." },
+    caption: { text: "#{@school.name} - #{@cohort.display_name} cohort", size: 'xl' } do %>
 
     <% add_participant_form.mentor_options.each_with_index do |mentor, i| %>
       <%= f.govuk_radio_button :mentor_id, mentor.id, label: { text: mentor.full_name }, link_errors: i == 0 %>

--- a/app/views/schools/add_participants/email.html.erb
+++ b/app/views/schools/add_participants/email.html.erb
@@ -4,10 +4,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
-    <h1 class="govuk-heading-xl">What’s <%= add_participant_form.full_name %>’s email address?</h1>
 
     <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
+      <h1 class="govuk-heading-xl">What’s <%= add_participant_form.full_name %>’s email address?</h1>
+
       <%= f.govuk_text_field :email, label: { hidden: true }, width: "three-quarters", hint: { text: "You can enter their personal or school email address." } %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/add_participants/name.html.erb
+++ b/app/views/schools/add_participants/name.html.erb
@@ -4,19 +4,19 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
+    <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <% if add_participant_form.type == :ect %>
-      <h1 class="govuk-heading-xl">What’s the full name of this ECT?</h1>
-    <% else %>
-      <h1 class="govuk-heading-xl">What’s the full name of this mentor?</h1>
-    <% end %>
-
-      <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
-        <%= f.govuk_text_field :full_name, width: "three-quarters", label: { hidden: true } %>
-
-        <%= f.govuk_submit "Continue" %>
+      <span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
+      <% if add_participant_form.type == :ect %>
+        <h1 class="govuk-heading-xl">What’s the full name of this ECT?</h1>
+      <% else %>
+        <h1 class="govuk-heading-xl">What’s the full name of this mentor?</h1>
       <% end %>
-    </div>
+
+      <%= f.govuk_text_field :full_name, width: "three-quarters", label: { hidden: true } %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -4,19 +4,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
-
     <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :start_term,
-          legend: { text: add_participant_form.start_term_legend, tag: 'h1', size: 'xl' } do %>
+      <%= f.govuk_error_summary %>
 
+      <%= f.govuk_radio_buttons_fieldset :start_term,
+        legend: { text: add_participant_form.start_term_legend, tag: 'h1', size: 'xl' },
+        caption: { text: "#{@school.name} - #{@cohort.display_name} cohort", size: 'xl' } do
+      %>
         <div class="govuk-inset-text">
           You’ll be able to add Autumn 2022 starters from May.
           We’ll email schools as soon as the new term is added.
         </div>
 
-        <% ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS.each do |term| %>
-          <%= f.govuk_radio_button :start_term, term, label: { text: term.humanize } %>
+        <% ParticipantProfile::ECF::CURRENT_START_TERM_OPTIONS.each_with_index do |term, index| %>
+          <%= f.govuk_radio_button :start_term, term, label: { text: term.humanize }, link_errors: index.zero? %>
         <% end %>
       <% end %>
 

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -1,9 +1,10 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: schools_participant_path(id: @profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change <%= @profile.ect? ? "ECT’s" : "mentor’s" %> email address</h1>
     <%= form_for @profile.user, url: schools_participant_update_email_path, method: :put do |f| %>
-      <%= f.govuk_text_field :email, label: { text: "Email address" } %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :email, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} email address", tag: 'h1', size: 'l' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -4,7 +4,7 @@
     <%= form_for @profile.user, url: schools_participant_update_email_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} email address", tag: 'h1', size: 'l' } %>
+      <%= f.govuk_text_field :email, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} email address", tag: 'h1', size: 'xl' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -4,7 +4,7 @@
     <%= form_for @profile.user, url: schools_participant_update_name_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :full_name, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} name", tag: 'h1', size: 'l' } %>
+      <%= f.govuk_text_field :full_name, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} name", tag: 'h1', size: 'xl' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -1,9 +1,10 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: schools_participant_path(id: @profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Change <%= @profile.ect? ? "ECT’s" : "mentor’s" %> name</h1>
     <%= form_for @profile.user, url: schools_participant_update_name_path, method: :put do |f| %>
-      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :full_name, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} name", tag: 'h1', size: 'l' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,16 @@ en:
               blank: "Enter an email address for your teacher"
             core_induction_programme_id:
               blank: "Select the materials you want to use"
+        schools/add_participant_form:
+          attributes:
+            mentor_id:
+              blank: "Choose a mentor"
+            start_term:
+              blank: "Choose a start term"
+        participant_mentor_form:
+          attributes:
+            mentor_id:
+              blank: "Choose a mentor"
 
   page_titles:
     lead_providers:

--- a/spec/features/participants/validation_spec.rb
+++ b/spec/features/participants/validation_spec.rb
@@ -70,8 +70,8 @@ RSpec.feature "Participant validation journey", with_feature_flags: { eligibilit
     expect(page).to be_accessible
 
     page.percy_snapshot("Participant validation journey: name")
-    expect(page.find_field("Your name").value).to eq ect_participant_profile.user.full_name
-    fill_in "Your name", with: "Correct Name"
+    expect(page.find_field("participants-participant-validation-form-full-name-field").value).to eq ect_participant_profile.user.full_name
+    fill_in "participants-participant-validation-form-full-name-field", with: "Correct Name"
     click_on "Continue"
 
     expect(page).to have_current_path participants_validation_step_path(:"no-match")

--- a/spec/features/schools/participants/add_participants_spec.rb
+++ b/spec/features/schools/participants/add_participants_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe "Add participants", js: true do
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT name"
 
-    when_i_click_on_continue
-    then_i_receive_a_missing_name_error_message
+    when_i_submit_an_empty_form
+    then_i_see_an_error_message("Enter a full name")
 
     when_i_add_ect_or_mentor_name
     when_i_click_on_continue
@@ -43,8 +43,8 @@ RSpec.describe "Add participants", js: true do
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor adds ECT email"
 
-    when_i_click_on_continue
-    then_i_receive_a_missing_email_error_message
+    when_i_submit_an_empty_form
+    then_i_see_an_error_message("Enter an email address")
 
     when_i_add_ect_or_mentor_email
     when_i_click_on_continue
@@ -52,9 +52,11 @@ RSpec.describe "Add participants", js: true do
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor selects ECT start term"
 
+    when_i_submit_an_empty_form
+    then_i_see_an_error_message("Choose a start term")
+
     when_i_choose_start_term
     when_i_click_on_continue
-
     then_i_am_taken_to_check_details_page
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor checks ECT details"
@@ -89,11 +91,15 @@ RSpec.describe "Add participants", js: true do
 
     when_i_add_ect_or_mentor_email
     when_i_click_on_continue
+    then_i_am_taken_to_choose_term_page_as_mentor
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor selects mentor start term"
 
     when_i_choose_start_term
     when_i_click_on_continue
-
     then_i_am_taken_to_check_details_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor checks mentor details"
 
     when_i_click_confirm_and_add
     then_i_am_taken_to_mentor_confirmation_page
@@ -140,6 +146,8 @@ RSpec.describe "Add participants", js: true do
 
     when_i_add_ect_or_mentor_email_that_already_exists
     when_i_click_on_continue
-    then_i_receive_an_email_already_taken_error_message
+    then_i_am_taken_to_email_already_taken_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor receives the email taken page"
   end
 end

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -177,4 +177,43 @@ RSpec.describe "Update participants details", js: true do
     and_the_page_should_be_accessible
     and_percy_should_be_sent_a_snapshot_named "Participant details without change links"
   end
+
+  scenario "Induction tutor can change ECT / mentor name from participant profile page" do
+    click_on "Sally Teacher"
+    then_i_am_taken_to_participant_profile
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor sees ECT profile"
+
+    when_i_click_on_change_name
+    then_i_am_taken_to_change_ect_name_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor changes existing ECT name"
+
+    when_i_change_ect_name_to_blank
+    when_i_click_on_continue
+    then_i_see_an_error_message("Enter a full name")
+
+    when_i_change_ect_name
+    when_i_click_on_continue
+    then_i_am_taken_to_participant_profile
+    then_i_can_view_the_updated_participant_name
+  end
+
+  scenario "Induction tutor can change ECT / mentor email from participant profile page" do
+    click_on "Sally Teacher"
+    then_i_am_taken_to_participant_profile
+
+    when_i_click_on_change_email
+    then_i_am_taken_to_change_ect_email_page
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor changes existing ECT email"
+
+    when_i_change_ect_email_to_blank
+    when_i_click_on_continue
+    then_i_see_an_error_message("Enter an email")
+
+    when_i_change_ect_email
+    when_i_click_on_continue
+    then_i_am_taken_to_participant_profile
+    then_i_can_view_the_updated_participant_email
+  end
 end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -360,6 +360,10 @@ module ManageTrainingSteps
     click_on("Confirm")
   end
 
+  def when_i_submit_an_empty_form
+    when_i_click_on_continue
+  end
+
   def when_i_click_on_continue
     click_on("Continue")
   end
@@ -544,6 +548,10 @@ module ManageTrainingSteps
     expect(page).to have_text("What happens next")
   end
 
+  def then_i_am_taken_to_email_already_taken_page
+    expect(page).to have_text("This email has already been added")
+  end
+
   def then_i_am_taken_to_mentor_confirmation_page
     expect(page).to have_selector("h1", text: "#{@participant_data[:full_name]} has been added as a mentor")
     expect(page).to have_text("What happens next")
@@ -621,18 +629,6 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Materials")
     expect(page).to have_text(@cip.name)
-  end
-
-  def then_i_receive_a_missing_name_error_message
-    expect(page).to have_text("Enter a full name")
-  end
-
-  def then_i_receive_a_missing_email_error_message
-    expect(page).to have_text("Enter an email address")
-  end
-
-  def then_i_receive_an_email_already_taken_error_message
-    expect(page).to have_text("This email has already been added")
   end
 
   def then_i_am_taken_to_view_details_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -483,6 +483,22 @@ module ManageTrainingSteps
     then_i_am_taken_to_your_ect_and_mentors_page
   end
 
+  def when_i_change_ect_name
+    fill_in "Change ECT’s name", with: @updated_participant_data[:full_name]
+  end
+
+  def when_i_change_ect_name_to_blank
+    fill_in "Change ECT’s name", with: ""
+  end
+
+  def when_i_change_ect_email
+    fill_in "Change ECT’s email", with: @updated_participant_data[:email]
+  end
+
+  def when_i_change_ect_email_to_blank
+    fill_in "Change ECT’s email", with: ""
+  end
+
   # Then_steps
 
   def then_i_am_taken_to_roles_page
@@ -534,6 +550,14 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s email address?")
   end
 
+  def then_i_am_taken_to_change_ect_name_page
+    expect(page).to have_selector("h1", text: "Change ECT’s name")
+  end
+
+  def then_i_am_taken_to_change_ect_email_page
+    expect(page).to have_selector("h1", text: "Change ECT’s email")
+  end
+
   def then_i_am_taken_to_change_how_you_run_programme_page
     expect(page).to have_selector("h1", text: "Change how you run your programme")
     expect(page).to have_text("Check the other options available for your school if this changes")
@@ -580,6 +604,10 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_course_choice_page
     expect(page).to have_text("Which training materials do you want this cohort to use?")
+  end
+
+  def then_i_am_taken_to_participant_profile
+    expect(page).to have_selector("h2", text: "Participant details")
   end
 
   def then_i_can_view_the_design_our_own_induction_dashboard
@@ -629,6 +657,14 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Materials")
     expect(page).to have_text(@cip.name)
+  end
+
+  def then_i_can_view_the_updated_participant_name
+    expect(page).to have_content @updated_participant_data[:full_name]
+  end
+
+  def then_i_can_view_the_updated_participant_email
+    expect(page).to have_content @updated_participant_data[:email]
   end
 
   def then_i_am_taken_to_view_details_page

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       ect_profile = create(:ect_participant_profile, school_cohort: school_cohort)
       put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-mentor"
       expect(response).to render_template("schools/participants/edit_mentor")
-      expect(response.body).to include "Choose one"
+      expect(response.body).to include "Choose a mentor"
     end
 
     it "updates analytics" do


### PR DESCRIPTION
## Ticket and context

Ticket: N/A

Some of the participant pages are not displaying the error summary when the question forms return validation errors. 

This PR:
- adds the missing error summary
- updates some of the validation error messages to be more accessible
- adds some more Percy screenshots

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
