### PR TITLE
[CPDLP-1472] cannot accept EHCO if already on ASO

### DIFF
--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -43,7 +43,7 @@ module NPQ
     def has_other_accepted_applications_with_same_course?
       NPQApplication.joins(:participant_identity)
         .where(participant_identity: { user_id: user.id })
-        .where(npq_course:)
+        .where(npq_course: npq_course.rebranded_alternative_courses)
         .where(lead_provider_approval_status: "accepted")
         .where.not(id: npq_application.id)
         .exists?

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -31,6 +31,36 @@ RSpec.describe NPQ::Accept do
       )
     end
 
+    context "when user applies for EHCO but has accepted ASO" do
+      let(:npq_course) { create(:npq_course, identifier: "npq-additional-support-offer") }
+      let(:npq_ehco) { create(:npq_course, identifier: "npq-early-headship-coaching-offer") }
+
+      let(:other_npq_application) do
+        NPQApplication.create!(
+          teacher_reference_number: trn,
+          participant_identity: identity,
+          npq_course: npq_ehco,
+          npq_lead_provider:,
+          school_urn: "123456",
+          school_ukprn: "12345678",
+          cohort: cohort_2021,
+        )
+      end
+
+      before do
+        create(:npq_aso_schedule)
+        create(:npq_ehco_schedule)
+
+        described_class.call(npq_application:)
+      end
+
+      it "does not accept the EHCO application" do
+        expect {
+          described_class.call(npq_application: other_npq_application)
+        }.not_to change { other_npq_application.reload.lead_provider_approval_status }
+      end
+    end
+
     context "when user has applied for the same course with another provider" do
       let(:other_npq_lead_provider) { create(:npq_lead_provider) }
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1472
- EHCO and ASO are conceptually the same course just rebranded
- But under the hood in the implementation these are different courses

### Changes proposed in this pull request

- Ensure that if a user is on ASO or EHCO any other ASO or EHCO application cannot be accepted

### Guidance to review

- none