### PR TITLE
[CPDLP-1215] Enable search by declaration ID on participant drilldown

### DIFF
--- a/app/controllers/finance/participants_controller.rb
+++ b/app/controllers/finance/participants_controller.rb
@@ -2,14 +2,14 @@
 
 module Finance
   class ParticipantsController < BaseController
-    before_action :find_user_by_id_or_external_id
+    before_action :find_user_by_query
 
     def index
       if params[:query]
         if @user
           redirect_to finance_participant_path(@user)
         else
-          flash.now[:alert] = "No user found"
+          flash.now[:alert] = "No records found"
         end
       end
     end
@@ -18,9 +18,11 @@ module Finance
 
   private
 
-    def find_user_by_id_or_external_id
+    def find_user_by_query
       query = params[:query] || params[:id]
-      @user = Identity.find_user_by(id: query) || NPQApplication.find_by(id: query)&.user
+      @user = Identity.find_user_by(id: query) ||
+        NPQApplication.find_by(id: query)&.user ||
+        ParticipantDeclaration.find_by(id: query)&.user
     end
   end
 end

--- a/app/views/finance/participants/index.html.erb
+++ b/app/views/finance/participants/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: finance_landing_page_path) %>
 
-<h1 class="govuk-heading-xl">Participants</h1>
+<h1 class="govuk-heading-xl">CPD contract data</h1>
 
 <%= render SearchBox.new(
   query: params[:query],
-  title: "Search participants",
-  hint: "Enter a participant or application ID",
+  title: "Search records",
+  hint: "Enter a participant, declaration or application ID",
 ) %>

--- a/spec/features/finance/participant_drilldown_spec.rb
+++ b/spec/features/finance/participant_drilldown_spec.rb
@@ -3,40 +3,81 @@
 require "rails_helper"
 
 RSpec.feature "Finance users participant drilldown", type: :feature do
-  let(:ect_user) { create(:user, :early_career_teacher) }
-  let(:ect_profile) { ect_user.early_career_teacher_profile }
-  let(:ect_declaration) { create(:ect_participant_declaration, user: ect_user, participant_profile: ect_profile) }
-  let(:ect_identity) { create :participant_identity, user: ect_user, external_identifier: SecureRandom.uuid }
+  describe "ECT user" do
+    let(:ect_user) { create(:user, :early_career_teacher) }
+    let(:ect_profile) { ect_user.early_career_teacher_profile }
+    let(:ect_declaration) { create(:ect_participant_declaration, user: ect_user, participant_profile: ect_profile) }
+    let(:ect_identity) { create :participant_identity, user: ect_user, external_identifier: SecureRandom.uuid }
 
-  let(:npq_user) { create(:user, :npq) }
-  let(:npq_profile) { npq_user.npq_profiles[0] }
-  let(:npq_declaration) { create(:npq_participant_declaration, user: npq_user, participant_profile: npq_profile) }
-  let(:npq_application) { create(:npq_application, participant_identity: npq_identity) }
-  let(:npq_identity) { create(:participant_identity, :npq_origin, user: npq_user) }
+    before do
+      given_i_am_logged_in_as_a_finance_user
+      and_an_ect_user_with_profile_and_declarations
+      when_i_visit_the_finance_homepage
+      and_i_click_on("Participant drilldown")
+      then_i_see("Search records")
+    end
 
-  scenario "viewing ECT user" do
-    given_i_am_logged_in_as_a_finance_user
-    and_an_ect_user_with_profile_and_declarations
-    when_i_visit_the_finance_homepage
-    and_i_click_on("Participant drilldown")
-    then_i_see("Search participants")
+    scenario "search by ID" do
+      when_i_fill_in("query", with: ect_user.id)
+      and_i_click_on("Search")
+      then_i_see("ParticipantProfile::ECT")
+      and_i_see("Declaration type#{ect_declaration.declaration_type}")
+    end
 
-    when_i_fill_in("query", with: ect_user.id)
-    and_i_click_on("Search")
-    then_i_see("ParticipantProfile::ECT")
-    and_i_see("Declaration type#{ect_declaration.declaration_type}")
+    scenario "search by external identifier" do
+      when_i_fill_in("query", with: ect_identity.external_identifier)
+      and_i_click_on("Search")
+      then_i_see("ParticipantProfile::ECT")
+      then_i_see(ect_user.id)
+    end
+
+    scenario "search by declaration ID" do
+      when_i_fill_in("query", with: ect_declaration.id)
+      and_i_click_on("Search")
+      then_i_see("ParticipantProfile::ECT")
+      then_i_see(ect_user.id)
+      then_i_see(ect_declaration.id)
+    end
   end
 
-  scenario "viewing ECT user by external identifier" do
-    given_i_am_logged_in_as_a_finance_user
-    and_an_ect_user_with_profile_and_declarations
-    when_i_visit_the_finance_homepage
-    and_i_click_on("Participant drilldown")
-    then_i_see("Search participants")
+  describe "NPQ user" do
+    let(:npq_user) { create(:user, :npq) }
+    let(:npq_profile) { npq_user.npq_profiles[0] }
+    let(:npq_declaration) { create(:npq_participant_declaration, user: npq_user, participant_profile: npq_profile) }
+    let(:npq_application) { create(:npq_application, participant_identity: npq_identity) }
+    let(:npq_identity) { create(:participant_identity, :npq_origin, user: npq_user) }
 
-    when_i_fill_in("query", with: ect_identity.external_identifier)
-    and_i_click_on("Search")
-    then_i_see(ect_user.id)
+    before do
+      given_i_am_logged_in_as_a_finance_user
+      and_an_npq_user_with_application_and_profile_and_declarations
+      when_i_visit_the_finance_homepage
+      and_i_click_on("Participant drilldown")
+      then_i_see("Search records")
+    end
+
+    scenario "search by ID" do
+      when_i_fill_in("query", with: npq_user.id)
+      and_i_click_on("Search")
+      then_i_see("Identity 1")
+      and_i_see("ParticipantProfile::NPQ")
+      and_i_see("Declaration type#{npq_declaration.declaration_type}")
+    end
+
+    scenario "search by application ID" do
+      when_i_fill_in("query", with: npq_application.id)
+      and_i_click_on("Search")
+      then_i_see("Identity 1")
+      and_i_see("ParticipantProfile::NPQ")
+      and_i_see("Declaration type#{npq_declaration.declaration_type}")
+    end
+
+    scenario "search by declaration ID" do
+      when_i_fill_in("query", with: npq_declaration.id)
+      and_i_click_on("Search")
+      and_i_see("ParticipantProfile::NPQ")
+      then_i_see(npq_user.id)
+      then_i_see(npq_declaration.id)
+    end
   end
 
   def when_i_visit_the_finance_homepage
@@ -71,33 +112,5 @@ RSpec.feature "Finance users participant drilldown", type: :feature do
     npq_identity
     npq_declaration
     npq_application
-  end
-
-  scenario "viewing NPQ user" do
-    given_i_am_logged_in_as_a_finance_user
-    and_an_npq_user_with_application_and_profile_and_declarations
-    when_i_visit_the_finance_homepage
-    and_i_click_on("Participant drilldown")
-    then_i_see("Search participants")
-
-    when_i_fill_in("query", with: npq_user.id)
-    and_i_click_on("Search")
-    then_i_see("Identity 1")
-    and_i_see("ParticipantProfile::NPQ")
-    and_i_see("Declaration type#{npq_declaration.declaration_type}")
-  end
-
-  scenario "viewing NPQ user by application ID" do
-    given_i_am_logged_in_as_a_finance_user
-    and_an_npq_user_with_application_and_profile_and_declarations
-    when_i_visit_the_finance_homepage
-    and_i_click_on("Participant drilldown")
-    then_i_see("Search participants")
-
-    when_i_fill_in("query", with: npq_application.id)
-    and_i_click_on("Search")
-    then_i_see("Identity 1")
-    and_i_see("ParticipantProfile::NPQ")
-    and_i_see("Declaration type#{npq_declaration.declaration_type}")
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket:
https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?assignee=602cf8957b23f400685d969d&selectedIssue=CPDLP-1215

## Tech review

* Updated controller to look for `ParticipantDeclaration` by id.
* Updated rspec tests

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
