### PR TITLE
[CPDLP-1469] ECF calculator only considers uplifts for started

### DIFF
--- a/app/services/finance/ecf/output_calculator2.rb
+++ b/app/services/finance/ecf/output_calculator2.rb
@@ -186,6 +186,7 @@ module Finance
           .where(statement: statement.previous_statements)
           .billable
           .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: "started" })
           .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
           .count
 
@@ -193,6 +194,7 @@ module Finance
           .where(statement: statement.previous_statements)
           .refundable
           .joins(:participant_declaration)
+          .where(participant_declarations: { declaration_type: "started" })
           .where("participant_declarations.sparsity_uplift = true OR participant_declarations.pupil_premium_uplift = true")
           .count
 

--- a/spec/services/finance/ecf/output_calculator2_spec.rb
+++ b/spec/services/finance/ecf/output_calculator2_spec.rb
@@ -1118,4 +1118,44 @@ RSpec.describe Finance::ECF::OutputCalculator2 do
       end
     end
   end
+
+  describe "#uplift_breakdown" do
+    before do
+      declarations = create_list(
+        :ect_participant_declaration, 1,
+        state: :paid,
+        declaration_type: "started",
+        sparsity_uplift: true,
+        pupil_premium_uplift: true
+      )
+
+      declarations.each do |dec|
+        Finance::StatementLineItem.create!(
+          statement: first_statement,
+          participant_declaration: dec,
+          state: dec.state,
+        )
+      end
+
+      declarations = create_list(
+        :ect_participant_declaration, 1,
+        state: :paid,
+        declaration_type: "retained-1",
+        sparsity_uplift: true,
+        pupil_premium_uplift: true
+      )
+
+      declarations.each do |dec|
+        Finance::StatementLineItem.create!(
+          statement: first_statement,
+          participant_declaration: dec,
+          state: dec.state,
+        )
+      end
+    end
+
+    it "only counts started declarations" do
+      expect(second_statement_calc.uplift_breakdown[:previous_count]).to eql(1)
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1469
- With the removal of duplicates the new test calculator does not count uplifts correctly

### Changes proposed in this pull request

- Count only uplifts on started declarations

### Guidance to review

- none