### PR TITLE
[CST-578] Not all participants visible in admin view

### DIFF
--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -6,11 +6,9 @@ module Admin
     skip_after_action :verify_policy_scoped
 
     def index
-      # TODO: multiple cohorts CPDRP-204
       @participant_profiles = policy_scope(ParticipantProfile::ECF, policy_scope_class: ParticipantProfilePolicy::Scope)
-        .active_record
-        .where(school_cohort_id: SchoolCohort.where(school: school, cohort: Cohort.current).select(:id))
-        .includes(:user)
+        .where(id: school.current_induction_records.select(:participant_profile_id))
+        .includes(participant_identity: :user)
         .order("users.full_name")
     end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -38,6 +38,8 @@ class School < ApplicationRecord
   has_many :school_mentors, dependent: :destroy
   has_many :mentor_profiles, through: :school_mentors, source: :participant_profile
 
+  has_many :current_induction_records, through: :school_cohorts, class_name: "InductionRecord"
+
   has_many :ecf_participant_profiles, through: :school_cohorts, source: :ecf_participant_profiles, class_name: "ParticipantProfile::ECF"
   has_many :ecf_participants, through: :ecf_participant_profiles, source: :user
   has_many :active_ecf_participant_profiles, through: :school_cohorts

--- a/spec/requests/admin/schools/participants_spec.rb
+++ b/spec/requests/admin/schools/participants_spec.rb
@@ -3,11 +3,16 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Schools::Participants", type: :request do
+  let(:cohort_2021) { Cohort.find_or_create_by!(start_year: 2021) }
+  let(:cohort_2022) { Cohort.find_or_create_by!(start_year: 2022) }
+
   let(:admin_user) { create(:user, :admin) }
   let(:school) { create(:school) }
-  let(:school_cohort) { create(:school_cohort, school: school) }
+  let(:school_cohort) { create(:school_cohort, school: school, cohort: cohort_2021) }
+  let(:school_cohort_22) { create(:school_cohort, school: school, cohort: cohort_2022) }
 
   let!(:ect_profile) { create :ect_participant_profile, school_cohort: school_cohort }
+  let!(:ect_profile_22) { create :ect_participant_profile, school_cohort: school_cohort_22 }
   let!(:mentor_profile) { create :mentor_participant_profile, school_cohort: school_cohort }
   let!(:npq_profile) { create(:npq_participant_profile, school: school) }
   let!(:unrelated_profile) { create :ecf_participant_profile }
@@ -15,6 +20,23 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
 
   before do
     sign_in admin_user
+
+    school_cohort.update!(default_induction_programme: InductionProgramme.create!(school_cohort: school_cohort,
+                                                                                  training_programme: :core_induction_programme))
+
+    school_cohort_22.update!(default_induction_programme: InductionProgramme.create!(school_cohort: school_cohort_22,
+                                                                                     training_programme: :core_induction_programme))
+
+    [ect_profile, mentor_profile, withdrawn_profile_record].each do |profile|
+      Induction::Enrol.call(participant_profile: profile,
+                            induction_programme: school_cohort.default_induction_programme)
+    end
+
+    Induction::Enrol.call(participant_profile: ect_profile_22,
+                          induction_programme: school_cohort_22.default_induction_programme)
+
+    withdrawn_profile_record.current_induction_record.update!(induction_status: withdrawn_profile_record.status,
+                                                              training_status: withdrawn_profile_record.training_status)
   end
 
   describe "GET /admin/schools/:school_slug/participants" do
@@ -24,12 +46,13 @@ RSpec.describe "Admin::Schools::Participants", type: :request do
       expect(response).to render_template("admin/schools/participants/index")
     end
 
-    it "only displays school's active participants" do
+    it "displays the school's active participants from any cohort" do
       get "/admin/schools/#{school.slug}/participants"
 
       expect(response.body).not_to include("No participants found for this school.")
       expect(assigns(:participant_profiles)).to include mentor_profile
       expect(assigns(:participant_profiles)).to include ect_profile
+      expect(assigns(:participant_profiles)).to include ect_profile_22
       expect(assigns(:participant_profiles)).not_to include npq_profile
       expect(assigns(:participant_profiles)).not_to include unrelated_profile
       expect(assigns(:participant_profiles)).not_to include withdrawn_profile_record


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-578)

Enable admin users to see all active participants in the school regardless of which cohort that are in

### Changes proposed in this pull request

### Guidance to review

