### PR TITLE
[CST-188]: add confirmation page when tutor changes a participant's email address

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -59,13 +59,6 @@ class Schools::ParticipantsController < Schools::BaseController
 
     Induction::ChangePreferredEmail.call(induction_record: @induction_record,
                                          preferred_email: identity.email)
-
-    if @profile.ect?
-      set_success_message(heading: "The ECT’s email address has been updated")
-    else
-      set_success_message(heading: "The mentor’s email address has been updated")
-    end
-    redirect_to schools_participant_path(id: @profile)
   end
 
   def email_used; end

--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -34,13 +34,15 @@ class Schools::ParticipantsController < Schools::BaseController
   end
 
   def edit_name
-    render helpers.edit_name_template(params[:reason])
+    @reason = params[:reason].presence&.to_sym
+    @selected_reason = params[:selected_reason].presence&.to_sym
+    render helpers.edit_name_template(@reason)
   end
 
   def update_name
     @old_name = @profile.full_name
 
-    if @profile.user.update(params.require(:user).permit(:full_name))
+    if @profile.user.update(full_name: params[:full_name])
       render :update_name
     else
       @profile.user.full_name = @old_name
@@ -52,7 +54,7 @@ class Schools::ParticipantsController < Schools::BaseController
 
   def update_email
     identity = @induction_record.preferred_identity
-    identity.assign_attributes(params.require(:participant_identity).permit(:email))
+    identity.assign_attributes(email: params[:email])
     redirect_to action: :email_used and return if email_used?(identity.email)
 
     render "schools/participants/edit_email" and return if identity.invalid?

--- a/app/helpers/schools/participants_helper.rb
+++ b/app/helpers/schools/participants_helper.rb
@@ -11,14 +11,22 @@ module Schools
       replace_with_a_different_person: :replace_with_a_different_person,
     }.freeze
 
+    class EditNameReason
+      include ActiveModel::Model
+
+      attr_accessor :reason, :name
+    end
+
     def edit_name_reasons
-      EDIT_NAME_TEMPLATE_BY_REASON.keys.map do |id|
-        OpenStruct.new(id:, name: t(id, scope: :reasons_to_edit_a_participants_name))
-      end
+      EDIT_NAME_TEMPLATE_BY_REASON.keys.map { |reason| edit_name_reason(reason) }
+    end
+
+    def edit_name_reason(key)
+      EditNameReason.new(reason: key, name: t(key, scope: :reasons_to_edit_a_participants_name))
     end
 
     def edit_name_template(reason)
-      EDIT_NAME_TEMPLATE_BY_REASON[reason&.to_sym] || :reason_to_edit_name
+      EDIT_NAME_TEMPLATE_BY_REASON[reason] || :reason_to_edit_name
     end
 
     def participant_not_started_validation?(profile, induction_record)

--- a/app/models/induction_programme.rb
+++ b/app/models/induction_programme.rb
@@ -16,11 +16,11 @@ class InductionProgramme < ApplicationRecord
 
   has_many :induction_records
   has_many :active_induction_records, -> { active }, class_name: "InductionRecord"
+  has_many :current_induction_records, -> { current }, class_name: "InductionRecord"
   has_many :transferring_in_induction_records, -> { transferring_in }, class_name: "InductionRecord"
   has_many :transferring_out_induction_records, -> { transferring_out }, class_name: "InductionRecord"
   has_many :transferred_induction_records, -> { transferred }, class_name: "InductionRecord"
   has_many :participant_profiles, through: :active_induction_records
-  has_many :current_induction_records, -> { current }, class_name: "InductionRecord"
   has_many :current_participant_profiles, through: :current_induction_records, source: :participant_profile
 
   delegate :school, to: :school_cohort

--- a/app/policies/participant_profile/ecf_policy.rb
+++ b/app/policies/participant_profile/ecf_policy.rb
@@ -10,6 +10,7 @@ class ParticipantProfile::ECFPolicy < ParticipantProfilePolicy
 
   def update?
     return true if admin?
+    return false if record.contacted_for_info?
 
     user.induction_coordinator? && same_school?
   end

--- a/app/policies/participant_profile/ecf_policy.rb
+++ b/app/policies/participant_profile/ecf_policy.rb
@@ -10,9 +10,6 @@ class ParticipantProfile::ECFPolicy < ParticipantProfilePolicy
 
   def update?
     return true if admin?
-    return false if record.user.npq_applications.any?
-    return false if record.completed_validation_wizard?
-    return false if record.participant_declarations.any?
 
     user.induction_coordinator? && same_school?
   end

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -15,7 +15,10 @@ module Participants
 
       def perform_action!
         ActiveRecord::Base.transaction do
-          ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:withdrawn], cpd_lead_provider:, reason:)
+          ParticipantProfileState.create!(participant_profile: user_profile,
+                                          state: ParticipantProfileState.states[:withdrawn],
+                                          cpd_lead_provider:,
+                                          reason:)
 
           user_profile.training_status_withdrawn!
           relevant_induction_record.update!(training_status: "withdrawn") if relevant_induction_record

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -7,7 +7,7 @@
     <%= form_for @induction_record.preferred_identity, url: schools_participant_update_email_path, method: :put do |f| %>
     <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email, label: { text: "Change #{@profile.ect? ? "ECT’s" : "mentor’s"} email address", tag: 'h1', size: 'xl' } %>
+      <%= f.govuk_text_field :email, label: { text: "What’s #{@profile.full_name}’s correct email address?", tag: 'h1', size: 'xl' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -5,9 +5,12 @@
     <span class="govuk-caption-xl"><%= @school.name %></span>
 
     <%= form_for @induction_record.preferred_identity, url: schools_participant_update_email_path, method: :put do |f| %>
-    <%= f.govuk_error_summary %>
-
-      <%= f.govuk_text_field :email, label: { text: "What’s #{@profile.full_name}’s correct email address?", tag: 'h1', size: 'xl' } %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :email,
+                             class: 'govuk-!-width-two-thirds',
+                             hint: -> { tag.p(t('participant.edit_email_hint')) },
+                             label: -> { tag.h1(t('participant.edit_email', name: @profile.full_name),
+                                                class: 'govuk-heading-xl') } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -4,9 +4,13 @@
 
     <span class="govuk-caption-xl"><%= @school.name %></span>
 
-    <%= form_for @induction_record.preferred_identity, url: schools_participant_update_email_path, method: :put do |f| %>
+    <%= form_with model: @induction_record.preferred_identity,
+                  scope: '',
+                  url: schools_participant_update_email_path,
+                  method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :email,
+                             value: nil,
                              class: 'govuk-!-width-two-thirds',
                              hint: -> { tag.p(t('participant.edit_email_hint')) },
                              label: -> { tag.h1(t('participant.edit_email', name: @profile.full_name),

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :email,
                              value: nil,
-                             class: 'govuk-!-width-two-thirds',
+                             width: 'two-thirds',
                              hint: -> { tag.p(t('participant.edit_email_hint')) },
                              label: { text: t('participant.edit_email', name: @profile.full_name),
                                       size: 'xl',

--- a/app/views/schools/participants/edit_email.html.erb
+++ b/app/views/schools/participants/edit_email.html.erb
@@ -13,8 +13,10 @@
                              value: nil,
                              class: 'govuk-!-width-two-thirds',
                              hint: -> { tag.p(t('participant.edit_email_hint')) },
-                             label: -> { tag.h1(t('participant.edit_email', name: @profile.full_name),
-                                                class: 'govuk-heading-xl') } %>
+                             label: { text: t('participant.edit_email', name: @profile.full_name),
+                                      size: 'xl',
+                                      tag: 'h1',
+                                      class: 'govuk-heading-xl' } %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name,
                              value: nil,
-                             class: 'govuk-!-width-two-thirds',
+                             width: 'two-thirds',
                              label: { text: t('participant.edit_name', name: @profile.full_name),
                                       size: 'xl',
                                       tag: 'h1',

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -12,8 +12,10 @@
       <%= f.govuk_text_field :full_name,
                              value: nil,
                              class: 'govuk-!-width-two-thirds',
-                             label: -> { tag.h1(t('participant.edit_name', name: @profile.full_name),
-                                                 class: 'govuk-heading-xl') } %>
+                             label: { text: t('participant.edit_name', name: @profile.full_name),
+                                      size: 'xl',
+                                      tag: 'h1',
+                                      class: 'govuk-heading-xl' } %>
       <%= f.govuk_submit %>
     <% end %>
 

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -1,14 +1,16 @@
 <% content_for :before_content,
                govuk_back_link(text: "Back",
-                               href: schools_participant_edit_name_path(participant_id: @profile)) %>
+                               href: schools_participant_edit_name_path(participant_id: @profile,
+                                                                        selected_reason: @reason)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <span class="govuk-caption-xl"><%= @school.name %></span>
-    <%= form_for @profile.user, url: schools_participant_update_name_path, method: :put do |f| %>
+    <%= form_with model: @profile.user, scope: '', url: schools_participant_update_name_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name,
+                             value: nil,
                              class: 'govuk-!-width-two-thirds',
                              label: -> { tag.h1(t('participant.edit_name', name: @profile.full_name),
                                                  class: 'govuk-heading-xl') } %>

--- a/app/views/schools/participants/edit_name.html.erb
+++ b/app/views/schools/participants/edit_name.html.erb
@@ -9,11 +9,9 @@
     <%= form_for @profile.user, url: schools_participant_update_name_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :full_name,
-                             label: {
-                               text: "What should we edit #{@profile.full_name}’s name to?",
-                               tag: 'h1',
-                               size: 'xl'
-                             } %>
+                             class: 'govuk-!-width-two-thirds',
+                             label: -> { tag.h1(t('participant.edit_name', name: @profile.full_name),
+                                                 class: 'govuk-heading-xl') } %>
       <%= f.govuk_submit %>
     <% end %>
 

--- a/app/views/schools/participants/reason_to_edit_name.html.erb
+++ b/app/views/schools/participants/reason_to_edit_name.html.erb
@@ -6,11 +6,13 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
 
-    <%= form_with url: schools_participant_edit_name_path(participant_id: @profile), method: :get do |f| %>
+    <%= form_with model: edit_name_reason(@selected_reason),
+                  scope: '',
+                  url: schools_participant_edit_name_path(participant_id: @profile), method: :get do |f| %>
       <%= f.govuk_collection_radio_buttons(
             :reason,
             edit_name_reasons,
-            :id,
+            :reason,
             :name,
             legend: -> { tag.h1(t('page_titles.schools.participants.reason_to_edit_name', name: @profile.full_name),
                                 class: 'govuk-heading-xl') }

--- a/app/views/schools/participants/reason_to_edit_name.html.erb
+++ b/app/views/schools/participants/reason_to_edit_name.html.erb
@@ -12,11 +12,8 @@
             edit_name_reasons,
             :id,
             :name,
-            legend: {
-              text: t('page_titles.schools.participants.reason_to_edit_name', name: @profile.full_name),
-              size: "xl",
-              tag: "h1"
-            }
+            legend: -> { tag.h1(t('page_titles.schools.participants.reason_to_edit_name', name: @profile.full_name),
+                                class: 'govuk-heading-xl') }
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/participants/replace_with_a_different_person.html.erb
+++ b/app/views/schools/participants/replace_with_a_different_person.html.erb
@@ -2,7 +2,8 @@
 
 <% content_for :before_content,
                govuk_back_link(text: "Back",
-                               href: schools_participant_edit_name_path(participant_id: @profile)) %>
+                               href: schools_participant_edit_name_path(participant_id: @profile,
+                                                                        selected_reason: @reason)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/participants/should_not_have_been_registered.html.erb
+++ b/app/views/schools/participants/should_not_have_been_registered.html.erb
@@ -2,7 +2,8 @@
 
 <% content_for :before_content,
                govuk_back_link(text: "Back",
-                               href: schools_participant_edit_name_path(participant_id: @profile)) %>
+                               href: schools_participant_edit_name_path(participant_id: @profile,
+                                                                        selected_reason: @reason)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -16,15 +16,13 @@
         <dd class="govuk-summary-list__value">
           <%= @profile.user.full_name %>
         </dd>
-        <% unless @induction_record.training_status_withdrawn? %>
-          <dd class="govuk-summary-list__actions">
-            <% if @profile.policy_class.new(current_user, @profile).edit_name? %>
-              <%= govuk_link_to schools_participant_edit_name_path(participant_id: @profile) do %>
-                Change <span class="govuk-visually-hidden">name</span>
-              <% end %>
+        <dd class="govuk-summary-list__actions">
+          <% if @profile.policy_class.new(current_user, @profile).edit_name? %>
+            <%= govuk_link_to schools_participant_edit_name_path(participant_id: @profile) do %>
+              Change <span class="govuk-visually-hidden">name</span>
             <% end %>
-          </dd>
-        <% end %>
+          <% end %>
+        </dd>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -33,15 +31,13 @@
         <dd class="govuk-summary-list__value">
           <%= @induction_record.preferred_identity.email %>
         </dd>
-        <% unless @induction_record.training_status_withdrawn? %>
           <dd class="govuk-summary-list__actions">
-            <% if @profile.policy_class.new(current_user, @profile).edit_email? %>
-              <%= govuk_link_to schools_participant_edit_email_path(participant_id: @profile) do %>
-                Change <span class="govuk-visually-hidden">email address</span>
-              <% end %>
+          <% if @profile.policy_class.new(current_user, @profile).edit_email? %>
+            <%= govuk_link_to schools_participant_edit_email_path(participant_id: @profile) do %>
+              Change <span class="govuk-visually-hidden">email address</span>
             <% end %>
+          <% end %>
           </dd>
-        <% end %>
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/schools/participants/update_email.html.erb
+++ b/app/views/schools/participants/update_email.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, t('participant.name_edited', old_name: @old_name, new_name: @profile.full_name) %>
+<% content_for :title, t('participant.email_edited', name: @profile.full_name) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7">
       <h1 class="govuk-panel__title">
-        <%= t('participant.name_edited', old_name: @old_name, new_name: @profile.full_name) %>
+        <%= t('participant.email_edited', name: @profile.full_name) %>
       </h1>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,7 +315,7 @@ en:
     edit_email: "What’s %{name}’s correct email address?"
     edit_email_hint: "You can enter their personal or school email address."
     edit_name: "What should we edit %{name}’s name to?"
-    email_edited: "%{name}’s email has been updated"
+    email_edited: "%{name}’s email address has been updated"
     name_edited: "%{old_name}’s name has been edited to %{new_name}"
   reasons_to_edit_a_participants_name:
     name_has_changed: "They’ve changed their name - for example, due to marriage or divorce"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -311,7 +311,9 @@ en:
         replace_with_a_different_person: "You cannot make that change by editing %{name}’s name"
         reason_to_edit_name: "Why do you need to edit %{name}’s name?"
 
-  participant_name_edited: "%{old_name}’s name has been edited to %{new_name}"
+  participant:
+    email_edited: "%{name}’s email has been updated"
+    name_edited: "%{old_name}’s name has been edited to %{new_name}"
   reasons_to_edit_a_participants_name:
     name_has_changed: "They’ve changed their name - for example, due to marriage or divorce"
     name_is_incorrect: "Their name has been entered incorrectly"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,6 +312,9 @@ en:
         reason_to_edit_name: "Why do you need to edit %{name}’s name?"
 
   participant:
+    edit_email: "What’s %{name}’s correct email address?"
+    edit_email_hint: "You can enter their personal or school email address."
+    edit_name: "What should we edit %{name}’s name to?"
     email_edited: "%{name}’s email has been updated"
     name_edited: "%{old_name}’s name has been edited to %{new_name}"
   reasons_to_edit_a_participants_name:

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe "Update participants details", js: true do
     end
 
     scenario "Induction tutor can change the appropriate body from participant profile page" do
+      given_the_ect_has_been_validated
       click_on "Sally Teacher"
       then_i_am_taken_to_participant_profile
       and_i_see_no_appropriate_body_selected

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -152,7 +152,13 @@ RSpec.describe "Update participants details", js: true do
     and_percy_should_be_sent_a_snapshot_named "Participant details without change links"
   end
 
+  scenario "Induction tutor can't change ECT / mentor name or email for a participant contacted for info" do
+    when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
+    and_it_should_not_allow_a_sit_to_edit_the_participant_details
+  end
+
   scenario "Induction tutor can change ECT / mentor name form the profile page when their name has changed" do
+    given_the_ect_has_been_validated
     when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor sees ECT profile"
@@ -182,6 +188,7 @@ RSpec.describe "Update participants details", js: true do
   end
 
   scenario "Induction tutor can change ECT / mentor name form the profile page when their name was incorrect" do
+    given_the_ect_has_been_validated
     when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     when_i_click_on_change_name
     when_i_choose_name_is_incorrect_from_the_reason_to_change_school_participant_name_page
@@ -196,16 +203,17 @@ RSpec.describe "Update participants details", js: true do
   end
 
   scenario "Induction tutor can't remove an ECT / mentor by changing their name in participant profile page" do
+    given_the_ect_has_been_validated
     when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     when_i_click_on_change_name
     when_i_choose_should_not_be_registered_from_the_reason_to_change_school_participant_name_page
     then_i_cant_edit_the_participant_name_on_the_school_participant_should_not_have_been_registered_page "Sally Teacher"
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor can't edit the name of a participant because they should not have been registered"
-    then_i_can_remove_the_participant_from_the_school_participant_should_not_have_been_registered_page "Sally Teacher"
   end
 
   scenario "Induction tutor can't replace an ECT / mentor by changing their name in participant profile page" do
+    given_the_ect_has_been_validated
     when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     when_i_click_on_change_name
     when_i_choose_replaced_by_a_different_person_from_the_reason_to_change_school_participant_name_page
@@ -216,6 +224,7 @@ RSpec.describe "Update participants details", js: true do
   end
 
   scenario "Induction tutor can change ECT / mentor email from participant profile page" do
+    given_the_ect_has_been_validated
     when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     when_i_click_on_change_email
     then_i_am_on_the_edit_school_participant_email_page

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -161,13 +161,13 @@ RSpec.describe "Update participants details", js: true do
     then_i_am_on_the_reason_to_change_school_participant_name_page
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Why do you need to edit ect name"
-    and_i_confirm_the_participant_name_on_the_reason_to_change_school_participant_name_page_with_name "Sally Teacher"
+    and_i_confirm_the_participant_on_the_reason_to_change_school_participant_name_page_with_name "Sally Teacher"
 
     when_i_choose_they_have_changed_their_name_from_the_reason_to_change_school_participant_name_page
     then_i_am_on_the_edit_school_participant_name_page
     then_the_page_should_be_accessible
     then_percy_should_be_sent_a_snapshot_named "Induction tutor edits the name of a participant"
-    and_i_confirm_the_participant_name_on_the_edit_school_participant_name_page_with_name "Sally Teacher"
+    and_i_confirm_the_participant_on_the_edit_school_participant_name_page_with_name "Sally Teacher"
 
     when_i_set_a_blank_name_on_the_edit_school_participant_name_page
     then_i_see_an_error_message "Enter a full name"
@@ -178,7 +178,7 @@ RSpec.describe "Update participants details", js: true do
     then_percy_should_be_sent_a_snapshot_named "Induction tutor completed the change of a participant's name"
 
     when_i_return_to_the_participant_profile_from_the_school_participant_name_updated_page
-    then_i_confirm_participant_name_on_the_school_participant_details_page "Sally Teacher"
+    then_i_confirm_the_participant_on_the_school_participant_details_page_with_name "Sally Teacher"
   end
 
   scenario "Induction tutor can change ECT / mentor name form the profile page when their name was incorrect" do
@@ -186,7 +186,7 @@ RSpec.describe "Update participants details", js: true do
     when_i_click_on_change_name
     when_i_choose_name_is_incorrect_from_the_reason_to_change_school_participant_name_page
     then_i_am_on_the_edit_school_participant_name_page
-    and_i_confirm_the_participant_name_on_the_edit_school_participant_name_page_with_name "Sally Teacher"
+    and_i_confirm_the_participant_on_the_edit_school_participant_name_page_with_name "Sally Teacher"
 
     when_i_set_the_name_on_the_edit_school_participant_name_page_with_new_name "Jane Teacher"
     then_i_see_a_confirmation_message_on_the_school_participant_name_updated_page_with_old_name_and_new_name "Sally Teacher", "Jane Teacher"
@@ -216,21 +216,26 @@ RSpec.describe "Update participants details", js: true do
   end
 
   scenario "Induction tutor can change ECT / mentor email from participant profile page" do
-    click_on "Sally Teacher"
-    then_i_am_taken_to_participant_profile
-
+    when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     when_i_click_on_change_email
-    then_i_am_taken_to_change_ect_email_page
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor changes existing ECT email"
+    then_i_am_on_the_edit_school_participant_email_page
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor edits the email of a participant"
+    and_i_confirm_the_participant_on_the_edit_school_participant_email_page_with_name "Sally Teacher"
 
-    when_i_change_ect_email_to_blank
-    when_i_click_on_continue
-    then_i_see_an_error_message("Enter an email")
+    when_i_set_a_blank_email_on_the_edit_school_participant_email_page
+    then_i_see_an_error_message "Enter an email"
 
-    when_i_change_ect_email
-    when_i_click_on_continue
-    then_i_am_taken_to_participant_profile
-    then_i_can_view_the_updated_participant_email
+    when_i_set_an_invalid_email_on_the_edit_school_participant_email_page
+    then_i_see_an_error_message "Enter an email"
+
+    when_i_set_the_email_on_the_edit_school_participant_email_page_with_new_email "jane@school.com"
+    then_i_see_a_confirmation_message_on_the_school_participant_email_updated_page_with_name "Sally Teacher"
+    then_the_page_should_be_accessible
+    then_percy_should_be_sent_a_snapshot_named "Induction tutor completed the change of a participant's email"
+
+    when_i_return_to_the_participant_profile_from_the_school_participant_email_updated_page
+    then_i_confirm_the_participant_on_the_school_participant_details_page_with_name "Sally Teacher"
   end
 
   context "When the school cohort does not have an appropriate body assigned" do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -88,6 +88,10 @@ module ManageTrainingSteps
     expect(page).to have_text(@school_cohort.delivery_partner.name)
   end
 
+  def given_the_ect_has_been_validated
+    create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect)
+  end
+
   def given_an_ect_has_been_withdrawn_by_the_provider
     @participant_profile_ect.training_status_withdrawn!
     @participant_profile_ect.induction_records.latest.training_status_withdrawn!
@@ -389,6 +393,7 @@ module ManageTrainingSteps
   def and_it_should_not_allow_a_sit_to_edit_the_participant_details
     expect(page).not_to have_link("//a[text()='Change']")
   end
+  alias_method :then_it_should_not_allow_a_sit_to_edit_the_participant_details, :and_it_should_not_allow_a_sit_to_edit_the_participant_details
 
   def and_i_click_on_view_your_early_career_teacher_and_mentor_details
     click_on("View your early career teacher and mentor details")

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -595,14 +595,6 @@ module ManageTrainingSteps
     then_i_am_taken_to_your_ect_and_mentors_page
   end
 
-  def when_i_change_mentor_name
-    fill_in "What should we edit #{@participant_profile_mentor.full_name}’s name to?", with: @updated_participant_data[:full_name]
-  end
-
-  def when_i_change_mentor_name_to_blank
-    fill_in "What should we edit #{@participant_profile_mentor.full_name}’s name to?", with: ""
-  end
-
   def when_i_change_ect_email
     fill_in "Change ECT’s email", with: @updated_participant_data[:email]
   end
@@ -678,14 +670,6 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "What should we edit #{@participant_profile_mentor.full_name}’s name to?")
   end
 
-  def then_i_am_taken_to_why_change_mentor_name_page
-    expect(page).to have_selector("h1", text: "Why do you need to edit #{@participant_profile_mentor.full_name}’s name?")
-  end
-
-  def then_i_am_taken_to_change_ect_email_page
-    expect(page).to have_selector("h1", text: "Change ECT’s email")
-  end
-
   def then_i_am_taken_to_change_how_you_run_programme_page
     expect(page).to have_selector("h1", text: "Change how you run your training programme")
     expect(page).to have_text("Check the other options available for your school if this changes")
@@ -736,10 +720,6 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_participant_profile
     expect(page).to have_text("Name")
-  end
-
-  def then_i_am_taken_to_the_ect_name_change_confirmation_page
-    expect(page).to have_text("#{@participant_profile_ect.full_name}’s name has been edited to #{@updated_participant_data[:full_name]}")
   end
 
   def then_i_am_taken_to_do_you_know_your_teachers_trn_page

--- a/spec/policies/participant_profile/ecf_policy_spec.rb
+++ b/spec/policies/participant_profile/ecf_policy_spec.rb
@@ -105,10 +105,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to forbid_action(:withdraw_record) }
-      it { is_expected.to forbid_action(:edit_name) }
-      it { is_expected.to forbid_action(:update_name) }
-      it { is_expected.to forbid_action(:edit_email) }
-      it { is_expected.to forbid_action(:update_email) }
+      it { is_expected.to permit_action(:edit_name) }
+      it { is_expected.to permit_action(:update_name) }
+      it { is_expected.to permit_action(:edit_email) }
+      it { is_expected.to permit_action(:update_email) }
       it { is_expected.to permit_action(:edit_start_term) }
       it { is_expected.to permit_action(:update_start_term) }
     end
@@ -120,10 +120,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to permit_action(:withdraw_record) }
-      it { is_expected.to forbid_action(:edit_name) }
-      it { is_expected.to forbid_action(:update_name) }
-      it { is_expected.to forbid_action(:edit_email) }
-      it { is_expected.to forbid_action(:update_email) }
+      it { is_expected.to permit_action(:edit_name) }
+      it { is_expected.to permit_action(:update_name) }
+      it { is_expected.to permit_action(:edit_email) }
+      it { is_expected.to permit_action(:update_email) }
       it { is_expected.to permit_action(:edit_start_term) }
       it { is_expected.to permit_action(:update_start_term) }
     end
@@ -135,10 +135,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to forbid_action(:withdraw_record) }
-      it { is_expected.to forbid_action(:edit_name) }
-      it { is_expected.to forbid_action(:update_name) }
-      it { is_expected.to forbid_action(:edit_email) }
-      it { is_expected.to forbid_action(:update_email) }
+      it { is_expected.to permit_action(:edit_name) }
+      it { is_expected.to permit_action(:update_name) }
+      it { is_expected.to permit_action(:edit_email) }
+      it { is_expected.to permit_action(:update_email) }
       it { is_expected.to forbid_action(:edit_start_term) }
       it { is_expected.to forbid_action(:update_start_term) }
     end
@@ -150,10 +150,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to permit_action(:withdraw_record) }
-      it { is_expected.to forbid_action(:edit_name) }
-      it { is_expected.to forbid_action(:update_name) }
-      it { is_expected.to forbid_action(:edit_email) }
-      it { is_expected.to forbid_action(:update_email) }
+      it { is_expected.to permit_action(:edit_name) }
+      it { is_expected.to permit_action(:update_name) }
+      it { is_expected.to permit_action(:edit_email) }
+      it { is_expected.to permit_action(:update_email) }
       it { is_expected.to forbid_action(:edit_start_term) }
       it { is_expected.to forbid_action(:update_start_term) }
     end
@@ -164,10 +164,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to permit_action(:withdraw_record) }
-      it { is_expected.to forbid_action(:edit_name) }
-      it { is_expected.to forbid_action(:update_name) }
-      it { is_expected.to forbid_action(:edit_email) }
-      it { is_expected.to forbid_action(:update_email) }
+      it { is_expected.to permit_action(:edit_name) }
+      it { is_expected.to permit_action(:update_name) }
+      it { is_expected.to permit_action(:edit_email) }
+      it { is_expected.to permit_action(:update_email) }
       it { is_expected.to permit_action(:edit_start_term) }
       it { is_expected.to permit_action(:update_start_term) }
     end

--- a/spec/policies/participant_profile/ecf_policy_spec.rb
+++ b/spec/policies/participant_profile/ecf_policy_spec.rb
@@ -94,10 +94,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
     let(:user) { create(:user, :induction_coordinator, schools: [participant_profile.school]) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_action(:withdraw_record) }
-    it { is_expected.to permit_action(:edit_name) }
-    it { is_expected.to permit_action(:update_name) }
-    it { is_expected.to permit_action(:edit_email) }
-    it { is_expected.to permit_action(:update_email) }
+    it { is_expected.to forbid_action(:edit_name) }
+    it { is_expected.to forbid_action(:update_name) }
+    it { is_expected.to forbid_action(:edit_email) }
+    it { is_expected.to forbid_action(:update_email) }
 
     context "after the participant has provided validation data" do
       before do
@@ -130,6 +130,7 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
 
     context "with a declaration" do
       before do
+        create(:ecf_participant_validation_data, participant_profile:)
         declaration_type = participant_profile.ect? ? :ect_participant_declaration : :mentor_participant_declaration
         create(declaration_type, participant_profile:, user: participant_profile.user)
       end
@@ -150,10 +151,10 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to permit_action(:withdraw_record) }
-      it { is_expected.to permit_action(:edit_name) }
-      it { is_expected.to permit_action(:update_name) }
-      it { is_expected.to permit_action(:edit_email) }
-      it { is_expected.to permit_action(:update_email) }
+      it { is_expected.to forbid_action(:edit_name) }
+      it { is_expected.to forbid_action(:update_name) }
+      it { is_expected.to forbid_action(:edit_email) }
+      it { is_expected.to forbid_action(:update_email) }
       it { is_expected.to forbid_action(:edit_start_term) }
       it { is_expected.to forbid_action(:update_start_term) }
     end
@@ -164,16 +165,20 @@ RSpec.describe ParticipantProfile::ECFPolicy, type: :policy do
       end
 
       it { is_expected.to permit_action(:withdraw_record) }
-      it { is_expected.to permit_action(:edit_name) }
-      it { is_expected.to permit_action(:update_name) }
-      it { is_expected.to permit_action(:edit_email) }
-      it { is_expected.to permit_action(:update_email) }
+      it { is_expected.to forbid_action(:edit_name) }
+      it { is_expected.to forbid_action(:update_name) }
+      it { is_expected.to forbid_action(:edit_email) }
+      it { is_expected.to forbid_action(:update_email) }
       it { is_expected.to permit_action(:edit_start_term) }
       it { is_expected.to permit_action(:update_start_term) }
     end
   end
 
   context "induction tutor at a different school" do
+    before do
+      create(:ecf_participant_validation_data, participant_profile:)
+    end
+
     let(:user) { create(:user, :induction_coordinator) }
     it { is_expected.to forbid_action(:show) }
     it { is_expected.to forbid_action(:withdraw_record) }

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
   describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-name" do
     it "renders the update name template with the new name of an ect" do
       put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-name",
-          params: { user: { full_name: "Joe Bloggs" } }
+          params: { full_name: "Joe Bloggs" }
 
       expect(response).to render_template("schools/participants/update_name")
       expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s name has been edited to Joe Bloggs"))
@@ -250,7 +250,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
 
     it "renders the update name template with the new name of a mentor" do
       put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name",
-          params: { user: { full_name: "Sally Mentor" } }
+          params: { full_name: "Sally Mentor" }
 
       expect(response).to render_template("schools/participants/update_name")
       expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s name has been edited to Sally Mentor"))
@@ -259,9 +259,8 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
 
     it "rejects a blank name" do
       expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name", params: {
-          user: { full_name: "" },
-        }
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name",
+            params: { full_name: "" }
       }.not_to change { mentor_user.reload.full_name }
 
       expect(response).to render_template("schools/participants/edit_name")
@@ -273,40 +272,40 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-email"
 
       expect(response).to render_template("schools/participants/edit_email")
-      expect(response.body).to include(CGI.escapeHTML(ect_user.email))
+      expect(response.body).to include(CGI.escapeHTML(ect_user.full_name))
     end
 
     it "renders the edit email template with the correct name for a mentor" do
       get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-email"
 
       expect(response).to render_template("schools/participants/edit_email")
-      expect(response.body).to include(CGI.escapeHTML(mentor_user.email))
+      expect(response.body).to include(CGI.escapeHTML(mentor_user.full_name))
     end
   end
 
   describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-email" do
     it "updates the email of an ECT" do
       put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email",
-          params: { participant_identity: { email: "new@email.com" } }
+          params: { email: "new@email.com" }
 
       expect(response).to render_template("schools/participants/update_email")
-      expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s email has been updated"))
+      expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s email address has been updated"))
       expect(ect_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
     end
 
     it "updates the email of a mentor" do
       put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-          params: { participant_identity: { email: "new@email.com" } }
+          params: { email: "new@email.com" }
 
       expect(response).to render_template("schools/participants/update_email")
-      expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s email has been updated"))
+      expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s email address has been updated"))
       expect(mentor_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
     end
 
     it "rejects a blank email" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-            params: { participant_identity: { email: "" } }
+            params: { email: "" }
       }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
 
       expect(response).to render_template("schools/participants/edit_email")
@@ -315,7 +314,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
     it "rejects a malformed email" do
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-            params: { participant_identity: { email: "nonsense" } }
+            params: { email: "nonsense" }
       }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
 
       expect(response).to render_template("schools/participants/edit_email")
@@ -325,7 +324,7 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       other_user = create(:user)
       expect {
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-            params: { participant_identity: { email: other_user.email } }
+            params: { email: other_user.email }
       }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
 
       expect(response).to redirect_to("/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/email-used")

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -286,46 +286,48 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
 
   describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-email" do
     it "updates the email of an ECT" do
-      expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email", params: {
-          participant_identity: { email: "new@email.com" },
-        }
-      }.to change { ect_profile.current_induction_record.preferred_identity.email }.to("new@email.com")
+      put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email",
+          params: { participant_identity: { email: "new@email.com" } }
+
+      expect(response).to render_template("schools/participants/update_email")
+      expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s email has been updated"))
+      expect(ect_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
     end
 
     it "updates the email of a mentor" do
-      expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          participant_identity: { email: "new@email.com" },
-        }
-      }.to change { mentor_profile.current_induction_record.preferred_identity.email }.to("new@email.com")
+      put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+          params: { participant_identity: { email: "new@email.com" } }
+
+      expect(response).to render_template("schools/participants/update_email")
+      expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s email has been updated"))
+      expect(mentor_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
     end
 
     it "rejects a blank email" do
       expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          participant_identity: { email: "" },
-        }
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+            params: { participant_identity: { email: "" } }
       }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+
       expect(response).to render_template("schools/participants/edit_email")
     end
 
     it "rejects a malformed email" do
       expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          participant_identity: { email: "nonsense" },
-        }
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+            params: { participant_identity: { email: "nonsense" } }
       }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+
       expect(response).to render_template("schools/participants/edit_email")
     end
 
     it "rejects an email in use by another user" do
       other_user = create(:user)
       expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email", params: {
-          participant_identity: { email: other_user.email },
-        }
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+            params: { participant_identity: { email: other_user.email } }
       }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+
       expect(response).to redirect_to("/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/email-used")
     end
   end
@@ -335,24 +337,6 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
       get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/email-used"
 
       expect(response).to render_template("schools/participants/email_used")
-    end
-  end
-
-  describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-name" do
-    it "updates the name of an ECT" do
-      expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-name", params: {
-          user: { full_name: "Joe Bloggs" },
-        }
-      }.to change { ect_user.reload.full_name }.to("Joe Bloggs")
-    end
-
-    it "updates the name of a mentor" do
-      expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name", params: {
-          user: { full_name: "Sally Mentor" },
-        }
-      }.to change { mentor_user.reload.full_name }.to("Sally Mentor")
     end
   end
 

--- a/spec/requests/schools/participants_request_spec.rb
+++ b/spec/requests/schools/participants_request_spec.rb
@@ -165,169 +165,255 @@ RSpec.describe "Schools::Participants", type: :request, js: true, with_feature_f
   end
 
   describe "GET /schools/:school_id/cohorts/:start_year/participants/:id/edit-name" do
-    context "when no reason to change the name is included in the request" do
-      it "renders the reason_to_edit_name template to ask for a reason to edit the participant's name" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name"
+    context "when the participant is in contacted for info status" do
+      it "don't allow the edition of the name of an ECT" do
+        expect {
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name"
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
 
-        expect(response).to render_template("schools/participants/reason_to_edit_name")
-        expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+      it "don't allow the edition of the name of a mentor" do
+        expect {
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-name"
+        }.to raise_exception(Pundit::NotAuthorizedError)
       end
     end
 
-    context "when unknown reason to change the name is included in the request" do
-      it "renders the reason_to_edit_name template to ask for a reason to edit the participant's name" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name",
-            params: { reason: "any_unknown_reason" }
-
-        expect(response).to render_template("schools/participants/reason_to_edit_name")
-        expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+    context "when the participant is not in contacted for info status" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: ect_profile)
+        create(:ecf_participant_validation_data, participant_profile: mentor_profile)
       end
-    end
 
-    context "when the participant's name has changed in real life for any reason" do
-      it "renders the edit name template with the current name of the participant" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name?",
-            params: { reason: "name_has_changed" }
+      context "when no reason to change the name is included in the request" do
+        it "renders the reason_to_edit_name template to ask for a reason to edit the participant's name" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name"
 
-        expect(response).to render_template("schools/participants/edit_name")
-        expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+          expect(response).to render_template("schools/participants/reason_to_edit_name")
+          expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+        end
       end
-    end
 
-    context "when the current participant's name is incorrect" do
-      it "renders the edit name template with the current name of the participant" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name?",
-            params: { reason: "name_is_incorrect" }
+      context "when unknown reason to change the name is included in the request" do
+        it "renders the reason_to_edit_name template to ask for a reason to edit the participant's name" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name",
+              params: { reason: "any_unknown_reason" }
 
-        expect(response).to render_template("schools/participants/edit_name")
-        expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+          expect(response).to render_template("schools/participants/reason_to_edit_name")
+          expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+        end
       end
-    end
 
-    context "when a participant should not have been registered" do
-      it "renders the should not have been registered template with the current name of the participant" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-name?",
-            params: { reason: "should_not_have_been_registered" }
+      context "when the participant's name has changed in real life for any reason" do
+        it "renders the edit name template with the current name of the participant" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name",
+              params: { reason: "name_has_changed" }
 
-        expect(response).to render_template("schools/participants/should_not_have_been_registered")
-        expect(response.body).to include(CGI.escapeHTML(mentor_profile.full_name))
-        expect(response.body).to include(CGI.escapeHTML("remove all their information from this service."))
+          expect(response).to render_template("schools/participants/edit_name")
+          expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+        end
       end
-    end
 
-    context "when an ect needs to be replaced with a different person" do
-      it "renders the replace with a different person template with the current name of the ect" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name?",
-            params: { reason: "replace_with_a_different_person" }
+      context "when the current participant's name is incorrect" do
+        it "renders the edit name template with the current name of the participant" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name",
+              params: { reason: "name_is_incorrect" }
 
-        expect(response).to render_template("schools/participants/replace_with_a_different_person")
-        expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
-        expect(response.body).to include(CGI.escapeHTML("Add the other ECT to this service"))
+          expect(response).to render_template("schools/participants/edit_name")
+          expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+        end
       end
-    end
 
-    context "when a mentor needs to be replaced with a different person" do
-      it "renders the replace with a different person template with the current name of the mentor" do
-        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-name?",
-            params: { reason: "replace_with_a_different_person" }
+      context "when a participant should not have been registered" do
+        it "renders the should not have been registered template with the current name of the participant" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-name",
+              params: { reason: "should_not_have_been_registered" }
 
-        expect(response).to render_template("schools/participants/replace_with_a_different_person")
-        expect(response.body).to include(CGI.escapeHTML(mentor_profile.full_name))
-        expect(response.body).to include(CGI.escapeHTML("Add the other mentor to this service"))
+          expect(response).to render_template("schools/participants/should_not_have_been_registered")
+          expect(response.body).to include(CGI.escapeHTML(mentor_profile.full_name))
+        end
+      end
+
+      context "when an ect needs to be replaced with a different person" do
+        it "renders the replace with a different person template with the current name of the ect" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-name",
+              params: { reason: "replace_with_a_different_person" }
+
+          expect(response).to render_template("schools/participants/replace_with_a_different_person")
+          expect(response.body).to include(CGI.escapeHTML(ect_profile.full_name))
+          expect(response.body).to include(CGI.escapeHTML("Add the other ECT to this service"))
+        end
+      end
+
+      context "when a mentor needs to be replaced with a different person" do
+        it "renders the replace with a different person template with the current name of the mentor" do
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-name",
+              params: { reason: "replace_with_a_different_person" }
+
+          expect(response).to render_template("schools/participants/replace_with_a_different_person")
+          expect(response.body).to include(CGI.escapeHTML(mentor_profile.full_name))
+          expect(response.body).to include(CGI.escapeHTML("Add the other mentor to this service"))
+        end
       end
     end
   end
 
   describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-name" do
-    it "renders the update name template with the new name of an ect" do
-      put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-name",
-          params: { full_name: "Joe Bloggs" }
+    context "when the participant is not in contacted for info status" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: ect_profile)
+        create(:ecf_participant_validation_data, participant_profile: mentor_profile)
+      end
 
-      expect(response).to render_template("schools/participants/update_name")
-      expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s name has been edited to Joe Bloggs"))
-      expect(ect_profile.reload.full_name).to eq("Joe Bloggs")
-    end
+      it "renders the update name template with the new name of an ect" do
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-name",
+            params: { full_name: "Joe Bloggs" }
 
-    it "renders the update name template with the new name of a mentor" do
-      put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name",
-          params: { full_name: "Sally Mentor" }
+        expect(response).to render_template("schools/participants/update_name")
+        expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s name has been edited to Joe Bloggs"))
+        expect(ect_profile.reload.full_name).to eq("Joe Bloggs")
+      end
 
-      expect(response).to render_template("schools/participants/update_name")
-      expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s name has been edited to Sally Mentor"))
-      expect(mentor_profile.reload.full_name).to eq("Sally Mentor")
-    end
-
-    it "rejects a blank name" do
-      expect {
+      it "renders the update name template with the new name of a mentor" do
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name",
-            params: { full_name: "" }
-      }.not_to change { mentor_user.reload.full_name }
+            params: { full_name: "Sally Mentor" }
 
-      expect(response).to render_template("schools/participants/edit_name")
+        expect(response).to render_template("schools/participants/update_name")
+        expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s name has been edited to Sally Mentor"))
+        expect(mentor_profile.reload.full_name).to eq("Sally Mentor")
+      end
+
+      it "rejects a blank name" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name",
+              params: { full_name: "" }
+        }.not_to change { mentor_user.reload.full_name }
+
+        expect(response).to render_template("schools/participants/edit_name")
+      end
+    end
+
+    context "when the participant is in contacted for info status" do
+      it "don't allow a SIT to update the name of an ect" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-name",
+              params: { full_name: "Joe Bloggs" }
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
+
+      it "don't allow a SIT to update the name of a mentor" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-name",
+              params: { full_name: "Sally Mentor" }
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
     end
   end
 
   describe "GET /schools/:school_id/cohorts/:start_year/participants/:id/edit-email" do
-    it "renders the edit email template with the correct name for an ECT" do
-      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-email"
+    context "when the participant is not in contacted for info status" do
+      it "renders the edit email template with the correct name for an ECT" do
+        create(:ecf_participant_validation_data, participant_profile: ect_profile)
 
-      expect(response).to render_template("schools/participants/edit_email")
-      expect(response.body).to include(CGI.escapeHTML(ect_user.full_name))
+        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-email"
+
+        expect(response).to render_template("schools/participants/edit_email")
+        expect(response.body).to include(CGI.escapeHTML(ect_user.full_name))
+      end
+
+      it "renders the edit email template with the correct name for a mentor" do
+        create(:ecf_participant_validation_data, participant_profile: mentor_profile)
+
+        get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-email"
+
+        expect(response).to render_template("schools/participants/edit_email")
+        expect(response.body).to include(CGI.escapeHTML(mentor_user.full_name))
+      end
     end
 
-    it "renders the edit email template with the correct name for a mentor" do
-      get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-email"
+    context "when the participant is in contacted for info status" do
+      it "don't allow the edition of the email of an ECT" do
+        expect {
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/edit-email"
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
 
-      expect(response).to render_template("schools/participants/edit_email")
-      expect(response.body).to include(CGI.escapeHTML(mentor_user.full_name))
+      it "don't allow the edition of the email of a mentor" do
+        expect {
+          get "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/edit-email"
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
     end
   end
 
   describe "PUT /schools/:school_id/cohorts/:start_year/participants/:id/update-email" do
-    it "updates the email of an ECT" do
-      put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email",
-          params: { email: "new@email.com" }
+    context "when the participant is not in contacted for info status" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: ect_profile)
+        create(:ecf_participant_validation_data, participant_profile: mentor_profile)
+      end
 
-      expect(response).to render_template("schools/participants/update_email")
-      expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s email address has been updated"))
-      expect(ect_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
-    end
+      it "updates the email of an ECT" do
+        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email",
+            params: { email: "new@email.com" }
 
-    it "updates the email of a mentor" do
-      put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-          params: { email: "new@email.com" }
+        expect(response).to render_template("schools/participants/update_email")
+        expect(response.body).to include(CGI.escapeHTML("#{ect_profile.full_name}’s email address has been updated"))
+        expect(ect_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
+      end
 
-      expect(response).to render_template("schools/participants/update_email")
-      expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s email address has been updated"))
-      expect(mentor_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
-    end
-
-    it "rejects a blank email" do
-      expect {
+      it "updates the email of a mentor" do
         put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-            params: { email: "" }
-      }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+            params: { email: "new@email.com" }
 
-      expect(response).to render_template("schools/participants/edit_email")
+        expect(response).to render_template("schools/participants/update_email")
+        expect(response.body).to include(CGI.escapeHTML("#{mentor_profile.full_name}’s email address has been updated"))
+        expect(mentor_profile.current_induction_record.preferred_identity.email).to eq("new@email.com")
+      end
+
+      it "rejects a blank email" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+              params: { email: "" }
+        }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+
+        expect(response).to render_template("schools/participants/edit_email")
+      end
+
+      it "rejects a malformed email" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+              params: { email: "nonsense" }
+        }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+
+        expect(response).to render_template("schools/participants/edit_email")
+      end
+
+      it "rejects an email in use by another user" do
+        other_user = create(:user)
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+              params: { email: other_user.email }
+        }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+
+        expect(response).to redirect_to("/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/email-used")
+      end
     end
 
-    it "rejects a malformed email" do
-      expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-            params: { email: "nonsense" }
-      }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
+    context "when the participant is in contacted for info status" do
+      it "don't allow a SIT to update the email of an ect" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{ect_profile.id}/update-email",
+              params: { email: "new@email.com" }
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
 
-      expect(response).to render_template("schools/participants/edit_email")
-    end
-
-    it "rejects an email in use by another user" do
-      other_user = create(:user)
-      expect {
-        put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
-            params: { email: other_user.email }
-      }.not_to change { mentor_profile.current_induction_record.preferred_identity.email }
-
-      expect(response).to redirect_to("/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/email-used")
+      it "don't allow a SIT to update the email of a mentor" do
+        expect {
+          put "/schools/#{school.slug}/cohorts/#{cohort.start_year}/participants/#{mentor_profile.id}/update-email",
+              params: { email: "new@email.com" }
+        }.to raise_exception(Pundit::NotAuthorizedError)
+      end
     end
   end
 

--- a/spec/support/features/pages/schools/edit_school_participant_email_page.rb
+++ b/spec/support/features/pages/schools/edit_school_participant_email_page.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../base_page"
+
+module Pages
+  class EditSchoolParticipantEmailPage < ::Pages::BasePage
+    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-email"
+    set_primary_heading(/\AWhat’s (.*)’s correct email address\?\z/)
+
+    def confirm_the_participant(name:)
+      element_has_content?(header, "What’s #{name}’s correct email address?")
+    end
+
+    def set_a_blank_email
+      fill_in("participant_identity[email]", with: "")
+      click_on("Continue")
+    end
+
+    def set_an_invalid_email
+      fill_in("participant_identity[email]", with: "invalidemail")
+      click_on("Continue")
+    end
+
+    def set_the_email(new_email:)
+      fill_in("participant_identity[email]", with: new_email)
+      click_on("Continue")
+
+      Pages::SchoolParticipantEmailUpdatedPage.loaded
+    end
+  end
+end

--- a/spec/support/features/pages/schools/edit_school_participant_email_page.rb
+++ b/spec/support/features/pages/schools/edit_school_participant_email_page.rb
@@ -12,17 +12,17 @@ module Pages
     end
 
     def set_a_blank_email
-      fill_in("participant_identity[email]", with: "")
+      fill_in("email", with: "")
       click_on("Continue")
     end
 
     def set_an_invalid_email
-      fill_in("participant_identity[email]", with: "invalidemail")
+      fill_in("email", with: "invalidemail")
       click_on("Continue")
     end
 
     def set_the_email(new_email:)
-      fill_in("participant_identity[email]", with: new_email)
+      fill_in("email", with: new_email)
       click_on("Continue")
 
       Pages::SchoolParticipantEmailUpdatedPage.loaded

--- a/spec/support/features/pages/schools/edit_school_participant_name_page.rb
+++ b/spec/support/features/pages/schools/edit_school_participant_name_page.rb
@@ -7,8 +7,13 @@ module Pages
     set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name{?reason*}"
     set_primary_heading(/\AWhat should we edit (.*)’s name to\?\z/)
 
-    def confirm_the_participant_name(name:)
+    def confirm_the_participant(name:)
       element_has_content?(header, "What should we edit #{name}’s name to?")
+    end
+
+    def set_a_blank_name
+      fill_in("user[full_name]", with: "")
+      click_on("Continue")
     end
 
     def set_the_name(new_name:)
@@ -16,11 +21,6 @@ module Pages
       click_on("Continue")
 
       Pages::SchoolParticipantNameUpdatedPage.loaded
-    end
-
-    def set_a_blank_name
-      fill_in("user[full_name]", with: "")
-      click_on("Continue")
     end
   end
 end

--- a/spec/support/features/pages/schools/edit_school_participant_name_page.rb
+++ b/spec/support/features/pages/schools/edit_school_participant_name_page.rb
@@ -4,7 +4,7 @@ require_relative "../base_page"
 
 module Pages
   class EditSchoolParticipantNamePage < ::Pages::BasePage
-    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name{?reason*}"
+    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name"
     set_primary_heading(/\AWhat should we edit (.*)’s name to\?\z/)
 
     def confirm_the_participant(name:)
@@ -12,12 +12,12 @@ module Pages
     end
 
     def set_a_blank_name
-      fill_in("user[full_name]", with: "")
+      fill_in("full_name", with: "")
       click_on("Continue")
     end
 
     def set_the_name(new_name:)
-      fill_in("user[full_name]", with: new_name)
+      fill_in("full_name", with: new_name)
       click_on("Continue")
 
       Pages::SchoolParticipantNameUpdatedPage.loaded

--- a/spec/support/features/pages/schools/reason_to_change_school_participant_name_page.rb
+++ b/spec/support/features/pages/schools/reason_to_change_school_participant_name_page.rb
@@ -35,7 +35,7 @@ module Pages
       Pages::EditSchoolParticipantNamePage.loaded
     end
 
-    def confirm_the_participant_name(name:)
+    def confirm_the_participant(name:)
       element_has_content?(header, "Why do you need to edit #{name}’s name?")
     end
   end

--- a/spec/support/features/pages/schools/school_participant_details_page.rb
+++ b/spec/support/features/pages/schools/school_participant_details_page.rb
@@ -8,8 +8,8 @@ module Pages
     # this is a hack as the participants name is the page title
     set_primary_heading(/^.*$/)
 
-    def confirm_participant_name(participant_name)
-      has_primary_heading? participant_name
+    def confirm_the_participant(name:)
+      has_primary_heading? name
     end
 
     def confirm_email_address(email)

--- a/spec/support/features/pages/schools/school_participant_email_updated_page.rb
+++ b/spec/support/features/pages/schools/school_participant_email_updated_page.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../base_page"
+
+module Pages
+  class SchoolParticipantEmailUpdatedPage < ::Pages::BasePage
+    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/update-email"
+    set_primary_heading(/\A(.*)’s email has been updated\z/)
+
+    def see_a_confirmation_message(name:)
+      element_has_content?(header, "#{name}’s email has been updated")
+    end
+
+    def return_to_the_participant_profile
+      click_on "Return to their details"
+
+      Pages::SchoolParticipantDetailsPage.loaded
+    end
+
+    def return_to_the_ect_and_mentors
+      click_on "Return to your ECTs and mentors"
+
+      Pages::SchoolParticipantsDashboardPage.loaded
+    end
+  end
+end

--- a/spec/support/features/pages/schools/school_participant_email_updated_page.rb
+++ b/spec/support/features/pages/schools/school_participant_email_updated_page.rb
@@ -5,10 +5,10 @@ require_relative "../base_page"
 module Pages
   class SchoolParticipantEmailUpdatedPage < ::Pages::BasePage
     set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/update-email"
-    set_primary_heading(/\A(.*)’s email has been updated\z/)
+    set_primary_heading(/\A(.*)’s email address has been updated\z/)
 
     def see_a_confirmation_message(name:)
-      element_has_content?(header, "#{name}’s email has been updated")
+      element_has_content?(header, "#{name}’s email address has been updated")
     end
 
     def return_to_the_participant_profile

--- a/spec/support/features/pages/schools/school_participant_replaced_by_a_different_person_page.rb
+++ b/spec/support/features/pages/schools/school_participant_replaced_by_a_different_person_page.rb
@@ -4,7 +4,7 @@ require_relative "../base_page"
 
 module Pages
   class SchoolParticipantReplacedByADifferentPersonPage < ::Pages::BasePage
-    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name{?reason*}"
+    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name"
     set_primary_heading(/\AYou cannot make that change by editing (.*)’s name\z/)
 
     def cant_edit_the_participant_name(name)

--- a/spec/support/features/pages/schools/school_participant_should_not_have_been_registered_page.rb
+++ b/spec/support/features/pages/schools/school_participant_should_not_have_been_registered_page.rb
@@ -4,7 +4,7 @@ require_relative "../base_page"
 
 module Pages
   class SchoolParticipantShouldNotHaveBeenRegisteredPage < ::Pages::BasePage
-    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name{?reason*}"
+    set_url "/schools/{slug}/cohorts/{cohort}/participants/{participant_id}/edit-name"
     set_primary_heading(/\AYou cannot make that change by editing (.*)’s name\z/)
 
     def cant_edit_the_participant_name(name)

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -326,7 +326,7 @@ module Steps
         raise "Participant Type \"#{scenario.participant_type}\" not recognised"
       end
 
-      and_i_confirm_participant_name_on_the_school_participant_details_page "the Participant"
+      and_i_confirm_the_participant_on_the_school_participant_details_page_with_name "the Participant"
       and_i_confirm_full_name_on_the_school_participant_details_page "the Participant"
       and_i_confirm_email_address_on_the_school_participant_details_page scenario.participant_email
       and_i_confirm_status_on_the_school_participant_details_page "Eligible to start"
@@ -340,7 +340,7 @@ module Steps
       when_i_view_participant_details_from_the_school_dashboard_page
       and_i_view_not_training_on_the_school_participants_dashboard_page "the Participant"
 
-      and_i_confirm_participant_name_on_the_school_participant_details_page "the Participant"
+      and_i_confirm_the_participant_on_the_school_participant_details_page_with_name "the Participant"
       and_i_confirm_full_name_on_the_school_participant_details_page "the Participant"
       and_i_confirm_email_address_on_the_school_participant_details_page scenario.participant_email
       and_i_confirm_status_on_the_school_participant_details_page "Eligible to start"


### PR DESCRIPTION
### Context

- Ticket: [As a SIT, I can edit a participant's email address](https://dfedigital.atlassian.net/browse/CST-188)

### Changes proposed in this pull request
  Added a confirmation view once a tutor has been able to successfully update the email address of one of their participants.

It also includes a few tweaks:
- Keep marked the option selected by a SIT when they click back in one of the views to change a participant's name 
- Do not pre-fill the input box to edit a participant's name or email address

### Guidance to review

