### PR TITLE
Bugfix: Set challenge_deadline to current time for relationship

### DIFF
--- a/app/services/induction/create_relationship.rb
+++ b/app/services/induction/create_relationship.rb
@@ -13,6 +13,7 @@ class Induction::CreateRelationship < BaseService
                                    lead_provider: lead_provider,
                                    delivery_partner: delivery_partner) do |partnership|
       partnership.relationship = true
+      partnership.challenge_deadline = Time.zone.now
     end
   end
 

--- a/spec/services/induction/create_relationship_spec.rb
+++ b/spec/services/induction/create_relationship_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Induction::CreateRelationship do
       expect(school_cohort.school.partnerships.last).to be_relationship
     end
 
-    it "the PArtnership doesn't have a challenge window" do
+    it "the Partnership doesn't have a challenge window" do
       service.call(school_cohort: school_cohort,
                    lead_provider: lead_provider,
                    delivery_partner: delivery_partner)

--- a/spec/services/induction/create_relationship_spec.rb
+++ b/spec/services/induction/create_relationship_spec.rb
@@ -23,5 +23,13 @@ RSpec.describe Induction::CreateRelationship do
 
       expect(school_cohort.school.partnerships.last).to be_relationship
     end
+
+    it "the PArtnership doesn't have a challenge window" do
+      service.call(school_cohort: school_cohort,
+                   lead_provider: lead_provider,
+                   delivery_partner: delivery_partner)
+
+      expect(school_cohort.school.partnerships.last).not_to be_in_challenge_window
+    end
   end
 end


### PR DESCRIPTION
## Ticket and context

Fixes issue with a "relationship" type of `Partnership` where the `challenge_deadline` isn't being set and subsequently any calls to `Partnership#in_challenge_window?` generate an error.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
