### PR TITLE
[CPDLP-1379] Fix where we get a participant's status from in the DP proposition

### DIFF
--- a/app/components/delivery_partners/participants/table_row.rb
+++ b/app/components/delivery_partners/participants/table_row.rb
@@ -18,8 +18,9 @@ module DeliveryPartners
                to: :induction_record,
                allow_nil: true
 
-      def initialize(participant_profile:)
+      def initialize(participant_profile:, delivery_partner:)
         @participant_profile = participant_profile
+        @delivery_partner = delivery_partner
       end
 
       def status_tag
@@ -40,10 +41,19 @@ module DeliveryPartners
 
     private
 
-      attr_reader :participant_profile
+      attr_reader :participant_profile, :delivery_partner
 
       def induction_record
-        participant_profile.induction_records.active.latest
+        @induction_record ||= participant_profile.induction_records.includes(induction_programme: [:partnership]).where(
+          induction_programme: {
+            partnerships: {
+              delivery_partner: delivery_partner,
+              challenged_at: nil,
+              challenge_reason: nil,
+              pending: false,
+            },
+          },
+        ).latest
       end
 
       def status_name

--- a/app/views/delivery_partners/participants/index.html.erb
+++ b/app/views/delivery_partners/participants/index.html.erb
@@ -43,7 +43,7 @@
 
   <tbody class="govuk-table__body">
     <% if @participant_profiles.any? %>
-      <%= render DeliveryPartners::Participants::TableRow.with_collection(@participant_profiles) %>
+      <%= render DeliveryPartners::Participants::TableRow.with_collection(@participant_profiles, delivery_partner: current_user.delivery_partner_profile.delivery_partner) %>
     <% else %>
       <tr class="govuk-table__row">
         <td colspan="10" class="govuk-table__cell">

--- a/spec/components/delivery_partners/participants/table_row_spec.rb
+++ b/spec/components/delivery_partners/participants/table_row_spec.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe DeliveryPartners::Participants::TableRow, type: :view_component do
-  component { described_class.new participant_profile: participant_profile }
+  component { described_class.new participant_profile: participant_profile, delivery_partner: delivery_partner }
 
+  let(:school) { create(:school) }
+  let(:school_cohort) { create(:school_cohort, school: school) }
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:partnership) do
+    create(
+      :partnership,
+      school: school,
+      delivery_partner: delivery_partner,
+      challenged_at: nil,
+      challenge_reason: nil,
+      pending: false,
+    )
+  end
   let!(:participant_profile) { create :ecf_participant_profile }
+  let!(:participant_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
 
   context "when the request for details has not been sent yet" do
     it { is_expected.to have_text("Contacted for information") }


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1379

### Changes proposed in this pull request

* Added fix to table row component to make sure correct `induction_record` was used for training_status and lead provider

### Guidance to review

