### PR TITLE
[CPDLP-1164] one off rake task to resolve issues in ECF schedule start date - revert & dash fixes

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 yarn 1.22.0
 ruby 2.7.5
+nodejs 16.14.2

--- a/db/seeds/schedules/npq_aso.csv
+++ b/db/seeds/schedules/npq_aso.csv
@@ -1,20 +1,20 @@
 schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
 npq-aso-november,NPQ ASO November,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq-aso-november,NPQ ASO November,2021,Output 2 – Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq-aso-november,NPQ ASO November,2021,Output 3 – Retention Point 2,retained-2,01/11/2021,,01/11/2021
-npq-aso-november,NPQ ASO November,2021,Output 4 – Participant Completion,completed,01/11/2021,,01/11/2021
+npq-aso-november,NPQ ASO November,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
+npq-aso-november,NPQ ASO November,2021,Output 3 - Retention Point 2,retained-2,01/11/2021,,01/11/2021
+npq-aso-november,NPQ ASO November,2021,Output 4 - Participant Completion,completed,01/11/2021,,01/11/2021
 ,,,,,,
 npq-aso-december,NPQ ASO December,2021,Output 1 - Participant Start,started,01/12/2021,,01/12/2021
-npq-aso-december,NPQ ASO December,2021,Output 2 – Retention Point 1,retained-1,01/12/2021,,01/12/2021
-npq-aso-december,NPQ ASO December,2021,Output 3 – Retention Point 2,retained-2,01/12/2021,,01/12/2021
-npq-aso-december,NPQ ASO December,2021,Output 4 – Participant Completion,completed,01/12/2021,,01/12/2021
+npq-aso-december,NPQ ASO December,2021,Output 2 - Retention Point 1,retained-1,01/12/2021,,01/12/2021
+npq-aso-december,NPQ ASO December,2021,Output 3 - Retention Point 2,retained-2,01/12/2021,,01/12/2021
+npq-aso-december,NPQ ASO December,2021,Output 4 - Participant Completion,completed,01/12/2021,,01/12/2021
 ,,,,,,
 npq-aso-march,NPQ ASO March,2021,Output 1 - Participant Start,started,01/03/2022,,01/03/2022
-npq-aso-march,NPQ ASO March,2021,Output 2 – Retention Point 1,retained-1,01/03/2022,,01/03/2022
-npq-aso-march,NPQ ASO March,2021,Output 3 – Retention Point 2,retained-2,01/03/2022,,01/03/2022
-npq-aso-march,NPQ ASO March,2021,Output 4 – Participant Completion,completed,01/03/2022,,01/03/2022
+npq-aso-march,NPQ ASO March,2021,Output 2 - Retention Point 1,retained-1,01/03/2022,,01/03/2022
+npq-aso-march,NPQ ASO March,2021,Output 3 - Retention Point 2,retained-2,01/03/2022,,01/03/2022
+npq-aso-march,NPQ ASO March,2021,Output 4 - Participant Completion,completed,01/03/2022,,01/03/2022
 ,,,,,,
 npq-aso-june,NPQ ASO June,2021,Output 1 - Participant Start,started,01/06/2022,,01/06/2022
-npq-aso-june,NPQ ASO June,2021,Output 2 – Retention Point 1,retained-1,01/06/2022,,01/06/2022
-npq-aso-june,NPQ ASO June,2021,Output 3 – Retention Point 2,retained-2,01/06/2022,,01/06/2022
-npq-aso-june,NPQ ASO June,2021,Output 4 – Participant Completion,completed,01/06/2022,,01/06/2022
+npq-aso-june,NPQ ASO June,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,,01/06/2022
+npq-aso-june,NPQ ASO June,2021,Output 3 - Retention Point 2,retained-2,01/06/2022,,01/06/2022
+npq-aso-june,NPQ ASO June,2021,Output 4 - Participant Completion,completed,01/06/2022,,01/06/2022

--- a/db/seeds/schedules/npq_leadership.csv
+++ b/db/seeds/schedules/npq_leadership.csv
@@ -1,10 +1,10 @@
 schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
 npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 – Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 – Retention Point 2,retained-2,01/11/2021,,01/11/2021
-npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 – Participant Completion,completed,01/11/2021,,01/11/2021
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 3 - Retention Point 2,retained-2,01/11/2021,,01/11/2021
+npq-leadership-autumn,NPQ Leadership Autumn,2021,Output 4 - Participant Completion,completed,01/11/2021,,01/11/2021
 ,,,,,,
 npq-leadership-spring,NPQ Leadership Spring,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 – Retention Point 1,retained-1,01/01/2022,,01/01/2022
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 – Retention Point 2,retained-2,01/01/2022,,01/01/2022
-npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 – Participant Completion,completed,01/01/2022,,01/01/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 3 - Retention Point 2,retained-2,01/01/2022,,01/01/2022
+npq-leadership-spring,NPQ Leadership Spring,2021,Output 4 - Participant Completion,completed,01/01/2022,,01/01/2022

--- a/db/seeds/schedules/npq_specialist.csv
+++ b/db/seeds/schedules/npq_specialist.csv
@@ -1,8 +1,8 @@
 schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date
 npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 1 - Participant Start,started,01/11/2021,,01/11/2021
-npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 – Retention Point 1,retained-1,01/11/2021,,01/11/2021
-npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 – Participant Completion,completed,01/11/2021,,01/11/2021
+npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 2 - Retention Point 1,retained-1,01/11/2021,,01/11/2021
+npq-specialist-autumn,NPQ Specialist Autumn,2021,Output 3 - Participant Completion,completed,01/11/2021,,01/11/2021
 ,,,,,,
 npq-specialist-spring,NPQ Specialist Spring,2021,Output 1 - Participant Start,started,01/01/2022,,01/01/2022
-npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 – Retention Point 1,retained-1,01/01/2022,,01/01/2022
-npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 – Participant Completion,completed,01/01/2022,,01/01/2022
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 2 - Retention Point 1,retained-1,01/01/2022,,01/01/2022
+npq-specialist-spring,NPQ Specialist Spring,2021,Output 3 - Participant Completion,completed,01/01/2022,,01/01/2022

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -29,32 +29,4 @@ namespace :one_offs do
       end
     end
   end
-
-  desc "Resolve issues in ECF hard schedule reference data - CPDLP-1164"
-  task resolve_issues_in_ecf_schedule_start_date: :environment do
-    changes = {
-      "ecf-standard-january" => {
-        "Output 6 - Participant Completion" => "2023-05-01", # from: 1 February 2023
-      },
-      "ecf-standard-april" => {
-        "Output 1 - Participant Start" => "2022-02-01", # from: 1 March 2022
-        "Output 2 - Retention Point 1" => "2022-05-01", # from: 1 June 2022
-        "Output 3 - Retention Point 2" => "2022-10-01", # from: 1 November 2022
-        "Output 4 - Retention Point 3" => "2023-02-01", # from: 1 March 2023
-        "Output 5 - Retention Point 4" => "2023-05-01", # from: 1 June 2023
-        "Output 6 - Participant Completion" => "2023-11-01", # from: 1 December 2023
-      },
-    }
-
-    changes.each do |schedule_identifier, milestone_changes|
-      Finance::Schedule.where(schedule_identifier: schedule_identifier).find_each do |schedule|
-        puts "Schedule: #{schedule_identifier}"
-        milestone_changes.each do |name, start_date|
-          milestone = schedule.milestones.where(name: name).first
-          puts "Milestone change: #{milestone.start_date.iso8601} to #{start_date}"
-          milestone.update!(start_date: start_date)
-        end
-      end
-    end
-  end
 end

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -6,11 +6,11 @@ FactoryBot.define do
       after(:create) do |schedule|
         [
           { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 11, 30), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
-          { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
-          { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
-          { name: "Output 4 – Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
-          { name: "Output 5 – Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
-          { name: "Output 6 – Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
+          { name: "Output 2 - Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
+          { name: "Output 3 - Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
+          { name: "Output 4 - Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
+          { name: "Output 5 - Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
+          { name: "Output 6 - Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
         ].each do |hash|
           Finance::Milestone.find_or_create_by!(
             schedule: schedule,
@@ -27,9 +27,9 @@ FactoryBot.define do
       after(:create) do |schedule|
         [
           { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
-          { name: "Output 2 – Retention Point 1", start_date: Date.new(2021, 11, 1), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
-          { name: "Output 3 – Retention Point 2", start_date: Date.new(2022, 2, 1), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
-          { name: "Output 4 – Participant Completion", start_date: Date.new(2023, 2, 1), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
+          { name: "Output 2 - Retention Point 1", start_date: Date.new(2021, 11, 1), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
+          { name: "Output 3 - Retention Point 2", start_date: Date.new(2022, 2, 1), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
+          { name: "Output 4 - Participant Completion", start_date: Date.new(2023, 2, 1), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
         ].each do |hash|
           Finance::Milestone.find_or_create_by!(
             schedule: schedule,


### PR DESCRIPTION
## Ticket and context

Ticket:
https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1164

## Tech review

* Reverted commit for rake task `one_offs:resolve_issues_in_ecf_schedule_start_date` : https://github.com/DFE-Digital/early-careers-framework/pull/1921
* Updated seed files and spec factory to replace long dash (–) with normal dash (-)

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
