### PR TITLE
Maintain school cohorts in analytics database

### DIFF
--- a/app/jobs/analytics/upsert_ecf_school_cohort_job.rb
+++ b/app/jobs/analytics/upsert_ecf_school_cohort_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Analytics::UpsertECFSchoolCohortJob < ApplicationJob
+  def perform(school_cohort:)
+    Analytics::ECFSchoolCohortService.upsert_record(school_cohort)
+  end
+end

--- a/app/models/analytics/ecf_school_cohort.rb
+++ b/app/models/analytics/ecf_school_cohort.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Analytics
+  class ECFSchoolCohort < BaseRecord
+  end
+end

--- a/app/services/analytics/ecf_school_cohort_service.rb
+++ b/app/services/analytics/ecf_school_cohort_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Analytics
+  class ECFSchoolCohortService
+    class << self
+      def upsert_record(school_cohort)
+        return unless %w[test development production].include? Rails.env
+
+        record = Analytics::ECFSchoolCohort.find_or_initialize_by(school_cohort_id: school_cohort.id)
+        record.school_id = school_cohort.school_id
+        record.school_name = school_cohort.school.name
+        record.school_urn = school_cohort.school.urn
+
+        record.cohort_id = school_cohort.cohort_id
+        record.cohort = school_cohort.cohort.start_year
+
+        record.induction_programme_choice = school_cohort.induction_programme_choice
+        record.default_induction_programme_training_choice = school_cohort&.default_induction_programme&.training_programme
+
+        record.created_at = school_cohort.created_at
+        record.updated_at = school_cohort.updated_at
+
+        record.save!
+      end
+    end
+  end
+end

--- a/db/analytics_migrate/20220520074752_create_analytics_ecf_school_cohorts.rb
+++ b/db/analytics_migrate/20220520074752_create_analytics_ecf_school_cohorts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateAnalyticsECFSchoolCohorts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ecf_school_cohorts do |t|
+      t.uuid :school_cohort_id
+      t.uuid :school_id
+      t.string :school_name
+      t.string :school_urn
+      t.uuid :cohort_id
+      t.string :cohort
+      t.string :induction_programme_choice
+      t.string :default_induction_programme_training_choice
+      t.timestamps
+    end
+  end
+end

--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_31_150652) do
+ActiveRecord::Schema.define(version: 2022_05_20_074752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -42,6 +42,19 @@ ActiveRecord::Schema.define(version: 2022_01_31_150652) do
     t.string "schedule_identifier"
     t.string "external_id"
     t.index ["participant_profile_id"], name: "index_ecf_participants_on_participant_profile_id"
+  end
+
+  create_table "ecf_school_cohorts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "school_cohort_id"
+    t.uuid "school_id"
+    t.string "school_name"
+    t.string "school_urn"
+    t.uuid "cohort_id"
+    t.string "cohort"
+    t.string "induction_programme_choice"
+    t.string "default_induction_programme_training_choice"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "ecf_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe SchoolCohort, type: :model do
     expect(profile.reload.updated_at).to be_within(1.second).of 2.weeks.ago
   end
 
+  it "updates analytics when any attributes changes", :with_default_schedules do
+    school_cohort = create(:school_cohort, opt_out_of_updates: false)
+    school_cohort.opt_out_of_updates = true
+    expect {
+      school_cohort.save!
+    }.to have_enqueued_job(Analytics::UpsertECFSchoolCohortJob).with(
+      school_cohort: school_cohort,
+    )
+  end
+
   it {
     is_expected.to define_enum_for(:induction_programme_choice).with_values(
       full_induction_programme: "full_induction_programme",


### PR DESCRIPTION
### Context

This PR adds `school_cohorts` to the analytics database and it in sync with the primary table. There is an `after_save` callback on `SchoolCohort` that runs a background job to create or update the school cohort in the analytics database.
