### PR TITLE
Fix the induction tutor email link style

### DIFF
--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -19,7 +19,7 @@
       <td class="govuk-table__cell">
         <% if @induction_coordinator %>
           <%= @induction_coordinator.full_name %><br>
-          <%= mail_to @induction_coordinator.email, @induction_coordinator.email  %>
+          <%= govuk_mail_to @induction_coordinator.email, @induction_coordinator.email  %>
         <% end %>
       </td>
       <td class="govuk-table__cell">


### PR DESCRIPTION
### Context

Without the `class: 'govuk-link'` it doesn't pick up the GOV.UK styles and is the wrong shade of blue.

### Changes proposed in this pull request

Use the `govuk_mail_to` (from [govuk-components](https://govuk-components.netlify.app/helpers/link/#output-rendered-using-the-class-helpers)) helper instead of the regular Rails `mail_to` one.

### Guidance to review

| Before | After |
| ----- | ------ |
| ![Screenshot from 2022-07-04 15-41-42](https://user-images.githubusercontent.com/128088/177177138-8eb99be7-f177-43a9-9caf-d437acc217a3.png) | ![Screenshot from 2022-07-04 15-41-50](https://user-images.githubusercontent.com/128088/177177149-b20b7cdf-4ad0-4710-a069-8e7f044bdd63.png) |
