### PR TITLE
CPDLP-1122 ensure providers cant see future declarations

### DIFF
--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -149,22 +149,35 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
       end
 
       context "when the participant transfers to a new school with a different lead provider" do
-        let(:programme) { create(:induction_programme, :fip) }
-        let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: programme.partnership.lead_provider.cpd_lead_provider) }
-        let(:bearer_token) { "Bearer #{token}" }
+        let(:new_programme) { create(:induction_programme, :fip) }
+        let(:transfer_lp_token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: new_programme.partnership.lead_provider.cpd_lead_provider) }
+        let(:transfer_lp_bearer_token) { "Bearer #{transfer_lp_token}" }
 
         before do
           induction_record.leaving!(ect_profile.schedule.milestones.first.start_date + 1)
-          Induction::Enrol.call(participant_profile: ect_profile, induction_programme: programme, start_date: ect_profile.schedule.milestones.first.start_date + 1)
-
-          default_headers[:Authorization] = bearer_token
+          Induction::Enrol.call(participant_profile: ect_profile, induction_programme: new_programme, start_date: ect_profile.schedule.milestones.first.start_date + 1)
         end
 
         it "is possible for new lead provider to post a declaration" do
+          default_headers[:Authorization] = transfer_lp_bearer_token
+
           updated_params = valid_params.merge({ declaration_date: (ect_profile.schedule.milestones.first.start_date + 2).rfc3339 })
           post "/api/v1/participant-declarations", params: build_params(updated_params)
 
           expect(response.status).to eq 200
+        end
+
+        it "is it not possible for previous lead provider to view new lead providers declaration " do
+          default_headers[:Authorization] = transfer_lp_bearer_token
+
+          updated_params = valid_params.merge({ declaration_date: (ect_profile.schedule.milestones.first.start_date + 2).rfc3339 })
+          post "/api/v1/participant-declarations", params: build_params(updated_params)
+
+          expect(response.status).to eq 200
+
+          default_headers[:Authorization] = bearer_token
+          expect { get "/api/v1/participant-declarations/#{ect_profile.participant_declarations.first.id}" }
+            .to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
           expect(response.status).to eq 200
         end
 
-        it "is it not possible for previous lead provider to view new lead providers declaration " do
+        it "is not possible for previous lead provider to view future declarations" do
           default_headers[:Authorization] = transfer_lp_bearer_token
 
           updated_params = valid_params.merge({ declaration_date: (ect_profile.schedule.milestones.first.start_date + 2).rfc3339 })


### PR DESCRIPTION
## Ticket and context

Test scenario to ensure providers can't see future declarations once a participant has transferred 

Ticket: [1122 ](https://dfedigital.atlassian.net/browse/CPDLP-1122)

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
