### PR TITLE
simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 ### Context
 
+- Ticket: 
+
 ### Changes proposed in this pull request
 
 ### Guidance to review

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,6 @@
-## Ticket and context
+### Context
 
-Ticket:
+### Changes proposed in this pull request
 
-## Tech review
+### Guidance to review
 
-### Is there anything that the code reviewer should know?
-
-### Code quality checks
-- [ ] All commit messages are meaningful and true
-- [ ] Added enough automated tests
-
-### HTML Checks
-- [ ] All new pages have automated accessibility checks
-- [ ] All new pages have visual tests via Percy
-
-### Gotchas
-- [ ] All `School` queries are correctly scoped - `eligible` when they need to be
-
-## Product review
-
-### How can someone see it it review app?
-1. Click the link to review app (posted by a `github-actions` bot below)
-2. Follow the steps from the ticket.
-
-## External API changes
-
-Does this change anything in our external APIs? If so, did you remember to update the CHANGELOG for Lead Providers? (docs/source/release-notes)


### PR DESCRIPTION
## Ticket and context

Ticket: n/a

- hardly anyone adhered to the old PR template which suggests it is not fit for purpose
- it seems like more of a burden than providing value to the PR
- i have chosen to simplify for the benefit of author and reviewers

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- n/a

## External API changes

- none