### PR TITLE
Don't load transfer and multi-cohort seeds by default

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,7 @@ load Rails.root.join(*seed_path, "initial_seed.rb").to_s
 load Rails.root.join(*seed_path, "schedules.rb").to_s
 
 if %w[development deployed_development test sandbox].include?(Rails.env)
-  %w[test_data dummy_structures transfer_seeds multi_cohort_seeds].each do |seed|
+  %w[test_data dummy_structures].each do |seed|
     load Rails.root.join(*seed_path, "#{seed}.rb").to_s
   end
 end


### PR DESCRIPTION
### Context

If you require these seeds you can add them to your PR/review app.
