### PR TITLE
Back fill only those with a single induction record

### DIFF
--- a/lib/tasks/update_participant_profile_states.rake
+++ b/lib/tasks/update_participant_profile_states.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :update_participant_profile_states do
+  desc "Back filling cpd_lead_providers on participant_profile_states"
+  task populate_cpd_lead_provider: :environment do
+    PaperTrail.request.controller_info = {
+      reason: "Back filling cpd_lead_providers on participant_profile_states",
+    }
+
+    participant_profiles_with_a_single_induction_record = ParticipantProfile::ECF.joins(:induction_records).group(:id).having("count(*) < 2")
+
+    participant_profiles_with_a_single_induction_record.includes(:participant_profile_states).each do |pp|
+      pp.participant_profile_states.each do |ps|
+        ps.update_column(:cpd_lead_provider_id, pp.induction_records&.active&.latest&.induction_programme&.partnership&.lead_provider&.cpd_lead_provider&.id)
+      end
+    end
+  end
+end

--- a/lib/tasks/update_participant_profile_states.rake
+++ b/lib/tasks/update_participant_profile_states.rake
@@ -11,8 +11,8 @@ namespace :update_participant_profile_states do
 
     participant_profiles_with_a_single_induction_record = ParticipantProfile::ECF.joins(:induction_records).group(:id).having("count(*) < 2")
 
-    participant_profiles_with_a_single_induction_record.includes(:participant_profile_states).each do |pp|
-      pp.participant_profile_states.each do |ps|
+    participant_profiles_with_a_single_induction_record.includes(:participant_profile_states).find_each do |pp|
+      pp.participant_profile_states.find_each do |ps|
         ps.update_column(:cpd_lead_provider_id, pp.induction_records&.active&.latest&.induction_programme&.partnership&.lead_provider&.cpd_lead_provider&.id)
       end
     end


### PR DESCRIPTION
### WIP - currently looking into different scenarios for backfill

e.g. 
1. participants with two induction records and same lead provider
2. participants with two induction records and different lead provider - is there any way of knowing which profile state belongs to which LP


### Context

CPDLP-1124 we have added lead providers to participant_profile_states - to backfill data we have some issues if the participant has already two induction records as they are likely to have states that belong to different lead providers

- Ticket: CPDLP-1124 (an extension)

### Changes proposed in this pull request

This PR will try to capture as many scenarios as possible for the backfill, including the most straight forward which is copying the lead provider if there is only a single induction record as these participants are likely to only have had a single LP

### Guidance to review

