### PR TITLE
CPDLP-1440 Allow active state to be recorded

### DIFF
--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -31,7 +31,7 @@ module EarlyCareerTeachers
                     }.merge(ect_attributes))
                   end
 
-        ParticipantProfileState.create!(participant_profile: profile)
+        ParticipantProfileState.create!(participant_profile: profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
         if school_cohort.default_induction_programme.present?
           Induction::Enrol.call(participant_profile: profile,
                                 induction_programme: school_cohort.default_induction_programme,

--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -3,6 +3,8 @@
 class Induction::Enrol < BaseService
   def call
     ActiveRecord::Base.transaction do
+      record_active_profile_participant_state!
+
       participant_profile.induction_records.create!(
         induction_programme:,
         start_date:,
@@ -13,9 +15,6 @@ class Induction::Enrol < BaseService
         mentor_profile:,
         school_transfer:,
       )
-      # TODO: here would be a convenient place to reactivate a withdrawn / deferred profile
-      # However this needs some checking/work by the LP team
-      # reactivate_profile! unless participant_profile.active_training_status?
     end
   end
 
@@ -48,9 +47,9 @@ private
     participant_profile.schedule.milestones.first.start_date
   end
 
-  def reactivate_profile!
+  def record_active_profile_participant_state!
     ParticipantProfileState.create!(participant_profile:,
                                     state: ParticipantProfileState.states[:active],
-                                    cpd_lead_provider: induction_programme.lead_provider&.cpd_lead_provider)
+                                    cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
   end
 end

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -26,7 +26,7 @@ module Mentors
           participant_identity: Identity::Create.call(user:),
         }.merge(mentor_attributes))
 
-        ParticipantProfileState.create!(participant_profile: mentor_profile)
+        ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
 
         if school_cohort.default_induction_programme.present?
           Induction::Enrol.call(participant_profile: mentor_profile,

--- a/spec/services/induction/enrol_spec.rb
+++ b/spec/services/induction/enrol_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Induction::Enrol do
       expect { service.call(participant_profile:, induction_programme:) }.to change { induction_programme.induction_records.count }.by 1
     end
 
+    it "creates a participant_profile_state" do
+      expect { subject.call(participant_profile:, induction_programme:) }.to change { ParticipantProfileState.count }.by(1)
+    end
+
     context "without optional params" do
       let(:induction_record) do
         service.call(participant_profile:, induction_programme:)


### PR DESCRIPTION
### Context

- Ticket: 1440

### Changes proposed in this pull request

CPDLP-1383 removed the validations in PPS, and here it is possible to start recording an active profile state when a ppt transfers

It also adds in the Lead Provider (if it exists, and sometimes it won't when a ppt is created)

### Guidance to review

I would re-run some backfilling on PPSs following this PR

