### PR TITLE
[CPDLP-1382] EDT seeing mismatches between ecf/participants JSON and CSV endpoints

### DIFF
--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -69,12 +69,12 @@ module Api
           )
 
         if updated_since.present?
-          scope = scope
+          scope
             .where(users: { updated_at: updated_since.. })
-            .order("users.updated_at, users.id")
+            .order("induction_records.updated_at, users.id")
+        else
+          scope.order("induction_records.created_at")
         end
-
-        scope.order("users.created_at")
       end
 
       # inner most query

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe "Participants API", type: :request do
 
         it "returns users in a consistent order" do
           users = User.all
-          users.first.update!(created_at: 1.day.ago)
-          users.last.update!(created_at: 2.days.ago)
+          users.first.participant_profiles.first.induction_records.first.update!(created_at: 1.day.ago)
+          users.last.participant_profiles.first.induction_records.first.update!(created_at: 2.days.ago)
 
           get "/api/v1/participants/ecf"
           expect(parsed_response["data"][0]["id"]).to eq User.last.id

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
 
         it "returns users in a consistent order" do
           users = User.all
-          users.first.update!(created_at: 1.day.ago)
-          users.last.update!(created_at: 2.days.ago)
+          users.first.participant_profiles.first.induction_records.first.update!(created_at: 1.day.ago)
+          users.last.participant_profiles.first.induction_records.first.update!(created_at: 2.days.ago)
 
           get "/api/v1/participants"
           expect(parsed_response["data"][0]["id"]).to eq User.last.id


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1382

### Changes proposed in this pull request

* Set order column to induction_records.updated_at/created_at to fix issues of ordering in pagination

### Guidance to review

