### PR TITLE
[CPDLP-1049] Introduce statement line items

### DIFF
--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -32,20 +32,7 @@ class Finance::Statement < ApplicationRecord
     end
 
     def attach(participant_declaration)
-      statement = statement_for(participant_declaration)
-      statement.participant_declarations << participant_declaration
-    end
-
-  private
-
-    def statement_for(participant_declaration)
-      cohort = participant_declaration.participant_profile.schedule.cohort
-      case participant_declaration
-      when ParticipantDeclaration::ECF
-        participant_declaration.cpd_lead_provider.lead_provider.next_output_fee_statement(cohort)
-      when ParticipantDeclaration::NPQ
-        participant_declaration.cpd_lead_provider.npq_lead_provider.next_output_fee_statement(cohort)
-      end
+      Finance::DeclarationStatementAttacher.new(participant_declaration: participant_declaration).call
     end
   end
 

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -7,7 +7,10 @@ class Finance::Statement < ApplicationRecord
 
   belongs_to :cpd_lead_provider
   belongs_to :cohort
+
   has_many :participant_declarations
+  has_many :statement_line_items, class_name: "Finance::StatementLineItem"
+
   scope :payable,                   -> { where("deadline_date < DATE(NOW()) AND payment_date >= DATE(NOW())") }
   scope :closed,                    -> { where("payment_date < ?", Date.current) }
   scope :with_future_deadline_date, -> { where("deadline_date >= DATE(NOW())") }

--- a/app/models/finance/statement_line_item.rb
+++ b/app/models/finance/statement_line_item.rb
@@ -5,4 +5,9 @@ class Finance::StatementLineItem < ApplicationRecord
 
   belongs_to :statement
   belongs_to :participant_declaration
+
+  scope :eligible, -> { where(state: "eligible") }
+  scope :payable, -> { where(state: "payable") }
+  scope :paid, -> { where(state: "paid") }
+  scope :voided, -> { where(state: "voided") }
 end

--- a/app/models/finance/statement_line_item.rb
+++ b/app/models/finance/statement_line_item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Finance::StatementLineItem < ApplicationRecord
+  self.table_name = "statement_line_items"
+
+  belongs_to :statement
+  belongs_to :participant_declaration
+end

--- a/app/models/finance/statement_line_item.rb
+++ b/app/models/finance/statement_line_item.rb
@@ -6,8 +6,12 @@ class Finance::StatementLineItem < ApplicationRecord
   belongs_to :statement
   belongs_to :participant_declaration
 
-  scope :eligible, -> { where(state: "eligible") }
-  scope :payable, -> { where(state: "payable") }
-  scope :paid, -> { where(state: "paid") }
-  scope :voided, -> { where(state: "voided") }
+  enum state: {
+    submitted: "submitted",
+    eligible: "eligible",
+    payable: "payable",
+    paid: "paid",
+    voided: "voided",
+    ineligible: "ineligible",
+  }
 end

--- a/app/models/finance/statement_line_item.rb
+++ b/app/models/finance/statement_line_item.rb
@@ -14,4 +14,19 @@ class Finance::StatementLineItem < ApplicationRecord
     voided: "voided",
     ineligible: "ineligible",
   }
+
+  scope :billable, -> { where(state: %w[eligible payable paid]) }
+
+  validate :validate_single_billable_relationship, on: [:create]
+
+private
+
+  def validate_single_billable_relationship
+    if Finance::StatementLineItem
+      .where(participant_declaration: participant_declaration)
+      .billable
+      .exists?
+      errors.add(:participant_declaration, "is already asscociated to another statement as a billable")
+    end
+  end
 end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -12,6 +12,8 @@ class ParticipantDeclaration < ApplicationRecord
   belongs_to :statement, optional: true, class_name: "Finance::Statement"
   has_many :supersedes, class_name: "ParticipantDeclaration", foreign_key: :superseded_by_id, inverse_of: :superseded_by
 
+  has_many :statement_line_items, class_name: "Finance::StatementLineItem"
+
   enum state: {
     submitted: "submitted",
     eligible: "eligible",

--- a/app/services/finance/declaration_statement_attacher.rb
+++ b/app/services/finance/declaration_statement_attacher.rb
@@ -12,7 +12,14 @@ module Finance
     end
 
     def call
-      statement.participant_declarations << participant_declaration
+      ApplicationRecord.transaction do
+        statement.participant_declarations << participant_declaration
+        StatementLineItem.create!(
+          statement: statement,
+          participant_declaration: participant_declaration,
+          state: participant_declaration.state,
+        )
+      end
     end
 
   private

--- a/app/services/finance/declaration_statement_attacher.rb
+++ b/app/services/finance/declaration_statement_attacher.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Finance
+  # Given a declaration
+  # Work out which statement it should belong to
+  # Attach the declaration to said statement
+  class DeclarationStatementAttacher
+    attr_reader :participant_declaration
+
+    def initialize(participant_declaration:)
+      @participant_declaration = participant_declaration
+    end
+
+    def call
+      statement.participant_declarations << participant_declaration
+    end
+
+  private
+
+    def cohort
+      participant_declaration.participant_profile.schedule.cohort
+    end
+
+    def statement
+      case participant_declaration
+      when ParticipantDeclaration::ECF
+        participant_declaration.cpd_lead_provider.lead_provider.next_output_fee_statement(cohort)
+      when ParticipantDeclaration::NPQ
+        participant_declaration.cpd_lead_provider.npq_lead_provider.next_output_fee_statement(cohort)
+      end
+    end
+  end
+end

--- a/app/services/importers/statement_line_items.rb
+++ b/app/services/importers/statement_line_items.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Importers::StatementLineItems
+  def call
+    declarations.find_each do |declaration|
+      Finance::StatementLineItem.find_or_create_by!(
+        statement: declaration.statement,
+        participant_declaration: declaration,
+        state: declaration.state,
+      )
+    end
+  end
+
+private
+
+  def declarations
+    ParticipantDeclaration
+      .where("statement_id is not null")
+      .includes(:statement)
+  end
+end

--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -16,7 +16,7 @@ class VoidParticipantDeclaration
 
     ApplicationRecord.transaction do
       declaration.make_voided!
-      line_item.update!(state: "voided") if line_item
+      line_item.voided! if line_item
     end
 
     Api::V1::ParticipantDeclarationSerializer.new(declaration).serializable_hash.to_json

--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -14,12 +14,19 @@ class VoidParticipantDeclaration
     raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_already_voided) if declaration.voided?
     raise Api::Errors::InvalidTransitionError, I18n.t(:declaration_not_voidable) unless declaration.voidable?
 
-    declaration.make_voided!
+    ApplicationRecord.transaction do
+      declaration.make_voided!
+      line_item.update!(state: "voided") if line_item
+    end
 
     Api::V1::ParticipantDeclarationSerializer.new(declaration).serializable_hash.to_json
   end
 
 private
+
+  def line_item
+    declaration.statement_line_items.find_by(state: %w[eligible payable])
+  end
 
   def declaration
     @declaration ||= ParticipantDeclaration.for_lead_provider(cpd_lead_provider).find(id)

--- a/db/migrate/20220518120740_create_statement_line_items.rb
+++ b/db/migrate/20220518120740_create_statement_line_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateStatementLineItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :statement_line_items do |t|
+      t.references :statement
+      t.references :participant_declaration
+
+      t.text :state, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_18_140603) do
+ActiveRecord::Schema.define(version: 2022_05_18_120740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -874,6 +874,16 @@ ActiveRecord::Schema.define(version: 2022_05_18_140603) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "statement_line_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "statement_id", null: false
+    t.uuid "participant_declaration_id", null: false
+    t.text "state", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["participant_declaration_id"], name: "index_statement_line_items_on_participant_declaration_id"
+    t.index ["statement_id"], name: "index_statement_line_items_on_statement_id"
   end
 
   create_table "statements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/finance/statements/mark_as_payable_spec.rb
+++ b/spec/jobs/finance/statements/mark_as_payable_spec.rb
@@ -6,13 +6,24 @@ RSpec.describe Finance::Statements::MarkAsPayable do
   include_context "with default schedules"
 
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
-  let!(:statement)        { create(:ecf_statement, output_fee: true, deadline_date: Date.new(2021, 12, 31), cpd_lead_provider: cpd_lead_provider) }
+  let!(:statement) do
+    create(
+      :ecf_statement,
+      output_fee: true,
+      deadline_date: Date.new(2021, 12, 31),
+      cpd_lead_provider: cpd_lead_provider,
+    )
+  end
 
   before do
     travel_to Date.new(2021, 12, 31) do
-      create(:ect_participant_declaration, :eligible,   statement: statement)
-      create(:ect_participant_declaration, :ineligible, statement: statement)
-      create(:ect_participant_declaration, :voided,     statement: statement)
+      eligible_dec = create(:ect_participant_declaration, :eligible, statement: statement)
+      ineligible_dec = create(:ect_participant_declaration, :ineligible, statement: statement)
+      voided_dec = create(:ect_participant_declaration, :voided, statement: statement)
+
+      Finance::StatementLineItem.create!(statement: statement, participant_declaration: eligible_dec, state: "eligible")
+      Finance::StatementLineItem.create!(statement: statement, participant_declaration: ineligible_dec, state: "ineligible")
+      Finance::StatementLineItem.create!(statement: statement, participant_declaration: voided_dec, state: "voided")
     end
   end
 
@@ -22,6 +33,15 @@ RSpec.describe Finance::Statements::MarkAsPayable do
         described_class.perform_now
       end
     }.to change(statement.reload.participant_declarations.payable, :count).from(0).to(1)
+
     expect(statement.reload.type).to eq("Finance::Statement::ECF::Payable")
+  end
+
+  it "transitions lines items to payable" do
+    expect {
+      travel_to Date.new(2022, 1, 1) do
+        described_class.perform_now
+      end
+    }.to change(statement.reload.statement_line_items.payable, :count).from(0).to(1)
   end
 end

--- a/spec/models/finance/statement_line_item_spec.rb
+++ b/spec/models/finance/statement_line_item_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::StatementLineItem do
+  let(:statement) { create(:ecf_statement) }
+  let(:declaration) { create(:ect_participant_declaration, :eligible) }
+
+  describe "validations" do
+    let!(:existing_line_item) do
+      described_class.create!(
+        statement: statement,
+        participant_declaration: declaration,
+        state: declaration.state,
+      )
+    end
+
+    it "cannot be billed to multiple statements" do
+      expect {
+        described_class.create(
+          statement: statement,
+          participant_declaration: declaration,
+          state: declaration.state,
+        )
+      }.not_to change(Finance::StatementLineItem, :count)
+    end
+  end
+end

--- a/spec/services/finance/declaration_statement_attacher_spec.rb
+++ b/spec/services/finance/declaration_statement_attacher_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::DeclarationStatementAttacher do
+  let(:declaration) { create(:ect_participant_declaration, cpd_lead_provider: cpd_lead_provider) }
+  let(:statement) { create(:ecf_statement, output_fee: true, deadline_date: 2.months.from_now) }
+  let(:cpd_lead_provider) { statement.cpd_lead_provider }
+
+  subject { described_class.new(participant_declaration: declaration) }
+
+  describe "#call" do
+    it "creates line item" do
+      expect {
+        subject.call
+      }.to change(Finance::StatementLineItem, :count).by(1)
+    end
+
+    it "create line item with same state as declaration" do
+      subject.call
+
+      line_item = Finance::StatementLineItem.last
+      expect(line_item.state).to eql(declaration.state)
+    end
+  end
+end

--- a/spec/services/finance/declaration_statement_attacher_spec.rb
+++ b/spec/services/finance/declaration_statement_attacher_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Finance::DeclarationStatementAttacher do
     it "creates line item" do
       expect {
         subject.call
-      }.to change(Finance::StatementLineItem, :count).by(1)
+      }.to change { statement.reload.statement_line_items.count }.by(1)
     end
 
     it "create line item with same state as declaration" do

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe VoidParticipantDeclaration do
       it "update line item state to voided" do
         subject.call
         expect(declaration.reload).to be_voided
-        expect(line_item.reload.state).to eql("voided")
+        expect(line_item.reload).to be_voided
       end
     end
   end

--- a/spec/services/void_participant_declaration_spec.rb
+++ b/spec/services/void_participant_declaration_spec.rb
@@ -85,5 +85,39 @@ RSpec.describe VoidParticipantDeclaration do
         }.to raise_error Api::Errors::InvalidTransitionError
       end
     end
+
+    context "when declaration is attached to a statement" do
+      let(:declaration) do
+        create(
+          :ect_participant_declaration,
+          user: user,
+          cpd_lead_provider: cpd_lead_provider,
+          declaration_date: declaration_date,
+          participant_profile: profile,
+          state: "payable",
+        )
+      end
+
+      let!(:statement) do
+        create(
+          :ecf_statement,
+          cpd_lead_provider: cpd_lead_provider,
+          output_fee: true,
+          deadline_date: 3.months.from_now,
+        )
+      end
+
+      let(:line_item) { declaration.statement_line_items.first }
+
+      before do
+        Finance::DeclarationStatementAttacher.new(participant_declaration: declaration).call
+      end
+
+      it "update line item state to voided" do
+        subject.call
+        expect(declaration.reload).to be_voided
+        expect(line_item.reload.state).to eql("voided")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1049
- In order to accomplish clawbacks we need to associate a declaration with multiple statements
- One for where we payout and potentially another for when we do a refund
- At the moment a declaration can only be associated with a single statement
- So a join table has been introduced to overcome this limitation

### Changes proposed in this pull request

- Introduce statement line items
- This joins statements and declarations together
- The old mechanism has been left in place as it is still used whilst new mechanism is slotted into position and missing data backfilled
- Added class to backfill line items for existing declarations associated with a statement
- When declarations are auto attached to a statement the line item is also created
- When voiding a declaration the line item is also updated to reflect the new `voided` state
- When transitioning a statement to `payable`, the state of line items are also transitioned 
- There is a slight gap as code to transition to `paid` does not exist yet

### Guidance to review

- `Importers::StatementLineItems.new.call` should backfill line items