### PR TITLE
[CN-131] [CPDLP-1303] Enhanced funding flag

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -55,6 +55,18 @@ class NPQApplication < ApplicationRecord
     end
   end
 
+  # this builds upon #eligible_for_funding
+  # eligible_for_funding is solely based on what NPQ app knows
+  # eg school, course etc
+  # here we need to account for previous enrollments too
+  def eligible_for_dfe_funding
+    if participant_identity.npq_applications.where(npq_course: npq_course).accepted.any?
+      false
+    else
+      eligible_for_funding
+    end
+  end
+
 private
 
   def push_enrollment_to_big_query

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -60,14 +60,28 @@ class NPQApplication < ApplicationRecord
   # eg school, course etc
   # here we need to account for previous enrollments too
   def eligible_for_dfe_funding
-    if participant_identity.npq_applications.where(npq_course: npq_course).accepted.any?
+    if previously_funded?
       false
     else
       eligible_for_funding
     end
   end
 
+  def ineligible_for_funding_reason
+    if previously_funded?
+      return "previously-funded"
+    end
+
+    unless eligible_for_funding
+      "establishment-ineligible"
+    end
+  end
+
 private
+
+  def previously_funded?
+    participant_identity.npq_applications.where(npq_course: npq_course).accepted.any?
+  end
 
   def push_enrollment_to_big_query
     if (saved_changes.keys & %w[id lead_provider_approval_status]).present?

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -80,7 +80,11 @@ class NPQApplication < ApplicationRecord
 private
 
   def previously_funded?
-    participant_identity.npq_applications.where(npq_course: npq_course).accepted.any?
+    participant_identity.npq_applications
+      .where(npq_course: npq_course)
+      .where(eligible_for_funding: true)
+      .accepted
+      .any?
   end
 
   def push_enrollment_to_big_query

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -81,7 +81,7 @@ private
 
   def previously_funded?
     participant_identity.npq_applications
-      .where(npq_course: npq_course)
+      .where(npq_course: npq_course.rebranded_alternative_courses)
       .where(eligible_for_funding: true)
       .accepted
       .any?

--- a/app/serializers/api/v1/npq_application_csv_serializer.rb
+++ b/app/serializers/api/v1/npq_application_csv_serializer.rb
@@ -62,7 +62,7 @@ module Api
           record.school_ukprn,
           record.private_childcare_provider_urn,
           record.headteacher_status,
-          record.eligible_for_funding,
+          record.eligible_for_dfe_funding,
           record.funding_choice,
           record.npq_course.identifier,
           record.lead_provider_approval_status,

--- a/app/serializers/api/v1/npq_application_csv_serializer.rb
+++ b/app/serializers/api/v1/npq_application_csv_serializer.rb
@@ -46,6 +46,7 @@ module Api
           created_at
           updated_at
           cohort
+          ineligible_for_funding_reason
         ]
       end
 
@@ -72,6 +73,7 @@ module Api
           record.created_at.rfc3339,
           record.updated_at.rfc3339,
           record.cohort.start_year.to_s,
+          record.ineligible_for_funding_reason,
         ]
       end
     end

--- a/app/serializers/api/v1/npq_application_serializer.rb
+++ b/app/serializers/api/v1/npq_application_serializer.rb
@@ -63,6 +63,8 @@ module Api
       attribute :cohort do |object|
         object.cohort.start_year.to_s
       end
+
+      attribute(:eligible_for_funding, &:eligible_for_dfe_funding)
     end
   end
 end

--- a/app/serializers/api/v1/npq_application_serializer.rb
+++ b/app/serializers/api/v1/npq_application_serializer.rb
@@ -9,8 +9,6 @@ module Api
       include JSONAPI::Serializer::Instrumentation
 
       attributes :course_identifier,
-                 :created_at,
-                 :eligible_for_funding,
                  :email,
                  :email_validated,
                  :employer_name,
@@ -18,6 +16,7 @@ module Api
                  :full_name,
                  :funding_choice,
                  :headteacher_status,
+                 :ineligible_for_funding_reason,
                  :participant_id,
                  :private_childcare_provider_urn,
                  :teacher_reference_number,
@@ -25,7 +24,6 @@ module Api
                  :school_urn,
                  :school_ukprn,
                  :status,
-                 :updated_at,
                  :works_in_school
 
       attribute(:participant_id) do |object|

--- a/app/serializers/api/v2/npq_application_csv_serializer.rb
+++ b/app/serializers/api/v2/npq_application_csv_serializer.rb
@@ -45,6 +45,7 @@ module Api
           employment_role
           created_at
           updated_at
+          ineligible_for_funding_reason
         ]
       end
 
@@ -70,6 +71,7 @@ module Api
           record.employment_role,
           record.created_at.rfc3339,
           record.updated_at.rfc3339,
+          record.ineligible_for_funding_reason,
         ]
       end
     end

--- a/app/serializers/api/v2/npq_application_csv_serializer.rb
+++ b/app/serializers/api/v2/npq_application_csv_serializer.rb
@@ -61,7 +61,7 @@ module Api
           record.school_ukprn,
           record.private_childcare_provider_urn,
           record.headteacher_status,
-          record.eligible_for_funding,
+          record.eligible_for_dfe_funding,
           record.funding_choice,
           record.npq_course.identifier,
           record.lead_provider_approval_status,

--- a/spec/factories/npq_courses.rb
+++ b/spec/factories/npq_courses.rb
@@ -7,4 +7,14 @@ FactoryBot.define do
     sequence(:name) { |n| "NPQ Course #{n}" }
     identifier { (Finance::Schedule::NPQLeadership::IDENTIFIERS + Finance::Schedule::NPQSpecialist::IDENTIFIERS).sample }
   end
+
+  factory :npq_leadship_course, class: "NPQCourse" do
+    sequence(:name) { |n| "NPQ Leadership Course #{n}" }
+    identifier { Finance::Schedule::NPQLeadership::IDENTIFIERS.sample }
+  end
+
+  factory :npq_specialist_course, class: "NPQCourse" do
+    sequence(:name) { |n| "NPQ Specialist Course #{n}" }
+    identifier { Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample }
+  end
 end

--- a/spec/factories/npq_courses.rb
+++ b/spec/factories/npq_courses.rb
@@ -17,4 +17,14 @@ FactoryBot.define do
     sequence(:name) { |n| "NPQ Specialist Course #{n}" }
     identifier { Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample }
   end
+
+  factory :npq_aso_course, class: "NPQCourse" do
+    sequence(:name) { |n| "NPQ ASO Course #{n}" }
+    identifier { Finance::Schedule::NPQSupport::IDENTIFIERS.sample }
+  end
+
+  factory :npq_ehco_course, class: "NPQCourse" do
+    sequence(:name) { |n| "NPQ EHCO Course #{n}" }
+    identifier { Finance::Schedule::NPQEhco::IDENTIFIERS.sample }
+  end
 end

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -185,5 +185,30 @@ RSpec.describe NPQApplication, type: :model do
         expect(subject.ineligible_for_funding_reason).to eql("previously-funded")
       end
     end
+
+    context "when there is a previously accepted ASO and applying for EHC0" do
+      let(:npq_aso_course) { create(:npq_aso_course) }
+      let(:npq_ehco_course) { create(:npq_ehco_course) }
+
+      subject { create(:npq_application, eligible_for_funding: true, npq_course: npq_ehco_course) }
+
+      before do
+        create(:npq_aso_schedule)
+        create(:npq_ehco_schedule)
+
+        create(
+          :npq_application,
+          :accepted,
+          participant_identity: subject.participant_identity,
+          eligible_for_funding: true,
+          npq_course: npq_aso_course,
+          npq_lead_provider: subject.npq_lead_provider,
+        )
+      end
+
+      it "returns previously-funded" do
+        expect(subject.ineligible_for_funding_reason).to eql("previously-funded")
+      end
+    end
   end
 end

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -93,6 +93,31 @@ RSpec.describe NPQApplication, type: :model do
       end
     end
 
+    context "when second application which is eligble for funding but first was not" do
+      subject do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          npq_course: npq_course,
+        )
+      end
+
+      before do
+        create(
+          :npq_application,
+          :accepted,
+          participant_identity: subject.participant_identity,
+          eligible_for_funding: false,
+          npq_course: subject.npq_course,
+          npq_lead_provider: subject.npq_lead_provider,
+        )
+      end
+
+      it "returns true" do
+        expect(subject.eligible_for_dfe_funding).to be_truthy
+      end
+    end
+
     context "when second application is for a different course which is also eligble for funding" do
       subject do
         create(

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
               created_at
               updated_at
               cohort
+              ineligible_for_funding_reason
             ],
           )
         end

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
               employment_role
               created_at
               updated_at
+              ineligible_for_funding_reason
             ],
           )
         end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -3060,6 +3060,16 @@
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"
+          },
+          "ineligible_for_funding_reason": {
+            "description": "Indicates why this NPQ participant is not eligible for DfE funding",
+            "type": "string",
+            "nullable": true,
+            "example": "establishment-ineligible",
+            "enum": [
+              "establishment-ineligible",
+              "previously-funded"
+            ]
           }
         }
       },

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -131,3 +131,11 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  ineligible_for_funding_reason:
+    description: "Indicates why this NPQ participant is not eligible for DfE funding"
+    type: string
+    nullable: true
+    example: "establishment-ineligible"
+    enum:
+      - "establishment-ineligible"
+      - "previously-funded"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -3123,6 +3123,16 @@
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"
+          },
+          "ineligible_for_funding_reason": {
+            "description": "Indicates why this NPQ participant is not eligible for DfE funding",
+            "type": "string",
+            "nullable": true,
+            "example": "establishment-ineligible",
+            "enum": [
+              "establishment-ineligible",
+              "previously-funded"
+            ]
           }
         }
       },

--- a/swagger/v2/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v2/component_schemas/NPQApplicationAttributes.yml
@@ -127,3 +127,11 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  ineligible_for_funding_reason:
+    description: "Indicates why this NPQ participant is not eligible for DfE funding"
+    type: string
+    nullable: true
+    example: "establishment-ineligible"
+    enum:
+      - "establishment-ineligible"
+      - "previously-funded"


### PR DESCRIPTION
## Ticket and context

- https://dfedigital.atlassian.net/browse/CPDLP-1303
- Enhances `eligible_for_funding` flag in API
- It now takes into consideration if the participant has a previously accepted application for the same course
- If it does, it now returns not eligible for funding
- Added `ineligible_for_funding_reason` which provides a reason why an application is ineligible if it is ineligible

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Find someone with a previously accepted application
- Create a new application for them
- Download/View applications via API
- `eligible_for_funding` should be false
- `ineligible_for_funding_reason` should be populated with `previously-funded`
- Another test...
- Create an application for a private school
- `ineligible_for_funding_reason` should be populated with `establishment-ineligible`
- See updated docs at https://ecf-review-pr-2049.london.cloudapps.digital/api-reference/reference-v1.html#schema-npqapplicationattributes

## External API changes

- Yes, documentation has been updated