### PR TITLE
[CPDLP-1468] When profile becomes eligible, attach declarations

### DIFF
--- a/app/services/record_declarations/actions/make_declarations_eligible_for_participant_profile.rb
+++ b/app/services/record_declarations/actions/make_declarations_eligible_for_participant_profile.rb
@@ -5,7 +5,12 @@ module RecordDeclarations
     class MakeDeclarationsEligibleForParticipantProfile
       class << self
         def call(participant_profile:)
-          participant_profile.participant_declarations.submitted.each(&:make_eligible!)
+          ApplicationRecord.transaction do
+            participant_profile.participant_declarations.submitted.each do |participant_declaration|
+              participant_declaration.make_eligible!
+              Finance::DeclarationStatementAttacher.new(participant_declaration:).call
+            end
+          end
         end
       end
     end

--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe StoreParticipantEligibility do
       expect(ect_profile.ecf_participant_eligibility).to be_none_reason
     end
 
-    it "updates any submitted declarations" do
-      declaration = create(:ect_participant_declaration, user: ect_profile.user, participant_profile: ect_profile, course_identifier: "ecf-induction")
-      expect(declaration).to be_submitted
-      expect { service.call(participant_profile: ect_profile, eligibility_options:) }.to change { DeclarationState.count }.by(1)
-      declaration.reload
-      expect(declaration).to be_eligible
+    it "calls service for eligibility triggers" do
+      allow(RecordDeclarations::Actions::MakeDeclarationsEligibleForParticipantProfile).to receive(:call).with(participant_profile: ect_profile)
+
+      service.call(participant_profile: ect_profile, eligibility_options:)
+
+      expect(RecordDeclarations::Actions::MakeDeclarationsEligibleForParticipantProfile).to have_received(:call)
     end
 
     context "when an eligibility record exists" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1468
- There is a case where a participant is not yet eligible but a declaration has been submitted
- Later the participant is found to be eligible as a result their declaration(s) are changed to payable
- However when this happens we are not attaching them to a relevant statement therefore will not be paid for

### Changes proposed in this pull request

- When participant becomes eligible also attach declarations to relevant statement

### Guidance to review

- after this is deployed will need to find eligible declarations left behind and attach them to the next statement