### PR TITLE
[CPDLP-1185] - add extra started milestone for ECF April standard

### DIFF
--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -19,7 +19,7 @@ module RecordDeclarations
     validates :parsed_date, future_date: true, allow_blank: true
     validate :date_has_the_right_format
     validate :validate_schedule_present
-    validate :validate_milestone_exists
+    validate :validate_milestone_schedule_exists
 
     delegate :schedule, :participant_declarations, to: :user_profile, allow_nil: true
 
@@ -140,11 +140,21 @@ module RecordDeclarations
     end
 
     def milestone
-      schedule&.milestones&.find_by(declaration_type: declaration_type)
+      milestone_schedule && milestone_schedule.milestone
     end
 
-    def validate_milestone_exists
-      if milestone.blank?
+    def milestone_schedule
+      @milestone_schedule ||= begin
+        scope = schedule.schedule_milestones.joins(:milestone)
+        scope
+          .where("milestones.start_date <= ? AND milestones.milestone_date >= ?", parsed_date, parsed_date)
+          .or(scope.where("milestones.start_date <= ? AND milestones.milestone_date IS NULL", parsed_date))
+          .find_by(declaration_type: declaration_type)
+      end
+    end
+
+    def validate_milestone_schedule_exists
+      if milestone_schedule.blank?
         errors.add(:declaration_type, I18n.t(:mismatch_declaration_type_for_schedule))
       end
     end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -145,6 +145,8 @@ module RecordDeclarations
 
     def milestone_schedule
       @milestone_schedule ||= begin
+        return nil unless schedule
+
         scope = schedule.schedule_milestones.joins(:milestone)
         scope
           .where("milestones.start_date <= ? AND milestones.milestone_date >= ?", parsed_date, parsed_date)

--- a/db/migrate/20220503132944_change_schedule_milestones_index.rb
+++ b/db/migrate/20220503132944_change_schedule_milestones_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ChangeScheduleMilestonesIndex < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :schedule_milestones, column: %i[schedule_id milestone_id declaration_type], name: :schedules_milestones_schedule_milestone_declaration_type
+    remove_index :schedule_milestones, column: %i[milestone_id schedule_id declaration_type], name: :milestones_schedules_schedule_milestone_declaration_type
+
+    add_index :schedule_milestones, %i[schedule_id milestone_id], algorithm: :concurrently
+
+    add_index :schedule_milestones, %i[milestone_id schedule_id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_092522) do
+ActiveRecord::Schema.define(version: 2022_05_03_132944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -737,9 +737,9 @@ ActiveRecord::Schema.define(version: 2022_04_13_092522) do
     t.string "declaration_type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["milestone_id", "schedule_id", "declaration_type"], name: "milestones_schedules_schedule_milestone_declaration_type", unique: true
+    t.index ["milestone_id", "schedule_id"], name: "index_schedule_milestones_on_milestone_id_and_schedule_id"
     t.index ["milestone_id"], name: "index_schedule_milestones_on_milestone_id"
-    t.index ["schedule_id", "milestone_id", "declaration_type"], name: "schedules_milestones_schedule_milestone_declaration_type", unique: true
+    t.index ["schedule_id", "milestone_id"], name: "index_schedule_milestones_on_schedule_id_and_milestone_id"
     t.index ["schedule_id"], name: "index_schedule_milestones_on_schedule_id"
   end
 

--- a/db/seeds/schedules/ecf_standard.csv
+++ b/db/seeds/schedules/ecf_standard.csv
@@ -14,6 +14,7 @@ ecf-standard-january,ECF Standard January,2021,Output 5 - Retention Point 4,reta
 ecf-standard-january,ECF Standard January,2021,Output 6 - Participant Completion,completed,2023-02-01,2023-10-31,2023-11-30
 ,,,,,,,
 ecf-standard-april,ECF Standard April,2021,Output 1 - Participant Start,started,01/03/2022,30/04/2022,31/05/2022
+ecf-standard-april,ECF Standard April,2021,Output 1.1 - Participant Start,started,01/05/2022,31/05/2022,30/06/2022
 ecf-standard-april,ECF Standard April,2021,Output 2 - Retention Point 1,retained-1,01/06/2022,30/09/2022,31/10/2022
 ecf-standard-april,ECF Standard April,2021,Output 3 - Retention Point 2,retained-2,01/11/2022,31/01/2023,28/02/2023
 ecf-standard-april,ECF Standard April,2021,Output 4 - Retention Point 3,retained-3,01/03/2023,30/04/2023,31/05/2023

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -3,41 +3,25 @@
 FactoryBot.define do
   factory :schedule, class: "Finance::Schedule" do
     trait(:with_ecf_milestones) do
-      after(:create) do |schedule|
-        [
-          { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), milestone_date: Date.new(2021, 11, 30), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
-          { name: "Output 2 - Retention Point 1", start_date: Date.new(2021, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
-          { name: "Output 3 - Retention Point 2", start_date: Date.new(2022, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
-          { name: "Output 4 - Retention Point 3", start_date: Date.new(2022, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
-          { name: "Output 5 - Retention Point 4", start_date: Date.new(2022, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
-          { name: "Output 6 - Participant Completion", start_date: Date.new(2023, 2, 1), milestone_date: Date.new(2023, 4, 30), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
-        ].each do |hash|
-          Finance::Milestone.find_or_create_by!(
-            schedule: schedule,
-            name: hash[:name],
-            start_date: hash[:start_date],
-            milestone_date: hash[:milestone_date],
-            payment_date: hash[:payment_date],
-          ).update!(declaration_type: hash[:declaration_type])
-        end
+      after(:create) do |_schedule|
+        Importers::SeedSchedule.new(
+          path_to_csv: Rails.root.join("db/seeds/schedules/ecf_standard.csv"),
+          klass: Finance::Schedule::ECF,
+        ).call
       end
     end
 
     trait(:with_npq_milestones) do
-      after(:create) do |schedule|
-        [
-          { name: "Output 1 - Participant Start", start_date: Date.new(2021, 9, 1), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
-          { name: "Output 2 - Retention Point 1", start_date: Date.new(2021, 11, 1), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
-          { name: "Output 3 - Retention Point 2", start_date: Date.new(2022, 2, 1), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
-          { name: "Output 4 - Participant Completion", start_date: Date.new(2023, 2, 1), payment_date: Date.new(2023, 5, 31), declaration_type: "completed" },
-        ].each do |hash|
-          Finance::Milestone.find_or_create_by!(
-            schedule: schedule,
-            name: hash[:name],
-            start_date: hash[:start_date],
-            payment_date: hash[:payment_date],
-          ).update!(declaration_type: hash[:declaration_type])
-        end
+      after(:create) do |_schedule|
+        Importers::SeedSchedule.new(
+          path_to_csv: Rails.root.join("db/seeds/schedules/npq_specialist.csv"),
+          klass: Finance::Schedule::NPQSpecialist,
+        ).call
+
+        Importers::SeedSchedule.new(
+          path_to_csv: Rails.root.join("db/seeds/schedules/npq_leadership.csv"),
+          klass: Finance::Schedule::NPQLeadership,
+        ).call
       end
     end
 

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -5,8 +5,6 @@ require "rails_helper"
 RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :feature, js: true do
   include Finance::NPQPaymentsHelper
 
-  let(:npq_leadership_schedule) { create(:npq_leadership_schedule) }
-  let(:npq_specialist_schedule) { create(:npq_specialist_schedule) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, name: "Lead Provider") }
   let(:npq_lead_provider) { create(:npq_lead_provider, cpd_lead_provider: cpd_lead_provider, name: "NPQ Lead Provider") }
   let(:npq_leading_teaching_contract) { create(:npq_contract, :npq_leading_teaching, npq_lead_provider: npq_lead_provider) }
@@ -185,7 +183,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   def then_i_should_see_correct_course_summary
     within first(".app-application-card__header") do
       expect(page).to have_content("Started")
-      expect(page).to have_content(total_participants_for(npq_specialist_schedule.milestones.first))
+      expect(page).to have_content(total_participants_for(Finance::Schedule::NPQLeadership.default.schedule_milestones.find_by(declaration_type: "started")))
       expect(page).to have_content("Total declarations")
       expect(page).to have_content(total_declarations(npq_leading_behaviour_culture_contract))
     end
@@ -238,8 +236,8 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     statement.participant_declarations.for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier).paid_payable_or_eligible.group(:declaration_type).count
   end
 
-  def total_participants_for(milestone)
-    participants_per_declaration_type.fetch(milestone.declaration_type, 0)
+  def total_participants_for(milestone_schedule)
+    participants_per_declaration_type.fetch(milestone_schedule.declaration_type, 0)
   end
 
   def output_payment

--- a/spec/models/finance/schedule/ecf_spec.rb
+++ b/spec/models/finance/schedule/ecf_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
     schedule = described_class.find_by(schedule_identifier: "ecf-standard-april")
 
     expect(schedule).to be_present
-    expect(schedule.milestones.count).to eql(6)
+    expect(schedule.milestones.count).to eql(7)
 
     schedule = described_class.find_by(schedule_identifier: "ecf-reduced-april")
 

--- a/spec/services/record_declarations/base_spec.rb
+++ b/spec/services/record_declarations/base_spec.rb
@@ -156,7 +156,13 @@ RSpec.describe RecordDeclarations::Base do
 
     context "when milestone has null milestone_date" do
       before do
-        Finance::Milestone.find_by(declaration_type: "started").update!(milestone_date: nil)
+        ect_participant_profile
+          .schedule
+          .schedule_milestones
+          .where(declaration_type: "started")
+          .first
+          .milestone
+          .update!(milestone_date: nil)
       end
 
       it "does not have errors on milestone_date" do
@@ -166,7 +172,7 @@ RSpec.describe RecordDeclarations::Base do
 
     context "when declaration_type does not exist for the schedule" do
       before do
-        ect_participant_profile.schedule.milestones.find_by(declaration_type: "retained-4").destroy
+        ect_participant_profile.schedule.schedule_milestones.find_by(declaration_type: "retained-4").destroy
       end
 
       subject do

--- a/spec/services/record_declarations/retained/npq_spec.rb
+++ b/spec/services/record_declarations/retained/npq_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe RecordDeclarations::Retained::NPQ do
   include_context "lead provider profiles and courses"
   include_context "service record declaration params"
 
-  let(:cutoff_start_datetime) { npq_profile.schedule.milestones.where(declaration_type: "started").first.start_date.beginning_of_day }
-  let(:cutoff_end_datetime) { npq_profile.schedule.milestones[1].milestone_date.end_of_day }
+  let(:milestone) { npq_profile.schedule.schedule_milestones.find_by(declaration_type: "started").milestone }
+  let(:cutoff_start_datetime) { milestone.start_date.beginning_of_day }
+  let(:cutoff_end_datetime) { milestone.milestone_date.end_of_day }
 
   before do
     travel_to cutoff_start_datetime + 2.days

--- a/spec/support/with_default_schedules.rb
+++ b/spec/support/with_default_schedules.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.shared_context "with default schedules", shared_context: :metadata do
-  before do
-    create(:ecf_schedule)
-    create(:npq_specialist_schedule)
-    create(:npq_leadership_schedule)
-    create(:npq_aso_schedule)
-  end
+  let!(:ecf_schedule)            { create(:ecf_schedule) }
+  let!(:npq_specialist_schedule) { create(:npq_specialist_schedule) }
+  let!(:npq_leadership_schedule) { create(:npq_leadership_schedule) }
+  let!(:npq_aso_schedule)        { create(:npq_aso_schedule) }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Use milestone_schedule to for validation which was left over from previous statment
automation story - deduplicating milestones which will allow to edit a
milestone's `milestone_date` easily, as there now is only one milestone for a
given start_date + milestone_date pair.

We can now have multiple start date within a schedule allowing us to as this
extra period.

## Ticket and context

Ticket:

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
