### PR TITLE
Remove unused job

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -22,10 +22,6 @@ check_no_induction_or_no_qts_participants:
   cron: "0 7 * * 1"
   class: "CheckParticipantsInductionAndQtsJob"
   queue: default
-check_no_qts_participants:
-  cron: "0 7 * * 1"
-  class: "CheckNoQtsParticipantsJob"
-  queue: default
 enrol_school_cohorts:
   cron: "0 3 * * *"
   class: "EnrolSchoolCohortsJob"


### PR DESCRIPTION
This was accidentally left in when i was combined to separate jobs. It can be removed.

Its causing an error in [sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3294481982/?project=5748989&query=is%3Aunresolved)