### PR TITLE
[CST-779] Prevent an LP from claiming a school with a different previous LP and no current cohort

### DIFF
--- a/app/models/partnership_csv_upload.rb
+++ b/app/models/partnership_csv_upload.rb
@@ -59,12 +59,20 @@ private
         errors << { urn:, message: "School not eligible for inductions", school_name: school.name, row_number: index + 1 }
       elsif school.lead_provider(cohort.start_year) == lead_provider
         errors << { urn:, message: "Your school - already confirmed", school_name: school.name, row_number: index + 1 }
-      elsif school.lead_provider(cohort.start_year).present?
+      elsif school.lead_provider(cohort.start_year).present? || has_previous_cohort_and_matching_lead_provider?(school)
         errors << { urn:, message: "Recruited by other provider", school_name: school.name, row_number: index + 1 }
       end
     end
 
     errors
+  end
+
+  def has_previous_cohort_and_matching_lead_provider?(school)
+    previous_year_lead_provider = school.lead_provider(cohort.start_year - 1)
+
+    return false if previous_year_lead_provider.blank?
+
+    previous_year_lead_provider != lead_provider && school.school_cohorts.find_by(cohort:).blank?
   end
 
   def strip_bom(string)


### PR DESCRIPTION
### Context

A lead provider can claim a school for the cohort selected even if the school has not set up this cohort. 
We want to allow schools to set up that cohort and choose whether they're continuing with their previous years provider before being claimed. 

- Ticket: [779](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-779)

### Changes proposed in this pull request

Extra conditional to check whether a school has a provider for it's previous years cohort and if they've set up the cohort that's trying to be claimed


