### PR TITLE
[Bugfix] Use induction record for training_status checks

### DIFF
--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -16,7 +16,7 @@
         <dd class="govuk-summary-list__value">
           <%= @profile.user.full_name %>
         </dd>
-        <% unless @profile.training_status_withdrawn? %>
+        <% unless @induction_record.training_status_withdrawn? %>
           <dd class="govuk-summary-list__actions">
             <% if @profile.policy_class.new(current_user, @profile).edit_name? %>
               <%= govuk_link_to schools_participant_edit_name_path(participant_id: @profile) do %>
@@ -33,7 +33,7 @@
         <dd class="govuk-summary-list__value">
           <%= @induction_record.preferred_identity.email %>
         </dd>
-        <% unless @profile.training_status_withdrawn? %>
+        <% unless @induction_record.training_status_withdrawn? %>
           <dd class="govuk-summary-list__actions">
             <% if @profile.policy_class.new(current_user, @profile).edit_email? %>
               <%= govuk_link_to schools_participant_edit_email_path(participant_id: @profile) do %>
@@ -50,13 +50,15 @@
         <dd class="govuk-summary-list__value">
           <%= @profile.start_term.humanize %>
         </dd>
-        <dd class="govuk-summary-list__actions">
-          <% if @profile.policy_class.new(current_user, @profile).edit_start_term? %>
-            <%= govuk_link_to schools_participant_edit_start_term_path(participant_id: @profile) do %>
-              Change <span class="govuk-visually-hidden">start term</span>
+        <% unless @induction_record.training_status_withdrawn? %>
+          <dd class="govuk-summary-list__actions">
+            <% if @profile.policy_class.new(current_user, @profile).edit_start_term? %>
+              <%= govuk_link_to schools_participant_edit_start_term_path(participant_id: @profile) do %>
+                Change <span class="govuk-visually-hidden">start term</span>
+              <% end %>
             <% end %>
-          <% end %>
-        </dd>
+          </dd>
+        <% end %>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -78,7 +80,7 @@
         <dd class="govuk-summary-list__actions">
         </dd>
       </div>
-      <% unless @profile.training_status_withdrawn? %>
+      <% unless @induction_record.training_status_withdrawn? %>
         <% if @profile.ect? %>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
@@ -113,7 +115,7 @@
     </dl>
   
 
-<% unless @profile.training_status_withdrawn? %>
+<% unless @induction_record.training_status_withdrawn? %>
   <p class="govuk-body"><%= render Schools::Participants::RemoveFromCohortComponent.new(profile: @profile, current_user: current_user) %></p>
 <% end %>
 


### PR DESCRIPTION
### Context

In the schools dashboard, when viewing a participants details, content to change values is hidden when `participant_profile.training_status_withdrawn?`, however this should be referring to `induction_record.training_status_withdrawn?` now instead (particularly important for transferring participants).

### Changes proposed in this pull request

Updates the checks in the participant details view to use the induction record

### Guidance to review

