### PR TITLE
[Design update] - ECT and mentors dashboard

### DIFF
--- a/app/views/schools/participants/_ects.html.erb
+++ b/app/views/schools/participants/_ects.html.erb
@@ -1,6 +1,10 @@
 <% if ect_profiles.contacted_for_info.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Contacted for information</h2>
-  <p class="govuk-!-margin-bottom-3">We need this to check their eligibility with the Teaching Regulation Agency.</p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contacted for information</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">We need this to check their eligibility with the Teaching Regulation Agency.</p>
+    </div>
+  </div>
 
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="checked_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
@@ -12,9 +16,12 @@
 <% end %>
 
 <% if ect_profiles.details_being_checked.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">DfE checking eligibility</h2>
-  <p class="govuk-!-margin-bottom-3">We’re checking these people’s details with the Teaching Regulation Agency.
-    We’ll confirm if they’re eligible for this programme soon.</p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">DfE checking eligibility</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">We’re checking these people’s details with the Teaching Regulation Agency. We’ll confirm if they’re eligible for this programme soon.</p>
+    </div>
+  </div>
 
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="details_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
@@ -26,11 +33,12 @@
 <% end %>
 
 <% if ect_profiles.no_qts_participants.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Checking QTS</h2>
-  <p class="govuk-!-margin-bottom-3">
-    These ECTs do not have qualified teacher status (QTS) yet. They need this to be eligible for funded training.
-    We’ll keep checking their status and notify you if something changes.
-  </p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Checking QTS</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">These ECTs do not have qualified teacher status (QTS) yet. They need this to be eligible for funded training. We’ll keep checking their status and notify you if something changes.</p>
+    </div>
+  </div>
 
 <table class="govuk-table govuk-!-margin-bottom-9" data-test="no_qts">
   <% if FeatureFlag.active?(:change_of_circumstances) %>
@@ -42,15 +50,18 @@
 <% end %>
 
 <% if ect_profiles.eligible.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Eligible to start</h2>
-
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Eligible to start</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
   <% if @school_cohort.core_induction_programme? %>
-    <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. They have access to their materials.</p>
+    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. They have access to their materials.</p>
   <% elsif @school_cohort.delivery_partner.present? %>
-    <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.</p>
+    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.</p>
   <% else %>
-    <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
+    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
   <% end %>
+    </div>
+  </div>
 
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="eligible_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>

--- a/app/views/schools/participants/_mentors.html.erb
+++ b/app/views/schools/participants/_mentors.html.erb
@@ -1,6 +1,10 @@
 <% if mentor_profiles.contacted_for_info.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Contacted for information</h2>
-  <p class="govuk-!-margin-bottom-3">We need this to check their eligibility with the Teaching Regulation Agency.</p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Contacted for information</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">We need this to check their eligibility with the Teaching Regulation Agency.</p>
+    </div>
+  </div>
 
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="checked">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
@@ -12,10 +16,12 @@
 <% end %>
 
 <% if mentor_profiles.details_being_checked.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">DfE checking eligibility</h2>
-  <p class="govuk-!-margin-bottom-3">We’re checking these people’s details with the Teaching Regulation Agency.
-    We’ll confirm if they’re eligible for this programme soon.</p>
-
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">DfE checking eligibility</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-!-margin-bottom-3">We’re checking these people’s details with the Teaching Regulation Agency. We’ll confirm if they’re eligible for this programme soon.</p>
+    </div>
+  </div>
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="details">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
       <%= render Schools::Participants::CocStatusTable.new(induction_records: mentor_profiles.details_being_checked) %>
@@ -26,15 +32,18 @@
 <% end %>
 
 <% if mentor_profiles.eligible.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Eligible to start</h2>
-
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Eligible to start</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
   <% if @school_cohort.core_induction_programme? %>
-    <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. They have access to their materials.</p>
+    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. They have access to their materials.</p>
   <% elsif @school_cohort.delivery_partner.present? %>
-    <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.</p>
+    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.</p>
   <% else %>
-    <p class="govuk-!-margin-bottom-3">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
+    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
   <% end %>
+  </div>
+</div>
 
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="eligible">
     <% if FeatureFlag.active?(:change_of_circumstances) %>

--- a/app/views/schools/participants/_moving_school.html.erb
+++ b/app/views/schools/participants/_moving_school.html.erb
@@ -1,14 +1,22 @@
 <% if transferring_in.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Transferring to your school</h2>
-  <p class="govuk-!-margin-bottom-3">You’ve told us these people are joining you from another school. You need to arrange how they’ll continue their training.</p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Transferring to your school</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">You’ve told us these people are joining you from another school. You need to arrange how they’ll continue their training.</p>
+    </div>
+  </div>
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="transferring_in">
     <%= render Schools::Participants::CocStatusTable.new(induction_records: transferring_in) %>
   </table>
 <% end %>
 
 <% if transferring_out.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Transferring from your school</h2>
-  <p class="govuk-!-margin-bottom-3">You’ve told us these people are moving to a new school. Their new school will arrange how they’ll continue their training.</p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Transferring from your school</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">You’ve told us these people are moving to a new school. Their new school will arrange how they’ll continue their training.</p>
+    </div>
+  </div>
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="transferring_out">
     <%= render Schools::Participants::CocStatusTable.new(induction_records: transferring_out) %>
   </table>

--- a/app/views/schools/participants/_not_training.html.erb
+++ b/app/views/schools/participants/_not_training.html.erb
@@ -1,13 +1,17 @@
 <% if withdrawn.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">No longer being trained</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">No longer being trained</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
   <% if @school.lead_provider(@school_cohort.cohort.start_year).present? %>
-    <p>
+    <p class="govuk-body">
       Your provider reported that they’re not training the people listed below. If this is wrong, contact <%= @school.lead_provider(@school_cohort.cohort.start_year).name %>
       <% if @school.delivery_partner_for(@school_cohort.cohort.start_year) %>
         or <%= @school.delivery_partner_for(@school_cohort.cohort.start_year).name %>.
       <% end %>
     </p>
   <% end %>
+  </div>
+</div>
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="withdrawn_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
       <%= render Schools::Participants::CocStatusTable.new(induction_records: withdrawn) %>
@@ -18,9 +22,12 @@
 <% end %>
 
 <% if ineligible.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Not eligible for funded training</h2>
-  <p class="govuk-!-margin-bottom-3">We’ve checked these people’s details and found they’re not eligible for this
-    programme.</p>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Not eligible for funded training</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">We’ve checked these people’s details and found they’re not eligible for this programme.</p>
+    </div>
+  </div>
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligble_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
       <%= render Schools::Participants::CocStatusTable.new(induction_records: ineligible) %>

--- a/app/views/schools/participants/_not_training.html.erb
+++ b/app/views/schools/participants/_not_training.html.erb
@@ -1,46 +1,50 @@
 <% if withdrawn.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">No longer being trained</h2>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-  <% if @school.lead_provider(@school_cohort.cohort.start_year).present? %>
-    <p class="govuk-body">
-      Your provider reported that they’re not training the people listed below. If this is wrong, contact <%= @school.lead_provider(@school_cohort.cohort.start_year).name %>
-      <% if @school.delivery_partner_for(@school_cohort.cohort.start_year) %>
-        or <%= @school.delivery_partner_for(@school_cohort.cohort.start_year).name %>.
-      <% end %>
-    </p>
-  <% end %>
-  </div>
-</div>
-  <table class="govuk-table govuk-!-margin-bottom-9" data-test="withdrawn_ects">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">No longer being trained</h2>
+    <div class="govuk-grid-row">
+
+        <div class="govuk-grid-column-two-thirds">
+            <% if @school.lead_provider(@school_cohort.cohort.start_year).present? %>
+            <p class="govuk-body">Your provider reported that they’re not training the people listed below. If this is wrong, contact <%= @school.lead_provider(@school_cohort.cohort.start_year).name %>
+            <% if @school.delivery_partner_for(@school_cohort.cohort.start_year) %>
+            or <%= @school.delivery_partner_for(@school_cohort.cohort.start_year).name %>.
+            <% end %>
+            </p>
+            <% end %>
+        </div>
+    </div>
+    <table class="govuk-table govuk-!-margin-bottom-9" data-test="withdrawn_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
-      <%= render Schools::Participants::CocStatusTable.new(induction_records: withdrawn) %>
+        <%= render Schools::Participants::CocStatusTable.new(induction_records: withdrawn) %>
     <% else %>
-      <%= render Schools::Participants::StatusTable.new(participant_profiles: withdrawn, school_cohort: @school_cohort) %>
+        <%= render Schools::Participants::StatusTable.new(participant_profiles: withdrawn, school_cohort: @school_cohort) %>
     <% end %>
-  </table>
+    </table>
 <% end %>
 
 <% if ineligible.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Not eligible for funded training</h2>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">We’ve checked these people’s details and found they’re not eligible for this programme.</p>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Not eligible for funded training</h2>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">We’ve checked these people’s details and found they’re not eligible for this programme.</p>
+        </div>
     </div>
-  </div>
-  <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligble_ects">
+    <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligble_ects">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
       <%= render Schools::Participants::CocStatusTable.new(induction_records: ineligible) %>
     <% else %>
       <%= render Schools::Participants::StatusTable.new(participant_profiles: ineligible, school_cohort: @school_cohort) %>
     <% end %>
-  </table>
+    </table>
 <% end %>
 
 <% if transferred.any? %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Transferred from your school</h2>
-  <p class="govuk-!-margin-bottom-3">You told us these people moved to a new school.</p>
-  <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligble_ects">
-    <%= render Schools::Participants::CocStatusTable.new(induction_records: transferred) %>
-  </table>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Transferred from your school</h2>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-!-margin-bottom-3">You told us these people moved to a new school.</p>
+        </div>
+    </div>
+    <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligble_ects">
+        <%= render Schools::Participants::CocStatusTable.new(induction_records: transferred) %>
+    </table>
 <% end %>


### PR DESCRIPTION
Put correct grid system in for each status so the content wraps after 2/3 and tightened up the spacing between headers and paragraphs. 

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/4470050/168292502-1837c92a-0a60-499e-ac50-e98918e02e21.png">
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/4470050/168292557-9b44b170-a324-4d0a-b229-af793365c6b0.png">
 
 as examples.