### PR TITLE
CST-827 cohort 2 registration comms July 2022

### DIFF
--- a/app/mailers/participant_mailer.rb
+++ b/app/mailers/participant_mailer.rb
@@ -17,6 +17,8 @@ class ParticipantMailer < ApplicationMailer
     ect_cip_added_and_validated: "b0d58248-c49e-4ec6-bca2-2c4cf151c421",
     mentor_cip_added_and_validated: "1396072b-4dc7-473d-aef7-22e674e42874",
     preterm_reminder: "3bece922-871e-49a9-88a1-83eeb8821ab1",
+    preterm_reminder_unconfirmed_for_2022: "0556f857-39b2-4a86-8a79-f42c91cd9a6b",
+    sit_contact_address_bounce: "c414ed7d-a3ef-43f0-a452-ee1a5f376fcc",
   }.freeze
 
   def participant_added(participant_profile:)
@@ -79,6 +81,61 @@ class ParticipantMailer < ApplicationMailer
         sign_in: new_user_session_url(**UTMService.email(:preterm_reminder)),
       },
     ).tag(:preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
+  end
+
+  def preterm_reminder_unconfirmed_for_2022(induction_coordinator_profile:)
+    template_mail(
+      PARTICIPANT_TEMPLATES[:preterm_reminder_unconfirmed_for_2022],
+      to: induction_coordinator_profile.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: induction_coordinator_profile.user.full_name,
+        sign_in: new_user_session_url(**UTMService.email(:preterm_reminder_unconfirmed_for_2022)),
+      },
+    ).tag(:preterm_reminder_unconfirmed_for_2022).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
+  end
+
+  def fip_preterm_reminder(induction_coordinator_profile:, school_name:)
+    template_mail(
+      PARTICIPANT_TEMPLATES[:fip_preterm_reminder],
+      to: induction_coordinator_profile.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: induction_coordinator_profile.user.full_name,
+        school_name:,
+        sign_in: new_user_session_url,
+      },
+    ).tag(:fip_preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
+  end
+
+  def cip_preterm_reminder(induction_coordinator_profile:, school_name:)
+    template_mail(
+      PARTICIPANT_TEMPLATES[:cip_preterm_reminder],
+      to: induction_coordinator_profile.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: induction_coordinator_profile.user.full_name,
+        school_name:,
+        sign_in: new_user_session_url,
+      },
+    ).tag(:cip_preterm_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
+  end
+
+  def sit_contact_address_bounce(induction_coordinator_profile:, school_name:)
+    template_mail(
+      PARTICIPANT_TEMPLATES[:sit_contact_address_bounce],
+      to: induction_coordinator_profile.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: induction_coordinator_profile.user.full_name,
+        school_name:,
+        sign_in: new_user_session_url,
+      },
+    ).tag(:sit_contact_address_bounce).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
   end
 
   def sit_has_added_and_validated_participant(participant_profile:, school_name:)


### PR DESCRIPTION
### Context

- Ticket: [827](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-827)

### Changes proposed in this pull request

**Mailers for:**
-  those who have neither registered for their 2022/23 programme nor confirmed that they won’t have ECTs in 2022/23 (i.e. no reaction to our original email in May) - 0556f857-39b2-4a86-8a79-f42c91cd9a6b
- those who have confirmed that they are expecting ECTs and told us that their programme choice is either FIP or CIP, but have not added their ECTs and mentors to the service yet - 12969797-c110-436d-b10b-7f7d08d4d9df & 623cb545-1bc4-4407-94a1-474e2a080e39
- original launch email bounced because the email address isn’t recognised or active and the induction tutor has likely changed - c414ed7d-a3ef-43f0-a452-ee1a5f376fcc

We used to have two separate (CIP and FIP) pre term reminders that were [swapped out for a single one](https://github.com/DFE-Digital/early-careers-framework/commit/2c568e73f09bdcc8913c6a4a4cd49f307da1a9b1) , ive just added these back in. 

