### PR TITLE
Check only first name matches when checking for existing validation data

### DIFF
--- a/app/controllers/schools/transferring_participants_controller.rb
+++ b/app/controllers/schools/transferring_participants_controller.rb
@@ -282,9 +282,11 @@ module Schools
     end
 
     def participant_profile
+      first_name = @transferring_participant_form.full_name.split(" ").first
+
       @participant_profile ||= ParticipantProfile::ECF.joins(:ecf_participant_validation_data)
-          .where("LOWER(full_name) = ? AND trn = ? AND date_of_birth = ?",
-                 @transferring_participant_form.full_name.downcase,
+          .where("full_name ILIKE ? AND trn = ? AND date_of_birth = ?",
+                 "#{first_name} %",
                  @transferring_participant_form.trn,
                  @transferring_participant_form.date_of_birth).first
     end

--- a/spec/requests/schools/transferring_participants_spec.rb
+++ b/spec/requests/schools/transferring_participants_spec.rb
@@ -98,15 +98,30 @@ RSpec.describe "Schools::TransferringParticipants", type: :request, with_feature
     end
 
     describe "PUT /schools/:school_id/cohorts/:cohort_id/participants/transferring-participant/full-name" do
-      it "redirects to the teacher start date template" do
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/full-name",
-            params: { schools_transferring_participant_form: {
-              full_name: ect.user.full_name,
-              trn: ecf_participant_validation_data.trn,
-              date_of_birth: ecf_participant_validation_data.date_of_birth,
-            } }
+      context "user has provided exact name as in dqt" do
+        it "redirects to the teacher start date template" do
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/full-name",
+              params: { schools_transferring_participant_form: {
+                full_name: ect.user.full_name,
+                trn: ecf_participant_validation_data.trn,
+                date_of_birth: ecf_participant_validation_data.date_of_birth,
+              } }
 
-        expect(subject).to redirect_to "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/teacher-start-date"
+          expect(subject).to redirect_to "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/teacher-start-date"
+        end
+      end
+
+      context "user has provided correct first name" do
+        it "redirects to the teacher start date template" do
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/full-name",
+              params: { schools_transferring_participant_form: {
+                full_name: ect.user.full_name.split(" ").first,
+                trn: ecf_participant_validation_data.trn,
+                date_of_birth: ecf_participant_validation_data.date_of_birth,
+              } }
+
+          expect(subject).to redirect_to "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/teacher-start-date"
+        end
       end
     end
 


### PR DESCRIPTION
We were checking against a full name match when searching for ecf validation data in the transfer journey. This was causing problems when people were transferring ppts as this is the name stored from the DQT. If there's any difference in this then it won't match. Reducing it to just a first name matches how we initially validate against the DQT.

I've tested the updated statement a few times with some Zendesk tickets that have been raised because of the initial problem, it's finding the validation data just using the first name, trn and dob. 