### PR TITLE
Participant history viewer

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -8,6 +8,7 @@ module Admin
     before_action :load_participant, except: :index
     before_action :historical_induction_records, only: :show, unless: -> { @participant_profile.npq? }
     before_action :latest_induction_record, only: :show, unless: -> { @participant_profile.npq? }
+    before_action :event_list, only: :show
 
     def show; end
 
@@ -92,8 +93,12 @@ module Admin
       scope.order("DATE(users.created_at) ASC, users.full_name")
     end
 
+    def event_list
+      @event_list ||= ParticipantEventHistory.from_profile(@participant_profile).events
+    end
+
     def historical_induction_records
-      @historical_induction_records ||= @participant_profile.induction_records.order(created_at: :desc).offset(1)
+      @historical_induction_records ||= @participant_profile.induction_records.ordered_historically.offset(1)
     end
 
     def latest_induction_record

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -58,6 +58,13 @@ class InductionRecord < ApplicationRecord
 
   scope :for_school, ->(school) { joins(:school).where(school: { id: school.id }) }
 
+  def self.ordered_historically
+    order(
+      arel_table[:start_date].asc,
+      arel_table[:end_date].asc.nulls_first,
+    )
+  end
+
   def self.latest
     order(created_at: :asc).last
   end

--- a/app/models/participant_event_history.rb
+++ b/app/models/participant_event_history.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+class ParticipantEventHistory
+  class ParticipantEvent
+    attr_reader :date, :description, :reporter
+
+    def initialize(date, description, reporter)
+      @date = date
+      @description = description
+      @reporter = reporter
+    end
+  end
+
+  attr_reader :events
+
+  def initialize(user)
+    @user = user
+    @events = []
+
+    record_user_events @user unless @user.nil?
+    record_teacher_record_events @user.teacher_profile unless @user.teacher_profile.nil?
+
+    @user.participant_identities.each { |identity| record_identity_events(identity) } unless @user.participant_identities.empty?
+
+    unless @user.participant_profiles.empty?
+      @user.participant_profiles.each do |profile|
+        record_profile_events(profile)
+        induction_records = profile.induction_records.sort_by { |record| [record.start_date, record.end_date.nil?, record.end_date] }
+
+        record_induction_record_events(induction_records) unless profile.induction_records.empty?
+        record_participant_declaration_events(profile.participant_declarations.sort_by(&:created_at))
+
+        next unless profile.ecf?
+
+        record_validation_events(profile.ecf_participant_validation_data) unless profile.ecf_participant_validation_data.nil?
+        record_eligibility_events(profile.ecf_participant_eligibility) unless profile.ecf_participant_eligibility.nil?
+
+        record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.nil?
+
+        # if profile.mentor?
+        # profile.school_mentors
+        # end
+      end
+    end
+
+    @events.sort_by!(&:date)
+  end
+
+  def self.from_profile(profile)
+    new(profile.user)
+  end
+
+  def self.from_user(user)
+    new(user)
+  end
+
+private
+
+  def record_user_events(user)
+    @events.push ParticipantEvent.new(user.created_at, "Registered with the system", user.school&.name || "Unknown")
+
+    user.versions&.each do |version|
+      version.object_changes&.each do |key, value|
+        description = user_event_description(key, value)
+        unless description.nil?
+          @events.push ParticipantEvent.new(version.created_at, description, version.whodunnit || "Unknown")
+        end
+      end
+    end
+  end
+
+  def user_event_description(key, _value)
+    case key
+    when "login_token"
+      "Logged in"
+    when "email"
+      "Changed email address"
+    when "full_name"
+      "Changed name"
+    when "discarded_at"
+      "Removed from the system"
+    when "created_at"
+      nil
+    when "updated_at"
+      nil
+    else
+      "User.#{key}"
+    end
+  end
+
+  def record_teacher_record_events(teacher_record)
+    @events.push ParticipantEvent.new(teacher_record.created_at, "Teacher record created", teacher_record.school&.name || "Unknown")
+
+    teacher_record.versions&.each do |version|
+      version.object_changes&.each do |key, value|
+        description = teacher_record_event_description(key, value)
+        unless description.nil?
+          @events.push ParticipantEvent.new(version.created_at, description, version.whodunnit || "Unknown")
+        end
+      end
+    end
+  end
+
+  def teacher_record_event_description(key, value)
+    case key
+    when "trn"
+      "TRN #{value.nil? ? 'removed' : 'updated'}"
+    when "school_id"
+      "Transferred to another school"
+    when "user_id"
+      "TeacherProfile reassigned to a different user"
+    when "created_at"
+      nil
+    when "updated_at"
+      nil
+    else
+      "TeacherRecord.#{key}"
+    end
+  end
+
+  def record_profile_events(profile)
+    @events.push ParticipantEvent.new(profile.created_at, "Participant Profile created", profile.school&.name || "Unknown")
+
+    profile.versions&.each do |version|
+      version.object_changes&.each do |key, value|
+        description = profile_event_description(key, value)
+        unless description.nil?
+          @events.push ParticipantEvent.new(version.created_at, description, version.whodunnit || "Unknown")
+        end
+      end
+    end
+  end
+
+  def profile_event_description(key, value)
+    case key
+    when "type"
+      "Participant became a #{value.new}"
+    when "core_induction_programme_id"
+      "Switched induction programme"
+    when "cohort_id"
+      "Moved to a different cohort"
+    when "mentor_profile_id"
+      "New Mentor assigned"
+    when "status"
+      "Participant was #{value.new}"
+    when "school_cohort_id"
+      "Moved to a different cohort"
+    when "teacher_profile_id"
+      "New Teacher Record identified"
+    when "schedule_id"
+      "Switched Schedule"
+    when "npq_course_id"
+      "NPQ Course change"
+    when "school_urn"
+      "Transferred to another school"
+    when "school_ukprn"
+      nil
+    when "request_for_details_sent_at"
+      "Validation request sent"
+    when "training_status"
+      "Training status changed to #{value.new}"
+    when "notes"
+      nil
+    when "created_at"
+      nil
+    when "updated_at"
+      nil
+    else
+      "Participation.#{key}"
+    end
+  end
+
+  def record_identity_events(identity)
+    # identity is not auditable
+    @events.push ParticipantEvent.new(identity.created_at, "Identity created", "Unknown")
+  end
+
+  def record_induction_record_events(induction_records)
+    @events.push ParticipantEvent.new(induction_records.first.created_at, "InductionRecords started", "Unknown")
+
+    induction_records.each_with_index do |record, index|
+      next_record = induction_records[index]
+      next if next_record.nil?
+
+      record.attributes.each do |key, value|
+        description = induction_record_event_description(key, next_record[key], value)
+        unless description.nil? || next_record[key] == value
+          @events.push ParticipantEvent.new(next_record.created_at, description, "Unknown")
+        end
+      end
+    end
+  end
+
+  def induction_record_event_description(key, value_new, _value_old)
+    case key
+    when "induction_programme_id"
+      "Switched induction programme"
+    when "participant_profile_id"
+      "Induction Records assigned to new Participation"
+    when "schedule_id"
+      "Switched Schedule"
+    when "start_date"
+      nil
+    when "end_date"
+      nil
+    when "training_status"
+      "Training status changed to #{value_new}"
+    when "preferred_identity_id"
+      "Preferred Identity changed"
+    when "induction_status"
+      if value_new == "changed"
+        nil
+      else
+        "Training status changed to #{value_new}"
+      end
+    when "mentor_profile_id"
+      "New Mentor assigned"
+    when "school_transfer"
+      "School transfer reported"
+    when "appropriate_body_id"
+      "New Appropriate Body assigned"
+    when "created_at"
+      nil
+    when "updated_at"
+      nil
+    else
+      "InductionRecords.#{key}"
+    end
+  end
+
+  def record_participant_declaration_events(declarations)
+    declarations.each do |declaration|
+      @events.push ParticipantEvent.new(declaration.declaration_date, "#{declaration.declaration_type} milestone reached", declaration.cpd_lead_provider.name)
+
+      declaration.declaration_states.each do |declaration_state|
+        @events.push ParticipantEvent.new(declaration_state.created_at, "#{declaration.declaration_type} declaration #{%w[submitted paid].exclude?(declaration_state.state) ? 'made ' : ' '}#{declaration_state.state}", declaration.cpd_lead_provider.name)
+      end
+    end
+  end
+
+  def record_validation_events(validation_data)
+    # validation_data is not auditable
+    if !validation_data.trn.nil? || !validation_data.full_name.nil? || !validation_data.nino.nil? || !validation_data.date_of_birth.nil?
+      @events.push ParticipantEvent.new(validation_data.created_at, "Validation data provided", validation_data.full_name)
+    end
+  end
+
+  def record_eligibility_events(eligibility)
+    @events.push ParticipantEvent.new(eligibility.created_at, "Eligibility status changed to #{eligibility.status}", "System")
+
+    eligibility.versions&.each do |version|
+      version.object_changes&.each do |key, value|
+        if key == :state
+          @events.push ParticipantEvent.new(version.created_at, "Eligibility status changed to #{value.new}", version.whodunnit || "Unknown")
+        end
+      end
+    end
+  end
+
+  def record_validation_decision_events(decisions)
+    decisions.each do |decision|
+      @events.push ParticipantEvent.new(decision.created_at, decision.approved, "System")
+
+      decision.versions&.each do |version|
+        version.object_changes&.each do |key, value|
+          if key == :state
+            @events.push ParticipantEvent.new(version.created_at, value.new ? "Validation approved" : "Validation not-approved", version.whodunnit || "Unknown")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/participant_event_history.rb
+++ b/app/models/participant_event_history.rb
@@ -36,10 +36,6 @@ class ParticipantEventHistory
         record_eligibility_events(profile.ecf_participant_eligibility) unless profile.ecf_participant_eligibility.nil?
 
         record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.nil?
-
-        # if profile.mentor?
-        # profile.school_mentors
-        # end
       end
     end
 

--- a/app/views/admin/participants/_events.html.erb
+++ b/app/views/admin/participants/_events.html.erb
@@ -1,0 +1,22 @@
+<% if event_list.any? %>
+  <h2 class="govuk-heading-l">Events</h2>
+
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+      <tr>
+        <th scope="row" class="govuk-table__header">Date</th>
+        <th scope="row" class="govuk-table__header">Description</th>
+        <th scope="row" class="govuk-table__header">Reporter</th>
+      </tr>
+      <% event_list.each do |event| %>
+        <tr>
+          <td class="govuk-table__cell"><%= event.date.to_s(:govuk) %></td>
+          <td class="govuk-table__cell"><%= event.description %></td>
+          <td class="govuk-table__cell"><%= event.reporter %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <h2>No event history was found</h2>
+<% end %>

--- a/app/views/admin/participants/_history.html.erb
+++ b/app/views/admin/participants/_history.html.erb
@@ -7,26 +7,27 @@
   </tbody>
 </table>
 
-<table class="govuk-table">
-  <tbody class="govuk-table__body">
-    <% if historical_induction_records.any? %>
-      <h2>School transfers</h2>
-      <tr>
-       <th scope="row" class="govuk-table__header">School name</th>
-       <th scope="row" class="govuk-table__header">Induction Programme</th>
-       <th scope="row" class="govuk-table__header">Start Date</th>
-       <th scope="row" class="govuk-table__header">End Date</th>
-      </tr>
-      <% historical_induction_records.each do |record| %>
+<% if historical_induction_records.any? %>
+  <h2 class="govuk-heading-l">School transfers</h2>
+
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
         <tr>
-         <td class="govuk-table__cell"><%= record.school_cohort.school.name %></td>
-         <td class="govuk-table__cell"><%= record.induction_programme.training_programme.humanize %></td>
-         <td class="govuk-table__cell"><%= record.start_date.to_date.to_s(:govuk) %></td>
-         <td class="govuk-table__cell"><%= record.end_date&.to_date&.to_s(:govuk) %></td>
+         <th scope="row" class="govuk-table__header">School name</th>
+         <th scope="row" class="govuk-table__header">Induction Programme</th>
+         <th scope="row" class="govuk-table__header">Start Date</th>
+         <th scope="row" class="govuk-table__header">End Date</th>
         </tr>
-      <% end %>
-    <% else %>
-      <h2>No transfer history</h2>
-    <% end %>
-  </tbody>
-</table>
+        <% historical_induction_records.each do |record| %>
+          <tr>
+           <td class="govuk-table__cell"><%= record.school_cohort.school.name %></td>
+           <td class="govuk-table__cell"><%= record.induction_programme.training_programme.humanize %></td>
+           <td class="govuk-table__cell"><%= record.start_date.to_date.to_s(:govuk) %></td>
+           <td class="govuk-table__cell"><%= record.end_date&.to_date&.to_s(:govuk) %></td>
+          </tr>
+        <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <h2>No transfer history</h2>
+<% end %>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -21,10 +21,20 @@
         <% component.tab(label: 'History') do %>
           <%= render partial: 'history', locals: { historical_induction_records: @historical_induction_records, latest_induction_record: @latest_induction_record } %>
         <% end %>
+        <% component.tab(label: 'Events') do %>
+          <%= render partial: 'events', locals: { event_list: @event_list } %>
+        <% end %>
       <% end %>
     <% else %>
-       <%= render Admin::Participants::Details.new(profile: @participant_profile) %>
-       <%= render Admin::Participants::ValidationTasks.new(profile: @participant_profile) %>
+      <%= govuk_tabs(title: 'Contents') do |component| %>
+        <% component.tab(label: 'Details') do %>
+          <%= render Admin::Participants::Details.new(profile: @participant_profile) %>
+          <%= render Admin::Participants::ValidationTasks.new(profile: @participant_profile) %>
+        <% end %>
+        <% component.tab(label: 'Events') do %>
+          <%= render partial: 'events', locals: { event_list: @event_list } %>
+        <% end %>
+      <% end %>
     <% end %>
 
     <% if @participant_profile.policy_class.new(current_user, @participant_profile).withdraw_record? %>

--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -57,7 +57,7 @@
 
 <h4>Induction records</h4>
 
-<% pp.induction_records.order(:start_date).each do |ir| %>
+<% pp.induction_records.ordered_historically.each do |ir| %>
   <h5>Induction record: <%= ir.id %></h5>
 
   <%= govuk_summary_list do |summary_list| %>

--- a/spec/models/participant_event_history_spec.rb
+++ b/spec/models/participant_event_history_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantEventHistory, type: :model do
+  let!(:profile) do
+    induction_record = create(:induction_record)
+    induction_record.participant_profile
+  end
+
+  let(:mentor) { create :mentor_participant_profile }
+
+  after do
+    PaperTrail.enabled = false
+  end
+
+  it "should have 5 records when just created" do
+    event_list = described_class.from_profile(profile).events
+    expect(event_list.count).to eq 5
+
+    descriptions = event_list.map(&:description)
+
+    expect(descriptions).to include "Registered with the system"
+    expect(descriptions).to include "Teacher record created"
+    expect(descriptions).to include "Identity created"
+    expect(descriptions).to include "Participant Profile created"
+    expect(descriptions).to include "InductionRecords started"
+  end
+
+  it "should have 6 records after a name change" do
+    PaperTrail.enabled = true
+    profile.user.update! full_name: "Martin Luthor"
+
+    event_list = described_class.from_profile(profile).events
+    expect(event_list.count).to eq 6
+
+    descriptions = event_list.map(&:description)
+
+    expect(descriptions).to include "Changed name"
+  end
+
+  it "should have 8 records after a name, TRN and Mentor change" do
+    PaperTrail.enabled = true
+    profile.user.update! full_name: "Martin Luthor"
+    profile.user.teacher_profile.update! trn: "0123456"
+
+    Induction::ChangeMentor.call induction_record: profile.induction_records.latest,
+                                 mentor_profile: mentor
+
+    event_list = described_class.from_profile(profile).events
+    expect(event_list.count).to eq 8
+
+    descriptions = event_list.map(&:description)
+
+    expect(descriptions).to include "Changed name"
+    expect(descriptions).to include "TRN updated"
+    expect(descriptions).to include "New Mentor assigned"
+  end
+end


### PR DESCRIPTION
### Context

It should be possible to see the historical events or changes to a CPD record over time in order to help determine whay a record is in the state is is and where we might go to correct or undo any actions that misreported information.

### Changes proposed in this pull request

Add an events tab to the Admin Participants UI to allow Admin Users to view the event history of the record.

Provide a model within the application that understands how to traverse the relevant parts of the data model and papertrails in order to identify significant events in the record making process and transform them into an event list.

### Guidance to review

login as an admin user and proceed to the participants dashboard, from here you can bring up any participants screen and view the events tab.

bring up the rails console in your chosen environment and run a query to find a `User` or `ParticipantProfile` object. Call `ParticipantEventHistory.from_user` or `ParticipantEventHistory.from_profile` and access the `events` attribute to see a full list of events created for a record.

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/259493/180733925-1c9de146-b600-443c-9751-e9b7f8873d31.png">
