### PR TITLE
[Bugfix] Prevent schools appearing twice in admin view

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -11,6 +11,7 @@ module Admin
       @query = params[:query]
 
       @pagy, @schools = pagy(policy_scope(School)
+                               .distinct
                                .includes(:induction_coordinators, :local_authority)
                                .ransack(induction_coordinators_email_or_urn_or_name_cont: @query)
                                .result

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe "Admin::Schools", type: :request do
         get "/admin/schools", params: { query: "mary" }
         expect(assigns(:schools)).to match_array [included_school]
       end
+
+      context "when there is more than one induction coordinator" do
+        before do
+          create(:user, :induction_coordinator, email: "john@schools.org", schools: [included_school])
+          create(:user, :induction_coordinator, email: "mary@schools.org", schools: [included_school])
+        end
+
+        it "only returns the school once" do
+          get "/admin/schools", params: { query: "090120" }
+          expect(assigns(:schools)).to match_array [included_school]
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

Sometimes a school has more than one SIT registered (perhaps as the result of a school merger) and this results in a cartesian product and the school appearing more than once in the list.
This PR just adds a `distinct` clause to the query to prevent this from appearing.


### Changes proposed in this pull request

### Guidance to review

