### PR TITLE
removed rogue cohort in captions

### DIFF
--- a/app/views/schools/add_participants/yourself.html.erb
+++ b/app/views/schools/add_participants/yourself.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %> - <%= @cohort.display_name %> cohort</span>
+    <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl">Are you sure you want to add yourself as a mentor?</h1>
 
     <p class="govuk-body">The induction tutor and mentor roles are separate. <%= govuk_link_to "Check what each role needs to do", roles_schools_cohort_path, class: "govuk-link--no-visited-state" %>.</p>

--- a/app/views/schools/cohorts/programme_choice.html.erb
+++ b/app/views/schools/cohorts/programme_choice.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @cohort.display_name %> cohort</span>
+    <span class="govuk-caption-xl"><%= @cohort.display_name %></span>
     <h1 class="govuk-heading-xl govuk-!-margin-top-2">Choose an induction programme</h1>
     <p class="govuk-body-l">
       <strong>You’ve chosen to:</strong>

--- a/app/views/schools/participants/remove.html.erb
+++ b/app/views/schools/participants/remove.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :before_content, govuk_back_link( text: "Back", href: schools_participant_path(id: @profile)) %>
 
-<span class="govuk-caption-xl"><%= @cohort.display_name %> cohort</span>
+<span class="govuk-caption-xl"><%= @cohort.display_name %></span>
 <h1 class="govuk-heading-xl">Confirm you want to remove <%= @profile.user.full_name %></h1>
 
 <div class="govuk-grid-row">

--- a/app/views/schools/partnerships/index.html.erb
+++ b/app/views/schools/partnerships/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-l"><%= @cohort.display_name %> cohort</span>
+    <span class="govuk-caption-xl"><%= @cohort.display_name %></span>
     <% if @partnership %>
     <%= render partial: "signed_up_with_provider" %>
     <% else %>


### PR DESCRIPTION
Removed some rogue - Cohort content from page caption. We no longer use this.