### PR TITLE
[CPDLP-1221] Infer participant#status from induction record

### DIFF
--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -77,7 +77,12 @@ module Api
       end
 
       attribute :status do |induction_record|
-        induction_record.participant_profile.status
+        case induction_record.induction_status
+        when "active", "completed", "leaving"
+          "active"
+        when "withdrawn", "changed"
+          "withdrawn"
+        end
       end
 
       attribute :teacher_reference_number do |induction_record|

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Participants API", type: :request do
     create(:ect_participant_profile, :withdrawn_record, school_cohort: school_cohort)
       .tap do |profile|
         Induction::Enrol.call(participant_profile: profile, induction_programme: induction_programme)
-          .tap { |induction_record| induction_record.update!(training_status: "withdrawn") }
+          .tap { |induction_record| induction_record.update!(training_status: "withdrawn", induction_status: "withdrawn") }
       end
   end
 

--- a/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  module V1
+    RSpec.describe ParticipantFromInductionRecordSerializer do
+      let(:induction_record) { create(:induction_record) }
+
+      subject { described_class.new(induction_record) }
+
+      describe "status" do
+        context "when active" do
+          it "returns active" do
+            expect(subject.serializable_hash[:data][:attributes][:status]).to eql("active")
+          end
+        end
+
+        context "when completed" do
+          let(:induction_record) { create(:induction_record, induction_status: "completed") }
+
+          it "returns active" do
+            expect(subject.serializable_hash[:data][:attributes][:status]).to eql("active")
+          end
+        end
+
+        context "when leaving" do
+          let(:induction_record) { create(:induction_record, induction_status: "leaving") }
+
+          it "returns active" do
+            expect(subject.serializable_hash[:data][:attributes][:status]).to eql("active")
+          end
+        end
+
+        context "when withdrawn" do
+          let(:induction_record) { create(:induction_record, induction_status: "withdrawn") }
+
+          it "returns withdrawn" do
+            expect(subject.serializable_hash[:data][:attributes][:status]).to eql("withdrawn")
+          end
+        end
+
+        context "when changed" do
+          let(:induction_record) { create(:induction_record, induction_status: "changed") }
+
+          it "returns withdrawn" do
+            expect(subject.serializable_hash[:data][:attributes][:status]).to eql("withdrawn")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1221

- `InductionRecord#status` has been deprecated
- We now figure out a participant status from the `InductionRecord#induction_status`
- Everything tallies up in prod so there should be no data issues:
```
InductionRecord.joins(:participant_profile).where("participant_profiles.status != induction_records.induction_status").count
=> 0
```

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Find a user and fetch via api
- Change their induction status via backend
- Fetch from API again
- Should see different status

## External API changes

- Changes are transparent