### PR TITLE
Make calculator read cached uplifts

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -49,7 +49,9 @@ class ParticipantDeclaration < ApplicationRecord
   scope :retained, -> { where(declaration_type: %w[retained-1 retained-2 retained-3 retained-4]).order(declaration_date: "desc").unique_id }
   scope :completed, -> { for_declaration("completed").order(declaration_date: "desc").unique_id }
 
-  scope :uplift, -> { where(participant_profile_id: ParticipantProfile.uplift.select(:id)) }
+  scope :sparsity, -> { where(sparsity_uplift: true) }
+  scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
+  scope :uplift, -> { sparsity.or(pupil_premium) }
 
   scope :ect, -> { where(participant_profile_id: ParticipantProfile::ECT.select(:id)) }
   scope :mentor, -> { where(participant_profile_id: ParticipantProfile::Mentor.select(:id)) }

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -41,10 +41,6 @@ class ParticipantProfile < ApplicationRecord
 
   scope :npqs, -> { where(type: NPQ.name) }
 
-  scope :sparsity, -> { where(sparsity_uplift: true) }
-  scope :pupil_premium, -> { where(pupil_premium_uplift: true) }
-  scope :uplift, -> { sparsity.or(pupil_premium) }
-
   attr_reader :participant_type
 
   class_attribute :validation_steps

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -27,15 +27,21 @@ FactoryBot.define do
     end
 
     trait :sparsity_uplift do
-      uplift { :sparsity_uplift }
+      sparsity_uplift { true }
+    end
+
+    trait :without_uplift do
+      sparsity_uplift { false }
+      pupil_premium_uplift { false }
     end
 
     trait :pupil_premium_uplift do
-      uplift { :pupil_premium_uplift }
+      pupil_premium_uplift { true }
     end
 
     trait :uplift_flags do
-      uplift { :uplift_flags }
+      sparsity_uplift { true }
+      pupil_premium_uplift { true }
     end
 
     trait :submitted do

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
       before do
         declaration = create(
-        :ect_participant_declaration, :without_uplift,
+          :ect_participant_declaration, :without_uplift,
           cpd_lead_provider:,
           state: "eligible",
           participant_profile: profile

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Finance::ECF::StatementCalculator do
         :ect_participant_declaration, :without_uplift,
           cpd_lead_provider:,
           state: "eligible",
-          participant_profile: profile,
+          participant_profile: profile
         )
 
         Finance::StatementLineItem.create!(
@@ -232,7 +232,7 @@ RSpec.describe Finance::ECF::StatementCalculator do
           :ect_participant_declaration, :pupil_premium_uplift,
           cpd_lead_provider:,
           state: "eligible",
-          participant_profile: profile,
+          participant_profile: profile
         )
       end
 

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Finance::ECF::StatementCalculator do
 
       before do
         declaration = create(
-          :ect_participant_declaration,
+        :ect_participant_declaration, :without_uplift,
           cpd_lead_provider:,
           state: "eligible",
           participant_profile: profile,
@@ -226,10 +226,10 @@ RSpec.describe Finance::ECF::StatementCalculator do
     end
 
     context "when uplift is applicable" do
-      let(:profile) { create(:ect_participant_profile, :uplift_flags) }
+      let(:profile) { create(:ect_participant_profile) }
       let(:declaration) do
         create(
-          :ect_participant_declaration,
+          :ect_participant_declaration, :pupil_premium_uplift,
           cpd_lead_provider:,
           state: "eligible",
           participant_profile: profile,


### PR DESCRIPTION
### Context

- Ticket: Second part of [CPDLP-1084](https://dfedigital.atlassian.net/browse/CPDLP-1084)

### Changes proposed in this pull request
Instead of reading uplifts from profile, calculator now reads cached values from participant declaration

### Guidance to review

