### PR TITLE
Default to active registration cohort tab for SITs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -99,14 +99,6 @@ private
   end
 
   def school_dashboard_with_tab_path(school)
-    current_cohort = Cohort.current
-    registration_cohort = Cohort.active_registration_cohort
-    default_cohort = if current_cohort != registration_cohort && school.school_cohorts.where(cohort: registration_cohort).exists?
-                       current_cohort
-                     else
-                       registration_cohort
-                     end
-
-    schools_dashboard_path(school_id: school.slug, anchor: TabLabelDecorator.new(default_cohort.description).parameterize)
+    schools_dashboard_path(school_id: school.slug, anchor: TabLabelDecorator.new(Cohort.active_registration_cohort.description).parameterize)
   end
 end

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
         and_there_is_a_withdrawn_ect_who_will_be_transferring
         and_i_am_signed_in_as_an_induction_coordinator
+        and_i_have_selected_my_cohort_tab
         when_i_click_to_view_ects_and_mentors
         then_i_am_taken_to_your_ect_and_mentors_page
       end
@@ -222,6 +223,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
                                                        induction_record:,
                                                        lead_provider_profile: @lead_provider_profile,
                                                      ))
+      end
+
+      def and_i_have_selected_my_cohort_tab
+        click_on @cohort.description
       end
 
       def allow_participant_transfer_mailers

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
         and_there_is_an_ect_who_will_be_transferring
         and_i_am_signed_in_as_an_induction_coordinator
+        and_i_have_selected_my_cohort_tab
         when_i_click_to_view_ects_and_mentors
         then_i_am_taken_to_your_ect_and_mentors_page
       end
@@ -339,6 +340,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
                                                        induction_record:,
                                                        lead_provider_profile: @lead_provider_profile,
                                                      ))
+      end
+
+      def and_i_have_selected_my_cohort_tab
+        click_on @cohort.description
       end
 
       def allow_participant_transfer_mailers

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
         and_there_is_an_ect_who_will_be_transferring
         and_i_am_signed_in_as_an_induction_coordinator
+        and_i_have_selected_my_cohort_tab
         when_i_click_to_view_ects_and_mentors
         then_i_am_taken_to_your_ect_and_mentors_page
       end
@@ -347,6 +348,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
                                                        induction_record:,
                                                        lead_provider_profile: @lead_provider_profile,
                                                      ))
+      end
+
+      def and_i_have_selected_my_cohort_tab
+        click_on @cohort.description
       end
 
       def allow_participant_transfer_mailers

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
         and_there_is_a_mentor_who_will_be_transferring
         and_i_am_signed_in_as_an_induction_coordinator
+        and_i_have_selected_my_cohort_tab
         when_i_click_to_view_ects_and_mentors
         then_i_am_taken_to_your_ect_and_mentors_page
       end
@@ -310,6 +311,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
                                                        induction_record:,
                                                        lead_provider_profile: @lead_provider_profile,
                                                      ))
+      end
+
+      def and_i_have_selected_my_cohort_tab
+        click_on @cohort.description
       end
 
       def allow_participant_transfer_mailers

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
         and_there_is_an_ect_who_will_be_transferring
         and_i_am_signed_in_as_an_induction_coordinator
+        and_i_have_selected_my_cohort_tab
         when_i_click_to_view_ects_and_mentors
         then_i_am_taken_to_your_ect_and_mentors_page
       end
@@ -166,6 +167,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
       def and_it_should_list_the_schools_mentors
         expect(page).to have_text(@mentor.user.full_name)
+      end
+
+      def and_i_have_selected_my_cohort_tab
+        click_on @cohort.description
       end
 
       def set_dqt_validation_result

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "returns the school dashboard path (show)" do
         expect(helper.profile_dashboard_path(induction_coordinator)).to eq("/schools/#{school.slug}")
       end
+
+      context "when a new registration cohort is active", with_feature_flags: { multiple_cohorts: "active" }, travel_to: Time.zone.now + 3.years do
+        let(:future_cohort) { create(:cohort, start_year: Time.zone.now.year, registration_start_date: Time.zone.now - 1.day) }
+
+        before do
+          SchoolCohort.create!(school:, cohort: future_cohort, induction_programme_choice: "full_induction_programme")
+        end
+
+        it "returns the school dashboard path with the active registration tab selected" do
+          expect(helper.profile_dashboard_path(induction_coordinator)).to eq("/schools/#{school.slug}##{TabLabelDecorator.new(future_cohort.description).parameterize}")
+        end
+      end
     end
 
     context "when the induction coordinator has more than one school" do


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-824)

Make default tab for SITs the active registration cohort for their school

### Changes proposed in this pull request
Make the default tab always be the one for the active registration cohort

### Guidance to review

