### PR TITLE
[CPDLP-1531] Return error when operating on withdrawn profile

### DIFF
--- a/app/services/participants/change_schedule/ecf.rb
+++ b/app/services/participants/change_schedule/ecf.rb
@@ -86,7 +86,9 @@ module Participants
       end
 
       def not_already_withdrawn
-        errors.add(:participant_id, I18n.t(:withdrawn_participant)) if relevant_induction_record&.training_status_withdrawn?
+        if user_profile.present? && relevant_induction_record&.training_status_withdrawn?
+          errors.add(:participant_id, I18n.t(:withdrawn_participant))
+        end
       end
 
       def schedule_valid_with_pending_declarations

--- a/app/services/participants/defer/validate_and_change_state.rb
+++ b/app/services/participants/defer/validate_and_change_state.rb
@@ -6,12 +6,15 @@ module Participants
       extend ActiveSupport::Concern
       include ActiveModel::Validations
 
+      prepended do
+        validate :not_already_withdrawn
+        validate :not_already_deferred
+      end
+
       included do
         attr_accessor :reason
 
         validates :reason, inclusion: { in: reasons }
-        validate :not_already_withdrawn
-        validate :not_already_deferred
       end
 
       def perform_action!

--- a/app/services/participants/early_career_teacher.rb
+++ b/app/services/participants/early_career_teacher.rb
@@ -3,9 +3,13 @@
 module Participants
   module EarlyCareerTeacher
     include ECF
+
     extend ActiveSupport::Concern
+
     included do
       extend EarlyCareerTeacherClassMethods
+
+      validate :validate_profile_not_withdrawn
     end
 
     def early_career_teacher_profile
@@ -18,6 +22,16 @@ module Participants
     module EarlyCareerTeacherClassMethods
       def valid_courses
         %w[ecf-induction]
+      end
+    end
+
+  private
+
+    def validate_profile_not_withdrawn
+      return unless participant_identity
+
+      if early_career_teacher_profile.nil? && participant_identity.participant_profiles.ects.any?
+        errors.add :base, I18n.t("withdrawn_participant")
       end
     end
   end

--- a/app/services/participants/mentor.rb
+++ b/app/services/participants/mentor.rb
@@ -3,9 +3,13 @@
 module Participants
   module Mentor
     include ECF
+
     extend ActiveSupport::Concern
+
     included do
       extend MentorClassMethods
+
+      validate :validate_profile_not_withdrawn
     end
 
     def mentor_profile
@@ -18,6 +22,16 @@ module Participants
     module MentorClassMethods
       def valid_courses
         %w[ecf-mentor]
+      end
+    end
+
+  private
+
+    def validate_profile_not_withdrawn
+      return unless participant_identity
+
+      if mentor_profile.nil? && participant_identity.participant_profiles.mentors.any?
+        errors.add :base, I18n.t("withdrawn_participant")
       end
     end
   end

--- a/app/services/participants/resume/validate_and_change_state.rb
+++ b/app/services/participants/resume/validate_and_change_state.rb
@@ -6,7 +6,7 @@ module Participants
       extend ActiveSupport::Concern
       include ActiveModel::Validations
 
-      included do
+      prepended do
         validate :not_already_active
         validate :not_already_withdrawn
       end

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -6,11 +6,14 @@ module Participants
       extend ActiveSupport::Concern
       include ActiveModel::Validations
 
+      prepended do
+        validate :not_already_withdrawn
+      end
+
       included do
         attr_accessor :reason
 
         validates :reason, inclusion: { in: reasons }
-        validate :not_already_withdrawn
       end
 
       def perform_action!

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -84,7 +84,7 @@ FactoryBot.define do
     end
 
     after :build do |participant_profile|
-      participant_profile.participant_identity = Identity::Create.call(user: participant_profile.user)
+      participant_profile.participant_identity ||= Identity::Create.call(user: participant_profile.user)
     end
   end
 end

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -417,4 +417,74 @@ RSpec.describe "Participants API", type: :request do
       Induction::Enrol.call(participant_profile: early_career_teacher_profile, induction_programme:)
     end
   end
+
+  describe "PUT /api/v1/participants/ecf/ID/defer" do
+    context "with withdrawn profile and incorrect course" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:ect_participant_profile, :withdrawn) }
+      let(:url) { "/api/v1/participants/#{early_career_teacher_profile.user.id}/defer" }
+      let(:params) { { data: { attributes: { course_identifier: "ecf-mentor", reason: "career-break" } } } }
+
+      it "is not successful and returns an error message" do
+        put url, params: params
+        expect(response).not_to be_successful
+        expect(response.body).to include("The property '#/participant_id' must be a valid Participant ID")
+      end
+    end
+  end
+
+  describe "PUT /api/v1/participants/ecf/ID/resume" do
+    context "with withdrawn profile and incorrect course" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:ect_participant_profile, :withdrawn) }
+      let(:url) { "/api/v1/participants/#{early_career_teacher_profile.user.id}/resume" }
+      let(:params) { { data: { attributes: { course_identifier: "ecf-mentor" } } } }
+
+      it "is not successful and returns an error message" do
+        put url, params: params
+        expect(response).not_to be_successful
+        expect(response.body).to include("The property '#/participant_id' must be a valid Participant ID")
+      end
+    end
+  end
+
+  describe "PUT /api/v1/participants/ecf/ID/withdraw" do
+    context "with withdrawn profile and incorrect course" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:ect_participant_profile, :withdrawn) }
+      let(:url) { "/api/v1/participants/#{early_career_teacher_profile.user.id}/withdraw" }
+      let(:params) { { data: { attributes: { course_identifier: "ecf-mentor" } } } }
+
+      it "is not successful and returns an error message" do
+        put url, params: params
+        expect(response).not_to be_successful
+        expect(response.body).to include("The property '#/participant_id' must be a valid Participant ID")
+      end
+    end
+  end
+
+  describe "PUT /api/v1/participants/ecf/ID/change-schedule" do
+    context "with withdrawn profile and incorrect course" do
+      let(:new_schedule) { create(:ecf_schedule) }
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:ect_participant_profile, :withdrawn) }
+      let(:url) { "/api/v1/participants/#{early_career_teacher_profile.user.id}/change-schedule" }
+      let(:params) do
+        {
+          data: {
+            attributes: {
+              course_identifier: "ecf-mentor",
+              schedule_identifier: new_schedule.schedule_identifier,
+            },
+          },
+        }
+      end
+
+      it "is not successful and returns an error message" do
+        put url, params: params
+        expect(response).not_to be_successful
+        expect(response.body).to include("The property '#/participant_id' must be a valid Participant ID")
+      end
+    end
+  end
 end

--- a/spec/services/participants/early_career_teacher_spec.rb
+++ b/spec/services/participants/early_career_teacher_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Participants::EarlyCareerTeacher do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+      include Participants::EarlyCareerTeacher
+
+      attr_accessor :participant_identity
+    end
+  end
+
+  subject { klass.new(participant_identity:) }
+
+  describe "validation" do
+    context "when single profile is withdrawn" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:ect_participant_profile, :withdrawn) }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:base]).to include("Cannot perform actions on a withdrawn participant")
+      end
+    end
+
+    context "when 2 profiles: 1 active, 1 withdrawn" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:ect_participant_profile) }
+
+      before do
+        create(:ect_participant_profile, :withdrawn, participant_identity:)
+      end
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end

--- a/spec/services/participants/mentor_spec.rb
+++ b/spec/services/participants/mentor_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Participants::Mentor do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+      include Participants::Mentor
+
+      attr_accessor :participant_identity
+    end
+  end
+
+  subject { klass.new(participant_identity:) }
+
+  describe "validation" do
+    context "when single profile is withdrawn" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:mentor_participant_profile, :withdrawn) }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:base]).to include("Cannot perform actions on a withdrawn participant")
+      end
+    end
+
+    context "when 2 profiles: 1 active, 1 withdrawn" do
+      let(:participant_identity) { participant_profile.participant_identity }
+      let(:participant_profile) { create(:mentor_participant_profile) }
+
+      before do
+        create(:mentor_participant_profile, :withdrawn, participant_identity:)
+      end
+
+      it "is valid" do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1531
- When a provider attempts to change schedule and the profile is withdrawn
- This currently explodes as there is a scope that returns only active profiles so therefore returns `nil`
- We then attempt to send messages to this `nil` object 

### Changes proposed in this pull request

- Add validation so that if no active profile is found and there are other profiles, it adds an error that the participant is withdrawn
- This short circuits reaching the code that sends messages to `nil` 
- This fixes change schedule when attempting to operate on a withdrawn profile

### Guidance to review

- none