### PR TITLE
[CPDLP-1217] Add eligible_for_funding status to drilldown

### DIFF
--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -10,6 +10,11 @@
   <% end %>
 
   <% summary_list.row do |row| %>
+    <% row.key { "Eligible for funding" } %>
+    <% row.value { pp.fundable?.to_s.upcase } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
     <% row.key { "Lead provider" } %>
     <% row.value { pp&.school_cohort&.school&.active_partnerships[0]&.lead_provider&.name } %>
   <% end %>

--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -10,6 +10,11 @@
   <% end %>
 
   <% summary_list.row do |row| %>
+    <% row.key { "Eligible for funding" } %>
+    <% row.value { pp.fundable?.to_s.upcase } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
     <% row.key { "NPQ course" } %>
     <% row.value { pp.npq_course&.name } %>
   <% end %>

--- a/spec/views/finance/participants/show.html.erb_spec.rb
+++ b/spec/views/finance/participants/show.html.erb_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe "finance/participants/show.html.erb" do
       expect(rendered).to have_content("Training programmeFull induction programme")
     end
 
+    it "renders eligible for funding" do
+      assign :user, user
+
+      render
+
+      expect(rendered).to have_content("Eligible for funding#{profile.fundable?.to_s.upcase}")
+    end
+
     context "when there are declarations" do
       let!(:declaration) { create(:ect_participant_declaration, user: user, participant_profile: profile) }
 
@@ -65,6 +73,14 @@ RSpec.describe "finance/participants/show.html.erb" do
 
       expect(rendered).to have_content("Lead provider#{profile.npq_application.npq_lead_provider.name}")
       expect(rendered).to have_content("School URN#{profile.npq_application.school_urn}")
+    end
+
+    it "renders eligible for funding" do
+      assign :user, user
+
+      render
+
+      expect(rendered).to have_content("Eligible for funding#{profile.fundable?.to_s.upcase}")
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket:
https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1217

## Tech review

* Added `Eligible for funding` row for participants drill down page.

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
