### PR TITLE
[CPDLP-1285] ECF Statements specify contract_version

### DIFF
--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -7,6 +7,7 @@ class Finance::Statement::ECF < Finance::Statement
 
   def contract
     CallOffContract.find_by!(
+      version: contract_version,
       cohort: cohort,
       lead_provider: lead_provider,
     )

--- a/spec/factories/call_off_contract.rb
+++ b/spec/factories/call_off_contract.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     set_up_fee { 149_651 }
     lead_provider { build(:lead_provider, cpd_lead_provider: build(:cpd_lead_provider)) }
     cohort { Cohort.current || create(:cohort, :current) }
+    version { "1.0" }
     raw do
       {
         "uplift_target": 0.33,

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Finance users payment breakdowns", :with_default_schedules, type:
   let!(:lead_provider)    { create(:lead_provider, name: "Test provider", id: "cffd2237-c368-4044-8451-68e4a4f73369") }
   let(:cpd_lead_provider) { lead_provider.cpd_lead_provider }
   let!(:statement)        { create(:ecf_statement, cpd_lead_provider: cpd_lead_provider) }
-  let!(:contract)         { create(:call_off_contract, lead_provider: lead_provider) }
+  let!(:contract)         { create(:call_off_contract, lead_provider: lead_provider, version: "0.0.1") }
   let(:school)            { create(:school) }
   let(:cohort)            { contract.cohort }
   let!(:school_cohort)    { create(:school_cohort, school: school, cohort: cohort) }


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1285

### Changes proposed in this pull request

* Use `Finance::Statement::ECF.contract_version` to specify `CallOffContract.version`

### Guidance to review

