### PR TITLE
Use induction records instead of participant profile

### DIFF
--- a/app/components/schools/participants/remove_from_cohort_component.html.erb
+++ b/app/components/schools/participants/remove_from_cohort_component.html.erb
@@ -1,5 +1,5 @@
 <% if manual_removal_possible? %>
-<%= govuk_link_to "Remove #{name} from this cohort", schools_participant_remove_path(school_id: profile.school, cohort_id: profile.cohort, participant_id: profile) %>
+<%= govuk_link_to "Remove #{name} from this cohort", schools_participant_remove_path(school_id: induction_record.school, cohort_id: induction_record.school_cohort.cohort, participant_id: induction_record.participant_profile) %>
 <% elsif fip? %>
   <% if lead_provider %>
     Contact <%= lead_provider.name %> if you want to remove <%= name %> from this cohort.

--- a/app/components/schools/participants/remove_from_cohort_component.rb
+++ b/app/components/schools/participants/remove_from_cohort_component.rb
@@ -3,33 +3,33 @@
 module Schools
   module Participants
     class RemoveFromCohortComponent < BaseComponent
-      def initialize(profile:, current_user:)
-        @profile = profile
+      def initialize(induction_record:, current_user:)
+        @induction_record = induction_record
         @current_user = current_user
       end
 
     private
 
-      attr_reader :current_user, :profile
+      attr_reader :current_user, :induction_record
 
       def manual_removal_possible?
-        ParticipantProfile::ECFPolicy.new(current_user, profile).withdraw_record?
+        ParticipantProfile::ECFPolicy.new(current_user, induction_record.participant_profile).withdraw_record?
       end
 
       def fip?
-        profile.school_cohort.full_induction_programme?
+        induction_record.enrolled_in_fip?
       end
 
       def cip?
-        profile.school_cohort.core_induction_programme?
+        induction_record.enrolled_in_cip?
       end
 
       def name
-        profile.user.full_name
+        induction_record.user.full_name
       end
 
       def lead_provider
-        profile.school_cohort.lead_provider
+        induction_record.induction_programme.lead_provider
       end
     end
   end

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -113,9 +113,9 @@
     </dl>
   
 
-<% unless @profile.training_status_withdrawn? %>
-  <p class="govuk-body"><%= render Schools::Participants::RemoveFromCohortComponent.new(profile: @profile, current_user: current_user) %></p>
+<% unless @induction_record.training_status_withdrawn? %>
+  <p class="govuk-body"><%= render Schools::Participants::RemoveFromCohortComponent.new(induction_record: @induction_record, current_user: current_user) %></p>
 <% end %>
 
-</div>
+    </div>
 </div>

--- a/spec/components/schools/participants/remove_from_cohort_component_spec.rb
+++ b/spec/components/schools/participants/remove_from_cohort_component_spec.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe Schools::Participants::RemoveFromCohortComponent, type: :view_component do
-  let(:school_cohort) { create :school_cohort }
+  let(:school_cohort) { create(:school_cohort, :fip) }
+  let(:induction_programme) { create(:induction_programme, :fip, school_cohort:, partnership: nil) }
   let(:profile) { create :ecf_participant_profile, school_cohort: }
-  component { described_class.new(profile:) }
+  # component { described_class.new(profile:) }
   let(:induction_coordinator) { create(:user, :induction_coordinator, schools: [school_cohort.school]) }
-  component { described_class.new(current_user: induction_coordinator, profile:) }
+  let(:induction_record) { Induction::Enrol.call(participant_profile: profile, induction_programme:) }
+  component { described_class.new(current_user: induction_coordinator, induction_record:) }
+
+  before do
+    school_cohort.update!(default_induction_programme: induction_programme)
+  end
 
   context "when the validation hasn’t started yet" do
     it "displays the link to remove the participant" do
-      expect(rendered).to have_link(href: schools_participant_remove_path(profile.school, profile.cohort, profile))
+      expect(rendered).to have_link(href: schools_participant_remove_path(induction_record.school, school_cohort.cohort, profile))
     end
   end
 
@@ -17,7 +23,7 @@ RSpec.describe Schools::Participants::RemoveFromCohortComponent, type: :view_com
     let!(:validation_data) { create :ecf_participant_validation_data, participant_profile: profile }
 
     it "does not display the removal link" do
-      expect(rendered).not_to have_link(href: schools_participant_remove_path(profile.school, profile.cohort, profile))
+      expect(rendered).not_to have_link(href: schools_participant_remove_path(induction_record.school, school_cohort.cohort, profile))
     end
 
     context "when the cohort undertakes the full induction programme" do
@@ -28,11 +34,12 @@ RSpec.describe Schools::Participants::RemoveFromCohortComponent, type: :view_com
       it { is_expected.to have_content "contact your training provider to remove them" }
 
       it "displays the lead_provider name" do
-        Partnership.create!(cohort: school_cohort.cohort,
-                            lead_provider:,
-                            school: school_cohort.school,
-                            delivery_partner:)
+        partnership = Partnership.create!(cohort: school_cohort.cohort,
+                                          lead_provider:,
+                                          school: school_cohort.school,
+                                          delivery_partner:)
 
+        induction_programme.update!(partnership:)
         expect(rendered).to have_content(lead_provider.name)
       end
     end
@@ -41,6 +48,7 @@ RSpec.describe Schools::Participants::RemoveFromCohortComponent, type: :view_com
       stub_component MailToSupportComponent
 
       let(:school_cohort) { create :school_cohort, :cip }
+      let(:induction_programme) { create :induction_programme, :cip, school_cohort: }
 
       it { is_expected.to have_rendered_component(MailToSupportComponent).with("contact us") }
     end


### PR DESCRIPTION
### Context

Fix an issue where the RemoveFromCohortComponent was wrongly using the programme choice and partnership information held on the school/school_cohort associated with the participant profile not from the induction_programme the participant is enrolled in, which was causing the wrong message to be displayed for transferring/transferred participants.

### Changes proposed in this pull request

### Guidance to review

