### PR TITLE
Remove "status" column from InductionRecord

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -3,6 +3,8 @@
 class InductionRecord < ApplicationRecord
   has_paper_trail
 
+  self.ignored_columns = %w[status]
+
   belongs_to :induction_programme
   belongs_to :participant_profile, class_name: "ParticipantProfile::ECF"
   belongs_to :schedule, class_name: "Finance::Schedule"

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -5,7 +5,7 @@ class Induction::Enrol < BaseService
     participant_profile.induction_records.create!(
       induction_programme: induction_programme,
       start_date: start_date,
-      status: :active,
+      induction_status: :active,
       schedule: participant_profile.schedule,
       preferred_identity: preferred_identity,
       mentor_profile: mentor_profile,

--- a/db/migrate/20220413092522_remove_status_from_induction_record.rb
+++ b/db/migrate/20220413092522_remove_status_from_induction_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveStatusFromInductionRecord < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :induction_records, :status, :string, null: false, default: "active", index: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_11_143508) do
+ActiveRecord::Schema.define(version: 2022_04_13_092522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -360,7 +360,6 @@ ActiveRecord::Schema.define(version: 2022_04_11_143508) do
     t.uuid "induction_programme_id", null: false
     t.uuid "participant_profile_id", null: false
     t.uuid "schedule_id", null: false
-    t.string "status", default: "active", null: false
     t.datetime "start_date", null: false
     t.datetime "end_date"
     t.datetime "created_at", precision: 6, null: false
@@ -374,7 +373,6 @@ ActiveRecord::Schema.define(version: 2022_04_11_143508) do
     t.index ["participant_profile_id"], name: "index_induction_records_on_participant_profile_id"
     t.index ["preferred_identity_id"], name: "index_induction_records_on_preferred_identity_id"
     t.index ["schedule_id"], name: "index_induction_records_on_schedule_id"
-    t.index ["status"], name: "index_induction_records_on_status"
   end
 
   create_table "lead_provider_cips", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/services/induction/change_preferred_email_spec.rb
+++ b/spec/services/induction/change_preferred_email_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Induction::ChangePreferredEmail do
     let(:school_cohort) { create :school_cohort }
     let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
     let(:participant_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
-    let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: participant_profile, status: :active, start_date: 6.months.ago) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme: induction_programme, participant_profile: participant_profile, start_date: 6.months.ago) }
     let!(:new_email) { "example.id2@example.com" }
 
     subject(:service) { described_class }

--- a/spec/services/induction/change_programme_spec.rb
+++ b/spec/services/induction/change_programme_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Induction::ChangeProgramme do
     let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
     let(:new_induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
     let(:participant_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
-    let!(:induction_record) { create(:induction_record, induction_programme: induction_programme, participant_profile: participant_profile, status: :active, start_date: 6.months.ago) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme: induction_programme, participant_profile: participant_profile, start_date: 6.months.ago) }
     let(:action_date) { Time.zone.now }
     let(:mentor_profile) { create(:mentor_participant_profile) }
 

--- a/spec/services/set_participant_categories_spec.rb
+++ b/spec/services/set_participant_categories_spec.rb
@@ -172,7 +172,9 @@ RSpec.describe SetParticipantCategories do
       context "change_of_circumstances feature flag active" do
         before do
           FeatureFlag.activate(:change_of_circumstances)
-          ParticipantProfile::ECF.all.each { |participant_profile| create(:induction_record, induction_programme: induction_programme, participant_profile: participant_profile, status: "active") }
+          ParticipantProfile::ECF.all.each do |participant_profile|
+            Induction::Enrol.call(induction_programme: induction_programme, participant_profile: participant_profile)
+          end
 
           transferring_in_participant.induction_records.first.update!(start_date: 2.weeks.from_now)
           transferring_out_participant.induction_records.first.leaving!(6.weeks.from_now)


### PR DESCRIPTION
## Ticket and context

We previously added `induction_status` to `InductionRecord` to provide a better named replacement for `status`.
This PR now removes `status` from `InductionRecord`

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
