### PR TITLE
[Bugfix] Use InductionRecord.training_status when available for status tag component

### DIFF
--- a/app/components/admin/participants/table_row.html.erb
+++ b/app/components/admin/participants/table_row.html.erb
@@ -23,6 +23,6 @@
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Validation status</span>
-    <%= render ParticipantStatusTagComponent.new(profile: profile) %>
+    <%= render ParticipantStatusTagComponent.new(profile: profile, induction_record: induction_record) %>
   </td>
 </tr>

--- a/app/components/admin/participants/table_row.rb
+++ b/app/components/admin/participants/table_row.rb
@@ -15,7 +15,7 @@ module Admin
 
     private
 
-      attr_reader :profile, :induction_record
+      attr_reader :profile
 
       def induction_record
         return unless @profile.ect? || @profile.mentor?

--- a/app/components/admin/participants/table_row.rb
+++ b/app/components/admin/participants/table_row.rb
@@ -7,6 +7,7 @@ module Admin
 
       def initialize(profile:)
         @profile = profile
+        @induction_record = get_induction_record
       end
 
       def school_urn
@@ -15,9 +16,17 @@ module Admin
 
     private
 
-      attr_reader :profile
+      attr_reader :profile, :induction_record
 
-      delegate :school, to: :profile
+      def get_induction_record
+        return unless @profile.ect? || @profile.mentor?
+
+        @profile.current_induction_record || @profile.induction_records.latest
+      end
+
+      def school
+        induction_record&.school || profile.school
+      end
     end
   end
 end

--- a/app/components/admin/participants/table_row.rb
+++ b/app/components/admin/participants/table_row.rb
@@ -7,7 +7,6 @@ module Admin
 
       def initialize(profile:)
         @profile = profile
-        @induction_record = get_induction_record
       end
 
       def school_urn
@@ -18,10 +17,10 @@ module Admin
 
       attr_reader :profile, :induction_record
 
-      def get_induction_record
+      def induction_record
         return unless @profile.ect? || @profile.mentor?
 
-        @profile.current_induction_record || @profile.induction_records.latest
+        @induction_record ||= @profile.current_induction_record || @profile.induction_records.latest
       end
 
       def school

--- a/app/views/admin/schools/participants/index.html.erb
+++ b/app/views/admin/schools/participants/index.html.erb
@@ -22,7 +22,7 @@
           <td class="govuk-table__cell"><%= t participant.participant_type, scope: "schools.participants.type" %></td>
           <td class="govuk-table__cell"><%= participant.cohort&.start_year %></td>
           <td class="govuk-table__cell">
-            <%= render ParticipantStatusTagComponent.new(profile: participant) %>
+            <%= render ParticipantStatusTagComponent.new(profile: participant, induction_record: participant.induction_records.for_school(@school).latest) %>
           </td>
         </tr>
       <% end %>

--- a/spec/components/admin/participants/table_row_spec.rb
+++ b/spec/components/admin/participants/table_row_spec.rb
@@ -16,5 +16,15 @@ RSpec.describe Admin::Participants::TableRow, type: :view_component do
 
     it { is_expected.to have_content school.name }
     it { is_expected.to have_content school.urn }
+
+    context "when the profile has induction records" do
+      let(:school_cohort) { create(:school_cohort, :fip) }
+      let(:school_2) { school_cohort.school }
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
+      let!(:induction_record) { Induction::Enrol.call(participant_profile:, induction_programme:) }
+
+      it { is_expected.to have_content school_2.name }
+      it { is_expected.to have_content school_2.urn }
+    end
   end
 end

--- a/spec/components/participant_status_tag_component_spec.rb
+++ b/spec/components/participant_status_tag_component_spec.rb
@@ -109,10 +109,19 @@ RSpec.describe ParticipantStatusTagComponent, type: :view_component do
     end
 
     context "has a withdrawn status" do
-      let(:school_cohort) { create(:school_cohort, :cip) }
-      let(:participant_profile) {  create(:ect_participant_profile, training_status: "withdrawn", school_cohort:, user: create(:user, email: "ray.clemence@example.com")) }
+      let(:school_cohort) { create(:school_cohort, :fip) }
+      let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort:, user: create(:user, email: "ray.clemence@example.com")) }
+      let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :eligible, participant_profile:) }
+      let(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
+      let!(:induction_record) { Induction::Enrol.call(participant_profile:, induction_programme:) }
 
       it { is_expected.to have_selector(".govuk-tag.govuk-tag--red", exact_text: "Withdrawn by provider") }
+
+      context "when an active induction record is available" do
+        component { described_class.new(profile: participant_profile, induction_record:) }
+
+        it { is_expected.to have_selector(".govuk-tag.govuk-tag--green", exact_text: "Eligible to start") }
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

The admin ui is inconsistent with the view the SIT sees when a participant has withdrawn training status.  The status tag component uses the `training_status` from the participant profile not the induction record so this PR adds the induction record to the call when available.

### Changes proposed in this pull request

### Guidance to review

