### PR TITLE
10 nodes for scenarios

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -19,6 +19,11 @@ jobs:
     name: Run rspec
     runs-on: ubuntu-20.04
     needs: create-nonce
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [10]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     env:
       RAILS_ENV: test
@@ -30,6 +35,8 @@ jobs:
       ANALYTICS_DB_PASSWORD: ''
       ANALYTICS_DB_HOSTNAME: 127.0.0.1
       ANALYTICS_DB_PORT: 5432
+      CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+      CI_NODE_INDEX: ${{ matrix.ci_node_index }}
 
     services:
       postgres:
@@ -62,6 +69,9 @@ jobs:
 
       - name: Set up test database
         run: bin/rails db:create db:schema:load
+
+      - name: Webpacker
+        run: bin/webpacker
 
       - name: Run tests
         run: bundle exec bin/scenarios_ci

--- a/bin/rspec_ci
+++ b/bin/rspec_ci
@@ -1,12 +1,14 @@
 #!/usr/bin/env ruby
 
+ci_node_total = ENV["CI_NODE_TOTAL"] || "1"
+ci_node_index = ENV["CI_NODE_INDEX"] || "0"
+github_sha = ENV['GITHUB_SHA'] || "fake-sha-123"
+
 tests = Dir["spec/**/*_spec.rb"].
   sort.
   # Add randomization seed based on SHA of each commit
-  shuffle(random: Random.new(ENV['GITHUB_SHA'].to_i(16))).
+  shuffle(random: Random.new(github_sha.to_i(16))).
   select.
-  with_index do |el, i|
-    i % ENV["CI_NODE_TOTAL"].to_i == ENV["CI_NODE_INDEX"].to_i
-  end
+  with_index { |el, i| i % ci_node_total.to_i == ci_node_index.to_i }
 
 exec "bundle exec rspec #{tests.join(" ")} --format documentation --profile"

--- a/bin/scenarios_ci
+++ b/bin/scenarios_ci
@@ -1,3 +1,9 @@
 #!/usr/bin/env ruby
 
-exec "bundle exec rspec --tag end_to_end_scenario --format documentation --order read"
+ci_node_total = ENV["CI_NODE_TOTAL"] || "1"
+ci_node_index = ENV["CI_NODE_INDEX"] || "0"
+
+scenario_numbers = (1..99).to_a
+                     .select { | num | num % ci_node_total.to_i == ci_node_index.to_i }
+
+exec "SCENARIOS=#{scenario_numbers.join(",")} bundle exec rspec --tag end_to_end_scenario --format documentation --order read"


### PR DESCRIPTION
Sets up scenario test action to run in parallel on 10 nodes, also adds default values to `rspec_ci` so it can be used to run locally without setting env vars.