### PR TITLE
[CPDLP-1159] exclude participants if partnership is challenged

### DIFF
--- a/app/controllers/api/v1/test_ecf_participants_controller.rb
+++ b/app/controllers/api/v1/test_ecf_participants_controller.rb
@@ -66,12 +66,14 @@ module Api
       # this query deals with the following scenario
       # given one profile with 2 induction records
       # we only want to return the latest induction record
+      # we also exclude any partnerships that have been challenged
       def induction_record_ids_with_deduped_induction_records
         query = InductionRecord
           .joins(induction_programme: { partnership: :lead_provider })
           .joins(participant_profile: %i[user participant_identity])
           .select("DISTINCT ON (participant_profiles.id) participant_profile_id, induction_records.id")
           .where(induction_programme: { partnerships: { lead_provider: lead_provider } })
+          .where(induction_programme: { partnerships: { challenged_at: nil, challenge_reason: nil } })
           .order("participant_profiles.id", start_date: :desc)
           .to_sql
 

--- a/spec/requests/api/v1/test_ecf_participants_spec.rb
+++ b/spec/requests/api/v1/test_ecf_participants_spec.rb
@@ -217,6 +217,23 @@ RSpec.describe "Participants API", type: :request do
               expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
             end
           end
+
+          context "partnership has been challenged" do
+            let(:partnership) do
+              create(
+                :partnership,
+                lead_provider: lead_provider,
+                challenged_at: 10.days.ago,
+                challenge_reason: Partnership.challenge_reasons[:not_confirmed],
+              )
+            end
+
+            it "does not return the partipant" do
+              get "/api/v1/test_ecf_participants"
+
+              expect(parsed_response["data"].size).to be_zero
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1159

- when lead provider views participants exclude any where the partnership has been challenged

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- n/a

## External API changes

- None