### PR TITLE
Ruby 3.1 Rubocop fix

### DIFF
--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe SchoolCohort, type: :model do
       let(:delivery_partner) { create(:delivery_partner, name: "Wunderbar Partner") }
 
       before do
-        Induction::CreateRelationship.call(school_cohort: school_cohort,
-                                           lead_provider: lead_provider,
-                                           delivery_partner: delivery_partner)
+        Induction::CreateRelationship.call(school_cohort:,
+                                           lead_provider:,
+                                           delivery_partner:)
       end
 
       it "does not return the relationship provider" do
@@ -169,9 +169,9 @@ RSpec.describe SchoolCohort, type: :model do
       let(:delivery_partner) { create(:delivery_partner, name: "Wunderbar Partner") }
 
       before do
-        Induction::CreateRelationship.call(school_cohort: school_cohort,
-                                           lead_provider: lead_provider,
-                                           delivery_partner: delivery_partner)
+        Induction::CreateRelationship.call(school_cohort:,
+                                           lead_provider:,
+                                           delivery_partner:)
       end
 
       it "does not return the relationship delivery partner" do


### PR DESCRIPTION
### Context

- Ticket: related to CST-153

### Guidance to review

Rubocop is raising new lint issues now that Ruby 3.1 is used.
The PR contains the fixes suggested.
