### PR TITLE
Adds a page to view invalid payments against applications

### DIFF
--- a/app/components/admin/npq/applications/analysis/table.html.erb
+++ b/app/components/admin/npq/applications/analysis/table.html.erb
@@ -1,0 +1,13 @@
+<div class="nhsuk-table-container">
+  <table data-test="admin-npq-applications-invalid-payments-analysis-table" class="govuk-table nhsuk-table-responsive">
+    <thead  class="nhsuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Full name</th>
+        <th scope="col" class="govuk-table__header">Date added</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body nhsuk-table__body">
+      <%= render Admin::NPQ::Applications::Analysis::TableRow.with_collection(applications) %>
+    </tbody>
+  </table>
+</div>

--- a/app/components/admin/npq/applications/analysis/table.html.erb
+++ b/app/components/admin/npq/applications/analysis/table.html.erb
@@ -3,7 +3,12 @@
     <thead  class="nhsuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Full name</th>
-        <th scope="col" class="govuk-table__header">Date added</th>
+        <th scope="col" class="govuk-table__header">Application Status</th>
+        <th scope="col" class="govuk-table__header">Course</th>
+        <th scope="col" class="govuk-table__header">Last Declaration</th>
+        <th scope="col" class="govuk-table__header">Lead Provider</th>
+        <th scope="col" class="govuk-table__header">Status</th>
+        <th scope="col" class="govuk-table__header">Date</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body nhsuk-table__body">

--- a/app/components/admin/npq/applications/analysis/table.rb
+++ b/app/components/admin/npq/applications/analysis/table.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  module NPQ
+    module Applications
+      module Analysis
+        class Table < BaseComponent
+          def initialize(applications:)
+            @applications = applications
+          end
+
+        private
+
+          attr_reader :applications
+        end
+      end
+    end
+  end
+end

--- a/app/components/admin/npq/applications/analysis/table_row.html.erb
+++ b/app/components/admin/npq/applications/analysis/table_row.html.erb
@@ -1,12 +1,32 @@
+<% declaration = application.profile.participant_declarations.where(state: %w[paid payable]).first %>
+
 <tr class="govuk-table__row nhsuk-table__row">
   <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Full name</span>
-    <div class="school-name-with-tag">
-      <%= govuk_link_to application.profile.user.full_name, admin_participant_path(application.profile) %>
-    </div>
+    <%= govuk_link_to application.user.full_name, admin_participant_path(application.profile) %>
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">
-    <span class="nhsuk-table-responsive__heading">Date added</span>
-    <%= application.created_at.to_date.to_s(:govuk_short) %>
+    <span class="nhsuk-table-responsive__heading">Application Status</span>
+    <%= application.lead_provider_approval_status %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Course</span>
+    <%= application.npq_course.name %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Last Declaration</span>
+    <%= declaration.declaration_type %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Lead Provider</span>
+    <%= declaration.cpd_lead_provider.name %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Status</span>
+    <%= declaration.state %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Date</span>
+    <%= declaration.created_at.to_date.to_s(:govuk_short) %>
   </td>
 </tr>

--- a/app/components/admin/npq/applications/analysis/table_row.html.erb
+++ b/app/components/admin/npq/applications/analysis/table_row.html.erb
@@ -1,0 +1,12 @@
+<tr class="govuk-table__row nhsuk-table__row">
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Full name</span>
+    <div class="school-name-with-tag">
+      <%= govuk_link_to application.profile.user.full_name, admin_participant_path(application.profile) %>
+    </div>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Date added</span>
+    <%= application.created_at.to_date.to_s(:govuk_short) %>
+  </td>
+</tr>

--- a/app/components/admin/npq/applications/analysis/table_row.rb
+++ b/app/components/admin/npq/applications/analysis/table_row.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module NPQ
+    module Applications
+      module Analysis
+        class TableRow < BaseComponent
+          with_collection_parameter :application
+
+          def initialize(application:)
+            @application = application
+          end
+
+        private
+
+          attr_reader :application
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/npq/applications/analysis_controller.rb
+++ b/app/controllers/admin/npq/applications/analysis_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Admin
+  module NPQ
+    module Applications
+      class AnalysisController < Admin::BaseController
+        skip_after_action :verify_policy_scoped
+
+        def invalid_payments_analysis
+          authorize NPQApplication
+
+          @applications = unaccepted_npq_applications_that_are_payable
+        end
+
+      private
+
+        def unaccepted_npq_applications_that_are_payable
+          NPQApplication.left_outer_joins(profile: [:participant_declarations])
+                        .where.not(participant_profiles: { id: nil })
+                        .where(lead_provider_approval_status: %w[pending rejected],
+                               participant_profiles: {
+                                 participant_declarations: { state: %w[paid payable] },
+                               })
+                        .uniq
+        end
+      end
+    end
+  end
+end

--- a/app/policies/npq_application_policy.rb
+++ b/app/policies/npq_application_policy.rb
@@ -9,6 +9,10 @@ class NPQApplicationPolicy < ApplicationPolicy
     admin?
   end
 
+  def invalid_payments_analysis?
+    admin?
+  end
+
   class Scope < Scope
     def resolve
       return scope.all if user.admin?

--- a/app/views/admin/npq/applications/analysis/invalid_payments_analysis.html.erb
+++ b/app/views/admin/npq/applications/analysis/invalid_payments_analysis.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "Applications Analysis" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-header-xl">Potentially Invalid NPQ Application participant records</h1>
+
+    <h2 class="govuk-header-l">Paid or Payable declarations made against a rejected or pending NPQ Application</h2>
+
+    <%= render Admin::NPQ::Applications::Analysis::Table.new(applications: @applications) %>
+  </div>
+</div>

--- a/app/views/admin/npq/applications/analysis/invalid_payments_analysis.html.erb
+++ b/app/views/admin/npq/applications/analysis/invalid_payments_analysis.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-header-xl">Potentially Invalid NPQ Application participant records</h1>
+    <h1 class="govuk-header-xl">NPQ Application analysis</h1>
 
-    <h2 class="govuk-header-l">Paid or Payable declarations made against a rejected or pending NPQ Application</h2>
+    <p class="govuk-body-l">Paid or Payable declarations made against a rejected or pending NPQ Application</p>
 
     <%= render Admin::NPQ::Applications::Analysis::Table.new(applications: @applications) %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -323,6 +323,7 @@ Rails.application.routes.draw do
     namespace :npq do
       resource :applications, only: [] do
         resource :exports, only: %i[new create], controller: "applications/exports"
+        get "/analysis", to: "applications/analysis#invalid_payments_analysis", as: :analysis
       end
     end
   end

--- a/spec/components/admin/npq/applications/analysis/table_row_spec.rb
+++ b/spec/components/admin/npq/applications/analysis/table_row_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::NPQ::Applications::Analysis::TableRow, type: :view_component do
+  let!(:cohort) { create :cohort }
+  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+  let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
+  let(:npq_lead_provider) { create :npq_lead_provider }
+
+  let(:application) do
+    npq_application = create(:npq_application, :rejected,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    participant_profile = create(:npq_participant_profile, npq_application:)
+
+    create(:npq_participant_declaration,
+           declaration_type: "started",
+           user: npq_application.user,
+           participant_profile:,
+           course_identifier: npq_course.identifier,
+           state: "paid")
+
+    npq_application
+  end
+
+  component { described_class.new application: }
+
+  it { is_expected.to have_link application.user.full_name, href: admin_participant_path(application.profile) }
+  it { is_expected.to have_content application.created_at.to_date.to_s(:govuk_short) }
+end

--- a/spec/components/admin/npq/applications/analysis/table_row_spec.rb
+++ b/spec/components/admin/npq/applications/analysis/table_row_spec.rb
@@ -27,5 +27,10 @@ RSpec.describe Admin::NPQ::Applications::Analysis::TableRow, type: :view_compone
   component { described_class.new application: }
 
   it { is_expected.to have_link application.user.full_name, href: admin_participant_path(application.profile) }
-  it { is_expected.to have_content application.created_at.to_date.to_s(:govuk_short) }
+  it { is_expected.to have_content "rejected" }
+  it { is_expected.to have_content npq_course.name }
+  it { is_expected.to have_content "started" }
+  it { is_expected.to have_content "NPQ Lead Provider" }
+  it { is_expected.to have_content "paid" }
+  it { is_expected.to have_content declaration.created_at.to_date.to_s(:govuk_short) }
 end

--- a/spec/components/admin/npq/applications/analysis/table_row_spec.rb
+++ b/spec/components/admin/npq/applications/analysis/table_row_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Admin::NPQ::Applications::Analysis::TableRow, type: :view_compone
            declaration_type: "started",
            user: npq_application.user,
            participant_profile:,
+           cpd_lead_provider: npq_lead_provider.cpd_lead_provider,
            course_identifier: npq_course.identifier,
            state: "paid")
 
@@ -26,11 +27,12 @@ RSpec.describe Admin::NPQ::Applications::Analysis::TableRow, type: :view_compone
 
   component { described_class.new application: }
 
+  it { is_expected.to have_content "Full name\n    #{application.user.full_name}" }
   it { is_expected.to have_link application.user.full_name, href: admin_participant_path(application.profile) }
-  it { is_expected.to have_content "rejected" }
+  it { is_expected.to have_content "Application Status\n    rejected" }
   it { is_expected.to have_content npq_course.name }
-  it { is_expected.to have_content "started" }
-  it { is_expected.to have_content "NPQ Lead Provider" }
-  it { is_expected.to have_content "paid" }
-  it { is_expected.to have_content declaration.created_at.to_date.to_s(:govuk_short) }
+  it { is_expected.to have_content "Last Declaration\n    started" }
+  it { is_expected.to have_content "Lead Provider\n    #{npq_lead_provider.cpd_lead_provider.name}" }
+  it { is_expected.to have_content "Status\n    paid" }
+  it { is_expected.to have_content "Date\n    #{application.profile.participant_declarations.first.created_at.to_date.to_s(:govuk_short)}" }
 end

--- a/spec/components/admin/npq/applications/analysis/table_spec.rb
+++ b/spec/components/admin/npq/applications/analysis/table_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::NPQ::Applications::Analysis::Table, type: :view_component do
+  let!(:cohort) { create :cohort }
+  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+  let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
+  let(:npq_lead_provider) { create :npq_lead_provider }
+
+  let(:rejected_application_with_payment) do
+    npq_application = create(:npq_application, :rejected,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    participant_profile = create(:npq_participant_profile, npq_application:)
+
+    create(:npq_participant_declaration,
+           declaration_type: "started",
+           user: npq_application.user,
+           participant_profile:,
+           course_identifier: npq_course.identifier,
+           state: "paid")
+
+    npq_application
+  end
+  let(:rejected_application_with_payable) do
+    npq_application = create(:npq_application, :rejected,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    participant_profile = create(:npq_participant_profile, npq_application:)
+
+    create(:npq_participant_declaration,
+           declaration_type: "started",
+           user: npq_application.user,
+           participant_profile:,
+           course_identifier: npq_course.identifier,
+           state: "payable")
+
+    npq_application
+  end
+
+  let(:applications) { [rejected_application_with_payment, rejected_application_with_payable] }
+
+  component { described_class.new applications: }
+  request_path "/admin/npq/applications/analysis"
+
+  stub_component Admin::NPQ::Applications::Analysis::TableRow
+
+  it "renders table row for each application" do
+    applications.each do |application|
+      expect(rendered).to have_rendered(Admin::NPQ::Applications::Analysis::TableRow).with(application:)
+    end
+  end
+end

--- a/spec/factories/npq_application.rb
+++ b/spec/factories/npq_application.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
       end
     end
 
+    trait :rejected do
+      lead_provider_approval_status { "rejected" }
+    end
+
     trait :not_in_school do
       works_in_school { false }
       school_urn { nil }

--- a/spec/requests/admin/npq/applications/analysis_spec.rb
+++ b/spec/requests/admin/npq/applications/analysis_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::NPQ::Applications::Analysis", type: :request do
+  let!(:admin_user) { create :user, :admin }
+
+  let!(:cohort) { create :cohort }
+  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+  let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
+  let(:npq_lead_provider) { create :npq_lead_provider }
+
+  let!(:accepted_application) do
+    npq_application = create(:npq_application, :accepted,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    npq_application
+  end
+  let!(:accepted_application_with_payment) do
+    npq_application = create(:npq_application, :accepted,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    create(:npq_participant_declaration,
+           declaration_type: "started",
+           user: npq_application.user,
+           participant_profile: npq_application.profile,
+           course_identifier: npq_course.identifier,
+           state: "paid")
+
+    npq_application
+  end
+
+  let!(:rejected_application) do
+    npq_application = create(:npq_application, :rejected,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    create(:npq_participant_profile)
+
+    npq_application
+  end
+  let!(:rejected_application_with_payment) do
+    npq_application = create(:npq_application, :rejected,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    participant_profile = create(:npq_participant_profile, npq_application:)
+
+    create(:npq_participant_declaration,
+           declaration_type: "started",
+           user: npq_application.user,
+           participant_profile:,
+           course_identifier: npq_course.identifier,
+           state: "paid")
+
+    npq_application
+  end
+  let!(:rejected_application_with_payable) do
+    npq_application = create(:npq_application, :rejected,
+                             npq_lead_provider:,
+                             npq_course:,
+                             cohort:)
+
+    participant_profile = create(:npq_participant_profile, npq_application:)
+
+    create(:npq_participant_declaration,
+           declaration_type: "started",
+           user: npq_application.user,
+           participant_profile:,
+           course_identifier: npq_course.identifier,
+           state: "payable")
+
+    npq_application
+  end
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /admin/npq/applications/analysis" do
+    it "renders the index template for payments made against invalid NPQ applications" do
+      get "/admin/npq/applications/analysis"
+      expect(response).to render_template "admin/npq/applications/analysis/invalid_payments_analysis"
+    end
+
+    it "includes applications with invalid applications" do
+      get "/admin/npq/applications/analysis"
+
+      expect(assigns(:applications)).to include rejected_application_with_payment
+      expect(assigns(:applications)).to include rejected_application_with_payable
+    end
+
+    it "does not include applications that are valid" do
+      get "/admin/npq/applications/analysis"
+
+      expect(assigns(:applications)).not_to include accepted_application_with_payment
+    end
+
+    it "does not include applications that have no associated payments" do
+      get "/admin/npq/applications/analysis"
+
+      expect(assigns(:applications)).not_to include accepted_application
+      expect(assigns(:applications)).not_to include rejected_application
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1529](https://dfedigital.atlassian.net/browse/CPDLP-1529)

### Changes proposed in this pull request

Add a new view to the admin area available only to AdminProfiles which lists all NPQ applications know to have payments made against them or payable declarations even though the NPQ Application associated with the NPQ Profile is not "Accepted"

### Guidance to review

login as an Admin user and visit `/admin/npq/applications/analysis`

<img width="990" alt="image" src="https://user-images.githubusercontent.com/259493/179544027-999bd41a-0f87-41e8-9a50-a48cd194dd54.png">

#### Query used to identify the records

```
NPQApplication.left_outer_joins(profile: [:participant_declarations])
              .where.not(participant_profiles: { id: nil })
              .where(lead_provider_approval_status: %w[pending rejected],
                  participant_profiles: {
                  participant_declarations: { state: %w[paid payable] },
              })
              .uniq
```
