### PR TITLE
[Bugfix] Fix issue with changing participant email failing feature spec 

### DIFF
--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -32,11 +32,7 @@
           Email address
         </dt>
         <dd class="govuk-summary-list__value">
-          <% if FeatureFlag.active?(:change_of_circumstances) %>
-            <%= @induction_record.preferred_identity.email %>
-          <% else %>
-            <%= @profile.user.email %>
-          <% end %>
+          <%= @induction_record.preferred_identity.email %>
         </dd>
         <% unless @profile.training_status_withdrawn? %>
           <dd class="govuk-summary-list__actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,10 @@ en:
         lead_provider_approval_status: Status
     errors:
       models:
+        participant_identity:
+          attributes:
+            email:
+              <<: *email_error_messages
         user:
           attributes:
             email:


### PR DESCRIPTION
### Context

Feature spec that tests updating a participants email was failing. This fixes it.

2 issues:

1. Incorrect error shown for blank email address
2. Code to update email assumed change_of_circumstances feature, but spec running without that on.

### Changes proposed in this pull request

### Guidance to review

