### PR TITLE
[CST-432] Transfer out journey

### DIFF
--- a/app/components/schools/participants/coc_status_table.rb
+++ b/app/components/schools/participants/coc_status_table.rb
@@ -36,6 +36,8 @@ module Schools
       def date_column_heading
         if transferring_in_participants?
           "Joining"
+        elsif transferring_out_participants?
+          "Leaving"
         elsif transferred_participants?
           "Transferred"
         else

--- a/app/components/schools/participants/coc_status_table_row.rb
+++ b/app/components/schools/participants/coc_status_table_row.rb
@@ -28,7 +28,7 @@ module Schools
 
       # Add transferring_out? || transferred? back in once transfer out journey has been done.
       def date_column_value
-        if transferred?
+        if transferred? || transferring_out?
           induction_record.end_date.to_date.to_s(:govuk)
         elsif transferring_in?
           induction_record.start_date.to_date.to_s(:govuk)

--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -18,6 +18,8 @@ module Schools
     def check_answers
       @induction_record.leaving_induction_status!
       @induction_record.update!(end_date: @transfer_out_form.end_date, school_transfer: true)
+
+      reset_form_data
       store_form_redirect_to_next_step(:complete)
     end
 

--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -17,7 +17,7 @@ module Schools
 
     def check_answers
       @induction_record.leaving_induction_status!
-      @induction_record.update!(end_date: @transfer_out_form.end_date)
+      @induction_record.update!(end_date: @transfer_out_form.end_date, school_transfer: true)
       store_form_redirect_to_next_step(:complete)
     end
 

--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -9,7 +9,9 @@ module Schools
 
     skip_after_action :verify_authorized
 
-    def check_transfer; end
+    def check_transfer
+      reset_form_data
+    end
 
     def teacher_end_date
       store_form_redirect_to_next_step(:check_answers)
@@ -19,7 +21,6 @@ module Schools
       @induction_record.leaving_induction_status!
       @induction_record.update!(end_date: @transfer_out_form.end_date, school_transfer: true)
 
-      reset_form_data
       store_form_redirect_to_next_step(:complete)
     end
 

--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Schools
+  class TransferOutController < ::Schools::BaseController
+    before_action :load_transfer_out_form, except: %i[check_transfer]
+    before_action :set_school_cohort
+    before_action :set_participant
+    before_action :validate_request_or_render, except: %i[check_transfer]
+
+    skip_after_action :verify_authorized
+
+    def check_transfer; end
+
+    def teacher_end_date
+      store_form_redirect_to_next_step(:check_answers)
+    end
+
+    def check_answers
+      @induction_record.leaving_induction_status!
+      @induction_record.update!(end_date: @transfer_out_form.end_date)
+      store_form_redirect_to_next_step(:complete)
+    end
+
+  private
+
+    def load_transfer_out_form
+      @transfer_out_form = TransferOutForm.new(session[:schools_transfer_out_form])
+      @transfer_out_form.assign_attributes(transfer_out_form_params)
+    end
+
+    def transfer_out_form_params
+      return {} unless params.key?(:schools_transfer_out_form)
+
+      params.require(:schools_transfer_out_form).permit(:end_date)
+    end
+
+    def validate_request_or_render
+      render unless request.put? && step_valid?
+    end
+
+    def store_form_redirect_to_next_step(step)
+      session[:schools_transfer_out_form] = @transfer_out_form.serializable_hash
+      redirect_to action: step
+    end
+
+    def step_valid?
+      @transfer_out_form.valid? action_name.to_sym
+    end
+
+    def set_participant
+      @profile = ParticipantProfile.find(params[:transfer_out_participant_id])
+      @induction_record = @profile.induction_records.for_school(@school).latest
+    end
+
+    def reset_form_data
+      session.delete(:schools_transfer_out_form)
+    end
+  end
+end

--- a/app/forms/schools/transfer_out_form.rb
+++ b/app/forms/schools/transfer_out_form.rb
@@ -12,7 +12,7 @@ module Schools
 
     def attributes
       {
-        end_date: end_date,
+        end_date:,
       }
     end
 

--- a/app/forms/schools/transfer_out_form.rb
+++ b/app/forms/schools/transfer_out_form.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Schools
+  class TransferOutForm
+    include ActiveModel::Model
+    include ActiveRecord::AttributeAssignment
+    include ActiveModel::Serialization
+
+    attr_accessor :end_date
+
+    validate :teacher_end_date
+
+    def attributes
+      {
+        end_date: end_date,
+      }
+    end
+
+  private
+
+    def teacher_end_date
+      @end_date = ActiveRecord::Type::Date.new.cast(end_date)
+      if @end_date.blank?
+        errors.add(:end_date, I18n.t("errors.end_date.blank"))
+      elsif @end_date.year.digits.length != 4
+        errors.add(:end_date, I18n.t("errors.end_date.invalid"))
+      end
+    end
+  end
+end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -44,9 +44,10 @@ class InductionRecord < ApplicationRecord
   scope :cip, -> { joins(:induction_programme).merge(InductionProgramme.core_induction_programme) }
 
   scope :active, -> { active_induction_status.where("(end_date IS NULL OR end_date > ?) AND (start_date < ? OR school_transfer=false)", Time.zone.now, Time.zone.now) }
-  scope :current, -> { active.or(transferring_out) }
+  scope :current, -> { active.or(sit_unknown_transferring_out) }
   scope :transferring_in, -> { active_induction_status.where("start_date > ? AND school_transfer=true", Time.zone.now) }
-  scope :transferring_out, -> { leaving_induction_status.where("end_date > ?", Time.zone.now) }
+  scope :transferring_out, -> { leaving_induction_status.where("end_date > ? AND school_transfer=true", Time.zone.now) }
+  scope :sit_unknown_transferring_out, -> { leaving_induction_status.where("end_date > ? AND school_transfer=false", Time.zone.now) }
   scope :transferred, -> { leaving_induction_status.where("end_date < ?", Time.zone.now) }
   scope :mentors, -> { joins(:participant_profile).where(participant_profiles: { type: "ParticipantProfile::Mentor" }) }
   scope :ects, -> { joins(:participant_profile).where(participant_profiles: { type: "ParticipantProfile::ECT" }) }

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -83,7 +83,7 @@ class InductionRecord < ApplicationRecord
   end
 
   def transferring_out?
-    leaving_induction_status? && end_date.present? && end_date > Time.zone.now
+    leaving_induction_status? && end_date.present? && end_date > Time.zone.now && school_transfer
   end
 
   def transferred?

--- a/app/services/coc_set_participant_categories.rb
+++ b/app/services/coc_set_participant_categories.rb
@@ -105,7 +105,7 @@ private
     InductionRecordPolicy::Scope.new(
       user,
       school_cohort
-        .active_induction_records
+        .current_induction_records
         .where.not(training_status: :withdrawn)
         .joins(:participant_profile)
         .where(participant_profiles: { type: profile_type.to_s })

--- a/app/services/coc_set_participant_categories.rb
+++ b/app/services/coc_set_participant_categories.rb
@@ -14,7 +14,7 @@ class CocSetParticipantCategories < BaseService
       contacted_for_info_participants,
       details_being_checked,
       transferring_in_participants,
-      [],
+      transferring_out_participants,
       transferred_participants,
       no_qts_participants,
     )
@@ -105,7 +105,7 @@ private
     InductionRecordPolicy::Scope.new(
       user,
       school_cohort
-        .current_induction_records
+        .active_induction_records
         .where.not(training_status: :withdrawn)
         .joins(:participant_profile)
         .where(participant_profiles: { type: profile_type.to_s })

--- a/app/views/schools/participants/_not_training.html.erb
+++ b/app/views/schools/participants/_not_training.html.erb
@@ -44,7 +44,7 @@
             <p class="govuk-!-margin-bottom-3">You told us these people moved to a new school.</p>
         </div>
     </div>
-    <table class="govuk-table govuk-!-margin-bottom-9" data-test="ineligble_ects">
+    <table class="govuk-table govuk-!-margin-bottom-9" data-test="transferred">
         <%= render Schools::Participants::CocStatusTable.new(induction_records: transferred) %>
     </table>
 <% end %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -41,17 +41,17 @@
         <% end %>
       <% end %>
 
-      <% if @withdrawn.any? || @ineligible.any? || @transferred.any? %>
-        <% component.tab(label: 'Not training') do %>
-          <%= render partial: 'not_training', locals: { withdrawn: @withdrawn, ineligible: @ineligible, transferred: @transferred } %>
-        <% end %>
-      <% end %>
-
       <% if FeatureFlag.active?(:change_of_circumstances) %>
         <% if @transferring_in.any? || @transferring_out.any? %>
           <% component.tab(label: 'Moving school') do %>
             <%= render partial: 'moving_school', locals: { transferring_in: @transferring_in, transferring_out: @transferring_out } %>
           <% end %>
+        <% end %>
+      <% end %>
+
+      <% if @withdrawn.any? || @ineligible.any? || @transferred.any? %>
+        <% component.tab(label: 'Not training') do %>
+          <%= render partial: 'not_training', locals: { withdrawn: @withdrawn, ineligible: @ineligible, transferred: @transferred } %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -97,7 +97,7 @@
       <% end %>
     </dl>
 
-    <% if @induction_record.training_status_active? %>
+    <% unless @induction_record.leaving_induction_status? && @induction_record.school_transfer %>
       <h3 class="govuk-heading-m">No longer training?</h3>
       <p class="govuk-body">Tell us <%= govuk_link_to "#{@profile.user.full_name} is transferring to another school", schools_transfer_out_participant_check_transfer_path(transfer_out_participant_id: @profile.id) %> </p>
     <% end %>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -3,12 +3,12 @@
 <% content_for :before_content, govuk_back_link( text: "Back", href: schools_participants_path) %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= @profile.user.full_name %></h1>
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl"><%= @profile.user.full_name %></h1>
 
-        <dl class="govuk-summary-list govuk-!-margin-bottom-7">
+    <dl class="govuk-summary-list govuk-!-margin-bottom-7">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Name
@@ -97,10 +97,14 @@
       <% end %>
     </dl>
 
+    <% if @induction_record.training_status_active? %>
+      <h3 class="govuk-heading-m">No longer training?</h3>
+      <p class="govuk-body">Tell us <%= govuk_link_to "#{@profile.user.full_name} is transferring to another school", schools_transfer_out_participant_check_transfer_path(transfer_out_participant_id: @profile.id) %> </p>
+    <% end %>
 
-<% unless @induction_record.training_status_withdrawn? %>
-  <p class="govuk-body"><%= render Schools::Participants::RemoveFromCohortComponent.new(induction_record: @induction_record, current_user: current_user) %></p>
-<% end %>
+    <% unless @induction_record.training_status_withdrawn? %>
+      <p class="govuk-body"><%= render Schools::Participants::RemoveFromCohortComponent.new(induction_record: @induction_record, current_user: current_user) %></p>
+    <% end %>
 
-    </div>
+  </div>
 </div>

--- a/app/views/schools/transfer_out/check_answers.html.erb
+++ b/app/views/schools/transfer_out/check_answers.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "Check your answers" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: { action: :teacher_end_date }) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl">Check your answers</h1>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <% summary_list.row do |row| %>
+        <% row.key { "Name" } %>
+        <% row.value { @profile.user.full_name.titleize } %>
+        <% row.action(text: :none) %>
+      <% end %>
+
+      <% summary_list.row do |row| %>
+        <% row.key { "Leaving date" } %>
+        <% row.value { @transfer_out_form.end_date.to_date.to_s(:govuk) } %>
+        <% row.action(text: "Change",
+                      visually_hidden_text: "end date",
+                      href: url_for({ action: :teacher_end_date})) %>
+      <% end %>
+    <% end %>
+
+    <%= form_for @transfer_out_form, url: { action: :check_answers }, method: :put do |f| %>
+      <%= f.govuk_submit "Confirm and continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/transfer_out/check_transfer.html.erb
+++ b/app/views/schools/transfer_out/check_transfer.html.erb
@@ -1,0 +1,22 @@
+<% title = "Is #{@profile.user.full_name.titleize} transferring to another school where they’ll continue their induction?" %>
+
+<% content_for :title, title %>
+
+<% content_for :before_content, govuk_back_link( text: "Back", href: schools_participant_path(id: @profile.id)) %>
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+
+  		<span class="govuk-caption-xl"><%= @school.name %></span>
+		<h1 class="govuk-heading-xl"><%= title %></h1>
+
+    	<p class="govuk-body">If they’re leaving your school for a different reason, you must contact your training provider to remove them instead. Reasons may include:</p>
+    	<ul class="govuk-list govuk-list--bullet">
+			  <li>leaving teaching</li>
+			  <li>taking a break from teaching</li>
+			  <li>taking a teaching job outside of England</li>
+    	</ul>
+    	<p class="govuk-body govuk-!-margin-bottom-7">If this person is moving to work at a new school where they’ll continue their induction, confirm below.</p>
+    	<%= govuk_button_link_to "Continue",  schools_transfer_out_participant_teacher_end_date_path %>
+
+  	</div>
+</div>

--- a/app/views/schools/transfer_out/complete.html.erb
+++ b/app/views/schools/transfer_out/complete.html.erb
@@ -1,18 +1,27 @@
-<% content_for :title, "transfer added" %>
-<% participant_name = @profile.user.full_name.titleize %>
+<% title = "#{@profile.user.full_name&.titleize}’s leaving date has been submitted" %>
+
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <%= govuk_panel title_text: "#{participant_name}'s leaving date has been submitted", text: nil, classes: "govuk-!-margin-bottom-7" %>
+        <%= govuk_panel title_text: title, text: nil, classes: "govuk-!-margin-bottom-7" %>
 
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We’ll tell <%= participant_name %> that you’ve reported their transfer. They’ll appear in the ’moving schools’
+        <p class="govuk-body">We’ll tell <%= @profile.user.full_name&.titleize %> that you’ve reported their transfer. They’ll appear in the ’moving schools’
         section of your dashboard until their leaving date.</p>
 
-        <p class="govuk-body">You need to let their training provider know that they’re transferring to another school.</p>
         <p class="govuk-body">They should continue with their current training programme until their leaving date.
         Their new school will arrange how they’ll continue their training after that.</p>
+
+        <h2 class="govuk-heading-m">Remember to:</h2>
+
+        <ol class="govuk-list govuk-list--number">
+          <li>Report this transfer to your appropriate body. They need to complete some checks and update <%= @profile.user.full_name&.titleize %>’s record with the Teaching Regulation Agency (TRA).</li>
+          <li>If you work with a training provider, let them know that this person is transferring to another school.</li>
+        </ol>
+
+        <p class="govuk-body">The person mentoring this ECT can continue their training, even if they do not have another ECT assigned to them yet.</p>
 
         <%= govuk_link_to "View your ECTs and mentors", schools_participants_path, class: "govuk-link govuk-link--no-visited-state" %>
 

--- a/app/views/schools/transfer_out/complete.html.erb
+++ b/app/views/schools/transfer_out/complete.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "transfer added" %>
+<% participant_name = @profile.user.full_name.titleize %>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <%= govuk_panel title_text: "#{participant_name}'s leaving date has been submitted", text: nil, classes: "govuk-!-margin-bottom-7" %>
+
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p class="govuk-body">We’ll tell <%= participant_name %> that you’ve reported their transfer. They’ll appear in the ’moving schools’
+        section of your dashboard until their leaving date.</p>
+
+        <p class="govuk-body">You need to let their training provider know that they’re transferring to another school.</p>
+        <p class="govuk-body">They should continue with their current training programme until their leaving date.
+        Their new school will arrange how they’ll continue their training after that.</p>
+
+        <%= govuk_link_to "View your ECTs and mentors", schools_participants_path, class: "govuk-link govuk-link--no-visited-state" %>
+
+    </div>
+</div>

--- a/app/views/schools/transfer_out/complete.html.erb
+++ b/app/views/schools/transfer_out/complete.html.erb
@@ -21,8 +21,11 @@
           <li>If you work with a training provider, let them know that this person is transferring to another school.</li>
         </ol>
 
-        <p class="govuk-body">The person mentoring this ECT can continue their training, even if they do not have another ECT assigned to them yet.</p>
-
+        <% if @profile.ect? %>
+          <p class="govuk-body">The person mentoring this ECT can continue their training, even if they do not have another ECT assigned to them yet.</p>
+        <% else %>
+          <p class="govuk-body">You need to assign a new mentor for any ECTs they’ve been working with.</p>
+        <% end %>
         <%= govuk_link_to "View your ECTs and mentors", schools_participants_path, class: "govuk-link govuk-link--no-visited-state" %>
 
     </div>

--- a/app/views/schools/transfer_out/teacher_end_date.html.erb
+++ b/app/views/schools/transfer_out/teacher_end_date.html.erb
@@ -1,0 +1,26 @@
+<% title = "When is #{@profile.user.full_name.titleize} leaving your school?" %>
+
+<% content_for :title, title %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: schools_transfer_out_participant_check_transfer_path) %>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <span class="govuk-caption-xl"><%= @school.name %></span>
+        <h1 class="govuk-heading-xl"><%= title %></h1>
+
+        <%= form_for @transfer_out_form, url: { action: :teacher_end_date }, method: :put do |f| %>
+
+            <%= f.govuk_error_summary %>
+
+            <%= f.govuk_date_field :end_date,
+                width: "two-thirds",
+                legend: { text: title, class: "govuk-visually-hidden" },
+                hint: { text: "For example, 14 7 2023"}
+            %>
+            <%= f.govuk_submit "Continue" %>
+        <% end %>
+
+    </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,9 @@ en:
       blank: "Enter start date"
       invalid: "Invalid start date"
       before_schedule_start_date: "Start date must be after %{date}"
+    end_date:
+      blank: "Enter end date"
+      invalid: "Invalid end date"
     name:
       blank: "Enter a name"
     full_name: &full_name_error_messages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -469,6 +469,15 @@ Rails.application.routes.draw do
             get "complete", to: "transferring_participants#complete", as: :complete
           end
 
+          resources :transfer_out_participant, path: "transfer-out", only: [] do
+            get "is-teacher-transferring", to: "transfer_out#check_transfer", as: :check_transfer
+            get "teacher-end-date", to: "transfer_out#teacher_end_date", as: :teacher_end_date
+            put "teacher-end-date", to: "transfer_out#teacher_end_date"
+            get "check-answers", to: "transfer_out#check_answers", as: :check_answers
+            put "check-answers", to: "transfer_out#check_answers"
+            get "complete", to: "transfer_out#complete", as: :complete
+          end
+
           resources :participants, only: %i[index show destroy] do
             get :remove
             get :edit_name, path: "edit-name"

--- a/spec/features/schools/participants/transfer_out/no_transfer_out.rb
+++ b/spec/features/schools/participants/transfer_out/no_transfer_out.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "transfer out participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+  context "An ECT has been transferred in to another school" do
+    before do
+      set_participant_data
+      given_two_schools_have_chosen_fip_for_2021
+      and_a_participant_has_been_transferred_in_to_another_school
+      and_i_am_signed_in_as_an_induction_coordinator
+      and_select_the_most_recent_cohort
+    end
+
+    scenario "Old induction tutor only sees the transfer once the end date has passed" do
+      when_i_click_to_view_ects_and_mentors
+      then_i_am_taken_to_your_ect_and_mentors_page
+      then_i_should_still_see_the_participant_in_my_ects
+      and_i_should_not_see_any_transferring_participants
+
+      travel_to(@participant_data[:end_date] + 1.day)
+
+      visit current_path
+
+      then_i_should_see_the_participants_as_having_transferred
+    end
+
+    # given
+
+    def given_two_schools_have_chosen_fip_for_2021
+      @cohort = create(:cohort, start_year: 2021)
+      @school_one = create(:school, name: "Fip School 1")
+      @school_two = create(:school, name: "Fip School 2")
+      @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+      @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+      @ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_one)
+      @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one, partnership: @partnership_1)
+      @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two, partnership: @partnership_2)
+      @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
+      Induction::Enrol.call(participant_profile: @ect, induction_programme: @induction_programme_one)
+    end
+
+    # when
+
+    def when_i_click_to_view_ects_and_mentors
+      click_on "Manage"
+    end
+
+    def when_i_select(option)
+      choose(option)
+    end
+
+    # then
+
+    def then_i_am_taken_to_your_ect_and_mentors_page
+      expect(page).to have_selector("h1", text: "Your ECTs and mentors")
+      expect(page).to have_text("Add an ECT or mentor")
+      expect(page).to have_text("Add yourself as a mentor")
+    end
+
+    def and_i_should_not_see_any_transferring_participants
+      expect(page).not_to have_selector("h2", text: "Transferring from your school")
+    end
+
+    def then_i_should_still_see_the_participant_in_my_ects
+      expect(page).to have_selector("h2", text: "Contacted for information")
+      within(:xpath, "//table[@data-test='checked_ects']/tbody/tr[1]") do
+        expect(page).to have_xpath(".//td[1]", text: @ect.user.full_name)
+      end
+    end
+
+    def then_i_should_see_the_participants_as_having_transferred
+      date = @participant_data[:end_date]
+      expect(page).to have_selector("h2", text: "Transferred from your school")
+      within(:xpath, "//table[@data-test='transferred']/tbody/tr[1]") do
+        expect(page).to have_xpath(".//td[1]", text: @participant_data[:full_name])
+        expect(page).to have_xpath(".//td[2]", text: date.to_date.to_s(:govuk))
+      end
+    end
+
+    def and_they_wont_be_listed_as_a_transfer_out
+      expect(page).not_to have_selector("h2", text: "Transferring from your school")
+      within(:xpath, "//table[@data-test='transferring_out']/tbody/tr[1]")
+    end
+
+    # and
+
+    def and_i_am_signed_in_as_an_induction_coordinator
+      @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort_one.school], user: create(:user, full_name: "Carl Coordinator"))
+      privacy_policy = create(:privacy_policy)
+      privacy_policy.accept!(@induction_coordinator_profile.user)
+      sign_in_as @induction_coordinator_profile.user
+    end
+
+    def and_a_participant_has_been_transferred_in_to_another_school
+      Induction::TransferAndContinueExistingFip.call(
+        school_cohort: @school_cohort_two,
+        participant_profile: @ect,
+        email: @ect.user.email,
+        end_date: @participant_data[:end_date],
+      )
+    end
+
+    def and_select_the_most_recent_cohort
+      click_on Cohort.active_registration_cohort.description
+    end
+
+    def set_participant_data
+      @participant_data = {
+        trn: "1001000",
+        full_name: "Sally Teacher",
+        start_date: Time.zone.today.prev_month,
+        end_date: Date.new(2022, 10, 24),
+        email: "sally-teacher@example.com",
+      }
+    end
+  end
+end

--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "old and new SIT transferring the same participant", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+  context "Transfer out an ECT that has already been transferred in" do
+    before do
+      set_participant_data
+      given_two_schools_have_chosen_fip_for_2021
+      and_a_participant_has_been_transferred_in_to_another_school
+      and_i_am_signed_in_as_an_induction_coordinator
+      and_select_the_most_recent_cohort
+    end
+
+    scenario "Induction tutor only sees the transfer once they done it themselves" do
+      when_i_click_to_view_ects_and_mentors
+      then_i_am_taken_to_your_ect_and_mentors_page
+      then_i_should_still_see_the_participant_in_my_active_participants
+      and_i_should_not_see_any_transferring_participants
+
+      when_i_click_on_an_ect
+      then_i_should_be_on_the_ect_details_page
+
+      when_i_click_to_transfer_out_a_participant
+      then_i_should_be_on_the_check_transfer_page
+
+      click_on "Continue"
+      then_i_should_be_on_the_teacher_end_date_page
+
+      when_i_add_a_valid_end_date
+      click_on "Continue"
+
+      then_i_should_be_on_the_check_your_answers_page
+
+      click_on "Confirm and continue"
+      then_i_should_be_on_the_complete_page
+
+      click_on "View your ECTs and mentors"
+      then_i_am_taken_to_your_ect_and_mentors_page
+      then_i_should_see_the_transfer_out_participant
+      and_they_should_not_be_under_their_previous_heading
+
+      travel_to(@participant_data[:end_date] + 1.day)
+
+      visit current_path
+
+      then_i_should_see_the_participants_as_having_transferred
+    end
+
+    # given
+
+    def given_two_schools_have_chosen_fip_for_2021
+      @cohort = create(:cohort, start_year: 2021)
+      @school_one = create(:school, name: "Fip School 1")
+      @school_two = create(:school, name: "Fip School 2")
+      @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+      @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+      @ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_one)
+      @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one, partnership: @partnership_1)
+      @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two, partnership: @partnership_2)
+      @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
+      Induction::Enrol.call(participant_profile: @ect, induction_programme: @induction_programme_one)
+    end
+
+    def and_a_participant_has_been_transferred_in_to_another_school
+      Induction::TransferAndContinueExistingFip.call(
+        school_cohort: @school_cohort_two,
+        participant_profile: @ect,
+        email: @ect.user.email,
+        end_date: Time.zone.now.next_month,
+      )
+    end
+
+    # when
+
+    def when_i_click_to_view_ects_and_mentors
+      click_on "Manage"
+    end
+
+    def when_i_click_on_an_ect
+      click_on @participant_data[:full_name]
+    end
+
+    def when_i_click_to_transfer_out_a_participant
+      click_on "#{@participant_data[:full_name]} is transferring to another school"
+    end
+
+    def when_i_add_a_valid_end_date
+      fill_in "Day", with: "24"
+      fill_in "Month", with: "10"
+      fill_in "Year", with: "2022"
+    end
+
+    def when_i_select(option)
+      choose(option)
+    end
+
+    # then
+
+    def then_i_am_taken_to_your_ect_and_mentors_page
+      expect(page).to have_selector("h1", text: "Your ECTs and mentors")
+      expect(page).to have_text("Add an ECT or mentor")
+      expect(page).to have_text("Add yourself as a mentor")
+    end
+
+    def then_i_should_still_see_the_participant_in_my_active_participants
+      expect(page).to have_selector("h2", text: "Contacted for information")
+      within(:xpath, "//table[@data-test='checked_ects']/tbody/tr[1]") do
+        expect(page).to have_xpath(".//td[1]", text: @ect.user.full_name)
+      end
+    end
+
+    def then_i_should_be_on_the_ect_details_page
+      expect(page).to have_text(@participant_data[:full_name])
+      expect(page).to have_text("Tell us #{@participant_data[:full_name]} is transferring to another school")
+    end
+
+    def then_i_should_be_on_the_check_transfer_page
+      expect(page).to have_selector("h1", text: "Is #{@participant_data[:full_name]} transferring to another school where they’ll continue their induction?")
+    end
+
+    def then_i_should_be_on_the_teacher_end_date_page
+      expect(page).to have_selector("h1", text: "When is #{@participant_data[:full_name]} leaving your school?")
+    end
+
+    def then_i_should_be_on_the_check_your_answers_page
+      date = @participant_data[:end_date]
+      expect(page).to have_selector("h1", text: "Check your answers")
+      expect(page).to have_selector("dd", text: @participant_data[:full_name])
+      expect(page).to have_selector("dd", text: date.to_date.to_s(:govuk))
+    end
+
+    def then_i_should_be_on_the_complete_page
+      expect(page).to have_selector("h2", text: "What happens next")
+      expect(page).to have_text("We’ll tell #{@participant_data[:full_name]} that you’ve reported their transfer")
+    end
+
+    def then_i_should_see_the_transfer_out_participant
+      date = @participant_data[:end_date]
+      expect(page).to have_selector("h2", text: "Transferring from your school")
+      within(:xpath, "//table[@data-test='transferring_out']/tbody/tr[1]") do
+        expect(page).to have_xpath(".//td[1]", text: @participant_data[:full_name])
+        expect(page).to have_xpath(".//td[4]", text: date.to_date.to_s(:govuk))
+      end
+    end
+
+    def then_i_should_see_the_participants_as_having_transferred
+      date = @participant_data[:end_date]
+      expect(page).to have_selector("h2", text: "Transferred from your school")
+      within(:xpath, "//table[@data-test='transferred']/tbody/tr[1]") do
+        expect(page).to have_xpath(".//td[1]", text: @participant_data[:full_name])
+        expect(page).to have_xpath(".//td[2]", text: date.to_date.to_s(:govuk))
+      end
+    end
+
+    # and
+
+    def and_i_am_signed_in_as_an_induction_coordinator
+      @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort_one.school], user: create(:user, full_name: "Carl Coordinator"))
+      privacy_policy = create(:privacy_policy)
+      privacy_policy.accept!(@induction_coordinator_profile.user)
+      sign_in_as @induction_coordinator_profile.user
+    end
+
+    def and_select_the_most_recent_cohort
+      click_on Cohort.active_registration_cohort.description
+    end
+
+    def and_i_should_not_see_any_transferring_participants
+      expect(page).not_to have_selector("h2", text: "Transferring from your school")
+    end
+
+    def and_they_should_not_be_under_their_previous_heading
+      expect(page).not_to have_selector("h2", text: "Contacted for information")
+    end
+
+    def set_participant_data
+      @participant_data = {
+        trn: "1001000",
+        full_name: "Sally Teacher",
+        start_date: Time.zone.today.prev_month,
+        end_date: Date.new(2022, 10, 24),
+        email: "sally-teacher@example.com",
+      }
+    end
+  end
+end

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "transfer out participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+  context "Transfer out an ECT" do
+    before do
+      set_participant_data
+      given_a_school_have_chosen_fip_for_2021
+      and_i_am_signed_in_as_an_induction_coordinator
+      and_select_the_most_recent_cohort
+      when_i_click_to_view_ects_and_mentors
+      then_i_am_taken_to_your_ect_and_mentors_page
+    end
+
+    scenario "Induction tutor can transfer an ECT out of their school" do
+      when_i_click_on_an_ect
+      then_i_should_be_on_the_ect_details_page
+
+      when_i_click_to_transfer_out_a_participant
+      then_i_should_be_on_the_check_transfer_page
+
+      click_on "Continue"
+      then_i_should_be_on_the_teacher_end_date_page
+
+      click_on "Continue"
+      then_i_should_see_enter_end_date_error_message
+
+      when_i_add_an_invalid_date
+      click_on "Continue"
+      then_i_should_see_invalid_end_date_error_message
+
+      when_i_add_a_valid_end_date
+      click_on "Continue"
+
+      then_i_should_be_on_the_check_your_answers_page
+
+      click_on "Confirm and continue"
+      then_i_should_be_on_the_complete_page
+
+      click_on "View your ECTs and mentors"
+      then_i_am_taken_to_your_ect_and_mentors_page
+      then_i_should_see_the_transfer_out_participant
+    end
+
+    # given
+
+    def given_a_school_have_chosen_fip_for_2021
+      @cohort = create(:cohort, start_year: 2021)
+      @school_one = create(:school, name: "Fip School 1")
+      @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+      @ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_one)
+      @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one)
+      @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
+      Induction::Enrol.call(participant_profile: @ect, induction_programme: @induction_programme_one)
+    end
+
+    # when
+
+    def when_i_click_to_view_ects_and_mentors
+      click_on "Manage"
+    end
+
+    def when_i_click_on_an_ect
+      click_on @participant_data[:full_name]
+    end
+
+    def when_i_click_to_transfer_out_a_participant
+      click_on "#{@participant_data[:full_name]} is transferring to another school"
+    end
+
+    def when_i_add_an_invalid_date
+      fill_in "Day", with: "24"
+      fill_in "Month", with: "10"
+      fill_in "Year", with: "23"
+    end
+
+    def when_i_add_a_valid_end_date
+      fill_in "Day", with: "24"
+      fill_in "Month", with: "10"
+      fill_in "Year", with: "2022"
+    end
+
+    def when_i_select(option)
+      choose(option)
+    end
+
+    # then
+
+    def then_i_am_taken_to_your_ect_and_mentors_page
+      expect(page).to have_selector("h1", text: "Your ECTs and mentors")
+      expect(page).to have_text("Add an ECT or mentor")
+      expect(page).to have_text("Add yourself as a mentor")
+    end
+
+    def then_i_should_be_on_the_ect_details_page
+      expect(page).to have_text(@participant_data[:full_name])
+      expect(page).to have_text("Tell us #{@participant_data[:full_name]} is transferring to another school")
+    end
+
+    def then_i_should_be_on_the_teacher_end_date_page
+      expect(page).to have_selector("h1", text: "When is #{@participant_data[:full_name]} leaving your school?")
+    end
+
+    def then_i_should_be_on_the_check_your_answers_page
+      date = @participant_data[:end_date]
+      expect(page).to have_selector("h1", text: "Check your answers")
+      expect(page).to have_selector("dd", text: @participant_data[:full_name])
+      expect(page).to have_selector("dd", text: date.to_date.to_s(:govuk))
+    end
+
+    def then_i_should_be_on_the_complete_page
+      expect(page).to have_selector("h2", text: "What happens next")
+      expect(page).to have_text("We’ll tell #{@participant_data[:full_name]} that you’ve reported their transfer")
+    end
+
+    def then_i_should_be_on_the_check_transfer_page
+      expect(page).to have_selector("h1", text: "Is #{@participant_data[:full_name]} transferring to another school where they’ll continue their induction?")
+    end
+
+    def then_i_should_see_enter_end_date_error_message
+      expect(page).to have_text("Enter end date")
+    end
+
+    def then_i_should_see_invalid_end_date_error_message
+      expect(page).to have_text("Invalid end date")
+    end
+
+    def then_i_should_see_the_transfer_out_participant
+      date = @participant_data[:end_date]
+      expect(page).to have_selector("h2", text: "Transferring from your school")
+      within(:xpath, "//table[@data-test='transferring_out']/tbody/tr[1]") do
+        expect(page).to have_xpath(".//td[1]", text: @participant_data[:full_name])
+        expect(page).to have_xpath(".//td[4]", text: date.to_date.to_s(:govuk))
+      end
+    end
+
+    # and
+
+    def and_i_am_signed_in_as_an_induction_coordinator
+      @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort_one.school], user: create(:user, full_name: "Carl Coordinator"))
+      privacy_policy = create(:privacy_policy)
+      privacy_policy.accept!(@induction_coordinator_profile.user)
+      sign_in_as @induction_coordinator_profile.user
+    end
+
+    def and_select_the_most_recent_cohort
+      click_on Cohort.active_registration_cohort.description
+    end
+
+    def set_participant_data
+      @participant_data = {
+        trn: "1001000",
+        full_name: "Sally Teacher",
+        end_date: Date.new(2022, 10, 24),
+        email: "sally-teacher@example.com",
+      }
+    end
+  end
+end

--- a/spec/services/coc_set_participant_categories_spec.rb
+++ b/spec/services/coc_set_participant_categories_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "returns induction_records in correct category" do
         # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
-        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, fip_transferring_out_participant].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor].map(&:current_induction_record))
 
         # ineligible
@@ -132,7 +132,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         expect(@ect_categories.transferring_in).to match_array(fip_transferring_in_participant.induction_records.latest)
 
         # transferring_out
-        # expect(@ect_categories.transferring_out).to match_array(fip_transferring_out_participant.current_induction_record)
+        expect(@ect_categories.transferring_out).to match_array(fip_transferring_out_participant.current_induction_record)
 
         # transferred
         expect(@ect_categories.transferred).to match_array([fip_transferred_participant, fip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
@@ -154,7 +154,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "returns participants in correct category" do
         # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
-        expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_transferring_out_participant, cip_ect_no_qts].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
 
         # ineligible
@@ -176,7 +176,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         # expect(@ect_categories.transferring_in).to match_array(cip_transferring_in_participant.induction_records.latest)
 
         # transferring_out
-        # expect(@ect_categories.transferring_out).to match_array(cip_transferring_out_participant.current_induction_record)
+        expect(@ect_categories.transferring_out).to match_array(cip_transferring_out_participant.current_induction_record)
 
         # transferred
         expect(@ect_categories.no_qts_participants).to be_empty
@@ -196,7 +196,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "returns participants in correct category" do
         # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
-        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, fip_transferring_out_participant, cip_transferring_out_participant, cip_ect_no_qts].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor, cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
 
         # ineligible
@@ -218,7 +218,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         # expect(@ect_categories.transferring_in).to match_array([fip_transferring_in_participant, cip_transferring_in_participant].map { |profile| profile.induction_records.latest })
 
         # transferring_out
-        # expect(@ect_categories.transferring_out).to match_array([fip_transferring_out_participant, cip_transferring_out_participant].map(&:current_induction_record))
+        expect(@ect_categories.transferring_out).to match_array([fip_transferring_out_participant, cip_transferring_out_participant].map(&:current_induction_record))
 
         # transferred
         expect(@ect_categories.transferred).to match_array([fip_transferred_participant, fip_transferred_withdrawn_participant, cip_transferred_participant, cip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
@@ -257,7 +257,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       it "only returns ECTs for the selected school cohort" do
         ect_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::ECT)
         # Transferring out needs to be removed when we build the transfer out journey
-        expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, cip_transferring_out_participant, fip_transferring_in_participant, cip_transferring_in_participant, cip_ect_no_qts].map(&:current_induction_record).compact)
+        expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, fip_transferring_in_participant, cip_transferring_in_participant, cip_ect_no_qts].map(&:current_induction_record).compact)
       end
 
       it "only returns mentors for the selected school cohort" do

--- a/spec/services/coc_set_participant_categories_spec.rb
+++ b/spec/services/coc_set_participant_categories_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
       # NOTE: all categories under one spec as otherwise very slow
       it "returns induction_records in correct category" do
-        # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
         expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor].map(&:current_induction_record))
@@ -132,7 +131,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         expect(@ect_categories.transferring_in).to match_array(fip_transferring_in_participant.induction_records.latest)
 
         # transferring_out
-        expect(@ect_categories.transferring_out).to match_array(fip_transferring_out_participant.current_induction_record)
+        expect(@ect_categories.transferring_out).to match_array(fip_transferring_out_participant.induction_records.latest)
 
         # transferred
         expect(@ect_categories.transferred).to match_array([fip_transferred_participant, fip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
@@ -152,7 +151,6 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
       # NOTE: all categories under one spec as otherwise very slow
       it "returns participants in correct category" do
-        # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
         expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
@@ -176,7 +174,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         # expect(@ect_categories.transferring_in).to match_array(cip_transferring_in_participant.induction_records.latest)
 
         # transferring_out
-        expect(@ect_categories.transferring_out).to match_array(cip_transferring_out_participant.current_induction_record)
+        expect(@ect_categories.transferring_out).to match_array(cip_transferring_out_participant.induction_records.latest)
 
         # transferred
         expect(@ect_categories.no_qts_participants).to be_empty
@@ -194,7 +192,6 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
       # NOTE: all categories under one spec as otherwise very slow
       it "returns participants in correct category" do
-        # Transferring out needs to be removed from eligible when we build the transfer out journey
         # eligible
         expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor, cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
@@ -218,7 +215,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         # expect(@ect_categories.transferring_in).to match_array([fip_transferring_in_participant, cip_transferring_in_participant].map { |profile| profile.induction_records.latest })
 
         # transferring_out
-        expect(@ect_categories.transferring_out).to match_array([fip_transferring_out_participant, cip_transferring_out_participant].map(&:current_induction_record))
+        expect(@ect_categories.transferring_out).to match_array([fip_transferring_out_participant, cip_transferring_out_participant].map { |profile| profile.induction_records.latest })
 
         # transferred
         expect(@ect_categories.transferred).to match_array([fip_transferred_participant, fip_transferred_withdrawn_participant, cip_transferred_participant, cip_transferred_withdrawn_participant].map { |profile| profile.induction_records.latest })
@@ -239,7 +236,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
           Induction::Enrol.call(participant_profile: profile, induction_programme: cip_programme)
         end
         cip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now)
-        cip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now)
+        cip_transferring_out_participant.induction_records.first.update!(school_transfer: true, induction_status: :leaving, end_date: 1.month.from_now)
         cip_transferred_participant.induction_records.first.leaving!(1.month.ago)
         cip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!
         cip_withdrawn_ect.induction_records.first.training_status_withdrawn!
@@ -256,7 +253,6 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
       it "only returns ECTs for the selected school cohort" do
         ect_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::ECT)
-        # Transferring out needs to be removed when we build the transfer out journey
         expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, fip_transferring_in_participant, cip_transferring_in_participant, cip_ect_no_qts].map(&:current_induction_record).compact)
       end
 
@@ -274,7 +270,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       Induction::Enrol.call(participant_profile: profile, induction_programme: fip_programme)
     end
     fip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
-    fip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now)
+    fip_transferring_out_participant.induction_records.first.update!(school_transfer: true, induction_status: :leaving, end_date: 1.month.from_now)
     fip_transferred_participant.induction_records.first.leaving!(1.month.ago)
     fip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
     fip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!
@@ -304,7 +300,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       Induction::Enrol.call(participant_profile: profile, induction_programme: cip_programme)
     end
     cip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
-    cip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now)
+    cip_transferring_out_participant.induction_records.first.update!(school_transfer: true, induction_status: :leaving, end_date: 1.month.from_now)
     cip_transferred_participant.induction_records.first.leaving!(1.month.ago)
     cip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
     cip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!


### PR DESCRIPTION
### Context

- Ticket: [432](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-432)

### Changes proposed in this pull request

#### PPT show with link to transfer out
<img width="871" alt="Screenshot 2022-06-14 at 09 14 46" src="https://user-images.githubusercontent.com/69353998/173528828-91ddaa38-87cf-47fa-8b24-80c549d84ebd.png">

##### Bump to check the ppt is transferring
<img width="747" alt="Screenshot 2022-06-14 at 09 14 51" src="https://user-images.githubusercontent.com/69353998/173528869-bd653a18-24b2-4e62-8705-89b941846d75.png">

#### Enter end date
<img width="751" alt="Screenshot 2022-06-14 at 09 14 56" src="https://user-images.githubusercontent.com/69353998/173528939-f99536df-b9b5-4fcf-a226-88a03d866316.png">

#### Confirm name and end date
<img width="733" alt="Screenshot 2022-06-14 at 09 15 10" src="https://user-images.githubusercontent.com/69353998/173528987-37dfcb22-1f14-481d-96b4-4814f4988085.png">

#### ECT confirmation page
<img width="783" alt="Screenshot 2022-06-14 at 09 15 21" src="https://user-images.githubusercontent.com/69353998/173529041-803c3913-307d-4f10-ac9a-59b593db0dd0.png">

#### Mentor confirmation page
<img width="646" alt="Screenshot 2022-06-14 at 09 15 52" src="https://user-images.githubusercontent.com/69353998/173529133-c0d9aa84-3830-49bf-bb47-3f7fb87841bb.png">

### Guidance to review

In addition to the transfer out route i've amended the participant categories and added a scope on the induction record. 
This is to cover the following scenarios

- PPT is transferred in but *is not* transferred out, old SIT still see's the PPT in either ECTs or Mentors. They never show on the 'Moving school' tab
- PPT is transferred out and moves straight into 'Moving School' tab
- PPT is transferred in and then transferred out. Goes in to moving schools tab once transferred out. 

For all the above, a PPT will only ever move into the Not training tab once the end date on the latest induction record for that school has passed. 
