### PR TITLE
Allow school inviter to run in the background

### DIFF
--- a/app/forms/nomination_request_form.rb
+++ b/app/forms/nomination_request_form.rb
@@ -36,7 +36,7 @@ class NominationRequestForm
       ActiveRecord::Base.transaction do
         raise TooManyEmailsError if reached_email_limit
 
-        invite_schools_service.run([school.urn])
+        invite_schools_service.perform([school.urn])
       end
     end
   end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -58,7 +58,6 @@ class SchoolMailer < ApplicationMailer
         school_name: school.name,
         nomination_link: nomination_url,
         expiry_date: expiry_date,
-        subject: "Important: NQT induction changes",
       },
     ).tag(:request_to_nominate_sit).associate_with(school)
   end

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -3,7 +3,7 @@
 namespace :schools do
   desc "Send nomination invitations to schools"
   task :send_invites, [:school_urns] => :environment do |_task, args|
-    InviteSchools.new.run(args.school_urns.split)
+    InviteSchools.new.perform(args.school_urns.split)
   end
 
   desc "Send chaser nomination invites to schools without induction coordinators"

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe InviteSchools do
     let(:nomination_email) { school.nomination_emails.last }
 
     it "creates a record for the nomination email" do
-      expect { invite_schools.run [school.urn] }
+      expect { invite_schools.perform [school.urn] }
         .to change { school.nomination_emails.count }.by 1
     end
 
     it "creates a nomination email with the correct fields" do
-      invite_schools.run [school.urn]
+      invite_schools.perform [school.urn]
       expect(nomination_email.sent_to).to eq school.primary_contact_email
       expect(nomination_email.sent_at).to be_present
       expect(nomination_email.token).to be_present
@@ -54,12 +54,12 @@ RSpec.describe InviteSchools do
           ),
         ).and_call_original
 
-        invite_schools.run [school.urn]
+        invite_schools.perform [school.urn]
       end
     end
 
     it "sets the notify id on the nomination email record" do
-      invite_schools.run [school.urn]
+      invite_schools.perform [school.urn]
       expect(nomination_email.notify_id).to eq "notify_id"
     end
 
@@ -77,7 +77,7 @@ RSpec.describe InviteSchools do
             ),
           ).and_call_original
 
-          invite_schools.run [school.urn]
+          invite_schools.perform [school.urn]
         end
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe InviteSchools do
           ),
         ).and_call_original
 
-        invite_schools.run [school.urn]
+        invite_schools.perform [school.urn]
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe InviteSchools do
       let(:another_school) { create(:school) }
 
       it "skips to the next school_id" do
-        invite_schools.run [school.urn, another_school.urn]
+        invite_schools.perform [school.urn, another_school.urn]
         expect(school.nomination_emails).to be_empty
         expect(another_school.nomination_emails).not_to be_empty
       end


### PR DESCRIPTION
### Context

We're about to invite schools without a SIT for 22/23. This PR allows the mailer to run in the background so that we can depend on Sidekiq to automatically retry invitations if they were to fail.
