### PR TITLE
[CN-133] Targeted NPQ funding

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -91,6 +91,7 @@ module Api
             :works_in_school,
             :employer_name,
             :employment_role,
+            :targeted_support_funding_eligibility,
           ).transform_keys! { |key| key == "national_insurance_number" ? "nino" : key }
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,6 +67,14 @@ module ApplicationHelper
     params[:controller].start_with?("finance")
   end
 
+  def bool_to_tag(bool)
+    if bool
+      '<strong class="govuk-tag govuk-tag--green">YES</strong>'
+    else
+      '<strong class="govuk-tag govuk-tag--red">NO</strong>'
+    end.html_safe
+  end
+
 private
 
   def post_2020_ecf_participant?(user)

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -30,6 +30,11 @@
   <% end %>
 
   <% summary_list.row do |row| %>
+    <% row.key { "Targeted support funding eligibility" } %>
+    <% row.value { bool_to_tag(application.targeted_support_funding_eligibility) } %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
     <% row.key { "Created at" } %>
     <% row.value { application.created_at.to_s(:govuk) } %>
   <% end %>

--- a/db/migrate/20220509091143_add_extra_eligiblity_npq_applications.rb
+++ b/db/migrate/20220509091143_add_extra_eligiblity_npq_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExtraEligiblityNPQApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_applications, :targeted_support_funding_eligibility, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_29_144309) do
+ActiveRecord::Schema.define(version: 2022_05_09_091143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -483,6 +483,7 @@ ActiveRecord::Schema.define(version: 2022_04_29_144309) do
     t.boolean "works_in_school"
     t.string "employer_name"
     t.string "employment_role"
+    t.boolean "targeted_support_funding_eligibility", default: false
     t.index ["npq_course_id"], name: "index_npq_applications_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_applications_on_npq_lead_provider_id"
     t.index ["participant_identity_id"], name: "index_npq_applications_on_participant_identity_id"

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
               headteacher_status: "no",
               eligible_for_funding: true,
               funding_choice: "school",
+              targeted_support_funding_eligibility: true,
             },
             relationships: {
               user: {
@@ -180,6 +181,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(npq_application.eligible_for_funding).to eql(true)
         expect(npq_application.funding_choice).to eql("school")
         expect(npq_application.lead_provider_approval_status).to eql("pending")
+        expect(npq_application.targeted_support_funding_eligibility).to be_truthy
       end
 
       it "returns a 201" do

--- a/spec/views/finance/participants/show.html.erb_spec.rb
+++ b/spec/views/finance/participants/show.html.erb_spec.rb
@@ -73,14 +73,10 @@ RSpec.describe "finance/participants/show.html.erb" do
 
       expect(rendered).to have_content("Lead provider#{profile.npq_application.npq_lead_provider.name}")
       expect(rendered).to have_content("School URN#{profile.npq_application.school_urn}")
-    end
-
-    it "renders eligible for funding" do
-      assign :user, user
-
-      render
 
       expect(rendered).to have_content("Eligible for funding#{profile.fundable?.to_s.upcase}")
+
+      expect(rendered).to have_content("Targeted support funding eligibility#{profile.npq_application.targeted_support_funding_eligibility ? 'YES' : 'NO'}")
     end
   end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: https://dfedigital.atlassian.net/browse/CN-133

- Added database migration to support extra NPQ funding flag on applications
- Incoming API requests from NPQ rails app can now populate this field
- After the integration is complete was can start exposing this in the API to lead providers via another PR to come
- Flag has been added to finance area for visibility

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [x] All commit messages are meaningful and true
- [x] Added enough automated tests

### HTML Checks
- [x] All new pages have automated accessibility checks
- [x] All new pages have visual tests via Percy

### Gotchas
- [x] All `School` queries are correctly scoped - `eligible` when they need to be

## Product review

### How can someone see it it review app?

- Login as a finance user
- View a user with an NPQ application
- Should see their application as not eligible for the new funding flag

## External API changes

- None