### PR TITLE
Add the missing challenge partnership link in the cohort details tabs

### DIFF
--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -1,6 +1,7 @@
 <% lead_provider = school_cohort.default_induction_programme&.lead_provider %>
 <% delivery_partner =  school_cohort.default_induction_programme&.delivery_partner %>
 <% ects_count = school_cohort.current_induction_records.count %>
+<% partnership = school_cohort.school.partnerships.active.find_by(cohort: school_cohort.cohort) %>
 
 <% if school_cohort.school_chose_cip? && school_cohort.default_induction_programme&.core_induction_programme.blank? %>
 <div class="govuk-body">
@@ -54,5 +55,18 @@
         <% row.action(text: "Change", href: schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
       <% end %>
     <% end %>
+  <% end %>
+<% end %>
+
+
+<% if partnership %>
+  <% if partnership&.in_challenge_window? %>
+    <p class="govuk-body">
+      If this does not look right, <%= govuk_link_to "report that your school has been confirmed incorrectly", challenge_partnership_path(partnership: partnership) %>. This link will expire on <%= partnership.challenge_deadline&.strftime("%d/%m/%Y") %>.
+    </p>
+  <% else %>
+    <p class="govuk-body">
+    If this does not look right, contact: <%= render MailToSupportComponent.new %>
+    </p>
   <% end %>
 <% end %>

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -133,6 +133,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       then_i_am_taken_to_the_manage_your_training_page
       and_i_see_the_current_lead_provider
       and_i_see_the_delivery_partner
+      and_i_see_the_challenge_link
     end
 
     context "Changing training" do

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -143,6 +143,10 @@ module ChooseProgrammeSteps
     expect(page).to have_content(@delivery_partner.name)
   end
 
+  def and_i_see_the_challenge_link
+    expect(page).to have_link(text: "report that your school has been confirmed incorrectly")
+  end
+
   def and_cohort_for_next_academic_year_is_created
     create(:cohort, start_year: 2022)
   end


### PR DESCRIPTION
### Context

Display the link to challenge the partnership when FIP schools choose to keep the same programme.

### Changes proposed in this pull request

### Guidance to review

