### PR TITLE
CST-723 - change LD DP issue

### DIFF
--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -54,5 +54,17 @@ private
     @school.school_cohorts.find_by(cohort: Cohort.active_registration_cohort.previous)
   end
 
-  helper_method :set_up_new_cohort?, :previous_school_cohort
+  def school_cohort_lead_provider_name(school_cohort)
+    return school_cohort.lead_provider.name if school_cohort.lead_provider.present?
+    return "To be confirmed" if school_cohort.default_induction_programme.lead_provider_to_be_confirmed?
+    return school_cohort.previous_lead_provider&.name
+  end
+
+  def school_cohort_delivery_partner_name(school_cohort)
+    return school_cohort.delivery_partner.name if school_cohort.delivery_partner.present?
+    return "To be confirmed" if school_cohort.default_induction_programme.delivery_partner_to_be_confirmed?
+    return school_cohort.previous_delivery_partner&.name
+  end
+
+  helper_method :set_up_new_cohort?, :previous_school_cohort, :school_cohort_lead_provider_name, :school_cohort_delivery_partner_name
 end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -56,14 +56,18 @@ private
 
   def school_cohort_lead_provider_name(school_cohort)
     return school_cohort.lead_provider.name if school_cohort.lead_provider.present?
+
     return "To be confirmed" if school_cohort.default_induction_programme&.lead_provider_to_be_confirmed?
-    return school_cohort.previous_lead_provider&.name || "To be confirmed"
+
+    school_cohort.previous_lead_provider&.name || "To be confirmed"
   end
 
   def school_cohort_delivery_partner_name(school_cohort)
     return school_cohort.delivery_partner.name if school_cohort.delivery_partner.present?
+
     return "To be confirmed" if school_cohort.default_induction_programme&.delivery_partner_to_be_confirmed?
-    return school_cohort.previous_delivery_partner&.name || "To be confirmed"
+
+    school_cohort.previous_delivery_partner&.name || "To be confirmed"
   end
 
   helper_method :set_up_new_cohort?, :previous_school_cohort, :school_cohort_lead_provider_name, :school_cohort_delivery_partner_name

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -55,19 +55,21 @@ private
   end
 
   def school_cohort_lead_provider_name(school_cohort)
-    return school_cohort.lead_provider.name if school_cohort.lead_provider.present?
-
-    return "To be confirmed" if school_cohort.default_induction_programme&.lead_provider_to_be_confirmed?
-
-    school_cohort.previous_lead_provider&.name || "To be confirmed"
+    if school_cohort.lead_provider.present?
+      school_cohort.lead_provider.name
+    elsif school_cohort.default_induction_programme&.delivery_partner_to_be_confirmed?
+      school_cohort.previous_lead_provider&.name
+    else
+      "To be confirmed"
+    end
   end
 
   def school_cohort_delivery_partner_name(school_cohort)
-    return school_cohort.delivery_partner.name if school_cohort.delivery_partner.present?
-
-    return "To be confirmed" if school_cohort.default_induction_programme&.delivery_partner_to_be_confirmed?
-
-    school_cohort.previous_delivery_partner&.name || "To be confirmed"
+    if school_cohort.delivery_partner.present?
+      school_cohort.delivery_partner.name
+    else
+      "To be confirmed"
+    end
   end
 
   helper_method :set_up_new_cohort?, :previous_school_cohort, :school_cohort_lead_provider_name, :school_cohort_delivery_partner_name

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -54,11 +54,18 @@ private
     @school.school_cohorts.find_by(cohort: Cohort.active_registration_cohort.previous)
   end
 
+  def previous_lead_provider(school_cohort)
+    school = school_cohort.school
+    previous_start_year = school_cohort.cohort.start_year - 1
+    previous_school_cohort = school.school_cohorts.find_by(cohort: Cohort.find_by(start_year: previous_start_year))
+    previous_school_cohort.lead_provider
+  end
+
   def school_cohort_lead_provider_name(school_cohort)
     if school_cohort.lead_provider.present?
       school_cohort.lead_provider.name
     elsif school_cohort.default_induction_programme&.delivery_partner_to_be_confirmed?
-      school_cohort.previous_lead_provider&.name
+      previous_lead_provider(school_cohort)&.name
     else
       "To be confirmed"
     end

--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -56,14 +56,14 @@ private
 
   def school_cohort_lead_provider_name(school_cohort)
     return school_cohort.lead_provider.name if school_cohort.lead_provider.present?
-    return "To be confirmed" if school_cohort.default_induction_programme.lead_provider_to_be_confirmed?
-    return school_cohort.previous_lead_provider&.name
+    return "To be confirmed" if school_cohort.default_induction_programme&.lead_provider_to_be_confirmed?
+    return school_cohort.previous_lead_provider&.name || "To be confirmed"
   end
 
   def school_cohort_delivery_partner_name(school_cohort)
     return school_cohort.delivery_partner.name if school_cohort.delivery_partner.present?
-    return "To be confirmed" if school_cohort.default_induction_programme.delivery_partner_to_be_confirmed?
-    return school_cohort.previous_delivery_partner&.name
+    return "To be confirmed" if school_cohort.default_induction_programme&.delivery_partner_to_be_confirmed?
+    return school_cohort.previous_delivery_partner&.name || "To be confirmed"
   end
 
   helper_method :set_up_new_cohort?, :previous_school_cohort, :school_cohort_lead_provider_name, :school_cohort_delivery_partner_name

--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -167,7 +167,9 @@ module Schools
     def set_cohort_induction_programme!(programme_choice, opt_out_of_updates: false)
       Induction::SetCohortInductionProgramme.call(school_cohort: school_cohort,
                                                   programme_choice: programme_choice,
-                                                  opt_out_of_updates: opt_out_of_updates)
+                                                  opt_out_of_updates: opt_out_of_updates,
+                                                  lead_provider_to_be_confirmed: lead_provider_to_be_confirmed?,
+                                                  delivery_partner_to_be_confirmed: delivery_partner_to_be_confirmed?)
     end
 
     def school_cohort
@@ -192,6 +194,14 @@ module Schools
 
     def save_school_choice!
       set_cohort_induction_programme!(@setup_school_cohort_form.attributes[:how_will_you_run_training_choice])
+    end
+
+    def lead_provider_to_be_confirmed?
+      @setup_school_cohort_form.attributes[:what_changes_choice] == "change_lead_provider"
+    end
+
+    def delivery_partner_to_be_confirmed?
+      @setup_school_cohort_form.attributes[:what_changes_choice] == "change_delivery_partner"
     end
   end
 end

--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -168,7 +168,6 @@ module Schools
       Induction::SetCohortInductionProgramme.call(school_cohort: school_cohort,
                                                   programme_choice: programme_choice,
                                                   opt_out_of_updates: opt_out_of_updates,
-                                                  lead_provider_to_be_confirmed: lead_provider_to_be_confirmed?,
                                                   delivery_partner_to_be_confirmed: delivery_partner_to_be_confirmed?)
     end
 
@@ -194,10 +193,6 @@ module Schools
 
     def save_school_choice!
       set_cohort_induction_programme!(@setup_school_cohort_form.attributes[:how_will_you_run_training_choice])
-    end
-
-    def lead_provider_to_be_confirmed?
-      @setup_school_cohort_form.attributes[:what_changes_choice] == "change_lead_provider"
     end
 
     def delivery_partner_to_be_confirmed?

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -59,8 +59,24 @@ class SchoolCohort < ApplicationRecord
     school.lead_provider(cohort.start_year)
   end
 
+  def lead_provider_to_be_confirmed?
+    default_induction_programme.lead_provider_to_be_confirmed
+  end
+
+  def previous_lead_provider
+    school.lead_provider(cohort.start_year - 1)
+  end
+
   def delivery_partner
     school.delivery_partner_for(cohort.start_year)
+  end
+
+  def delivery_partner_to_be_confirmed?
+    default_induction_programme.delivery_partner_to_be_confirmed
+  end
+
+  def previous_delivery_partner
+    school.delivery_partner_for(cohort.start_year - 1)
   end
 
   def school_chose_cip?

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -39,6 +39,7 @@ class SchoolCohort < ApplicationRecord
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
 
   delegate :description, :academic_year, to: :cohort
+  delegate :delivery_partner_to_be_confirmed, to: :default_induction_programme
 
   after_save do |school_cohort|
     unless school_cohort.saved_changes.empty?
@@ -65,14 +66,6 @@ class SchoolCohort < ApplicationRecord
 
   def delivery_partner
     school.delivery_partner_for(cohort.start_year)
-  end
-
-  def delivery_partner_to_be_confirmed?
-    default_induction_programme.delivery_partner_to_be_confirmed
-  end
-
-  def previous_delivery_partner
-    school.delivery_partner_for(cohort.start_year - 1)
   end
 
   def school_chose_cip?

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -60,10 +60,6 @@ class SchoolCohort < ApplicationRecord
     school.lead_provider(cohort.start_year)
   end
 
-  def previous_lead_provider
-    school.lead_provider(cohort.start_year - 1)
-  end
-
   def delivery_partner
     school.delivery_partner_for(cohort.start_year)
   end

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -59,10 +59,6 @@ class SchoolCohort < ApplicationRecord
     school.lead_provider(cohort.start_year)
   end
 
-  def lead_provider_to_be_confirmed?
-    default_induction_programme.lead_provider_to_be_confirmed
-  end
-
   def previous_lead_provider
     school.lead_provider(cohort.start_year - 1)
   end

--- a/app/services/induction/set_cohort_induction_programme.rb
+++ b/app/services/induction/set_cohort_induction_programme.rb
@@ -25,7 +25,11 @@ private
 
   attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme, :lead_provider_to_be_confirmed, :delivery_partner_to_be_confirmed
 
-  def initialize(school_cohort:, programme_choice:, opt_out_of_updates: false, core_induction_programme: nil, lead_provider_to_be_confirmed: false, delivery_partner_to_be_confirmed: false)
+  def initialize(school_cohort:, programme_choice:,
+                 opt_out_of_updates: false,
+                 core_induction_programme: nil,
+                 lead_provider_to_be_confirmed: false,
+                 delivery_partner_to_be_confirmed: false)
     # NOTE: this is mainly called during addition of a school_cohort and the model may not
     # be persisted as yet
     @school_cohort = school_cohort
@@ -41,7 +45,7 @@ private
       training_programme: programme_choice,
       school_cohort: school_cohort,
       lead_provider_to_be_confirmed: lead_provider_to_be_confirmed,
-      delivery_partner_to_be_confirmed: delivery_partner_to_be_confirmed
+      delivery_partner_to_be_confirmed: delivery_partner_to_be_confirmed,
     }
 
     case programme_choice

--- a/app/services/induction/set_cohort_induction_programme.rb
+++ b/app/services/induction/set_cohort_induction_programme.rb
@@ -23,21 +23,25 @@ class Induction::SetCohortInductionProgramme < BaseService
 
 private
 
-  attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme
+  attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme, :lead_provider_to_be_confirmed, :delivery_partner_to_be_confirmed
 
-  def initialize(school_cohort:, programme_choice:, opt_out_of_updates: false, core_induction_programme: nil)
+  def initialize(school_cohort:, programme_choice:, opt_out_of_updates: false, core_induction_programme: nil, lead_provider_to_be_confirmed: false, delivery_partner_to_be_confirmed: false)
     # NOTE: this is mainly called during addition of a school_cohort and the model may not
     # be persisted as yet
     @school_cohort = school_cohort
     @programme_choice = programme_choice.to_s
     @opt_out_of_updates = opt_out_of_updates
     @core_induction_programme = core_induction_programme
+    @lead_provider_to_be_confirmed = lead_provider_to_be_confirmed
+    @delivery_partner_to_be_confirmed = delivery_partner_to_be_confirmed
   end
 
   def programme_attrs
     attrs = {
       training_programme: programme_choice,
       school_cohort: school_cohort,
+      lead_provider_to_be_confirmed: lead_provider_to_be_confirmed,
+      delivery_partner_to_be_confirmed: delivery_partner_to_be_confirmed
     }
 
     case programme_choice

--- a/app/services/induction/set_cohort_induction_programme.rb
+++ b/app/services/induction/set_cohort_induction_programme.rb
@@ -23,12 +23,11 @@ class Induction::SetCohortInductionProgramme < BaseService
 
 private
 
-  attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme, :lead_provider_to_be_confirmed, :delivery_partner_to_be_confirmed
+  attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme, :delivery_partner_to_be_confirmed
 
   def initialize(school_cohort:, programme_choice:,
                  opt_out_of_updates: false,
                  core_induction_programme: nil,
-                 lead_provider_to_be_confirmed: false,
                  delivery_partner_to_be_confirmed: false)
     # NOTE: this is mainly called during addition of a school_cohort and the model may not
     # be persisted as yet
@@ -36,7 +35,6 @@ private
     @programme_choice = programme_choice.to_s
     @opt_out_of_updates = opt_out_of_updates
     @core_induction_programme = core_induction_programme
-    @lead_provider_to_be_confirmed = lead_provider_to_be_confirmed
     @delivery_partner_to_be_confirmed = delivery_partner_to_be_confirmed
   end
 
@@ -44,7 +42,6 @@ private
     attrs = {
       training_programme: programme_choice,
       school_cohort: school_cohort,
-      lead_provider_to_be_confirmed: lead_provider_to_be_confirmed,
       delivery_partner_to_be_confirmed: delivery_partner_to_be_confirmed,
     }
 

--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -1,5 +1,5 @@
-<% lead_provider = school_cohort.default_induction_programme&.lead_provider %>
-<% delivery_partner =  school_cohort.default_induction_programme&.delivery_partner %>
+<% lead_provider = school_cohort_lead_provider_name(school_cohort) %>
+<% delivery_partner = school_cohort_delivery_partner_name(school_cohort) %>
 <% ects_count = school_cohort.current_induction_records.count %>
 <% latest_partnership = school_cohort.school.partnerships.where(cohort: school_cohort.cohort, relationship: false).order(created_at: :desc).limit(1).first %>
 
@@ -40,7 +40,7 @@
       <% if latest_partnership&.challenged? == true %>
         <% row.value(text: nil) %>
       <% else %>
-        <% row.value(text: lead_provider&.name ? lead_provider.name : "To be confirmed") %>
+        <% row.value(text: lead_provider) %>
       <% end %>
       <% row.action(text: :none) %>
     <% end %>
@@ -49,7 +49,7 @@
       <% if latest_partnership&.challenged? == true %>
         <% row.value(text: nil) %>
       <% else %>
-        <% row.value(text: delivery_partner&.name ? delivery_partner.name : "To be confirmed") %>
+        <% row.value(text: delivery_partner) %>
       <% end %>
       <% row.action(text: :none) %>
     <% end %>

--- a/db/migrate/20220516123711_add_to_be_confirmed_to_induction_programme.rb
+++ b/db/migrate/20220516123711_add_to_be_confirmed_to_induction_programme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddToBeConfirmedToInductionProgramme < ActiveRecord::Migration[6.1]
   def change
     add_column :induction_programmes, "lead_provider_to_be_confirmed", :boolean, default: false

--- a/db/migrate/20220516123711_add_to_be_confirmed_to_induction_programme.rb
+++ b/db/migrate/20220516123711_add_to_be_confirmed_to_induction_programme.rb
@@ -1,0 +1,6 @@
+class AddToBeConfirmedToInductionProgramme < ActiveRecord::Migration[6.1]
+  def change
+    add_column :induction_programmes, "lead_provider_to_be_confirmed", :boolean, default: false
+    add_column :induction_programmes, "delivery_partner_to_be_confirmed", :boolean, default: false
+  end
+end

--- a/db/migrate/20220516123711_add_to_be_confirmed_to_induction_programme.rb
+++ b/db/migrate/20220516123711_add_to_be_confirmed_to_induction_programme.rb
@@ -2,7 +2,6 @@
 
 class AddToBeConfirmedToInductionProgramme < ActiveRecord::Migration[6.1]
   def change
-    add_column :induction_programmes, "lead_provider_to_be_confirmed", :boolean, default: false
     add_column :induction_programmes, "delivery_partner_to_be_confirmed", :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -362,7 +362,6 @@ ActiveRecord::Schema.define(version: 2022_05_16_123711) do
     t.string "training_programme", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "lead_provider_to_be_confirmed", default: false
     t.boolean "delivery_partner_to_be_confirmed", default: false
     t.index ["core_induction_programme_id"], name: "index_induction_programmes_on_core_induction_programme_id"
     t.index ["partnership_id"], name: "index_induction_programmes_on_partnership_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_140603) do
+ActiveRecord::Schema.define(version: 2022_05_16_123711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -362,6 +362,8 @@ ActiveRecord::Schema.define(version: 2022_05_12_140603) do
     t.string "training_programme", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "lead_provider_to_be_confirmed", default: false
+    t.boolean "delivery_partner_to_be_confirmed", default: false
     t.index ["core_induction_programme_id"], name: "index_induction_programmes_on_core_induction_programme_id"
     t.index ["partnership_id"], name: "index_induction_programmes_on_partnership_id"
     t.index ["school_cohort_id"], name: "index_induction_programmes_on_school_cohort_id"

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -213,7 +213,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
         and_i_see_training_provider_to_be_confirmed
-        and_i_see_delivery_partner_to_be_the_previous_one
+        and_i_see_delivery_partner_to_be_confirmed
       end
 
       scenario "A school chooses to change delivery partner" do

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -213,7 +213,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
         and_i_see_training_provider_to_be_confirmed
-        and_i_see_delivery_partner_to_be_confirmed
+        and_i_see_delivery_partner_to_be_the_previous_one
       end
 
       scenario "A school chooses to change delivery partner" do
@@ -245,7 +245,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
         when_i_click_on_the_return_to_your_training_link
         then_i_am_taken_to_the_manage_your_training_page
-        and_i_see_training_provider_to_be_confirmed
+        and_i_see_training_partner_to_be_the_previous_one
         and_i_see_delivery_partner_to_be_confirmed
       end
 

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -174,6 +174,16 @@ module ChooseProgrammeSteps
     expect(page).to have_summary_row("Delivery partner", "To be confirmed")
   end
 
+  def and_i_see_delivery_partner_to_be_the_previous_one
+    name = @school_cohort.delivery_partner.name
+    expect(page).to have_summary_row("Delivery partner", name)
+  end
+
+  def and_i_see_training_partner_to_be_the_previous_one
+    name = @school_cohort.lead_provider.name
+    expect(page).to have_summary_row("Training provider", name)
+  end
+
   def and_i_see_programme_to_dfe_accredited_materials
     expect(page).to have_summary_row("Programme", "DfE accredited materials")
   end

--- a/spec/support/matchers/have_summary_row.rb
+++ b/spec/support/matchers/have_summary_row.rb
@@ -8,7 +8,11 @@ module Support
       match do |actual|
         key_node = find_key_node(actual, key)
         value_node = find_value_node(key_node)
-        expect(value_node).to have_content(value)
+        if value_node.text != value
+          @failure_message = "Expected summary row \"#{key}\" with value \"#{value}\" but value \"#{value_node.text}\" found instead"
+          return false
+        end
+        true
       rescue Capybara::ElementNotFound
         false
       end


### PR DESCRIPTION
### Context

- Ticket: CST-723

### Changes proposed in this pull request

When a school set up the next cohort and choose to either change the lead provider or the delivery partner the dashboard shows that both of them need to be confirmed.
This is happening because the partnership is not created in the case above.
The solution proposed is to have two flags on the induction programme that store whether the lead provider or the delivery partner need to be confirmed.
