### PR TITLE
[CST-754] Extend login expiry time from 1 hour to 12 hours

### DIFF
--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -22,7 +22,7 @@ module Devise
 
           user = Identity.find_user_by(email:)
 
-          token_expiry = 60.minutes.from_now
+          token_expiry = 12.hours.from_now
           result = user&.update(
             login_token: SecureRandom.hex(10),
             login_token_valid_until: token_expiry,

--- a/spec/cypress/support/step_definitions/database.js
+++ b/spec/cypress/support/step_definitions/database.js
@@ -77,7 +77,7 @@ Given("I am logged in as existing user with {}", (argsStr) => {
   cy.appEval(
     `User.find_by(${argsStrRails}).update(
       login_token: "abcdefghij",
-      login_token_valid_until: 60.minutes.from_now)`
+      login_token_valid_until: 12.hours.from_now)`
   );
   cy.visit(`/users/confirm_sign_in?login_token=abcdefghij`);
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     email { Faker::Internet.unique.safe_email }
     full_name { Faker::Name.name }
     login_token { Faker::Alphanumeric.alpha(number: 10) }
-    login_token_valid_until { 1.hour.from_now }
+    login_token_valid_until { 12.hours.from_now }
 
     trait :admin do
       admin_profile

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -46,7 +46,7 @@ module UserHelper
   def sign_in_as(user)
     token = "test-user-token-#{Time.zone.now.to_f}"
     user.update! login_token: token,
-                 login_token_valid_until: 1.hour.from_now
+                 login_token_valid_until: 12.hours.from_now
 
     visit users_confirm_sign_in_path(login_token: token)
     click_button "Continue"


### PR DESCRIPTION
### Context

- Ticket: [754](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=6239ad1e761efb0069ccde5e&selectedIssue=CST-754)

### Changes proposed in this pull request
Extending the login time for user session. See linked ticket for reasons as to why it's being extended



