### PR TITLE
[CPDLP-1052] Utilise Statement line items

### DIFF
--- a/app/controllers/finance/banding_tracker/providers_controller.rb
+++ b/app/controllers/finance/banding_tracker/providers_controller.rb
@@ -15,7 +15,7 @@ module Finance
       def paid_participant_count_per_bands
         @paid_participant_count_per_bands ||= lead_provider
                                                 .participant_declarations
-                                                .joins(:statement)
+                                                .joins(:billable_statements)
                                                 .paid
                                                 .group(:declaration_type)
                                                 .where(statements: { cohort: Cohort.current })
@@ -25,7 +25,7 @@ module Finance
       def payable_participant_count_per_bands
         @payable_participant_count_per_bands ||= lead_provider
                                                    .participant_declarations
-                                                   .joins(:statement)
+                                                   .joins(:billable_statements)
                                                    .payable
                                                    .group(:declaration_type)
                                                    .where(statements: { cohort: Cohort.current })

--- a/app/controllers/finance/ecf/participant_declarations/voided_controller.rb
+++ b/app/controllers/finance/ecf/participant_declarations/voided_controller.rb
@@ -8,7 +8,7 @@ module Finance
           @ecf_lead_provider = LeadProvider.find(params[:payment_breakdown_id])
           @cpd_lead_provider = @ecf_lead_provider.cpd_lead_provider
           @statement = @cpd_lead_provider.statements.find_by_humanised_name(params[:statement_id])
-          @voided_declarations = @statement.voided_participant_declarations
+          @voided_declarations = @statement.participant_declarations.voided
         end
       end
     end

--- a/app/controllers/finance/npq/participant_declarations/voided_controller.rb
+++ b/app/controllers/finance/npq/participant_declarations/voided_controller.rb
@@ -10,7 +10,7 @@ module Finance
           @npq_lead_provider   = lead_provider_scope.find(params[:lead_provider_id])
           @cpd_lead_provider   = @npq_lead_provider.cpd_lead_provider
           @statement           = @cpd_lead_provider.npq_lead_provider.statements.find_by_humanised_name(params[:statement_id])
-          @voided_declarations = @statement.voided_participant_declarations
+          @voided_declarations = @statement.participant_declarations.voided
         end
 
       private

--- a/app/jobs/finance/statements/mark_as_payable.rb
+++ b/app/jobs/finance/statements/mark_as_payable.rb
@@ -8,7 +8,10 @@ module Finance
           Finance::Statement.transaction do
             statement.payable!
 
-            statement.participant_declarations.find_each do |declaration|
+            statement
+              .participant_declarations
+              .billable
+              .find_each do |declaration|
               declaration.make_payable!
 
               line_item = StatementLineItem.find_by(statement: statement, participant_declaration: declaration)

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -8,8 +8,17 @@ class Finance::Statement < ApplicationRecord
   belongs_to :cpd_lead_provider
   belongs_to :cohort
 
-  has_many :participant_declarations
   has_many :statement_line_items, class_name: "Finance::StatementLineItem"
+  has_many :participant_declarations, through: :statement_line_items
+
+  has_many :billable_statement_line_items,
+           -> { where(state: %w[eligible payable paid]) },
+           class_name: "Finance::StatementLineItem"
+
+  has_many :billable_participant_declarations,
+           class_name: "ParticipantDeclaration",
+           through: :billable_statement_line_items,
+           source: :participant_declaration
 
   scope :payable,                   -> { where("deadline_date < DATE(NOW()) AND payment_date >= DATE(NOW())") }
   scope :closed,                    -> { where("payment_date < ?", Date.current) }

--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -2,8 +2,6 @@
 
 class Finance::Statement::ECF < Finance::Statement
   has_one :lead_provider, through: :cpd_lead_provider
-  has_many :participant_declarations,        -> { not_voided.not_ineligible }, foreign_key: :statement_id
-  has_many :voided_participant_declarations, -> { voided }, foreign_key: :statement_id, class_name: "ParticipantDeclaration::ECF"
 
   def contract
     CallOffContract.find_by!(

--- a/app/models/finance/statement/ecf/paid.rb
+++ b/app/models/finance/statement/ecf/paid.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Finance::Statement::ECF::Paid < Finance::Statement::ECF
-  has_many :participant_declarations, -> { paid }, foreign_key: :statement_id
-
   def open?
     false
   end

--- a/app/models/finance/statement/ecf/payable.rb
+++ b/app/models/finance/statement/ecf/payable.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Finance::Statement::ECF::Payable < Finance::Statement::ECF
-  has_many :participant_declarations, -> { payable }, foreign_key: :statement_id
-
   def open?
     false
   end

--- a/app/models/finance/statement/npq.rb
+++ b/app/models/finance/statement/npq.rb
@@ -2,9 +2,6 @@
 
 class Finance::Statement::NPQ < Finance::Statement
   has_one :npq_lead_provider, through: :cpd_lead_provider
-  has_many :participant_declarations,        -> { not_voided.not_ineligible }, foreign_key: :statement_id
-  has_many :voided_participant_declarations, -> { voided }, foreign_key: :statement_id, class_name: "ParticipantDeclaration::NPQ"
-  has_many :not_eligible_participant_declarations, -> { voided.ineligible }, foreign_key: :statement_id, class_name: "ParticipantDeclaration::NPQ"
 
   def payable!
     update!(type: "Finance::Statement::NPQ::Payable")

--- a/app/models/finance/statement/npq/paid.rb
+++ b/app/models/finance/statement/npq/paid.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Finance::Statement::NPQ::Paid < Finance::Statement::NPQ
-  has_many :participant_declarations, -> { paid }, foreign_key: :statement_id
-
   def open?
     false
   end

--- a/app/models/finance/statement/npq/payable.rb
+++ b/app/models/finance/statement/npq/payable.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Finance::Statement::NPQ::Payable < Finance::Statement::NPQ
-  has_many :participant_declarations, -> { payable }, foreign_key: :statement_id
-
   def open?
     false
   end

--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -2,7 +2,9 @@
 
 class ParticipantDeclaration::ECF < ParticipantDeclaration
   include RecordDeclarations::ECF
-  belongs_to :statement, optional: true, class_name: "Finance::Statement::ECF"
+
+  has_many :statements, class_name: "Finance::Statement::ECF", through: :statement_line_items
+
   validate :validate_backdated_declaration_before_induction_record_end_date
 
   def validate_backdated_declaration_before_induction_record_end_date

--- a/app/models/participant_declaration/npq.rb
+++ b/app/models/participant_declaration/npq.rb
@@ -4,8 +4,10 @@ class ParticipantDeclaration::NPQ < ParticipantDeclaration
   include RecordDeclarations::NPQ
 
   belongs_to :participant_profile, class_name: "ParticipantProfile::NPQ"
+
   has_one :npq_application, through: :participant_profile
-  belongs_to :statement, optional: true, class_name: "Finance::Statement::NPQ"
+
+  has_many :statements, class_name: "Finance::Statement::NPQ", through: :statement_line_items
 
   scope :for_course, ->(course_identifier) { where(course_identifier: course_identifier) }
   scope :eligible_for_lead_provider_and_course, ->(cpd_lead_provider, course_identifier) { for_lead_provider(cpd_lead_provider).for_course(course_identifier).eligible }

--- a/app/services/finance/declaration_statement_attacher.rb
+++ b/app/services/finance/declaration_statement_attacher.rb
@@ -13,7 +13,6 @@ module Finance
 
     def call
       ApplicationRecord.transaction do
-        statement.participant_declarations << participant_declaration
         StatementLineItem.create!(
           statement: statement,
           participant_declaration: participant_declaration,

--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -38,7 +38,7 @@ module Finance
       end
 
       def voided_declarations
-        statement.voided_participant_declarations
+        statement.participant_declarations.voided
       end
 
       event_types.each do |event_type|

--- a/app/services/finance/npq/course_statement_calculator.rb
+++ b/app/services/finance/npq/course_statement_calculator.rb
@@ -16,6 +16,7 @@ module Finance
       def total_declarations
         statement
           .participant_declarations
+          .where(state: %w[eligible payable paid]) # needs to be on join table
           .for_course_identifier(course.identifier)
           .unique_id
           .count
@@ -27,7 +28,8 @@ module Finance
 
       def not_eligible_declarations
         statement
-          .not_eligible_participant_declarations
+          .participant_declarations
+          .where(state: %w[ineligible voided]) # needs to be on join table
           .for_course_identifier(course.identifier)
           .unique_id
           .count
@@ -77,6 +79,7 @@ module Finance
       def participants_per_declaration_type
         @participants_per_declaration_type ||= statement
           .participant_declarations
+          .where(state: %w[eligible payable paid]) # needs to be on join table
           .for_course_identifier(course.identifier)
           .group(:declaration_type)
           .count

--- a/app/services/finance/npq/statement_calculator.rb
+++ b/app/services/finance/npq/statement_calculator.rb
@@ -48,19 +48,18 @@ module Finance
     private
 
       def voided_declarations
-        statement.voided_participant_declarations.unique_id
+        statement.participant_declarations.voided.unique_id
       end
 
       def statement_declarations_per_contract(contract)
-        statement
-          .participant_declarations
+        statement_declarations
           .for_course_identifier(contract.course_identifier)
           .unique_id
           .count
       end
 
       def statement_declarations
-        statement.participant_declarations
+        statement.billable_participant_declarations
       end
 
       def output_payments

--- a/app/services/finance/participant_aggregator.rb
+++ b/app/services/finance/participant_aggregator.rb
@@ -20,7 +20,9 @@ module Finance
       aggregations(event_type: event_type).tap do |h|
         h[:previous_participants] =
           recorder
-          .where(statement: previous_statements)
+          .joins(:billable_statements)
+          .where(statements: { deadline_date: ..(statement.deadline_date - 1.day) })
+          .where(statements: { cpd_lead_provider: statement.cpd_lead_provider })
           .public_send(event_type)
           .count
       end
@@ -40,13 +42,6 @@ module Finance
       Hash.new do |hash, key|
         hash[key] = aggregate(aggregation_type: key, event_type: event_type)
       end
-    end
-
-    def previous_statements
-      Finance::Statement::ECF.where(
-        deadline_date: ..(statement.deadline_date - 1.day),
-        cpd_lead_provider: statement.cpd_lead_provider,
-      )
     end
 
     def aggregate(aggregation_type:, event_type:)

--- a/app/services/statements/mark_as_paid.rb
+++ b/app/services/statements/mark_as_paid.rb
@@ -12,6 +12,11 @@ module Statements
           .participant_declarations
           .payable
           .each(&:make_paid!)
+
+        statement
+          .statement_line_items
+          .payable
+          .each(&:paid!)
       end
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
-  config.domain = ENV["DOMAIN"]
+  config.domain = ENV["DOMAIN"] || "example.com"
 
   config.support_email = "continuing-professional-development@digital.education.gov.uk"
 

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -114,9 +114,12 @@ module ValidTestDataGenerator
           created_at: profile.schedule.milestones.first.start_date + 1.day,
         )
 
-        Finance::StatementLineItem.create!(
-          statement: november_statement,
+        line_item = Finance::StatementLineItem.find_or_initialize_by(
           participant_declaration: started_declaration,
+        )
+
+        line_item.update!(
+          statement: november_statement,
           state: started_declaration.state,
         )
 
@@ -163,9 +166,12 @@ module ValidTestDataGenerator
           created_at: profile.schedule.milestones.first.start_date + 1.day,
         )
 
-        Finance::StatementLineItem.create!(
-          statement: november_statement,
+        line_item = Finance::StatementLineItem.find_or_initialize_by(
           participant_declaration: started_declaration,
+        )
+
+        line_item.update!(
+          statement: november_statement,
           state: started_declaration.state,
         )
 

--- a/lib/tasks/valid_test_data_generator.rb
+++ b/lib/tasks/valid_test_data_generator.rb
@@ -112,7 +112,12 @@ module ValidTestDataGenerator
         started_declaration.make_payable!
         started_declaration.update!(
           created_at: profile.schedule.milestones.first.start_date + 1.day,
+        )
+
+        Finance::StatementLineItem.create!(
           statement: november_statement,
+          participant_declaration: started_declaration,
+          state: started_declaration.state,
         )
 
         return if (profile.schedule.milestones.second.start_date + 1.day) > Time.zone.now
@@ -156,7 +161,12 @@ module ValidTestDataGenerator
         started_declaration.make_payable!
         started_declaration.update!(
           created_at: profile.schedule.milestones.first.start_date + 1.day,
+        )
+
+        Finance::StatementLineItem.create!(
           statement: november_statement,
+          participant_declaration: started_declaration,
+          state: started_declaration.state,
         )
 
         return if (profile.schedule.milestones.second.start_date + 1.day) > Time.zone.now

--- a/spec/features/finance/banding_tracker_spec.rb
+++ b/spec/features/finance/banding_tracker_spec.rb
@@ -19,13 +19,23 @@ RSpec.feature "Banding tracker", type: :feature, js: true do
   let(:next_cohort_statement) { create :ecf_statement, :output_fee, cpd_lead_provider: cpd_lead_provider, cohort: next_cohort }
 
   def generate_declarations(state:)
-    with_options(cpd_lead_provider: cpd_lead_provider, state: state, statement: statement) do
-      create_list(:ect_participant_declaration, 17, declaration_type: "started")
-      create_list(:ect_participant_declaration, 5,  declaration_type: "retained-1")
-      create_list(:ect_participant_declaration, 4,  declaration_type: "retained-2")
-      create_list(:ect_participant_declaration, 3,  declaration_type: "retained-3")
-      create_list(:ect_participant_declaration, 1,  declaration_type: "retained-4")
-      create_list(:ect_participant_declaration, 0,  declaration_type: "completed")
+    declarations = []
+
+    with_options(cpd_lead_provider: cpd_lead_provider, state: state) do
+      declarations << create_list(:ect_participant_declaration, 17, declaration_type: "started")
+      declarations << create_list(:ect_participant_declaration, 5,  declaration_type: "retained-1")
+      declarations << create_list(:ect_participant_declaration, 4,  declaration_type: "retained-2")
+      declarations << create_list(:ect_participant_declaration, 3,  declaration_type: "retained-3")
+      declarations << create_list(:ect_participant_declaration, 1,  declaration_type: "retained-4")
+      declarations << create_list(:ect_participant_declaration, 0,  declaration_type: "completed")
+    end
+
+    declarations.flatten.each do |declaration|
+      Finance::StatementLineItem.create!(
+        statement: statement,
+        participant_declaration: declaration,
+        state: declaration.state,
+      )
     end
   end
 
@@ -33,8 +43,30 @@ RSpec.feature "Banding tracker", type: :feature, js: true do
     create(:ecf_schedule)
     generate_declarations(state: :payable)
     generate_declarations(state: :paid)
-    create(:ect_participant_declaration, :paid, declaration_type: "started", statement: next_cohort_statement, cpd_lead_provider: cpd_lead_provider)
-    create(:ect_participant_declaration, :payable, declaration_type: "started", statement: next_cohort_statement, cpd_lead_provider: cpd_lead_provider)
+
+    declaration = create(
+      :ect_participant_declaration, :paid,
+      declaration_type: "started",
+      cpd_lead_provider: cpd_lead_provider
+    )
+
+    Finance::StatementLineItem.create!(
+      statement: next_cohort_statement,
+      participant_declaration: declaration,
+      state: declaration.state,
+    )
+
+    declaration = create(
+      :ect_participant_declaration, :payable,
+      declaration_type: "started",
+      cpd_lead_provider: cpd_lead_provider
+    )
+
+    Finance::StatementLineItem.create!(
+      statement: next_cohort_statement,
+      participant_declaration: declaration,
+      state: declaration.state,
+    )
   end
 
   it "displays the distribution of declaration by band, retention type and declaration state" do

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -123,10 +123,15 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
 
     ParticipantDeclaration::NPQ
       .where(state: %w[ineligible voided], cpd_lead_provider: cpd_lead_provider)
-      .update_all(statement_id: statement.id) # voided payable
+      .each do |declaration|
+        Finance::StatementLineItem.create(statement: statement, participant_declaration: declaration, state: declaration.state)
+      end
+
     ParticipantDeclaration::NPQ
       .where(state: %w[eligible payable], cpd_lead_provider: cpd_lead_provider)
-      .update_all(statement_id: statement.id)
+      .each do |declaration|
+        Finance::StatementLineItem.create(statement: statement, participant_declaration: declaration, state: declaration.state)
+      end
   end
 
   def then_i_should_see_correct_statement_summary
@@ -238,7 +243,12 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def participants_per_declaration_type
-    statement.participant_declarations.for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier).paid_payable_or_eligible.group(:declaration_type).count
+    statement
+      .participant_declarations
+      .for_course_identifier(npq_leading_behaviour_culture_contract.course_identifier)
+      .paid_payable_or_eligible
+      .group(:declaration_type)
+      .count
   end
 
   def total_participants_for(milestone)
@@ -288,6 +298,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   def statement_declarations_per_contract(contract)
     statement
       .participant_declarations
+      .where(state: %w[eligible payable paid])
       .for_course_identifier(contract.course_identifier)
       .unique_id
       .count
@@ -298,7 +309,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def statement_declarations
-    statement.participant_declarations
+    statement.billable_participant_declarations
   end
 
   def total_retained
@@ -314,12 +325,13 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def voided_declarations
-    statement.voided_participant_declarations.unique_id
+    statement.participant_declarations.voided.unique_id
   end
 
   def total_declarations(contract)
     statement
       .participant_declarations
+      .where(state: %w[eligible payable paid])
       .for_course_identifier(contract.course_identifier)
       .unique_id
       .count

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.feature "Finance users payment breakdowns", :with_default_schedules, type: :feature, js: true do
   include FinanceHelper
+  include ActionView::Helpers::NumberHelper
 
   let!(:lead_provider)    { create(:lead_provider, name: "Test provider", id: "cffd2237-c368-4044-8451-68e4a4f73369") }
   let(:cpd_lead_provider) { lead_provider.cpd_lead_provider }
@@ -146,12 +147,10 @@ private
           evidence_held: "other",
         },
       )
+
       started_declaration = ParticipantDeclaration.find(JSON.parse(serialized_started_declaration).dig("data", "id"))
       started_declaration.make_eligible!
       started_declaration.make_payable!
-      started_declaration.update!(
-        statement: nov_statement,
-      )
     end
   end
 
@@ -175,9 +174,9 @@ private
       declaration.make_eligible!
       declaration.make_payable!
       declaration.make_voided!
-      declaration.update!(
-        statement: nov_statement,
-      )
+
+      declaration.statement_line_items.first.update!(statement: nov_statement, state: declaration.state)
+
       declaration
     end
   end
@@ -201,9 +200,6 @@ private
       started_declaration = ParticipantDeclaration.find(JSON.parse(serialized_started_declaration).dig("data", "id"))
       started_declaration.make_eligible!
       started_declaration.make_payable!
-      started_declaration.update!(
-        statement: nov_statement,
-      )
     end
   end
 
@@ -226,9 +222,6 @@ private
       retained_declaration = ParticipantDeclaration.find(JSON.parse(serialized_started_declaration).dig("data", "id"))
       retained_declaration.make_eligible!
       retained_declaration.make_payable!
-      retained_declaration.update!(
-        statement: jan_statement,
-      )
     end
   end
 
@@ -250,9 +243,6 @@ private
       )
       retained_declaration = ParticipantDeclaration.find(JSON.parse(serialized_started_declaration).dig("data", "id"))
       retained_declaration.make_eligible!
-      retained_declaration.update!(
-        statement: jan_statement,
-      )
     end
   end
 
@@ -275,7 +265,6 @@ private
       declaration = ParticipantDeclaration.find(JSON.parse(serialized_started_declaration).dig("data", "id"))
       declaration.update!(
         state: "ineligible",
-        statement: jan_statement,
       )
       declaration
     end
@@ -340,7 +329,7 @@ private
       expect(page).to have_content(number_to_pounds(total_payment_with_vat_breakdown))
 
       expect(page).to have_content("Output payment")
-      expect(page).to have_content(output_payment_total)
+      expect(page).to have_content(number_with_delimiter(output_payment_total))
 
       expect(page).to have_content("Service fee")
       expect(page).to have_content(number_to_pounds(service_fee_total))

--- a/spec/jobs/finance/statements/mark_as_payable_spec.rb
+++ b/spec/jobs/finance/statements/mark_as_payable_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Finance::Statements::MarkAsPayable do
 
   before do
     travel_to Date.new(2021, 12, 31) do
-      eligible_dec = create(:ect_participant_declaration, :eligible, statement: statement)
-      ineligible_dec = create(:ect_participant_declaration, :ineligible, statement: statement)
-      voided_dec = create(:ect_participant_declaration, :voided, statement: statement)
+      eligible_dec = create(:ect_participant_declaration, :eligible)
+      ineligible_dec = create(:ect_participant_declaration, :ineligible)
+      voided_dec = create(:ect_participant_declaration, :voided)
 
       Finance::StatementLineItem.create!(statement: statement, participant_declaration: eligible_dec, state: "eligible")
       Finance::StatementLineItem.create!(statement: statement, participant_declaration: ineligible_dec, state: "ineligible")

--- a/spec/models/participant_declaration/ecf_spec.rb
+++ b/spec/models/participant_declaration/ecf_spec.rb
@@ -3,5 +3,4 @@
 require "rails_helper"
 
 RSpec.describe ParticipantDeclaration::ECF do
-  it { is_expected.to belong_to(:statement).class_name("Finance::Statement::ECF").optional }
 end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
 
           declaration = ParticipantDeclaration::ECF.find(JSON.parse(response.body).dig("data", "id"))
           expect(declaration.participant_profile.schedule).to eq(next_schedule)
-          expect(declaration.statement.cohort).to eq(next_cohort)
+          expect(declaration.statements.first.cohort).to eq(next_cohort)
         end
       end
 

--- a/spec/services/finance/ecf/calculation_orchestrator_spec.rb
+++ b/spec/services/finance/ecf/calculation_orchestrator_spec.rb
@@ -136,8 +136,31 @@ RSpec.describe Finance::ECF::CalculationOrchestrator do
       let(:with_uplift) { :sparsity_uplift }
 
       before do
-        create_list(:ect_participant_declaration, 5, with_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
-        create_list(:mentor_participant_declaration, 5, with_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
+        declarations = create_list(
+          :ect_participant_declaration, 5, with_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
+        declarations = create_list(
+          :mentor_participant_declaration, 5, with_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       context "when only sparsity_uplift flag was set" do
@@ -172,8 +195,32 @@ RSpec.describe Finance::ECF::CalculationOrchestrator do
 
     context "when no uplift flags were set" do
       before do
-        create_list(:ect_participant_declaration, 5, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
-        create_list(:mentor_participant_declaration, 5, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
+        declarations = create_list(
+          :ect_participant_declaration, 5, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
+        declarations = create_list(
+          :mentor_participant_declaration, 5, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
         normal_outcome[:other_fees][:uplift].tap do |hash|
           hash[:participants] = 0
           hash[:subtotal] = 0
@@ -193,7 +240,18 @@ RSpec.describe Finance::ECF::CalculationOrchestrator do
       end
 
       before do
-        create_list(:mentor_participant_declaration, 10, :sparsity_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
+        declarations = create_list(
+          :mentor_participant_declaration, 10, :sparsity_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns the total calculation" do
@@ -209,7 +267,18 @@ RSpec.describe Finance::ECF::CalculationOrchestrator do
       end
 
       before do
-        create_list(:ect_participant_declaration, 10, :sparsity_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
+        declarations = create_list(
+          :ect_participant_declaration, 10, :sparsity_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns the total calculation" do
@@ -219,8 +288,31 @@ RSpec.describe Finance::ECF::CalculationOrchestrator do
 
     context "when both mentor profile and ect profile declaration records available" do
       before do
-        create_list(:ect_participant_declaration, 5, :sparsity_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
-        create_list(:mentor_participant_declaration, 5, :sparsity_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
+        declarations = create_list(
+          :ect_participant_declaration, 5, :sparsity_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
+        declarations = create_list(
+          :mentor_participant_declaration, 5, :sparsity_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns the total calculation" do
@@ -236,8 +328,23 @@ RSpec.describe Finance::ECF::CalculationOrchestrator do
       end
 
       before do
-        create_list(:ect_participant_declaration, 10, :sparsity_uplift, :eligible, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider, statement: statement)
-        create_list(:ect_participant_declaration, 10, :sparsity_uplift, :submitted, cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider)
+        declarations = create_list(
+          :ect_participant_declaration, 10, :sparsity_uplift, :eligible,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
+        create_list(
+          :ect_participant_declaration, 10, :sparsity_uplift, :submitted,
+          cpd_lead_provider: call_off_contract.lead_provider.cpd_lead_provider
+        )
       end
 
       it "returns the total calculation, and ineligible declarations are put in not_yet_included_participants field" do

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -24,12 +24,19 @@ RSpec.describe Finance::ECF::StatementCalculator do
       let!(:other_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider: other_lead_provider) }
 
       before do
-        create_list(
+        declarations = create_list(
           :ect_participant_declaration, 1,
           cpd_lead_provider: other_cpd_lead_provider,
-          state: "eligible",
-          statement: other_statement
+          state: "eligible"
         )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: other_statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns zero" do
@@ -39,12 +46,19 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
     context "when band is partially populated" do
       before do
-        create_list(
+        declarations = create_list(
           :ect_participant_declaration, 1,
           cpd_lead_provider: cpd_lead_provider,
-          state: "eligible",
-          statement: statement
+          state: "eligible"
         )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns the number of declarations" do
@@ -54,12 +68,19 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
     context "when the band had overflowed" do
       before do
-        create_list(
+        declarations = create_list(
           :ect_participant_declaration, 3,
           cpd_lead_provider: cpd_lead_provider,
-          state: "eligible",
-          statement: statement
+          state: "eligible"
         )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns the maximum number allowed in the band" do
@@ -71,12 +92,19 @@ RSpec.describe Finance::ECF::StatementCalculator do
       let!(:previous_statement) { create(:ecf_statement, cpd_lead_provider: cpd_lead_provider, deadline_date: 5.weeks.ago) }
 
       before do
-        create_list(
+        declarations = create_list(
           :ect_participant_declaration, 1,
           cpd_lead_provider: cpd_lead_provider,
-          state: "eligible",
-          statement: previous_statement
+          state: "eligible"
         )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: previous_statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       context "there are no declarations on this statement" do
@@ -87,12 +115,19 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
       context "there are declarations on this statement, partly filling it" do
         before do
-          create_list(
+          declarations = create_list(
             :ect_participant_declaration, 1,
             cpd_lead_provider: cpd_lead_provider,
-            state: "eligible",
-            statement: statement
+            state: "eligible"
           )
+
+          declarations.each do |declaration|
+            Finance::StatementLineItem.create!(
+              statement: statement,
+              participant_declaration: declaration,
+              state: declaration.state,
+            )
+          end
         end
 
         it "returns number of permitted declarations" do
@@ -102,12 +137,19 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
       context "there are declarations on this statement, over filling it" do
         before do
-          create_list(
+          declarations = create_list(
             :ect_participant_declaration, 2,
             cpd_lead_provider: cpd_lead_provider,
-            state: "eligible",
-            statement: statement
+            state: "eligible"
           )
+
+          declarations.each do |declaration|
+            Finance::StatementLineItem.create!(
+              statement: statement,
+              participant_declaration: declaration,
+              state: declaration.state,
+            )
+          end
         end
 
         it "returns max number of permitted declarations" do
@@ -120,19 +162,33 @@ RSpec.describe Finance::ECF::StatementCalculator do
       let!(:previous_statement) { create(:ecf_statement, cpd_lead_provider: cpd_lead_provider, deadline_date: 5.weeks.ago) }
 
       before do
-        create_list(
+        declarations = create_list(
           :ect_participant_declaration, 2,
           cpd_lead_provider: cpd_lead_provider,
-          state: "eligible",
-          statement: previous_statement
+          state: "eligible"
         )
 
-        create_list(
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: previous_statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
+        declarations = create_list(
           :ect_participant_declaration, 1,
           cpd_lead_provider: cpd_lead_provider,
-          state: "eligible",
-          statement: statement
+          state: "eligible"
         )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
       end
 
       it "returns zero" do
@@ -150,12 +206,17 @@ RSpec.describe Finance::ECF::StatementCalculator do
       let(:profile) { create(:ect_participant_profile) }
 
       before do
-        create(
+        declaration = create(
           :ect_participant_declaration,
           cpd_lead_provider: cpd_lead_provider,
           state: "eligible",
-          statement: statement,
           participant_profile: profile,
+        )
+
+        Finance::StatementLineItem.create!(
+          statement: statement,
+          participant_declaration: declaration,
+          state: declaration.state,
         )
       end
 
@@ -166,14 +227,20 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
     context "when uplift is applicable" do
       let(:profile) { create(:ect_participant_profile, :uplift_flags) }
-
-      before do
+      let(:declaration) do
         create(
           :ect_participant_declaration,
           cpd_lead_provider: cpd_lead_provider,
           state: "eligible",
-          statement: statement,
           participant_profile: profile,
+        )
+      end
+
+      before do
+        Finance::StatementLineItem.create!(
+          statement: statement,
+          participant_declaration: declaration,
+          state: declaration.state,
         )
       end
 

--- a/spec/services/statements/mark_as_paid_spec.rb
+++ b/spec/services/statements/mark_as_paid_spec.rb
@@ -3,23 +3,38 @@
 require "rails_helper"
 
 RSpec.describe Statements::MarkAsPaid do
-  subject(:service) { described_class.new(statement) }
-
   let(:cpd_lead_provider) { create(:cpd_lead_provider) }
   let(:payable_declaration) { create(:npq_participant_declaration, :payable) }
   let(:voided_declaration) { create(:npq_participant_declaration, :voided) }
-  let(:statement) do
-    create :npq_statement, cpd_lead_provider: cpd_lead_provider do |statement|
-      statement.participant_declarations << payable_declaration
-      statement.participant_declarations << voided_declaration
-    end
+  let(:statement) { create :npq_statement, cpd_lead_provider: cpd_lead_provider }
+
+  before do
+    Finance::StatementLineItem.create!(
+      statement: statement,
+      participant_declaration: payable_declaration,
+      state: payable_declaration.state,
+    )
+
+    Finance::StatementLineItem.create!(
+      statement: statement,
+      participant_declaration: voided_declaration,
+      state: voided_declaration.state,
+    )
   end
 
+  subject { described_class.new(statement) }
+
   describe "#call" do
-    it "transitions the payable declarations to paid", :aggregate_failures do
+    it "transitions the payable declarations to paid" do
       expect {
-        service.call
-      }.to change(statement.participant_declarations.paid, :count).from(0).to(1)
+        subject.call
+      }.to change(statement.reload.participant_declarations.paid, :count).from(0).to(1)
+    end
+
+    it "transitions the payable line items to paid" do
+      expect {
+        subject.call
+      }.to change(statement.reload.statement_line_items.paid, :count).from(0).to(1)
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1052
- Builds upon https://github.com/DFE-Digital/early-careers-framework/pull/2133
- At this point in time statement line items have been introduced
- Newly attached declarations should now be creating line items
- Previously existing attached declarations should have been backfilled with line items

### Changes proposed in this pull request

- There should be no behavioural change for this PR, no new functionality, existing functionality remains the same
- Start using line items to power everything instead of `Declaration#statement_id`
- Introduce the concept of `billable`, there is where money flows outwards to cover `eligible`, `payable`, `paid`
- Later i plan to introduce `refundable` where money flowing inwards to cover the clawback states
- NOTE: we are still using the `state` on the declaration and not the line item in this change. in the next change i will swap this over the `state` on the line item as clawbacks are introduced.

### Guidance to review

- n/a