### PR TITLE
CST-842 Store official induction start date

### DIFF
--- a/db/migrate/20220707091857_add_induction_start_date_to_participant_profile.rb
+++ b/db/migrate/20220707091857_add_induction_start_date_to_participant_profile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInductionStartDateToParticipantProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_profiles, :induction_start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -652,8 +652,8 @@ ActiveRecord::Schema.define(version: 2022_07_07_091857) do
     t.string "training_status", default: "active", null: false
     t.string "profile_duplicity", default: "single", null: false
     t.uuid "participant_identity_id"
-    t.string "notes"
     t.string "start_term", default: "autumn_2021", null: false
+    t.string "notes"
     t.date "induction_start_date"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
@@ -771,9 +771,9 @@ ActiveRecord::Schema.define(version: 2022_07_07_091857) do
     t.string "declaration_type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["milestone_id", "schedule_id"], name: "index_schedule_milestones_on_milestone_id_and_schedule_id"
+    t.index ["milestone_id", "schedule_id", "declaration_type"], name: "milestones_schedules_schedule_milestone_declaration_type", unique: true
     t.index ["milestone_id"], name: "index_schedule_milestones_on_milestone_id"
-    t.index ["schedule_id", "milestone_id"], name: "index_schedule_milestones_on_schedule_id_and_milestone_id"
+    t.index ["schedule_id", "milestone_id", "declaration_type"], name: "schedules_milestones_schedule_milestone_declaration_type", unique: true
     t.index ["schedule_id"], name: "index_schedule_milestones_on_schedule_id"
   end
 
@@ -914,8 +914,8 @@ ActiveRecord::Schema.define(version: 2022_07_07_091857) do
     t.datetime "updated_at", precision: 6, null: false
     t.decimal "original_value"
     t.uuid "cohort_id", null: false
-    t.string "contract_version", default: "0.0.1"
     t.boolean "output_fee", default: true
+    t.string "contract_version", default: "0.0.1"
     t.decimal "reconcile_amount", default: "0.0", null: false
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_27_093758) do
+ActiveRecord::Schema.define(version: 2022_07_07_091857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -652,8 +652,9 @@ ActiveRecord::Schema.define(version: 2022_06_27_093758) do
     t.string "training_status", default: "active", null: false
     t.string "profile_duplicity", default: "single", null: false
     t.uuid "participant_identity_id"
-    t.string "start_term", default: "autumn_2021", null: false
     t.string "notes"
+    t.string "start_term", default: "autumn_2021", null: false
+    t.date "induction_start_date"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_participant_profiles_on_core_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_participant_profiles_on_mentor_profile_id"
@@ -770,9 +771,9 @@ ActiveRecord::Schema.define(version: 2022_06_27_093758) do
     t.string "declaration_type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["milestone_id", "schedule_id", "declaration_type"], name: "milestones_schedules_schedule_milestone_declaration_type", unique: true
+    t.index ["milestone_id", "schedule_id"], name: "index_schedule_milestones_on_milestone_id_and_schedule_id"
     t.index ["milestone_id"], name: "index_schedule_milestones_on_milestone_id"
-    t.index ["schedule_id", "milestone_id", "declaration_type"], name: "schedules_milestones_schedule_milestone_declaration_type", unique: true
+    t.index ["schedule_id", "milestone_id"], name: "index_schedule_milestones_on_schedule_id_and_milestone_id"
     t.index ["schedule_id"], name: "index_schedule_milestones_on_schedule_id"
   end
 
@@ -913,8 +914,8 @@ ActiveRecord::Schema.define(version: 2022_06_27_093758) do
     t.datetime "updated_at", precision: 6, null: false
     t.decimal "original_value"
     t.uuid "cohort_id", null: false
-    t.boolean "output_fee", default: true
     t.string "contract_version", default: "0.0.1"
+    t.boolean "output_fee", default: true
     t.decimal "reconcile_amount", default: "0.0", null: false
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-842)
Store the official induction start date for a participant so that it persists over their training
This needs to be populated either by some backfill task or at the point of adding/validating a participant.

### Changes proposed in this pull request
Add `induction_start_date` column to `participant_profiles` table.

### Guidance to review

