### PR TITLE
Bugfix: Check for npq profile in admin/participants/show

### DIFF
--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Participant detail" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
 
-<% if @participant_profile.user.participant? %>
+<% unless @participant_profile.npq? %>
   <span class="govuk-caption-l"><%= @latest_induction_record&.user&.user_description %></span>
 <% end %>
 <h1 class="govuk-heading-xl">
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <% if @participant_profile.user.participant? %>
+    <% unless @participant_profile.npq? %>
       <%= govuk_tabs(title: 'Contents') do |component| %>
         <% component.tab(label: 'Details') do %>
           <%= render partial: 'details', locals: { latest_induction_record: @latest_induction_record } %>


### PR DESCRIPTION
The previous way of checking for the participant was using legacy associations and it looks like that not all users have this, i.e. an early career teacher profile or mentor profile against the user. The previous call was causing it to check for the ECTPending view, which has been removed from admin/participant/details component. Doing the check directly on the participant profile should stop this error.

See [commit that removed the ECTPending and MentorPending](https://github.com/DFE-Digital/early-careers-framework/commit/fd2a8e1cbf94f9f15713079aa44bec0b3cc1f87e), which has been replaced with the details, schools and history partials - [admin views](https://github.com/DFE-Digital/early-careers-framework/tree/develop/app/views/admin/participants)

[Error in Sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3226641388/?project=5748989) 

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Login as admin
3. Check various ECT or Mentor records
