### PR TITLE
[CPDLP-1055] fix previous statements

### DIFF
--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -18,6 +18,13 @@ class Finance::Statement::ECF < Finance::Statement
   def calculator
     @calculator ||= Finance::ECF::StatementCalculator.new(statement: self)
   end
+
+  def previous_statements
+    Finance::Statement::ECF
+      .where(cohort:)
+      .where(cpd_lead_provider:)
+      .where("payment_date < ?", payment_date)
+  end
 end
 
 require "finance/statement/ecf/payable"

--- a/app/models/finance/statement/npq.rb
+++ b/app/models/finance/statement/npq.rb
@@ -6,6 +6,13 @@ class Finance::Statement::NPQ < Finance::Statement
   def payable!
     update!(type: "Finance::Statement::NPQ::Payable")
   end
+
+  def previous_statements
+    Finance::Statement::NPQ
+      .where(cohort:)
+      .where(cpd_lead_provider:)
+      .where("payment_date < ?", payment_date)
+  end
 end
 
 require "finance/statement/npq/payable"


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1055
- this is need as there are many subclasses of a statement

### Changes proposed in this pull request

- when looking a previous limits we hardcode the subclass we want to use since there are many subclasses
- otherwise does not form correct query to find previous statements

### Guidance to review

- none