### PR TITLE
Use Ruby 3.1.2 for E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
         uses: ruby/setup-ruby@v1.106.0
         with:
           bundler-cache: true
-          ruby-version: '2.7.5'
+          ruby-version: '3.1.2'
 
       - name: Set up Node
         uses: actions/setup-node@v2.5.1


### PR DESCRIPTION
### Context

We recently upgraded Ruby to `3.1.2` but forgot to update the E2E test environment so that it also uses that version

