### PR TITLE
[CPDLP-1326] Expose api targeted flag

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -3,7 +3,7 @@
 class NPQApplication < ApplicationRecord
   has_paper_trail only: %i[user_id npq_lead_provider_id npq_course_id created_at updated_at lead_provider_approval_status]
 
-  self.ignored_columns = %w[user_id]
+  self.ignored_columns = %w[user_id targeted_support_funding_eligibility]
 
   has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id, touch: true
   belongs_to :participant_identity

--- a/app/serializers/api/v1/npq_application_serializer.rb
+++ b/app/serializers/api/v1/npq_application_serializer.rb
@@ -25,7 +25,8 @@ module Api
                  :employment_role,
                  :status,
                  :created_at,
-                 :updated_at
+                 :updated_at,
+                 :targeted_delivery_funding_eligibility
 
       attribute(:participant_id) do |object|
         object.participant_identity.external_identifier

--- a/db/migrate/20220516085012_drop_original_funding_flag.rb
+++ b/db/migrate/20220516085012_drop_original_funding_flag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropOriginalFundingFlag < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_column :npq_applications, :targeted_support_funding_eligibility, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_140603) do
+ActiveRecord::Schema.define(version: 2022_05_16_085012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -494,7 +494,6 @@ ActiveRecord::Schema.define(version: 2022_05_12_140603) do
     t.boolean "works_in_school"
     t.string "employer_name"
     t.string "employment_role"
-    t.boolean "targeted_support_funding_eligibility", default: false
     t.uuid "cohort_id"
     t.boolean "targeted_delivery_funding_eligibility", default: false
     t.index ["cohort_id"], name: "index_npq_applications_on_cohort_id"

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,6 +9,13 @@ weight: 7
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l" id="16-5-2022">16th May 2022</h2>
+<p class="govuk-body-m">
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Added <code>targeted_delivery_funding_eligibility</code> to NPQ applications</li>
+  </ul>
+</p>
+
 <h2 class="govuk-heading-l" id="11-5-2022">11th May 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">

--- a/spec/serializers/api/v1/npq_application_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq_application_serializer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  module V1
+    RSpec.describe NPQApplicationSerializer do
+      let(:application) do
+        create(
+          :npq_application,
+          targeted_delivery_funding_eligibility: true,
+        )
+      end
+
+      subject { described_class.new(application) }
+
+      describe "serialization" do
+        it "outputs correctly" do
+          output = subject.serializable_hash
+
+          expect(output[:data][:attributes][:targeted_delivery_funding_eligibility]).to eql(true)
+        end
+      end
+    end
+  end
+end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -3049,6 +3049,11 @@
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"
+          },
+          "targeted_delivery_funding_eligibility": {
+            "description": "Indicates if the application is eligible for targeted delivery funding",
+            "type": "boolean",
+            "example": true
           }
         }
       },
@@ -3191,6 +3196,11 @@
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"
+          },
+          "targeted_delivery_funding_eligibility": {
+            "description": "Indicates if the application is eligible for targeted delivery funding",
+            "type": "boolean",
+            "example": true
           }
         }
       },

--- a/swagger/v1/component_schemas/NPQApplicationAttributes.yml
+++ b/swagger/v1/component_schemas/NPQApplicationAttributes.yml
@@ -122,3 +122,7 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  targeted_delivery_funding_eligibility:
+    description: "Indicates if the application is eligible for targeted delivery funding"
+    type: boolean
+    example: true

--- a/swagger/v1/component_schemas/NPQApplicationCsvRow.yml
+++ b/swagger/v1/component_schemas/NPQApplicationCsvRow.yml
@@ -115,3 +115,7 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  targeted_delivery_funding_eligibility:
+    description: "Indicates if the application is eligible for targeted delivery funding"
+    type: boolean
+    example: true


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1326
- We want to surface `targeted_delivery_funding_eligibility` to lead providers in the API
- So they are clear on what funding they will receive

### Changes proposed in this pull request

- Expose `targeted_delivery_funding_eligibility` in API v1 on NPQ applications
- Updated docs
- Updated change log 

### Guidance to review

- Fetch an NPQ application via API
- Should see `false` on `targeted_delivery_funding_eligibility`
- Although may `true` if correct criteria met
- View docs on review app
- Should see extra field on NPQ applications
- Should see updated change log