### PR TITLE
[CST-776] Fix change induction programme via admin ui

### DIFF
--- a/app/controllers/admin/schools/cohorts/change_programme_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_programme_controller.rb
@@ -19,7 +19,8 @@ module Admin
         end
 
         def update
-          ChangeInductionService.new(school: @school, cohort: @cohort).change_induction_provision(@induction_choice_form.programme_choice)
+          Induction::ChangeCohortInductionProgramme.call(school_cohort: school_cohort,
+                                                         programme_choice: @induction_choice_form.programme_choice)
 
           set_success_message heading: "Induction programme has been changed"
           redirect_to admin_school_cohorts_path

--- a/app/controllers/admin/schools/cohorts/change_training_materials_controller.rb
+++ b/app/controllers/admin/schools/cohorts/change_training_materials_controller.rb
@@ -26,9 +26,8 @@ module Admin
       private
 
         def update_training_materials
-          service = ChangeInductionService.new(school: @school, cohort: @cohort)
-          new_materials = @core_induction_programme_choice_form.core_induction_programme
-          service.change_cip_materials(new_materials)
+          Induction::ChangeCoreInductionProgramme.call(school_cohort: SchoolCohort.find_by!(school: @school, cohort: @cohort),
+                                                       core_induction_programme: @core_induction_programme_choice_form.core_induction_programme)
         end
 
         def set_school_and_cohort

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -47,6 +47,10 @@ class Partnership < ApplicationRecord
 
   scope :active, -> { unchallenged.where(pending: false) }
 
+  def active?
+    challenged_at.nil? && challenge_reason.nil? && pending == false
+  end
+
 private
 
   def update_analytics

--- a/app/services/induction/change_cohort_induction_programme.rb
+++ b/app/services/induction/change_cohort_induction_programme.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Induction::ChangeCohortInductionProgramme < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      previous_programme = school_cohort.default_induction_programme
+
+      if previous_programme&.full_induction_programme? && previous_programme&.partnership&.active?
+        raise ArgumentError, "Cannot change induction programme for a partnered school"
+      end
+
+      Induction::SetCohortInductionProgramme.call(school_cohort: school_cohort,
+                                                  programme_choice: programme_choice,
+                                                  opt_out_of_updates: programme_choice == "no_early_career_teachers",
+                                                  core_induction_programme: core_induction_programme)
+
+      new_programme = school_cohort.default_induction_programme
+
+      if previous_programme.present? && new_programme.present?
+        Induction::MigrateParticipantsToNewProgramme.call(from_programme: previous_programme,
+                                                          to_programme: new_programme)
+      end
+    end
+  end
+
+private
+
+  attr_reader :school_cohort, :programme_choice, :opt_out_of_updates, :core_induction_programme
+
+  def initialize(school_cohort:, programme_choice:, core_induction_programme: nil)
+    @school_cohort = school_cohort
+    @programme_choice = programme_choice.to_s
+    @core_induction_programme = core_induction_programme
+  end
+end

--- a/app/services/induction/change_core_induction_programme.rb
+++ b/app/services/induction/change_core_induction_programme.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Induction::ChangeCoreInductionProgramme < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      default_induction_programme = school_cohort.default_induction_programme
+
+      if default_induction_programme.present? && default_induction_programme.core_induction_programme?
+        if default_induction_programme.core_induction_programme.blank?
+          default_induction_programme.update!(core_induction_programme: core_induction_programme)
+          school_cohort.update!(core_induction_programme: core_induction_programme)
+        elsif default_induction_programme.core_induction_programme != core_induction_programme
+          # existing CIP materials replaced so create a new programme and migrate
+          # all the participants to the new one
+          programme = InductionProgramme.create!(school_cohort: school_cohort,
+                                                 training_programme: "core_induction_programme",
+                                                 core_induction_programme: core_induction_programme)
+
+          Induction::MigrateParticipantsToNewProgramme.call(from_programme: default_induction_programme,
+                                                            to_programme: programme)
+
+          school_cohort.update!(default_induction_programme: programme, core_induction_programme: core_induction_programme)
+        end
+      end
+    end
+  end
+
+private
+
+  attr_reader :school_cohort, :core_induction_programme
+
+  def initialize(school_cohort:, core_induction_programme:)
+    @school_cohort = school_cohort
+    @core_induction_programme = core_induction_programme
+  end
+end

--- a/spec/services/induction/change_cohort_induction_programme_spec.rb
+++ b/spec/services/induction/change_cohort_induction_programme_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::ChangeCohortInductionProgramme do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:induction_programme) { create(:induction_programme, :cip, school_cohort: school_cohort) }
+    let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+    let!(:mentor_induction_record) { Induction::Enrol.call(induction_programme: induction_programme, participant_profile: mentor_profile, start_date: 6.months.ago) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme: induction_programme, participant_profile: ect_profile, start_date: 6.months.ago, mentor_profile: mentor_profile) }
+    let(:programme_choice) { "full_induction_programme" }
+
+    subject(:service) { described_class }
+
+    before do
+      school_cohort.update!(default_induction_programme: induction_programme)
+    end
+
+    it "changes the programme choice on the school cohort" do
+      service.call(school_cohort: school_cohort, programme_choice: programme_choice)
+      expect(school_cohort).to be_full_induction_programme
+    end
+
+    it "creates a new induction programme of the correct type" do
+      expect {
+        service.call(school_cohort: school_cohort, programme_choice: programme_choice)
+      }.to change { InductionProgramme.full_induction_programme.count }.by 1
+    end
+
+    it "changes the default induction programme programme choice on the school cohort" do
+      service.call(school_cohort: school_cohort, programme_choice: programme_choice)
+      expect(school_cohort.default_induction_programme).to be_full_induction_programme
+    end
+
+    it "enrols any participants into the new programme" do
+      service.call(school_cohort: school_cohort, programme_choice: programme_choice)
+      expect(induction_programme.induction_records.active.count).to eq 0
+      expect(school_cohort.default_induction_programme.induction_records.active.count).to eq 2
+    end
+
+    context "when existing programme is a partnered FIP" do
+      let(:partnership) { create(:partnership, school: school_cohort.school, cohort: school_cohort.cohort) }
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort, partnership: partnership) }
+      let(:programme_choice) { "core_induction_programme" }
+
+      it "raises an error" do
+        expect {
+          service.call(school_cohort: school_cohort, programme_choice: programme_choice)
+        }.to raise_error ArgumentError
+      end
+    end
+  end
+end

--- a/spec/services/induction/change_core_induction_programme_spec.rb
+++ b/spec/services/induction/change_core_induction_programme_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::ChangeCoreInductionProgramme do
+  describe "#call" do
+    let(:school_cohort) { create(:school_cohort) }
+    let(:core_induction_programme) { create(:core_induction_programme, name: "Super provider") }
+    let(:core_induction_programme_2) { create(:core_induction_programme, name: "Mega provider") }
+    let(:induction_programme) { create(:induction_programme, :cip, school_cohort: school_cohort, core_induction_programme: core_induction_programme) }
+    let(:ect_profile) { create(:ect_participant_profile, school_cohort: school_cohort) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort: school_cohort) }
+
+    subject(:service) { described_class }
+
+    before do
+      Induction::Enrol.call(induction_programme: induction_programme,
+                            participant_profile: mentor_profile,
+                            start_date: 6.months.ago)
+
+      Induction::Enrol.call(induction_programme: induction_programme,
+                            participant_profile: ect_profile,
+                            start_date: 6.months.ago,
+                            mentor_profile: mentor_profile)
+
+      school_cohort.update!(default_induction_programme: induction_programme, core_induction_programme: core_induction_programme)
+    end
+
+    it "adds a new induction programme" do
+      expect {
+        service.call(school_cohort: school_cohort,
+                     core_induction_programme: core_induction_programme_2)
+      }.to change { InductionProgramme.count }.by 1
+    end
+
+    it "sets the new programme as the default for the school cohort" do
+      service.call(school_cohort: school_cohort,
+                   core_induction_programme: core_induction_programme_2)
+
+      expect(school_cohort.default_induction_programme).to eq school_cohort.induction_programmes.order(created_at: :desc).first
+    end
+
+    it "sets the core_induction_programme on the new programme" do
+      service.call(school_cohort: school_cohort,
+                   core_induction_programme: core_induction_programme_2)
+
+      expect(school_cohort.default_induction_programme.core_induction_programme).to eq core_induction_programme_2
+    end
+
+    it "migrates the participants to the new programme" do
+      service.call(school_cohort: school_cohort,
+                   core_induction_programme: core_induction_programme_2)
+
+      expect(school_cohort.default_induction_programme.induction_records).to match_array [ect_profile.current_induction_record, mentor_profile.current_induction_record]
+    end
+
+    context "when the default programme does not have a core_induction_programme" do
+      let(:induction_programme) { create(:induction_programme, :cip, school_cohort: school_cohort, core_induction_programme: nil) }
+
+      it "does not create a new induction_programme" do
+        expect {
+          service.call(school_cohort: school_cohort,
+                       core_induction_programme: core_induction_programme_2)
+        }.not_to change { InductionProgramme.count }
+      end
+
+      it "sets the core_induction_programme on the existing programme" do
+        service.call(school_cohort: school_cohort,
+                     core_induction_programme: core_induction_programme_2)
+
+        expect(induction_programme.core_induction_programme).to eq core_induction_programme_2
+      end
+
+      it "does not change the default induction programme for the school cohort" do
+        service.call(school_cohort: school_cohort,
+                     core_induction_programme: core_induction_programme_2)
+
+        expect(school_cohort.default_induction_programme).to eq induction_programme
+      end
+    end
+
+    context "when the default induction programme is not a CIP" do
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort) }
+
+      it "does not create a new induction_programme" do
+        expect {
+          service.call(school_cohort: school_cohort,
+                       core_induction_programme: core_induction_programme_2)
+        }.not_to change { InductionProgramme.count }
+      end
+
+      it "does not set the core_induction_programme on the existing programme" do
+        service.call(school_cohort: school_cohort,
+                     core_induction_programme: core_induction_programme_2)
+
+        expect(induction_programme.core_induction_programme).to be_nil
+      end
+
+      it "does not change the default induction programme for the school cohort" do
+        service.call(school_cohort: school_cohort,
+                     core_induction_programme: core_induction_programme_2)
+
+        expect(school_cohort.default_induction_programme).to eq induction_programme
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-776)

Changing the induction programme choice via the admin UI was not:
* setting up a new `InductionProgramme`
* making it the default programme for the school cohort
* migrating participants from the previous programme to the new one

This PR adds a couple of services to replace the existing method.

### Changes proposed in this pull request

### Guidance to review

