### PR TITLE
Add link "Return to manage your training" to change SIT success page

### DIFF
--- a/app/views/schools/change_sit/success.html.erb
+++ b/app/views/schools/change_sit/success.html.erb
@@ -12,5 +12,7 @@
       <li>tell us if things change at your school, for example if ECTs join or not</li>
     </ul>
     <p class="govuk-body">This person is now our contact for ECT training at your school.</p>
+
+    <%= govuk_link_to "Return to manage your training", schools_dashboard_path, class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>


### PR DESCRIPTION
### Context

- Ticket: CST-764

### Changes proposed in this pull request

Link "Return to manage your training" added to change SIT success page

### Guidance to review

