### PR TITLE
[CST-775] Enable withdrawn participants to transfer to FIP school

### DIFF
--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -2,10 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe "transferring participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true do
+RSpec.describe "transferring participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
   context "Attempting to transfer an ECT to a school" do
     context "ECT has been withdrawn" do
       before do
+        allow_participant_transfer_mailers
         set_participant_data
         set_dqt_validation_result
         given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
@@ -15,7 +16,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         then_i_am_taken_to_your_ect_and_mentors_page
       end
 
-      scenario "SIT must contact support to transfer withdrawn participants" do
+      scenario "SIT can transfer a withdrawn participant" do
         when_i_click_to_add_a_new_ect_or_mentor
         then_i_should_be_on_the_who_to_add_page
 
@@ -37,7 +38,28 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         when_i_add_a_valid_date_of_birth
         click_on "Continue"
 
-        then_i_should_be_taken_to_the_cannot_add_page
+        then_i_should_be_on_the_teacher_start_date_page
+        when_i_add_a_valid_start_date
+        click_on "Continue"
+
+        then_i_should_be_on_the_add_email_page
+        when_i_update_the_email_with("sally-teacher@example.com")
+        click_on "Continue"
+
+        then_i_should_be_on_the_select_mentor_page
+        and_it_should_list_the_schools_mentors
+        when_i_assign_a_mentor
+        click_on "Continue"
+
+        then_i_should_be_taken_to_the_check_your_answers_page
+        click_on "Confirm and add"
+        then_i_should_be_on_the_complete_page
+
+        and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
+        and_the_schools_current_provider_is_notified_with(:provider_transfer_in_notification)
+
+        click_on "View your ECTs and mentors"
+        then_i_am_taken_to_your_ect_and_mentors_page
       end
 
       # given
@@ -50,11 +72,13 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
         @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
         @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
+        @lead_provider_profile = create(:lead_provider_profile, lead_provider: @lead_provider)
+        @lead_provider_two = create(:lead_provider, name: "Massive Provider Ltd")
         @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
         @other_delivery_partner = create(:delivery_partner, name: "Fantastic Delivery Team")
         @mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_cohort_one)
         @partnership_one = create(:partnership, school: @school_one, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort)
-        @partnership_two = create(:partnership, school: @school_two, lead_provider: @lead_provider, delivery_partner: @other_delivery_partner, cohort: @cohort)
+        @partnership_two = create(:partnership, school: @school_two, lead_provider: @lead_provider_two, delivery_partner: @other_delivery_partner, cohort: @cohort)
         @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one, partnership: @partnership_one)
         @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two, partnership: @partnership_two)
         @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
@@ -95,6 +119,12 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         fill_in "Year", with: "1990"
       end
 
+      def when_i_add_a_valid_start_date
+        fill_in "Day", with: "24"
+        fill_in "Month", with: "10"
+        fill_in "Year", with: "2023"
+      end
+
       def when_i_assign_a_mentor
         choose(@mentor.user.full_name)
       end
@@ -132,9 +162,28 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         expect(page).to have_selector("h1", text: "Who do you want to add?")
       end
 
-      def then_i_should_be_taken_to_the_cannot_add_page
-        expect(page).to have_selector("h1", text: "You cannot add #{@participant_data[:full_name]}")
-        expect(page).to have_text("Contact us for help to register this person at your school")
+      def then_i_should_be_on_the_teacher_start_date_page
+        expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s start date at your school")
+      end
+
+      def then_i_should_be_on_the_add_email_page
+        expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s email address?")
+      end
+
+      def then_i_should_be_on_the_select_mentor_page
+        expect(page).to have_selector("h1", text: "Who will #{@participant_data[:full_name]}’s mentor be?")
+      end
+
+      def then_i_should_be_taken_to_the_check_your_answers_page
+        expect(page).to have_selector("h1", text: "Check your answers")
+        expect(page).to have_selector("dd", text: @mentor.user.full_name)
+        expect(page).to have_selector("dd", text: @lead_provider_two.name)
+        expect(page).to have_selector("dd", text: @other_delivery_partner.name)
+      end
+
+      def then_i_should_be_on_the_complete_page
+        expect(page).to have_selector("h2", text: "What happens next")
+        expect(page).to have_text("We’ll let #{@participant_profile_ect.user.full_name}")
       end
 
       # and
@@ -148,9 +197,36 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
       def and_there_is_a_withdrawn_ect_who_will_be_transferring
         @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_two)
-        Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_two)
-        @participant_profile_ect.training_status_withdrawn!
+        induction_record = Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_two, start_date: 3.months.ago)
         create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
+        ParticipantProfileState.create!(participant_profile: @participant_profile_ect, state: ParticipantProfileState.states[:withdrawn], cpd_lead_provider: @induction_programme_two.lead_provider&.cpd_lead_provider)
+        @participant_profile_ect.training_status_withdrawn!
+        induction_record.training_status_withdrawn!
+      end
+
+      def and_it_should_list_the_schools_mentors
+        expect(page).to have_text(@mentor.user.full_name)
+      end
+
+      def and_the_participant_should_be_notified_with(notification_method)
+        expect(ParticipantTransferMailer).to have_received(notification_method)
+                                               .with(hash_including(
+                                                       induction_record: @participant_profile_ect.induction_records.latest,
+                                                     ))
+      end
+
+      def and_the_schools_current_provider_is_notified_with(notification_method)
+        induction_record = @participant_profile_ect.induction_records.latest
+        expect(ParticipantTransferMailer).to have_received(notification_method)
+                                               .with(hash_including(
+                                                       induction_record: induction_record,
+                                                       lead_provider_profile: @lead_provider_profile,
+                                                     ))
+      end
+
+      def allow_participant_transfer_mailers
+        allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_call_original
+        allow(ParticipantTransferMailer).to receive(:provider_transfer_in_notification).and_call_original
       end
 
       def set_dqt_validation_result


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-775)

Currently we prevent withdrawn participants from transferring in the FIP to FIP transfer journey because of complications regarding making their `training_status` "active" with use of the `ParticipantProfileState`.  Work is underway to enable this in the LP team, in the meantime we can enable transfers and set the `training_status` without using the `ParticipantProfileState`.

There have been some assumptions made in the transfer journey, given that the participant has been withdrawn:
1. The participant is treated as if they are at the same LP and DP as the school (no options to choose different programme)
2. Only the new LP is notified of the transfer in


### Changes proposed in this pull request

I've added a placeholder to reactivate the `ParticipantProfileState` that is currently commented out to the `Induction::Enrol` service

### Guidance to review

