### PR TITLE
[Bugfix] Pass induction_record to participant status tag component

### DIFF
--- a/app/views/admin/participants/_details.html.erb
+++ b/app/views/admin/participants/_details.html.erb
@@ -41,7 +41,7 @@
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Validation status</th>
-      <td class="govuk-table__cell"><%= render ParticipantStatusTagComponent.new(profile: latest_induction_record.participant_profile) %></td>
+      <td class="govuk-table__cell"><%= render ParticipantStatusTagComponent.new(profile: latest_induction_record.participant_profile, induction_record: latest_induction_record) %></td>
       <td class="govuk-table__cell"></td>
     </tr>
     <tr class="govuk-table__row">


### PR DESCRIPTION
### Context

Pass induction record to (recently fixed) participant status tag component to ensure correct training status is displayed to admin on the details tab view for a participant.

### Changes proposed in this pull request

### Guidance to review

