### PR TITLE
[Bug fix] Handle partnership change

### DIFF
--- a/app/services/induction/change_partnership.rb
+++ b/app/services/induction/change_partnership.rb
@@ -13,7 +13,7 @@ class Induction::ChangePartnership < BaseService
         default_induction_programme.update!(partnership: partnership)
 
       elsif default_induction_programme.partnership != partnership &&
-        default_induction_programme.partnership.challenged?
+          default_induction_programme.partnership.challenged?
 
         ActiveRecord::Base.transaction do
           # existing FIP partnership replaced so create a new programme and migrate

--- a/app/services/induction/change_partnership.rb
+++ b/app/services/induction/change_partnership.rb
@@ -8,7 +8,7 @@ class Induction::ChangePartnership < BaseService
         default_induction_programme.full_induction_programme?
 
       if default_induction_programme.partnership.blank?
-        # there was no partnership we presume there was none when the school chose FIP
+        # there is no partnership, we presume there was none when the school chose FIP
         # so we can just update the programme
         default_induction_programme.update!(partnership: partnership)
 

--- a/app/services/induction/change_partnership.rb
+++ b/app/services/induction/change_partnership.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Induction::ChangePartnership < BaseService
+  def call
+    default_induction_programme = school_cohort.default_induction_programme
+
+    if default_induction_programme.present? &&
+        default_induction_programme.full_induction_programme?
+
+      if default_induction_programme.partnership.blank?
+        # there was no partnership we presume there was none when the school chose FIP
+        # so we can just update the programme
+        default_induction_programme.update!(partnership: partnership)
+
+      elsif default_induction_programme.partnership != partnership &&
+        default_induction_programme.partnership.challenged?
+
+        ActiveRecord::Base.transaction do
+          # existing FIP partnership replaced so create a new programme and migrate
+          # all the participants to the new one
+          programme = InductionProgramme.create!(school_cohort: school_cohort,
+                                                 training_programme: "full_induction_programme",
+                                                 partnership: partnership)
+
+          Induction::MigrateParticipantsToNewProgramme.call(from_programme: default_induction_programme,
+                                                            to_programme: programme)
+
+          school_cohort.update!(default_induction_programme: programme)
+        end
+      end
+    end
+  end
+
+private
+
+  attr_reader :school_cohort, :partnership
+
+  def initialize(school_cohort:, partnership:)
+    @school_cohort = school_cohort
+    @partnership = partnership
+  end
+end

--- a/app/services/induction/migrate_participants_to_new_programme.rb
+++ b/app/services/induction/migrate_participants_to_new_programme.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Induction::MigrateParticipantsToNewProgramme < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      from_programme.induction_records.each do |induction_record|
+        # this will duplicate the induction record and set the new programme
+        ChangeInductionRecord.call(induction_record: induction_record,
+                                   changes: { induction_programme_id: to_programme.id })
+      end
+    end
+  end
+
+private
+
+  attr_reader :from_programme, :to_programme
+
+  def initialize(from_programme:, to_programme:)
+    @from_programme = from_programme
+    @to_programme = to_programme
+  end
+end

--- a/app/services/induction/migrate_participants_to_new_programme.rb
+++ b/app/services/induction/migrate_participants_to_new_programme.rb
@@ -5,8 +5,8 @@ class Induction::MigrateParticipantsToNewProgramme < BaseService
     ActiveRecord::Base.transaction do
       from_programme.induction_records.each do |induction_record|
         # this will duplicate the induction record and set the new programme
-        ChangeInductionRecord.call(induction_record: induction_record,
-                                   changes: { induction_programme_id: to_programme.id })
+        Induction::ChangeInductionRecord.call(induction_record: induction_record,
+                                              changes: { induction_programme_id: to_programme.id })
       end
     end
   end

--- a/app/services/partnerships/report.rb
+++ b/app/services/partnerships/report.rb
@@ -29,13 +29,8 @@ module Partnerships
 
         # if a FIP has been chosen but the partnership was not present at the time
         # add it to the programme when it's reported
-        induction_programme = school_cohort.default_induction_programme
-        if induction_programme.present? &&
-            induction_programme.full_induction_programme? &&
-            induction_programme.partnership.blank?
-
-          school_cohort.default_induction_programme.update!(partnership: partnership)
-        end
+        Induction::ChangePartnership.call(school_cohort: school_cohort,
+                                          partnership: partnership)
 
         partnership.event_logs.create!(
           event: :reported,

--- a/spec/services/induction/change_partnership_spec.rb
+++ b/spec/services/induction/change_partnership_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Induction::ChangePartnership do
       school_cohort.update!(default_induction_programme: induction_programme)
     end
 
-
     it "adds a new induction programme" do
       expect {
         service.call(school_cohort: school_cohort,

--- a/spec/services/induction/change_partnership_spec.rb
+++ b/spec/services/induction/change_partnership_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::ChangePartnership do
+  describe "#call" do
+    let(:school_cohort) { create(:school_cohort) }
+    let(:lead_provider) { create(:lead_provider, name: "Super provider") }
+    let(:lead_provider_2) { create(:lead_provider, name: "Mega provider") }
+    let(:partnership) { create(:partnership, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider: lead_provider) }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort, partnership: partnership) }
+    let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+    let(:new_partnership) { create(:partnership, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider: lead_provider_2) }
+
+    subject(:service) { described_class }
+
+    before do
+      Induction::Enrol.call(induction_programme: induction_programme,
+                            participant_profile: mentor_profile,
+                            start_date: 6.months.ago)
+
+      Induction::Enrol.call(induction_programme: induction_programme,
+                            participant_profile: ect_profile,
+                            start_date: 6.months.ago,
+                            mentor_profile: mentor_profile)
+
+      partnership.update!(challenged_at: 1.day.ago, challenge_reason: "mistake")
+      school_cohort.update!(default_induction_programme: induction_programme)
+    end
+
+
+    it "adds a new induction programme" do
+      expect {
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+      }.to change { InductionProgramme.count }.by 1
+    end
+
+    it "sets the new programme as the default for the school cohort" do
+      service.call(school_cohort: school_cohort,
+                   partnership: new_partnership)
+
+      expect(school_cohort.default_induction_programme).to eq school_cohort.induction_programmes.order(created_at: :desc).first
+    end
+
+    it "sets the partnership on the new programme" do
+      service.call(school_cohort: school_cohort,
+                   partnership: new_partnership)
+
+      expect(school_cohort.default_induction_programme.partnership).to eq new_partnership
+    end
+
+    it "migrates the participants to the new programme" do
+      service.call(school_cohort: school_cohort,
+                   partnership: new_partnership)
+
+      expect(school_cohort.default_induction_programme.induction_records).to match_array [ect_profile.current_induction_record, mentor_profile.current_induction_record]
+    end
+
+    context "when the default programme does not have a partnership" do
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort, partnership: nil) }
+
+      it "does not create a new induction_programme" do
+        expect {
+          service.call(school_cohort: school_cohort,
+                       partnership: new_partnership)
+        }.not_to change { InductionProgramme.count }
+      end
+
+      it "sets the partnership on the existing programme" do
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+
+        expect(induction_programme.partnership).to eq new_partnership
+      end
+
+      it "does not change the default induction programme for the school cohort" do
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+
+        expect(school_cohort.default_induction_programme).to eq induction_programme
+      end
+    end
+
+    context "when the default induction programme is not a FIP" do
+      let(:induction_programme) { create(:induction_programme, :cip, school_cohort: school_cohort) }
+
+      it "does not create a new induction_programme" do
+        expect {
+          service.call(school_cohort: school_cohort,
+                       partnership: new_partnership)
+        }.not_to change { InductionProgramme.count }
+      end
+
+      it "does not set the partnership on the existing programme" do
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+
+        expect(induction_programme.partnership).to be_nil
+      end
+
+      it "does not change the default induction programme for the school cohort" do
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+
+        expect(school_cohort.default_induction_programme).to eq induction_programme
+      end
+    end
+  end
+end

--- a/spec/services/induction/change_partnership_spec.rb
+++ b/spec/services/induction/change_partnership_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Induction::ChangePartnership do
     let(:school_cohort) { create(:school_cohort) }
     let(:lead_provider) { create(:lead_provider, name: "Super provider") }
     let(:lead_provider_2) { create(:lead_provider, name: "Mega provider") }
-    let(:partnership) { create(:partnership, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider: lead_provider) }
+    let(:partnership) { create(:partnership, :challenged, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider: lead_provider) }
     let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort, partnership: partnership) }
     let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
     let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
@@ -23,7 +23,6 @@ RSpec.describe Induction::ChangePartnership do
                             start_date: 6.months.ago,
                             mentor_profile: mentor_profile)
 
-      partnership.update!(challenged_at: 1.day.ago, challenge_reason: "mistake")
       school_cohort.update!(default_induction_programme: induction_programme)
     end
 
@@ -96,6 +95,31 @@ RSpec.describe Induction::ChangePartnership do
                      partnership: new_partnership)
 
         expect(induction_programme.partnership).to be_nil
+      end
+
+      it "does not change the default induction programme for the school cohort" do
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+
+        expect(school_cohort.default_induction_programme).to eq induction_programme
+      end
+    end
+
+    context "when the existing partnership has not been challenged" do
+      let(:partnership) { create(:partnership, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider: lead_provider) }
+
+      it "does not create a new induction_programme" do
+        expect {
+          service.call(school_cohort: school_cohort,
+                       partnership: new_partnership)
+        }.not_to change { InductionProgramme.count }
+      end
+
+      it "does not set the partnership on the existing programme" do
+        service.call(school_cohort: school_cohort,
+                     partnership: new_partnership)
+
+        expect(induction_programme.partnership).to eq partnership
       end
 
       it "does not change the default induction programme for the school cohort" do

--- a/spec/services/induction/migrate_participants_to_new_programme_spec.rb
+++ b/spec/services/induction/migrate_participants_to_new_programme_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Induction::MigrateParticipantsToNewProgramme do
                             mentor_profile: mentor_profile)
     end
 
-
     it "adds new induction records for the participants" do
       expect {
         service.call(from_programme: induction_programme,

--- a/spec/services/induction/migrate_participants_to_new_programme_spec.rb
+++ b/spec/services/induction/migrate_participants_to_new_programme_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::MigrateParticipantsToNewProgramme do
+  describe "#call" do
+    let(:school_cohort) { create(:school_cohort) }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+    let(:induction_programme_2) { create(:induction_programme, :cip, school_cohort: school_cohort) }
+    let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+
+    subject(:service) { described_class }
+
+    before do
+      Induction::Enrol.call(induction_programme: induction_programme,
+                            participant_profile: mentor_profile,
+                            start_date: 6.months.ago)
+
+      Induction::Enrol.call(induction_programme: induction_programme,
+                            participant_profile: ect_profile,
+                            start_date: 6.months.ago,
+                            mentor_profile: mentor_profile)
+    end
+
+
+    it "adds new induction records for the participants" do
+      expect {
+        service.call(from_programme: induction_programme,
+                     to_programme: induction_programme_2)
+      }.to change { InductionRecord.count }.by 2
+    end
+
+    it "updates the old programmes induction records to changing status" do
+      service.call(from_programme: induction_programme,
+                   to_programme: induction_programme_2)
+
+      expect(induction_programme.induction_records.changed_induction_status.count).to eq 2
+    end
+
+    it "migrates the participants to the new programme" do
+      service.call(from_programme: induction_programme,
+                   to_programme: induction_programme_2)
+
+      expect(ect_profile.current_induction_record.induction_programme).to eq induction_programme_2
+      expect(mentor_profile.current_induction_record.induction_programme).to eq induction_programme_2
+    end
+  end
+end


### PR DESCRIPTION
### Context

When a partnership is challenged and subsequently a new partnership declared we should:
 * Add a new `InductionProgramme`
 * Add any participants from the previous (default) induction programme to the new induction programme
 * Set the new induction programme as the default for the school cohort

### Changes proposed in this pull request

### Guidance to review

