### PR TITLE
Prevent duplicate statements when importing the SeedStatements

### DIFF
--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -10,7 +10,6 @@ class Importers::SeedStatements
           name: statement_data.name,
           cpd_lead_provider:,
           cohort: Cohort.find_by(start_year: 2021),
-          contract_version: statement_data.contract_version,
         )
         statement.update!(
           deadline_date: statement_data.deadline_date,
@@ -18,6 +17,7 @@ class Importers::SeedStatements
           cohort: Cohort.find_by(start_year: 2021),
           output_fee: statement_data.output_fee,
           type: class_for(statement_data, namespace: Finance::Statement::ECF),
+          contract_version: statement_data.contract_version,
         )
       end
     end
@@ -30,7 +30,6 @@ class Importers::SeedStatements
           name: statement_data.name,
           cpd_lead_provider:,
           cohort:,
-          contract_version: statement_data.contract_version,
         )
 
         statement.update!(
@@ -39,6 +38,7 @@ class Importers::SeedStatements
           cohort:,
           output_fee: statement_data.output_fee,
           type: class_for(statement_data, namespace: Finance::Statement::NPQ),
+          contract_version: statement_data.contract_version,
         )
       end
     end

--- a/spec/services/importers/seed_statements_spec.rb
+++ b/spec/services/importers/seed_statements_spec.rb
@@ -21,5 +21,38 @@ RSpec.describe Importers::SeedStatements do
         subject.call
       }.to change(Finance::Statement::NPQ, :count).by(36)
     end
+
+    context "with updated contract version" do
+      let(:new_contract_version) { "99.99.99" }
+      let(:statement_name) { "May 2024" }
+
+      before do
+        subject.call
+        allow(subject).to receive(method_name).and_return(altered_statements)
+        subject.call
+      end
+
+      context "when ECF statements" do
+        let(:method_name) { :ecf_statements }
+        let(:altered_statements) do
+          [OpenStruct.new(name: statement_name, deadline_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 25), contract_version: new_contract_version, output_fee: true)]
+        end
+
+        it "does not creates duplicate statements" do
+          expect(Finance::Statement::ECF.where(name: statement_name).count).to eq(1)
+        end
+      end
+
+      context "when NPQ statements" do
+        let(:method_name) { :npq_statements }
+        let(:altered_statements) do
+          [OpenStruct.new(name: statement_name, deadline_date: Date.new(2024, 4, 25), payment_date: Date.new(2024, 5, 25), contract_version: new_contract_version, output_fee: false)]
+        end
+
+        it "does not creates duplicate statements" do
+          expect(Finance::Statement::NPQ.where(name: statement_name).count).to eq(1)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1456](https://dfedigital.atlassian.net/browse/CPDLP-1456)

The seed statements import create duplicate records when updating the contract version in the seed data. We want to update the contract version instead of creating a new statement.

The issue was revealed when the contract version of the NPQ statement for "March 2022" when bumped up to `0.0.2`.

### Changes proposed in this pull request

Look for statements based on their name, provider and cohort and update the contract version once the statement is found or created.

### Guidance to review
1. Run the import on your local
2. Confirm 30 ECF records and 36 NPQ records were created
3. Update the contract version in some of the records and do step 1 and step 2 again. No new records should be created.

**Note:** I've not changed the contract version of the NPQ statement for "March 2022" and the next time the SeedStatements will be imported again, the contract version will be updated to `0.0.2`.