### PR TITLE
[CPDLP-1414] can change schedule on withdrawn profile

### DIFF
--- a/app/services/participants/change_schedule/ecf.rb
+++ b/app/services/participants/change_schedule/ecf.rb
@@ -86,7 +86,7 @@ module Participants
       end
 
       def not_already_withdrawn
-        errors.add(:participant_id, I18n.t(:withdrawn_participant)) if participant_profile_state&.withdrawn?
+        errors.add(:participant_id, I18n.t(:withdrawn_participant)) if relevant_induction_record&.training_status_withdrawn?
       end
 
       def schedule_valid_with_pending_declarations


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1414
- A user with 2 profiles where first provider has withdrawn
- This is causing the new provider not able to change schedule
- As we are still observing the state of the profile when we should be observing the state of the relevant induction record

### Changes proposed in this pull request

- When changing schedule check the state of the relevant induction record not the profile 

### Guidance to review

- none