### PR TITLE
[CPDLP-1464] Permit declarations after a clawback

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -142,11 +142,13 @@ class ParticipantDeclaration < ApplicationRecord
   end
 
   def duplicate_declarations
-    self.class.joins(participant_profile: :teacher_profile)
+    self
+      .class
+      .joins(participant_profile: :teacher_profile)
       .where(participant_profiles: { teacher_profiles: { trn: participant_profile.teacher_profile.trn } })
       .where.not(participant_profiles: { teacher_profiles: { trn: nil } })
       .where.not(user_id:, id:)
-      .where.not(state: self.class.states[:voided])
+      .where(state: %w[submitted eligible payable paid])
       .where(
         declaration_type:,
         course_identifier:,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
   missing_course_identifier: "The property '#/course_identifier' must be present"
   missing_participant_id: "The property '#/participant_id' must be present"
   missing_cpd_lead_provider: "The property '#/cpd_lead_provider' must be present"
+  declaration_already_exists: There already exists a declaration that will be or has been paid for this event
   already_active: The participant is already active
   invalid_withdrawal: The participant is already withdrawn
   invalid_resume: Cannot resume a withdrawn participant

--- a/spec/features/participant_declarations/block_participant_declaration_paid_twice_spec.rb
+++ b/spec/features/participant_declarations/block_participant_declaration_paid_twice_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Block participant declaration paid twice", type: :feature do
     then_the_declaration_made_is_valid
     and_schedule_change_is_submitted_for_this_participant
     and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
-    then_second_declaration_is_created
+    then_one_declaration_is_created
   end
 
   scenario "Declaration submitted for a changed lead provider" do
@@ -27,6 +27,6 @@ RSpec.feature "Block participant declaration paid twice", type: :feature do
     then_the_declaration_made_is_valid
     and_lead_provider_changed_for_the_participant
     and_the_lead_provider_submits_a_declaration_for_the_ect_using_their_id
-    then_second_declaration_is_created
+    then_one_declaration_is_created
   end
 end

--- a/spec/features/participant_declarations/participant_declaration_steps.rb
+++ b/spec/features/participant_declarations/participant_declaration_steps.rb
@@ -135,9 +135,8 @@ module ParticipantDeclarationSteps
     Induction::Enrol.call(participant_profile: @ect_profile, induction_programme: new_induction_programme)
   end
 
-  def then_second_declaration_is_created
+  def then_one_declaration_is_created
     expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started", state: "submitted").count).to eq(1)
-    expect(ParticipantDeclaration.where(course_identifier: "ecf-induction", declaration_type: "started", state: "ineligible").count).to eq(1)
   end
 
   def then_second_declaration_is_not_created

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -89,21 +89,19 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(ParticipantDeclaration.order(:created_at).last).to be_eligible
       end
 
-      it "does create duplicate declarations with the same declaration date and stores the duplicate declaration attempts" do
+      it "does not create duplicate declarations with the same declaration date" do
         params = build_params(valid_params)
         post "/api/v1/participant-declarations", params: params
         original_id = parsed_response["id"]
 
         expect { post "/api/v1/participant-declarations", params: }
-            .to change(ParticipantDeclaration, :count).by(1)
-        expect { post "/api/v1/participant-declarations", params: }
-            .to change(ParticipantDeclarationAttempt, :count).by(1)
+            .not_to change(ParticipantDeclaration, :count)
 
-        expect(response.status).to eq 200
+        expect(response.status).to eq 422
         expect(parsed_response["id"]).to eq(original_id)
       end
 
-      it "does create duplicate declarations with different declaration date and stores the duplicate declaration attempts" do
+      it "does not create duplicate declarations with different declaration date" do
         params = build_params(valid_params)
 
         new_valid_params = valid_params
@@ -114,12 +112,10 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         post "/api/v1/participant-declarations", params: params
         original_id = parsed_response["id"]
 
-        expect { post "/api/v1/participant-declarations", params: }
-            .to change(ParticipantDeclaration, :count).by(1)
         expect { post "/api/v1/participant-declarations", params: params_with_different_declaration_date }
-            .to change(ParticipantDeclarationAttempt, :count).by(1)
+            .not_to change(ParticipantDeclaration, :count)
 
-        expect(response.status).to eq 400
+        expect(response.status).to eq 422
         expect(parsed_response["id"]).to eq(original_id)
       end
 
@@ -236,8 +232,8 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
             new_updated_params = valid_params.merge({ declaration_date: (milestone_start_date + 2).rfc3339 })
             post "/api/v1/participant-declarations", params: build_params(new_updated_params)
 
-            expect(response.status).to eq 400
-            expect(response.body).to include("Declaration with given participant ID already exists")
+            expect(response.status).to eq 422
+            expect(response.body).to include("There already exists a declaration that will be or has been paid for this event")
           end
         end
 

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -61,21 +61,19 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         expect(ParticipantDeclaration.order(:created_at).last).to be_eligible
       end
 
-      it "does create duplicate declarations with the same declaration date and stores the duplicate declaration attempts" do
+      it "does not create duplicate declarations with the same declaration date" do
         params = build_params(valid_params)
         post "/api/v1/participant-declarations", params: params
         original_id = parsed_response["id"]
 
         expect { post "/api/v1/participant-declarations", params: }
-            .to change(ParticipantDeclaration, :count).by(1)
-        expect { post "/api/v1/participant-declarations", params: }
-            .to change(ParticipantDeclarationAttempt, :count).by(1)
+            .not_to change(ParticipantDeclaration, :count)
 
-        expect(response.status).to eq 200
+        expect(response.status).to eq 422
         expect(parsed_response["id"]).to eq(original_id)
       end
 
-      it "does create duplicate declarations with different declaration date and stores the duplicate declaration attempts" do
+      it "does not create duplicate declarations with different declaration date" do
         params = build_params(valid_params)
 
         new_valid_params = valid_params
@@ -86,12 +84,10 @@ RSpec.describe "participant-declarations endpoint spec", type: :request do
         post "/api/v1/participant-declarations", params: params
         original_id = parsed_response["id"]
 
-        expect { post "/api/v1/participant-declarations", params: }
-            .to change(ParticipantDeclaration, :count).by(1)
         expect { post "/api/v1/participant-declarations", params: params_with_different_declaration_date }
-            .to change(ParticipantDeclarationAttempt, :count).by(1)
+            .not_to change(ParticipantDeclaration, :count)
 
-        expect(response.status).to eq 400
+        expect(response.status).to eq 422
         expect(parsed_response["id"]).to eq(original_id)
       end
 

--- a/spec/support/shared_examples/participant_declaration_support.rb
+++ b/spec/support/shared_examples/participant_declaration_support.rb
@@ -15,18 +15,22 @@ RSpec.shared_examples "a participant declaration service" do
     expect { described_class.call(params: given_params) }.to change { ParticipantDeclaration.count }.by(1)
   end
 
-  it "does create exact duplicates" do
+  it "does not create exact duplicates" do
     expect {
       described_class.call(params: given_params)
+    }.to change { ParticipantDeclaration.count }.by(1)
+
+    expect {
       described_class.call(params: given_params)
-    }.to change { ParticipantDeclaration.count }.by(2)
+    }.to raise_error(ActionController::ParameterMissing)
+     .and(not_change { ParticipantDeclaration.count })
   end
 
   it "does not create close duplicates and throws an error" do
     expect {
       described_class.call(params: given_params)
       described_class.call(params: params_with_different_date)
-    }.to raise_error(ActiveRecord::RecordNotUnique)
+    }.to raise_error(ActionController::ParameterMissing)
   end
 
   context "when user is not a participant" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1464
- After something has clawed back we want providers to be able to submit again for this event

### Changes proposed in this pull request

- After a declaration is `awaiting_clawback` or `clawed_back` then a subsequent new declaration can be sent
- also no longer creates an additional declaration if submitted (or onwards) event is found and returns an error instead

### Guidance to review

- none