### PR TITLE
Add additional restriction on sending email for sit adding themselves

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -359,7 +359,7 @@ module Schools
     end
 
     def sit_adding_themselves?
-      type == :self
+      type == :self || current_user.induction_coordinator?
     end
   end
 end

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -267,8 +267,16 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         end
       end
 
-      context "A SIT is adding themselves as a mentor" do
-        it " does not send the SIT an email saying they have been added and validated" do
+      context "A SIT is adding themselves as a mentor and type is not self" do
+        it "does not send the SIT an email saying they have been added and validated" do
+          create(:induction_coordinator_profile, user: user)
+          form.save!
+          expect(ParticipantMailer).not_to have_received(:sit_has_added_and_validated_participant)
+        end
+      end
+
+      context "A SIT is adding themselves as a mentor and type is set to self" do
+        it "does not send the SIT an email saying they have been added and validated" do
           form.type = :self
           form.save!
           expect(ParticipantMailer).not_to have_received(:sit_has_added_and_validated_participant)
@@ -277,12 +285,12 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
 
     describe "sit_adding_themselves?" do
-      it "sit is adding themselves" do
+      it "returns true when type is set to self" do
         form.type = :self
         expect(form.sit_adding_themselves?).to be true
       end
 
-      it "sit is adding a participant" do
+      it "returns false when type is not self" do
         form.type = :mentor
         expect(form.sit_adding_themselves?).to be false
       end

--- a/spec/requests/schools/add_participants_spec.rb
+++ b/spec/requests/schools/add_participants_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Schools::AddParticipant", type: :request do
 
   describe "GET /schools/:school_id/cohorts/:cohort_id/participants/add" do
     before do
-      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/add", params: { type: :joining }
+      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/add", params: { type: :ect }
     end
 
     it "sets up the form in the session" do


### PR DESCRIPTION
There was a sentry error showing again that the mailer had failed because of a incorrect template match. I think this is because they've gone through the journey fully rather than just adding themselves via the 'add yourself as a mentor'. This will stop the email being sent if they do go through the full journey.

