### PR TITLE
Add nil safety to full name on form.

### DIFF
--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name.titleize %></h1>
+    <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name&.titleize %></h1>
 
     <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at a different school</p>
 

--- a/app/views/schools/add_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/cannot_find_their_details.html.erb
@@ -1,4 +1,4 @@
-<% title = "We cannot find #{add_participant_form.full_name.titleize}" %>
+<% title = "We cannot find #{add_participant_form.full_name&.titleize}" %>
 
 <% content_for :title, title %>
 
@@ -6,17 +6,17 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">We cannot find <%= add_participant_form.full_name.titleize %>’s record</h1>
+        <h1 class="govuk-heading-xl">We cannot find <%= add_participant_form.full_name&.titleize %>’s record</h1>
 
         <p class="govuk-body">Check the information you’ve entered is correct.</p>
-        <p class="govuk-body">We need to find <%= add_participant_form.full_name.titleize %> in the Teaching Regulation Agency records to make sure they’re eligible for this funded programme.</p>
+        <p class="govuk-body">We need to find <%= add_participant_form.full_name&.titleize %> in the Teaching Regulation Agency records to make sure they’re eligible for this funded programme.</p>
 
         <%= govuk_summary_list do |summary_list| %>
             <% summary_list.row do |row| %>
                 <% row.key { "Name" } %>
-                <% row.value { add_participant_form.full_name.titleize } %>
+                <% row.value { add_participant_form.full_name&.titleize } %>
                 <% row.action(text: "Change",
                     visually_hidden_text: "name",
                     href: url_for( { step: :name } )) %>
@@ -40,7 +40,7 @@
         <% end %>
 
         <h3 class="govuk-heading-s">If this information is correct.</h3>
-        <p class="govuk-body">You can still continue to register <%= add_participant_form.full_name.titleize %>. We'll contact them to check their information.</p>
+        <p class="govuk-body">You can still continue to register <%= add_participant_form.full_name&.titleize %>. We'll contact them to check their information.</p>
 
         <%= govuk_button_link_to "Confirm and continue", step_schools_add_participants_path(step: :email)  %>
 

--- a/app/views/schools/add_participants/confirm.html.erb
+++ b/app/views/schools/add_participants/confirm.html.erb
@@ -11,7 +11,7 @@
      <%= govuk_summary_list do |summary_list| %>
        <% summary_list.row do |row| %>
          <% row.key { "Name" } %>
-         <% row.value { add_participant_form.full_name.titleize } %>
+         <% row.value { add_participant_form.full_name&.titleize } %>
          <% unless add_participant_form.type == :self %>
            <% unless add_participant_form.dqt_record %>
              <% row.action text: "Change",

--- a/app/views/schools/add_participants/do_you_know_teachers_trn.html.erb
+++ b/app/views/schools/add_participants/do_you_know_teachers_trn.html.erb
@@ -1,4 +1,4 @@
-<% title = "Do you know #{add_participant_form.full_name.titleize }’s teacher reference number (TRN)?" %>
+<% title = "Do you know #{add_participant_form.full_name&.titleize }’s teacher reference number (TRN)?" %>
 
 <% content_for :title, title %>
 
@@ -15,7 +15,7 @@
             inline: true,
             legend: { text: title, tag: 'h1', size: 'xl' } do %>
             <p class="govuk-body">We need this to confirm they’re eligible for this programme. Adding it now will help us do this more quickly.</p>
-            <p class="govuk-body">If you do not know it, we’ll ask <%= add_participant_form.full_name.titleize %> to tell us instead.</p>
+            <p class="govuk-body">If you do not know it, we’ll ask <%= add_participant_form.full_name&.titleize %> to tell us instead.</p>
 
             <%= f.govuk_radio_button :do_you_know_teachers_trn, :true, label: { text: "Yes" } %>
             <%= f.govuk_radio_button :do_you_know_teachers_trn, :false, label: { text: "No" } %>

--- a/app/views/schools/add_participants/dob.html.erb
+++ b/app/views/schools/add_participants/dob.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{add_participant_form.full_name.titleize }’s date of birth?" %>
+<% title = "What’s #{add_participant_form.full_name&.titleize }’s date of birth?" %>
 
 <% content_for :title, title %>
 
@@ -6,9 +6,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        
+
         <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
         <%= f.govuk_error_summary %>
             <%= f.govuk_date_field :date_of_birth,

--- a/app/views/schools/add_participants/eligibility_confirmation/_exempt_from_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_exempt_from_induction.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_panel title_text: "#{profile.user.full_name.titleize} does not need to serve statutory induction for early career teachers", text: nil, classes: "govuk-!-margin-bottom-8" %>
+<%= govuk_panel title_text: "#{profile.user.full_name&.titleize} does not need to serve statutory induction for early career teachers", text: nil, classes: "govuk-!-margin-bottom-8" %>
 
 <p>Their Teaching Regulation Agency record shows that they do not need to complete a statutory induction, or take part in ECF-based training.</p>
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_ineligible.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_ineligible.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m"><%= profile.user.full_name.titleize %> eligible for the early career teacher training programme</h2>
+<h2 class="govuk-heading-m"><%= profile.user.full_name&.titleize %> eligible for the early career teacher training programme</h2>
 
 <h2 class="govuk-heading-m">Why?</h2>
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_manual_check_needed.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_manual_check_needed.html.erb
@@ -1,5 +1,5 @@
 <p>We’re checking this person’s details with the Teaching Regulation Agency.</p>
 
-<p>We may need to contact <%= profile.user.full_name.titleize %> for more information to complete their registration.</p>
+<p>We may need to contact <%= profile.user.full_name&.titleize %> for more information to complete their registration.</p>
 
-<p>We’ll pass <%= profile.user.full_name.titleize %>’s details to your training provider.</p>
+<p>We’ll pass <%= profile.user.full_name&.titleize %>’s details to your training provider.</p>

--- a/app/views/schools/add_participants/eligibility_confirmation/_no_qts_reason.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_no_qts_reason.html.erb
@@ -1,2 +1,2 @@
-<p><%= profile.user.full_name.titleize %> does not have qualified teacher status (QTS) yet. They need this to be eligible for funded traning.</p>
+<p><%= profile.user.full_name&.titleize %> does not have qualified teacher status (QTS) yet. They need this to be eligible for funded traning.</p>
 <p>We’ll keep checking their status and notify you if something changes.</p>

--- a/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body"><%= profile.user.full_name.titleize %> is not eligible for the early career teacher training programme</p>
+<p class="govuk-body"><%= profile.user.full_name&.titleize %> is not eligible for the early career teacher training programme</p>
 
 <h2 class="govuk-heading-m">Why?</h2>
 <p class="govuk-body">Our records show they started or completed their statutory induction before 1 September 2021. Teachers are only eligible for the new 2-year funded training if they started their induction after that date.</p>

--- a/app/views/schools/add_participants/start_date.html.erb
+++ b/app/views/schools/add_participants/start_date.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{add_participant_form.full_name.titleize}’s induction start date?" %>
+<% title = "What’s #{add_participant_form.full_name&.titleize}’s induction start date?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/add_participants/transfer.html.erb
+++ b/app/views/schools/add_participants/transfer.html.erb
@@ -1,4 +1,4 @@
-<% title = "Is #{add_participant_form.full_name.titleize} transferring from another school?" %>
+<% title = "Is #{add_participant_form.full_name&.titleize} transferring from another school?" %>
 
 <% content_for :title, title %>
 
@@ -8,11 +8,11 @@
     <div class="govuk-grid-column-two-thirds">
 
         <span class="govuk-caption-xl"><%= @school.name %></span>
-      
+
         <%= form_for add_participant_form, url: { action: :transfer, step: :transfer }, method: :put do |f| %>
         <%= f.govuk_error_summary %>
             <%= f.govuk_radio_buttons_fieldset :transfer,
-                inline: true,        
+                inline: true,
                 legend: { text: title, tag: 'h1', size: 'xl' } do %>
 
                 <%= f.govuk_radio_button :transfer, :true, label: { text: "Yes" } %>

--- a/app/views/schools/add_participants/trn.html.erb
+++ b/app/views/schools/add_participants/trn.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{add_participant_form.full_name.titleize}’s teacher reference number (TRN)?" %>
+<% title = "What’s #{add_participant_form.full_name&.titleize}’s teacher reference number (TRN)?" %>
 
 <% content_for :title, title %>
 
@@ -6,9 +6,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        
+
         <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
         <%= f.govuk_error_summary %>
             <%= f.govuk_text_field :trn,


### PR DESCRIPTION
This was causing an error in [sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3280306034/?project=5748989) likely caused by the user manually entering the url and there being no name in the form.
