### PR TITLE
[CN-308] Retrospectively remove ECHO from targeted support funding eligibility

### DIFF
--- a/app/services/npq/ehco/targeted_delivery_funding_eligibility_updater.rb
+++ b/app/services/npq/ehco/targeted_delivery_funding_eligibility_updater.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module NPQ
+  module Ehco
+    class TargetedDeliveryFundingEligibilityUpdater
+      REOPEN_DATE = Time.zone.parse("6 June 2022 12:00")
+
+      class << self
+        delegate :run, to: :new
+      end
+
+      def run
+        logger = Logger.new($stdout)
+        logger.info "Updating EHCO NPQ Applications, this may take a couple of minutes..."
+
+        ehco_npq_course = NPQCourse.find_by(id: "66dff4af-a518-498f-9042-36a41f9e8aa7")
+
+        arel_table = NPQApplication.arel_table
+        npq_applications = ehco_npq_course.npq_applications
+                                          .where(targeted_delivery_funding_eligibility: true)
+                                          .where(arel_table[:created_at].gteq(REOPEN_DATE))
+
+        updated_count = 0
+
+        npq_applications.find_each do |npq_application|
+          logger.info "Updating EHCO NPQ Application #{npq_application.id}"
+          npq_application.update!(targeted_delivery_funding_eligibility: false)
+
+          updated_count += 1
+        rescue StandardError => e
+          logger.error "Encountered errors while updating EHCO NPQ Application ID##{npq_application.id}: #{e.message}"
+        end
+
+        logger.info "Updated EHCO NPQ Application count: #{updated_count}"
+      end
+    end
+  end
+end

--- a/app/services/npq/ehco/targeted_delivery_funding_eligibility_updater.rb
+++ b/app/services/npq/ehco/targeted_delivery_funding_eligibility_updater.rb
@@ -13,7 +13,7 @@ module NPQ
         logger = Logger.new($stdout)
         logger.info "Updating EHCO NPQ Applications, this may take a couple of minutes..."
 
-        ehco_npq_course = NPQCourse.find_by(id: "66dff4af-a518-498f-9042-36a41f9e8aa7")
+        ehco_npq_course = NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer")
 
         arel_table = NPQApplication.arel_table
         npq_applications = ehco_npq_course.npq_applications

--- a/lib/tasks/npq/ehco/update_targeted_delivery_funding_eligibility.rake
+++ b/lib/tasks/npq/ehco/update_targeted_delivery_funding_eligibility.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :npq do
+  namespace :ehco do
+    namespace :update_targeted_delivery_funding_eligibility do
+      desc "DRY RUN: Marks targeted_delivery_funding_eligibility on all EHCO NPQ applications as false"
+      task dry_run: :environment do
+        NPQApplication.transaction do
+          NPQ::Ehco::TargetedDeliveryFundingEligibilityUpdater.run
+
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      desc "Marks targeted_delivery_funding_eligibility on all EHCO NPQ applications as false"
+      task run: :environment do
+        NPQ::Ehco::TargetedDeliveryFundingEligibilityUpdater.run
+      end
+    end
+  end
+end

--- a/spec/services/npq/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
+++ b/spec/services/npq/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::Ehco::TargetedDeliveryFundingEligibilityUpdater do
+  subject { described_class.run }
+
+  let(:ehco_course) { create(:npq_ehco_course) }
+
+  let(:applicable_application_hash) do
+    {
+      npq_course: ehco_course,
+      targeted_delivery_funding_eligibility: true,
+      created_at: described_class::REOPEN_DATE + 1.day,
+    }
+  end
+
+  let!(:application_with_targeted_funding_set)     { create(:npq_application, applicable_application_hash) }
+  let!(:application_with_targeted_funding_set_two) { create(:npq_application, applicable_application_hash) }
+  let!(:application_before_cutoff)                 { create(:npq_application, applicable_application_hash.merge(created_at: described_class::REOPEN_DATE - 1.day)) }
+  let!(:application_wrong_course)                  { create(:npq_application, applicable_application_hash.merge(npq_course: create(:npq_leadship_course))) }
+  let!(:application_not_marked_for_funding)        { create(:npq_application, applicable_application_hash.merge(targeted_delivery_funding_eligibility: false)) }
+
+  it "updates the targeted_delivery_funding_eligibility flag for applicable records" do
+    expect { subject }.to change {
+      [
+        application_with_targeted_funding_set,
+        application_with_targeted_funding_set_two,
+      ].each(&:reload).map(&:targeted_delivery_funding_eligibility)
+    }.from([true, true]).to([false, false])
+  end
+
+  it "does not update the targeted_delivery_funding_eligibility flag for inapplicable records" do
+    expect { subject }.to_not change {
+      [
+        application_before_cutoff,
+        application_wrong_course,
+        application_not_marked_for_funding,
+      ].each(&:reload).map(&:targeted_delivery_funding_eligibility)
+    }
+  end
+end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-308

### Changes proposed in this pull request

Adds rake task that updates `targeted_delivery_funding_eligibility` to false for all Application records with the EHCO course, `targeted_delivery_funding_eligibility` set to true, and where created after the relaunch.

### Guidance to review

1. Create an Application record with these attributes:
```
  course == Course.ehco.first
  created_at >= 6 June 2022 12:00
  targeted_delivery_funding_eligibility == true
```
2. Run ehco:update_targeted_delivery_funding_eligibility:dry_run 
3. See that it has shown that this record will be updated
4. Check that targeted_delivery_funding_eligibility change has not been persisted.
5. Run ehco:update_targeted_delivery_funding_eligibility:run
6. Check that targeted_delivery_funding_eligibility change has been persisted.
