### PR TITLE
Use correct identity for admin view external id

### DIFF
--- a/app/views/admin/participants/_details.html.erb
+++ b/app/views/admin/participants/_details.html.erb
@@ -25,7 +25,7 @@
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">External ID</th>
-      <td class="govuk-table__cell"><%= latest_induction_record.preferred_identity.external_identifier %></td>
+      <td class="govuk-table__cell"><%= latest_induction_record.participant_profile.participant_identity.external_identifier %></td>
       <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">


### PR DESCRIPTION
### Context

In the participant details view for admins the external id presented was from the preferred_identity on the induction record when it should be from the participant_identity on the participant_profile

### Changes proposed in this pull request

### Guidance to review

