### PR TITLE
Associate the NPQ applications on sandbox to the active registration cohort

### DIFF
--- a/app/jobs/create_new_fake_sandbox_data_job.rb
+++ b/app/jobs/create_new_fake_sandbox_data_job.rb
@@ -41,6 +41,7 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
           npq_course: NPQCourse.all.sample,
           npq_lead_provider:,
           participant_identity: identity,
+          cohort: random_school_cohort.cohort,
         )
       end
     end

--- a/app/jobs/create_new_fake_sandbox_data_job.rb
+++ b/app/jobs/create_new_fake_sandbox_data_job.rb
@@ -41,7 +41,7 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
           npq_course: NPQCourse.all.sample,
           npq_lead_provider:,
           participant_identity: identity,
-          cohort: random_school_cohort.cohort,
+          cohort: Cohort.active_registration_cohort,
         )
       end
     end

--- a/spec/jobs/create_new_fake_sandbox_data_job_spec.rb
+++ b/spec/jobs/create_new_fake_sandbox_data_job_spec.rb
@@ -28,5 +28,11 @@ RSpec.describe "CreateNewFakeSandboxDataJob", :with_default_schedules do
       expect(npq_lead_provider.reload.npq_applications.count).to eq(10)
       expect(npq_lead_provider.reload.npq_participants.count).to eq(0)
     end
+
+    it "should associate the NPQ applications to the active registration cohort" do
+      CreateNewFakeSandboxDataJob.new.perform
+
+      expect(npq_lead_provider.reload.npq_applications.last.cohort.start_year).to eq(Cohort.active_registration_cohort.start_year)
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1474](https://dfedigital.atlassian.net/browse/CPDLP-1474)

Providers have been reporting that they are unable to see the NPQ Applications test data on sandbox. The issue seems to be that the NPQ applications are not associated to any cohorts, so we need to associate them to a cohort.

### Changes proposed in this pull request

Associate the records to the active registration cohort when they are created.

### Guidance to review

