### PR TITLE
Reject npq withdrawals without started declarations

### DIFF
--- a/app/controllers/api/v1/npq_participants_controller.rb
+++ b/app/controllers/api/v1/npq_participants_controller.rb
@@ -17,10 +17,10 @@ module Api
           perform_action(service_namespace: ::Participants::Withdraw)
         else
           render json: {
-            error: {
+            error: [{
               title: "No started declaration found",
               detail: "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance.",
-            },
+            }],
           }, status: :unprocessable_entity
         end
       end

--- a/spec/docs/v1/npq_participants_spec.rb
+++ b/spec/docs/v1/npq_participants_spec.rb
@@ -146,6 +146,14 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
                   "$ref": "#/components/schemas/NPQParticipantWithdrawRequest",
                 }
 
+      before do
+        create(:npq_participant_declaration,
+               declaration_type: "started",
+               user: npq_application.user,
+               participant_profile: npq_application.user.participant_profiles.first,
+               course_identifier: npq_application.npq_course.identifier)
+      end
+
       response "200", "The NPQ participant being withdrawn" do
         let(:id) { npq_application.participant_identity.external_identifier }
         let(:attributes) do

--- a/spec/docs/v1/npq_participants_spec.rb
+++ b/spec/docs/v1/npq_participants_spec.rb
@@ -7,7 +7,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:Authorization) { "Bearer #{token}" }
-  let!(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:) }
+  let!(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
 
   path "/api/v1/participants/npq" do
     get "Retrieve multiple NPQ participants" do
@@ -145,14 +145,6 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
                 schema: {
                   "$ref": "#/components/schemas/NPQParticipantWithdrawRequest",
                 }
-
-      before do
-        create(:npq_participant_declaration,
-               declaration_type: "started",
-               user: npq_application.user,
-               participant_profile: npq_application.user.participant_profiles.first,
-               course_identifier: npq_application.npq_course.identifier)
-      end
 
       response "200", "The NPQ participant being withdrawn" do
         let(:id) { npq_application.participant_identity.external_identifier }

--- a/spec/factories/npq_application.rb
+++ b/spec/factories/npq_application.rb
@@ -38,5 +38,15 @@ FactoryBot.define do
       kind_of_nursery { "private_nursery" }
       private_childcare_provider_urn { "EY#{rand(100_000..999_999)}" }
     end
+
+    trait :with_started_declaration do
+      after :create do |npq_application|
+        create(:npq_participant_declaration,
+               declaration_type: "started",
+               user: npq_application.user,
+               participant_profile: npq_application.user.participant_profiles.first,
+               course_identifier: npq_application.npq_course.identifier)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "NPQ Participants API", type: :request do
 
   describe "GET /api/v1/participants/npq", :with_default_schedules do
     let!(:npq_applications) do
-      create_list(:npq_application, 3, :accepted, npq_lead_provider:, school_urn: "123456")
+      create_list(:npq_application, 3, :accepted, :with_started_declaration, npq_lead_provider:, school_urn: "123456")
     end
 
     context "when authorized" do
@@ -112,14 +112,6 @@ RSpec.describe "NPQ Participants API", type: :request do
         end
 
         context "when there is a started declaration" do
-          before do
-            create(:npq_participant_declaration,
-                   declaration_type: "started",
-                   user: npq_application.user,
-                   participant_profile: npq_application.user.participant_profiles.first,
-                   course_identifier: npq_course.identifier)
-          end
-
           it_behaves_like "a participant withdraw action endpoint" do
             it "changes the training status of a participant to withdrawn" do
               put url, params: params
@@ -131,6 +123,8 @@ RSpec.describe "NPQ Participants API", type: :request do
         end
 
         context "when there are no started declarations" do
+          let(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:, school_urn: "123456") }
+
           it "returns an error message" do
             put url, params: params
 


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1342](https://dfedigital.atlassian.net/browse/CPDLP-1342)

Withdrawals affect providers KPIs and SRM do not want providers submitting withdrawals if the participant has not started.

### Changes proposed in this pull request

Overriding the `withdraw` API method in the NPQ participants controller to check if there is a started declaration for the participant and the course the lead provider is submitting the withdraw for. If it exists, then perform the withdraw action, otherwise return an error.

### Guidance to review
Scenario 1:
Send a [participant withdraw request](https://ecf-sandbox.london.cloudapps.digital/api-reference/reference-v1.html#api-v1-participants-npq-id-withdraw-put) that doesn't have a started declaration. You should receive an error instead.

Scenario 2:
Send a [participant withdraw request](https://ecf-sandbox.london.cloudapps.digital/api-reference/reference-v1.html#api-v1-participants-npq-id-withdraw-put) when a started declaration exists. The withdrawn should be successful.
