### PR TITLE
CST-624 Add mailer to invite existing schools to choose programme for 22/23

### DIFF
--- a/app/mailers/participant_mailer.rb
+++ b/app/mailers/participant_mailer.rb
@@ -10,8 +10,7 @@ class ParticipantMailer < ApplicationMailer
     mentor_fip: "ba3d4caf-5ef8-4a14-9e79-b7719780da09",
     sit_mentor_cip: "7aa80a9c-e486-42e8-92c8-7f970459d37d",
     sit_mentor_fip: "0b7f850f-f26a-4e62-9fc5-17fbd8286e49",
-    fip_preterm_reminder: "12969797-c110-436d-b10b-7f7d08d4d9df",
-    cip_preterm_reminder: "623cb545-1bc4-4407-94a1-474e2a080e39",
+    preterm_reminder: "3bece922-871e-49a9-88a1-83eeb8821ab1",
   }.freeze
 
   def participant_added(participant_profile:)
@@ -63,34 +62,17 @@ class ParticipantMailer < ApplicationMailer
     ).tag(:request_for_details).associate_with(participant_profile, as: :participant_profile)
   end
 
-  def fip_preterm_reminder(induction_coordinator_profile:, season:, school_name:)
+  def preterm_reminder(induction_coordinator_profile:)
     template_mail(
-      PARTICIPANT_TEMPLATES[:fip_preterm_reminder],
+      PARTICIPANT_TEMPLATES[:preterm_reminder],
       to: induction_coordinator_profile.user.email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        season: season,
         name: induction_coordinator_profile.user.full_name,
-        school_name: school_name,
-        sign_in: new_user_session_url,
+        sign_in: new_user_session_url(**UTMService.email(:preterm_reminder)),
       },
-    ).tag(:fip_preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
-  end
-
-  def cip_preterm_reminder(induction_coordinator_profile:, season:, school_name:)
-    template_mail(
-      PARTICIPANT_TEMPLATES[:cip_preterm_reminder],
-      to: induction_coordinator_profile.user.email,
-      rails_mailer: mailer_name,
-      rails_mail_template: action_name,
-      personalisation: {
-        season: season,
-        name: induction_coordinator_profile.user.full_name,
-        school_name: school_name,
-        sign_in: new_user_session_url,
-      },
-    ).tag(:cip_preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
+    ).tag(:preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
   end
 
 private

--- a/app/models/concerns/gias_types.rb
+++ b/app/models/concerns/gias_types.rb
@@ -8,6 +8,9 @@ module GiasTypes
   CIP_ONLY_TYPE_CODES = [10, 11, 30, 37].freeze
   CIP_ONLY_EXCEPT_WELSH_CODES = [10, 11, 37].freeze
 
+  # Types that *are* eligible but we would prefer not to send communications to.
+  NO_INVITATIONS_TYPE_CODES = [47, 48].freeze
+
   OPEN_STATUS_CODES = ELIGIBLE_STATUS_CODES
   CLOSED_STATUS_CODES = [2, 4].freeze
 

--- a/spec/services/invite_ects_spec.rb
+++ b/spec/services/invite_ects_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InviteEcts do
+  subject(:invite_ects) { described_class.new }
+  let!(:cohort) { create(:cohort, :next) }
+
+  let!(:school) { create(:school) }
+  let!(:school_cohort) { create(:school_cohort, school: school) }
+
+  let!(:induction_coordinator_profile) { create(:induction_coordinator_profile, schools: [school]) }
+
+  before(:all) do
+    FeatureFlag.activate(:multiple_cohorts)
+    RSpec::Mocks.configuration.verify_partial_doubles = false
+  end
+
+  before(:each) do
+    allow_any_instance_of(Mail::TestMailer).to receive_message_chain(:response, :id) { "notify_id" }
+  end
+
+  after(:all) do
+    FeatureFlag.deactivate(:multiple_cohorts)
+    RSpec::Mocks.configuration.verify_partial_doubles = true
+  end
+
+  describe "#preterm_reminder" do
+    it "sends the nomination email" do
+      expect(ParticipantMailer).to receive(:preterm_reminder).with(
+        hash_including(induction_coordinator_profile: induction_coordinator_profile),
+      ).and_call_original
+
+      invite_ects.preterm_reminder
+    end
+
+    context "with an induction profile that has already received the email" do
+      before do
+        create(:email, associated_with: [induction_coordinator_profile], tags: %w[preterm_reminder])
+      end
+
+      it "does not send the email again" do
+        expect(ParticipantMailer).to receive(:preterm_reminder).never
+
+        invite_ects.preterm_reminder
+      end
+    end
+
+    context "where the school is a childrens centre" do
+      before do
+        school.update!(school_type_code: GiasTypes::NO_INVITATIONS_TYPE_CODES.sample)
+      end
+
+      it "does not send the email again" do
+        expect(ParticipantMailer).to receive(:preterm_reminder).never
+
+        invite_ects.preterm_reminder
+      end
+    end
+
+    context "where the school has already chosen a programme" do
+      before { create :school_cohort, school: school, cohort: cohort }
+
+      it "does not send the email again" do
+        expect(ParticipantMailer).to receive(:preterm_reminder).never
+
+        invite_ects.preterm_reminder
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CST-624

The criteria should be:

To send to existing schools:
- defined as any school registered in our service with a nominated SIT (this includes SITs that opted out for 2021 to 2022)
- we'll email the SIT directly
- the SIT will sign in and use the new multiple cohort journey (to confirm their programme for FIP, or select again for CIP and DIY)
- once the SIT has confirmed their programme choice for 2022 to 2023, the school will leave this list
- links to ((sign_in)) which should include GA tracking
- variable ((SIT_name)) should include the full name of the SIT