### PR TITLE
[Bugfix] Prevent showing relationship providers on dashboard

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -95,11 +95,11 @@ class School < ApplicationRecord
   end
 
   def lead_provider(year)
-    partnerships.unchallenged.joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
+    partnerships.unchallenged.where(relationship: false).joins(%i[lead_provider cohort]).find_by(cohorts: { start_year: year })&.lead_provider
   end
 
   def delivery_partner_for(year)
-    partnerships.unchallenged.joins(%i[delivery_partner cohort]).find_by(cohorts: { start_year: year })&.delivery_partner
+    partnerships.unchallenged.where(relationship: false).joins(%i[delivery_partner cohort]).find_by(cohorts: { start_year: year })&.delivery_partner
   end
 
   def participants_for(cohort)

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -59,11 +59,11 @@ class SchoolCohort < ApplicationRecord
   end
 
   def lead_provider
-    default_induction_programme&.lead_provider || school.lead_provider(cohort.start_year)
+    school.lead_provider(cohort.start_year)
   end
 
   def delivery_partner
-    default_induction_programme&.delivery_partner || school.delivery_partner_for(cohort.start_year)
+    school.delivery_partner_for(cohort.start_year)
   end
 
   def school_chose_cip?

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -59,11 +59,11 @@ class SchoolCohort < ApplicationRecord
   end
 
   def lead_provider
-    school.lead_provider(cohort.start_year)
+    default_induction_programme&.lead_provider || school.lead_provider(cohort.start_year)
   end
 
   def delivery_partner
-    school.delivery_partner_for(cohort.start_year)
+    default_induction_programme&.delivery_partner || school.delivery_partner_for(cohort.start_year)
   end
 
   def school_chose_cip?

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -24,24 +24,28 @@ module ChooseProgrammeSteps
     given_there_is_a_school_that_has_chosen_fip_for_2021
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
     @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
-    create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+    @partnership = create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+    @induction_programme.update!(partnership: @partnership)
+    @lead_provider_user = create(:user)
+    @lead_provider.users << @lead_provider_user
   end
 
   def given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
     given_there_is_a_school_that_has_chosen_fip_for_2021
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
     @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
-    create(:partnership, :challenged, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+    @partnership = create(:partnership, :challenged, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+    @induction_programme.update!(partnership: @partnership)
+    @lead_provider_user = create(:user)
+    @lead_provider.users << @lead_provider_user
   end
 
   def given_there_is_a_school_that_has_chosen_fip_for_2021
     @cohort = @cohort_2022 = create(:cohort, start_year: 2021)
     @school = create(:school, name: "Fip School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
-    @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort)
+    @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort, partnership: nil)
     @school_cohort.update!(default_induction_programme: @induction_programme)
-    @lead_provider_user = create(:user)
-    @school_cohort.default_induction_programme.partnership.lead_provider.users << @lead_provider_user
   end
 
   # Then steps

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -9,7 +9,7 @@ module ManageTrainingSteps
     @cohort = create(:cohort, start_year: 2021)
     @school = create(:school, name: "Fip School")
     @school_cohort = create(:school_cohort, school: @school, cohort: @cohort, induction_programme_choice: "full_induction_programme")
-    @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort)
+    @induction_programme = create(:induction_programme, :fip, school_cohort: @school_cohort, partnership: nil)
     @school_cohort.update!(default_induction_programme: @induction_programme)
   end
 
@@ -17,14 +17,16 @@ module ManageTrainingSteps
     given_there_is_a_school_that_has_chosen_fip_for_2021
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
     @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
-    create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+    @partnership = create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 2.weeks.ago)
+    @induction_programme.update!(partnership: @partnership)
   end
 
   def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered_but_challenged
     given_there_is_a_school_that_has_chosen_fip_for_2021
     @lead_provider = create(:lead_provider, name: "Big Provider Ltd")
     @delivery_partner = create(:delivery_partner, name: "Amazing Delivery Team")
-    create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 1.week.from_now, challenged_at: 1.day.ago, challenge_reason: "mistake")
+    @partnership = create(:partnership, school: @school, lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort: @cohort, challenge_deadline: 1.week.from_now, challenged_at: 1.day.ago, challenge_reason: "mistake")
+    @induction_programme.update!(partnership: @partnership)
   end
 
   def given_there_is_a_school_that_has_chosen_cip_for_2021

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -114,6 +114,21 @@ RSpec.describe SchoolCohort, type: :model do
       end
     end
 
+    context "when FIP is chosen and there are relationship partnerships" do
+      let(:lead_provider) { create(:lead_provider, name: "Super Smashing Great Provider") }
+      let(:delivery_partner) { create(:delivery_partner, name: "Wunderbar Partner") }
+
+      before do
+        Induction::CreateRelationship.call(school_cohort: school_cohort,
+                                           lead_provider: lead_provider,
+                                           delivery_partner: delivery_partner)
+      end
+
+      it "does not return the relationship provider" do
+        expect(school_cohort.lead_provider).to be_nil
+      end
+    end
+
     context "when the school has chosen CIP for the cohort" do
       let(:cip) { create(:core_induction_programme) }
 
@@ -146,6 +161,21 @@ RSpec.describe SchoolCohort, type: :model do
 
       it "returns the delivery partner" do
         expect(school_cohort.delivery_partner).to eq(delivery_partner)
+      end
+    end
+
+    context "when FIP is chosen and there are relationship partnerships" do
+      let(:lead_provider) { create(:lead_provider, name: "Super Smashing Great Provider") }
+      let(:delivery_partner) { create(:delivery_partner, name: "Wunderbar Partner") }
+
+      before do
+        Induction::CreateRelationship.call(school_cohort: school_cohort,
+                                           lead_provider: lead_provider,
+                                           delivery_partner: delivery_partner)
+      end
+
+      it "does not return the relationship delivery partner" do
+        expect(school_cohort.delivery_partner).to be_nil
       end
     end
 


### PR DESCRIPTION
### Context

Now that we have the ability to create `Partnership`s to represent "relationships" (for participants that have transferred and are doing a different induction programme) these are being surfaced instead of the actual `Partnership` providers in the UI.  This PR ensures we only select active partnerships that are not relationships `where(relationship: false)` when retrieving lead provider and delivery partners for the school cohort.

### Changes proposed in this pull request

### Guidance to review

