### PR TITLE
[CPDLP-1467] return relevant npq profile for calling provider

### DIFF
--- a/app/services/participants/npq.rb
+++ b/app/services/participants/npq.rb
@@ -21,11 +21,12 @@ module Participants
       return unless participant_identity
 
       @user_profile ||= ParticipantProfile::NPQ
-        .includes(npq_application: :npq_course)
+        .includes(npq_application: [:npq_course, { npq_lead_provider: [:cpd_lead_provider] }])
         .where(participant_identity:)
         .npqs
         .active_record
         .where('npq_courses.identifier': course_identifier)
+        .where(npq_applications: { npq_lead_providers: { cpd_lead_provider: } })
         .first
     end
 

--- a/spec/services/participants/npq_spec.rb
+++ b/spec/services/participants/npq_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::NPQ do
+  let(:user) { profile_one.user }
+  let(:teacher_profile) { profile_one.teacher_profile }
+
+  let!(:profile_one) { create(:npq_participant_profile) }
+  let!(:profile_two) { create(:npq_participant_profile, user:, teacher_profile:) }
+
+  let(:klass) do
+    Class.new do
+      include Participants::NPQ
+
+      attr_reader :cpd_lead_provider, :course_identifier
+
+      def initialize(cpd_lead_provider:, course_identifier:)
+        @cpd_lead_provider = cpd_lead_provider
+        @course_identifier = course_identifier
+      end
+
+      def participant_identity
+        ParticipantIdentity.first
+      end
+    end
+  end
+
+  describe "#user_profile" do
+    context "when there are 2 active profiles with different lead providers" do
+      it "returns profile relevant to the provider" do
+        cpd_lead_provider = profile_one.npq_application.npq_lead_provider.cpd_lead_provider
+        course_identifier = profile_one.npq_application.npq_course.identifier
+
+        instance = klass.new(cpd_lead_provider:, course_identifier:)
+        expect(instance.user_profile).to eql(profile_one)
+
+        cpd_lead_provider = profile_two.npq_application.npq_lead_provider.cpd_lead_provider
+        course_identifier = profile_two.npq_application.npq_course.identifier
+
+        instance = klass.new(cpd_lead_provider:, course_identifier:)
+        expect(instance.user_profile).to eql(profile_two)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1467
- We have data issues that around de-dupe that have not been resolved and are causing issues
- And at the moment we need to workaround these

### Changes proposed in this pull request

- when a user has 2 active NPQ profiles from different lead providers
- select the profile that matches the calling lead provider

### Guidance to review

- none