### PR TITLE
[CPDLP-1471] ECF GET participant endpoint response can be inaccurate

### DIFF
--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -48,10 +48,8 @@ module Api
       end
 
       active_participant_attribute :email do |induction_record|
-        # NOTE: using this will retain the original email exposed to provider
-        induction_record.participant_profile.participant_identity.email
-        # NOTE: use this instead to use new (de-duped) email
-        # induction_record.participant_profile.user.email
+        induction_record.preferred_identity&.email ||
+          induction_record.participant_profile.user.email
       end
 
       attribute :full_name do |induction_record|

--- a/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
@@ -49,6 +49,15 @@ module Api
         end
       end
 
+      describe "#email" do
+        let(:participant_identity) { create(:participant_identity, email: "second_email@example.com") }
+        let(:induction_record) { create(:induction_record, preferred_identity: participant_identity) }
+
+        it "returns preferred identity email" do
+          expect(subject.serializable_hash[:data][:attributes][:email]).to eql(participant_identity.email)
+        end
+      end
+
       describe "#updated_at" do
         let(:induction_record) { create(:induction_record) }
         let(:user) { induction_record.participant_profile.user }


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1471

### Changes proposed in this pull request

* Updated `Api::V1::ParticipantFromInductionRecordSerializera` to use preferred_identity

### Guidance to review

