### PR TITLE
Extra conditional on sending added_and_validated_email

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -333,8 +333,9 @@ module Schools
 
       participant_validation_record = validation_record(profile)
 
-      send_added_and_validated_email(profile) if profile && participant_validation_record
-      profile && !sit_adding_themselves?
+      send_added_and_validated_email(profile) if profile && participant_validation_record && !sit_adding_themselves?
+
+      profile
     end
 
     def store_validation_result!(profile)

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -334,7 +334,7 @@ module Schools
       participant_validation_record = validation_record(profile)
 
       send_added_and_validated_email(profile) if profile && participant_validation_record
-      profile
+      profile && !sit_adding_themselves?
     end
 
     def store_validation_result!(profile)
@@ -355,6 +355,10 @@ module Schools
 
     def validation_record(profile)
       ECFParticipantValidationData.find_by(participant_profile: profile)
+    end
+
+    def sit_adding_themselves?
+      type == :self
     end
   end
 end

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         config: {},
       }
 
-      form.type = form.type_options.sample
+      form.type = %i[ect mentor].sample
       form.full_name = Faker::Name.name
       form.email = Faker::Internet.email
       form.trn = "1234567"

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -266,6 +266,26 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
           expect(ParticipantMailer).to have_received(:sit_has_added_and_validated_participant).with(participant_profile: profile, school_name: school_cohort.school.name)
         end
       end
+
+      context "A SIT is adding themselves as a mentor" do
+        it " does not send the SIT an email saying they have been added and validated" do
+          form.type = :self
+          form.save!
+          expect(ParticipantMailer).not_to have_received(:sit_has_added_and_validated_participant)
+        end
+      end
+    end
+
+    describe "sit_adding_themselves?" do
+      it "sit is adding themselves" do
+        form.type = :self
+        expect(form.sit_adding_themselves?).to be true
+      end
+
+      it "sit is adding a participant" do
+        form.type = :mentor
+        expect(form.sit_adding_themselves?).to be false
+      end
     end
 
     context "no dqt record is present" do


### PR DESCRIPTION
When a SIT adds themselves as a mentor it's erroring because there is no template for this instance. We're adding a temporary conditional to check if they're adding selves so that sentry doesn't error. We'll decide later whether to stick with this or add a new template.

[Error in sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3262680691/?project=5748989&query=is%3Aunresolved)


