### PR TITLE
Update the journeys router in school manage training

### DIFF
--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -17,7 +17,7 @@ module Schools
       if no_ects_expected
         store_form_redirect_to_next_step :no_expected_ects
       elsif ects_expected
-        if previous_school_cohort&.full_induction_programme?
+        if @school.partnerships.active.find_by(cohort: previous_school_cohort.cohort) && previous_school_cohort&.full_induction_programme?
           store_form_redirect_to_next_step(:change_provider)
         else
           store_form_redirect_to_next_step :how_will_you_run_training

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -111,6 +111,19 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
   end
 
   context "FIP" do
+    scenario "A school with challenged partnership chooses expects ects" do
+      given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
+      and_cohort_for_next_academic_year_is_created
+      and_the_next_cohort_is_open_for_registrations
+      and_i_am_signed_in_as_an_induction_coordinator
+      when_i_start_programme_selection_for_next_cohort
+      then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+      when_i_choose_ects_expected
+      and_i_click_continue
+      then_i_am_taken_to_the_how_will_you_run_training_page
+    end
+
     scenario "A school chooses to keep the same FIP programme in the new cohort" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -27,6 +27,13 @@ module ChooseProgrammeSteps
     create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
   end
 
+  def given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
+    given_there_is_a_school_that_has_chosen_fip_for_2021
+    @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
+    @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
+    create(:partnership, :challenged, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+  end
+
   def given_there_is_a_school_that_has_chosen_fip_for_2021
     @cohort = create(:cohort, start_year: 2021)
     @school = create(:school, name: "Fip School")


### PR DESCRIPTION
### Context
Currently we allow FIP schools to choose to continue in the new cohort with the previous programme, even when it is challenged. 

Schools should be able to do that only when there is an active partnership in the previous cohort.

### Changes proposed in this pull request

Update the journey logic when ects are expected for the new cohort, to also check if there's an active partnership in the previous cohort.

### Guidance to review

