### PR TITLE
Guard copying the previous cohort programme

### DIFF
--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -48,7 +48,7 @@ module Schools
         store_form_redirect_to_next_step :what_changes
       when "no"
         # skip if there is already a programme selected for the school cohort
-        use_the_same_training_programme!
+        use_the_same_training_programme! unless active_partnership?
 
         store_form_redirect_to_next_step :complete
       end
@@ -122,6 +122,10 @@ module Schools
       previous_partnership_copy.save!
 
       set_cohort_induction_programme!("full_induction_programme")
+    end
+
+    def active_partnership?
+      @school.active_partnerships.find_by(cohort: cohort, relationship: false).present?
     end
 
     def load_form

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -137,7 +137,12 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       and_i_see_the_lead_provider
       and_i_see_the_delivery_partner
 
-      when_i_choose_no
+      and_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_complete_page
+
+      when_i_go_back_to_change_provider_page
+      and_i_choose_no
       and_i_click_continue
       then_i_am_taken_to_the_complete_page
 

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -35,7 +35,7 @@ module ChooseProgrammeSteps
   end
 
   def given_there_is_a_school_that_has_chosen_fip_for_2021
-    @cohort = create(:cohort, start_year: 2021)
+    @cohort = @cohort_2022 = create(:cohort, start_year: 2021)
     @school = create(:school, name: "Fip School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort)
@@ -131,7 +131,7 @@ module ChooseProgrammeSteps
   end
 
   def and_cohort_2022_is_created
-    create(:cohort, start_year: 2022)
+    @cohort_2022 = create(:cohort, start_year: 2022)
   end
 
   def and_the_next_cohort_is_open_for_registrations
@@ -159,7 +159,7 @@ module ChooseProgrammeSteps
   end
 
   def and_cohort_for_next_academic_year_is_created
-    create(:cohort, start_year: 2022)
+    @cohort_2022 = create(:cohort, start_year: 2022)
   end
 
   def and_i_see_add_ects_link
@@ -194,6 +194,10 @@ module ChooseProgrammeSteps
 
   def and_i_visit_the_school_manage_training
     visit(schools_dashboard_path(@school))
+  end
+
+  def and_i_choose_no
+    when_i_choose_no
   end
 
   # When steps
@@ -258,6 +262,10 @@ module ChooseProgrammeSteps
     click_on("report that your school has been confirmed incorrectly")
     choose("This looks like a mistake")
     click_on("Submit")
+  end
+
+  def when_i_go_back_to_change_provider_page
+    visit change_provider_schools_setup_school_cohort_path(@school, @cohort_2022)
   end
 
   def then_i_see_black_lp_and_dp_names


### PR DESCRIPTION
### Context

Sentry reports a unique constraint violation caused by the `use_the_same_training_programme!` method.

It's likely users go back in history and click submit again.

### Changes proposed in this pull request

Call the method only when there's no active partnership for the cohort.

### Guidance to review

