### PR TITLE
Bugfix: Handle no lead provider in check details view

### DIFF
--- a/app/views/schools/transferring_participants/check_answers.html.erb
+++ b/app/views/schools/transferring_participants/check_answers.html.erb
@@ -56,7 +56,7 @@
         <% row.key { "Training with" } %>
         <% if @transferring_participant_form.using_schools_programme? %>
           <% row.value do %>
-            <div><%= @school_cohort.default_induction_programme.lead_provider.name %></div>
+            <div><%= @school_cohort.default_induction_programme.lead_provider&.name %></div>
             <div><%= @school_cohort.default_induction_programme.delivery_partner&.name %></div>
           <% end %>
           <% if @transferring_participant_form.switch_to_schools_programme? %>


### PR DESCRIPTION
## Ticket and context

Quick bugfix from Sentry.  It is possible that the school transferring a participant does not yet have a partnership in place so the lead provider could be be nil.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
