### PR TITLE
[Bug fix]  Stop a SIT from transferring a user who's already enrolled at the school

### DIFF
--- a/app/controllers/schools/transferring_participants_controller.rb
+++ b/app/controllers/schools/transferring_participants_controller.rb
@@ -3,9 +3,10 @@
 module Schools
   class TransferringParticipantsController < ::Schools::BaseController
     before_action :load_joining_participant_form, except: %i[what_we_need]
-    before_action :latest_induction_record, only: %i[email choose_mentor teachers_current_programme schools_current_programme check_answers complete]
     before_action :set_current_steps, except: %i[what_we_need]
     before_action :set_school_cohort
+    before_action :latest_induction_record, only: %i[teacher_start_date email choose_mentor teachers_current_programme schools_current_programme check_answers complete]
+    before_action :already_enrolled_at_school?, only: %i[teacher_start_date email choose_mentor teachers_current_programme schools_current_programme check_answers]
     before_action :validate_request_or_render, except: %i[what_we_need]
 
     skip_after_action :verify_authorized
@@ -287,6 +288,10 @@ module Schools
       @transferring_participant_form.full_name.present? &&
         @transferring_participant_form.trn.present? &&
         @transferring_participant_form.date_of_birth.present?
+    end
+
+    def already_enrolled_at_school?
+      render :already_enrolled_at_school and return if @latest_induction_record.school == @school_cohort.school
     end
 
     def participant_profile

--- a/app/views/schools/transferring_participants/already_enrolled_at_school.html.erb
+++ b/app/views/schools/transferring_participants/already_enrolled_at_school.html.erb
@@ -1,1 +1,16 @@
-<h1>already here</h1>
+<% content_for :title, "You cannot add #{@transferring_participant_form.full_name}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl"> You cannot add <%= @transferring_participant_form.full_name %></h1>
+
+    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at your school</p>
+
+    <p class="govuk-body">Contact us for help to register this person at your school:
+    <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>
+
+    <%= govuk_link_to "View your ECTs and mentors", schools_participants_path, class: "govuk-link govuk-link--no-visited-state" %>
+
+  </div>
+</div>

--- a/app/views/schools/transferring_participants/already_enrolled_at_school.html.erb
+++ b/app/views/schools/transferring_participants/already_enrolled_at_school.html.erb
@@ -1,0 +1,1 @@
+<h1>already here</h1>

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
         given_a_school_has_chosen_fip_for_2021_and_partnered
         and_they_have_already_added_this_ect
         and_i_am_signed_in_as_an_induction_coordinator
+        and_i_have_selected_my_cohort_tab
         when_i_click_to_view_ects_and_mentors
         then_i_am_taken_to_your_ect_and_mentors_page
       end
@@ -48,6 +49,7 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
           given_a_school_has_chosen_fip_for_2021_and_partnered
           and_they_have_already_added_this_ect
           and_i_am_signed_in_as_an_induction_coordinator
+          and_i_have_selected_my_cohort_tab
           when_i_click_to_view_ects_and_mentors
           then_i_am_taken_to_your_ect_and_mentors_page
         end
@@ -57,6 +59,9 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
           then_i_should_be_on_the_who_to_add_page
 
           when_i_select "A new ECT"
+          click_on "Continue"
+          then_i_should_be_on_what_we_need_for_adding_participant_page
+
           click_on "Continue"
           then_i_am_taken_to_add_ect_name_page
 
@@ -155,6 +160,11 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
     expect(page).to have_text("To do this, you need to tell us their")
   end
 
+  def then_i_should_be_on_what_we_need_for_adding_participant_page
+    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_text("You can now choose to enter their teacher reference number ")
+  end
+
   def then_i_am_taken_to_add_ect_name_page
     expect(page).to have_selector("h1", text: "What’s this person’s full name?")
   end
@@ -198,6 +208,10 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
     @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_one)
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
     Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_one)
+  end
+
+  def and_i_have_selected_my_cohort_tab
+    click_on @cohort.description
   end
 
   # data setup

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
   end
 
   def then_i_should_be_on_the_already_enrolled_page
-    expect(page).to have_selector("h1", text: "already here")
+    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at your school")
   end
 
   def then_i_am_should_be_on_are_they_a_transfer_page

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Transferring participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+  context "At transfer journey entry point" do
+    context "Participant is already enrolled at the school" do
+      before do
+        set_participant_data
+        set_dqt_validation_result
+        given_a_school_has_chosen_fip_for_2021_and_partnered
+        and_they_have_already_added_this_ect
+        and_i_am_signed_in_as_an_induction_coordinator
+        when_i_click_to_view_ects_and_mentors
+        then_i_am_taken_to_your_ect_and_mentors_page
+      end
+
+      scenario "Induction tutor is stopped early in the transfer journey" do
+        when_i_click_to_add_an_ect_or_mentor
+        then_i_should_be_on_the_who_to_add_page
+
+        when_i_select_transfer_teacher_option
+        click_on "Continue"
+        then_i_should_be_on_what_we_need_page
+
+        click_on "Continue"
+        then_i_should_be_on_full_name_page
+
+        when_i_update_the_name_with(@participant_data[:full_name])
+        click_on "Continue"
+        then_i_should_be_on_trn_page
+
+        when_i_add_a_valid_trn
+        click_on "Continue"
+        then_i_should_be_on_the_date_of_birth_page
+
+        when_i_add_a_valid_date_of_birth
+        click_on "Continue"
+        then_i_should_be_on_the_already_enrolled_page
+      end
+    end
+
+    context "At add ECT/add Mentor entry point" do
+      context "Participant is already enrolled at the school" do
+        before do
+          set_participant_data
+          set_dqt_validation_result
+          given_a_school_has_chosen_fip_for_2021_and_partnered
+          and_they_have_already_added_this_ect
+          and_i_am_signed_in_as_an_induction_coordinator
+          when_i_click_to_view_ects_and_mentors
+          then_i_am_taken_to_your_ect_and_mentors_page
+        end
+
+        scenario "Adding an ECT switches to transfer journey" do
+          when_i_click_to_add_an_ect_or_mentor
+          then_i_should_be_on_the_who_to_add_page
+
+          when_i_select "A new ECT"
+          click_on "Continue"
+          then_i_am_taken_to_add_ect_name_page
+
+          when_i_update_the_name_with(@participant_data[:full_name])
+          click_on "Continue"
+          then_i_am_taken_to_do_you_know_your_teachers_trn_page
+
+          when_i_select "Yes"
+          click_on "Continue"
+          then_i_should_be_on_trn_page
+
+          when_i_add_the_trn
+          click_on "Continue"
+          then_i_should_be_on_the_date_of_birth_page
+
+          when_i_add_a_valid_date_of_birth
+          click_on "Continue"
+          then_i_am_should_be_on_are_they_a_transfer_page
+
+          when_i_select "Yes"
+          click_on "Continue"
+          then_i_should_be_on_the_already_enrolled_page
+        end
+      end
+    end
+  end
+
+  # given
+
+  def given_a_school_has_chosen_fip_for_2021_and_partnered
+    @cohort = create(:cohort, start_year: 2021)
+    @school_one = create(:school, name: "Fip School 1")
+    create(:school_cohort, school: @school_one, cohort: create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+    @school_cohort_one = create(:school_cohort, school: @school_one, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+    @mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_cohort_one)
+    @induction_programme_one = create(:induction_programme, :fip, school_cohort: @school_cohort_one, partnership: @partnership_one)
+    @school_cohort_one.update!(default_induction_programme: @induction_programme_one)
+    Induction::Enrol.call(participant_profile: @mentor, induction_programme: @induction_programme_one)
+    Mentors::AddToSchool.call(school: @school_one, mentor_profile: @mentor)
+  end
+
+  # when
+
+  def when_i_click_to_view_ects_and_mentors
+    click_on "Manage"
+  end
+
+  def when_i_click_to_add_an_ect_or_mentor
+    click_on "Add an ECT or mentor"
+  end
+
+  def when_i_select_transfer_teacher_option
+    choose("A teacher transferring from another school where they’ve started ECF-based training or mentoring", allow_label_click: true)
+  end
+
+  def when_i_update_the_name_with(name)
+    fill_in "Full_name", with: name
+  end
+
+  def when_i_add_a_valid_trn
+    fill_in "Teacher reference number (TRN)", with: "1001000"
+  end
+
+  def when_i_add_a_valid_date_of_birth
+    fill_in "Day", with: "24"
+    fill_in "Month", with: "10"
+    fill_in "Year", with: "1990"
+  end
+
+  def when_i_select(option)
+    choose option, allow_label_click: true
+  end
+
+  def when_i_add_the_trn
+    fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)?", with: @participant_data[:trn]
+  end
+
+  # then
+
+  def then_i_am_taken_to_your_ect_and_mentors_page
+    expect(page).to have_selector("h1", text: "Your ECTs and mentors")
+    expect(page).to have_text("Add an ECT or mentor")
+    expect(page).to have_text("Add yourself as a mentor")
+  end
+
+  def then_i_should_be_on_check_transfer_page
+    expect(page).to have_selector("h1", text: "Check you’re reporting this for the correct academic year")
+  end
+
+  def then_i_should_be_on_the_who_to_add_page
+    expect(page).to have_selector("h1", text: "Who do you want to add?")
+  end
+
+  def then_i_should_be_on_what_we_need_page
+    expect(page).to have_selector("h1", text: "What we need from you")
+    expect(page).to have_text("To do this, you need to tell us their")
+  end
+
+  def then_i_am_taken_to_add_ect_name_page
+    expect(page).to have_selector("h1", text: "What’s this person’s full name?")
+  end
+
+  def then_i_should_be_on_full_name_page
+    expect(page).to have_selector("h1", text: "What’s this person’s full name?")
+  end
+
+  def then_i_should_be_on_trn_page
+    expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)")
+  end
+
+  def then_i_should_be_on_the_date_of_birth_page
+    expect(page).to have_selector("h1", text: "What’s #{@participant_data[:full_name]}’s date of birth")
+  end
+
+  def then_i_am_taken_to_do_you_know_your_teachers_trn_page
+    expect(page).to have_selector("h1", text: "Do you know #{@participant_data[:full_name]}’s teacher reference number (TRN)?")
+  end
+
+  def then_i_should_be_on_the_already_enrolled_page
+    expect(page).to have_selector("h1", text: "already here")
+  end
+
+  def then_i_am_should_be_on_are_they_a_transfer_page
+    expect(page).to have_selector("h1", text: "Is #{@participant_profile_ect.user.full_name} transferring from another school?")
+    expect(page).to have_text("Yes")
+    expect(page).to have_text("No")
+  end
+
+  # and
+
+  def and_i_am_signed_in_as_an_induction_coordinator
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort_one.school], user: create(:user, full_name: "Carl Coordinator"))
+    privacy_policy = create(:privacy_policy)
+    privacy_policy.accept!(@induction_coordinator_profile.user)
+    sign_in_as @induction_coordinator_profile.user
+  end
+
+  def and_they_have_already_added_this_ect
+    @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_one)
+    create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
+    Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_one)
+  end
+
+  # data setup
+
+  def set_dqt_validation_result
+    response = {
+      trn: @participant_data[:trn],
+      full_name: @participant_data[:full_name],
+      nino: nil,
+      dob: @participant_data[:date_of_birth],
+      config: {},
+    }
+    allow_any_instance_of(ParticipantValidationService).to receive(:validate).and_return(response)
+  end
+
+  def set_participant_data
+    @participant_data = {
+      trn: "1001000",
+      full_name: "Sally Teacher",
+      date_of_birth: Date.new(1990, 10, 24),
+      email: "sally-teacher@example.com",
+    }
+  end
+end

--- a/spec/requests/schools/transferring_participants_spec.rb
+++ b/spec/requests/schools/transferring_participants_spec.rb
@@ -154,7 +154,12 @@ RSpec.describe "Schools::TransferringParticipants", type: :request, with_feature
 
   describe "GET /schools/:school_id/cohorts/:cohort_id/participants/transferring-participant/teacher-start-date" do
     it "renders the teacher start date template" do
-      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/teacher-start-date", params: { schools_transferring_participant_form: { full_name: ect.user.full_name } }
+      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/transferring-participant/teacher-start-date",
+          params: { schools_transferring_participant_form: {
+            full_name: ect.user.full_name,
+            trn: ecf_participant_validation_data.trn,
+            date_of_birth: ecf_participant_validation_data.date_of_birth,
+          } }
 
       expect(subject).to render_template "schools/transferring_participants/teacher_start_date"
     end


### PR DESCRIPTION
This is to fix https://sentry.io/organizations/dfe-teacher-services/issues/3244970437/?project=5748989&query=is%3Aunresolved

### Context

- Ticket: 

### Changes proposed in this pull request

Stopping a user from transferring a participant who is already enrolled at the school from being transferred in. We're getting a few sentry errors coming through. 

### Guidance to review

<img width="761" alt="Screenshot 2022-07-04 at 11 33 01" src="https://user-images.githubusercontent.com/69353998/177137456-117f0368-eb5c-4f02-9c90-94a27d14a6a4.png">
