### PR TITLE
Display blank LP and DP names when the partnership is challenged

### DIFF
--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -1,7 +1,7 @@
 <% lead_provider = school_cohort.default_induction_programme&.lead_provider %>
 <% delivery_partner =  school_cohort.default_induction_programme&.delivery_partner %>
 <% ects_count = school_cohort.current_induction_records.count %>
-<% partnership = school_cohort.school.partnerships.active.find_by(cohort: school_cohort.cohort) %>
+<% latest_partnership = school_cohort.school.partnerships.where(cohort: school_cohort.cohort, relationship: false).order(created_at: :desc).limit(1).first %>
 
 <% if school_cohort.school_chose_cip? && school_cohort.default_induction_programme&.core_induction_programme.blank? %>
 
@@ -37,12 +37,20 @@
   <% if school_cohort.full_induction_programme? %>
     <% list.row do |row| %>
       <% row.key(text: "Training provider") %>
-      <% row.value(text: lead_provider&.name ? lead_provider.name : "To be confirmed") %>
+      <% if latest_partnership&.challenged? == true %>
+        <% row.value(text: nil) %>
+      <% else %>
+        <% row.value(text: lead_provider&.name ? lead_provider.name : "To be confirmed") %>
+      <% end %>
       <% row.action(text: :none) %>
     <% end %>
     <% list.row do |row| %>
       <% row.key(text: "Delivery partner") %>
-      <% row.value(text: delivery_partner&.name ? delivery_partner.name : "To be confirmed") %>
+      <% if latest_partnership&.challenged? == true %>
+        <% row.value(text: nil) %>
+      <% else %>
+        <% row.value(text: delivery_partner&.name ? delivery_partner.name : "To be confirmed") %>
+      <% end %>
       <% row.action(text: :none) %>
     <% end %>
   <% elsif school_cohort.core_induction_programme? %>
@@ -58,11 +66,10 @@
   <% end %>
 <% end %>
 
-
-<% if partnership %>
-  <% if partnership&.in_challenge_window? %>
+<% if latest_partnership&.challenged? == false %>
+  <% if latest_partnership&.in_challenge_window? %>
     <p class="govuk-body">
-      If this does not look right, <%= govuk_link_to "report that your school has been confirmed incorrectly", challenge_partnership_path(partnership: partnership) %>. This link will expire on <%= partnership.challenge_deadline&.strftime("%d/%m/%Y") %>.
+      If this does not look right, <%= govuk_link_to "report that your school has been confirmed incorrectly", challenge_partnership_path(partnership: latest_partnership) %>. This link will expire on <%= latest_partnership.challenge_deadline&.strftime("%d/%m/%Y") %>.
     </p>
   <% else %>
     <p class="govuk-body">

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -136,6 +136,33 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       and_i_see_the_challenge_link
     end
 
+    scenario "Empty LP and DP names for challenged partnerships" do
+      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+      and_cohort_for_next_academic_year_is_created
+      and_the_next_cohort_is_open_for_registrations
+      and_i_am_signed_in_as_an_induction_coordinator
+      when_i_start_programme_selection_for_next_cohort
+      then_i_am_taken_to_ects_expected_in_next_academic_year_page
+
+      when_i_choose_ects_expected
+      and_i_click_continue
+      then_i_am_taken_to_the_change_provider_page
+      and_i_see_the_current_lead_provider
+      and_i_see_the_delivery_partner
+
+      when_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_complete_page
+
+      when_i_click_on_the_return_to_your_training_link
+      then_i_am_taken_to_the_manage_your_training_page
+
+      when_i_challenge_the_new_cohort_partnership
+      and_i_visit_the_school_manage_training
+      then_i_see_black_lp_and_dp_names
+      and_i_do_not_see_the_challenge_link
+    end
+
     context "Changing training" do
       scenario "A school chooses to use a different lead provider" do
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -147,6 +147,10 @@ module ChooseProgrammeSteps
     expect(page).to have_link(text: "report that your school has been confirmed incorrectly")
   end
 
+  def and_i_do_not_see_the_challenge_link
+    expect(page).to_not have_link(text: "report that your school has been confirmed incorrectly")
+  end
+
   def and_cohort_for_next_academic_year_is_created
     create(:cohort, start_year: 2022)
   end
@@ -179,6 +183,10 @@ module ChooseProgrammeSteps
     expect(page).to have_css("h2", text: "Choose your training materials")
     expect(page).to have_link("Tell us which materials you’ll use")
     expect(page).to have_link("compare materials")
+  end
+
+  def and_i_visit_the_school_manage_training
+    visit(schools_dashboard_path(@school))
   end
 
   # When steps
@@ -237,5 +245,16 @@ module ChooseProgrammeSteps
 
   def when_i_choose_to_design_and_deliver_own_programme
     choose("Design and deliver you own programme based on the Early Career Framework (ECF)")
+  end
+
+  def when_i_challenge_the_new_cohort_partnership
+    click_on("report that your school has been confirmed incorrectly")
+    choose("This looks like a mistake")
+    click_on("Submit")
+  end
+
+  def then_i_see_black_lp_and_dp_names
+    expect(page).to have_summary_row("Training provider", "")
+    expect(page).to have_summary_row("Delivery partner", "")
   end
 end


### PR DESCRIPTION
### Context

We should not display the Lead Provider and Delivery Partner names when the partnership is challenged.

### Changes proposed in this pull request

Retrieve the latest partnership for the cohort and display:
- the LP and DP names, when it's not challenged
- "To be confirmed", when the partnership does not exist yet (pending)
-  no LP and DP names, when it's challenged


### Guidance to review

