### PR TITLE
Add email to send to schools whose SITs email has bounced

### DIFF
--- a/app/mailers/participant_mailer.rb
+++ b/app/mailers/participant_mailer.rb
@@ -124,18 +124,19 @@ class ParticipantMailer < ApplicationMailer
     ).tag(:cip_register_participants_reminder).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
   end
 
-  def sit_contact_address_bounce(induction_coordinator_profile:, school_name:)
+  def sit_contact_address_bounce(induction_coordinator_profile:, school:)
+    email_address = school.primary_contact_email || school.secondary_contact_email
+
     template_mail(
       PARTICIPANT_TEMPLATES[:sit_contact_address_bounce],
-      to: induction_coordinator_profile.user.email,
+      to: email_address,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        name: induction_coordinator_profile.user.full_name,
-        school_name:,
-        sign_in: new_user_session_url,
+        school_name: school.name,
+        induction_coordinator_profile_email: induction_coordinator_profile.user.email,
       },
-    ).tag(:sit_contact_address_bounce).associate_with(induction_coordinator_profile, as: :induction_coordinator_profile)
+    ).tag(:sit_contact_address_bounce).associate_with(school, as: :school)
   end
 
   def sit_has_added_and_validated_participant(participant_profile:, school_name:)

--- a/app/services/contact_school.rb
+++ b/app/services/contact_school.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ContactSchool
+  # We sent school sits an email to remind them to register for a programme in the next cohort
+  # Some of these emails bounced because the emails incorrect or no longer in use
+  # This is a follow up to contact schools who's SITs email has bounced.
+
+  def sit_email_address_check(sit_email_addresses)
+    sit_email_addresses.each do |email|
+      user = User.find_by_email(email)
+
+      next unless user&.induction_coordinator?
+
+      induction_coordinator_profile = user.induction_coordinator_profile
+
+      next unless induction_coordinator_profile.schools.any?
+
+      user.induction_coordinator_profile.schools.each do |school|
+        ParticipantMailer.sit_contact_address_bounce(induction_coordinator_profile:, school:).deliver_later
+      end
+    end
+  end
+end

--- a/spec/services/contact_school_spec.rb
+++ b/spec/services/contact_school_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ContactSchool do
+  subject { described_class.new }
+
+  let!(:school) { create(:school) }
+  let!(:school_two) { create(:school) }
+  let!(:induction_coordinator_profile) { create(:induction_coordinator_profile, schools: [school]) }
+  let!(:user) { create(:user) }
+
+  before(:all) do
+    RSpec::Mocks.configuration.verify_partial_doubles = false
+  end
+
+  before(:each) do
+    allow_any_instance_of(Mail::TestMailer).to receive_message_chain(:response, :id) { "notify_id" }
+  end
+
+  after(:all) do
+    RSpec::Mocks.configuration.verify_partial_doubles = true
+  end
+
+  describe "#sit_email_address_check" do
+    it "sends the reminder email" do
+      expect(ParticipantMailer).to receive(:sit_contact_address_bounce).with(
+        hash_including(induction_coordinator_profile:, school:),
+      ).and_call_original
+
+      subject.sit_email_address_check([induction_coordinator_profile.user.email])
+    end
+
+    context "the induction coordinator has multiple schools" do
+      before do
+        induction_coordinator_profile.schools << school_two
+      end
+
+      it "sends a reminder to each school" do
+        expect(ParticipantMailer).to receive(:sit_contact_address_bounce).and_call_original.twice
+
+        subject.sit_email_address_check([induction_coordinator_profile.user.email])
+      end
+    end
+
+    it "does not send unless the user is an induction coordinator" do
+      expect(ParticipantMailer).not_to receive(:sit_contact_address_bounce).and_call_original
+      subject.sit_email_address_check([user.email])
+    end
+
+    context "SIT does not have any schools associated with them" do
+      before do
+        induction_coordinator_profile.update!(schools: [])
+      end
+
+      it "it does not try to send an email" do
+        expect(ParticipantMailer).not_to receive(:sit_contact_address_bounce).and_call_original
+        subject.sit_email_address_check([induction_coordinator_profile.user.email])
+      end
+    end
+  end
+end


### PR DESCRIPTION
We sent a batch of comms in May asking school induction tutors to register a programme for the 2022 cohort. We had a number of email addresses that bounced back. We have a specific template to contact all the schools to check that the SITs email is still correct or update it if necessary.

A list of the emails will be retrieved from prod. You can get a list of these from the status we've added when tagging

````Email.where(tags: "{preterm_reminder}", status: %w[permanent-failure temporary-failure technical-failure])````

Emails in may were tagged with ````preterm_reminder````

### Context

- Ticket: [827](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-827)

### Changes proposed in this pull request

Adding a service to contact schools for SIT emails that have bounced.

### Guidance to review

This is the final lot to send in this batch of comms (see the ticket linked). 

