### PR TITLE
[CPDLP-1475] users with 2+ NPQ profiles can change schedule

### DIFF
--- a/app/services/participants/change_schedule/npq.rb
+++ b/app/services/participants/change_schedule/npq.rb
@@ -42,7 +42,17 @@ module Participants
       attr_reader :schedule_identifier, :cohort_year
 
       def user_profile
-        user&.npq_profiles&.active_record&.includes({ npq_application: [:npq_course] })&.where('npq_courses.identifier': course_identifier)&.first
+        user
+          .npq_profiles
+          .active_record
+          .includes({ npq_application: [:npq_course] })
+          .where('npq_courses.identifier': course_identifier)
+          .where({ npq_application: { npq_lead_provider: } })
+          .first
+      end
+
+      def npq_lead_provider
+        cpd_lead_provider.npq_lead_provider
       end
 
       def matches_lead_provider?


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1475
- this is a workaround for bad data where users have multiple NPQ profiles
- providers are failing to change schedule as it is not picking the correct profile

### Changes proposed in this pull request

- users with multiple NPQ profiles with different providers can now change schedule
- we observe the calling provider and scope profiles to that provider

### Guidance to review

- none