### PR TITLE
[Bug-fix] Prevent a SIT from transferring a user without a previous cohort

### DIFF
--- a/app/helpers/transfer_participant_helper.rb
+++ b/app/helpers/transfer_participant_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module TransferParticipantHelper
+  def transfer_participant_in_cohort(cohort, school)
+    school_cohort = SchoolCohort.find_by(school:, cohort:)
+
+    if doing_fip?(school_cohort)
+      what_we_need_schools_transferring_participant_path(cohort_id: cohort)
+    else
+      contact_support_schools_transferring_participant_path
+    end
+  end
+
+private
+
+  def doing_fip?(school_cohort)
+    school_cohort.induction_programmes.any?(&:full_induction_programme?)
+  end
+end

--- a/app/helpers/transfer_participant_helper.rb
+++ b/app/helpers/transfer_participant_helper.rb
@@ -13,7 +13,4 @@ module TransferParticipantHelper
 
 private
 
-  def doing_fip?(school_cohort)
-    school_cohort.induction_programmes.any?(&:full_induction_programme?)
-  end
 end

--- a/app/helpers/transfer_participant_helper.rb
+++ b/app/helpers/transfer_participant_helper.rb
@@ -4,7 +4,7 @@ module TransferParticipantHelper
   def transfer_participant_in_cohort(cohort, school)
     school_cohort = SchoolCohort.find_by(school:, cohort:)
 
-    if doing_fip?(school_cohort)
+    if school_cohort&.full_induction_programme?
       what_we_need_schools_transferring_participant_path(cohort_id: cohort)
     else
       contact_support_schools_transferring_participant_path

--- a/app/helpers/transfer_participant_helper.rb
+++ b/app/helpers/transfer_participant_helper.rb
@@ -10,7 +10,4 @@ module TransferParticipantHelper
       contact_support_schools_transferring_participant_path
     end
   end
-
-private
-
 end

--- a/app/views/schools/transferring_participants/check_transfer.html.erb
+++ b/app/views/schools/transferring_participants/check_transfer.html.erb
@@ -11,7 +11,7 @@
 
     <p class="govuk-body">If a teacher has already started their ECF-based training or mentoring at another school in the <%= current_cohort_description %> academic year:</p>
     <div class="govuk-inset-text">
-      <%= link_to "Report a transferring ECT or mentor who started training in the #{current_cohort_description} academic year", what_we_need_schools_transferring_participant_path(cohort_id: Cohort.active_registration_cohort.previous), class: "govuk-link" %>
+      <%= link_to "Report a transferring ECT or mentor who started training in the #{current_cohort_description} academic year", transfer_participant_in_cohort(Cohort.active_registration_cohort.previous, @school), class: "govuk-link" %>
     </div>
 
     <p class="govuk-body">If a teacher has not started their ECF-based training or mentoring at another school:</p>

--- a/app/views/schools/transferring_participants/contact_support.html.erb
+++ b/app/views/schools/transferring_participants/contact_support.html.erb
@@ -7,7 +7,7 @@
     <h1 class="govuk-heading-xl">This ECT’s training record needs to be transferred manually</h1>
 
     <p class="govuk-body">Email our support tam at
-      <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
+      <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk" %>
     </p>
 
     <p class="govuk-body">Include the ECT’s:</p>

--- a/app/views/schools/transferring_participants/contact_support.html.erb
+++ b/app/views/schools/transferring_participants/contact_support.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title, "This ECT’s training record needs to be transferred manually" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl">This ECT’s training record needs to be transferred manually</h1>
+
+    <p class="govuk-body">Email our support tam at
+      <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
+    </p>
+
+    <p class="govuk-body">Include the ECT’s:</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>full name</li>
+        <li>teacher reference number</li>
+        <li>date of birth</li>
+        <li>email address (personal or school)</li>
+        <li>sart date at your school</li>
+    </ul>
+
+    <p class="govuk-body">Tell us:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>how the ECT will continue their ECF-based training at your school - for example, with a DfE-funded training provider</li>
+      <li>the lead provider and delivery partner you’ve chosen for their training, if applicable</li>
+    </ul>
+
+    <p class="govuk-body"><%= govuk_link_to "View your ECTs and mentors", schools_participants_path, class: "govuk-link govuk-link--no-visited-state" %></p>
+
+  </div>
+</div>

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_active_cohort_speedbump_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_active_cohort_speedbump_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
   context "Transferring a participant to a school" do
     context "School has not created a programme for the previous cohort" do
       before do
-        given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+        given_there_are_two_schools_that_have_chosen_fip_for_2022_and_partnered
         and_i_am_signed_in_as_an_induction_coordinator
         and_select_the_most_recent_cohort
         when_i_click_to_view_ects_and_mentors
@@ -27,7 +27,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
       # given
 
-      def given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+      def given_there_are_two_schools_that_have_chosen_fip_for_2022_and_partnered
         @school_one = create(:school, name: "Fip School 1")
         @school_one_2021_cohort = create(:school_cohort, school: @school_one, cohort: create(:cohort, start_year: 2021), induction_programme_choice: "no_early_career_teachers")
         @school_one_2022_cohort = create(:school_cohort, school: @school_one, cohort: create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_active_cohort_speedbump_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_active_cohort_speedbump_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "transferring participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+  context "Transferring a participant to a school" do
+    context "School has not created a programme for the previous cohort" do
+      before do
+        given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+        and_i_am_signed_in_as_an_induction_coordinator
+        and_select_the_most_recent_cohort
+        when_i_click_to_view_ects_and_mentors
+        then_i_am_taken_to_your_ect_and_mentors_page
+      end
+
+      scenario "Induction tutor is redirected to contact support" do
+        when_i_click_to_add_an_ect_or_mentor
+        then_i_should_be_on_the_who_to_add_page
+
+        when_i_select_transfer_teacher_option
+        click_on "Continue"
+
+        then_i_should_be_on_check_transfer_page
+        when_i_choose_to_continue_the_transfer_journey
+        then_i_should_be_on_the_contact_support_page
+      end
+
+      # given
+
+      def given_there_are_two_schools_that_have_chosen_fip_for_2021_and_partnered
+        @school_one = create(:school, name: "Fip School 1")
+        @school_one_2021_cohort = create(:school_cohort, school: @school_one, cohort: create(:cohort, start_year: 2021), induction_programme_choice: "no_early_career_teachers")
+        @school_one_2022_cohort = create(:school_cohort, school: @school_one, cohort: create(:cohort, start_year: 2022), induction_programme_choice: "full_induction_programme")
+        @mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor"), school_cohort: @school_one_2022_cohort)
+        @school_one_2022_cohort_induction_programme = create(:induction_programme, :fip, school_cohort: @school_one_2022_cohort)
+        Induction::Enrol.call(participant_profile: @mentor, induction_programme: @school_one_2022_cohort_induction_programme)
+        Mentors::AddToSchool.call(school: @school_one, mentor_profile: @mentor)
+      end
+
+      # when
+
+      def when_i_click_to_view_ects_and_mentors
+        click_on "Manage"
+      end
+
+      def when_i_click_to_add_an_ect_or_mentor
+        click_on "Add an ECT or mentor"
+      end
+
+      def when_i_select_transfer_teacher_option
+        choose("A teacher transferring from another school where they’ve started ECF-based training or mentoring", allow_label_click: true)
+      end
+
+      def when_i_choose_to_continue_the_transfer_journey
+        click_on "Report a transferring ECT or mentor who started training in the #{Cohort.active_registration_cohort.previous.description} academic year"
+      end
+
+      def when_i_select(option)
+        choose(option)
+      end
+
+      # then
+
+      def then_i_am_taken_to_your_ect_and_mentors_page
+        expect(page).to have_selector("h1", text: "Your ECTs and mentors")
+        expect(page).to have_text("Add an ECT or mentor")
+        expect(page).to have_text("Add yourself as a mentor")
+      end
+
+      def then_i_should_be_on_the_contact_support_page
+        expect(page).to have_selector("h1", text: "This ECT’s training record needs to be transferred manually")
+      end
+
+      def then_i_should_be_on_the_who_to_add_page
+        expect(page).to have_selector("h1", text: "Who do you want to add?")
+      end
+
+      def then_i_should_be_on_check_transfer_page
+        expect(page).to have_selector("h1", text: "Check you’re reporting this for the correct academic year")
+      end
+
+      # and
+
+      def and_i_am_signed_in_as_an_induction_coordinator
+        @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_one], user: create(:user, full_name: "Carl Coordinator"))
+        privacy_policy = create(:privacy_policy)
+        privacy_policy.accept!(@induction_coordinator_profile.user)
+        sign_in_as @induction_coordinator_profile.user
+      end
+
+      def and_select_the_most_recent_cohort
+        click_on Cohort.active_registration_cohort.description
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

There's a [sentry error](https://sentry.io/organizations/dfe-teacher-services/issues/3353853344/?project=5748989&referrer=issue_alert-slack) where if a SIT can try to transfer a ppt from to the 2021 to their school, even if they don't have a school cohort for that year. This blocks them from doing it. We need them, at the minute, to create a full induction programme before they're able to do so. This is a quick fix, as agreed with Mili, Brian and Jo, that tells the user to go to support.

- Ticket: No ticket, but there is one in the backlog to handle this in a better way [828](https://dfedigital.atlassian.net/browse/CST-828)

### Changes proposed in this pull request
Redirecting to contact support if the school cohort does not have a FIP for the 2021 cohort year set up. 

<img width="733" alt="Screenshot 2022-06-30 at 14 26 17" src="https://user-images.githubusercontent.com/69353998/176688955-954a7365-6e1a-446b-ae23-9237129feb03.png">


