### PR TITLE
[CST-510] Mentors in multiple cohorts (Part 2)

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -128,7 +128,11 @@ class Schools::ParticipantsController < Schools::BaseController
 private
 
   def set_mentors_added
-    @mentors_added = @school.mentor_profiles_for(@cohort).any?
+    @mentors_added = if FeatureFlag.active?(:multiple_cohorts)
+                       @school.school_mentors.any?
+                     else
+                       @school.mentor_profiles_for(@cohort).any?
+                     end
   end
 
   def build_mentor_form

--- a/app/controllers/schools/transferring_participants_controller.rb
+++ b/app/controllers/schools/transferring_participants_controller.rb
@@ -90,7 +90,7 @@ module Schools
 
     def cannot_add; end
 
-    helper_method :with_same_provider_and_different_delivery_partner?
+    helper_method :with_same_provider_and_different_delivery_partner?, :show_mentor?
 
   private
 
@@ -229,6 +229,14 @@ module Schools
 
     def with_same_provider_and_different_delivery_partner?
       with_the_same_provider? && !with_the_same_delivery_partner?
+    end
+
+    def show_mentor?
+      if FeatureFlag.active?(:multiple_cohorts)
+        @latest_induction_record.participant_profile.ect? && @school_cohort.school.school_mentors.any?
+      else
+        @latest_induction_record.participant_profile.ect? && @school_cohort.active_mentors.any?
+      end
     end
 
     # Target lead provider

--- a/app/forms/participant_mentor_form.rb
+++ b/app/forms/participant_mentor_form.rb
@@ -13,7 +13,11 @@ class ParticipantMentorForm
   end
 
   def available_mentors
-    SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id).active_mentors.order(:full_name)
+    if FeatureFlag.active?(:multiple_cohorts)
+      User.where(id: school.school_mentors.joins(preferred_identity: :user).select("users.id")).order(:full_name)
+    else
+      SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id).active_mentors.order(:full_name)
+    end
   end
 
 private

--- a/app/forms/participant_mentor_form.rb
+++ b/app/forms/participant_mentor_form.rb
@@ -14,7 +14,7 @@ class ParticipantMentorForm
 
   def available_mentors
     if FeatureFlag.active?(:multiple_cohorts)
-      User.where(id: school.school_mentors.joins(preferred_identity: :user).select("users.id")).order(:full_name)
+      school.mentors
     else
       SchoolCohort.find_by(school_id: school_id, cohort_id: cohort_id).active_mentors.order(:full_name)
     end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -87,7 +87,11 @@ module Schools
     end
 
     def mentor_options
-      @mentor_options ||= school_cohort.active_mentors.order(:full_name)
+      @mentor_options ||= if FeatureFlag.active?(:multiple_cohorts)
+                            school_cohort.school.mentors
+                          else
+                            school_cohort.active_mentors.order(:full_name)
+                          end
     end
 
     def mentor

--- a/app/helpers/transferring_participant_helper.rb
+++ b/app/helpers/transferring_participant_helper.rb
@@ -17,7 +17,13 @@ module TransferringParticipantHelper
   end
 
   def teachers_programme_path_previous_step(participant, school_cohort)
-    if participant.ect? && school_cohort.active_mentors.any?
+    if FeatureFlag.active?(:multiple_cohorts)
+      if participant.ect? && school_cohort.school.school_mentors.any?
+        choose_mentor_schools_transferring_participant_path
+      else
+        email_schools_transferring_participant_path
+      end
+    elsif participant.ect? && school_cohort.active_mentors.any?
       choose_mentor_schools_transferring_participant_path
     else
       email_schools_transferring_participant_path

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -112,6 +112,10 @@ class School < ApplicationRecord
     school_cohorts.find_by(cohort: cohort)&.ecf_participant_profiles&.mentors&.active_record || []
   end
 
+  def mentors
+    User.where(id: school_mentors.joins(preferred_identity: :user).select("users.id")).order(:full_name)
+  end
+
   def registered?
     induction_coordinator_profiles.any?
   end

--- a/app/views/schools/transferring_participants/check_answers.html.erb
+++ b/app/views/schools/transferring_participants/check_answers.html.erb
@@ -42,13 +42,13 @@
                       href: url_for({ action: :email})) %>
       <% end %>
 
-      <% if @latest_induction_record.participant_profile.ect? && @school_cohort.active_mentors.any? %>
-          <% summary_list.row do |row| %>
-            <% row.key { "Mentor" } %>
-            <% row.value { @transferring_participant_form.mentor_id.present? ? @transferring_participant_form.mentor.full_name.titleize : "Assign a mentor later" } %>
-            <% row.action(text: "Change",
-                          visually_hidden_text: "mentor",
-                          href: url_for({ action: :choose_mentor})) %>
+      <% if show_mentor? %>
+        <% summary_list.row do |row| %>
+          <% row.key { "Mentor" } %>
+          <% row.value { @transferring_participant_form.mentor_id.present? ? @transferring_participant_form.mentor.full_name.titleize : "Assign a mentor later" } %>
+          <% row.action(text: "Change",
+                        visually_hidden_text: "mentor",
+                        href: url_for({ action: :choose_mentor})) %>
         <% end %>
       <% end %>
 

--- a/app/views/schools/transferring_participants/choose_mentor.html.erb
+++ b/app/views/schools/transferring_participants/choose_mentor.html.erb
@@ -11,8 +11,14 @@
     legend: { text: title, tag: 'h1', size: 'xl' },
     hint: { text: "You can tell us later if you’re not sure." } do %>
 
-    <% @school_cohort.current_induction_records.mentors.each do |mentor| %>
-      <%= f.govuk_radio_button :mentor_id, mentor.user.id, label: { text: mentor.user.full_name } %>
+    <% if FeatureFlag.active?(:multiple_cohorts) %>
+      <% @school_cohort.school.mentors.each do |mentor| %>
+        <%= f.govuk_radio_button :mentor_id, mentor.id, label: { text: mentor.full_name } %>
+      <% end %>
+    <% else %>
+      <% @school_cohort.current_induction_records.mentors.each do |mentor| %>
+        <%= f.govuk_radio_button :mentor_id, mentor.user.id, label: { text: mentor.user.full_name } %>
+      <% end %>
     <% end %>
 
     <%= f.govuk_radio_divider %>

--- a/spec/forms/participant_mentor_form_spec.rb
+++ b/spec/forms/participant_mentor_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ParticipantMentorForm, type: :model do
     end
 
     context "when multiple cohorts are active", with_feature_flags: { multiple_cohorts: "active" } do
-      let(:cohort_2022) { Cohort.find_by(start_year: 2022) ||  create(:cohort, start_year: 2022) }
+      let(:cohort_2022) { Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022) }
       let(:school_cohort_2) { create(:school_cohort, school: school, cohort: cohort_2022) }
 
       context "when there are mentors in the school mentor pool" do

--- a/spec/forms/participant_mentor_form_spec.rb
+++ b/spec/forms/participant_mentor_form_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe ParticipantMentorForm, type: :model do
   describe "#available_mentors" do
-    let(:school_cohort) { create(:school_cohort) }
+    let(:cohort_2021) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
+    let(:school_cohort) { create(:school_cohort, cohort: cohort_2021) }
     let(:school) { school_cohort.school }
 
     subject { described_class.new(school_id: school.id, cohort_id: school_cohort.cohort_id) }
@@ -17,6 +18,31 @@ RSpec.describe ParticipantMentorForm, type: :model do
       active_mentor_record = create(:mentor_participant_profile, school_cohort: school_cohort).user
 
       expect(subject.available_mentors).to include(active_mentor_record)
+    end
+
+    context "when multiple cohorts are active", with_feature_flags: { multiple_cohorts: "active" } do
+      let(:cohort_2022) { Cohort.find_by(start_year: 2022) ||  create(:cohort, start_year: 2022) }
+      let(:school_cohort_2) { create(:school_cohort, school: school, cohort: cohort_2022) }
+
+      context "when there are mentors in the school mentor pool" do
+        let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+        let(:mentor_profile_2) { create(:mentor_participant_profile, school_cohort: school_cohort_2) }
+
+        before do
+          Mentors::AddToSchool.call(school: school, mentor_profile: mentor_profile)
+          Mentors::AddToSchool.call(school: school, mentor_profile: mentor_profile_2)
+        end
+
+        it "includes to mentors in the pool" do
+          expect(subject.available_mentors).to match_array [mentor_profile.user, mentor_profile_2.user]
+        end
+      end
+
+      context "when there are no mentors in the school mentor pool" do
+        it "does not return any mentors" do
+          expect(subject.available_mentors).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Schools::AddParticipantForm, type: :model do
-  let(:school_cohort) { create :school_cohort }
+  let(:cohort_2021) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
+  let(:school_cohort) { create(:school_cohort, cohort: cohort_2021) }
+  let(:school) { school_cohort.school }
   let(:user) { create :user }
 
   subject(:form) { described_class.new(current_user_id: user.id, school_cohort_id: school_cohort.id) }
@@ -20,6 +22,31 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
       active_mentor_record = create(:mentor_participant_profile, school_cohort: school_cohort).user
 
       expect(form.mentor_options).to include(active_mentor_record)
+    end
+
+    context "when multiple cohorts are active", with_feature_flags: { multiple_cohorts: "active" } do
+      let(:cohort_2022) { Cohort.find_by(start_year: 2022) ||  create(:cohort, start_year: 2022) }
+      let(:school_cohort_2) { create(:school_cohort, school: school, cohort: cohort_2022) }
+
+      context "when there are mentors in the school mentor pool" do
+        let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+        let(:mentor_profile_2) { create(:mentor_participant_profile, school_cohort: school_cohort_2) }
+
+        before do
+          Mentors::AddToSchool.call(school: school, mentor_profile: mentor_profile)
+          Mentors::AddToSchool.call(school: school, mentor_profile: mentor_profile_2)
+        end
+
+        it "includes to mentors in the pool" do
+          expect(form.mentor_options).to match_array [mentor_profile.user, mentor_profile_2.user]
+        end
+      end
+
+      context "when there are no mentors in the school mentor pool" do
+        it "does not return any mentors" do
+          expect(form.mentor_options).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     context "when multiple cohorts are active", with_feature_flags: { multiple_cohorts: "active" } do
-      let(:cohort_2022) { Cohort.find_by(start_year: 2022) ||  create(:cohort, start_year: 2022) }
+      let(:cohort_2022) { Cohort.find_by(start_year: 2022) || create(:cohort, start_year: 2022) }
       let(:school_cohort_2) { create(:school_cohort, school: school, cohort: cohort_2022) }
 
       context "when there are mentors in the school mentor pool" do

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
   let(:ect_profile) { create(:ect_participant_profile, mentor_profile: mentor_user.mentor_profile, school_cohort: school_cohort) }
   let!(:ect_user) { ect_profile.user }
   let!(:withdrawn_ect) { create(:ect_participant_profile, :withdrawn_record, school_cohort: school_cohort).user }
-  let!(:unrelated_mentor) { create(:mentor_participant_profile, school_cohort: another_cohort).user }
+  let!(:unrelated_mentor_profile) { create(:mentor_participant_profile, school_cohort: another_cohort) }
+  let!(:unrelated_mentor) { unrelated_mentor_profile.user }
   let!(:unrelated_ect) { create(:ect_participant_profile, school_cohort: another_cohort).user }
   let!(:delivery_partner) { create(:delivery_partner, name: "Delivery Partner") }
   let!(:lead_provider) { create(:lead_provider, name: "Lead Provider", cohorts: [cohort]) }
@@ -95,6 +96,29 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       it "uses the mentor from the induction record" do
         get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}"
         expect(assigns(:mentor)).to eq mentor_user_2
+      end
+
+      context "when multiple cohorts are active", with_feature_flags: { multiple_cohorts: "active" } do
+        context "when there are mentors in the pool" do
+          let!(:school_mentors) { [mentor_profile, mentor_profile_2, unrelated_mentor_profile] }
+          before do
+            school_mentors.each do |profile|
+              Mentors::AddToSchool.call(school: school, mentor_profile: profile)
+            end
+          end
+
+          it "mentors_added is true" do
+            get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}"
+            expect(assigns(:mentors_added)).to be true
+          end
+        end
+
+        context "when there are no mentors in the pool" do
+          it "mentors_added is false" do
+            get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}"
+            expect(assigns(:mentors_added)).to be false
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Ticket and context

[Jira Ticket:](https://dfedigital.atlassian.net/browse/CST-510)

[Part 1](https://github.com/DFE-Digital/early-careers-framework/pull/2036) added the back-end changes to support having a mentor "pool" at schools to facilitate making mentors visible across cohorts.

Part 2 now implementing this for selecting mentors for ECTs in the UI. 

**Note:** Because of the tight deadline we've decided only to enable selecting mentors across any cohort at this point. The user journey changes in the ticket will be implemented after go live.

**Note:** Before this can go live we need to populate the `school_mentors` of each school with the active mentors in that school


## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true
- [ ] Added enough automated tests

### HTML Checks
- [ ] All new pages have automated accessibility checks
- [ ] All new pages have visual tests via Percy

### Gotchas
- [ ] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.

## External API changes

Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)
