### PR TITLE
[CPDLP-1335] Internal API NPQ funding

### DIFF
--- a/app/controllers/api/v1/npq_funding_controller.rb
+++ b/app/controllers/api/v1/npq_funding_controller.rb
@@ -5,7 +5,7 @@ module Api
     class NPQFundingController < Api::ApiController
       include ApiTokenAuthenticatable
 
-      def index
+      def show
         render json: service.call
       end
 

--- a/app/controllers/api/v1/npq_funding_controller.rb
+++ b/app/controllers/api/v1/npq_funding_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NPQFundingController < Api::ApiController
+      include ApiTokenAuthenticatable
+
+      def index
+        render json: service.call
+      end
+
+    private
+
+      def service
+        @service ||= NPQ::FundingEligibility.new(
+          trn: params[:trn],
+          npq_course_identifier: params[:npq_course_identifier],
+        )
+      end
+
+      def access_scope
+        ApiToken.where(private_api_access: true)
+      end
+    end
+  end
+end

--- a/app/services/npq/funding_eligibility.rb
+++ b/app/services/npq/funding_eligibility.rb
@@ -21,23 +21,22 @@ module NPQ
       @npq_course ||= NPQCourse.find_by!(identifier: npq_course_identifier)
     end
 
-    def user
-      teacher_profile.user if teacher_profile
+    def users
+      User.where(teacher_profile: teacher_profiles)
     end
 
-    def teacher_profile
-      @teacher_profile ||= TeacherProfile.find_by(trn: trn)
+    def teacher_profiles
+      @teacher_profiles ||= TeacherProfile.where(trn: trn)
     end
 
     def previously_funded?
-      return false unless user
-
-      user
-        .npq_applications
+      users.flat_map.any? do |user|
+        user.npq_applications
         .where(npq_course: npq_course)
         .where(eligible_for_funding: true)
         .accepted
         .any?
+      end
     end
   end
 end

--- a/app/services/npq/funding_eligibility.rb
+++ b/app/services/npq/funding_eligibility.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module NPQ
+  class FundingEligibility
+    attr_reader :trn, :npq_course_identifier
+
+    def initialize(trn:, npq_course_identifier:)
+      @trn = trn
+      @npq_course_identifier = npq_course_identifier
+    end
+
+    def call
+      {
+        previously_funded: previously_funded?,
+      }
+    end
+
+  private
+
+    def npq_course
+      @npq_course ||= NPQCourse.find_by!(identifier: npq_course_identifier)
+    end
+
+    def user
+      teacher_profile.user if teacher_profile
+    end
+
+    def teacher_profile
+      @teacher_profile ||= TeacherProfile.find_by(trn: trn)
+    end
+
+    def previously_funded?
+      return false unless user
+
+      user
+        .npq_applications
+        .where(npq_course: npq_course)
+        .where(eligible_for_funding: true)
+        .accepted
+        .any?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,9 @@ Rails.application.routes.draw do
 
     namespace :v1 do
       concern :participant_actions, Participants::Routing.new
+
+      resources :npq_funding, only: [:index], path: "npq-funding"
+
       resources :ecf_participants, path: "participants/ecf", only: %i[index] do
         concerns :participant_actions
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       concern :participant_actions, Participants::Routing.new
 
-      resources :npq_funding, only: [:index], path: "npq-funding"
+      resources :npq_funding, only: [:show], path: "npq-funding", param: :trn
 
       resources :ecf_participants, path: "participants/ecf", only: %i[index] do
         concerns :participant_actions

--- a/spec/requests/api/v1/npq_funding_spec.rb
+++ b/spec/requests/api/v1/npq_funding_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe "NPQ Funding API", type: :request do
       end
 
       it "returns correct response" do
-        get "/api/v1/npq-funding?trn=1234567"
+        expect(NPQ::FundingEligibility).to receive(:new)
+          .with(trn: "1234567", npq_course_identifier: "npq-leading-literacy")
+          .and_call_original
+
+        get "/api/v1/npq-funding/1234567?npq_course_identifier=npq-leading-literacy"
         expect(parsed_response["previously_funded"]).to be(false)
       end
     end
@@ -22,7 +26,7 @@ RSpec.describe "NPQ Funding API", type: :request do
     context "when unauthorized" do
       it "returns 401 for invalid bearer token" do
         default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
-        get "/api/v1/npq-funding?trn=1234567"
+        get "/api/v1/npq-funding/1234567"
         expect(response.status).to eq 401
       end
     end

--- a/spec/requests/api/v1/npq_funding_spec.rb
+++ b/spec/requests/api/v1/npq_funding_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NPQ Funding API", type: :request do
+  let(:token) { NPQRegistrationApiToken.create_with_random_token!(private_api_access: true) }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:parsed_response) { JSON.parse(response.body) }
+
+  describe "GET /api/v1/npq-funding" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+      end
+
+      it "returns correct response" do
+        get "/api/v1/npq-funding?trn=1234567"
+        expect(parsed_response["previously_funded"]).to be(false)
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v1/npq-funding?trn=1234567"
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -42,6 +42,27 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
       end
     end
 
+    context "when previously funded with multiple teacher profiles" do
+      let(:trn) { application.teacher_reference_number }
+      let(:application) do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          teacher_reference_number_verified: true,
+        )
+      end
+      let(:npq_course) { application.npq_course }
+
+      before do
+        create(:teacher_profile, trn: trn)
+        NPQ::Accept.new(npq_application: application).call
+      end
+
+      it "returns truthy" do
+        expect(subject.call[:previously_funded]).to be_truthy
+      end
+    end
+
     context "when trn does not yield any teachers" do
       let(:trn) { "0000000" }
       let(:npq_course) { create(:npq_course) }

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
+  subject { described_class.new(trn: trn, npq_course_identifier: npq_course.identifier) }
+
+  describe "#call" do
+    context "when not previously funded" do
+      let(:trn) { application.teacher_reference_number }
+      let(:application) do
+        create(
+          :npq_application,
+          lead_provider_approval_status: "accepted",
+          eligible_for_funding: false,
+        )
+      end
+      let(:npq_course) { application.npq_course }
+
+      it "returns falsey" do
+        expect(subject.call[:previously_funded]).to be_falsey
+      end
+    end
+
+    context "when previously funded" do
+      let(:trn) { application.teacher_reference_number }
+      let(:application) do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          teacher_reference_number_verified: true,
+        )
+      end
+      let(:npq_course) { application.npq_course }
+
+      before do
+        NPQ::Accept.new(npq_application: application).call
+      end
+
+      it "returns truthy" do
+        expect(subject.call[:previously_funded]).to be_truthy
+      end
+    end
+
+    context "when trn does not yield any teachers" do
+      let(:trn) { "0000000" }
+      let(:npq_course) { create(:npq_course) }
+
+      subject { described_class.new(trn: trn, npq_course_identifier: npq_course.identifier) }
+
+      it "returns falsey" do
+        expect(subject.call[:previously_funded]).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1335

### Changes proposed in this pull request

- Added service class to calculate NPQ funding eligibility based on TRN and course
- Added private api endpoint so it is accessible via NPQ rails app api call

### Guidance to review

- Create a private api token
- Using this token request NPQ funding with `trn` and `npq_course_identifier`
- Should return appropriate result