### PR TITLE
CPDLP-1383 Relocate validations and update tests

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -26,7 +26,7 @@ class InductionRecord < ApplicationRecord
 
   validates :start_date, presence: true
 
-  validate :resume
+  validate :cannot_resume_from_withdrawn
 
   enum induction_status: {
     active: "active",
@@ -92,7 +92,7 @@ class InductionRecord < ApplicationRecord
     leaving_induction_status? && end_date.present? && end_date < Time.zone.now
   end
 
-  def resume
+  def cannot_resume_from_withdrawn
     errors.add(:base, I18n.t(:invalid_resume)) if training_status_changed?(from: "withdrawn", to: "active")
     errors.add(:base, I18n.t(:invalid_resume)) if training_status_changed?(from: "withdrawn", to: "deferred")
   end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -26,6 +26,8 @@ class InductionRecord < ApplicationRecord
 
   validates :start_date, presence: true
 
+  validate :resume
+
   enum induction_status: {
     active: "active",
     withdrawn: "withdrawn",
@@ -88,5 +90,10 @@ class InductionRecord < ApplicationRecord
 
   def transferred?
     leaving_induction_status? && end_date.present? && end_date < Time.zone.now
+  end
+
+  def resume
+    errors.add(:base, I18n.t(:invalid_resume)) if training_status_changed?(from: "withdrawn", to: "active")
+    errors.add(:base, I18n.t(:invalid_resume)) if training_status_changed?(from: "withdrawn", to: "deferred")
   end
 end

--- a/app/models/participant_profile_state.rb
+++ b/app/models/participant_profile_state.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class ParticipantProfileState < ApplicationRecord
-  # TODO: Add an active profile state to all ECF participants to avoid 'resume' actions with no profile states
-  validate :activation, if: -> { active? }
-  validate :withdrawal, if: -> { withdrawn? }
-  validate :deferral,   if: -> { deferred? }
-
   belongs_to :participant_profile
   belongs_to :cpd_lead_provider, optional: true
 
@@ -16,30 +11,4 @@ class ParticipantProfileState < ApplicationRecord
   }
 
   scope :most_recent, -> { order("created_at desc").limit(1) }
-
-private
-
-  def withdrawal
-    return unless current_state
-
-    errors.add(:base, I18n.t(:invalid_withdrawal)) if current_state.withdrawn?
-  end
-
-  def activation
-    return unless current_state
-
-    errors.add(:base, I18n.t(:already_active)) if current_state.active?
-    errors.add(:base, I18n.t(:invalid_resume)) if current_state.withdrawn?
-  end
-
-  def deferral
-    return unless current_state
-
-    errors.add(:base, I18n.t(:invalid_withdrawal)) if current_state.withdrawn?
-    errors.add(:base, I18n.t(:invalid_deferral)) if current_state.deferred?
-  end
-
-  def current_state
-    participant_profile.participant_profile_state
-  end
 end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -31,7 +31,7 @@ module EarlyCareerTeachers
                     }.merge(ect_attributes))
                   end
 
-        ParticipantProfileState.create!(participant_profile: profile)
+        ParticipantProfileState.create!(participant_profile: profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
         if school_cohort.default_induction_programme.present?
           Induction::Enrol.call(participant_profile: profile,
                                 induction_programme: school_cohort.default_induction_programme,

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -3,6 +3,8 @@
 class Induction::Enrol < BaseService
   def call
     ActiveRecord::Base.transaction do
+      record_active_profile_participant_state!
+
       participant_profile.induction_records.create!(
         induction_programme:,
         start_date:,
@@ -13,9 +15,6 @@ class Induction::Enrol < BaseService
         mentor_profile:,
         school_transfer:,
       )
-      # TODO: here would be a convenient place to reactivate a withdrawn / deferred profile
-      # However this needs some checking/work by the LP team
-      # reactivate_profile! unless participant_profile.active_training_status?
     end
   end
 
@@ -48,9 +47,9 @@ private
     participant_profile.schedule.milestones.first.start_date
   end
 
-  def reactivate_profile!
+  def record_active_profile_participant_state!
     ParticipantProfileState.create!(participant_profile:,
                                     state: ParticipantProfileState.states[:active],
-                                    cpd_lead_provider: induction_programme.lead_provider&.cpd_lead_provider)
+                                    cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
   end
 end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -26,7 +26,7 @@ module Mentors
           participant_identity: Identity::Create.call(user:),
         }.merge(mentor_attributes))
 
-        ParticipantProfileState.create!(participant_profile: mentor_profile)
+        ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
 
         if school_cohort.default_induction_programme.present?
           Induction::Enrol.call(participant_profile: mentor_profile,

--- a/app/services/participants/defer/validate_and_change_state.rb
+++ b/app/services/participants/defer/validate_and_change_state.rb
@@ -10,6 +10,8 @@ module Participants
         attr_accessor :reason
 
         validates :reason, inclusion: { in: reasons }
+        validate :not_already_withdrawn
+        validate :not_already_deferred
       end
 
       def perform_action!
@@ -21,6 +23,22 @@ module Participants
         end
 
         user_profile
+      end
+
+      def not_already_withdrawn
+        if user_profile.ecf?
+          errors.add(:induction_record, I18n.t(:invalid_withdrawal)) if relevant_induction_record&.training_status_withdrawn?
+        elsif user_profile&.training_status_withdrawn?
+          errors.add(:participant_profile, I18n.t(:invalid_withdrawal))
+        end
+      end
+
+      def not_already_deferred
+        if user_profile.ecf?
+          errors.add(:induction_record, I18n.t(:invalid_deferral)) if relevant_induction_record&.training_status_deferred?
+        elsif user_profile&.training_status_deferred?
+          errors.add(:participant_profile, I18n.t(:invalid_deferral))
+        end
       end
     end
   end

--- a/app/services/participants/resume/validate_and_change_state.rb
+++ b/app/services/participants/resume/validate_and_change_state.rb
@@ -3,6 +3,14 @@
 module Participants
   module Resume
     module ValidateAndChangeState
+      extend ActiveSupport::Concern
+      include ActiveModel::Validations
+
+      included do
+        validate :not_already_active
+        validate :not_already_withdrawn
+      end
+
       def perform_action!
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:active], cpd_lead_provider:)
@@ -11,6 +19,22 @@ module Participants
         end
 
         user_profile
+      end
+
+      def not_already_active
+        if user_profile.ecf?
+          errors.add(:induction_record, I18n.t(:already_active)) if relevant_induction_record&.training_status_active?
+        elsif user_profile&.training_status_active?
+          errors.add(:participant_profile, I18n.t(:already_active))
+        end
+      end
+
+      def not_already_withdrawn
+        if user_profile.ecf?
+          errors.add(:induction_record, I18n.t(:invalid_resume)) if relevant_induction_record&.training_status_withdrawn?
+        elsif user_profile&.training_status_withdrawn?
+          errors.add(:participant_profile, I18n.t(:invalid_resume))
+        end
       end
     end
   end

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -10,6 +10,7 @@ module Participants
         attr_accessor :reason
 
         validates :reason, inclusion: { in: reasons }
+        validate :not_already_withdrawn
       end
 
       def perform_action!
@@ -26,6 +27,14 @@ module Participants
         end
 
         user_profile
+      end
+
+      def not_already_withdrawn
+        if user_profile.ecf?
+          errors.add(:induction_record, I18n.t(:invalid_withdrawal)) if relevant_induction_record&.training_status_withdrawn?
+        elsif user_profile&.training_status_withdrawn?
+          errors.add(:participant_profile, I18n.t(:invalid_withdrawal))
+        end
       end
     end
   end

--- a/spec/docs/v1/participants_ecf_spec.rb
+++ b/spec/docs/v1/participants_ecf_spec.rb
@@ -110,7 +110,8 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                   "#/components/schemas/ECFParticipantResumeRequest",
                   "#/components/schemas/ECFParticipantResumeResponse",
                   "ECF Participant" do
-    let(:participant) { mentor_profile }
+    let(:participant) { deferred_mentor_profile }
+    let!(:mentor_induction_record_deferred) { create(:induction_record, induction_programme:, participant_profile: deferred_mentor_profile, training_status: "deferred") }
     let(:attributes) { { course_identifier: "ecf-mentor" } }
   end
 

--- a/spec/docs/v1/participants_spec.rb
+++ b/spec/docs/v1/participants_spec.rb
@@ -30,7 +30,8 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
                   "#/components/schemas/ECFParticipantResumeRequest",
                   "#/components/schemas/ECFParticipantResponse",
                   "ECF Participant" do
-    let(:participant) { mentor_profile }
+    let(:participant) { deferred_mentor_profile }
+    let!(:mentor_induction_record_deferred) { create(:induction_record, induction_programme:, participant_profile: deferred_mentor_profile, training_status: "deferred") }
     let(:attributes) { { course_identifier: "ecf-mentor" } }
   end
 

--- a/spec/docs/v2/participants_ecf_spec.rb
+++ b/spec/docs/v2/participants_ecf_spec.rb
@@ -110,7 +110,8 @@ describe "API", type: :request, swagger_doc: "v2/api_spec.json" do
                   "#/components/schemas/ECFParticipantResumeRequest",
                   "#/components/schemas/ECFParticipantResumeResponse",
                   "ECF Participant" do
-    let(:participant) { mentor_profile }
+    let(:participant) { deferred_mentor_profile }
+    let!(:mentor_induction_record_deferred) { create(:induction_record, induction_programme:, participant_profile: deferred_mentor_profile, training_status: "deferred") }
     let(:attributes) { { course_identifier: "ecf-mentor" } }
   end
 

--- a/spec/docs/v2/participants_spec.rb
+++ b/spec/docs/v2/participants_spec.rb
@@ -30,7 +30,8 @@ describe "API", type: :request, swagger_doc: "v2/api_spec.json" do
                   "#/components/schemas/ECFParticipantResumeRequest",
                   "#/components/schemas/ECFParticipantResponse",
                   "ECF Participant" do
-    let(:participant) { mentor_profile }
+    let(:participant) { deferred_mentor_profile }
+    let!(:mentor_induction_record_deferred) { create(:induction_record, induction_programme:, participant_profile: deferred_mentor_profile, training_status: "deferred") }
     let(:attributes) { { course_identifier: "ecf-mentor" } }
   end
 

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -110,4 +110,34 @@ RSpec.describe InductionRecord, type: :model do
       end
     end
   end
+
+  describe "withdrawal" do
+    let(:participant_profile) { create :ect_participant_profile }
+    let(:lead_provider) { create(:lead_provider) }
+    let(:partnership) { create(:partnership, lead_provider:) }
+    let(:induction_programme) { create(:induction_programme, partnership:) }
+    let(:induction_record) { create(:induction_record, induction_programme:, participant_profile:) }
+
+    let(:update_training_status_to_active) do
+      induction_record.update!(training_status: "active")
+    end
+
+    let(:update_training_status_to_deferred) do
+      induction_record.update!(training_status: "deferred")
+    end
+
+    before do
+      induction_record.update!(training_status: "withdrawn")
+    end
+
+    it "returns an error if the training_status change is from withdrawn to active" do
+      expect { update_training_status_to_active }
+        .to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Cannot resume a withdrawn participant")
+    end
+
+    it "returns an error if the training_status change is from withdrawn to deferred" do
+      expect { update_training_status_to_deferred }
+        .to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Cannot resume a withdrawn participant")
+    end
+  end
 end

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe "Participants API", type: :request do
 
         it "returns users in a consistent order" do
           users = User.all
-          users.first.participant_profiles.first.induction_records.first.update!(created_at: 1.day.ago)
-          users.last.participant_profiles.first.induction_records.first.update!(created_at: 2.days.ago)
+          users.first.participant_profiles.each { |pp| pp.induction_records.first.update!(created_at: 1.day.ago) }
+          users.last.participant_profiles.each { |pp| pp.induction_records.first.update!(created_at: 2.days.ago) }
 
           get "/api/v1/participants/ecf"
           expect(parsed_response["data"][0]["id"]).to eq User.last.id

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
 
         it "returns users in a consistent order" do
           users = User.all
-          users.first.participant_profiles.first.induction_records.first.update!(created_at: 1.day.ago)
-          users.last.participant_profiles.first.induction_records.first.update!(created_at: 2.days.ago)
+          users.first.participant_profiles.each { |pp| pp.induction_records.first.update!(created_at: 1.day.ago) }
+          users.last.participant_profiles.each { |pp| pp.induction_records.first.update!(created_at: 2.days.ago) }
 
           get "/api/v1/participants"
           expect(parsed_response["data"][0]["id"]).to eq User.last.id

--- a/spec/requests/api/v1/test_ecf_participants_spec.rb
+++ b/spec/requests/api/v1/test_ecf_participants_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "Participants API", type: :request do
             )
           end
 
-          it "does not return the partipant" do
+          it "does not return the participant" do
             get "/api/v1/participants/ecf"
 
             expect(parsed_response["data"].size).to be_zero

--- a/spec/services/induction/enrol_spec.rb
+++ b/spec/services/induction/enrol_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Induction::Enrol do
       expect { service.call(participant_profile:, induction_programme:) }.to change { induction_programme.induction_records.count }.by 1
     end
 
+    it "creates a participant_profile_state" do
+      expect { subject.call(participant_profile:, induction_programme:) }.to change { ParticipantProfileState.count }.by(1)
+    end
+
     context "without optional params" do
       let(:induction_record) do
         service.call(participant_profile:, induction_programme:)

--- a/spec/services/participants/defer/early_career_teacher_spec.rb
+++ b/spec/services/participants/defer/early_career_teacher_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Participants::Defer::EarlyCareerTeacher do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/defer/early_career_teacher_spec.rb
+++ b/spec/services/participants/defer/early_career_teacher_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Participants::Defer::EarlyCareerTeacher do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/defer/mentor_spec.rb
+++ b/spec/services/participants/defer/mentor_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Participants::Defer::Mentor do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/defer/mentor_spec.rb
+++ b/spec/services/participants/defer/mentor_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Participants::Defer::Mentor do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/defer/npq_spec.rb
+++ b/spec/services/participants/defer/npq_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Participants::Defer::NPQ do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/defer/npq_spec.rb
+++ b/spec/services/participants/defer/npq_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Participants::Defer::NPQ do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Participants::Resume::Mentor do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Participants::Resume::Mentor do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/resume/npq_spec.rb
+++ b/spec/services/participants/resume/npq_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Participants::Resume::NPQ do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/resume/npq_spec.rb
+++ b/spec/services/participants/resume/npq_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Participants::Resume::NPQ do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Participants::Withdraw::Mentor do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Participants::Withdraw::Mentor do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/services/participants/withdraw/npq_spec.rb
+++ b/spec/services/participants/withdraw/npq_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Participants::Withdraw::NPQ do
         ).call # must be different instance from subject
       end
 
-      it "creates a ParticipantProfileState" do
-        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
 

--- a/spec/services/participants/withdraw/npq_spec.rb
+++ b/spec/services/participants/withdraw/npq_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Participants::Withdraw::NPQ do
         ).call # must be different instance from subject
       end
 
-      it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid).and not_change { profile.reload.training_status }
+      it "creates a ParticipantProfileState" do
+        expect { subject.call }.to change { ParticipantProfileState.count }.by(1)
       end
     end
 

--- a/spec/shared/context/lead_provider_profiles_and_courses.rb
+++ b/spec/shared/context/lead_provider_profiles_and_courses.rb
@@ -12,6 +12,8 @@ RSpec.shared_context "lead provider profiles and courses" do
   let(:ecf_lead_provider) { cpd_lead_provider.lead_provider }
   let!(:ect_profile) { create(:ect_participant_profile, schedule: default_schedule) }
   let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort: ect_profile.school_cohort, schedule: default_schedule) }
+  let!(:deferred_mentor_profile) { create(:mentor_participant_profile, school_cohort: ect_profile.school_cohort, schedule: default_schedule) }
+
   let(:induction_coordinator_profile) { create(:induction_coordinator_profile) }
   let(:delivery_partner) { create(:delivery_partner) }
   let!(:school_cohort) { create(:school_cohort, school: ect_profile.school, cohort: ect_profile.cohort) }

--- a/spec/support/shared_examples/participant_actions_defer_support.rb
+++ b/spec/support/shared_examples/participant_actions_defer_support.rb
@@ -11,17 +11,17 @@ RSpec.shared_examples "JSON Participant Deferral endpoint" do |serialiser_type|
     expect(parsed_response.dig("data", "type")).to eq(serialiser_type)
   end
 
-  it "returns an error when the participant is already withdrawn" do
+  it "does not return an error when the participant is already withdrawn" do
     put withdrawal_url, params: withdrawal_params
     put url, params: params
 
-    expect(response).not_to be_successful
+    expect(response).to be_successful
   end
 
-  it "returns an error when the participant is already deferred" do
+  it "does not return an error when the participant is already deferred" do
     2.times { put url, params: }
 
-    expect(response).not_to be_successful
+    expect(response).to be_successful
   end
 end
 

--- a/spec/support/shared_examples/participant_actions_defer_support.rb
+++ b/spec/support/shared_examples/participant_actions_defer_support.rb
@@ -11,17 +11,17 @@ RSpec.shared_examples "JSON Participant Deferral endpoint" do |serialiser_type|
     expect(parsed_response.dig("data", "type")).to eq(serialiser_type)
   end
 
-  it "does not return an error when the participant is already withdrawn" do
+  it "returns an error when the participant is already withdrawn" do
     put withdrawal_url, params: withdrawal_params
     put url, params: params
 
-    expect(response).to be_successful
+    expect(response).not_to be_successful
   end
 
-  it "does not return an error when the participant is already deferred" do
+  it "returns an error when the participant is already deferred" do
     2.times { put url, params: }
 
-    expect(response).to be_successful
+    expect(response).not_to be_successful
   end
 end
 

--- a/spec/support/shared_examples/participant_actions_resume_support.rb
+++ b/spec/support/shared_examples/participant_actions_resume_support.rb
@@ -11,17 +11,17 @@ RSpec.shared_examples "JSON Participant Resume endpoint" do |serialiser_type|
     expect(parsed_response.dig("data", "type")).to eq(serialiser_type)
   end
 
-  it "does not return an error when the participant is already active" do
+  it "returns an error when the participant is already active" do
     2.times { put url, params: }
 
-    expect(response).to be_successful
+    expect(response).not_to be_successful
   end
 
-  it "does not return an error when the participant is already withdrawn" do
+  it "returns an error when the participant is already withdrawn" do
     put withdrawal_url, params: withdrawal_params
     put url, params: params
 
-    expect(response).to be_successful
+    expect(response).not_to be_successful
   end
 end
 

--- a/spec/support/shared_examples/participant_actions_resume_support.rb
+++ b/spec/support/shared_examples/participant_actions_resume_support.rb
@@ -11,17 +11,17 @@ RSpec.shared_examples "JSON Participant Resume endpoint" do |serialiser_type|
     expect(parsed_response.dig("data", "type")).to eq(serialiser_type)
   end
 
-  it "returns an error when the participant is already active" do
+  it "does not return an error when the participant is already active" do
     2.times { put url, params: }
 
-    expect(response).not_to be_successful
+    expect(response).to be_successful
   end
 
-  it "returns an error when the participant is withdrawn" do
+  it "does not return an error when the participant is already withdrawn" do
     put withdrawal_url, params: withdrawal_params
     put url, params: params
 
-    expect(response).not_to be_successful
+    expect(response).to be_successful
   end
 end
 

--- a/spec/support/shared_examples/participant_actions_withdraw_support.rb
+++ b/spec/support/shared_examples/participant_actions_withdraw_support.rb
@@ -3,10 +3,10 @@
 RSpec.shared_examples "a participant withdraw action endpoint" do
   let(:parsed_response) { JSON.parse(response.body) }
 
-  it "returns an error when the participant is already withdrawn" do
+  it "does not return an error when the participant is already withdrawn" do
     2.times { put url, params: }
 
-    expect(response).not_to be_successful
+    expect(response).to be_successful
   end
 
   context "with an invalid request" do

--- a/spec/support/shared_examples/participant_actions_withdraw_support.rb
+++ b/spec/support/shared_examples/participant_actions_withdraw_support.rb
@@ -3,10 +3,10 @@
 RSpec.shared_examples "a participant withdraw action endpoint" do
   let(:parsed_response) { JSON.parse(response.body) }
 
-  it "does not return an error when the participant is already withdrawn" do
+  it "returns an error when the participant is already withdrawn" do
     2.times { put url, params: }
 
-    expect(response).to be_successful
+    expect(response).not_to be_successful
   end
 
   context "with an invalid request" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1383

### Changes proposed in this pull request

If we are starting to record state changes from more than one LP from within the app, rather than a single LP through the api, we cannot keep the validations on participant_profile_states as they are:

e.g. If a participant is in an active state but is transferred to a new school (prior to being withdrawn), if we want to record the new active state, we should not receive a validation error

e.g. If a participant is in a withdrawn state, but is transferred to a new school, an active state following a withdrawn state would cause a validation error

### Guidance to review

Requirement of ticket: Current functionality remains the same, this means:

1) API users should still receive error messages if they: a) try to activate a withdrawn ppt, b) try to defer a withdrawn ppt
2)API users should still receive error messages if they a) resume an already active ppt, if they b) defer a deferred ppt c) withdraw an already withdrawn ppt

2) Also: in app activation of a withdrawn ppt is prevented



