### PR TITLE
[CST-733 ] SIT validates themselves via add journey

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -325,6 +325,10 @@ module Schools
       )
     end
 
+    def display_name
+      type == :self ? "your" : "#{full_name&.titleize}’s"
+    end
+
     def send_added_and_validated_email(profile)
       ParticipantMailer.sit_has_added_and_validated_participant(participant_profile: profile, school_name: school_cohort.school.name).deliver_later
     end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -12,7 +12,7 @@ module Schools
     attribute :existing_participant_profile
 
     step :yourself do
-      next_step :confirm
+      next_step :trn
     end
 
     step :name do
@@ -22,7 +22,9 @@ module Schools
       before_complete { check_records if check_for_dqt_record? }
 
       next_step do
-        if existing_participant_profile.present?
+        if type == :self
+          :trn
+        elsif existing_participant_profile.present?
           :transfer
         elsif dqt_record.present?
           :email
@@ -57,7 +59,9 @@ module Schools
                 length: { within: 5..7 }
       before_complete { check_records if check_for_dqt_record? }
       next_step do
-        if existing_participant_profile.present?
+        if type == :self
+          :dob
+        elsif existing_participant_profile.present?
           :transfer
         elsif dqt_record.present?
           :email
@@ -81,7 +85,9 @@ module Schools
       before_complete { check_records if check_for_dqt_record? }
 
       next_step do
-        if existing_participant_profile.present?
+        if type == :self
+          :confirm
+        elsif existing_participant_profile.present?
           :transfer
         elsif dqt_record.present?
           :email

--- a/app/helpers/sit_validate_participant_helper.rb
+++ b/app/helpers/sit_validate_participant_helper.rb
@@ -40,8 +40,4 @@ module SitValidateParticipantHelper
   def participant_has_no_qts?(profile)
     profile.ecf_participant_eligibility&.no_qts_reason?
   end
-
-  def display_name(form)
-    form.type == :self ? "your" : "#{form.full_name&.titleize}’s"
-  end
 end

--- a/app/helpers/sit_validate_participant_helper.rb
+++ b/app/helpers/sit_validate_participant_helper.rb
@@ -40,4 +40,8 @@ module SitValidateParticipantHelper
   def participant_has_no_qts?(profile)
     profile.ecf_participant_eligibility&.no_qts_reason?
   end
+
+  def display_name(form)
+    form.type == :self ? "your" : "#{form.full_name&.titleize}’s"
+  end
 end

--- a/app/views/schools/add_participants/_ect_or_mentor_details_summary.html.erb
+++ b/app/views/schools/add_participants/_ect_or_mentor_details_summary.html.erb
@@ -1,0 +1,86 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.row do |row| %>
+    <% row.key { "Name" } %>
+    <% row.value { add_participant_form.full_name.titleize } %>
+    <% unless add_participant_form.dqt_record %>
+      <% row.action text: "Change",
+                    visually_hidden_text: "name",
+                    href: url_for({ step: :name }
+                    ) %>
+    <% else %>
+      <% row.action() %>
+    <% end %>
+  <% end %>
+
+  <% if add_participant_form.trn %>
+   <% summary_list.row do |row| %>
+       <% row.key { "TRN" } %>
+       <% row.value { add_participant_form.trn } %>
+       <% unless add_participant_form.dqt_record.present? %>
+         <% row.action(text: "Change",
+                       visually_hidden_text: "TRN",
+                       href: url_for({ step: :trn })) %>
+       <% else %>
+         <% row.action() %>
+       <% end %>
+     <% end %>
+   <% end %>
+
+  <% if add_participant_form.date_of_birth %>
+    <% summary_list.row do |row| %>
+      <% row.key { "Date of birth" } %>
+      <% row.value { add_participant_form.date_of_birth.to_date.to_s(:govuk) } %>
+      <% unless add_participant_form.dqt_record.present? %>
+        <% row.action(text: "Change",
+                      visually_hidden_text: "date of birth",
+                      href: url_for({ step: :dob })) %>
+      <% else %>
+        <% row.action() %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% summary_list.row do |row| %>
+    <% row.key { "Email address" } %>
+    <% row.value { add_participant_form.email } %>
+    <% row.action(text: "Change",
+                 visually_hidden_text: "email address",
+                 href: url_for({ step: :email })) %>
+  <% end %>
+
+  <% if add_participant_form.start_date %>
+    <% summary_list.row do |row| %>
+      <% row.key { "Induction start" } %>
+      <% row.value { add_participant_form.start_date.to_date.to_s(:govuk) } %>
+      <% row.action(text: "Change",
+                    visually_hidden_text: "induction start date",
+                    href: url_for({ step: "start\-date" })) %>
+    <% end %>
+  <% end %>
+
+  <% if add_participant_form.type == :ect %>
+    <% summary_list.row do |row| %>
+      <% row.key { "Mentor" } %>
+      <% row.value { add_participant_form.mentor.present? ? add_participant_form.mentor.full_name : "Add later" } %>
+      <% if add_participant_form.type != :self && add_participant_form.mentor_options.any? %>
+        <% row.action(text: "Change",
+                      visually_hidden_text: "mentor",
+                      href: url_for({ step: "choose\-mentor" })) %>
+      <% else %>
+        <% row.action() %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if @school_cohort.default_induction_programme %>
+    <% summary_list.row do |row| %>
+      <% row.key { "Training with" } %>
+      <% row.value do %>
+        <p class="govuk-body"><%= @school_cohort.default_induction_programme.lead_provider&.name %></p>
+        <p class="govuk-body"><%= @school_cohort.default_induction_programme.delivery_partner&.name %></p>
+      <% end %>
+     <% row.action() %>
+    <% end %>
+  <% end %>
+<% end %>
+

--- a/app/views/schools/add_participants/_sit_confirm_self_details_summary.html.erb
+++ b/app/views/schools/add_participants/_sit_confirm_self_details_summary.html.erb
@@ -1,0 +1,42 @@
+<%= govuk_summary_list do |summary_list| %>
+  <% summary_list.row do |row| %>
+    <% row.key { "Name" } %>
+    <% row.value { add_participant_form.full_name.titleize } %>
+    <% unless add_participant_form.dqt_record %>
+      <% row.action text: "Change",
+                    visually_hidden_text: "name",
+                    href: url_for({ step: :name }
+                    ) %>
+      <% else %>
+        <% row.action() %>
+      <% end %>
+  <% end %>
+
+  <% if add_participant_form.trn %>
+    <% summary_list.row do |row| %>
+      <% row.key { "TRN" } %>
+      <% row.value { add_participant_form.trn } %>
+      <% unless add_participant_form.dqt_record.present? %>
+        <% row.action(text: "Change",
+                      visually_hidden_text: "TRN",
+                      href: url_for({ step: :trn })) %>
+      <% else %>
+        <% row.action() %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if add_participant_form.date_of_birth %>
+    <% summary_list.row do |row| %>
+      <% row.key { "Date of birth" } %>
+      <% row.value { add_participant_form.date_of_birth.to_date.to_s(:govuk) } %>
+      <% unless add_participant_form.dqt_record.present? %>
+        <% row.action(text: "Change",
+                      visually_hidden_text: "date of birth",
+                      href: url_for({ step: :dob })) %>
+      <% else %>
+        <% row.action() %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/schools/add_participants/complete.html.erb
+++ b/app/views/schools/add_participants/complete.html.erb
@@ -5,10 +5,6 @@
 
         <% if participant_profile.user == current_user %>
             <%= govuk_panel title_text: "You’ve been added as a mentor", text: nil, classes: "govuk-!-margin-bottom-7" %>
-            <h2 class="govuk-heading-m">What happens next</h2>
-
-            <p class="govuk-body">We’ll send you an email that explains what information we need from you.</p>
-
         <% elsif exempt_from_induction?(participant_profile) %>
             <%= render partial: 'schools/add_participants/eligibility_confirmation/exempt_from_induction', locals: { profile: participant_profile } %>
         <% else %>

--- a/app/views/schools/add_participants/confirm.html.erb
+++ b/app/views/schools/add_participants/confirm.html.erb
@@ -3,104 +3,16 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: back_link_path) %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">Check your answers</h1>
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl">Check your answers</h1>
 
-     <%= govuk_summary_list do |summary_list| %>
-       <% summary_list.row do |row| %>
-         <% row.key { "Name" } %>
-         <% row.value { add_participant_form.full_name.titleize } %>
-         <% unless add_participant_form.type == :self %>
-           <% unless add_participant_form.dqt_record %>
-             <% row.action text: "Change",
-                           visually_hidden_text: "name",
-                           href: url_for({ step: :name }
-                           ) %>
-            <% else %>
-              <% row.action() %>
-           <% end %>
-         <% end %>
-       <% end %>
-
-       <% if add_participant_form.trn %>
-         <% summary_list.row do |row| %>
-           <% row.key { "TRN" } %>
-           <% row.value { add_participant_form.trn } %>
-           <% unless add_participant_form.dqt_record.present? %>
-             <% row.action(text: "Change",
-                           visually_hidden_text: "TRN",
-                           href: url_for({ step: :trn })) %>
-           <% else %>
-             <% row.action() %>
-           <% end %>
-         <% end %>
-       <% end %>
-
-       <% if add_participant_form.date_of_birth %>
-         <% summary_list.row do |row| %>
-           <% row.key { "Date of birth" } %>
-           <% row.value { add_participant_form.date_of_birth.to_date.to_s(:govuk) } %>
-           <% unless add_participant_form.dqt_record.present? %>
-             <% row.action(text: "Change",
-                           visually_hidden_text: "date of birth",
-                           href: url_for({ step: :dob })) %>
-           <% else %>
-             <% row.action() %>
-           <% end %>
-         <% end %>
-       <% end %>
-
-       <% summary_list.row do |row| %>
-         <% row.key { "Email address" } %>
-         <% row.value { add_participant_form.email } %>
-         <% unless add_participant_form.type == :self %>
-           <% row.action(text: "Change",
-                         visually_hidden_text: "email address",
-                         href: url_for({ step: :email })) %>
-           <% else %>
-             <% row.action() %>
-         <% end %>
-       <% end %>
-
-       <% if add_participant_form.start_date %>
-         <% summary_list.row do |row| %>
-           <% row.key { "Induction start" } %>
-           <% row.value { add_participant_form.start_date.to_date.to_s(:govuk) } %>
-           <% row.action(text: "Change",
-                         visually_hidden_text: "induction start date",
-                         href: url_for({ step: "start\-date" })) %>
-         <% end %>
-       <% end %>
-
-       <% if add_participant_form.type == :ect %>
-         <% summary_list.row do |row| %>
-           <% row.key { "Mentor" } %>
-           <% row.value { add_participant_form.mentor.present? ? add_participant_form.mentor.full_name : "Add later" } %>
-           <% if add_participant_form.type != :self && add_participant_form.mentor_options.any? %>
-             <% row.action(text: "Change",
-                           visually_hidden_text: "mentor",
-                           href: url_for({ step: "choose\-mentor" })) %>
-             <% else %>
-              <% row.action() %>
-           <% end %>
-         <% end %>
-       <% end %>
-
-       <% if @school_cohort.default_induction_programme %>
-         <% summary_list.row do |row| %>
-           <% row.key { "Training with" } %>
-           <% row.value do %>
-              <p class="govuk-body"><%= @school_cohort.default_induction_programme.lead_provider&.name %></p>
-              <p class="govuk-body"><%= @school_cohort.default_induction_programme.delivery_partner&.name %></p>
-            <% end %>
-           <% row.action() %>
-         <% end %>
-       <% end %>
-     <% end %>
-
-
+    <% if add_participant_form.type == :self %>
+      <%= render partial: 'sit_confirm_self_details_summary', locals: { add_participant_form: add_participant_form } %>
+    <% else %>
+      <%= render partial: 'ect_or_mentor_details_summary', locals: { add_participant_form: add_participant_form } %>
+    <% end %>
 
     <%= form_for add_participant_form, url: { action: :complete }, method: :post do |f| %>
       <%= f.govuk_submit "Confirm and add" %>

--- a/app/views/schools/add_participants/dob.html.erb
+++ b/app/views/schools/add_participants/dob.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{add_participant_form.full_name.titleize }’s date of birth?" %>
+<% title = "What’s #{display_name(add_participant_form)} date of birth?" %>
 
 <% content_for :title, title %>
 
@@ -6,9 +6,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        
+
         <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
         <%= f.govuk_error_summary %>
             <%= f.govuk_date_field :date_of_birth,

--- a/app/views/schools/add_participants/dob.html.erb
+++ b/app/views/schools/add_participants/dob.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{display_name(add_participant_form)} date of birth?" %>
+<% title = "What’s #{add_participant_form.display_name} date of birth?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/add_participants/trn.html.erb
+++ b/app/views/schools/add_participants/trn.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{add_participant_form.full_name.titleize}’s teacher reference number (TRN)?" %>
+<% title = "What’s #{display_name(add_participant_form)} teacher reference number (TRN)?" %>
 
 <% content_for :title, title %>
 
@@ -6,9 +6,9 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        
+
         <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
         <%= f.govuk_error_summary %>
             <%= f.govuk_text_field :trn,

--- a/app/views/schools/add_participants/trn.html.erb
+++ b/app/views/schools/add_participants/trn.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{display_name(add_participant_form)} teacher reference number (TRN)?" %>
+<% title = "What’s #{add_participant_form.display_name} teacher reference number (TRN)?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/add_participants/yourself.html.erb
+++ b/app/views/schools/add_participants/yourself.html.erb
@@ -16,6 +16,6 @@
       <li>put safeguards in place so that your role as an ECT’s mentor is kept separate from your role in their assessment</li>
     </ul>
 
-    <%= govuk_button_to "Confirm", { action: :complete } %>
+    <%= govuk_button_link_to "Confirm and continue", step_schools_add_participants_path(step: :trn) %>
   </div>
 </div>

--- a/app/views/schools/add_participants/yourself.html.erb
+++ b/app/views/schools/add_participants/yourself.html.erb
@@ -16,6 +16,6 @@
       <li>put safeguards in place so that your role as an ECT’s mentor is kept separate from your role in their assessment</li>
     </ul>
 
-    <%= govuk_button_link_to "Confirm and continue", step_schools_add_participants_path(step: :trn) %>
+    <%= govuk_button_link_to "Confirm", step_schools_add_participants_path(step: :trn) %>
   </div>
 </div>

--- a/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/happy_path_sit_adds_self_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/happy_path_sit_adds_self_as_mentor_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require_relative "../../training_dashboard/manage_training_steps"
+require_relative "../../../training_dashboard/manage_training_steps"
 
 RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances: "active" }, js: true do
   include ManageTrainingSteps
 
   before do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    set_sit_data
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_have_added_an_ect
     and_i_have_added_a_mentor
@@ -15,7 +16,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     set_dqt_validation_result
   end
 
-  scenario "Induction tutor can add themselves as a mentor" do
+  scenario "Induction tutor can add themselves as a mentor and validates" do
     when_i_click_on_add_your_early_career_teacher_and_mentor_details
     then_i_am_taken_to_roles_page
     when_i_click_on_continue
@@ -33,7 +34,21 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     then_i_am_taken_to_are_you_sure_page
 
     when_i_click_on_confirm
+    then_i_am_taken_to_add_your_trn_page
+    when_i_add_my_trn
+    click_on "Continue"
+
+    then_i_am_taken_to_add_your_dob_page
+    when_i_add_my_date_of_birth
+    click_on "Continue"
+
+    then_i_am_taken_to_check_details_page
+    when_i_click_confirm_and_add
     then_i_am_taken_to_yourself_as_mentor_confirmation_page
+
+    sign_out
+    when_i_sign_back_in
+    then_i_am_taken_to_fip_induction_dashboard
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor confirmation"
   end

--- a/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/unhappy_path_sit_adds_themselves_as_mentor.rb
+++ b/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/unhappy_path_sit_adds_themselves_as_mentor.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../training_dashboard/manage_training_steps"
+
+RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances: "active" }, js: true do
+  include ManageTrainingSteps
+
+  before do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    set_sit_data
+    and_i_am_signed_in_as_an_induction_coordinator
+    and_i_have_added_an_ect
+    and_i_have_added_a_mentor
+    then_i_am_taken_to_fip_induction_dashboard
+    set_dqt_blank_validation_result
+  end
+
+  scenario "Induction tutor can add themselves as a mentor but does not validate" do
+    when_i_click_on_add_your_early_career_teacher_and_mentor_details
+    then_i_am_taken_to_roles_page
+    when_i_click_on_continue
+    then_i_am_taken_to_your_ect_and_mentors_page
+
+    when_i_click_on_add_myself_as_mentor
+    then_i_am_taken_to_are_you_sure_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor check"
+
+    when_i_click_on_check_what_each_role_needs_to_do
+    then_i_am_taken_to_roles_page
+
+    when_i_click_on_back
+    then_i_am_taken_to_are_you_sure_page
+
+    when_i_click_on_confirm
+    then_i_am_taken_to_add_your_trn_page
+    when_i_add_my_trn
+    click_on "Continue"
+
+    then_i_am_taken_to_add_your_dob_page
+    when_i_add_my_date_of_birth
+    click_on "Continue"
+
+    then_i_am_taken_to_check_details_page
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_yourself_as_mentor_confirmation_page
+
+    sign_out
+    when_i_sign_back_in
+    then_i_should_be_asked_to_validate
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor confirmation"
+  end
+end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -467,6 +467,10 @@ module ManageTrainingSteps
     click_on("Sign up")
   end
 
+  def when_i_sign_back_in
+    sign_in_as @induction_coordinator_profile.user
+  end
+
   def when_i_click_on_change_name
     click_on("Change name", visible: false)
   end
@@ -527,8 +531,19 @@ module ManageTrainingSteps
     fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)?", with: @participant_data[:trn]
   end
 
+  def when_i_add_my_trn
+    fill_in "What’s your teacher reference number (TRN)?", with: @sit_data[:trn]
+  end
+
   def when_i_add_a_date_of_birth
     date = @participant_data[:date_of_birth]
+    fill_in "Day", with: date.day
+    fill_in "Month", with: date.month
+    fill_in "Year", with: date.year
+  end
+
+  def when_i_add_my_date_of_birth
+    date = @sit_data[:date_of_birth]
     fill_in "Day", with: date.day
     fill_in "Month", with: date.month
     fill_in "Year", with: date.year
@@ -710,6 +725,15 @@ module ManageTrainingSteps
   def then_i_am_taken_to_add_teachers_trn_page
     expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)?")
     expect(page).to have_text("This unique ID:")
+  end
+
+  def then_i_am_taken_to_add_your_trn_page
+    expect(page).to have_selector("h1", text: "What’s your teacher reference number (TRN)?")
+    expect(page).to have_text("This unique ID:")
+  end
+
+  def then_i_am_taken_to_add_your_dob_page
+    expect(page).to have_selector("h1", text: "What’s your date of birth?")
   end
 
   def then_i_am_taken_to_add_date_of_birth_page
@@ -963,6 +987,10 @@ module ManageTrainingSteps
     expect(page).to have_css(".govuk-tabs__tab", text: "#{cohort} to #{cohort + 1}")
   end
 
+  def then_i_should_be_asked_to_validate
+    expect(page).to have_selector("h1", text: "Have you been given a teacher reference number (TRN)?")
+  end
+
   def then_i_see_the_cohort_tabs
     then_i_see_the_tab_for_the_cohort(2021)
     then_i_see_the_tab_for_the_cohort(2022)
@@ -984,6 +1012,25 @@ module ManageTrainingSteps
       start_term: "summer_2022",
       start_date: Date.new(2022, 9, 1),
     }
+  end
+
+  def set_sit_data
+    @sit_data = {
+      full_name: "Carl Coordinator",
+      trn: "7654321",
+      date_of_birth: Date.new(1981, 1, 22),
+    }
+  end
+
+  def set_sit_dqt_validation_result
+    response = {
+      trn: @sit_data[:trn],
+      full_name: @sit_data[:full_name],
+      nino: nil,
+      dob: @sit_data[:date_of_birth],
+      config: {},
+    }
+    allow_any_instance_of(ParticipantValidationService).to receive(:validate).and_return(response)
   end
 
   def set_updated_participant_data

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -176,6 +176,18 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
     end
   end
 
+  describe "#display_name" do
+    it "returns your" do
+      form.assign_attributes(type: :self)
+      expect(form.display_name).to eql("your")
+    end
+
+    it "returns the name of the participant who's being added" do
+      form.assign_attributes(type: :mentor, full_name: user.full_name)
+      expect(form.display_name).to eql("#{user.full_name.titleize}’s")
+    end
+  end
+
   describe "#save!" do
     before do
       response = {

--- a/spec/helpers/sit_validate_participant_helper_spec.rb
+++ b/spec/helpers/sit_validate_participant_helper_spec.rb
@@ -63,16 +63,4 @@ RSpec.describe SitValidateParticipantHelper, type: :helper do
       expect(helper.participant_has_no_qts?(ect_profile)).to be true
     end
   end
-
-  describe "#display_name" do
-    it "returns your" do
-      form.assign_attributes(type: :self)
-      expect(helper.display_name(form)).to eql("your")
-    end
-
-    it "returns the name of the participant who's being added" do
-      form.assign_attributes(type: :mentor, full_name: ect_profile.user.full_name)
-      expect(helper.display_name(form)).to eql("#{ect_profile.user.full_name.titleize}’s")
-    end
-  end
 end

--- a/spec/helpers/sit_validate_participant_helper_spec.rb
+++ b/spec/helpers/sit_validate_participant_helper_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe SitValidateParticipantHelper, type: :helper do
   let(:school_cohort) { create(:school_cohort) }
   let!(:ect_profile) { create(:ect_participant_profile, :ecf_participant_eligibility) }
   let!(:mentor_profile) { create(:mentor_participant_profile, :secondary_profile, :ecf_participant_eligibility) }
+  let(:user) { create(:user) }
+  let(:induction_coordinator_profile) { create(:induction_coordinator_profile, user:) }
+  let(:form) { Schools::AddParticipantForm.new(current_user_id: user.id) }
 
   describe "#ineligible?" do
     it "returns true when ineligible" do
@@ -58,6 +61,18 @@ RSpec.describe SitValidateParticipantHelper, type: :helper do
     it "returns true exempt from induction" do
       ect_profile.ecf_participant_eligibility.no_qts_reason!
       expect(helper.participant_has_no_qts?(ect_profile)).to be true
+    end
+  end
+
+  describe "#display_name" do
+    it "returns your" do
+      form.assign_attributes(type: :self)
+      expect(helper.display_name(form)).to eql("your")
+    end
+
+    it "returns the name of the participant who's being added" do
+      form.assign_attributes(type: :mentor, full_name: ect_profile.user.full_name)
+      expect(helper.display_name(form)).to eql("#{ect_profile.user.full_name.titleize}’s")
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [733](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-733)

SIT validating themselves as a mentor journey. 

![Screenshot 2022-06-14 at 09 42 30](https://user-images.githubusercontent.com/69353998/173534582-1bceaf0b-db16-4f2f-a29e-281d859b9db4.png)

![Screenshot 2022-06-14 at 09 42 39](https://user-images.githubusercontent.com/69353998/173534595-fce84278-24b7-40e1-8ce9-784b454c03df.png)

![Screenshot 2022-06-14 at 09 42 57](https://user-images.githubusercontent.com/69353998/173534602-d74c0cb8-82f4-4a24-9ff8-59b8597bb632.png)

![Screenshot 2022-06-14 at 09 43 06](https://user-images.githubusercontent.com/69353998/173534608-962dc639-4d6b-4dd3-b7d9-b7f4b26ac107.png)

![Screenshot 2022-06-14 at 09 43 31](https://user-images.githubusercontent.com/69353998/173534629-c21dc58d-ebb6-43dd-8bca-ebdc693448d3.png)


### Changes proposed in this pull request
- TRN and DOB pages for sit adding themselves as a mentor. 

### Guidance to review

**If a SIT attempts to validate themselves but we find no DQT record. we do not let them know this. It will continue to ask for them to update their information with the notification banner at the top of the page or when they log back in to the service** 

This will be iterated on in future work. Brian is aware of the loop and we'll look to improve the flow at a later date. 