### PR TITLE
[CST-573] Email to ECT or Mentor when SIT validates them

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -251,6 +251,7 @@ module Schools
     end
 
     def save!
+      profile = nil
       ActiveRecord::Base.transaction do
         profile = creators[participant_type].call(
           full_name: full_name,
@@ -259,10 +260,15 @@ module Schools
           school_cohort: school_cohort,
           mentor_profile_id: mentor&.mentor_profile&.id,
           start_date: start_date,
+          sit_validation: dqt_record.present? ? true : false,
         )
         store_validation_result!(profile) if dqt_record.present?
-        profile
       end
+
+      participant_validation_record = validation_record(profile)
+
+      send_added_and_validated_email(profile) if profile && participant_validation_record
+      profile
     end
 
     def store_validation_result!(profile)
@@ -275,6 +281,14 @@ module Schools
           full_name: full_name,
         },
       )
+    end
+
+    def send_added_and_validated_email(profile)
+      ParticipantMailer.sit_has_added_and_validated_participant(participant_profile: profile, school_name: school_cohort.school.name).deliver_later
+    end
+
+    def validation_record(profile)
+      ECFParticipantValidationData.find_by(participant_profile: profile)
     end
   end
 end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -96,7 +96,7 @@ module Schools
                 presence: { message: I18n.t("errors.email_address.blank") },
                 notify_email: { allow_blank: true }
 
-      before_complete { remove_trn_and_dob unless trn_known? }
+      before_complete { reset_dqt_details unless trn_known? }
       next_step do
         if email_already_taken?
           :email_taken
@@ -192,9 +192,10 @@ module Schools
       full_name.present? && trn.present? && dob.present?
     end
 
-    def remove_trn_and_dob
+    def reset_dqt_details
       self.dob = nil
       self.trn = nil
+      self.dqt_record = nil
     end
 
     def email_already_taken?

--- a/app/mailers/participant_mailer.rb
+++ b/app/mailers/participant_mailer.rb
@@ -12,6 +12,10 @@ class ParticipantMailer < ApplicationMailer
     sit_mentor_fip: "0b7f850f-f26a-4e62-9fc5-17fbd8286e49",
     fip_preterm_reminder: "12969797-c110-436d-b10b-7f7d08d4d9df",
     cip_preterm_reminder: "623cb545-1bc4-4407-94a1-474e2a080e39",
+    ect_fip_added_and_validated: "93fba542-f118-4855-9509-83583f251eab",
+    mentor_fip_added_and_validated: "f71fa01a-ecc2-49e5-999b-48ff0070e13a",
+    ect_cip_added_and_validated: "b0d58248-c49e-4ec6-bca2-2c4cf151c421",
+    mentor_cip_added_and_validated: "1396072b-4dc7-473d-aef7-22e674e42874",
   }.freeze
 
   def participant_added(participant_profile:)
@@ -93,12 +97,30 @@ class ParticipantMailer < ApplicationMailer
     ).tag(:cip_preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
   end
 
+  def sit_has_added_and_validated_participant(participant_profile:, school_name:)
+    template_mail(
+      PARTICIPANT_TEMPLATES[sit_validation_template participant_profile],
+      to: participant_profile.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        ppt_name: participant_profile.user.full_name,
+        school: school_name,
+      },
+    ).tag(:sit_has_added_and_validated_participant).associate_with(participant_profile, as: :participant_profile)
+  end
+
 private
 
   def template_type_for(profile)
     type = profile.participant_type
     type = :sit_mentor if type == :mentor && profile.user.induction_coordinator?
     "#{type}_#{profile.school_cohort.cip? ? 'cip' : 'fip'}".to_sym
+  end
+
+  def sit_validation_template(profile)
+    type_and_programme = template_type_for profile
+    "#{type_and_programme}_added_and_validated".to_sym
   end
 
   def what_each_person_does_url

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -31,8 +31,7 @@ module EarlyCareerTeachers
                                 start_date: start_date)
         end
       end
-
-      unless year_2020
+      unless year_2020 || sit_validation
         ParticipantMailer.participant_added(participant_profile: profile).deliver_later
         profile.update_column(:request_for_details_sent_at, Time.zone.now)
         ParticipantDetailsReminderJob.schedule(profile)
@@ -43,9 +42,9 @@ module EarlyCareerTeachers
 
   private
 
-    attr_reader :full_name, :email, :start_term, :school_cohort, :mentor_profile_id, :year_2020, :start_date
+    attr_reader :full_name, :email, :start_term, :school_cohort, :mentor_profile_id, :year_2020, :start_date, :sit_validation
 
-    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_term: "autumn_2021", start_date: nil, year_2020: false)
+    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_term: "autumn_2021", start_date: nil, year_2020: false, sit_validation: false)
       @full_name = full_name
       @email = email
       @start_term = start_term
@@ -53,6 +52,7 @@ module EarlyCareerTeachers
       @mentor_profile_id = mentor_profile_id
       @start_date = start_date
       @year_2020 = year_2020
+      @sit_validation = sit_validation
     end
 
     def ect_attributes

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -35,23 +35,26 @@ module Mentors
         end
       end
 
-      ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later
-      mentor_profile.update_column(:request_for_details_sent_at, Time.zone.now)
-      ParticipantDetailsReminderJob.schedule(mentor_profile)
+      unless sit_validation
+        ParticipantMailer.participant_added(participant_profile: mentor_profile).deliver_later
+        mentor_profile.update_column(:request_for_details_sent_at, Time.zone.now)
+        ParticipantDetailsReminderJob.schedule(mentor_profile)
+      end
 
       mentor_profile
     end
 
   private
 
-    attr_reader :full_name, :email, :start_term, :school_cohort, :start_date
+    attr_reader :full_name, :email, :start_term, :school_cohort, :start_date, :sit_validation
 
-    def initialize(full_name:, email:, school_cohort:, start_term: "autumn_2021", start_date: nil, **)
+    def initialize(full_name:, email:, school_cohort:, start_term: "autumn_2021", start_date: nil, sit_validation: false, **)
       @full_name = full_name
       @email = email
       @start_term = start_term
       @start_date = start_date
       @school_cohort = school_cohort
+      @sit_validation = sit_validation
     end
 
     def mentor_attributes

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -133,6 +133,32 @@ RSpec.describe EarlyCareerTeachers::Create do
     end
   end
 
+  context "when a SIT is adding and validating an ECT" do
+    it "does not schedule participant_added email" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: Faker::Name.name,
+          school_cohort: school_cohort,
+          sit_validation: true,
+        )
+      }.to_not have_enqueued_mail(ParticipantMailer, :participant_added)
+    end
+  end
+
+  context "when a SIT is adding and cannot validate an ECT" do
+    it "does schedule participant_added email" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: Faker::Name.name,
+          school_cohort: school_cohort,
+          sit_validation: false,
+        )
+      }.to have_enqueued_mail(ParticipantMailer, :participant_added)
+    end
+  end
+
   context "when the user has an active participant profile" do
     before do
       create(:ect_participant_profile, teacher_profile: create(:teacher_profile, user: user))

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -114,6 +114,32 @@ RSpec.describe Mentors::Create, :with_default_schedules do
     expect(ParticipantDetailsReminderJob).to have_received(:schedule).with(profile)
   end
 
+  context "when a SIT is adding and validating a Mentor" do
+    it "does not schedule participant_added email" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: Faker::Name.name,
+          school_cohort: school_cohort,
+          sit_validation: true,
+        )
+      }.to_not have_enqueued_mail(ParticipantMailer, :participant_added)
+    end
+  end
+
+  context "when a SIT is adding and cannot validate a Mentor" do
+    it "does schedule participant_added email" do
+      expect {
+        described_class.call(
+          email: user.email,
+          full_name: Faker::Name.name,
+          school_cohort: school_cohort,
+          sit_validation: false,
+        )
+      }.to have_enqueued_mail(ParticipantMailer, :participant_added)
+    end
+  end
+
   context "when the user has an active participant profile" do
     before do
       create(:ecf_participant_profile, teacher_profile: create(:teacher_profile, user: user))


### PR DESCRIPTION
## Ticket and context

Ticket: [573](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-573)

***TO BE MERGED AFTER THE UPDATE ADD PARTICIPANTS JOURNEY HAS BEEN MERGED**

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as a SIT 
 - FIP tutor cpd-test+tutor-10@example.com
 - CIP tutor cip-tutor-202@example.com
4. Go to add an ECT or Mentor
5. Go through the journey
 - For a teacher you can validate use a record from the test dqt
 - For someone you can't validate or don't know the trn add an example email
6. Check that it's the right email you've received 

