### PR TITLE
[CN-167] Accept new NPQ data

### DIFF
--- a/app/controllers/api/v1/npq_profiles_controller.rb
+++ b/app/controllers/api/v1/npq_profiles_controller.rb
@@ -93,13 +93,18 @@ module Api
             :employment_role,
             :targeted_delivery_funding_eligibility,
             :cohort,
+            :works_in_nursery,
+            :works_in_childcare,
+            :kind_of_nursery,
+            :private_childcare_provider_urn,
+            :funding_eligiblity_status_code,
           ).transform_keys! { |key| key == "national_insurance_number" ? "nino" : key }
       end
 
       def npq_application_update_params
         params
           .require(:data)
-          .permit(attributes: :eligible_for_funding)
+          .permit(attributes: %i[eligible_for_funding funding_eligiblity_status_code])
       end
     end
   end

--- a/db/migrate/20220523120336_add_early_years_and_eligibility_field_to_npq_applications.rb
+++ b/db/migrate/20220523120336_add_early_years_and_eligibility_field_to_npq_applications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddEarlyYearsAndEligibilityFieldToNPQApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_applications, :works_in_nursery, :boolean
+    add_column :npq_applications, :works_in_childcare, :boolean
+    add_column :npq_applications, :kind_of_nursery, :string
+    add_column :npq_applications, :private_childcare_provider_urn, :string
+    add_column :npq_applications, :funding_eligiblity_status_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_18_120740) do
+ActiveRecord::Schema.define(version: 2022_05_23_120336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -499,6 +499,11 @@ ActiveRecord::Schema.define(version: 2022_05_18_120740) do
     t.boolean "targeted_support_funding_eligibility", default: false
     t.uuid "cohort_id"
     t.boolean "targeted_delivery_funding_eligibility", default: false
+    t.boolean "works_in_nursery"
+    t.boolean "works_in_childcare"
+    t.string "kind_of_nursery"
+    t.string "private_childcare_provider_urn"
+    t.string "funding_eligiblity_status_code"
     t.index ["cohort_id"], name: "index_npq_applications_on_cohort_id"
     t.index ["npq_course_id"], name: "index_npq_applications_on_npq_course_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_applications_on_npq_lead_provider_id"

--- a/db/seeds/npq_applications.rb
+++ b/db/seeds/npq_applications.rb
@@ -18,7 +18,7 @@ module Seeds
           active_alert: false,
           date_of_birth: rand(60.years.ago.to_date..23.years.ago.to_date),
           teacher_reference_number: trn,
-          eligible_for_funding: [true, false].sample,
+          eligible_for_funding: eligible_for_funding?,
           funding_choice: ::NPQApplication.funding_choices.keys.sample,
           headteacher_status: ::NPQApplication.headteacher_statuses.keys.sample,
           nino: SecureRandom.hex,
@@ -28,6 +28,11 @@ module Seeds
           works_in_school: works_in_school,
           employer_name: employer_name,
           employment_role: employment_role,
+          works_in_nursery: works_in_nursery,
+          works_in_childcare: works_in_childcare,
+          kind_of_nursery: kind_of_nursery,
+          private_childcare_provider_urn: private_childcare_provider_urn,
+          funding_eligiblity_status_code: funding_eligiblity_status_code,
         },
         npq_course_id: NPQCourse.all.sample.id,
         npq_lead_provider_id: npq_lead_provider.id,
@@ -43,6 +48,41 @@ module Seeds
 
     def works_in_school
       @works_in_school ||= [true, false].sample
+    end
+
+    def works_in_nursery
+      works_in_childcare
+    end
+
+    def works_in_childcare
+      @works_in_childcare ||= !works_in_school
+    end
+
+    def kind_of_nursery
+      @kind_of_nursery = %w[
+        local_authority_maintained_nursery
+        preschool_class_as_part_of_school
+        private_nursery
+      ].sample
+    end
+
+    def private_nursery?
+      kind_of_nursery == "private_nursery"
+    end
+
+    def private_childcare_provider_urn
+      "EY123456" if private_nursery?
+    end
+
+    def eligible_for_funding?
+      @eligible_for_funding ||= [true, false].sample
+    end
+
+    def funding_eligiblity_status_code
+      return "funded" if eligible_for_funding?
+      return "not_on_early_years_register" if private_nursery?
+
+      "ineligible_establishment_type"
     end
 
     def employment_role

--- a/spec/factories/npq_application.rb
+++ b/spec/factories/npq_application.rb
@@ -27,5 +27,15 @@ FactoryBot.define do
       employer_name { "Some Company Ltd" }
       employment_role { "Director" }
     end
+
+    trait :in_private_childcare_provider do
+      works_in_school { false }
+      school_urn { nil }
+      school_ukprn { nil }
+      works_in_nursery { true }
+      works_in_childcare { true }
+      kind_of_nursery { "private_nursery" }
+      private_childcare_provider_urn { "EY#{rand(100_000..999_999)}" }
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CN-167

For the lead provider team to be able to send this information through to providers if required, they need the data available to the API serialisers in ECF.

### Changes proposed in this pull request

- Add extra optional params to create NPQApplication endpoint
  - Adds works_in_nursery => Whether an applicant has indicated they work in a nursery, answered only if in catchment and indicated they work in childcare
  - Adds works_in_childcare => Whether an applicant has indicated they work in childcare
  - Adds kind_of_nursery => Which type of nursery an applicant works in, only asked if they indicated their work in a nursery
  - Adds private_childcare_provider_urn => Ofsted URN of private childcare provider applicant works at if they work in a private nursery with an Ofsted URN
  - Adds funding_eligiblity_status_code => A more granular reason for why an applicant was not funded or if they are funded
  
- Add extra optional param to update NPQApplication endpoint
  - Adds funding_eligiblity_status_code => A more granular reason for why an applicant was not funded or if they are funded

### Guidance to review

- Pull down https://github.com/DFE-Digital/npq-registration/pull/407
- Pull down this branch
- Run both NPQ and ECF side by side
- Ensure API keys and env variables are set up to allow communication between the two
- Complete application on NPQ until you reach application completed page
- See new NPQApplication in ECF database after background job in NPQ runs

