### PR TITLE
[Bugfix] Add check for start_date prior to schedule start_date during transfer

### DIFF
--- a/app/controllers/schools/transferring_participants_controller.rb
+++ b/app/controllers/schools/transferring_participants_controller.rb
@@ -27,7 +27,8 @@ module Schools
     end
 
     def teacher_start_date
-      store_form_redirect_to_next_step(:email)
+      check_start_date_is_later_than_induction_start
+      store_form_redirect_to_next_step(:email) unless @transferring_participant_form.errors.any?
     end
 
     def email
@@ -297,6 +298,14 @@ module Schools
           check_first_name_only: true,
         },
       )
+    end
+
+    def check_start_date_is_later_than_induction_start
+      start_date = @transferring_participant_form.start_date
+      previous_date = participant_profile.induction_records.latest.schedule.milestones.first.start_date
+      if start_date < previous_date
+        @transferring_participant_form.errors.add(:start_date, I18n.t("errors.start_date.before_schedule_start_date", date: previous_date.to_date.to_s(:govuk)))
+      end
     end
 
     def reset_form_data

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
     start_date:
       blank: "Enter start date"
       invalid: "Invalid start date"
+      before_schedule_start_date: "Start date must be after %{date}"
     name:
       blank: "Enter a name"
     full_name: &full_name_error_messages

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         click_on "Continue"
         then_i_should_see_invalid_start_date_error_message
 
+        when_i_add_a_date_prior_to_the_participants_induction_start
+        click_on "Continue"
+        then_i_should_see_start_date_must_be_after_error_message
+
         when_i_add_a_valid_start_date
         click_on "Continue"
 
@@ -182,6 +186,12 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         fill_in "Year", with: "23"
       end
 
+      def when_i_add_a_date_prior_to_the_participants_induction_start
+        fill_in "Day", with: "24"
+        fill_in "Month", with: "10"
+        fill_in "Year", with: "1998"
+      end
+
       def when_i_add_a_valid_start_date
         fill_in "Day", with: "24"
         fill_in "Month", with: "10"
@@ -275,6 +285,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
       def then_i_should_see_invalid_start_date_error_message
         expect(page).to have_text("Invalid start date")
+      end
+
+      def then_i_should_see_start_date_must_be_after_error_message
+        expect(page).to have_text("Start date must be after #{@mentor.induction_records.first.schedule.milestones.first.start_date.to_date.to_s(:govuk)}")
       end
 
       def then_i_should_see_blank_email_date_error_message


### PR DESCRIPTION
### Context

There have been occurrences of SITs entering participants birth dates in the "start date" fields during the transfer of an existing participant.  Although we check for a valid date, we don't check that the date is chronologically correct in respect of the participant's existing schedule. This PR add a check to ensure the entered start date is after the start date of the first milestone of the participant's schedule.

### Changes proposed in this pull request

### Guidance to review

