### PR TITLE
[CPDLP-1108] Update API error response if ID is valid but course-identifier is wrong

### DIFF
--- a/app/services/participants/profile_attributes.rb
+++ b/app/services/participants/profile_attributes.rb
@@ -25,7 +25,7 @@ module Participants
     def participant_has_user_profile
       return if errors.any?
 
-      errors.add(:participant_id, I18n.t(:invalid_participant)) if user_profile.blank?
+      errors.add(:participant_id, I18n.t(:invalid_identifier)) if user_profile.blank?
     end
 
   private

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         invalid_participant_for_course_type = valid_params.merge({ course_identifier: "ecf-mentor" })
         post "/api/v1/participant-declarations", params: build_params(invalid_participant_for_course_type)
         expect(response.status).to eq 422
-        expect(JSON.parse(response.body)["errors"]).to include({ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }.stringify_keys)
+        expect(JSON.parse(response.body)["errors"]).to include({ title: "Bad or missing parameters", detail: I18n.t(:invalid_identifier) }.stringify_keys)
       end
 
       it "returns 422 when there are multiple errors" do

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         invalid_participant_for_course_type = valid_params.merge({ course_identifier: "ecf-mentor" })
         post "/api/v1/participant-declarations", params: build_params(invalid_participant_for_course_type)
         expect(response.status).to eq 422
-        expect(JSON.parse(response.body)["errors"]).to include({ title: "Bad or missing parameters", detail: I18n.t(:invalid_participant) }.stringify_keys)
+        expect(JSON.parse(response.body)["errors"]).to include({ title: "Bad or missing parameters", detail: I18n.t(:invalid_identifier) }.stringify_keys)
       end
 
       it "returns 422 when there are multiple errors" do


### PR DESCRIPTION
## Ticket and context

Ticket:
https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1108

## Tech review

* Updated error response for `/api/v1/participant-declarations` when `course_identifier` is incorrect
* Updated error response for `/api/v2/participant-declarations` when `course_identifier` is incorrect

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
