### PR TITLE
Fix validation controller error for 2021 cohort

### DIFF
--- a/app/controllers/participants/validations_controller.rb
+++ b/app/controllers/participants/validations_controller.rb
@@ -6,7 +6,7 @@ module Participants
 
     form Participants::ParticipantValidationForm, as: :validation_form
     setup_form do |form|
-      form.participant_profile_id = current_user.teacher_profile.current_ecf_profile.id
+      form.participant_profile_id = current_user.teacher_profile.ecf_profiles.first.id
       form.complete_step(:check_trn_given, check_trn_given: true) unless current_user.mentor?
     end
 


### PR DESCRIPTION
### Context
When a 2021 cohort user is trying to validation, the controller errors because it's trying to find their 2022 profile, which they don't have.

I was getting an error as below. This PR aims to resolve that. 

![Screenshot 2022-05-11 at 17 54 27](https://user-images.githubusercontent.com/69353998/167905306-7b56c8e8-3baf-4d8e-b884-3bad597c03ac.png)


### Changes proposed in this pull request

### Guidance to review

