### PR TITLE
[CPDLP-1274] - Check posting 2022 declarations will not assign to 202…

### DIFF
--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -39,11 +39,12 @@ class Finance::Statement < ApplicationRecord
   private
 
     def statement_for(participant_declaration)
+      cohort = participant_declaration.participant_profile.schedule.cohort
       case participant_declaration
       when ParticipantDeclaration::ECF
-        participant_declaration.cpd_lead_provider.lead_provider.next_output_fee_statement
+        participant_declaration.cpd_lead_provider.lead_provider.next_output_fee_statement(cohort)
       when ParticipantDeclaration::NPQ
-        participant_declaration.cpd_lead_provider.npq_lead_provider.next_output_fee_statement
+        participant_declaration.cpd_lead_provider.npq_lead_provider.next_output_fee_statement(cohort)
       end
     end
   end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -29,7 +29,7 @@ class LeadProvider < ApplicationRecord
   has_many :statements, through: :cpd_lead_provider, class_name: "Finance::Statement::ECF", source: :ecf_statements
   validates :name, presence: { message: "Enter a name" }
 
-  def next_output_fee_statement
-    statements.next_output_fee_statements.first
+  def next_output_fee_statement(cohort)
+    statements.next_output_fee_statements.where(cohort: cohort).first
   end
 end

--- a/app/models/npq_lead_provider.rb
+++ b/app/models/npq_lead_provider.rb
@@ -10,7 +10,7 @@ class NPQLeadProvider < ApplicationRecord
   has_many :statements, through: :cpd_lead_provider, class_name: "Finance::Statement::NPQ", source: :npq_statements
   has_many :participant_declarations, class_name: "ParticipantDeclaration::NPQ", through: :cpd_lead_provider
 
-  def next_output_fee_statement
-    statements.next_output_fee_statements.first
+  def next_output_fee_statement(cohort)
+    statements.next_output_fee_statements.where(cohort: cohort).first
   end
 end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -42,11 +42,24 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         create(:ecf_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider: cpd_lead_provider)
       end
 
+      context "when transitioned to another cohort" do
+        let(:next_cohort)   { create(:cohort, :next) }
+        let(:next_schedule) { create(:schedule, cohort: next_cohort) }
+        let!(:ect_profile)   { create(:ect_participant_profile, schedule: next_schedule) }
+        before do
+          create(:school_cohort, school: ect_profile.school, cohort: next_cohort)
+          create(:partnership, school: ect_profile.school, lead_provider: cpd_lead_provider.lead_provider, cohort: next_cohort, delivery_partner: delivery_partner)
+        end
+
+        it "create declaration record and declaration attempt and return id when successful" do
+        end
+      end
+
       it "create declaration record and declaration attempt and return id when successful" do
         params = build_params(valid_params)
         expect { post "/api/v1/participant-declarations", params: params }
-            .to change(ParticipantDeclaration, :count).by(1)
-            .and change(ParticipantDeclarationAttempt, :count).by(1)
+          .to change(ParticipantDeclaration, :count).by(1)
+                .and change(ParticipantDeclarationAttempt, :count).by(1)
         expect(ApiRequestAudit.order(created_at: :asc).last.body).to eq(params.to_s)
         expect(response.status).to eq 200
         expect(parsed_response["data"]["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -43,15 +43,25 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
       end
 
       context "when transitioned to another cohort" do
-        let(:next_cohort)   { create(:cohort, :next) }
-        let(:next_schedule) { create(:schedule, cohort: next_cohort) }
-        let!(:ect_profile)   { create(:ect_participant_profile, schedule: next_schedule) }
-        before do
-          create(:school_cohort, school: ect_profile.school, cohort: next_cohort)
-          create(:partnership, school: ect_profile.school, lead_provider: cpd_lead_provider.lead_provider, cohort: next_cohort, delivery_partner: delivery_partner)
-        end
+        let(:school)              { create(:school)}
+        let(:next_cohort)         { create(:cohort, :next) }
+        let(:next_school_cohort)  { create(:school_cohort, school: school, cohort: next_cohort) }
+        let(:next_schedule)       { create(:schedule, name: "ECF September 2022", cohort: next_cohort) }
+        let(:partnership)         { create(:partnership, school: school, lead_provider: cpd_lead_provider.lead_provider, cohort: next_cohort, delivery_partner: delivery_partner) }
+        let(:induction_programme) { create(:induction_programme, :fip, partnership: partnership) }
+        let(:profile)         { create(:ect_participant_profile, schedule: next_schedule) }
 
+        before do
+          create(:milestone, schedule: next_schedule, start_date: Date.new(2022, 9, 1), milestone_date: Date.new(2022, 11, 30)).tap do |milestone|
+            byebug
+          end
+          Induction::Enrol.call(participant_profile: ect, induction_programme: induction_programme)
+        end
         it "create declaration record and declaration attempt and return id when successful" do
+          byebug
+          pp build_params(valid_params)
+          post "/api/v1/participant-declarations", params: build_params(valid_params)
+
         end
       end
 

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         create(:ecf_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider: cpd_lead_provider)
       end
 
-      context "when transitioned to another cohort" do
+      context "when posting for the new cohort" do
         let(:school)              { create(:school) }
         let(:next_cohort)         { create(:cohort, :next) }
         let(:next_school_cohort)  { create(:school_cohort, school: school, cohort: next_cohort) }
@@ -76,7 +76,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         params = build_params(valid_params)
         expect { post "/api/v1/participant-declarations", params: params }
           .to change(ParticipantDeclaration, :count).by(1)
-                .and change(ParticipantDeclarationAttempt, :count).by(1)
+          .and change(ParticipantDeclarationAttempt, :count).by(1)
         expect(ApiRequestAudit.order(created_at: :asc).last.body).to eq(params.to_s)
         expect(response.status).to eq 200
         expect(parsed_response["data"]["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
       it "create declaration record and declaration attempt and return id when successful" do
         params = build_params(valid_params)
         expect { post "/api/v1/participant-declarations", params: params }
-          .to change(ParticipantDeclaration, :count).by(1)
-          .and change(ParticipantDeclarationAttempt, :count).by(1)
+            .to change(ParticipantDeclaration, :count).by(1)
+            .and change(ParticipantDeclarationAttempt, :count).by(1)
         expect(ApiRequestAudit.order(created_at: :asc).last.body).to eq(params.to_s)
         expect(response.status).to eq 200
         expect(parsed_response["data"]["id"]).to eq(ParticipantDeclaration.order(:created_at).last.id)

--- a/spec/requests/lead_providers/report_schools/base_spec.rb
+++ b/spec/requests/lead_providers/report_schools/base_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Lead Provider school reporting", type: :request do
   let(:user) { create(:user, :lead_provider) }
   let!(:cohort) { Cohort.current || create(:cohort, :current) }
-  let!(:cohort_2022) { create(:cohort, :next) }
+  let!(:cohort_2022) { Cohort.next || create(:cohort, :next) }
 
   before do
     sign_in user


### PR DESCRIPTION
## Ticket and context

[CPDLP-1274](https://dfedigital.atlassian.net/browse/CPDLP-1274)

Upon submission the declaration will be a attached to the statement for the relevant cohort which is lookup via the participant's schedule.

## NOTE:
this will still need to populate the 2022 cohort statements.