### PR TITLE
[CST-583] Update the lead provider dashboard to report partnerships for the new cohort

### DIFF
--- a/app/components/subnav_component/nav_item_component.html.erb
+++ b/app/components/subnav_component/nav_item_component.html.erb
@@ -1,4 +1,4 @@
-<li class="app-subnav__list-item<%= current_page?(path) ? " app-subnav__list-item--selected" : "" %>">
+<li class="app-subnav__list-item<%= current_page?(path, check_parameters: true) ? " app-subnav__list-item--selected" : "" %>">
   <%= govuk_link_to path, class: "app-subnav__link govuk-link--no-visited-state", "aria-current" => (current_page?(path) ? "page" : nil) do %>
     <%= content %> <%= "<span class='govuk-visually-hidden'>Current page</span>".html_safe if current_page?(path) %>
   <% end %>

--- a/app/controllers/lead_providers/partnerships_controller.rb
+++ b/app/controllers/lead_providers/partnerships_controller.rb
@@ -2,10 +2,12 @@
 
 module LeadProviders
   class PartnershipsController < ::LeadProviders::BaseController
+    before_action :set_lead_provider
+
     def show
       @partnership = Partnership
         .includes(:cohort, :delivery_partner, :school)
-        .where(lead_provider: current_user.lead_provider)
+        .where(lead_provider: @lead_provider)
         .find(params[:id])
       @school = @partnership.school
       @selected_cohort = @partnership.cohort
@@ -13,12 +15,21 @@ module LeadProviders
     end
 
     def active
-      @schools = current_user.lead_provider.active_partnerships.includes(:school, :delivery_partner)
+      @selected_cohort = params[:cohort] ? @lead_provider.cohorts.find_by(start_year: params[:cohort]) : Cohort.current
+
+      @schools = @lead_provider.active_partnerships.where(cohort: @selected_cohort).includes(:school, :delivery_partner)
+
       respond_to do |format|
         format.csv do
-          render body: Api::V1::PartnershipCsvSerializer.new(@schools).call
+          send_data Api::V1::PartnershipCsvSerializer.new(@schools).call, filename: "schools-#{@selected_cohort.start_year}.csv"
         end
       end
+    end
+
+  private
+
+    def set_lead_provider
+      @lead_provider = current_user.lead_provider
     end
   end
 end

--- a/app/controllers/lead_providers/report_schools/base_controller.rb
+++ b/app/controllers/lead_providers/report_schools/base_controller.rb
@@ -13,11 +13,7 @@ module LeadProviders
       def start
         clean_form!
 
-        report_schools_form.cohort_id = if FeatureFlag.active?(:multiple_cohorts)
-                                          Cohort.next.id
-                                        else
-                                          Cohort.current.id
-                                        end
+        report_schools_form.cohort_id = Cohort.next.id
         report_schools_form.lead_provider_id = current_user.lead_provider_profile.lead_provider.id
       end
 

--- a/app/controllers/lead_providers/report_schools/base_controller.rb
+++ b/app/controllers/lead_providers/report_schools/base_controller.rb
@@ -13,7 +13,7 @@ module LeadProviders
       def start
         clean_form!
 
-        report_schools_form.cohort_id = Cohort.current.id
+        report_schools_form.cohort_id = Cohort.next.id
         report_schools_form.lead_provider_id = current_user.lead_provider_profile.lead_provider.id
       end
 

--- a/app/controllers/lead_providers/report_schools/base_controller.rb
+++ b/app/controllers/lead_providers/report_schools/base_controller.rb
@@ -13,7 +13,11 @@ module LeadProviders
       def start
         clean_form!
 
-        report_schools_form.cohort_id = Cohort.next.id
+        report_schools_form.cohort_id = if FeatureFlag.active?(:multiple_cohorts)
+                                          Cohort.next.id
+                                        else
+                                          Cohort.current.id
+                                        end
         report_schools_form.lead_provider_id = current_user.lead_provider_profile.lead_provider.id
       end
 

--- a/app/controllers/lead_providers/your_schools_controller.rb
+++ b/app/controllers/lead_providers/your_schools_controller.rb
@@ -12,11 +12,14 @@ module LeadProviders
         redirect_to cohort: params[:selected_cohort_id]
         return
       end
-
-      # The search component only submits the query string, so the search will always
-      # run against the current cohort schools if the selected cohort is not persisted.
-      session[:selected_cohort] = params[:cohort] if params[:cohort]
-      @selected_cohort = session[:selected_cohort] ? @cohorts.find_by(start_year: session[:selected_cohort]) : Cohort.current
+      if FeatureFlag.active?(:multiple_cohorts)
+        # The search component only submits the query string, so the search will always
+        # run against the current cohort schools if the selected cohort is not persisted.
+        session[:selected_cohort] = params[:cohort] if params[:cohort]
+        @selected_cohort = session[:selected_cohort] ? @cohorts.find_by(start_year: session[:selected_cohort]) : Cohort.current
+      else
+        @selected_cohort = Cohort.current
+      end
 
       @partnerships = Partnership
         .includes(:delivery_partner, :cohort, :school)

--- a/app/controllers/lead_providers/your_schools_controller.rb
+++ b/app/controllers/lead_providers/your_schools_controller.rb
@@ -13,7 +13,10 @@ module LeadProviders
         return
       end
 
-      @selected_cohort = params[:cohort] ? @cohorts.find_by(start_year: params[:cohort]) : Cohort.current
+      # The search component only submits the query string, so the search will always
+      # run against the current cohort schools if the selected cohort is not persisted.
+      session[:selected_cohort] = params[:cohort] if params[:cohort]
+      @selected_cohort = session[:selected_cohort] ? @cohorts.find_by(start_year: session[:selected_cohort]) : Cohort.current
 
       @partnerships = Partnership
         .includes(:delivery_partner, :cohort, :school)

--- a/app/controllers/lead_providers/your_schools_controller.rb
+++ b/app/controllers/lead_providers/your_schools_controller.rb
@@ -5,7 +5,7 @@ module LeadProviders
     before_action :set_lead_provider
 
     def index
-      @cohorts ||= @lead_provider.cohorts
+      @cohorts ||= @lead_provider.cohorts.order(start_year: :desc)
 
       # Don't break old URLs
       if params[:selected_cohort_id]

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -13,7 +13,9 @@ class Cohort < ApplicationRecord
   end
 
   def self.next
-    find_by(start_year: 2022)
+    year = FeatureFlag.active?(:multiple_cohorts) ? 2022 : 2021
+
+    find_by(start_year: year)
   end
 
   def display_name

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -12,6 +12,10 @@ class Cohort < ApplicationRecord
     find_by(start_year: 2021)
   end
 
+  def self.next
+    find_by(start_year: 2022)
+  end
+
   def display_name
     start_year.to_s
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,6 +19,7 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = %i[
     eligibility_notifications
     change_of_circumstances
+    multiple_cohorts
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/views/dashboard/_navigation.html.erb
+++ b/app/views/dashboard/_navigation.html.erb
@@ -3,8 +3,14 @@
     <%= component.nav_item(path: dashboard_path) do %>
       Overview
     <% end %>
-    <%= component.nav_item(path: lead_providers_your_schools_path(cohort: Cohort.next)) do %>
-      Schools
+    <% if FeatureFlag.active?(:multiple_cohorts) %>
+      <%= component.nav_item(path: lead_providers_your_schools_path(cohort: Cohort.next)) do %>
+        Schools
+      <% end %>
+    <% else %>
+      <%= component.nav_item(path: lead_providers_your_schools_path) do %>
+        Schools
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/dashboard/_navigation.html.erb
+++ b/app/views/dashboard/_navigation.html.erb
@@ -3,14 +3,9 @@
     <%= component.nav_item(path: dashboard_path) do %>
       Overview
     <% end %>
-    <% if FeatureFlag.active?(:multiple_cohorts) %>
-      <%= component.nav_item(path: lead_providers_your_schools_path(cohort: Cohort.next)) do %>
-        Schools
-      <% end %>
-    <% else %>
-      <%= component.nav_item(path: lead_providers_your_schools_path) do %>
-        Schools
-      <% end %>
+
+    <%= component.nav_item(path: lead_providers_your_schools_path(cohort: Cohort.next)) do %>
+      Schools
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/dashboard/_navigation.html.erb
+++ b/app/views/dashboard/_navigation.html.erb
@@ -3,7 +3,7 @@
     <%= component.nav_item(path: dashboard_path) do %>
       Overview
     <% end %>
-    <%= component.nav_item(path: lead_providers_your_schools_path) do %>
+    <%= component.nav_item(path: lead_providers_your_schools_path(cohort: Cohort.next)) do %>
       Schools
     <% end %>
   <% end %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -9,7 +9,7 @@
         </h2>
         <p>Choose a delivery partner and upload schools using a CSV.</p>
         <h2 class="govuk-heading-m">
-          <%= govuk_link_to "Check your schools for #{Cohort.current.display_name}", lead_providers_your_schools_path %>
+          <%= govuk_link_to "Check your schools", lead_providers_your_schools_path(cohort: Cohort.next) %>
         </h2>
         <p>See which schools have added their early career teachers and mentors.</p>
       </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -9,11 +9,7 @@
         </h2>
         <p>Choose a delivery partner and upload schools using a CSV.</p>
         <h2 class="govuk-heading-m">
-          <% if FeatureFlag.active?(:multiple_cohorts) %>
-            <%= govuk_link_to "Check your schools", lead_providers_your_schools_path(cohort: Cohort.next) %>
-          <% else %>
-            <%= govuk_link_to "Check your schools for #{Cohort.current.display_name}", lead_providers_your_schools_path %>
-          <% end %>
+          <%= govuk_link_to "Check your schools", lead_providers_your_schools_path(cohort: Cohort.next) %>
         </h2>
         <p>See which schools have added their early career teachers and mentors.</p>
       </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -9,7 +9,11 @@
         </h2>
         <p>Choose a delivery partner and upload schools using a CSV.</p>
         <h2 class="govuk-heading-m">
-          <%= govuk_link_to "Check your schools", lead_providers_your_schools_path(cohort: Cohort.next) %>
+          <% if FeatureFlag.active?(:multiple_cohorts) %>
+            <%= govuk_link_to "Check your schools", lead_providers_your_schools_path(cohort: Cohort.next) %>
+          <% else %>
+            <%= govuk_link_to "Check your schools for #{Cohort.current.display_name}", lead_providers_your_schools_path %>
+          <% end %>
         </h2>
         <p>See which schools have added their early career teachers and mentors.</p>
       </div>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -15,7 +15,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Your schools</h1>
     <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path if @selected_cohort == Cohort.next %>
-    <%= govuk_button_link_to "Download schools for #{@selected_cohort.display_name}", active_lead_providers_partnerships_path(cohort: @selected_cohort, format: :csv) %>
+    <%= govuk_button_link_to "Download schools for #{@selected_cohort&.display_name}", active_lead_providers_partnerships_path(cohort: @selected_cohort, format: :csv) if @total_provider_schools.positive? %>
   </div>
 </div>
 

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -26,7 +26,7 @@
 <% if FeatureFlag.active?(:multiple_cohorts) %>
   <% if @cohorts.length > 1 %>
     <%= render SubnavComponent.new do |component| %>
-      <% @cohorts.reverse.each do |cohort| %>
+      <% @cohorts.each do |cohort| %>
         <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort)) do %>
           <%= cohort.start_year %> cohort
         <% end %>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -15,7 +15,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Your schools</h1>
     <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path %>
-    <%= govuk_button_link_to "Download schools for #{Cohort.current.display_name}", active_lead_providers_partnerships_path(format: :csv) %>
+    <%= govuk_button_link_to "Download schools for #{@selected_cohort.display_name}", active_lead_providers_partnerships_path(cohort: @selected_cohort, format: :csv) %>
   </div>
 </div>
 
@@ -40,7 +40,7 @@
 </div>
 
 <% if @total_provider_schools.positive? %>
-  <%= render SearchBox.new(query: params[:query], title: "Search schools in the #{@selected_cohort.display_name} cohort") %>
+  <%= render SearchBox.new(query: params[:query], title: "Search schools in the #{@selected_cohort&.display_name} cohort") %>
 
   <% if @partnerships.count.zero? %>
     <h2 class="govuk-heading-s govuk-!-margin-top-4">There are no matching results</h2>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -14,16 +14,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Your schools</h1>
-    <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path if @selected_cohort == Cohort.next %>
+    <% if FeatureFlag.active?(:multiple_cohorts) %>
+      <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path if @selected_cohort == Cohort.next %>
+    <% else %>
+      <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path %>
+    <% end %>
     <%= govuk_button_link_to "Download schools for #{@selected_cohort&.display_name}", active_lead_providers_partnerships_path(cohort: @selected_cohort, format: :csv) if @total_provider_schools.positive? %>
   </div>
 </div>
 
-<% if @cohorts.length > 1 %>
-  <%= render SubnavComponent.new do |component| %>
-    <% @cohorts.reverse.each do |cohort| %>
-      <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort)) do %>
-        <%= cohort.start_year %> cohort
+<% if FeatureFlag.active?(:multiple_cohorts) %>
+  <% if @cohorts.length > 1 %>
+    <%= render SubnavComponent.new do |component| %>
+      <% @cohorts.reverse.each do |cohort| %>
+        <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort)) do %>
+          <%= cohort.start_year %> cohort
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -22,8 +22,7 @@
 <% if @cohorts.length > 1 %>
   <%= render SubnavComponent.new do |component| %>
     <% @cohorts.reverse.each do |cohort| %>
-      <%# Use a query param to access cohorts other than the current one %>
-      <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort == Cohort.current ? nil : cohort)) do %>
+      <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort)) do %>
         <%= cohort.start_year %> cohort
       <% end %>
     <% end %>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -14,7 +14,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Your schools</h1>
-    <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path %>
+    <%= govuk_button_link_to "Confirm more schools", lead_providers_report_schools_start_path if @selected_cohort == Cohort.next %>
     <%= govuk_button_link_to "Download schools for #{@selected_cohort.display_name}", active_lead_providers_partnerships_path(cohort: @selected_cohort, format: :csv) %>
   </div>
 </div>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -21,7 +21,7 @@
 
 <% if @cohorts.length > 1 %>
   <%= render SubnavComponent.new do |component| %>
-    <% @cohorts.each do |cohort| %>
+    <% @cohorts.reverse.each do |cohort| %>
       <%# Use a query param to access cohorts other than the current one %>
       <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort == Cohort.current ? nil : cohort)) do %>
         <%= cohort.start_year %> cohort

--- a/db/seeds/initial_seed.rb
+++ b/db/seeds/initial_seed.rb
@@ -2,6 +2,7 @@
 
 Cohort.find_or_create_by!(start_year: 2020)
 cohort_2021 = Cohort.find_or_create_by!(start_year: 2021)
+cohort_2022 = Cohort.find_or_create_by!(start_year: 2022)
 
 ambition_cip = CoreInductionProgramme.find_or_create_by!(name: "Ambition Institute")
 edt_cip = CoreInductionProgramme.find_or_create_by!(name: "Education Development Trust")
@@ -17,7 +18,7 @@ ucl_cip = CoreInductionProgramme.find_or_create_by!(name: "UCL Institute of Educ
   { provider_name: "UCL Institute of Education", cip: ucl_cip },
 ].each do |seed|
   provider = LeadProvider.find_or_create_by!(name: seed[:provider_name])
-  provider.update!(cohorts: [cohort_2021]) unless provider.cohorts.any?
+  provider.update!(cohorts: [cohort_2021, cohort_2022]) unless provider.cohorts.any?
   LeadProviderCip.find_or_create_by!(lead_provider: provider, cohort: cohort_2021, core_induction_programme: seed[:cip])
 end
 

--- a/spec/cypress/integration/Dashboard.feature
+++ b/spec/cypress/integration/Dashboard.feature
@@ -1,6 +1,8 @@
 Feature: Dashboard page
   Background:
     Given cohort was created with start_year "2021"
+    And cohort was created with start_year "2022"
+
   Scenario: Visiting the dashboard
     Given I am logged in as a "lead_provider"
     Then I should be on "dashboard" page

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -1,6 +1,7 @@
 Feature: Report Schools flow
   Background:
     Given cohort was created with start_year "2021"
+    And cohort was created with start_year "2022"
     And I am logged in as a "lead_provider"
     And scenario "lead_provider_with_delivery_partners" has been run
 
@@ -8,7 +9,7 @@ Feature: Report Schools flow
     Given I am on "dashboard" page
     When I click on "link" containing "Confirm your schools"
     Then I should be on "lead providers report schools start" page
-    And "page body" should contain "2021"
+    And "page body" should contain "2022"
     And the page should be accessible
     And percy should be sent snapshot called "Lead provider report schools start page"
 

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -3,6 +3,7 @@ Feature: Report Schools flow
     Given cohort was created with start_year "2021"
     And cohort was created with start_year "2022"
     And I am logged in as a "lead_provider"
+    And feature multiple_cohorts is active
     And scenario "lead_provider_with_delivery_partners" has been run
 
   Scenario: Visiting the start page

--- a/spec/cypress/integration/lead_providers/YourSchools.feature
+++ b/spec/cypress/integration/lead_providers/YourSchools.feature
@@ -3,6 +3,7 @@ Feature: Your schools flow
     Given cohort was created with start_year "2021"
     And cohort was created with start_year "2022"
     And I am logged in as a "lead_provider"
+    And feature multiple_cohorts is active
     And scenario "lead_provider_with_schools" has been run
     And I am on "lead providers your schools" page
 
@@ -23,7 +24,7 @@ Feature: Your schools flow
     And I click on "link" containing "Check your schools"
     Then "page body" should contain "Your schools"
     And "page body" should contain "Confirm more schools"
-    And "page body" should contain "Download schools for 2022"
+    And "page body" should not contain "Download schools for 2022"
     And "schools table" should not exist
 
   Scenario: Searching my list of schools

--- a/spec/cypress/integration/lead_providers/YourSchools.feature
+++ b/spec/cypress/integration/lead_providers/YourSchools.feature
@@ -1,20 +1,30 @@
 Feature: Your schools flow
   Background:
     Given cohort was created with start_year "2021"
+    And cohort was created with start_year "2022"
     And I am logged in as a "lead_provider"
     And scenario "lead_provider_with_schools" has been run
     And I am on "lead providers your schools" page
 
   Scenario: Viewing my schools
     Then "page body" should contain "Your schools"
-    Then "page body" should contain "Confirm more schools"
-    Then "page body" should contain "Download schools for 2021"
+    And "page body" should not contain "Confirm more schools"
+    And "page body" should contain "2022 cohort"
+    And "page body" should contain "2021 cohort"
+    And "page body" should contain "Download schools for 2021"
     And the table should have 3 rows
     And "page body" should contain "Big School"
     And "page body" should contain "Middle School"
     And "page body" should contain "Small School"
     And the page should be accessible
     And percy should be sent snapshot
+
+    When I am on "dashboard" page
+    And I click on "link" containing "Check your schools"
+    Then "page body" should contain "Your schools"
+    And "page body" should contain "Confirm more schools"
+    And "page body" should contain "Download schools for 2022"
+    And "schools table" should not exist
 
   Scenario: Searching my list of schools
     When I type "900002" into "search box"

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :current do
       start_year { 2021 }
     end
+
+    trait :next do
+      start_year { 2022 }
+    end
   end
 end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Cohort, type: :model do
     end
   end
 
+  describe ".next" do
+    it "returns the 2022 cohort" do
+      cohort_2022 = Cohort.create!(start_year: 2022)
+
+      expect(Cohort.next).to eq cohort_2022
+    end
+  end
+
   describe "display_name" do
     it "displays the correct year" do
       expect(Cohort.new(start_year: 2021).display_name).to eq "2021"

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Cohort, type: :model do
+  let!(:cohort_2021) { Cohort.create!(start_year: 2021) }
+  let!(:cohort_2022) { Cohort.create!(start_year: 2022) }
+
   describe "#schedules" do
     subject { described_class.create!(start_year: 3000) }
 
@@ -13,25 +16,27 @@ RSpec.describe Cohort, type: :model do
     end
   end
 
-  it "can be created" do
-    expect {
-      Cohort.create(start_year: 2021)
-    }.to change { Cohort.count }.by(1)
-  end
-
   describe ".current" do
     it "returns the 2021 cohort" do
-      cohort_2021 = Cohort.create!(start_year: 2021)
-
       expect(Cohort.current).to eq cohort_2021
     end
   end
 
   describe ".next" do
-    it "returns the 2022 cohort" do
-      cohort_2022 = Cohort.create!(start_year: 2022)
+    context "when the feature flag is deactivated" do
+      it "returns the 2021 cohort" do
+        FeatureFlag.deactivate(:multiple_cohorts)
 
-      expect(Cohort.next).to eq cohort_2022
+        expect(Cohort.next).to eq cohort_2021
+      end
+    end
+
+    context "when the feature flag is activated" do
+      it "returns the 2022 cohort" do
+        FeatureFlag.activate(:multiple_cohorts)
+
+        expect(Cohort.next).to eq cohort_2022
+      end
     end
   end
 

--- a/spec/requests/lead_providers/partnerships_spec.rb
+++ b/spec/requests/lead_providers/partnerships_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Lead provider partnerships spec", type: :request do
   let(:user) { create :user, :lead_provider }
-  let(:cohort) { create :cohort }
+  let(:cohort) { create :cohort, :current }
 
   before do
     sign_in user
@@ -47,6 +47,10 @@ RSpec.describe "Lead provider partnerships spec", type: :request do
 
     it "returns the correct CSV content type header" do
       expect(response.headers["Content-Type"]).to include("text/csv")
+    end
+
+    it "returns a CSV file with the cohort start year in the filename" do
+      expect(response.headers["Content-Disposition"]).to include "schools-2021.csv"
     end
 
     it "returns only active partnerships" do

--- a/spec/requests/lead_providers/report_schools/base_spec.rb
+++ b/spec/requests/lead_providers/report_schools/base_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Lead Provider school reporting", type: :request do
   let(:user) { create(:user, :lead_provider) }
   let!(:cohort) { create(:cohort, :current) }
+  let!(:cohort_2022) { create(:cohort, :next) }
 
   before do
     sign_in user


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CST-583

We want the lead providers to view their school partnerships from multiple cohorts and allow them to begin reporting any new partnerships to DfE ahead of the start of the 2022/23 cohort.

The early registrations for the new cohort will start early May, so a feature flag is required.

Changes:
- Add the `multiple_cohorts` feature flag to enable the changes when we the new cohort opens for early registrations
- Add multiple cohort support to the lead provider dashboard by using the `cohort` param in the urls
- Scope the displayed schools, school exports and search results to the selected cohort
- Use better filenames when exporting the school partnerships
- Display the `confirm more schools` button only for the cohort that's open for registrations
- Display the `download schools` button only when there are schools for the selected cohort
- Update the nav item component to take url params under consideration when applying the css styles to the selected item

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
