### PR TITLE
Fix NPQApplication and cohort association

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -6,10 +6,11 @@ class NPQApplication < ApplicationRecord
   self.ignored_columns = %w[user_id]
 
   has_one :profile, class_name: "ParticipantProfile::NPQ", foreign_key: :id, touch: true
+  has_one :schedule, through: :profile
+  has_one :cohort, through: :schedule
   belongs_to :participant_identity
   belongs_to :npq_lead_provider
   belongs_to :npq_course
-  belongs_to :cohort, optional: true
 
   after_commit :push_enrollment_to_big_query
 


### PR DESCRIPTION
The cohort is now fetched via the partipant profile association

### Context

- Ticket: 

### Changes proposed in this pull request

### Guidance to review

