### PR TITLE
Create the programme changed email

### DIFF
--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -59,13 +59,12 @@ module Schools
     end
 
     def what_changes_confirmation
-      what_changes_choice = @setup_school_cohort_form.what_changes_choice
       programme_choice = @setup_school_cohort_form.programme_choice
 
       set_cohort_induction_programme!(programme_choice)
 
       if previous_school_cohort.full_induction_programme?
-        send_fip_programme_changed_email!(what_changes_choice)
+        send_fip_programme_changed_email!
       end
 
       store_form_redirect_to_next_step :what_changes_submitted
@@ -85,7 +84,7 @@ module Schools
 
   private
 
-    def send_fip_programme_changed_email!(what_changes_choice)
+    def send_fip_programme_changed_email!
       previous_partnership = previous_school_cohort.default_induction_programme.partnership
 
       previous_partnership.lead_provider.users.each do |lead_provider_user|
@@ -93,7 +92,7 @@ module Schools
           partnership: previous_partnership,
           user: lead_provider_user,
           cohort_year: school_cohort.academic_year,
-          what_changes_choice: what_changes_choice,
+          what_changes_choice: @setup_school_cohort_form.what_changes_choice,
         ).deliver_later
       end
     end

--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -92,7 +92,7 @@ module Schools
         LeadProviderMailer.programme_changed_email(
           partnership: previous_partnership,
           user: lead_provider_user,
-          cohort_year: school_cohort.description,
+          cohort_year: school_cohort.academic_year,
           what_changes_choice: what_changes_choice,
         ).deliver_later
       end

--- a/app/mailers/lead_provider_mailer.rb
+++ b/app/mailers/lead_provider_mailer.rb
@@ -3,6 +3,7 @@
 class LeadProviderMailer < ApplicationMailer
   WELCOME_EMAIL_TEMPLATE = "07773cdf-9db6-4880-9ac6-ab4454a71d65"
   PARTNERSHIP_CHALLENGED_TEMPLATE_ID = "01c1ab30-1a45-4ce7-b994-e4df8334f23b"
+  PROGRAMME_CHANGED_TEMPLATE_ID = "821c3b28-27a7-4ed4-9d1f-58e8f341dac7"
 
   def welcome_email(user:, lead_provider_name:, start_url:)
     template_mail(
@@ -35,5 +36,29 @@ class LeadProviderMailer < ApplicationMailer
         reason: reason,
       },
     ).tag(:partnership_challenged).associate_with(partnership)
+  end
+
+  def programme_changed_email(partnership:, user:, cohort_year:, what_changes_choice:)
+    lead_provider_name = partnership.lead_provider.name
+    delivery_partner_name = partnership.delivery_partner.name
+
+    reason = I18n.t(what_changes_choice, scope: "programme_changed_reasons",
+                                         lead_provider_name: lead_provider_name,
+                                         delivery_partner_name: delivery_partner_name)
+
+    template_mail(
+      PROGRAMME_CHANGED_TEMPLATE_ID,
+      to: user.email,
+      rails_mailer: mailer_name,
+      rails_mailer_template: action_name,
+      personalisation: {
+        name: user.full_name,
+        school_name: partnership.school.name,
+        school_urn: partnership.school.urn,
+        delivery_partner_name: delivery_partner_name,
+        cohort_year: cohort_year,
+        reason: reason,
+      },
+    ).tag(:fip_programme_changed)
   end
 end

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -37,7 +37,7 @@ class SchoolCohort < ApplicationRecord
 
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
 
-  delegate :description, to: :cohort
+  delegate :description, :academic_year, to: :cohort
 
   after_save do |school_cohort|
     unless school_cohort.saved_changes.empty?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,11 @@ en:
     career_break: Career break
     passed_induction: Passed Induction
     other: "Other"
+  programme_changed_reasons:
+    change_lead_provider: The school wants to leave %{lead_provider_name} and use a different lead provider
+    change_delivery_partner: The school wants to stay with %{lead_provider_name} but change their delivery partner, %{delivery_partner_name}
+    change_to_core_induction_programme: The school wants to deliver their own programme using DfE-accredited materials
+    change_to_design_our_own: The school wants to design and deliver their own programme based on the early career framework (ECF)
 
   # Errors
   fail: "FAIL"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,10 +16,10 @@ en:
     passed_induction: Passed Induction
     other: "Other"
   programme_changed_reasons:
-    change_lead_provider: The school wants to leave %{lead_provider_name} and use a different lead provider
-    change_delivery_partner: The school wants to stay with %{lead_provider_name} but change their delivery partner, %{delivery_partner_name}
-    change_to_core_induction_programme: The school wants to deliver their own programme using DfE-accredited materials
-    change_to_design_our_own: The school wants to design and deliver their own programme based on the early career framework (ECF)
+    change_lead_provider: the school wants to leave %{lead_provider_name} and use a different lead provider
+    change_delivery_partner: the school wants to stay with %{lead_provider_name} but change their delivery partner, %{delivery_partner_name}
+    change_to_core_induction_programme: the school wants to deliver their own programme using DfE-accredited materials
+    change_to_design_our_own: the school wants to design and deliver their own programme based on the early career framework (ECF)
 
   # Errors
   fail: "FAIL"

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -158,6 +158,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         then_i_am_taken_to_the_change_lead_provider_confirmation_page
 
         when_i_click_the_confirm_button
+        then_a_notification_email_is_sent_to_the_lead_provider
         then_i_am_taken_to_the_training_change_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
@@ -189,6 +190,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         then_i_am_taken_to_the_change_delivery_partner_confirmation_page
 
         when_i_click_the_confirm_button
+        then_a_notification_email_is_sent_to_the_lead_provider
         then_i_am_taken_to_the_training_change_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
@@ -220,6 +222,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         then_i_am_taken_to_the_change_to_design_own_programme_confirmation_page
 
         when_i_click_the_confirm_button
+        then_a_notification_email_is_sent_to_the_lead_provider
         then_i_am_taken_to_the_training_change_submitted_page
 
         when_i_click_on_the_return_to_your_training_link
@@ -250,6 +253,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         then_i_am_taken_to_the_change_to_design_and_deliver_own_programme_confirmation_page
 
         when_i_click_the_confirm_button
+        then_a_notification_email_is_sent_to_the_lead_provider
         then_i_am_taken_to_the_training_change_submitted_page
 
         when_i_click_on_the_return_to_your_training_link

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -33,6 +33,8 @@ module ChooseProgrammeSteps
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort)
     @school_cohort.update!(default_induction_programme: @induction_programme)
+    @lead_provider_user = create(:user)
+    @school_cohort.default_induction_programme.partnership.lead_provider.users << @lead_provider_user
   end
 
   # Then steps
@@ -96,6 +98,16 @@ module ChooseProgrammeSteps
 
   def then_i_am_taken_to_the_training_change_submitted_page
     expect(page).to have_content("You‘ve submitted your training information")
+  end
+
+  def then_a_notification_email_is_sent_to_the_lead_provider
+    expect(ActionMailer::MailDeliveryJob).to have_been_enqueued
+      .with(
+        "LeadProviderMailer",
+        "programme_changed_email",
+        "deliver_now",
+        a_hash_including(:args),
+      )
   end
 
   # And steps

--- a/spec/forms/schools/setup_school_cohort_form_spec.rb
+++ b/spec/forms/schools/setup_school_cohort_form_spec.rb
@@ -4,6 +4,19 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:expect_any_ects_choice).on(:expect_any_ects) }
     it { is_expected.to validate_presence_of(:how_will_you_run_training_choice).on(:how_will_you_run_training) }
+    it { is_expected.to validate_presence_of(:change_provider_choice).on(:change_provider) }
+    it { is_expected.to validate_presence_of(:what_changes_choice).on(:what_changes) }
+  end
+
+  describe ".PROGRAMME_CHOICES_MAP" do
+    it "returns a hash with the user programme choices and their respective programme types" do
+      expect(described_class::PROGRAMME_CHOICES_MAP).to eq({
+        "change_lead_provider" => "full_induction_programme",
+        "change_delivery_partner" => "full_induction_programme",
+        "change_to_core_induction_programme" => "core_induction_programme",
+        "change_to_design_our_own" => "design_our_own",
+      })
+    end
   end
 
   describe "#attributes" do
@@ -40,6 +53,33 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
           have_attributes(class: OpenStruct, id: "design_our_own", name: "Design and deliver you own programme based on the early career framework (ECF)"),
         ],
       )
+    end
+  end
+
+  describe "#what_changes_choices" do
+    it "returns an Array with the correct choices" do
+      lead_provider_name = "lead provider"
+      delivery_partner_name = "delivery partner"
+
+      expect(described_class.new.what_changes_choices(lead_provider_name, delivery_partner_name)).to match_array(
+        [
+          OpenStruct.new(id: "change_lead_provider", name: "Leave #{lead_provider_name} and use a different lead provider"),
+          OpenStruct.new(id: "change_delivery_partner", name: "Stay with #{lead_provider_name} but change your delivery partner, #{delivery_partner_name}"),
+          OpenStruct.new(id: "change_to_core_induction_programme", name: "Deliver your own programme using DfE-accredited materials"),
+          OpenStruct.new(id: "change_to_design_our_own", name: "Design and deliver you own programme based on the Early Career Framework (ECF)"),
+        ],
+      )
+    end
+  end
+
+  describe "#programme_choice" do
+    it "returns the programme type based on what user chooses to change" do
+      choices = { expect_any_ects_choice: "yes",
+                  how_will_you_run_training_choice: "core_induction_programme",
+                  change_provider_choice: "yes",
+                  what_changes_choice: "change_lead_provider" }
+
+      expect(described_class.new(choices).programme_choice).to eq("full_induction_programme")
     end
   end
 end

--- a/spec/mailers/lead_provider_mailer_spec.rb
+++ b/spec/mailers/lead_provider_mailer_spec.rb
@@ -38,4 +38,25 @@ RSpec.describe LeadProviderMailer, type: :mailer do
       expect(nomination_confirmation_email.from).to eq(["mail@example.com"])
     end
   end
+
+  describe "#programme_changed_email" do
+    let(:user) { create :user }
+    let(:partnership) { create :partnership, :challenged }
+    let(:cohort_year) { 2022 }
+    let(:what_changes_choice) { "change_lead_provider" }
+
+    let(:programme_changed_email) do
+      LeadProviderMailer.programme_changed_email(
+        user: user,
+        partnership: partnership,
+        cohort_year: cohort_year,
+        what_changes_choice: what_changes_choice,
+      ).deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(programme_changed_email.to).to eq([user.email])
+      expect(programme_changed_email.from).to eq(["mail@example.com"])
+    end
+  end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: CST-610

Let the previous LP know the school has chosen a different programme for the new cohort.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
