### PR TITLE
Inject data files as kwargs into UpdateStagedSchools

### DIFF
--- a/app/jobs/import_gias_data_job.rb
+++ b/app/jobs/import_gias_data_job.rb
@@ -3,6 +3,6 @@
 class ImportGiasDataJob < ApplicationJob
   def perform
     Rails.logger.info "Importing GIAS data..."
-    DataStage::FetchGiasDataFiles.call { |files| DataStage::UpdateStagedSchools.call(files) }
+    DataStage::FetchGiasDataFiles.call { |files| DataStage::UpdateStagedSchools.call(**files) }
   end
 end


### PR DESCRIPTION
### Context

Fixes: https://sentry.io/organizations/dfe-teacher-services/issues/3316490033/?environment=production&project=5748989&query=is%3Aunresolved

`DataStage::FetchGiasDataFiles.call` returns keyword args so we must inject them into the receiver as such.
