### PR TITLE
Add/update induction services to correctly preserve status

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -99,7 +99,10 @@ class Schools::ParticipantsController < Schools::BaseController
     @mentor_form = ParticipantMentorForm.new(participant_mentor_form_params.merge(school_id: @school.id, cohort_id: @cohort.id))
 
     if @mentor_form.valid?
-      @profile.update!(mentor_profile: @mentor_form.mentor ? @mentor_form.mentor.mentor_profile : nil)
+      mentor_profile = @mentor_form.mentor&.mentor_profile
+      @profile.update!(mentor_profile: mentor_profile)
+      Induction::ChangeMentor.call(induction_record: @profile.induction_records.for_school(@school).latest,
+                                   mentor_profile: mentor_profile)
 
       flash[:success] = { title: "Success", heading: "The mentor for this participant has been updated" }
       redirect_to schools_participant_path(id: @profile)

--- a/app/services/induction/change_induction_record.rb
+++ b/app/services/induction/change_induction_record.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Induction::ChangeInductionRecord < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      time_now = Time.zone.now
+
+      new_record = induction_record.dup
+      induction_record.changing!(time_now)
+
+      new_record.assign_attributes(changes.reverse_merge(start_date: time_now))
+      new_record.save!
+    end
+  end
+
+private
+
+  attr_reader :induction_record, :changes
+
+  def initialize(induction_record:, changes: {})
+    @induction_record = induction_record
+    @changes = changes
+  end
+end

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Induction::ChangeMentor < BaseService
+  def call
+    Induction::ChangeInductionRecord.call(induction_record: induction_record,
+                                          changes: { mentor_profile: mentor_profile })
+  end
+
+private
+
+  attr_reader :mentor_profile, :induction_record
+
+  def initialize(induction_record:, mentor_profile: nil)
+    @induction_record = induction_record
+    @mentor_profile = mentor_profile
+  end
+end

--- a/app/services/induction/change_mentor.rb
+++ b/app/services/induction/change_mentor.rb
@@ -2,8 +2,12 @@
 
 class Induction::ChangeMentor < BaseService
   def call
-    Induction::ChangeInductionRecord.call(induction_record: induction_record,
-                                          changes: { mentor_profile: mentor_profile })
+    ActiveRecord::Base.transaction do
+      Induction::ChangeInductionRecord.call(induction_record: induction_record,
+                                            changes: { mentor_profile: mentor_profile })
+
+      induction_record.participant_profile.update!(mentor_profile: mentor_profile)
+    end
   end
 
 private

--- a/app/services/induction/change_preferred_email.rb
+++ b/app/services/induction/change_preferred_email.rb
@@ -2,21 +2,8 @@
 
 class Induction::ChangePreferredEmail < BaseService
   def call
-    # NOTE: this in not the place to change a programme or transfer a participant
-    # This creates a new induction record to preserve the email address used
-    # at a point in time during induction.
-    # We could just update the induction_record but we'd then lose that
-    # ability to track it
-    ActiveRecord::Base.transaction do
-      time_now = Time.zone.now
-      induction_record.changing!(time_now)
-
-      Induction::Enrol.call(participant_profile: induction_record.participant_profile,
-                            induction_programme: induction_record.induction_programme,
-                            start_date: time_now,
-                            preferred_email: preferred_email,
-                            mentor_profile: induction_record.mentor_profile)
-    end
+    Induction::ChangeInductionRecord.call(induction_record: induction_record,
+                                          changes: { preferred_identity: preferred_identity })
   end
 
 private
@@ -26,5 +13,9 @@ private
   def initialize(induction_record:, preferred_email:)
     @induction_record = induction_record
     @preferred_email = preferred_email
+  end
+
+  def preferred_identity
+    Identity::Create.call(user: induction_record.user, email: preferred_email)
   end
 end

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: schools_participant_path(id: @profile)) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @profile.user, url: schools_participant_update_email_path, method: :put do |f| %>
+    <%= form_for @induction_record.preferred_identity, url: schools_participant_update_email_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :email, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} email address", tag: 'h1', size: 'xl' } %>

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_flags: { eligibility_notifications: "active" } do
   let(:user) { create(:user, :induction_coordinator, school_ids: [school.id]) }
   let(:school) { school_cohort.school }
-  let(:cohort) { create(:cohort) }
+  let(:cohort) { create(:cohort, :current) }
 
   let!(:school_cohort) { create(:school_cohort, cohort: cohort, induction_programme_choice: "full_induction_programme") }
   let!(:another_cohort) { create(:school_cohort) }
@@ -203,34 +203,34 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
     it "updates the email of an ECT" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email", params: {
-          user: { email: "new@email.com" },
+          participant_identity: { email: "new@email.com" },
         }
-      }.to change { ect_user.reload.email }.to("new@email.com")
+      }.to change { ect_profile.current_induction_record.preferred_identity.email }.to("new@email.com")
     end
 
     it "updates the email of a mentor" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          user: { email: "new@email.com" },
+          participant_identity: { email: "new@email.com" },
         }
-      }.to change { mentor_user.reload.email }.to("new@email.com")
+      }.to change { mentor_profile.current_induction_record.preferred_identity.email }.to("new@email.com")
     end
 
     it "rejects a blank email" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          user: { email: "" },
+          participant_identity: { email: "" },
         }
-      }.not_to change { mentor_user.reload.email }
+      }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
       expect(response).to render_template("schools/participants/edit_email")
     end
 
     it "rejects a malformed email" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          user: { email: "nonsense" },
+          participant_identity: { email: "nonsense" },
         }
-      }.not_to change { mentor_user.reload.email }
+      }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
       expect(response).to render_template("schools/participants/edit_email")
     end
 
@@ -238,9 +238,9 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       other_user = create(:user)
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          user: { email: other_user.email },
+          participant_identity: { email: other_user.email },
         }
-      }.not_to change { mentor_user.reload.email }
+      }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
       expect(response).to redirect_to("/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/email-used")
     end
   end

--- a/spec/services/induction/change_induction_record_spec.rb
+++ b/spec/services/induction/change_induction_record_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::ChangeInductionRecord do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+    let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile_2) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme: induction_programme, participant_profile: ect_profile, start_date: 6.months.ago, mentor_profile: mentor_profile) }
+    let(:preferred_identity) { Identity::Create.call(user: ect_profile.user, email: "newemail@example.com") }
+    let(:action_date) { 1.week.from_now }
+
+    subject(:service) { described_class }
+
+    it "adds a new induction record to the new programme for the participant" do
+      expect {
+        service.call(induction_record: induction_record,
+                     changes: { mentor_profile: mentor_profile_2 })
+      }.to change { ect_profile.induction_records.count }.by 1
+    end
+
+    it "creates a copy of the induction record with the specified changes" do
+      induction_record.leaving!(action_date)
+      service.call(induction_record: induction_record, changes: { preferred_identity: preferred_identity })
+      current_record = ect_profile.current_induction_record
+      expect(induction_record).to be_changed_induction_status
+      expect(current_record).to be_leaving_induction_status
+      expect(current_record.training_status).to eq induction_record.training_status
+      expect(current_record.start_date).to be_within(1.second).of Time.zone.now
+      expect(current_record.end_date).to be_within(1.second).of action_date
+      expect(current_record.mentor_profile).to eq induction_record.mentor_profile
+      expect(current_record.induction_programme).to eq induction_record.induction_programme
+      expect(current_record.participant_profile).to eq induction_record.participant_profile
+      expect(current_record.preferred_identity).to eq preferred_identity
+    end
+
+    it "marks the previous induction record as changing" do
+      service.call(induction_record: induction_record, changes: { mentor_profile: mentor_profile_2 })
+      expect(induction_record).to be_changed_induction_status
+    end
+
+    context "when the induction record is leaving" do
+      before do
+        induction_record.leaving!(action_date)
+        service.call(induction_record: induction_record, changes: { mentor_profile: mentor_profile_2 })
+      end
+
+      it "preserves the induction_status on the new record" do
+        expect(ect_profile.current_induction_record).to be_leaving_induction_status
+      end
+
+      it "preserves the end_date on the new record" do
+        expect(ect_profile.current_induction_record.end_date).to be_within(1.second).of action_date
+      end
+    end
+
+    context "when the induction record is withdrawn" do
+      before do
+        induction_record.training_status_withdrawn!
+        service.call(induction_record: induction_record, changes: { mentor_profile: mentor_profile_2 })
+      end
+
+      it "preserves the training_status on the new record" do
+        expect(ect_profile.current_induction_record).to be_training_status_withdrawn
+      end
+    end
+  end
+end

--- a/spec/services/induction/change_mentor_spec.rb
+++ b/spec/services/induction/change_mentor_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::ChangeMentor do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+    let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile_2) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme: induction_programme, participant_profile: ect_profile, start_date: 6.months.ago, mentor_profile: mentor_profile) }
+
+    subject(:service) { described_class }
+
+    it "adds a new induction record to the new programme for the participant" do
+      expect {
+        service.call(induction_record: induction_record,
+                     mentor_profile: mentor_profile_2)
+      }.to change { ect_profile.induction_records.count }.by 1
+    end
+
+    it "sets the mentor_profile to the correct value" do
+      service.call(induction_record: induction_record, mentor_profile: mentor_profile_2)
+      expect(ect_profile.current_induction_record.mentor_profile).to eq mentor_profile_2
+    end
+  end
+end

--- a/spec/services/induction/change_preferred_email_spec.rb
+++ b/spec/services/induction/change_preferred_email_spec.rb
@@ -31,12 +31,8 @@ RSpec.describe Induction::ChangePreferredEmail do
         expect(induction_record.reload.end_date).to be_within(1.second).of Time.zone.now
       end
 
-      it "sets the new induction record data correctly" do
+      it "sets the preferred identity email" do
         new_induction_record = induction_programme.active_induction_records.first
-
-        expect(new_induction_record).to be_active_induction_status
-        expect(new_induction_record.start_date).to be_within(1.second).of Time.zone.now
-        expect(new_induction_record.participant_profile).to eq participant_profile
         expect(new_induction_record.preferred_identity.email).to eq new_email
       end
     end


### PR DESCRIPTION
## Ticket and context

`Induction::Enrol` is used for enrolling participants into programmes but assumes that the `induction_status` and `training_status` will be active.  When we make a change to an induction record such as changing the mentor or preferred identity, we should duplicate the existing record and make the changes rather than enrol a new one.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
