### PR TITLE
Disable autocomplete in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
 COPY --from=middleman /public/ /app/public/
 
 RUN echo "cd /app && /usr/local/bin/bundle exec rails c" > /root/.ash_history
+RUN echo "IRB.conf[:USE_AUTOCOMPLETE] = false" > /root/.irbrc
 
 WORKDIR /app
 


### PR DESCRIPTION
### Context

- Ticket: n/a
- New ruby IRB changes has introduced autocomplete. This is super slow over the wire therefore should be disabled

### Changes proposed in this pull request

- Disables IRB autocomplete for Docker build

### Guidance to review

- login to box and start rails console
- autocomplete should no longer work