### PR TITLE
Fix validation for add or transfer participant page

### DIFF
--- a/app/controllers/schools/add_participants_controller.rb
+++ b/app/controllers/schools/add_participants_controller.rb
@@ -66,9 +66,9 @@ module Schools
     end
 
     def who_to_add_params
-      return {} unless params.key?(:schools_participant_type_form)
+      return {} unless params.key?(:schools_new_participant_or_transfer_form)
 
-      params.require(:schools_participant_type_form).permit(:type)
+      params.require(:schools_new_participant_or_transfer_form).permit(:type)
     end
 
     def email_used_in_the_same_school?

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -9,8 +9,6 @@ module Schools
     attribute :participant_type
     attribute :type
 
-    step :who
-
     step :yourself do
       next_step :confirm
     end

--- a/app/forms/schools/new_participant_or_transfer_form.rb
+++ b/app/forms/schools/new_participant_or_transfer_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Schools
+  class NewParticipantOrTransferForm
+    include ActiveModel::Model
+
+    attr_accessor :type
+
+    validates :type,
+              presence: { message: I18n.t("errors.type.blank") },
+              inclusion: { in: %w[transfer ect mentor] }
+  end
+end

--- a/app/lib/multistep/controller.rb
+++ b/app/lib/multistep/controller.rb
@@ -59,7 +59,7 @@ module Multistep
       helper_method :back_link_path, :current_step
       after_action :remove_form, only: :complete
 
-      before_action :ensure_form_present, except: %i[start]
+      before_action :ensure_form_present, except: %i[start who chosen_who_to_add]
     end
 
     attr_reader :result

--- a/app/views/schools/add_participants/who.html.erb
+++ b/app/views/schools/add_participants/who.html.erb
@@ -4,10 +4,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for add_participant_form, url: { action: :start }, method: :get do |f| %>
+    <%= form_with model: @who_to_add_form, url: chosen_who_to_add_schools_participants_path, method: :put do |f| %>
+
+      <%= f.govuk_error_summary %>
+
       <%= f.govuk_radio_buttons_fieldset :type , legend: { text: "Who do you want to add?", tag: 'h1', size: 'xl' } do %>
+
           <% if @school_cohort.school_chose_fip? %>
-            <%= f.govuk_radio_button :type, :joining, label: { text: "A teacher transferring from another school where they’ve started ECF-based training or mentoring" } %>
+            <%= f.govuk_radio_button :type, :transfer, label: { text: "A teacher transferring from another school where they’ve started ECF-based training or mentoring" } %>
           <% end %>
           <%= f.govuk_radio_button :type, :ect, label: { text: "A new ECT" } %>
           <%= f.govuk_radio_button :type, :mentor, label: { text: "A new mentor" } %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -19,7 +19,7 @@
     <div class="govuk-inset-text">
       <ul class="govuk-list">
         <% if FeatureFlag.active?(:change_of_circumstances) %>
-          <li><%= govuk_link_to "Add an ECT or mentor", add_schools_participants_path(cohort_id: @school_cohort.cohort.start_year, type: :teacher), class: "govuk-link--no-visited-state" %></li>
+          <li><%= govuk_link_to "Add an ECT or mentor", who_schools_participants_path(cohort_id: @school_cohort.cohort.start_year), class: "govuk-link--no-visited-state" %></li>
         <% else %>
           <li><%= govuk_link_to "Add a new ECT", add_schools_participants_path(cohort_id: @school_cohort.cohort.start_year, type: :ect), class: "govuk-link--no-visited-state" %></li>
           <li><%= govuk_link_to "Add a new mentor", add_schools_participants_path(cohort_id: @school_cohort.cohort.start_year, type: :mentor), class: "govuk-link--no-visited-state" %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,8 @@ en:
       taken: "There is already a user with this email address"
     email_address:
       blank: "Enter an email address"
+    type:
+      blank: "Select whether to add or transfer a teacher"
     start_term:
       blank: "Enter a start term"
     date_of_birth:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -435,6 +435,8 @@ Rails.application.routes.draw do
 
             collection do
               multistep_form :add, Schools::AddParticipantForm, controller: :add_participants
+              get :who, path: "who", controller: :add_participants
+              put :chosen_who_to_add, path: "chosen-who-to-add", controller: :add_participants
             end
           end
 

--- a/spec/requests/schools/add_participants_spec.rb
+++ b/spec/requests/schools/add_participants_spec.rb
@@ -27,24 +27,7 @@ RSpec.describe "Schools::AddParticipant", type: :request do
   describe "GET /schools/:school_id/cohorts/:cohort_id/participants/add/who", with_feature_flags: { change_of_circumstances: "active" } do
     context "when session has not been set up with the form" do
       before do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/add/who"
-      end
-
-      it { is_expected.to redirect_to schools_cohort_path(school_id: school.slug, cohort_id: cohort.start_year) }
-    end
-
-    context "when form has been set up in the session" do
-      before do
-        set_session(:schools_add_participant_form, {
-          type: :teacher,
-          full_name: Faker::Name.name,
-          email: Faker::Internet.email,
-          mentor_id: "later",
-          school_cohort_id: school_cohort.id,
-          current_user_id: user.id,
-          start_term: "Autumn 2050",
-        })
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/add/who", params: { type: :joining }
+        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/who"
       end
 
       it "renders the expected page" do


### PR DESCRIPTION
## Ticket and context

We're getting an error [in Sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3187412149/?project=5748989&query=is%3Aunresolved) when no option is selected in whether to add an ECT or Mentor or Transfer a participant. There was no validation being done. 

Because of how the existing add participant form works and having the new routing behind a feature flag i thought it'd be easier just to have a new form for this. 

Note, see commit `3569355` for info on updating the multistep controller before_action. It was causing slightly odd behaviour locally but adding the exceptions seemed to stop it.

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
3. login as a SIT
4. Go to the dashboard
5. Add a new ECT or Mentor
6. Don't select an option and you'll now get an error
7. Select one of the options and it should work as normal