### PR TITLE
Transferring participant back link fix

### DIFF
--- a/app/controllers/schools/transferring_participants_controller.rb
+++ b/app/controllers/schools/transferring_participants_controller.rb
@@ -4,6 +4,7 @@ module Schools
   class TransferringParticipantsController < ::Schools::BaseController
     before_action :load_joining_participant_form, except: %i[what_we_need]
     before_action :latest_induction_record, only: %i[email choose_mentor teachers_current_programme schools_current_programme check_answers complete]
+    before_action :set_current_steps, except: %i[what_we_need]
     before_action :set_school_cohort
     before_action :validate_request_or_render, except: %i[what_we_need]
 
@@ -292,6 +293,11 @@ module Schools
 
     def reset_form_data
       session.delete(:schools_transferring_participant_form)
+    end
+
+    def set_current_steps
+      @transferring_participant_form.current_step = action_name
+      @transferring_participant_form.update_steps
     end
   end
 end

--- a/app/forms/schools/transferring_participant_form.rb
+++ b/app/forms/schools/transferring_participant_form.rb
@@ -6,7 +6,7 @@ module Schools
     include ActiveRecord::AttributeAssignment
     include ActiveModel::Serialization
 
-    attr_accessor :full_name, :trn, :date_of_birth, :start_date, :email, :mentor_id, :schools_current_programme_choice, :teachers_current_programme_choice, :same_programme
+    attr_accessor :full_name, :trn, :date_of_birth, :start_date, :email, :mentor_id, :schools_current_programme_choice, :teachers_current_programme_choice, :same_programme, :current_step, :steps
 
     validates :full_name, presence: true, on: :full_name
     validates :trn,
@@ -33,6 +33,8 @@ module Schools
         schools_current_programme_choice: schools_current_programme_choice,
         teachers_current_programme_choice: teachers_current_programme_choice,
         same_programme: same_programme,
+        steps: steps,
+        current_step: current_step,
       }
     end
 
@@ -76,6 +78,27 @@ module Schools
 
     def mentor_profile
       mentor&.mentor_profile
+    end
+
+    def previous_step
+      remove_current_step
+      steps.last.to_sym
+    end
+
+    def remove_current_step
+      return if steps.nil?
+
+      if steps.include?(current_step)
+        steps.delete(current_step)
+      end
+    end
+
+    def update_steps
+      if steps.nil?
+        @steps = %w[what_we_need]
+      end
+
+      steps.push(current_step)
     end
 
   private

--- a/app/views/schools/transferring_participants/cannot_add.html.erb
+++ b/app/views/schools/transferring_participants/cannot_add.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "You cannot add #{@transferring_participant_form.full_name}" %>
 
-<% content_for :before_content, govuk_back_link( text: "Back", href:  @transferring_participant_form.previous_step) %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/cannot_add.html.erb
+++ b/app/views/schools/transferring_participants/cannot_add.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "You cannot add #{@transferring_participant_form.full_name}" %>
 
-<% content_for :before_content, govuk_back_link( text: "Back", href: transfer_journey_previous_step(@transferring_participant_form)) %>
+<% content_for :before_content, govuk_back_link( text: "Back", href:  @transferring_participant_form.previous_step) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/transferring_participants/cannot_find_their_details.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "We cannot find #{@transferring_participant_form.full_name_to_display}" %>
 
-<% content_for :before_content, govuk_back_link( text: "Back", href: { action: :dob }) %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
 
 <div class="govuk-grid-row">

--- a/app/views/schools/transferring_participants/check_answers.html.erb
+++ b/app/views/schools/transferring_participants/check_answers.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Check your answers" %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: transfer_journey_previous_step(@transferring_participant_form)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/choose_mentor.html.erb
+++ b/app/views/schools/transferring_participants/choose_mentor.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :email}) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: {action:  @transferring_participant_form.previous_step }) %>
 
 <span class="govuk-caption-xl"><%= @school.name %></span>
 

--- a/app/views/schools/transferring_participants/dob.html.erb
+++ b/app/views/schools/transferring_participants/dob.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: { action: :trn }) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/email.html.erb
+++ b/app/views/schools/transferring_participants/email.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title%>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :teacher_start_date}) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: {action:  @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/full_name.html.erb
+++ b/app/views/schools/transferring_participants/full_name.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "What’s this person’s full name?" %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :what_we_need }) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: {action: @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/schools_current_programme.html.erb
+++ b/app/views/schools/transferring_participants/schools_current_programme.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :teachers_current_programme}) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: {action: @transferring_participant_form.previous_step}) %>
 
 <span class="govuk-caption-xl"><%= @school.name %></span>
 

--- a/app/views/schools/transferring_participants/teacher_start_date.html.erb
+++ b/app/views/schools/transferring_participants/teacher_start_date.html.erb
@@ -1,6 +1,6 @@
 <% title = "What’s #{@transferring_participant_form.full_name_to_display} start date at your school?" %>
 <% content_for :title, title %>
-<% content_for :before_content, govuk_back_link(text: "Back", href: { action: :dob }) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action:  @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/transferring_participants/teachers_current_programme.html.erb
+++ b/app/views/schools/transferring_participants/teachers_current_programme.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: @transferring_participant_form.previous_step) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
 <span class="govuk-caption-xl"><%= @school.name %></span>
 

--- a/app/views/schools/transferring_participants/teachers_current_programme.html.erb
+++ b/app/views/schools/transferring_participants/teachers_current_programme.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: teachers_programme_path_previous_step(@participant_profile, @school_cohort)) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: @transferring_participant_form.previous_step) %>
 
 <span class="govuk-caption-xl"><%= @school.name %></span>
 

--- a/app/views/schools/transferring_participants/trn.html.erb
+++ b/app/views/schools/transferring_participants/trn.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, title %>
 
-<% content_for :before_content, govuk_back_link(text: "Back", href: {action: :full_name }) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -15,7 +15,7 @@ mentor_2 = FactoryBot.create :mentor_participant_profile,
                              created_at: Date.parse("06/05/2020")
 
 ect_1 = FactoryBot.create :ect_participant_profile,
-                          user: FactoryBot.create(:user, full_name: "ECT User 1", email: "young_prosacco@crist.net"),
+                          user: FactoryBot.create(:user, id: "05a85345-3d33-4bac-8152-07874b7ff328", full_name: "ECT User 1", email: "young_prosacco@crist.net"),
                           mentor_profile: mentor_1,
                           school_cohort: school_cohort,
                           created_at: Date.parse("01/07/2020")

--- a/spec/forms/schools/transferring_participant_form_spec.rb
+++ b/spec/forms/schools/transferring_participant_form_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe Schools::TransferringParticipantForm, type: :model do
   let(:school_cohort) { create(:school_cohort) }
   let(:user) { create(:user) }
@@ -220,6 +222,42 @@ RSpec.describe Schools::TransferringParticipantForm, type: :model do
         form.teachers_current_programme_choice = nil
         expect(form.valid?(:teachers_current_programme)).to be false
         expect(form.errors[:teachers_current_programme_choice]).to include "Select if the participant will continue with their current training programme"
+      end
+    end
+  end
+
+  describe "steps" do
+    it "add the current step to the steps when set to nil" do
+      form.steps = nil
+      form.current_step = "full_name"
+      form.update_steps
+      expect(form.steps).to eq(%w[what_we_need full_name])
+    end
+
+    it "add the current step to the steps when set to nil" do
+      form.steps = %w[what_we_need full_name trn dob email]
+      form.current_step = "choose_mentor"
+      form.update_steps
+      expect(form.steps).to eq(%w[what_we_need full_name trn dob email choose_mentor])
+    end
+
+    it "correctly shows the previous page action" do
+      form.steps = %w[what_we_need full_name trn]
+      form.current_step = "dob"
+      form.update_steps
+      expect(form.previous_step).to eq(:trn)
+      expect(form.steps).to eq(%w[what_we_need full_name trn])
+    end
+
+    context "sit has changed transferees details" do
+      it "correctly shows the previous page action for multiple steps in " do
+        form.steps = %w[what_we_need full_name trn cannot_find_their_details]
+        form.current_step = "trn"
+        form.update_steps
+        form.current_step = "email"
+        form.update_steps
+        expect(form.previous_step).to eq(:trn)
+        expect(form.steps).to eq(%w[what_we_need full_name trn cannot_find_their_details trn])
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

Because of the different routes you can go through the transferring participant journey the standard back links aren't sufficient, as you can end up in loops or redirected to the wrong previous page. This is attempting to address that problem. 

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
3. login in as a SIT, go through the transferring journey. 
4. Use the test DQT data to get past validation. 
5. Check back links act as they should 
