### PR TITLE
[CPDLP-1385] funding treats ASO and EHCO as the same course

### DIFF
--- a/app/models/npq_course.rb
+++ b/app/models/npq_course.rb
@@ -21,4 +21,15 @@ class NPQCourse < ApplicationRecord
       raise ArgumentError, "Invalid course identifier"
     end
   end
+
+  def rebranded_alternative_courses
+    case identifier
+    when "npq-additional-support-offer"
+      [self, NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer")]
+    when "npq-early-headship-coaching-offer"
+      [self, NPQCourse.find_by(identifier: "npq-additional-support-offer")]
+    else
+      [self]
+    end
+  end
 end

--- a/app/services/npq/funding_eligibility.rb
+++ b/app/services/npq/funding_eligibility.rb
@@ -21,6 +21,10 @@ module NPQ
       @npq_course ||= NPQCourse.find_by!(identifier: npq_course_identifier)
     end
 
+    def all_npq_courses
+      npq_course.rebranded_alternative_courses
+    end
+
     def users
       User.where(teacher_profile: teacher_profiles)
     end
@@ -32,7 +36,7 @@ module NPQ
     def previously_funded?
       users.flat_map.any? do |user|
         user.npq_applications
-        .where(npq_course: npq_course)
+        .where(npq_course: all_npq_courses)
         .where(eligible_for_funding: true)
         .accepted
         .any?

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -42,6 +42,31 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
       end
     end
 
+    context "when previously funded ASO and applying for EHCO" do
+      let(:trn) { application.teacher_reference_number }
+      let(:npq_course) { create(:npq_course, identifier: "npq-additional-support-offer") }
+      let(:application) do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          teacher_reference_number_verified: true,
+          npq_course: npq_course,
+        )
+      end
+
+      let!(:ehco_npq_course) { create(:npq_course, identifier: "npq-early-headship-coaching-offer") }
+
+      before do
+        NPQ::Accept.new(npq_application: application).call
+      end
+
+      subject { described_class.new(trn: trn, npq_course_identifier: "npq-early-headship-coaching-offer") }
+
+      it "returns truthy" do
+        expect(subject.call[:previously_funded]).to be_truthy
+      end
+    end
+
     context "when previously funded with multiple teacher profiles" do
       let(:trn) { application.teacher_reference_number }
       let(:application) do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1385
- ASO and EHCO are the same course
- EHCO is merely rebranded ASO

### Changes proposed in this pull request

- When checking funding make sure if user had funded ASO and now applying for ECHO treat them as the same course

### Guidance to review

- A similar thing will have to be done for the lead provider api side as it does not use the same service class but i might switch it to see it we can one point in the code to handle this