### PR TITLE
Declarations pagination error with UNION fix

### DIFF
--- a/app/services/api/participant_declarations/index.rb
+++ b/app/services/api/participant_declarations/index.rb
@@ -19,7 +19,7 @@ module Api
       scope = scope.where("user_id = ?", participant_id) if participant_id.present?
       scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
 
-      scope
+      scope.order(:created_at)
     end
 
   private


### PR DESCRIPTION
## Ticket and context

Ticket:

## Tech review

* Added created_at order to `ParticipantDeclarations::Index`, which fixes the issue.

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
