### PR TITLE
[CPDLP-1054] Clawback service

### DIFF
--- a/app/models/declaration_state.rb
+++ b/app/models/declaration_state.rb
@@ -14,6 +14,8 @@ class DeclarationState < ApplicationRecord
     paid: "paid",
     voided: "voided",
     ineligible: "ineligible",
+    awaiting_clawback: "awaiting_clawback",
+    clawed_back: "clawed_back",
   }
 
   states.each_key do |key|

--- a/app/models/finance/statement_line_item.rb
+++ b/app/models/finance/statement_line_item.rb
@@ -24,6 +24,7 @@ class Finance::StatementLineItem < ApplicationRecord
   scope :refundable, -> { where(state: REFUNDABLE_STATES) }
 
   validate :validate_single_billable_relationship, on: [:create]
+  validate :validate_single_refundable_relationship, on: [:create]
 
   def billable?
     BILLABLE_STATES.include?(state)
@@ -41,6 +42,15 @@ private
       .billable
       .exists?
       errors.add(:participant_declaration, "is already asscociated to another statement as a billable")
+    end
+  end
+
+  def validate_single_refundable_relationship
+    if refundable? && Finance::StatementLineItem
+      .where(participant_declaration:)
+      .refundable
+      .exists?
+      errors.add(:participant_declaration, "is already asscociated to another statement as a refundable")
     end
   end
 end

--- a/app/services/finance/clawback_declaration.rb
+++ b/app/services/finance/clawback_declaration.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Finance
+  class ClawbackDeclaration
+    include ActiveModel::Validations
+
+    attr_reader :participant_declaration
+
+    validate :validate_not_already_refunded
+    validate :validate_refundable_state
+
+    def initialize(participant_declaration:)
+      @participant_declaration = participant_declaration
+    end
+
+    def call
+      return if invalid?
+
+      ApplicationRecord.transaction do
+        participant_declaration.update!(state: "awaiting_clawback")
+
+        DeclarationStatementAttacher.new(participant_declaration:).call
+      end
+    end
+
+  private
+
+    def validate_not_already_refunded
+      if Finance::StatementLineItem
+        .where(participant_declaration:)
+        .refundable
+        .exists?
+        errors.add(:participant_declaration, "will or has been be refunded")
+      end
+    end
+
+    def validate_refundable_state
+      unless %w[paid].include?(participant_declaration.state)
+        errors.add(:participant_declaration, "must be paid before it can be clawed back")
+      end
+    end
+  end
+end

--- a/app/services/finance/clawback_declaration.rb
+++ b/app/services/finance/clawback_declaration.rb
@@ -17,7 +17,7 @@ module Finance
       return if invalid?
 
       ApplicationRecord.transaction do
-        participant_declaration.update!(state: "awaiting_clawback")
+        DeclarationState.awaiting_clawback!(participant_declaration)
 
         DeclarationStatementAttacher.new(participant_declaration:).call
       end

--- a/app/services/importers/clawbacks.rb
+++ b/app/services/importers/clawbacks.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Consumes a csv of declaration ids
+# Will create a clawback statement line item
+# and attach to relevant statement
+
+module Importers
+  class Clawbacks
+    attr_reader :path_to_csv, :errors
+
+    def initialize(path_to_csv:)
+      @path_to_csv = path_to_csv
+      @errors = []
+    end
+
+    def call
+      check_headers
+
+      rows.each do |row|
+        participant_declaration = ParticipantDeclaration.find_by(id: row["declaration_id"])
+
+        if participant_declaration.nil?
+          errors << "no declaration found with id: #{row['declaration_id']}"
+
+          next
+        end
+
+        service = Finance::ClawbackDeclaration.new(participant_declaration:)
+        service.call
+
+        if service.errors.any?
+          errors << "declaration #{row['declaration_id']} has the following issues: #{service.errors.full_messages.join(', ')}"
+        end
+      end
+    end
+
+  private
+
+    def check_headers
+      unless rows.headers == %w[declaration_id]
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true)
+    end
+  end
+end

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -64,6 +64,14 @@ FactoryBot.define do
       state { "voided" }
     end
 
+    trait :awaiting_clawback do
+      state { "awaiting_clawback" }
+    end
+
+    trait :clawed_back do
+      state { "clawed_back" }
+    end
+
     transient do
       uplift { [] }
     end

--- a/spec/models/finance/statement_line_item_spec.rb
+++ b/spec/models/finance/statement_line_item_spec.rb
@@ -7,22 +7,46 @@ RSpec.describe Finance::StatementLineItem do
   let(:declaration) { create(:ect_participant_declaration, :eligible) }
 
   describe "validations" do
-    let!(:existing_line_item) do
-      described_class.create!(
-        statement:,
-        participant_declaration: declaration,
-        state: declaration.state,
-      )
-    end
-
-    it "cannot be billed to multiple statements" do
-      expect {
-        described_class.create(
+    context "when already billied to a statement" do
+      let!(:existing_line_item) do
+        described_class.create!(
           statement:,
           participant_declaration: declaration,
           state: declaration.state,
         )
-      }.not_to change(Finance::StatementLineItem, :count)
+      end
+
+      it "cannot be billed to multiple statements" do
+        expect {
+          described_class.create(
+            statement:,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        }.not_to change(Finance::StatementLineItem, :count)
+      end
+    end
+
+    context "when already refunded to a statement" do
+      let(:declaration) { create(:ect_participant_declaration, :awaiting_clawback) }
+
+      let!(:existing_line_item) do
+        described_class.create!(
+          statement:,
+          participant_declaration: declaration,
+          state: declaration.state,
+        )
+      end
+
+      it "cannot be refunded to multiple statements" do
+        expect {
+          described_class.create(
+            statement:,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        }.not_to change(Finance::StatementLineItem, :count)
+      end
     end
   end
 end

--- a/spec/services/finance/clawback_declaration_spec.rb
+++ b/spec/services/finance/clawback_declaration_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Finance::ClawbackDeclaration do
       expect { subject.call }.to change { Finance::StatementLineItem.where(state: "awaiting_clawback", participant_declaration:, statement: next_statement).count }.by(1)
     end
 
+    it "create a correct declaration state record" do
+      participant_declaration
+
+      expect {
+        subject.call
+      }.to change { DeclarationState.where(participant_declaration:, state: "awaiting_clawback").count }.by(1)
+    end
+
     context "when declaration already clawed back" do
       before do
         subject.call

--- a/spec/services/finance/clawback_declaration_spec.rb
+++ b/spec/services/finance/clawback_declaration_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::ClawbackDeclaration do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+
+  let(:participant_declaration) { create(:ect_participant_declaration, :paid, cpd_lead_provider:) }
+
+  let!(:next_statement) { create(:ecf_statement, :output_fee, cpd_lead_provider:, deadline_date: 3.months.from_now) }
+
+  subject { described_class.new(participant_declaration:) }
+
+  describe "#call" do
+    it "mutates state of delaration to awaiting_clawback" do
+      expect { subject.call }.to change { participant_declaration.reload.state }.from("paid").to("awaiting_clawback")
+    end
+
+    it "creates correct clawback line item" do
+      expect { subject.call }.to change { Finance::StatementLineItem.where(state: "awaiting_clawback", participant_declaration:, statement: next_statement).count }.by(1)
+    end
+
+    context "when declaration already clawed back" do
+      before do
+        subject.call
+      end
+
+      it "does not create a line item" do
+        expect { subject.call }.to_not change { Finance::StatementLineItem.count }
+      end
+
+      it "attaches an error to the object" do
+        subject.call
+
+        expect(subject.errors[:participant_declaration]).to be_present
+      end
+    end
+
+    %i[ineligible submitted eligible voided payable awaiting_clawback clawed_back].each do |state|
+      context "when declaration cannot be clawed back as #{state}" do
+        let(:participant_declaration) { create(:ect_participant_declaration, state, cpd_lead_provider:) }
+
+        it "does not create a line item" do
+          expect { subject.call }.to_not change { Finance::StatementLineItem.count }
+        end
+
+        it "attaches an error to the object" do
+          subject.call
+
+          expect(subject.errors[:participant_declaration]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/services/finance/declaration_statement_attacher_spec.rb
+++ b/spec/services/finance/declaration_statement_attacher_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe Finance::DeclarationStatementAttacher do
   let(:declaration) { create(:ect_participant_declaration, cpd_lead_provider:) }
   let(:statement) { create(:ecf_statement, output_fee: true, deadline_date: 2.months.from_now) }

--- a/spec/services/importers/clawbacks_spec.rb
+++ b/spec/services/importers/clawbacks_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Importers::Clawbacks do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:path_to_csv) { csv.path }
+  let(:participant_declaration) { create(:ect_participant_declaration) }
+
+  subject { described_class.new(path_to_csv:) }
+
+  describe "#call" do
+    let(:mock_service) { instance_double("Finance::ClawbackDeclaration", call: true, errors: []) }
+
+    context "happy path" do
+      before do
+        csv.write "declaration_id"
+        csv.write "\n"
+        csv.write participant_declaration.id
+        csv.write "\n"
+        csv.close
+      end
+
+      it "delegates to service class" do
+        expect(Finance::ClawbackDeclaration).to receive(:new).with(participant_declaration:).and_return(mock_service)
+
+        subject.call
+
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context "when incorrect headers" do
+      before do
+        csv.write "foo"
+        csv.write "\n"
+        csv.write participant_declaration.id
+        csv.write "\n"
+        csv.close
+      end
+
+      it "throws an error" do
+        expect { subject.call }.to raise_error(NameError)
+      end
+    end
+
+    context "when declaration cannot be found" do
+      before do
+        csv.write "declaration_id"
+        csv.write "\n"
+        csv.write "some_random_id"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "populates errors" do
+        subject.call
+
+        expect(subject.errors).to eql(["no declaration found with id: some_random_id"])
+      end
+    end
+
+    context "when error from service" do
+      let(:participant_declaration) { create(:ect_participant_declaration, :voided) }
+
+      before do
+        csv.write "declaration_id"
+        csv.write "\n"
+        csv.write participant_declaration.id
+        csv.write "\n"
+        csv.close
+      end
+
+      it "does not add line item" do
+        expect { subject.call }.not_to change(Finance::StatementLineItem, :count)
+      end
+
+      it "populates errors" do
+        subject.call
+
+        expect(subject.errors).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1054
- We have a load of declarations ids in spreadsheets that we want to be able to clawback for

### Changes proposed in this pull request

- Adds a service that can process a single clawback for a given participant declaration
- It has been designed so that eventually we can plug this class into the API
- Adds an importer class that can process a CSV of declaration ids so we can bulk process clawbacks from the backend

### Guidance to review

- none