### PR TITLE
Update path to bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ COPY --from=assets-precompile /app /app
 COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
 COPY --from=middleman /public/ /app/public/
 
-RUN echo "cd /app && /usr/local/bundle/bin/bundle exec rails c" > /root/.ash_history
+RUN echo "cd /app && /usr/local/bin/bundle exec rails c" > /root/.ash_history
 
 WORKDIR /app
 


### PR DESCRIPTION
### Context

Ruby upgrade changed path to bundle exe that was stored in the shell history file for convenience.  This PR updated the path to use the new one

### Changes proposed in this pull request

### Guidance to review

