### PR TITLE
Remove trigger to notify SITs that ects induction has not been registered

### DIFF
--- a/app/services/store_participant_eligibility.rb
+++ b/app/services/store_participant_eligibility.rb
@@ -18,10 +18,6 @@ class StoreParticipantEligibility < BaseService
       send_ineligible_notification_emails
     end
 
-    if changed_to_manual_check? && doing_fip?
-      send_manual_check_notification_email
-    end
-
     @participant_eligibility
   end
 
@@ -50,12 +46,6 @@ private
 
   def changed_to_eligible?
     @participant_eligibility.eligible_status? && @previous_status != "eligible"
-  end
-
-  # We need to check if the record is new because "manual_check" is the default value for newly
-  # created participant eligibilities
-  def changed_to_manual_check?
-    @participant_eligibility.manual_check_status? && ((@previous_status != "manual_check") || @new_eligibility_record)
   end
 
   def changed_from_ineligible?

--- a/spec/services/store_participant_eligibility_spec.rb
+++ b/spec/services/store_participant_eligibility_spec.rb
@@ -57,51 +57,6 @@ RSpec.describe StoreParticipantEligibility do
       end
     end
 
-    context "when manual check status is determined" do
-      it "sends the ect_no_induction_email when reason is no_induction and there is no participant eligibility" do
-        eligibility_options[:no_induction] = true
-        expect {
-          service.call(participant_profile: ect_profile, eligibility_options:)
-        }.to have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
-          .with(
-            induction_tutor_email: induction_tutor.email,
-            participant_profile: ect_profile,
-          )
-      end
-
-      it "sends notifications if the previous state was eligible" do
-        create(:ecf_participant_eligibility, :eligible, participant_profile: ect_profile)
-        eligibility_options[:no_induction] = true
-        expect {
-          service.call(participant_profile: ect_profile, eligibility_options:)
-        }.to have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
-          .with(
-            induction_tutor_email: induction_tutor.email,
-            participant_profile: ect_profile,
-          )
-      end
-
-      it "sends notifications if the previous state was ineligible" do
-        create(:ecf_participant_eligibility, :ineligible, participant_profile: ect_profile)
-        eligibility_options[:no_induction] = true
-        expect {
-          service.call(participant_profile: ect_profile, eligibility_options:)
-        }.to have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
-          .with(
-            induction_tutor_email: induction_tutor.email,
-            participant_profile: ect_profile,
-          )
-      end
-
-      it "doesn't send notifications if the previous state was manual check" do
-        create(:ecf_participant_eligibility, :manual_check, participant_profile: ect_profile)
-        eligibility_options[:no_induction] = true
-        expect {
-          service.call(participant_profile: ect_profile, eligibility_options:)
-        }.to_not have_enqueued_mail(IneligibleParticipantMailer, :ect_no_induction_email)
-      end
-    end
-
     context "when ineligible status is determined" do
       context "without eligibility_notifications feature enabled" do
         it "does not send email notifications" do


### PR DESCRIPTION
See https://ukgovernmentdfe.slack.com/archives/C01J1J4FM50/p1657204131220079 for info on why it's being removed. 

The `changed_to_manual_check` method was unused elsewhere so have removed that aswell


