### PR TITLE
[CST-510] Mentors in multiple cohorts - Part 1

### DIFF
--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -10,6 +10,9 @@ class ParticipantProfile < ApplicationRecord
              dependent: :nullify
     has_many :mentees, through: :mentee_profiles, source: :user
 
+    has_many :school_mentors, dependent: :destroy, foreign_key: :participant_profile_id
+    has_many :schools, through: :school_mentors
+
     def mentor?
       true
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -35,6 +35,9 @@ class School < ApplicationRecord
   has_many :induction_coordinator_profiles, through: :induction_coordinator_profiles_schools
   has_many :induction_coordinators, through: :induction_coordinator_profiles, source: :user
 
+  has_many :school_mentors, dependent: :destroy
+  has_many :mentor_profiles, through: :school_mentors, source: :participant_profile
+
   has_many :ecf_participant_profiles, through: :school_cohorts, source: :ecf_participant_profiles, class_name: "ParticipantProfile::ECF"
   has_many :ecf_participants, through: :ecf_participant_profiles, source: :user
   has_many :active_ecf_participant_profiles, through: :school_cohorts

--- a/app/models/school_mentor.rb
+++ b/app/models/school_mentor.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SchoolMentor < ApplicationRecord
+  belongs_to :school
+  belongs_to :participant_profile, class_name: "ParticipantProfile::Mentor"
+  belongs_to :preferred_identity, class_name: "ParticipantIdentity"
+end

--- a/app/services/mentors/add_to_school.rb
+++ b/app/services/mentors/add_to_school.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Mentors
-  class AddToSchool< BaseService
+  class AddToSchool < BaseService
     def call
       SchoolMentor.find_or_create_by!(participant_profile: mentor_profile, school: school) do |record|
         record.preferred_identity = preferred_identity
@@ -10,12 +10,21 @@ module Mentors
 
   private
 
-    attr_reader :mentor_profile, :school, :preferred_identity
+    attr_reader :mentor_profile, :school, :preferred_email
 
-    def initialize(mentor_profile:, school:, preferred_identity: nil)
+    def initialize(mentor_profile:, school:, preferred_email: nil)
       @mentor_profile = mentor_profile
       @school = school
-      @preferred_identity = preferred_identity || mentor_profile.participant_identity
+      @preferred_email = preferred_email
+    end
+
+    def preferred_identity
+      if preferred_email.blank?
+        mentor_profile.participant_identity
+      else
+        Identity::Create.call(user: mentor_profile.participant_identity.user,
+                              email: preferred_email)
+      end
     end
   end
 end

--- a/app/services/mentors/add_to_school.rb
+++ b/app/services/mentors/add_to_school.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Mentors
+  class AddToSchool< BaseService
+    def call
+      SchoolMentor.find_or_create_by!(participant_profile: mentor_profile, school: school) do |record|
+        record.preferred_identity = preferred_identity
+      end
+    end
+
+  private
+
+    attr_reader :mentor_profile, :school, :preferred_identity
+
+    def initialize(mentor_profile:, school:, preferred_identity: nil)
+      @mentor_profile = mentor_profile
+      @school = school
+      @preferred_identity = preferred_identity || mentor_profile.participant_identity
+    end
+  end
+end

--- a/app/services/mentors/remove_from_school.rb
+++ b/app/services/mentors/remove_from_school.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mentors
+  class RemoveFromSchool< BaseService
+    def call
+      school.school_mentors.find_by(participant_profile: mentor_profile)&.destroy
+    end
+
+  private
+
+    attr_reader :mentor_profile, :from_school, :to_school, :preferred_identity
+
+    def initialize(mentor_profile:, school:)
+      @mentor_profile = mentor_profile
+      @school = school
+    end
+  end
+end

--- a/app/services/mentors/remove_from_school.rb
+++ b/app/services/mentors/remove_from_school.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module Mentors
-  class RemoveFromSchool< BaseService
+  class RemoveFromSchool < BaseService
     def call
       school.school_mentors.find_by(participant_profile: mentor_profile)&.destroy
     end
 
   private
 
-    attr_reader :mentor_profile, :from_school, :to_school, :preferred_identity
+    attr_reader :mentor_profile, :school
 
     def initialize(mentor_profile:, school:)
       @mentor_profile = mentor_profile

--- a/db/migrate/20220429144309_create_school_mentors.rb
+++ b/db/migrate/20220429144309_create_school_mentors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSchoolMentors < ActiveRecord::Migration[6.1]
+  def change
+    create_table :school_mentors do |t|
+      t.references :participant_profile, null: false, foreign_key: true, type: :uuid
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.references :preferred_identity, references: :participant_identities, null: false, type: :uuid, foreign_key: { to_table: :participant_identities }
+      t.timestamps
+    end
+
+    add_index :school_mentors, [:participant_profile_id, :school_id], unique: true
+  end
+end

--- a/db/migrate/20220429144309_create_school_mentors.rb
+++ b/db/migrate/20220429144309_create_school_mentors.rb
@@ -9,6 +9,6 @@ class CreateSchoolMentors < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
-    add_index :school_mentors, [:participant_profile_id, :school_id], unique: true
+    add_index :school_mentors, %i[participant_profile_id school_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,8 +119,6 @@ ActiveRecord::Schema.define(version: 2022_05_03_132944) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "start_year", limit: 2, null: false
-    t.datetime "registration_start_date"
-    t.datetime "academic_year_start_date"
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -119,6 +119,8 @@ ActiveRecord::Schema.define(version: 2022_05_03_132944) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "start_year", limit: 2, null: false
+    t.datetime "registration_start_date"
+    t.datetime "academic_year_start_date"
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 
@@ -803,6 +805,18 @@ ActiveRecord::Schema.define(version: 2022_05_03_132944) do
     t.index ["school_id"], name: "index_school_local_authority_districts_on_school_id"
   end
 
+  create_table "school_mentors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "participant_profile_id", null: false
+    t.uuid "school_id", null: false
+    t.uuid "preferred_identity_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["participant_profile_id", "school_id"], name: "index_school_mentors_on_participant_profile_id_and_school_id", unique: true
+    t.index ["participant_profile_id"], name: "index_school_mentors_on_participant_profile_id"
+    t.index ["preferred_identity_id"], name: "index_school_mentors_on_preferred_identity_id"
+    t.index ["school_id"], name: "index_school_mentors_on_school_id"
+  end
+
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -978,6 +992,9 @@ ActiveRecord::Schema.define(version: 2022_05_03_132944) do
   add_foreign_key "school_local_authorities", "schools"
   add_foreign_key "school_local_authority_districts", "local_authority_districts"
   add_foreign_key "school_local_authority_districts", "schools"
+  add_foreign_key "school_mentors", "participant_identities", column: "preferred_identity_id"
+  add_foreign_key "school_mentors", "participant_profiles"
+  add_foreign_key "school_mentors", "schools"
   add_foreign_key "schools", "networks"
   add_foreign_key "teacher_profiles", "schools"
   add_foreign_key "teacher_profiles", "users"

--- a/spec/services/mentors/add_to_school_spec.rb
+++ b/spec/services/mentors/add_to_school_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Mentors::AddToSchool do
+  let(:cohort) { create(:cohort, start_year: 2021) }
+  let(:school_cohort) { create(:school_cohort, cohort: cohort) }
+  let(:school) { school_cohort.school }
+  let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+
+  it "creates a school mentor record" do
+    expect {
+      described_class.call(
+        mentor_profile: mentor_profile,
+        school: school,
+      )
+    }.to change { SchoolMentor.count }.by(1)
+  end
+
+  it "adds the mentor to the school's mentor pool" do
+    described_class.call(
+      mentor_profile: mentor_profile,
+      school: school,
+    )
+
+    expect(school.mentor_profiles).to include mentor_profile
+  end
+
+  context "when an unused email is supplied" do
+    let(:email) { "ted.mentor@digital.example.com" }
+
+    it "adds an identity record" do
+      expect {
+        described_class.call(
+          mentor_profile: mentor_profile,
+          school: school,
+          preferred_email: email,
+        )
+      }.to change { ParticipantIdentity.count }.by(1)
+    end
+
+    it "sets the preferred identity on the school mentor" do
+      described_class.call(
+        mentor_profile: mentor_profile,
+        school: school,
+        preferred_email: email,
+      )
+      expect(school.school_mentors.first.preferred_identity.email).to eq email
+    end
+  end
+end

--- a/spec/services/mentors/remove_from_school_spec.rb
+++ b/spec/services/mentors/remove_from_school_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Mentors::RemoveFromSchool do
+  let(:cohort) { create(:cohort, start_year: 2021) }
+  let(:school_cohort) { create(:school_cohort, cohort: cohort) }
+  let(:school) { school_cohort.school }
+  let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+
+  before do
+    Mentors::AddToSchool.call(mentor_profile: mentor_profile, school: school)
+  end
+
+  it "removes the school mentor record" do
+    expect {
+      described_class.call(
+        mentor_profile: mentor_profile,
+        school: school,
+      )
+    }.to change { SchoolMentor.count }.by(-1)
+  end
+
+  it "removes the mentor from the school's mentor pool" do
+    described_class.call(
+      mentor_profile: mentor_profile,
+      school: school,
+    )
+
+    expect(school.mentor_profiles).not_to include mentor_profile
+  end
+end


### PR DESCRIPTION
## Ticket and context

[Jira Ticket:](https://dfedigital.atlassian.net/browse/CST-510)

Back-end changes to support having a cross-cohort pool of mentors at a school

* Migration to add new "join" table `school_mentors`
* Adds new join model `SchoolMentor` to link `School` and `ParticipantProfile::Mentor` types
* Adds services to add and remove mentors from `school_mentors`
* Adds `preferred_identity` on the `SchoolMentor` so we can use this later to provide a preferred email when we get to handling mentors at multiple schools (same as `InductionRecord.preferred_identity` method).

UI changes to adding mentors to follow in subsequent PRs.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
