### PR TITLE
Fix the failing scenario

### DIFF
--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       when_i_choose_ects_expected
       and_i_click_continue
       then_i_am_taken_to_the_change_provider_page
-      and_i_see_the_current_lead_provider
+      and_i_see_the_lead_provider
       and_i_see_the_delivery_partner
 
       when_i_choose_no


### PR DESCRIPTION
### Context

The `and_i_see_the_current_lead_provider` was renamed to `and_i_see_the_lead_provider` and  the tests are failing.

### Changes proposed in this pull request

Use the new step in the failing scenario.

### Guidance to review

