### PR TITLE
[CST-594] Prevent school creating a cohort with an invalid partnership

### DIFF
--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -8,13 +8,15 @@ module Schools
     before_action :school
     before_action :cohort
     before_action :previous_cohort, only: %i[what_changes what_changes_confirmation]
-    before_action :lead_provider_name, only: %i[what_changes what_changes_confirmation what_changes_submitted]
-    before_action :delivery_partner_name, only: %i[what_changes what_changes_confirmation what_changes_submitted]
+    before_action :lead_provider, only: %i[what_changes what_changes_confirmation what_changes_submitted change_provider provider_relation_invalid use_different_delivery_partner]
+    before_action :delivery_partner, only: %i[what_changes what_changes_confirmation what_changes_submitted change_provider provider_relation_invalid]
     before_action :validate_request_or_render,
                   only: %i[expect_any_ects
                            how_will_you_run_training
                            programme_confirmation
                            change_provider
+                           provider_relation_invalid
+                           use_different_delivery_partner
                            what_changes
                            what_changes_confirmation
                            what_changes_submitted
@@ -64,11 +66,24 @@ module Schools
       when "yes"
         store_form_redirect_to_next_step :what_changes
       when "no"
-        store_form
-        start_appropriate_body_selection from_path: url_for(action: :programme_confirmation),
-                                         submit_action: :save_provider_change,
-                                         school_name: @school.name
+        if provider_relationship_is_valid?
+          store_form
+          start_appropriate_body_selection from_path: url_for(action: :programme_confirmation),
+                                           submit_action: :save_provider_change,
+                                           school_name: @school.name
+        else
+          store_form_redirect_to_next_step :provider_relation_invalid
+        end
       end
+    end
+
+    def provider_relation_invalid; end
+
+    def use_different_delivery_partner
+      store_form
+      start_appropriate_body_selection from_path: url_for(action: :use_different_delivery_partner),
+                                       submit_action: :delivery_partner_choice,
+                                       school_name: @school.name
     end
 
     def what_changes
@@ -111,6 +126,17 @@ module Schools
       else
         use_the_same_training_programme!
       end
+      redirect_to action: :complete
+    end
+
+    def delivery_partner_choice
+      case @setup_school_cohort_form.use_different_delivery_partner_choice
+      when "yes"
+        @setup_school_cohort_form.what_changes_choice = "change_delivery_partner"
+      end
+
+      set_cohort_induction_programme!("full_induction_programme")
+
       redirect_to action: :complete
     end
 
@@ -173,7 +199,8 @@ module Schools
             .permit(:expect_any_ects_choice,
                     :how_will_you_run_training_choice,
                     :change_provider_choice,
-                    :what_changes_choice)
+                    :what_changes_choice,
+                    :use_different_delivery_partner_choice)
     end
 
     def validate_request_or_render
@@ -237,6 +264,11 @@ module Schools
 
     def delivery_partner_to_be_confirmed?
       @setup_school_cohort_form.what_changes_choice == "change_delivery_partner"
+    end
+
+    def provider_relationship_is_valid?
+      provider_relationship = ProviderRelationship.find_by(lead_provider: @lead_provider, delivery_partner: @delivery_partner, cohort:)
+      !provider_relationship.nil?
     end
 
     def end_appropriate_body_selection

--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -227,12 +227,12 @@ module Schools
       @previous_cohort ||= previous_school_cohort&.cohort
     end
 
-    def lead_provider_name
-      @lead_provider_name ||= school.lead_provider(previous_cohort.start_year)&.name
+    def lead_provider
+      @lead_provider ||= school.lead_provider(previous_cohort.start_year)
     end
 
-    def delivery_partner_name
-      @delivery_partner_name ||= school.delivery_partner_for(previous_cohort.start_year)&.name
+    def delivery_partner
+      @delivery_partner ||= school.delivery_partner_for(previous_cohort.start_year)
     end
 
     def delivery_partner_to_be_confirmed?

--- a/app/forms/schools/setup_school_cohort_form.rb
+++ b/app/forms/schools/setup_school_cohort_form.rb
@@ -7,12 +7,13 @@ module Schools
     include ActiveModel::Serialization
 
     attr_accessor :expect_any_ects_choice, :how_will_you_run_training_choice, :change_provider_choice,
-                  :what_changes_choice
+                  :what_changes_choice, :use_different_delivery_partner_choice
 
     validates :expect_any_ects_choice, presence: true, on: :expect_any_ects
     validates :how_will_you_run_training_choice, presence: true, on: :how_will_you_run_training
     validates :change_provider_choice, presence: true, on: :change_provider
     validates :what_changes_choice, presence: true, on: :what_changes
+    validates :use_different_delivery_partner_choice, presence: true, on: :use_different_delivery_partner
 
     PROGRAMME_CHOICES_MAP = {
       "change_lead_provider" => "full_induction_programme",
@@ -27,6 +28,7 @@ module Schools
         how_will_you_run_training_choice:,
         change_provider_choice:,
         what_changes_choice:,
+        use_different_delivery_partner_choice:,
       }
     end
 
@@ -52,6 +54,10 @@ module Schools
     end
 
     def change_provider_choices
+      yes_no_choices
+    end
+
+    def use_different_delivery_partner_choices
       yes_no_choices
     end
 

--- a/app/views/schools/setup_school_cohort/_change_delivery_partner_confirmation.html.erb
+++ b/app/views/schools/setup_school_cohort/_change_delivery_partner_confirmation.html.erb
@@ -2,7 +2,7 @@
 <h1 class="govuk-heading-xl">Are you sure you want to make this change?</h1>
 
 <p class="govuk-body">
-  <%= @delivery_partner_name %> will not be able to deliver training for ECTs and mentors starting in the
+  <%= @delivery_partner&.name %> will not be able to deliver training for ECTs and mentors starting in the
   <%= @cohort.description %> academic year.
 </p>
 <p class="govuk-body govuk-!-margin-bottom-7">

--- a/app/views/schools/setup_school_cohort/_change_delivery_partner_submitted.html.erb
+++ b/app/views/schools/setup_school_cohort/_change_delivery_partner_submitted.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">What happens next</h2>
-<p class="govuk-body">We’ll let <%= @delivery_partner_name %> know that your school wants to make a change for ECTs and
+<p class="govuk-body">We’ll let <%= @delivery_partner&.name %> know that your school wants to make a change for ECTs and
   mentors starting in the 2022 to 2023 academic year.</p>
 <p class="govuk-body">They may contact you to confirm this.</p>
 

--- a/app/views/schools/setup_school_cohort/_change_lead_provider_confirmation.html.erb
+++ b/app/views/schools/setup_school_cohort/_change_lead_provider_confirmation.html.erb
@@ -2,7 +2,7 @@
 <h1 class="govuk-heading-xl">Are you sure you want to make this change?</h1>
 
 <p class="govuk-body">
-  <%= @lead_provider_name %> and <%= @delivery_partner_name %> will not be able to deliver training for ECTs and mentors
+  <%= @lead_provider&.name %> and <%= @delivery_partner&.name %> will not be able to deliver training for ECTs and mentors
   starting in the <%= @cohort.description %> academic year.
 </p>
 <p class="govuk-body govuk-!-margin-bottom-7">

--- a/app/views/schools/setup_school_cohort/_change_lead_provider_submitted.html.erb
+++ b/app/views/schools/setup_school_cohort/_change_lead_provider_submitted.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">What happens next</h2>
-<p class="govuk-body">We’ll let <%= @lead_provider_name %> and <%= @delivery_partner_name %> know that your school wants
+<p class="govuk-body">We’ll let <%= @lead_provider&.name %> and <%= @delivery_partner&.name %> know that your school wants
   to make a change for ECTs and
   mentors starting in the 2022 to 2023 academic year.</p>
 <p class="govuk-body">They may contact you to confirm this.</p>

--- a/app/views/schools/setup_school_cohort/provider_relation_invalid.html.erb
+++ b/app/views/schools/setup_school_cohort/provider_relation_invalid.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "You cannot use this combination of lead provider and delivery partner for your new ECTs and their mentors" %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: change_provider_schools_setup_school_cohort_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+
+    <h1 class="govuk-heading-xl">You cannot use this combination of lead provider and delivery partner for your new ECTs and their mentors</h1>
+
+    <p class="govuk-body">This is because <%= @delivery_partner.name %> will not be continuing as a delivery partner for <%= @lead_provider.name %>.</p>
+
+    <p class="govuk-body">For ECTs and mentors starting training in the 2022 to 2023 academic year, you can either use:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your lead provider <%= @lead_provider.name %> with another delivery partner</li>
+      <li>another combination of lead provider and delivery partner</li>
+    </ul>
+
+    <%= govuk_link_to "Continue", { action: :use_different_delivery_partner }, class: "govuk-button" %>
+
+  </div>
+</div>

--- a/app/views/schools/setup_school_cohort/use_different_delivery_partner.html.erb
+++ b/app/views/schools/setup_school_cohort/use_different_delivery_partner.html.erb
@@ -1,0 +1,34 @@
+<% title = "Will you use #{@lead_provider.name} with another delivery partner?" %>
+
+<% content_for :title, title %>
+
+<% content_for :before_content, govuk_back_link(text: "Back", href: provider_relation_invalid_schools_setup_school_cohort_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+
+     <%= form_for @setup_school_cohort_form, url: { action: :use_different_delivery_partner }, method: :put do |f| %>
+       <%= f.govuk_error_summary %>
+       <%= f.govuk_collection_radio_buttons(
+           :use_different_delivery_partner_choice,
+           @setup_school_cohort_form.use_different_delivery_partner_choices,
+           :id, :name,
+           inline: true,
+           legend: { text: title, tag: 'h1', size: 'xl' }) do %>
+
+         <p class="govuk-body govuk-!-margin-top-5">This is for:</p>
+
+         <ul class="govuk-list govuk-list--bullet">
+           <li>new ECTs starting ECF-based training in the <%= @cohort.description %> academic year</li>
+           <li>any mentors due to start mentor training in the same year</li>
+         </ul>
+
+       <% end %>
+
+       <%= f.govuk_submit "Continue" %>
+     <% end %>
+
+  </div>
+</div>

--- a/app/views/schools/setup_school_cohort/what_changes.html.erb
+++ b/app/views/schools/setup_school_cohort/what_changes.html.erb
@@ -7,19 +7,19 @@
     <div class="govuk-grid-column-two-thirds">
 
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        
+
         <%= form_for @setup_school_cohort_form, url: { action: :what_changes }, method: :put do |f| %>
             <%= f.govuk_error_summary %>
 
             <%= f.govuk_collection_radio_buttons(
             :what_changes_choice,
-            @setup_school_cohort_form.what_changes_choices(@lead_provider_name, @delivery_partner_name),
+            @setup_school_cohort_form.what_changes_choices(@lead_provider&.name, @delivery_partner&.name),
             :id, :name,
             inline: true,
             legend: { text: title, tag: 'h1', size: 'xl' }) do %>
 
             <p class="govuk-body">The change will only apply for ECTs and mentors starting in the 2022 to 2023 academic year.</p>
-            
+
             <% end %>
 
             <%= f.govuk_submit "Continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,8 +282,12 @@ en:
               blank: "Choose whether your school expect any ECTs"
             how_will_you_run_training_choice:
               blank: "Choose how you will run training for new starters"
+            change_provider_choice:
+              blank: "Choose if you are planning to change your current training provider"
             what_changes_choice:
               blank: "Choose what change you plan to make"
+            use_different_delivery_partner_choice:
+              blank: "Choose if you will continue with another delivery partner"
             appropriate_body_type:
               blank: "Choose an appropriate body type"
             appropriate_body:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -440,6 +440,12 @@ Rails.application.routes.draw do
             get "what-changes", to: "setup_school_cohort#what_changes"
             put "what-changes", to: "setup_school_cohort#what_changes"
 
+            get "provider-relation-invalid", to: "setup_school_cohort#provider_relation_invalid"
+            put "provider-relation-invalid", to: "setup_school_cohort#provider_relation_invalid"
+
+            get "use-different-delivery-partner", to: "setup_school_cohort#use_different_delivery_partner"
+            put "use-different-delivery-partner", to: "setup_school_cohort#use_different_delivery_partner"
+
             get "what-changes-confirmation", to: "setup_school_cohort#what_changes_confirmation"
             put "what-changes-confirmation", to: "setup_school_cohort#what_changes_confirmation"
 

--- a/db/seeds/multi_cohort_seeds.rb
+++ b/db/seeds/multi_cohort_seeds.rb
@@ -65,6 +65,12 @@ Partnership.find_or_create_by!(school: fip2_school,
   partnership.challenge_deadline = Date.new(2021, 12, 1)
 end
 
+Cohort.all.each do |cohort|
+  ProviderRelationship.find_or_create_by!(cohort:,
+                                          lead_provider:,
+                                          delivery_partner:)
+end
+
 Induction::SetCohortInductionProgramme.call(school_cohort: fip2_school_cohort,
                                             programme_choice: "full_induction_programme")
 

--- a/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
@@ -10,14 +10,12 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     FeatureFlag.activate(:multiple_cohorts)
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_cohort_for_next_academic_year_is_created
-    and_the_next_cohort_is_open_for_registrations
     and_i_am_signed_in_as_an_induction_coordinator
     when_i_start_programme_selection_for_next_cohort
     then_i_am_taken_to_ects_expected_in_next_academic_year_page
   end
 
-  context "school cohort provider relationship for 2022 is invalid" do
-    context "FIP"
+  context "school cohort provider relationship for 2022 is invalid", travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0) do
     scenario "school continues with same lead provider" do
       when_i_choose_ects_expected
       and_i_click_continue

--- a/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "./choose_programme_steps"
+
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false do
+  include ChooseProgrammeSteps
+
+  before do
+    FeatureFlag.activate(:multiple_cohorts)
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_cohort_for_next_academic_year_is_created
+    and_the_next_cohort_is_open_for_registrations
+    and_i_am_signed_in_as_an_induction_coordinator
+    when_i_start_programme_selection_for_next_cohort
+    then_i_am_taken_to_ects_expected_in_next_academic_year_page
+  end
+
+  context "school cohort provider relationship for 2022 is invalid" do
+    context "FIP"
+    scenario "school continues with same lead provider" do
+      when_i_choose_ects_expected
+      and_i_click_continue
+      then_i_am_taken_to_the_change_provider_page
+      and_i_see_the_lead_provider
+      and_i_see_the_delivery_partner
+
+      when_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_provider_relationship_invalid_page
+      and_i_click_continue
+      then_i_am_taken_to_the_use_different_delivery_partner
+
+      when_i_choose_yes
+      and_i_click_continue
+      then_i_am_taken_to_the_appropriate_body_appointed_page
+
+      when_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_complete_page
+
+      when_i_click_on_the_return_to_your_training_link
+      then_i_am_taken_to_the_manage_your_training_page
+      and_i_see_the_lead_provider
+      and_i_see_delivery_partner_to_be_confirmed
+    end
+
+    scenario "school continues with different lead provider" do
+      when_i_choose_ects_expected
+      and_i_click_continue
+      then_i_am_taken_to_the_change_provider_page
+      and_i_see_the_lead_provider
+      and_i_see_the_delivery_partner
+
+      when_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_provider_relationship_invalid_page
+      and_i_click_continue
+      then_i_am_taken_to_the_use_different_delivery_partner
+
+      when_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_appropriate_body_appointed_page
+
+      when_i_choose_no
+      and_i_click_continue
+      then_i_am_taken_to_the_complete_page
+
+      when_i_click_on_the_return_to_your_training_link
+      then_i_am_taken_to_the_manage_your_training_page
+      and_i_see_training_provider_to_be_confirmed
+      and_i_see_delivery_partner_to_be_confirmed
+    end
+  end
+end

--- a/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
@@ -3,11 +3,10 @@
 require "rails_helper"
 require_relative "./choose_programme_steps"
 
-RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false do
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0), with_feature_flags: { multiple_cohorts: "active" } do
   include ChooseProgrammeSteps
 
   before do
-    FeatureFlag.activate(:multiple_cohorts)
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_cohort_for_next_academic_year_is_created
     and_i_am_signed_in_as_an_induction_coordinator
@@ -15,7 +14,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     then_i_am_taken_to_ects_expected_in_next_academic_year_page
   end
 
-  context "school cohort provider relationship for 2022 is invalid", travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0) do
+  context "school cohort provider relationship for 2022 is invalid" do
     scenario "school continues with same lead provider" do
       when_i_choose_ects_expected
       and_i_click_continue

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -125,6 +125,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "A school with challenged partnership chooses expects ects" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
@@ -138,6 +139,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "A school chooses to keep the same FIP programme in the new cohort" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
@@ -176,6 +178,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "Empty LP and DP names for challenged partnerships" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
@@ -208,6 +211,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       scenario "A school chooses to use a different lead provider" do
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
+        and_a_provider_relationship_exists_for_the_lp_and_dp
         and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
@@ -247,6 +251,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       scenario "A school chooses to change delivery partner" do
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
+        and_a_provider_relationship_exists_for_the_lp_and_dp
         and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
@@ -284,6 +289,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       scenario "A school chooses to deliver own programme" do
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
+        and_a_provider_relationship_exists_for_the_lp_and_dp
         and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
@@ -319,6 +325,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       scenario "A school chooses to design and deliver own programme" do
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
+        and_a_provider_relationship_exists_for_the_lp_and_dp
         and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
@@ -363,6 +370,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "A school does not appoint an appropriate body" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
@@ -389,6 +397,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "A school chooses to appoint a local authority as appropriate body" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
@@ -423,6 +432,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "A school chooses to appoint a national organisation as appropriate body" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
@@ -457,6 +467,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     scenario "A school chooses to appoint a teaching school hub as appropriate body" do
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
+      and_a_provider_relationship_exists_for_the_lp_and_dp
       and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -3,20 +3,11 @@
 require "rails_helper"
 require_relative "./choose_programme_steps"
 
-RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false do
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0), with_feature_flags: { multiple_cohorts: "active" } do
   include ChooseProgrammeSteps
-
-  before do
-    FeatureFlag.activate(:multiple_cohorts)
-  end
-
-  after do
-    reset_time
-  end
 
   scenario "A school chooses no ECTs expected in next academic year" do
     given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_the_next_cohort_is_open_for_registrations
     and_i_am_signed_in_as_an_induction_coordinator
 
     when_i_start_programme_selection_for_next_cohort
@@ -35,7 +26,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
   scenario "A school chooses ECTs expected in next academic year and training DfE funded" do
     given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_the_next_cohort_is_open_for_registrations
     and_i_am_signed_in_as_an_induction_coordinator
 
     when_i_start_programme_selection_for_next_cohort
@@ -66,7 +56,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
   scenario "A school chooses ECTs expected in next academic year and deliver own programme" do
     given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_the_next_cohort_is_open_for_registrations
     and_i_am_signed_in_as_an_induction_coordinator
 
     when_i_start_programme_selection_for_next_cohort
@@ -95,7 +84,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
   scenario "A school chooses ECTs expected in next academic year and design and deliver own programme" do
     given_a_school_with_no_chosen_programme_for_next_academic_year
-    and_the_next_cohort_is_open_for_registrations
     and_i_am_signed_in_as_an_induction_coordinator
 
     when_i_start_programme_selection_for_next_cohort
@@ -126,7 +114,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_but_partnership_was_challenged
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -140,7 +127,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -179,7 +165,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -212,7 +197,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
         and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
         then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -252,7 +236,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
         and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
         then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -290,7 +273,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
         and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
         then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -326,7 +308,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
         given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
         and_cohort_for_next_academic_year_is_created
         and_a_provider_relationship_exists_for_the_lp_and_dp
-        and_the_next_cohort_is_open_for_registrations
         and_i_am_signed_in_as_an_induction_coordinator
         when_i_start_programme_selection_for_next_cohort
         then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -371,7 +352,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -398,7 +378,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -433,7 +412,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page
@@ -468,7 +446,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
       given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
       and_cohort_for_next_academic_year_is_created
       and_a_provider_relationship_exists_for_the_lp_and_dp
-      and_the_next_cohort_is_open_for_registrations
       and_i_am_signed_in_as_an_induction_coordinator
       when_i_start_programme_selection_for_next_cohort
       then_i_am_taken_to_ects_expected_in_next_academic_year_page

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -136,6 +136,14 @@ module ChooseProgrammeSteps
     expect(page).to have_content("Which teaching school hub have you appointed?")
   end
 
+  def then_i_am_taken_to_the_provider_relationship_invalid_page
+    expect(page).to have_content("You cannot use this combination of lead provider and delivery partner for your new ECTs and their mentors")
+  end
+
+  def then_i_am_taken_to_the_use_different_delivery_partner
+    expect(page).to have_content("Will you use #{@lead_provider.name} with another delivery partner?")
+  end
+
   # And steps
 
   def and_a_notification_email_is_sent_to_the_lead_provider
@@ -153,6 +161,10 @@ module ChooseProgrammeSteps
     privacy_policy = create(:privacy_policy)
     privacy_policy.accept!(@induction_coordinator_profile.user)
     sign_in_as @induction_coordinator_profile.user
+  end
+
+  def and_a_provider_relationship_exists_for_the_lp_and_dp
+    @provider_relationship = create(:provider_relationship, cohort: @cohort_2022, delivery_partner: @delivery_partner, lead_provider: @lead_provider)
   end
 
   def and_i_click_continue

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -3,14 +3,6 @@
 module ChooseProgrammeSteps
   include Capybara::DSL
 
-  def freeze_time
-    Timecop.freeze(Time.zone.local(2021, 5, 15, 16, 15, 0))
-  end
-
-  def reset_time
-    Timecop.return
-  end
-
   # Given steps
 
   def given_a_school_with_no_chosen_programme_for_next_academic_year
@@ -173,10 +165,6 @@ module ChooseProgrammeSteps
 
   def and_cohort_2022_is_created
     @cohort_2022 = create(:cohort, start_year: 2022)
-  end
-
-  def and_the_next_cohort_is_open_for_registrations
-    Timecop.freeze(Time.zone.local(2022, 5, 10, 16, 15, 0))
   end
 
   def and_the_dashboard_page_shows_the_no_ects_message

--- a/spec/forms/schools/setup_school_cohort_form_spec.rb
+++ b/spec/forms/schools/setup_school_cohort_form_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
       choices = { expect_any_ects_choice: "yes",
                   how_will_you_run_training_choice: "core_induction_programme",
                   change_provider_choice: "yes",
-                  what_changes_choice: "change_lead_provider" }
+                  what_changes_choice: "change_lead_provider",
+                  use_different_delivery_partner_choice: "yes" }
       expect(described_class.new(choices).attributes).to eq(choices)
     end
   end
@@ -36,6 +37,17 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
   describe "#expect_any_ects_choices" do
     it "returns an Array with the correct choices" do
       expect(described_class.new.expect_any_ects_choices).to match_array(
+        [
+          have_attributes(class: OpenStruct, id: "yes", name: "Yes"),
+          have_attributes(class: OpenStruct, id: "no", name: "No"),
+        ],
+      )
+    end
+  end
+
+  describe "#use_different_delivery_partner_choices" do
+    it "returns an Array with the correct choices" do
+      expect(described_class.new.use_different_delivery_partner_choices).to match_array(
         [
           have_attributes(class: OpenStruct, id: "yes", name: "Yes"),
           have_attributes(class: OpenStruct, id: "no", name: "No"),


### PR DESCRIPTION
### Context

- Ticket: [594](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-594)

### Changes proposed in this pull request

- Checking that a ProviderRelationship exists to prevent invalid partnerships
- Additional views showing SITs why they can't continue with creating a SchoolCohort and programme if the ProviderRelationship doesnt exist
- Specs for the above
- Updating exists SchoolCohort setup specs to create the ProviderRelationship, ensuring existing tests pass
- Updated routes for the new steps
- Updated SchoolCohortSetupForm
- Error messages, i spotted one was missing for the existing journey, so have added that. 

### Guidance to review

ProviderRelationships are created in the admin console. I think this is the first we've used a check against this, when creating a partnership/programme. 

This ticket relates to [805](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5f3543bb3e9e2e004db3189d&selectedIssue=CST-805). We want to reject all these after this has been  released.
<img width="731" alt="Screenshot 2022-07-15 at 14 30 52" src="https://user-images.githubusercontent.com/69353998/179234234-a7e1a096-88b2-4f04-9b79-1ba1a6226153.png">

<img width="707" alt="Screenshot 2022-07-15 at 14 30 58" src="https://user-images.githubusercontent.com/69353998/179234251-b47da317-22ef-4d9c-9486-0ff458b0bd5a.png">



