### PR TITLE
[CPDLP-1263] Statement seeder only provides genesis seeds

### DIFF
--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -1,20 +1,29 @@
 # frozen_string_literal: true
 
+# This class provides a mechnism to import genesis statements
+# It is not designed to keep statements in sync
+# For that should be done by hand
+
 class Importers::SeedStatements
   def call
     LeadProvider.includes(:cpd_lead_provider).each do |lead_provider|
       cpd_lead_provider = lead_provider.cpd_lead_provider
 
       ecf_statements.each do |statement_data|
-        statement = Finance::Statement::ECF.find_or_create_by!(
+        statement = Finance::Statement::ECF.find_by(
           name: statement_data.name,
           cpd_lead_provider:,
-          cohort: Cohort.find_by(start_year: 2021),
+          cohort:,
         )
-        statement.update!(
+
+        next if statement
+
+        Finance::Statement::ECF.create!(
+          name: statement_data.name,
+          cpd_lead_provider:,
+          cohort:,
           deadline_date: statement_data.deadline_date,
           payment_date: statement_data.payment_date,
-          cohort: Cohort.find_by(start_year: 2021),
           output_fee: statement_data.output_fee,
           type: class_for(statement_data, namespace: Finance::Statement::ECF),
           contract_version: statement_data.contract_version,
@@ -26,13 +35,17 @@ class Importers::SeedStatements
       cpd_lead_provider = npq_lead_provider.cpd_lead_provider
 
       npq_statements.each do |statement_data|
-        statement = Finance::Statement::NPQ.find_or_create_by!(
+        statement = Finance::Statement::NPQ.find_by(
           name: statement_data.name,
           cpd_lead_provider:,
           cohort:,
         )
 
-        statement.update!(
+        next if statement
+
+        Finance::Statement::NPQ.create!(
+          name: statement_data.name,
+          cpd_lead_provider:,
           deadline_date: statement_data.deadline_date,
           payment_date: statement_data.payment_date,
           cohort:,
@@ -96,7 +109,7 @@ private
     [
       { name: "January 2022",   deadline_date: Date.new(2021, 12, 25),  payment_date: Date.new(2022, 1, 25),  contract_version: "0.0.1", output_fee: true  },
       { name: "February 2022",  deadline_date: Date.new(2022, 1, 25),   payment_date: Date.new(2022, 2, 25),  contract_version: "0.0.1", output_fee: false },
-      { name: "March 2022",     deadline_date: Date.new(2022, 2, 25),   payment_date: Date.new(2022, 3, 25),  contract_version: "0.0.2", output_fee: true  },
+      { name: "March 2022",     deadline_date: Date.new(2022, 2, 25),   payment_date: Date.new(2022, 3, 25),  contract_version: "0.0.1", output_fee: true  },
       { name: "April 2022",     deadline_date: Date.new(2022, 3, 25),   payment_date: Date.new(2022, 4, 25),  contract_version: "0.0.1", output_fee: false },
       { name: "May 2022",       deadline_date: Date.new(2022, 4, 25),   payment_date: Date.new(2022, 5, 25),  contract_version: "0.0.1", output_fee: false },
       { name: "June 2022",      deadline_date: Date.new(2022, 5, 25),   payment_date: Date.new(2022, 6, 25),  contract_version: "0.0.1", output_fee: false },

--- a/spec/services/importers/seed_statements_spec.rb
+++ b/spec/services/importers/seed_statements_spec.rb
@@ -21,38 +21,5 @@ RSpec.describe Importers::SeedStatements do
         subject.call
       }.to change(Finance::Statement::NPQ, :count).by(36)
     end
-
-    context "with updated contract version" do
-      let(:new_contract_version) { "99.99.99" }
-      let(:statement_name) { "May 2024" }
-
-      before do
-        subject.call
-        allow(subject).to receive(method_name).and_return(altered_statements)
-        subject.call
-      end
-
-      context "when ECF statements" do
-        let(:method_name) { :ecf_statements }
-        let(:altered_statements) do
-          [OpenStruct.new(name: statement_name, deadline_date: Date.new(2024, 4, 30), payment_date: Date.new(2024, 5, 25), contract_version: new_contract_version, output_fee: true)]
-        end
-
-        it "does not creates duplicate statements" do
-          expect(Finance::Statement::ECF.where(name: statement_name).count).to eq(1)
-        end
-      end
-
-      context "when NPQ statements" do
-        let(:method_name) { :npq_statements }
-        let(:altered_statements) do
-          [OpenStruct.new(name: statement_name, deadline_date: Date.new(2024, 4, 25), payment_date: Date.new(2024, 5, 25), contract_version: new_contract_version, output_fee: false)]
-        end
-
-        it "does not creates duplicate statements" do
-          expect(Finance::Statement::NPQ.where(name: statement_name).count).to eq(1)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1263
- `Importers::SeedStatements` was used to mutate data which had undesired outcomes
- We want to make this class do initial seeding only

### Changes proposed in this pull request

- Make this importer for genesis data only
- If it finds a record already exists it will simply skip it
- We do not want to use this class to mutate data this needs to be done by hand

### Guidance to review

- none