### PR TITLE
[CPDLP-1316] NPQ cohort can be injected

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -92,6 +92,7 @@ module Api
             :employer_name,
             :employment_role,
             :targeted_support_funding_eligibility,
+            :cohort,
           ).transform_keys! { |key| key == "national_insurance_number" ? "nino" : key }
       end
 

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -9,6 +9,7 @@ class NPQApplication < ApplicationRecord
   belongs_to :participant_identity
   belongs_to :npq_lead_provider
   belongs_to :npq_course
+  belongs_to :cohort, optional: true
 
   after_commit :push_enrollment_to_big_query
 

--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -34,11 +34,16 @@ module NPQ
     attr_accessor :npq_application_params, :npq_course_id, :npq_lead_provider_id, :user_id
 
     def npq_application_attributes
-      npq_application_params.except(:user_id).merge(
+      npq_application_params.except(:user_id, :cohort).merge(
         npq_course: npq_course,
         npq_lead_provider: npq_lead_provider,
         participant_identity: participant_identity,
+        cohort: cohort,
       )
+    end
+
+    def cohort
+      @cohort ||= Cohort.find_by(start_year: npq_application_params[:cohort])
     end
 
     def npq_course

--- a/db/migrate/20220510115548_add_cohort_npq_applications.rb
+++ b/db/migrate/20220510115548_add_cohort_npq_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCohortNPQApplications < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :npq_applications, :cohort, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_09_091143) do
+ActiveRecord::Schema.define(version: 2022_05_10_115548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -486,6 +486,8 @@ ActiveRecord::Schema.define(version: 2022_05_09_091143) do
     t.string "employer_name"
     t.string "employment_role"
     t.boolean "targeted_support_funding_eligibility", default: false
+    t.uuid "cohort_id"
+    t.index ["cohort_id"], name: "index_npq_applications_on_cohort_id"
     t.index ["npq_course_id"], name: "index_npq_applications_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_applications_on_npq_lead_provider_id"
     t.index ["participant_identity_id"], name: "index_npq_applications_on_participant_identity_id"

--- a/spec/requests/api/v1/npq_profiles_spec.rb
+++ b/spec/requests/api/v1/npq_profiles_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
   let(:token) { NPQRegistrationApiToken.create_with_random_token! }
   let(:bearer_token) { "Bearer #{token}" }
   let(:parsed_response) { JSON.parse(response.body) }
+  let!(:cohort_2021) { Cohort.current || create(:cohort, :current) }
+  let!(:cohort_2022) { create(:cohort, :next) }
 
   describe "#show" do
     before do
@@ -133,6 +135,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
               eligible_for_funding: true,
               funding_choice: "school",
               targeted_support_funding_eligibility: true,
+              cohort: cohort_2022.start_year,
             },
             relationships: {
               user: {
@@ -182,6 +185,7 @@ RSpec.describe "NPQ profiles api endpoint", type: :request do
         expect(npq_application.funding_choice).to eql("school")
         expect(npq_application.lead_provider_approval_status).to eql("pending")
         expect(npq_application.targeted_support_funding_eligibility).to be_truthy
+        expect(npq_application.cohort.start_year).to eql(2022)
       end
 
       it "returns a 201" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1316
- NPQ applications are not cohort aware
- This PR gets us a step closer

### Changes proposed in this pull request

- Default all existing NPQ applications to 2021
- Allow NPQ rails app to inject the cohort when applying

### Guidance to review

- Client work for this change is yet to be written
- So you could hand craft an API call and application should be assigned to set cohort