### PR TITLE
[CPDLP-1360] Improve InductionRecord serializer updated_at

### DIFF
--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -116,7 +116,10 @@ module Api
       end
 
       attribute :updated_at do |induction_record|
-        induction_record.participant_profile.user.updated_at.rfc3339
+        [
+          induction_record.participant_profile.user.updated_at,
+          induction_record.updated_at,
+        ].max.rfc3339
       end
     end
   end

--- a/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
@@ -9,7 +9,7 @@ module Api
 
       subject { described_class.new(induction_record) }
 
-      describe "status" do
+      describe "#status" do
         context "when active" do
           it "returns active" do
             expect(subject.serializable_hash[:data][:attributes][:status]).to eql("active")
@@ -46,6 +46,19 @@ module Api
           it "returns withdrawn" do
             expect(subject.serializable_hash[:data][:attributes][:status]).to eql("withdrawn")
           end
+        end
+      end
+
+      describe "#updated_at" do
+        let(:induction_record) { create(:induction_record, updated_at: 1.day.ago) }
+        let(:user) { induction_record.participant_profile.user }
+
+        before do
+          user.update!(updated_at: 10.days.ago)
+        end
+
+        it "considers updated_at of induction record" do
+          expect(Time.zone.parse(subject.serializable_hash[:data][:attributes][:updated_at])).to be_within(2.days).of(1.day.ago)
         end
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1360
- Providers are not updating/refreshing records as the `updated_at` field is not accurately reflecting when a record has been updated

### Changes proposed in this pull request

- `ParticipantFromInductionRecordSerializer` `updated_at` now considers more info to more accurately reflect when record was updated at

### Guidance to review

- Find ECF user via API
- Touch their induction record
- `updated_at` should have been affected