### PR TITLE
[CPDLP-1469] Don't de-dupe declarations for ECF statements

### DIFF
--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -11,6 +11,15 @@ module Finance
         @calculator = StatementCalculator.new(statement: @statement)
       end
 
+      def show2
+        @ecf_lead_provider = lead_provider_scope.find(params[:payment_breakdown_id])
+        statement_name = params[:statement_id].humanize.gsub("-", " ")
+        @statement = @ecf_lead_provider.statements.find_by(name: statement_name)
+        @calculator = StatementCalculator2.new(statement: @statement)
+
+        render :show
+      end
+
     private
 
       def identifier_to_name

--- a/app/services/finance/ecf/output_calculator.rb
+++ b/app/services/finance/ecf/output_calculator.rb
@@ -12,7 +12,7 @@ module Finance
       def banding_breakdown
         return @banding_breakdown if @banding_breakdown
 
-        bandings = declaration_types.each.map do |declaration_type|
+        bandings = declaration_types.map do |declaration_type|
           current_banding_for_declaration_type(declaration_type)
         end
 

--- a/app/services/finance/ecf/output_calculator2.rb
+++ b/app/services/finance/ecf/output_calculator2.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    class OutputCalculator2
+      attr_reader :statement
+
+      def initialize(statement:)
+        @statement = statement
+      end
+
+      def banding_breakdown
+        return @banding_breakdown if @banding_breakdown
+
+        bandings = declaration_types.each.map do |declaration_type|
+          current_banding_for_declaration_type(declaration_type)
+        end
+
+        result = bandings[0]
+
+        band_letters.each do |letter|
+          bandings[1..].each do |banding|
+            new_chunk = banding.find { |e| e[:band] == letter }
+            result.find { |e| e[:band] == letter }.merge!(new_chunk)
+          end
+        end
+
+        @banding_breakdown = result
+      end
+
+      def uplift_breakdown
+        @uplift_breakdown ||= {
+          previous_count: previous_fill_level_for_uplift,
+          count: current_billable_count_for_uplift - current_refundable_count_for_uplift,
+          additions: current_billable_count_for_uplift,
+          subtractions: current_refundable_count_for_uplift,
+        }
+      end
+
+      def fee_for_declaration(band_letter:, type:)
+        percentage = case type
+                     when :started
+                       started_event_percentage
+                     when :completed
+                       completed_event_percentage
+                     when :retained_1, :retained_2, :retained_3, :retained_4
+                       retained_event_percentage
+                     end
+
+        percentage * band_for_letter(band_letter).output_payment_per_participant
+      end
+
+    private
+
+      def band_for_letter(letter)
+        bands.zip(:a..:z).find { |e| e[1] == letter }[0]
+      end
+
+      def started_event_percentage
+        0.2
+      end
+
+      def completed_event_percentage
+        0.2
+      end
+
+      def retained_event_percentage
+        0.15
+      end
+
+      def declaration_types
+        %w[
+          started
+          retained-1
+          retained-2
+          retained-3
+          retained-4
+          completed
+        ]
+      end
+
+      # this is a 3 pass algorithm
+      # first pass adds billable declarations
+      # second pass subtracts refunds
+      # third pass further subtracts refunds if statement is net negative
+      def current_banding_for_declaration_type(declaration_type)
+        pot_size = current_billable_count_for_declaration_type(declaration_type)
+
+        banding = previous_banding_for_declaration_type(declaration_type).map do |hash|
+          band_capacity = hash[:max] - (hash[:min] - 1) - hash[:"previous_#{declaration_type.underscore}_count"]
+
+          fill_level = [pot_size, band_capacity].min
+
+          pot_size -= fill_level
+
+          hash[:"#{declaration_type.underscore}_count"] = fill_level
+          hash[:"#{declaration_type.underscore}_additions"] = fill_level
+
+          hash
+        end
+
+        pot_size = current_refundable_count_declaration_type(declaration_type)
+
+        banding = banding.reverse.map do |hash|
+          fill_level = hash[:"#{declaration_type.underscore}_count"]
+
+          available = [fill_level, pot_size].min
+
+          hash[:"#{declaration_type.underscore}_count"] = fill_level - available
+          hash[:"#{declaration_type.underscore}_subtractions"] = available
+
+          pot_size -= available
+
+          hash
+        end
+
+        if pot_size.positive?
+          banding = banding.map do |hash|
+            available = hash[:"previous_#{declaration_type.underscore}_count"]
+
+            unless available.zero?
+              reduction = [pot_size, available].min
+
+              hash[:"#{declaration_type.underscore}_count"] = -reduction
+              hash[:"#{declaration_type.underscore}_subtractions"] += reduction
+
+              pot_size -= reduction
+            end
+
+            hash
+          end
+        end
+
+        banding.reverse
+      end
+
+      def previous_banding_for_declaration_type(declaration_type)
+        pot_size = previous_fill_level_for_declaration_type(declaration_type)
+
+        bands.zip(:a..:z).map do |band, letter|
+          band_capacity = band.max - (band.min || 1) + 1
+
+          fill_level = [pot_size, band_capacity].min
+
+          pot_size -= fill_level
+
+          key_name = "previous_#{declaration_type.underscore}_count".to_sym
+
+          {
+            band: letter,
+            min: band.min || 1,
+            max: band.max,
+            key_name => fill_level,
+          }
+        end
+      end
+
+      def bands
+        statement.contract.bands.order(max: :asc)
+      end
+
+      def band_letters
+        bands.zip(:a..:z).map { |e| e[1] }
+      end
+
+      def previous_fill_level_for_declaration_type(declaration_type)
+        billable = Finance::StatementLineItem
+          .where(statement: statement.previous_statements)
+          .billable
+          .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: })
+          .count
+
+        refundable = Finance::StatementLineItem
+          .where(statement: statement.previous_statements)
+          .refundable
+          .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: })
+          .count
+
+        billable - refundable
+      end
+
+      def previous_fill_level_for_uplift
+        billable = Finance::StatementLineItem
+          .where(statement: statement.previous_statements)
+          .billable
+          .joins(:participant_declaration)
+          .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
+          .count
+
+        refundable = Finance::StatementLineItem
+          .where(statement: statement.previous_statements)
+          .refundable
+          .joins(:participant_declaration)
+          .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
+          .count
+
+        billable - refundable
+      end
+
+      def current_billable_count_for_declaration_type(declaration_type)
+        statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: })
+          .count
+      end
+
+      def current_refundable_count_declaration_type(declaration_type)
+        statement
+          .refundable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: })
+          .count
+      end
+
+      def current_billable_count_for_uplift
+        statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: "started" })
+          .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
+          .count
+      end
+
+      def current_refundable_count_for_uplift
+        statement
+          .refundable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: "started" })
+          .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
+          .count
+      end
+    end
+  end
+end

--- a/app/services/finance/ecf/output_calculator2.rb
+++ b/app/services/finance/ecf/output_calculator2.rb
@@ -12,7 +12,7 @@ module Finance
       def banding_breakdown
         return @banding_breakdown if @banding_breakdown
 
-        bandings = declaration_types.each.map do |declaration_type|
+        bandings = declaration_types.map do |declaration_type|
           current_banding_for_declaration_type(declaration_type)
         end
 

--- a/app/services/finance/ecf/statement_calculator2.rb
+++ b/app/services/finance/ecf/statement_calculator2.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "payment_calculator/ecf/service_fees"
+
+module Finance
+  module ECF
+    class StatementCalculator2
+      def self.event_types
+        %i[
+          started
+          retained_1
+          retained_2
+          retained_3
+          retained_4
+          completed
+        ]
+      end
+
+      def self.band_mapping
+        {
+          a: 0,
+          b: 1,
+          c: 2,
+          d: 3,
+        }
+      end
+
+      attr_reader :statement
+
+      delegate :contract, to: :statement
+
+      def initialize(statement:)
+        @statement = statement
+      end
+
+      def bands
+        @bands ||= statement.contract.bands.order(max: :asc)
+      end
+
+      def band_letters
+        (:a..:z).take(bands.size)
+      end
+
+      def vat
+        total * vat_rate
+      end
+
+      def voided_declarations
+        statement.participant_declarations.voided
+      end
+
+      event_types.each do |event_type|
+        band_mapping.each do |letter, _number|
+          define_method "#{event_type}_band_#{letter}_count" do
+            output_calculator.banding_breakdown.find { |e| e[:band] == letter }[:"#{event_type}_count"]
+          end
+
+          define_method "#{event_type}_band_#{letter}_additions" do
+            output_calculator.banding_breakdown.find { |e| e[:band] == letter }[:"#{event_type}_additions"]
+          end
+
+          define_method "#{event_type}_band_#{letter}_fee_per_declaration" do
+            output_calculator.fee_for_declaration(band_letter: letter, type: event_type)
+          end
+        end
+
+        define_method "additions_for_#{event_type}" do
+          output_calculator.banding_breakdown.sum do |hash|
+            hash[:"#{event_type}_additions"] * output_calculator.fee_for_declaration(band_letter: hash[:band], type: event_type)
+          end
+        end
+
+        define_method "deductions_for_#{event_type}" do
+          output_calculator.banding_breakdown.sum do |hash|
+            hash[:"#{event_type}_subtractions"] * output_calculator.fee_for_declaration(band_letter: hash[:band], type: event_type)
+          end
+        end
+      end
+
+      def fee_for_declaration(band_letter:, type:)
+        output_calculator.fee_for_declaration(band_letter:, type:)
+      end
+
+      def started_count
+        output_calculator.banding_breakdown.sum do |hash|
+          hash[:started_additions]
+        end
+      end
+
+      def retained_count
+        output_calculator.banding_breakdown.sum do |hash|
+          hash.select { |k, _| k.match(/retained_\d_additions/) }.values.sum
+        end
+      end
+
+      def completed_count
+        output_calculator.banding_breakdown.sum do |hash|
+          hash[:completed_additions]
+        end
+      end
+
+      def voided_count
+        voided_declarations.count
+      end
+
+      def uplift_count
+        output_calculator.uplift_breakdown[:count]
+      end
+
+      def uplift_additions_count
+        output_calculator.uplift_breakdown[:additions]
+      end
+
+      def uplift_deductions_count
+        output_calculator.uplift_breakdown[:subtractions]
+      end
+
+      def uplift_fee_per_declaration
+        statement.contract.uplift_amount
+      end
+
+      def total_for_uplift
+        previous_uplift_count = output_calculator.uplift_breakdown[:previous_count]
+        previous_uplift_amount = previous_uplift_count * uplift_fee_per_declaration
+
+        delta_uplift_count = output_calculator.uplift_breakdown[:count]
+        delta_uplift_amount = delta_uplift_count * uplift_fee_per_declaration
+
+        available = [(statement.contract.uplift_cap - previous_uplift_amount), 0].max
+
+        [available, delta_uplift_amount].min
+      end
+
+      def adjustments_total
+        total_for_uplift - clawback_deductions
+      end
+
+      def clawback_deductions
+        event_types.sum do |event_type|
+          public_send(:"deductions_for_#{event_type}")
+        end
+      end
+
+      def total(with_vat: false)
+        sum = service_fee + output_fee + adjustments_total + statement.reconcile_amount
+        sum += vat if with_vat
+        sum
+      end
+
+      def service_fee
+        PaymentCalculator::ECF::ServiceFees.new(contract:).call.sum { |hash| hash[:monthly] }
+      end
+
+      def output_fee
+        event_types.sum do |event_type|
+          public_send(:"additions_for_#{event_type}")
+        end
+      end
+
+    private
+
+      def output_calculator
+        @output_calculator ||= OutputCalculator.new(statement:)
+      end
+
+      def event_types
+        self.class.event_types
+      end
+
+      def band_mapping
+        self.class.band_mapping
+      end
+
+      def vat_rate
+        lead_provider.vat_chargeable? ? 0.2 : 0
+      end
+
+      def cpd_lead_provider
+        statement.cpd_lead_provider
+      end
+
+      def lead_provider
+        cpd_lead_provider.lead_provider
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,8 @@ Rails.application.routes.draw do
       resources :payment_breakdowns, only: [] do
         resources :statements, only: %i[show] do
           resource :voided, controller: "participant_declarations/voided", path: "voided", only: %i[show]
+
+          get :show2
         end
       end
     end

--- a/spec/services/finance/ecf/output_calculator2_spec.rb
+++ b/spec/services/finance/ecf/output_calculator2_spec.rb
@@ -1,0 +1,1121 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ECF::OutputCalculator2 do
+  let(:first_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 6.months.ago) }
+  let(:second_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 4.months.ago) }
+  let(:third_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 2.months.ago) }
+  let(:fourth_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 0.months.ago) }
+
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let!(:contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }
+
+  let(:first_statement_calc) { described_class.new(statement: first_statement) }
+  let(:second_statement_calc) { described_class.new(statement: second_statement) }
+  let(:third_statement_calc) { described_class.new(statement: third_statement) }
+  let(:fourth_statement_calc) { described_class.new(statement: fourth_statement) }
+
+  let(:relevant_started_keys) do
+    %i[
+      band
+      min
+      max
+      previous_started_count
+      started_count
+      started_additions
+      started_subtractions
+    ]
+  end
+
+  describe "#fee_for_declaration" do
+    subject { first_statement_calc }
+
+    it do
+      expect(subject.fee_for_declaration(band_letter: :a, type: :started)).to eql(48)
+      expect(subject.fee_for_declaration(band_letter: :a, type: :retained_1)).to eql(36)
+      expect(subject.fee_for_declaration(band_letter: :a, type: :completed)).to eql(48)
+
+      expect(subject.fee_for_declaration(band_letter: :b, type: :started)).to eql(36)
+      expect(subject.fee_for_declaration(band_letter: :b, type: :retained_2)).to eql(27)
+      expect(subject.fee_for_declaration(band_letter: :b, type: :completed)).to eql(36)
+
+      expect(subject.fee_for_declaration(band_letter: :c, type: :started)).to eql(24)
+      expect(subject.fee_for_declaration(band_letter: :c, type: :retained_3)).to eql(18)
+      expect(subject.fee_for_declaration(band_letter: :c, type: :completed)).to eql(24)
+
+      expect(subject.fee_for_declaration(band_letter: :d, type: :started)).to eql(12)
+      expect(subject.fee_for_declaration(band_letter: :d, type: :retained_3)).to eql(9)
+      expect(subject.fee_for_declaration(band_letter: :d, type: :completed)).to eql(12)
+    end
+  end
+
+  describe "#banding_breakdown" do
+    context "when nada declarations" do
+      it "returns empty bands" do
+        expected = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      end
+    end
+
+    context "when partially filled bands" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "returns correct bands" do
+        expected = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      end
+    end
+
+    context "when fully filled bands" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 2,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "returns correct bands" do
+        expected = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      end
+    end
+
+    context "when multiple bands" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 7,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "returns correct bands" do
+        expected = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      end
+    end
+
+    context "when overfilled all bands" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 9,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "does not count extra declarations" do
+        expected = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      end
+    end
+
+    context "next statement is present" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 3,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+
+        declarations = create_list(
+          :ect_participant_declaration, 3,
+          state: :payable
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: second_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "counts bands from where it left off" do
+        expected = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 2,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 1,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(expected)
+      end
+    end
+
+    context "when clawbacks present" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 5,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+
+        clawback_declarations = declarations.sample(2)
+
+        clawback_declarations.each do |dec|
+          dec.update!(state: "awaiting_clawback")
+
+          Finance::StatementLineItem.create!(
+            statement: second_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "can calculate refunds when current statement is empty" do
+        first_statement_expectation = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        second_statement_expectation = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 2,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 2,
+            started_count: -1,
+            started_additions: 0,
+            started_subtractions: 1,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 1,
+            started_count: -1,
+            started_additions: 0,
+            started_subtractions: 1,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(first_statement_expectation)
+        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(second_statement_expectation)
+      end
+    end
+
+    context "when clawbacks present" do
+      before do
+        setup_statement_one
+        setup_statement_two
+        setup_statement_three
+      end
+
+      def setup_statement_one
+        declarations = create_list(
+          :ect_participant_declaration, 3,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      def setup_statement_two
+        declarations = create_list(
+          :ect_participant_declaration, 3,
+          state: :paid
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: second_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+
+        clawback_line_items = first_statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { state: "paid" })
+          .order(Arel.sql("RANDOM()")).limit(1)
+
+        clawback_line_items.each do |line_item|
+          Finance::StatementLineItem.create!(
+            statement: second_statement,
+            participant_declaration: line_item.participant_declaration,
+            state: "clawed_back",
+          )
+
+          line_item.participant_declaration.update!(state: "clawed_back")
+        end
+      end
+
+      def setup_statement_three
+        declarations = create_list(
+          :ect_participant_declaration, 3,
+          state: :payable
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: third_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+
+        clawback_line_items = first_statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { state: "paid" })
+          .order(Arel.sql("RANDOM()"))
+          .limit(1)
+
+        clawback_line_items.each do |line_item|
+          Finance::StatementLineItem.create!(
+            statement: third_statement,
+            participant_declaration: line_item.participant_declaration,
+            state: "awaiting_clawback",
+          )
+
+          line_item.participant_declaration.update!(state: "awaiting_clawback")
+        end
+
+        clawback_line_items = second_statement
+          .billable_statement_line_items
+          .order(Arel.sql("RANDOM()"))
+          .joins(:participant_declaration)
+          .where(participant_declarations: { state: "paid" })
+          .limit(1)
+
+        clawback_line_items.each do |line_item|
+          Finance::StatementLineItem.create!(
+            statement: third_statement,
+            participant_declaration: line_item.participant_declaration,
+            state: "awaiting_clawback",
+          )
+
+          line_item.participant_declaration.update!(state: "awaiting_clawback")
+        end
+      end
+
+      it "can calculate refunds for typical use case" do
+        first_statement_expectation = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 0,
+            started_count: 2,
+            started_additions: 2,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        second_statement_expectation = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 2,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 1,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 2,
+            started_subtractions: 1,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        third_statement_expectation = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 2,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 2,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 1,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 2,
+            started_subtractions: 2,
+          },
+        ]
+
+        expect(first_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(first_statement_expectation)
+        expect(second_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(second_statement_expectation)
+        expect(third_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(third_statement_expectation)
+      end
+    end
+
+    context "when there is a clawback followed by a declaration again" do
+      let(:user) { create(:user, :early_career_teacher) }
+      let(:participant_profile) { user.participant_profiles.first }
+
+      before do
+        setup_statement_one
+        setup_statement_two
+        setup_statement_three
+      end
+
+      def setup_statement_one
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          state: :paid,
+          user:,
+          participant_profile:
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: first_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      def setup_statement_two
+        clawback_line_items = first_statement
+          .billable_statement_line_items
+          .joins(:participant_declaration)
+          .where(participant_declarations: { state: "paid" })
+
+        clawback_line_items.each do |li|
+          li.participant_declaration.update!(state: "clawed_back")
+
+          Finance::StatementLineItem.create!(
+            statement: second_statement,
+            participant_declaration: li.participant_declaration,
+            state: "clawed_back",
+          )
+        end
+      end
+
+      def setup_statement_three
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          state: :payable,
+          user:,
+          participant_profile:
+        )
+
+        declarations.each do |dec|
+          Finance::StatementLineItem.create!(
+            statement: third_statement,
+            participant_declaration: dec,
+            state: dec.state,
+          )
+        end
+      end
+
+      it "pays out again the latter declarations" do
+        fourth_statement_expectation = [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+            previous_started_count: 1,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :c,
+            min: 5,
+            max: 6,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+          {
+            band: :d,
+            min: 7,
+            max: 8,
+            previous_started_count: 0,
+            started_count: 0,
+            started_additions: 0,
+            started_subtractions: 0,
+          },
+        ]
+
+        expect(fourth_statement_calc.banding_breakdown.map { |e| e.slice(*relevant_started_keys) }).to eql(fourth_statement_expectation)
+      end
+    end
+
+    context "uplifts" do
+      context "when there an no uplifts" do
+        let(:expected) do
+          {
+            previous_count: 0,
+            count: 0,
+            additions: 0,
+            subtractions: 0,
+          }
+        end
+
+        it "returns zero current and previous uplifts" do
+          expect(first_statement_calc.uplift_breakdown).to eql(expected)
+        end
+      end
+
+      context "when there are uplifts" do
+        before do
+          declarations = create_list(
+            :ect_participant_declaration, 2,
+            state: :paid,
+            pupil_premium_uplift: true
+          )
+
+          declarations.each do |dec|
+            Finance::StatementLineItem.create!(
+              statement: first_statement,
+              participant_declaration: dec,
+              state: dec.state,
+            )
+          end
+        end
+
+        let(:expected) do
+          {
+            previous_count: 0,
+            count: 2,
+            additions: 2,
+            subtractions: 0,
+          }
+        end
+
+        it "returns current uplifts" do
+          expect(first_statement_calc.uplift_breakdown).to eql(expected)
+        end
+      end
+
+      context "when there are uplifts but not on started declarations" do
+        before do
+          declarations = create_list(
+            :ect_participant_declaration, 2,
+            state: :paid,
+            pupil_premium_uplift: true,
+            declaration_type: "retained-1"
+          )
+
+          declarations.each do |dec|
+            Finance::StatementLineItem.create!(
+              statement: first_statement,
+              participant_declaration: dec,
+              state: dec.state,
+            )
+          end
+        end
+
+        let(:expected) do
+          {
+            previous_count: 0,
+            count: 0,
+            additions: 0,
+            subtractions: 0,
+          }
+        end
+
+        it "does not count them" do
+          expect(first_statement_calc.uplift_breakdown).to eql(expected)
+        end
+      end
+
+      context "when there is net negative of uplifts on a single statement" do
+        before do
+          declarations = create_list(
+            :ect_participant_declaration, 2,
+            state: :paid,
+            pupil_premium_uplift: true
+          )
+
+          declarations.each do |dec|
+            Finance::StatementLineItem.create!(
+              statement: first_statement,
+              participant_declaration: dec,
+              state: dec.state,
+            )
+          end
+
+          clawback_line_items = first_statement
+            .billable_statement_line_items
+            .joins(:participant_declaration)
+            .where(participant_declarations: { state: "paid" })
+            .order(Arel.sql("RANDOM()"))
+            .limit(1)
+
+          clawback_line_items.each do |line_item|
+            Finance::StatementLineItem.create!(
+              statement: second_statement,
+              participant_declaration: line_item.participant_declaration,
+              state: "awaiting_clawback",
+            )
+
+            line_item.participant_declaration.update!(state: "awaiting_clawback")
+          end
+        end
+
+        let(:expected) do
+          {
+            previous_count: 2,
+            count: -1,
+            additions: 0,
+            subtractions: 1,
+          }
+        end
+
+        it "returns negative uplifts" do
+          expect(second_statement_calc.uplift_breakdown).to eql(expected)
+        end
+      end
+
+      context "when there are previous uplifts" do
+        before do
+          setup_statement_one
+          setup_statement_two
+          setup_statement_three
+        end
+
+        def setup_statement_one
+          declarations = create_list(
+            :ect_participant_declaration, 3,
+            state: :paid,
+            pupil_premium_uplift: true
+          )
+
+          declarations.each do |dec|
+            Finance::StatementLineItem.create!(
+              statement: first_statement,
+              participant_declaration: dec,
+              state: dec.state,
+            )
+          end
+        end
+
+        def setup_statement_two
+          declarations = create_list(
+            :ect_participant_declaration, 3,
+            state: :paid,
+            pupil_premium_uplift: true
+          )
+
+          declarations.each do |dec|
+            Finance::StatementLineItem.create!(
+              statement: second_statement,
+              participant_declaration: dec,
+              state: dec.state,
+            )
+          end
+
+          clawback_line_items = first_statement
+            .billable_statement_line_items
+            .joins(:participant_declaration)
+            .where(participant_declarations: { state: "paid" })
+            .order(Arel.sql("RANDOM()")).limit(1)
+
+          clawback_line_items.each do |line_item|
+            Finance::StatementLineItem.create!(
+              statement: second_statement,
+              participant_declaration: line_item.participant_declaration,
+              state: "clawed_back",
+            )
+
+            line_item.participant_declaration.update!(state: "clawed_back")
+          end
+        end
+
+        def setup_statement_three
+          declarations = create_list(
+            :ect_participant_declaration, 3,
+            state: :payable,
+            pupil_premium_uplift: true
+          )
+
+          declarations.each do |dec|
+            Finance::StatementLineItem.create!(
+              statement: third_statement,
+              participant_declaration: dec,
+              state: dec.state,
+            )
+          end
+
+          clawback_line_items = first_statement
+            .billable_statement_line_items
+            .joins(:participant_declaration)
+            .where(participant_declarations: { state: "paid" })
+            .order(Arel.sql("RANDOM()"))
+            .limit(1)
+
+          clawback_line_items.each do |line_item|
+            Finance::StatementLineItem.create!(
+              statement: third_statement,
+              participant_declaration: line_item.participant_declaration,
+              state: "awaiting_clawback",
+            )
+
+            line_item.participant_declaration.update!(state: "awaiting_clawback")
+          end
+
+          clawback_line_items = second_statement
+            .billable_statement_line_items
+            .order(Arel.sql("RANDOM()"))
+            .joins(:participant_declaration)
+            .where(participant_declarations: { state: "paid" })
+            .limit(1)
+
+          clawback_line_items.each do |line_item|
+            Finance::StatementLineItem.create!(
+              statement: third_statement,
+              participant_declaration: line_item.participant_declaration,
+              state: "awaiting_clawback",
+            )
+
+            line_item.participant_declaration.update!(state: "awaiting_clawback")
+          end
+        end
+
+        let(:statement_one_expectation) do
+          {
+            previous_count: 0,
+            count: 3,
+            additions: 3,
+            subtractions: 0,
+          }
+        end
+
+        let(:statement_two_expectation) do
+          {
+            previous_count: 3,
+            count: 2,
+            additions: 3,
+            subtractions: 1,
+          }
+        end
+
+        let(:statement_three_expectation) do
+          {
+            previous_count: 5,
+            count: 1,
+            additions: 3,
+            subtractions: 2,
+          }
+        end
+
+        it "returns correct uplifts" do
+          expect(first_statement_calc.uplift_breakdown).to eql(statement_one_expectation)
+          expect(second_statement_calc.uplift_breakdown).to eql(statement_two_expectation)
+          expect(third_statement_calc.uplift_breakdown).to eql(statement_three_expectation)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/finance/ecf/statement_calculator2_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator2_spec.rb
@@ -1,0 +1,687 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ECF::StatementCalculator2 do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+
+  let!(:statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 1.week.ago) }
+  let!(:contract) { create(:call_off_contract, :with_minimal_bands, lead_provider:) }
+
+  subject { described_class.new(statement:) }
+
+  describe "#total" do
+    let(:default_total) { BigDecimal("-0.5132793103448275862068965517241379310345e4") }
+
+    context "when there is a positive reconcile_amount" do
+      before do
+        statement.update!(reconcile_amount: 1234)
+      end
+
+      it "increases total" do
+        expect(subject.total(with_vat: false)).to eql(default_total + 1234)
+      end
+    end
+
+    context "when there is a negative reconcile_amount" do
+      before do
+        statement.update!(reconcile_amount: -1234)
+      end
+
+      it "descreases the total" do
+        expect(subject.total(with_vat: false)).to eql(default_total - 1234)
+      end
+    end
+
+    context "when VAT is applicable" do
+      before do
+        statement.update!(reconcile_amount: 1234)
+      end
+
+      it "affects the amount to reconcile by" do
+        expect(subject.total(with_vat: true)).to eql((default_total + 1234) * 1.2)
+      end
+    end
+  end
+
+  describe "#adjustments_total" do
+    context "when there are uplifts" do
+      let(:uplift_breakdown) do
+        {
+          previous_count: 0,
+          count: 2,
+          additions: 4,
+          subtractions: 2,
+        }
+      end
+
+      let(:banding_breakdown) do
+        []
+      end
+
+      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", uplift_breakdown:, banding_breakdown:) }
+
+      let!(:contract) { create(:call_off_contract, lead_provider:) }
+
+      before do
+        allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+      end
+
+      it "includes uplift adjustments" do
+        expect(subject.adjustments_total).to eql(200)
+      end
+    end
+
+    context "when there are clawbacks" do
+      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", banding_breakdown:, uplift_breakdown:) }
+
+      let(:uplift_breakdown) do
+        {
+          previous_count: 0,
+          count: 0,
+          additions: 0,
+          subtractions: 0,
+        }
+      end
+
+      let(:banding_breakdown) do
+        [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+
+            previous_started_count: 1,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+
+            previous_retained_1_count: 1,
+            retained_1_count: 1,
+            retained_1_additions: 1,
+            retained_1_subtractions: 0,
+
+            previous_retained_2_count: 1,
+            retained_2_count: 1,
+            retained_2_additions: 1,
+            retained_2_subtractions: 0,
+
+            previous_retained_3_count: 1,
+            retained_3_count: 1,
+            retained_3_additions: 1,
+            retained_3_subtractions: 0,
+
+            previous_retained_4_count: 1,
+            retained_4_count: 1,
+            retained_4_additions: 1,
+            retained_4_subtractions: 0,
+
+            previous_completed_count: 1,
+            completed_count: 1,
+            completed_additions: 1,
+            completed_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 2,
+            started_subtractions: 1,
+
+            previous_retained_1_count: 0,
+            retained_1_count: 1,
+            retained_1_additions: 2,
+            retained_1_subtractions: 1,
+
+            previous_retained_2_count: 0,
+            retained_2_count: 1,
+            retained_2_additions: 2,
+            retained_2_subtractions: 1,
+
+            previous_retained_3_count: 0,
+            retained_3_count: 1,
+            retained_3_additions: 2,
+            retained_3_subtractions: 1,
+
+            previous_retained_4_count: 0,
+            retained_4_count: 1,
+            retained_4_additions: 2,
+            retained_4_subtractions: 1,
+
+            previous_completed_count: 0,
+            completed_count: 1,
+            completed_additions: 2,
+            completed_subtractions: 1,
+          },
+        ]
+      end
+
+      before do
+        allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+        allow(output_calculator).to receive(:fee_for_declaration).and_return(48)
+      end
+
+      it "includes clawback adjustments" do
+        expect(subject.adjustments_total).to eql(-288)
+      end
+    end
+  end
+
+  describe "#additions_for_started" do
+    let(:banding_breakdown) do
+      [
+        {
+          band: :a,
+          min: 1,
+          max: 2,
+          previous_started_count: 1,
+          started_count: 1,
+          started_additions: 1,
+          started_subtractions: 0,
+        },
+        {
+          band: :b,
+          min: 3,
+          max: 4,
+          previous_started_count: 0,
+          started_count: 1,
+          started_additions: 2,
+          started_subtractions: 1,
+        },
+      ]
+    end
+
+    let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator") }
+
+    before do
+      allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+
+      allow(output_calculator).to receive(:banding_breakdown).and_return(banding_breakdown)
+
+      allow(output_calculator).to receive(:fee_for_declaration).and_return(48, 36, 36)
+    end
+
+    it "returns correct value across all bands" do
+      expect(subject.additions_for_started).to eql(48 + 36 + 36)
+    end
+  end
+
+  describe "#total_for_uplift" do
+    context "when there are no uplifts" do
+      it "returns zero" do
+        expect(subject.total_for_uplift).to be_zero
+      end
+    end
+
+    context "when there are uplifts" do
+      let(:uplift_breakdown) do
+        {
+          previous_count: 5,
+          count: 2,
+          additions: 4,
+          subtractions: 2,
+        }
+      end
+
+      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", uplift_breakdown:) }
+
+      let!(:contract) { create(:call_off_contract, lead_provider:) }
+
+      before do
+        allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+      end
+
+      it do
+        expect(subject.total_for_uplift).to eql(200)
+      end
+    end
+
+    context "when there is net negative uplifts" do
+      let(:uplift_breakdown) do
+        {
+          previous_count: 5,
+          count: -3,
+          additions: 1,
+          subtractions: 4,
+        }
+      end
+
+      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", uplift_breakdown:) }
+
+      before do
+        allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+      end
+
+      it do
+        expect(subject.total_for_uplift).to eql(-300)
+      end
+    end
+
+    context "when we pass the uplift cap threshold" do
+      let!(:contract) { create(:call_off_contract, lead_provider:) }
+
+      let(:uplift_breakdown) do
+        {
+          previous_count: 0,
+          count: 100_000,
+          additions: 100_000,
+          subtractions: 0,
+        }
+      end
+
+      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", uplift_breakdown:) }
+
+      before do
+        allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+      end
+
+      it "matches uplift_cap" do
+        expect(subject.total_for_uplift).to eql(statement.contract.uplift_cap)
+      end
+    end
+  end
+
+  describe "#uplift_fee_per_declaration" do
+    it do
+      expect(subject.uplift_fee_per_declaration).to eql(100)
+    end
+  end
+
+  describe "#started_count" do
+    let(:banding_breakdown) do
+      [
+        {
+          band: :a,
+          min: 1,
+          max: 2,
+          previous_started_count: 1,
+          started_count: 1,
+          started_additions: 1,
+          started_subtractions: 0,
+        },
+        {
+          band: :b,
+          min: 3,
+          max: 4,
+          previous_started_count: 0,
+          started_count: 1,
+          started_additions: 2,
+          started_subtractions: 1,
+        },
+      ]
+    end
+    let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", banding_breakdown:) }
+
+    before do
+      allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+    end
+
+    it "returns count of all started across bands" do
+      expect(subject.started_count).to eql(3)
+    end
+  end
+
+  describe "#retained_count" do
+    let(:banding_breakdown) do
+      [
+        {
+          band: :a,
+          min: 1,
+          max: 2,
+          previous_retained_1_count: 1,
+          retained_1_count: 1,
+          retained_1_additions: 1,
+          retained_1_subtractions: 0,
+          previous_started_count: 1,
+          retained_2_count: 1,
+          retained_2_additions: 1,
+          retained_2_subtractions: 0,
+        },
+        {
+          band: :b,
+          min: 3,
+          max: 4,
+          previous_retained_1_count: 0,
+          retained_1_count: 1,
+          retained_1_additions: 2,
+          retained_1_subtractions: 1,
+          previous_retained_2_count: 0,
+          retained_2_count: 1,
+          retained_2_additions: 2,
+          retained_2_subtractions: 1,
+        },
+      ]
+    end
+    let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", banding_breakdown:) }
+
+    before do
+      allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+    end
+
+    it "returns count of all retained across bands" do
+      expect(subject.retained_count).to eql(6)
+    end
+  end
+
+  describe "#completed_count" do
+    let(:banding_breakdown) do
+      [
+        {
+          band: :a,
+          min: 1,
+          max: 2,
+          previous_completed_count: 1,
+          completed_count: 1,
+          completed_additions: 1,
+          completed_subtractions: 0,
+        },
+        {
+          band: :b,
+          min: 3,
+          max: 4,
+          previous_completed_count: 0,
+          completed_count: 1,
+          completed_additions: 2,
+          completed_subtractions: 1,
+        },
+      ]
+    end
+    let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", banding_breakdown:) }
+
+    before do
+      allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+    end
+
+    it "returns count of all completed across bands" do
+      expect(subject.completed_count).to eql(3)
+    end
+  end
+
+  describe "#started_band_a_count" do
+    context "when there are no declarations" do
+      it "returns zero" do
+        expect(subject.started_band_a_count).to be_zero
+      end
+    end
+
+    context "when there are declarations attached to another statement for different provider" do
+      let(:other_cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+      let(:other_lead_provider) { other_cpd_lead_provider.lead_provider }
+
+      let!(:other_statement) { create(:ecf_statement, cpd_lead_provider: other_cpd_lead_provider, payment_date: 1.week.ago) }
+      let!(:other_contract) { create(:call_off_contract, :with_minimal_bands, lead_provider: other_lead_provider) }
+
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          cpd_lead_provider: other_cpd_lead_provider,
+          state: "eligible"
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: other_statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+      end
+
+      it "returns zero" do
+        expect(subject.started_band_a_count).to be_zero
+      end
+    end
+
+    context "when band is partially populated" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          cpd_lead_provider:,
+          state: "eligible"
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement:,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+      end
+
+      it "returns the number of declarations" do
+        expect(subject.started_band_a_count).to eql(1)
+      end
+    end
+
+    context "when the band had overflowed" do
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 3,
+          cpd_lead_provider:,
+          state: "eligible"
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement:,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+      end
+
+      it "returns the maximum number allowed in the band" do
+        expect(subject.started_band_a_count).to eql(2)
+      end
+    end
+
+    context "when there is a previous statement partially filling the band" do
+      let!(:previous_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 5.weeks.ago) }
+
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          cpd_lead_provider:,
+          state: "eligible"
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: previous_statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+      end
+
+      context "there are no declarations on this statement" do
+        it "returns zero" do
+          expect(subject.started_band_a_count).to be_zero
+        end
+      end
+
+      context "there are declarations on this statement, partly filling it" do
+        before do
+          declarations = create_list(
+            :ect_participant_declaration, 1,
+            cpd_lead_provider:,
+            state: "eligible"
+          )
+
+          declarations.each do |declaration|
+            Finance::StatementLineItem.create!(
+              statement:,
+              participant_declaration: declaration,
+              state: declaration.state,
+            )
+          end
+        end
+
+        it "returns number of permitted declarations" do
+          expect(subject.started_band_a_count).to eql(1)
+        end
+      end
+
+      context "there are declarations on this statement, over filling it" do
+        before do
+          declarations = create_list(
+            :ect_participant_declaration, 2,
+            cpd_lead_provider:,
+            state: "eligible"
+          )
+
+          declarations.each do |declaration|
+            Finance::StatementLineItem.create!(
+              statement:,
+              participant_declaration: declaration,
+              state: declaration.state,
+            )
+          end
+        end
+
+        it "returns max number of permitted declarations" do
+          expect(subject.started_band_a_count).to eql(1)
+        end
+      end
+    end
+
+    context "when there is a previous statement totally filling the band" do
+      let!(:previous_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 5.weeks.ago) }
+
+      before do
+        declarations = create_list(
+          :ect_participant_declaration, 2,
+          cpd_lead_provider:,
+          state: "eligible"
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement: previous_statement,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+
+        declarations = create_list(
+          :ect_participant_declaration, 1,
+          cpd_lead_provider:,
+          state: "eligible"
+        )
+
+        declarations.each do |declaration|
+          Finance::StatementLineItem.create!(
+            statement:,
+            participant_declaration: declaration,
+            state: declaration.state,
+          )
+        end
+      end
+
+      it "returns zero" do
+        expect(subject.started_band_a_count).to be_zero
+      end
+
+      it "returns declaration in next band" do
+        expect(subject.started_band_b_count).to eql(1)
+      end
+    end
+  end
+
+  describe "#uplift_count" do
+    context "when uplift is not applicable" do
+      let(:profile) { create(:ect_participant_profile) }
+
+      before do
+        declaration = create(
+          :ect_participant_declaration, :without_uplift,
+          cpd_lead_provider:,
+          state: "eligible",
+          participant_profile: profile
+        )
+
+        Finance::StatementLineItem.create!(
+          statement:,
+          participant_declaration: declaration,
+          state: declaration.state,
+        )
+      end
+
+      it "does not count it" do
+        expect(subject.uplift_count).to be_zero
+      end
+    end
+
+    context "when uplift is applicable" do
+      let(:profile) { create(:ect_participant_profile) }
+      let(:declaration) do
+        create(
+          :ect_participant_declaration, :pupil_premium_uplift,
+          cpd_lead_provider:,
+          state: "eligible",
+          participant_profile: profile
+        )
+      end
+
+      before do
+        Finance::StatementLineItem.create!(
+          statement:,
+          participant_declaration: declaration,
+          state: declaration.state,
+        )
+      end
+
+      it "does count it" do
+        expect(subject.uplift_count).to eql(1)
+      end
+    end
+
+    context "paid declaration transitions to awaiting_clawback" do
+      let(:old_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 2.months.ago) }
+      let(:new_statement) { create(:ecf_statement, cpd_lead_provider:, payment_date: 2.months.from_now) }
+
+      let(:declaration) do
+        create(
+          :ect_participant_declaration,
+          cpd_lead_provider:,
+          state: "paid",
+        )
+      end
+
+      before do
+        Finance::StatementLineItem.create!(
+          participant_declaration: declaration,
+          statement: old_statement,
+          state: declaration.state,
+        )
+
+        Finance::StatementLineItem.create!(
+          participant_declaration: declaration,
+          statement: new_statement,
+          state: "awaiting_clawback",
+        )
+      end
+
+      describe "#started_band_a_count" do
+        context "for old statement" do
+          subject { described_class.new(statement: old_statement) }
+
+          it "continues to count declaration" do
+            expect(subject.started_band_a_count).to eql(1)
+          end
+        end
+
+        context "for new statement" do
+          subject { described_class.new(statement: new_statement) }
+
+          it "counts the declaration" do
+            expect(subject.started_band_a_count).to eql(-1)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1469
- We are discounting duplicates for ECF statements
- This was to counter people who had double posted due to duplicates
- We now need to remove this feature so we can count legal double postings with a declaration followed by a clawback followed by another declaration

### Changes proposed in this pull request

- Added under a different endpoint so this can be tested with prod data before we roll out
- Do not discount duplicates for ECF
- Assess the damage there maybe none
- This way we can identity duplicates and clawback if needed
- If all is good the new version will supersede the old version and merged back into the one true version

### Guidance to review

- To view the new version of a statement, when view an existing ECF statement change the end of the URL to `statements/august-2022/show2` as an example
- Below is the diff between the old and new version for convenience of the reviewer

```
--- app/services/finance/ecf/output_calculator.rb	2022-07-21 11:29:14.000000000 +0100
+++ app/services/finance/ecf/output_calculator2.rb	2022-07-21 11:29:39.000000000 +0100
@@ -2,7 +2,7 @@

 module Finance
   module ECF
-    class OutputCalculator
+    class OutputCalculator2
       attr_reader :statement

       def initialize(statement:)
@@ -169,7 +169,6 @@
           .billable
           .joins(:participant_declaration)
           .where(participant_declarations: { declaration_type: })
-          .merge(ParticipantDeclaration.unique_id)
           .count

         refundable = Finance::StatementLineItem
@@ -177,7 +176,6 @@
           .refundable
           .joins(:participant_declaration)
           .where(participant_declarations: { declaration_type: })
-          .merge(ParticipantDeclaration.unique_id)
           .count

         billable - refundable
@@ -189,7 +187,6 @@
           .billable
           .joins(:participant_declaration)
           .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
-          .merge(ParticipantDeclaration.unique_id)
           .count

         refundable = Finance::StatementLineItem
@@ -197,7 +194,6 @@
           .refundable
           .joins(:participant_declaration)
           .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
-          .merge(ParticipantDeclaration.unique_id)
           .count

         billable - refundable
@@ -208,7 +204,6 @@
           .billable_statement_line_items
           .joins(:participant_declaration)
           .where(participant_declarations: { declaration_type: })
-          .merge(ParticipantDeclaration.unique_id)
           .count
       end

@@ -217,7 +212,6 @@
           .refundable_statement_line_items
           .joins(:participant_declaration)
           .where(participant_declarations: { declaration_type: })
-          .merge(ParticipantDeclaration.unique_id)
           .count
       end

@@ -227,7 +221,6 @@
           .joins(:participant_declaration)
           .where(participant_declarations: { declaration_type: "started" })
           .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
-          .merge(ParticipantDeclaration.unique_id)
           .count
       end

@@ -237,7 +230,6 @@
           .joins(:participant_declaration)
           .where(participant_declarations: { declaration_type: "started" })
           .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
-          .merge(ParticipantDeclaration.unique_id)
           .count
       end
     end
```