### PR TITLE
Add a service to transfer a participant to a correct school cohort

### DIFF
--- a/app/services/induction/transfer_to_correct_school_cohort.rb
+++ b/app/services/induction/transfer_to_correct_school_cohort.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class Induction::TransferToCorrectSchoolCohort < BaseService
+  # we're getting a lot of support queries to update ppts school cohort
+  # this is because users are adding ects/mentors to the wrong cohort
+  # we can use this to do the basics of a cohort transfer
+  # additional checks are needed to make sure all necessary changes have been done
+  def call
+    participant_profile = get_participant_profile
+
+    return Rails.logger.info "No participant profile with an active training status for #{email}" unless participant_profile
+
+    induction_record = participant_profile.induction_records.latest
+
+    correct_school_cohort = school_cohort_to_switch_to(induction_record)
+
+    return Rails.logger.info "No school cohort to transfer to for #{email}" unless correct_school_cohort
+
+    ActiveRecord::Base.transaction do
+      induction_record.update!(induction_programme: correct_school_cohort.default_induction_programme,
+                               start_date: start_date_for_cohort,
+                               schedule: default_cohort_schedule)
+      participant_profile.update!(school_cohort: correct_school_cohort,
+                                  schedule: default_cohort_schedule)
+    end
+  end
+
+  def initialize(email:, cohort:)
+    @email = email
+    @cohort = cohort
+  end
+
+  attr_reader :email, :cohort
+
+private
+
+  def get_user_identity
+    ParticipantIdentity.find_by_email(email)
+  end
+
+  def get_participant_profile
+    ParticipantProfile.find_by(training_status: "active", participant_identity: get_user_identity)
+  end
+
+  def school_cohort_to_switch_to(induction_record)
+    school = induction_record.school
+    SchoolCohort.find_by(school:, cohort:)
+  end
+
+  def start_date_for_cohort
+    cohort.academic_year_start_date
+  end
+
+  def default_cohort_schedule
+    Finance::Schedule::ECF.default_for(cohort:)
+  end
+end

--- a/spec/services/induction/transfer_to_correct_school_cohort_spec.rb
+++ b/spec/services/induction/transfer_to_correct_school_cohort_spec.rb
@@ -21,15 +21,17 @@ RSpec.describe Induction::TransferToCorrectSchoolCohort do
                    cohort: next_cohort)
     end
 
+    before do
+      Induction::SetCohortInductionProgramme.call(school_cohort: current_school_cohort,
+                                                  programme_choice: current_school_cohort.induction_programme_choice)
+      @induction_record = Induction::Enrol.call(participant_profile:,
+                                                induction_programme: current_school_cohort.default_induction_programme)
+    end
+
     context "participant has active training status" do
       before do
-        Induction::SetCohortInductionProgramme.call(school_cohort: current_school_cohort,
-                                                    programme_choice: current_school_cohort.induction_programme_choice)
         Induction::SetCohortInductionProgramme.call(school_cohort: next_school_cohort,
                                                     programme_choice: next_school_cohort.induction_programme_choice)
-        @induction_record = Induction::Enrol.call(participant_profile:,
-                                                  induction_programme: current_school_cohort.default_induction_programme)
-
         service_call
         @induction_record.reload
         participant_profile.reload
@@ -63,29 +65,46 @@ RSpec.describe Induction::TransferToCorrectSchoolCohort do
 
     context "there is no active participant profile" do
       before do
+        Induction::SetCohortInductionProgramme.call(school_cohort: next_school_cohort,
+                                                    programme_choice: next_school_cohort.induction_programme_choice)
         allow(Rails).to receive(:logger).and_return(fake_logger)
-        participant_profile.update!(training_status: "withdrawn")
-
+        participant_profile.training_status_withdrawn!
         service_call
+        @induction_record.reload
+        participant_profile.reload
       end
 
       it "returns early with an error" do
         expect(fake_logger).to have_received(:info).with("No participant profile with an active training status for #{email}")
+      end
+
+      it "does not update the induction record schedule" do
+        expect(@induction_record.schedule).to eq(current_schedule)
       end
     end
 
     context "there is no school cohort to transfer to" do
       before do
         allow(Rails).to receive(:logger).and_return(fake_logger)
-        Induction::SetCohortInductionProgramme.call(school_cohort: current_school_cohort,
-                                                    programme_choice: current_school_cohort.induction_programme_choice)
-        @induction_record = Induction::Enrol.call(participant_profile:,
-                                                  induction_programme: current_school_cohort.default_induction_programme)
         service_call
+        @induction_record.reload
+        participant_profile.reload
       end
 
       it "returns early with an error" do
         expect(fake_logger).to have_received(:info).with("No school cohort to transfer to for #{email}")
+      end
+
+      it "does not update the induction record schedule" do
+        expect(@induction_record.schedule).to eq(current_schedule)
+      end
+
+      it "does not update the induction record start_date" do
+        expect(@induction_record.start_date).not_to eq(next_cohort.academic_year_start_date)
+      end
+
+      it "does not update the participant profile schedule" do
+        expect(participant_profile.schedule).to eq(current_schedule)
       end
     end
   end

--- a/spec/services/induction/transfer_to_correct_school_cohort_spec.rb
+++ b/spec/services/induction/transfer_to_correct_school_cohort_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::TransferToCorrectSchoolCohort do
+  describe "#call" do
+    let!(:current_cohort) { create(:cohort, :current) }
+    let(:next_cohort) { create(:cohort, :next) }
+    let(:school) { create(:school, name: "Test School") }
+    let!(:current_school_cohort) { create(:school_cohort, :fip, school:, cohort: current_cohort) }
+    let(:next_school_cohort) { create(:school_cohort, :fip, school:, cohort: next_cohort) }
+    let!(:current_schedule) { create(:ecf_schedule, name: "2021 schedule", schedule_identifier: "ecf-standard-september", cohort: current_cohort) }
+    let!(:next_schedule) { create(:ecf_schedule, name: "2022 schedule", schedule_identifier: "ecf-standard-september", cohort: next_cohort) }
+    let(:participant_profile) { create(:ect_participant_profile, school_cohort: current_school_cohort) }
+    let(:email) { participant_profile.user.email }
+
+    let(:fake_logger) { double("logger", info: nil) }
+
+    subject(:service) { described_class }
+
+    let(:service_call) do
+      service.call(email:,
+                   cohort: next_cohort)
+    end
+
+    context "participant has active training status" do
+      before do
+        Induction::SetCohortInductionProgramme.call(school_cohort: current_school_cohort,
+                                                    programme_choice: current_school_cohort.induction_programme_choice)
+        Induction::SetCohortInductionProgramme.call(school_cohort: next_school_cohort,
+                                                    programme_choice: next_school_cohort.induction_programme_choice)
+        @induction_record = Induction::Enrol.call(participant_profile:,
+                                                  induction_programme: current_school_cohort.default_induction_programme)
+
+        service_call
+        @induction_record.reload
+        participant_profile.reload
+      end
+
+      describe "induction record updates" do
+        it "updates to the correct school cohort induction programme" do
+          expect(@induction_record.induction_programme).to eq(next_school_cohort.default_induction_programme)
+        end
+
+        it "updates to the correct schedule" do
+          expect(@induction_record.schedule).to eq(next_schedule)
+          expect(@induction_record.schedule.name).to eq("2022 schedule")
+        end
+
+        it "updates the start date" do
+          expect(@induction_record.start_date).to eq(next_cohort.academic_year_start_date)
+        end
+      end
+
+      describe "participant profile updates" do
+        it "updates the school cohort" do
+          expect(participant_profile.school_cohort).to eq(next_school_cohort)
+        end
+
+        it "updates the schedule" do
+          expect(participant_profile.schedule).to eq(next_schedule)
+        end
+      end
+    end
+
+    context "there is no active participant profile" do
+      before do
+        allow(Rails).to receive(:logger).and_return(fake_logger)
+        participant_profile.update!(training_status: "withdrawn")
+
+        service_call
+      end
+
+      it "returns early with an error" do
+        expect(fake_logger).to have_received(:info).with("No participant profile with an active training status for #{email}")
+      end
+    end
+
+    context "there is no school cohort to transfer to" do
+      before do
+        allow(Rails).to receive(:logger).and_return(fake_logger)
+        Induction::SetCohortInductionProgramme.call(school_cohort: current_school_cohort,
+                                                    programme_choice: current_school_cohort.induction_programme_choice)
+        @induction_record = Induction::Enrol.call(participant_profile:,
+                                                  induction_programme: current_school_cohort.default_induction_programme)
+        service_call
+      end
+
+      it "returns early with an error" do
+        expect(fake_logger).to have_received(:info).with("No school cohort to transfer to for #{email}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [838](https://dfedigital.atlassian.net/browse/CST-838) 
 
[Cohort transfers spreadsheet](https://docs.google.com/spreadsheets/d/12sL1aNI3IsGtHlR3OUDzemsfMTj_RHzcBjQu6skbdpw/edit#gid=0). To help speed up resolving cohort transfer support tickets we want to be able to quickly transfer the minimum required details to the correct school cohort. 

**this only allows a participant between school cohorts at their current school.** 
 
### Changes proposed in this pull request

Adding a service that updates a users induction record and participant profile. 

Induction Record:
 - induction programme
 - start date
 - schedule
 
Participant Profile:
 - school cohort
 - schedule

The start date is taken from the cohort academic year start date

### Guidance to review

At the minute this is to be used in the console 