### PR TITLE
Add no qts section to ECT tab on participants dashboard

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -21,6 +21,6 @@ module DashboardHelper
   end
 
   def participants_active?(profiles)
-    profiles.eligible.any? || profiles.contacted_for_info.any? || profiles.details_being_checked.any?
+    profiles.eligible.any? || profiles.contacted_for_info.any? || profiles.details_being_checked.any? || profiles.no_qts_participants.any?
   end
 end

--- a/app/services/coc_set_participant_categories.rb
+++ b/app/services/coc_set_participant_categories.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CocSetParticipantCategories < BaseService
-  ParticipantCategories = Struct.new(:eligible, :ineligible, :withdrawn, :contacted_for_info, :details_being_checked, :transferring_in, :transferring_out, :transferred)
+  ParticipantCategories = Struct.new(:eligible, :ineligible, :withdrawn, :contacted_for_info, :details_being_checked, :transferring_in, :transferring_out, :transferred, :no_qts_participants)
 
   # replace [] in call back to transferring_out_participants method once
   # transferring out journey is done
@@ -12,10 +12,11 @@ class CocSetParticipantCategories < BaseService
       ineligible_participants,
       withdrawn_participants,
       contacted_for_info_participants,
-      details_being_checked_participants,
+      details_being_checked,
       transferring_in_participants,
       [],
       transferred_participants,
+      no_qts_participants,
     )
   end
 
@@ -52,6 +53,14 @@ private
     active_induction_records
       .fip
       .merge(profile_type.details_being_checked)
+  end
+
+  def details_being_checked
+    details_being_checked_participants - no_qts_participants
+  end
+
+  def no_qts_participants
+    details_being_checked_participants.select { |record| record.participant_profile.ecf_participant_eligibility&.no_qts_reason? }
   end
 
   def transferring_in_participants

--- a/app/services/set_participant_categories.rb
+++ b/app/services/set_participant_categories.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SetParticipantCategories < BaseService
-  ParticipantCategories = Struct.new(:eligible, :ineligible, :withdrawn, :contacted_for_info, :details_being_checked)
+  ParticipantCategories = Struct.new(:eligible, :ineligible, :withdrawn, :contacted_for_info, :details_being_checked, :no_qts_participants)
 
   def call
     set_participant_categories
@@ -28,15 +28,15 @@ private
   end
 
   def fip_participant_categories_feature_flag_active
-    ParticipantCategories.new(eligible_participants, fip_flag_active_ineligible_participants, fip_flag_active_withdrawn_participants, contacted_for_info_participants, details_being_checked_participants)
+    ParticipantCategories.new(eligible_participants, fip_flag_active_ineligible_participants, fip_flag_active_withdrawn_participants, contacted_for_info_participants, details_being_checked, no_qts_participants)
   end
 
   def fip_participant_categories_feature_flag_inactive
-    ParticipantCategories.new([], [], withdrawn_participants, contacted_for_info_participants, fip_flag_inactive_details_being_checked_participants)
+    ParticipantCategories.new([], [], withdrawn_participants, contacted_for_info_participants, fip_flag_inactive_details_being_checked_participants, [])
   end
 
   def cip_participant_categories
-    ParticipantCategories.new(cip_eligible_participants, [], withdrawn_participants, contacted_for_info_participants, [])
+    ParticipantCategories.new(cip_eligible_participants, [], withdrawn_participants, contacted_for_info_participants, [], [])
   end
 
   def active_participant_profiles
@@ -63,6 +63,14 @@ private
     active_participant_profiles.details_being_checked.includes(:user).order("users.full_name").where.not(training_status: :withdrawn)
   end
 
+  def details_being_checked
+    details_being_checked_participants - no_qts_participants
+  end
+
+  def no_qts_participants
+    details_being_checked_participants.select { |profile| profile.ecf_participant_eligibility&.no_qts_reason? }
+  end
+
   def fip_flag_active_ineligible_participants
     ineligible_participants - eligible_participants
   end
@@ -72,10 +80,10 @@ private
   end
 
   def cip_eligible_participants
-    [*eligible_participants, *ineligible_participants, *details_being_checked_participants].uniq
+    [*eligible_participants, *ineligible_participants, *details_being_checked, *no_qts_participants].uniq
   end
 
   def fip_flag_inactive_details_being_checked_participants
-    [*details_being_checked_participants, *ineligible_participants, *eligible_participants].uniq
+    [*details_being_checked, *no_qts_participants, *ineligible_participants, *eligible_participants].uniq
   end
 end

--- a/app/views/schools/participants/_ects.html.erb
+++ b/app/views/schools/participants/_ects.html.erb
@@ -25,6 +25,22 @@
   </table>
 <% end %>
 
+<% if ect_profiles.no_qts_participants.any? %>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Checking QTS</h2>
+  <p class="govuk-!-margin-bottom-3">
+    These ECTs do not have qualified teacher status (QTS) yet. They need this to be eligible for funded training.
+    We’ll keep checking their status and notify you if something changes.
+  </p>
+
+<table class="govuk-table govuk-!-margin-bottom-9" data-test="no_qts">
+  <% if FeatureFlag.active?(:change_of_circumstances) %>
+    <%= render Schools::Participants::CocStatusTable.new(induction_records: ect_profiles.no_qts_participants) %>
+  <% else %>
+    <%= render Schools::Participants::StatusTable.new(participant_profiles: ect_profiles.no_qts_participants, school_cohort: @school_cohort) %>
+  <% end %>
+</table>
+<% end %>
+
 <% if ect_profiles.eligible.any? %>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Eligible to start</h2>
 

--- a/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_unpartnered_participants_spec.rb
@@ -192,4 +192,35 @@ RSpec.describe "Manage FIP unpartnered participants", js: true, with_feature_fla
       then_i_can_view_details_being_checked_mentor_status
     end
   end
+
+  context "Details being checked ECT with mentor" do
+    before do
+      and_i_have_added_a_contacted_for_info_mentor
+      and_i_have_added_a_no_qts_ect_with_mentor
+    end
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_no_qts_ects
+
+      when_i_click_on_the_participants_name "No-qts With-Mentor"
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_no_qts_status
+    end
+  end
+
+  context "Details being checked ECT without mentor" do
+    before { and_i_have_added_a_no_qts_ect_without_mentor }
+
+    scenario "Induction coordinators can view and manage participant" do
+      given_i_can_view_the_fip_induction_dashboard_without_partnership_details
+      when_i_navigate_to_participants_dashboard
+      then_i_can_view_no_qts_ects
+
+      when_i_click_on_the_participants_name "No-qts Without-Mentor"
+      then_i_am_taken_to_view_details_page
+      then_i_can_view_no_qts_status
+    end
+  end
 end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -316,20 +316,38 @@ module ManageTrainingSteps
 
   def and_i_have_added_a_details_being_checked_ect_with_mentor
     @details_being_checked_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort, start_term: "Spring 2022")
-    @details_being_checked_ect_with_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    @details_being_checked_ect_with_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
     Induction::Enrol.call(participant_profile: @details_being_checked_ect_with_mentor, induction_programme: @induction_programme)
   end
 
   def and_i_have_added_a_details_being_checked_ect_without_mentor
     @details_being_checked_ect_without_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC Without-Mentor"), school_cohort: @school_cohort)
-    @details_being_checked_ect_without_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    @details_being_checked_ect_without_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
     Induction::Enrol.call(participant_profile: @details_being_checked_ect_without_mentor, induction_programme: @induction_programme)
   end
 
   def and_i_have_added_a_details_being_checked_mentor
     @details_being_checked_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC Mentor"), school_cohort: @school_cohort)
-    @details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    @details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
     Induction::Enrol.call(participant_profile: @details_being_checked_mentor, induction_programme: @induction_programme)
+  end
+
+  def and_i_have_added_a_no_qts_ect_with_mentor
+    @no_qts_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "No-qts With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort, start_term: "Spring 2022")
+    @no_qts_ect_with_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    Induction::Enrol.call(participant_profile: @no_qts_ect_with_mentor, induction_programme: @induction_programme)
+  end
+
+  def and_i_have_added_a_no_qts_ect_without_mentor
+    @no_qts_ect_without_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "No-qts Without-Mentor"), school_cohort: @school_cohort)
+    @no_qts_ect_without_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    Induction::Enrol.call(participant_profile: @no_qts_ect_without_mentor, induction_programme: @induction_programme)
+  end
+
+  def and_i_have_added_a_no_qts_mentor
+    @no_qts_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "No-qts Mentor"), school_cohort: @school_cohort)
+    @no_qts_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    Induction::Enrol.call(participant_profile: @no_qts_mentor, induction_programme: @induction_programme)
   end
 
   def and_it_should_not_allow_a_sit_to_edit_the_participant_details
@@ -698,6 +716,10 @@ module ManageTrainingSteps
   end
 
   def then_i_can_view_details_being_checked_status
+    expect(page).to have_text("We’re checking this person’s details with the Teaching Regulation Agency.")
+  end
+
+  def then_i_can_view_no_qts_status
     expect(page).to have_text("Our checks show this person does not have qualified teacher status (QTS). Their status should be up to date if they completed their ITT in 2021.")
   end
 
@@ -747,6 +769,16 @@ module ManageTrainingSteps
   def then_i_can_view_details_being_checked_participants
     expect(page).to have_text("DfE checking eligibility")
     expect(page).to have_text("We’re checking these people’s details with the Teaching Regulation Agency. We’ll confirm if they’re eligible for this programme soon.")
+  end
+
+  def then_i_can_view_no_qts_ects
+    expect(page).to have_text("Checking QTS")
+    expect(page).to have_text("These ECTs do not have qualified teacher status (QTS) yet.")
+  end
+
+  def then_i_can_view_no_qts_mentors
+    expect(page).to have_text("Checking QTS")
+    expect(page).to have_text("These mentors do not have qualified teacher status (QTS) yet.")
   end
 
   def then_i_can_view_eligible_participants

--- a/spec/services/coc_set_participant_categories_spec.rb
+++ b/spec/services/coc_set_participant_categories_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
     let(:fip_transferring_out_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let(:fip_transferred_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let(:fip_transferred_withdrawn_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let(:fip_ect_no_qts) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let(:fip_mentor_no_qts) { create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     # CIP
     let(:cip_eligible_ect) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let(:cip_eligible_mentor) { create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
@@ -46,6 +48,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
     let(:cip_transferring_out_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let(:cip_transferred_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let(:cip_transferred_withdrawn_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let(:cip_ect_no_qts) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let(:cip_mentor_no_qts) { create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
 
     let(:fip_participants) do
       [
@@ -66,6 +70,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         fip_transferring_out_participant,
         fip_transferred_participant,
         fip_transferred_withdrawn_participant,
+        fip_ect_no_qts,
+        fip_mentor_no_qts,
       ]
     end
 
@@ -88,6 +94,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         cip_transferring_out_participant,
         cip_transferred_participant,
         cip_transferred_withdrawn_participant,
+        cip_ect_no_qts,
+        cip_mentor_no_qts,
       ]
     end
 
@@ -128,6 +136,10 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
         # transferred
         expect(@ect_categories.transferred).to match_array([fip_transferred_participant, fip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
+
+        # no_qts
+        expect(@ect_categories.no_qts_participants).to match_array(fip_ect_no_qts.current_induction_record)
+        expect(@mentor_categories.no_qts_participants).to match_array(fip_mentor_no_qts.current_induction_record)
       end
     end
 
@@ -142,8 +154,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "returns participants in correct category" do
         # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
-        expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_transferring_out_participant].map(&:current_induction_record))
-        expect(@mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_transferring_out_participant, cip_ect_no_qts].map(&:current_induction_record))
+        expect(@mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
 
         # ineligible
         expect(@ect_categories.ineligible).to be_empty
@@ -167,7 +179,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         # expect(@ect_categories.transferring_out).to match_array(cip_transferring_out_participant.current_induction_record)
 
         # transferred
-        expect(@ect_categories.transferred).to match_array([cip_transferred_participant, cip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
+        expect(@ect_categories.no_qts_participants).to be_empty
+        expect(@mentor_categories.no_qts_participants).to be_empty
       end
     end
 
@@ -183,8 +196,8 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "returns participants in correct category" do
         # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
-        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, fip_transferring_out_participant, cip_transferring_out_participant].map(&:current_induction_record))
-        expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor, cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, fip_transferring_out_participant, cip_transferring_out_participant, cip_ect_no_qts].map(&:current_induction_record))
+        expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor, cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
 
         # ineligible
         expect(@ect_categories.ineligible).to match_array(fip_ineligible_ect.current_induction_record)
@@ -209,6 +222,10 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
         # transferred
         expect(@ect_categories.transferred).to match_array([fip_transferred_participant, fip_transferred_withdrawn_participant, cip_transferred_participant, cip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
+
+        # no_qts
+        expect(@ect_categories.no_qts_participants).to match_array([fip_ect_no_qts.current_induction_record])
+        expect(@mentor_categories.no_qts_participants).to match_array([fip_mentor_no_qts.current_induction_record])
       end
     end
 
@@ -240,13 +257,13 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "only returns ECTs for the selected school cohort" do
         ect_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::ECT)
         # Transferring out needs to be removed when we build the transfer out journey
-        expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, cip_transferring_out_participant].map(&:current_induction_record))
+        expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, cip_transferring_out_participant, cip_ect_no_qts].map(&:current_induction_record))
       end
 
       it "only returns mentors for the selected school cohort" do
         mentor_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::Mentor)
 
-        expect(mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor].map(&:current_induction_record))
+        expect(mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
       end
     end
   end
@@ -267,8 +284,10 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
     fip_ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
     fip_ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
     fip_ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-    fip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-    fip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    fip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+    fip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+    fip_ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    fip_mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
     [fip_primary_mentor, fip_secondary_mentor].each do |profile|
       profile.ecf_participant_eligibility.determine_status
@@ -295,8 +314,10 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
     cip_ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
     cip_ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
     cip_ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-    cip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-    cip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    cip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+    cip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+    cip_ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+    cip_mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
     [cip_primary_mentor, cip_secondary_mentor].each do |profile|
       profile.ecf_participant_eligibility.determine_status

--- a/spec/services/set_participant_categories_spec.rb
+++ b/spec/services/set_participant_categories_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe SetParticipantCategories do
     let!(:withdrawn_ect) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, training_status: "withdrawn", school_cohort: school_cohort) }
     let!(:transferring_in_participant) { create(:ecf_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let!(:transferring_out_participant) { create(:ecf_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let!(:ect_no_qts) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
+    let!(:mentor_no_qts) { create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort: school_cohort) }
     let!(:induction_programme) { create(:induction_programme, school_cohort: school_cohort) }
 
     before do
@@ -45,14 +47,14 @@ RSpec.describe SetParticipantCategories do
       it "only returns ECTs for the selected school cohort" do
         ect_categories = service.call(school_cohort, induction_coordinator.user, "ParticipantProfile::ECT")
 
-        expect(ect_categories.eligible).to match_array [eligible_ect, ineligible_ect, ero_ect, details_being_checked_ect, @ects.first]
+        expect(ect_categories.eligible).to match_array [eligible_ect, ineligible_ect, ero_ect, details_being_checked_ect, ect_no_qts, @ects.first]
         expect(ect_categories.eligible).not_to include(@ects[1], @ects[2], eligible_mentor, ero_mentor)
       end
 
       it "only returns mentors for the selected school cohort" do
         mentor_categories = service.call(school_cohort, induction_coordinator.user, "ParticipantProfile::Mentor")
 
-        expect(mentor_categories.eligible).to match_array [eligible_mentor, ineligible_mentor, ero_mentor, details_being_checked_mentor, primary_mentor, secondary_mentor]
+        expect(mentor_categories.eligible).to match_array [eligible_mentor, ineligible_mentor, ero_mentor, details_being_checked_mentor, mentor_no_qts, primary_mentor, secondary_mentor]
         expect(mentor_categories.eligible).not_to include(@ects[1], @ects[2], eligible_ect, ero_ect)
       end
     end
@@ -61,14 +63,16 @@ RSpec.describe SetParticipantCategories do
       let(:school_cohort) { create(:school_cohort, :cip) }
       let(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school_cohort.school]) }
 
-      let(:cip_eligible_ects) { [eligible_ect, ineligible_ect, ero_ect, details_being_checked_ect] }
-      let(:cip_eligible_mentors) { [eligible_mentor, ineligible_mentor, ero_mentor, details_being_checked_mentor, primary_mentor, secondary_mentor] }
+      let(:cip_eligible_ects) { [eligible_ect, ineligible_ect, ero_ect, details_being_checked_ect, ect_no_qts] }
+      let(:cip_eligible_mentors) { [eligible_mentor, ineligible_mentor, ero_mentor, details_being_checked_mentor, primary_mentor, secondary_mentor, mentor_no_qts] }
       let(:cip_ineligible_ects) { [] }
       let(:cip_ineligible_mentors) { [] }
       let(:cip_contacted_for_info_ects) { [contacted_for_info_ect] }
       let(:cip_contacted_for_info_mentors) { [contacted_for_info_mentor] }
       let(:cip_details_being_checked_ects) { [] }
       let(:cip_details_being_checked_mentors) { [] }
+      let(:cip_no_qts_ect) { [] }
+      let(:cip_no_qts_mentor) { [] }
       let(:withdrawn_ects) { [withdrawn_ect] }
 
       before do
@@ -78,8 +82,10 @@ RSpec.describe SetParticipantCategories do
         ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
         ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
         ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-        details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+        details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+        ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+        mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
         @ect_categories = service.call(school_cohort, induction_coordinator.user, "ParticipantProfile::ECT")
         @mentor_categories = service.call(school_cohort, induction_coordinator.user, "ParticipantProfile::Mentor")
@@ -105,6 +111,11 @@ RSpec.describe SetParticipantCategories do
         expect(@mentor_categories.details_being_checked).to match_array(cip_details_being_checked_mentors)
       end
 
+      it "does not return participants in no_qts_participants category" do
+        expect(@ect_categories.no_qts_participants).to match_array(cip_no_qts_ect)
+        expect(@mentor_categories.no_qts_participants).to match_array(cip_no_qts_mentor)
+      end
+
       it "returns participants in withdrawn category" do
         expect(@ect_categories.withdrawn).to match_array(withdrawn_ect)
       end
@@ -125,6 +136,8 @@ RSpec.describe SetParticipantCategories do
       let(:withdrawn_ects) { [withdrawn_ect] }
       let(:transferring_in) { [transferring_in_participant] }
       let(:transferring_out) { [transferring_out_participant] }
+      let(:fip_no_qts_ects) { [ect_no_qts] }
+      let(:fip_no_qts_mentors) { [mentor_no_qts] }
 
       before do
         FeatureFlag.activate(:eligibility_notifications)
@@ -132,8 +145,10 @@ RSpec.describe SetParticipantCategories do
         ineligible_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
         ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
         ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-        details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+        details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+        ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+        mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
       end
 
       context "change_of_circumstances feature flag inactive" do
@@ -162,6 +177,11 @@ RSpec.describe SetParticipantCategories do
         it "returns details_being_checked participants in details_being_checked category" do
           expect(@ect_categories.details_being_checked).to match_array(fip_details_being_checked_ects)
           expect(@mentor_categories.details_being_checked).to match_array(fip_details_being_checked_mentors)
+        end
+
+        it "returns no_qts_participants in no_qts_participants category" do
+          expect(@ect_categories.no_qts_participants).to match_array(fip_no_qts_ects)
+          expect(@mentor_categories.no_qts_participants).to match_array(fip_no_qts_mentors)
         end
 
         it "returns withdrawn participants in withdrawn category" do
@@ -203,6 +223,11 @@ RSpec.describe SetParticipantCategories do
           expect(@mentor_categories.details_being_checked).to match_array(fip_details_being_checked_mentors)
         end
 
+        it "returns no_qts_participants in no_qts_participants category" do
+          expect(@ect_categories.no_qts_participants).to match_array(fip_no_qts_ects)
+          expect(@mentor_categories.no_qts_participants).to match_array(fip_no_qts_mentors)
+        end
+
         it "returns withdrawn participants in withdrawn category" do
           expect(@ect_categories.withdrawn).to match_array(withdrawn_ects)
         end
@@ -219,8 +244,10 @@ RSpec.describe SetParticipantCategories do
       let(:fip_ineligible_mentors) { [] }
       let(:fip_contacted_for_info_ects) { [contacted_for_info_ect] }
       let(:fip_contacted_for_info_mentors) { [contacted_for_info_mentor] }
-      let(:fip_details_being_checked_ects) { [eligible_ect, ineligible_ect, ero_ect, details_being_checked_ect] }
-      let(:fip_details_being_checked_mentors) { [eligible_mentor, ineligible_mentor, ero_mentor, details_being_checked_mentor, primary_mentor, secondary_mentor] }
+      let(:fip_details_being_checked_ects) { [eligible_ect, ineligible_ect, ero_ect, details_being_checked_ect, ect_no_qts] }
+      let(:fip_details_being_checked_mentors) { [eligible_mentor, ineligible_mentor, ero_mentor, details_being_checked_mentor, primary_mentor, secondary_mentor, mentor_no_qts] }
+      let(:fip_no_qts_ects) { [] }
+      let(:fip_no_qts_mentors) { [] }
       let(:withdrawn_ects) { [withdrawn_ect] }
 
       before do
@@ -230,8 +257,10 @@ RSpec.describe SetParticipantCategories do
         ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
         ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
         ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-        details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+        details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+        details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+        ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+        mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
         @ect_categories = service.call(school_cohort, induction_coordinator.user, "ParticipantProfile::ECT")
         @mentor_categories = service.call(school_cohort, induction_coordinator.user, "ParticipantProfile::Mentor")
@@ -255,6 +284,11 @@ RSpec.describe SetParticipantCategories do
       it "returns details_being_checked, ineligible and eligible participants in details_being_checked category" do
         expect(@ect_categories.details_being_checked).to match_array(fip_details_being_checked_ects)
         expect(@mentor_categories.details_being_checked).to match_array(fip_details_being_checked_mentors)
+      end
+
+      it "returns no_qts_participant, ineligible and eligible participants in no_qts_participants category" do
+        expect(@ect_categories.no_qts_participants).to match_array(fip_no_qts_ects)
+        expect(@mentor_categories.no_qts_participants).to match_array(fip_no_qts_mentors)
       end
 
       it "returns details_being_checked, ineligible and eligible participants in details_being_checked category" do


### PR DESCRIPTION
### Context

- Ticket: NA

### Changes proposed in this pull request

Showing a new section for participants with No qts on the dashboard. I've just followed the pattern for details being checked participants to decide where they should be displayed depending on the flag. 

<img width="1093" alt="Screenshot 2022-05-09 at 21 46 17" src="https://user-images.githubusercontent.com/69353998/167566891-1c4823b0-c415-4f50-9950-7f0b48251032.png">


### Guidance to review
Login as `cpd-test+tutor-10@example.com. A ppt with no qts is already on the dashboard. 

