### PR TITLE
[CPDLP-1443] Retrieve single participant records via the API

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -26,7 +26,7 @@ KEY=$(
         perl -nle'print $& if m{(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])|(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])}'
     )
 
-if [[ "$KEY" != "" ]] && [[ "$KEY" != /components/schemas/* ]]; then
+if [[ "$KEY" != "" ]] && [[ "$KEY" != *"/components/schemas/"* ]]; then
     echo "Found patterns for AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"
     echo "Please check your code and remove API keys."
     echo "$KEY"

--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -25,10 +25,20 @@ module Api
         end
       end
 
+      def show
+        participant_hash = ParticipantFromInductionRecordSerializer.new(induction_record).serializable_hash
+
+        render json: participant_hash.to_json
+      end
+
     private
 
       def induction_records
         @induction_records ||= ECFParticipants::Index.new(cpd_lead_provider: current_user, params:).induction_records
+      end
+
+      def induction_record
+        @induction_record = ECFParticipants::Index.new(cpd_lead_provider: current_user, params:).induction_record.first
       end
 
       def access_scope

--- a/app/controllers/api/v1/npq_participants_controller.rb
+++ b/app/controllers/api/v1/npq_participants_controller.rb
@@ -12,6 +12,10 @@ module Api
         render json: serializer_class.new(paginate(npq_participants), params: { cpd_lead_provider: current_user }).serializable_hash.to_json
       end
 
+      def show
+        render json: serializer_class.new(npq_participant, params: { cpd_lead_provider: current_user }).serializable_hash.to_json
+      end
+
       def withdraw
         if any_participant_declarations_started?
           perform_action(service_namespace: ::Participants::Withdraw)
@@ -46,6 +50,10 @@ module Api
         npq_participants = npq_participants.where("users.updated_at > ?", updated_since) if updated_since.present?
         npq_participants.order(:created_at)
         npq_participants
+      end
+
+      def npq_participant
+        @npq_participant ||= npq_lead_provider.npq_participants.find(params[:id])
       end
 
       def access_scope

--- a/app/services/api/v1/ecf_participants/index.rb
+++ b/app/services/api/v1/ecf_participants/index.rb
@@ -45,6 +45,12 @@ module Api
           end
         end
 
+        def induction_record
+          induction_records
+            .joins(participant_profile: [:participant_identity])
+            .where(participant_profile: { participant_identities: { external_identifier: params[:id] } })
+        end
+
       private
 
         def lead_provider

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
       resources :participant_declarations, only: %i[create index show], path: "participant-declarations" do
         member { put :void }
       end
-      resources :npq_participants, only: %i[index], path: "participants/npq" do
+      resources :npq_participants, only: %i[index show], path: "participants/npq" do
         concerns :participant_actions
       end
       resources :users, only: %i[index create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       concern :participant_actions, Participants::Routing.new
-      resources :ecf_participants, path: "participants/ecf", only: %i[index] do
+      resources :ecf_participants, path: "participants/ecf", only: %i[index show] do
         concerns :participant_actions
       end
       resources :participants, only: %i[index], controller: "ecf_participants"
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
       resources :participant_declarations, only: %i[create index show], path: "participant-declarations" do
         member { put :void }
       end
-      resources :npq_participants, only: %i[index], path: "participants/npq" do
+      resources :npq_participants, only: %i[index show], path: "participants/npq" do
         concerns :participant_actions
       end
       resources :npq_enrolments, only: %i[index], path: "npq-enrolments"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
 
       resources :npq_funding, only: [:show], path: "npq-funding", param: :trn
 
-      resources :ecf_participants, path: "participants/ecf", only: %i[index] do
+      resources :ecf_participants, path: "participants/ecf", only: %i[index show] do
         concerns :participant_actions
       end
       resources :participants, only: %i[index], controller: "ecf_participants"

--- a/spec/docs/v1/npq_participants_spec.rb
+++ b/spec/docs/v1/npq_participants_spec.rb
@@ -55,6 +55,38 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
     end
   end
 
+  path "/api/v1/participants/npq/{id}" do
+    get "Get a single NPQ participant" do
+      operationId :npq_participant
+      tags "NPQ participants"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The ID of the NPQ participant."
+
+      response "200", "A single NPQ participant" do
+        let(:id) { npq_application.participant_identity.external_identifier }
+
+        schema({ "$ref": "#/components/schemas/NPQParticipantResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+
   it_behaves_like "JSON Participant Change schedule documentation",
                   "/api/v1/participants/npq/{id}/change-schedule",
                   "#/components/schemas/NPQParticipantChangeScheduleRequest",

--- a/spec/docs/v1/participants_ecf_spec.rb
+++ b/spec/docs/v1/participants_ecf_spec.rb
@@ -91,6 +91,38 @@ describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
     end
   end
 
+  path "/api/v1/participants/ecf/{id}" do
+    get "Get a single ECF participant" do
+      operationId :ecf_participant
+      tags "ECF participants"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The ID of the ECF participant."
+
+      response "200", "A single ECF participant" do
+        let(:id) { mentor_profile.user.id }
+
+        schema({ "$ref": "#/components/schemas/ECFParticipantResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { mentor_profile.user.id }
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+
   it_behaves_like "JSON Participant Deferral documentation",
                   "/api/v1/participants/ecf/{id}/defer",
                   "#/components/schemas/ECFParticipantDeferRequest",

--- a/spec/docs/v2/npq_participants_spec.rb
+++ b/spec/docs/v2/npq_participants_spec.rb
@@ -55,6 +55,38 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
     end
   end
 
+  path "/api/v2/participants/npq/{id}" do
+    get "Get a single NPQ participant" do
+      operationId :npq_participant
+      tags "NPQ participants"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The ID of the NPQ participant."
+
+      response "200", "A single NPQ participant" do
+        let(:id) { npq_application.participant_identity.external_identifier }
+
+        schema({ "$ref": "#/components/schemas/NPQParticipantResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+
   it_behaves_like "JSON Participant Change schedule documentation",
                   "/api/v2/participants/npq/{id}/change-schedule",
                   "#/components/schemas/NPQParticipantChangeScheduleRequest",

--- a/spec/docs/v2/participants_ecf_spec.rb
+++ b/spec/docs/v2/participants_ecf_spec.rb
@@ -91,6 +91,38 @@ describe "API", type: :request, swagger_doc: "v2/api_spec.json" do
     end
   end
 
+  path "/api/v2/participants/ecf/{id}" do
+    get "Get a single ECF participant" do
+      operationId :ecf_participant
+      tags "ECF participants"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The ID of the ECF participant."
+
+      response "200", "A single ECF participant" do
+        let(:id) { mentor_profile.user.id }
+
+        schema({ "$ref": "#/components/schemas/ECFParticipantResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { mentor_profile.user.id }
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+
   it_behaves_like "JSON Participant Deferral documentation",
                   "/api/v2/participants/ecf/{id}/defer",
                   "#/components/schemas/ECFParticipantDeferRequest",

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/participant-declarations/{id}
         /api/v1/participant-declarations/{id}/void
         /api/v1/participants/ecf
+        /api/v1/participants/ecf/{id}
         /api/v1/participants/ecf.csv
         /api/v1/participants/ecf/{id}/defer
         /api/v1/participants/ecf/{id}/withdraw

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/npq-applications/{id}/accept
         /api/v1/npq-applications/{id}/reject
         /api/v1/participants/npq
+        /api/v1/participants/npq/{id}
         /api/v1/participants/npq/{id}/defer
         /api/v1/participants/npq/{id}/withdraw
         /api/v1/participants/npq/{id}/resume

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -407,6 +407,63 @@ RSpec.describe "Participants API", type: :request do
     end
   end
 
+  describe "GET /api/v2/participants/ecf/:id", :with_default_schedules, travel_to: Time.zone.local(2022, 7, 22, 11, 30, 0) do
+    let(:parsed_response) { JSON.parse(response.body) }
+
+    before do
+      default_headers[:Authorization] = bearer_token
+      get "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}"
+    end
+
+    context "when authorized" do
+      let(:expected_response) do
+        {
+          "data" => {
+            "id" => early_career_teacher_profile.participant_identity.external_identifier,
+            "type" => "participant",
+            "attributes" => {
+              "email" => (early_career_teacher_profile.induction_records[0].preferred_identity&.email || early_career_teacher_profile.user.email),
+              "full_name" => early_career_teacher_profile.user.full_name,
+              "mentor_id" => early_career_teacher_profile.mentor_profile&.participant_identity&.external_identifier,
+              "school_urn" => early_career_teacher_profile.induction_records[0].school_cohort.school.urn,
+              "participant_type" => early_career_teacher_profile.participant_type.to_s,
+              "cohort" => early_career_teacher_profile&.cohort&.start_year&.to_s,
+              "status" => early_career_teacher_profile.induction_records[0].induction_status,
+              "teacher_reference_number" => early_career_teacher_profile.teacher_profile.trn,
+              "teacher_reference_number_validated" => false,
+              "eligible_for_funding" => nil,
+              "pupil_premium_uplift" => early_career_teacher_profile.pupil_premium_uplift,
+              "sparsity_uplift" => early_career_teacher_profile.sparsity_uplift,
+              "training_status" => early_career_teacher_profile.training_status,
+              "schedule_identifier" => early_career_teacher_profile.induction_records[0].schedule&.schedule_identifier,
+              "updated_at" => Time.zone.local(2022, 7, 22, 11, 30, 0).rfc3339,
+            },
+          },
+        }
+      end
+
+      it "returns correct jsonapi content type header" do
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns 200" do
+        expect(response.status).to eq 200
+      end
+
+      it "returns correct data" do
+        expect(parsed_response).to eq(expected_response)
+      end
+    end
+
+    context "when unauthorized" do
+      let(:token) { "wrong_token" }
+
+      it "returns 401 for invalid bearer token" do
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
   describe "PUT /api/v2/participants/ecf/USER_ID/defer" do
     let(:parsed_response) { JSON.parse(response.body) }
     let(:url) { "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}/defer" }

--- a/spec/requests/api/v2/npq_participants_spec.rb
+++ b/spec/requests/api/v2/npq_participants_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "NPQ Participants API", type: :request do
   let(:bearer_token) { "Bearer #{token}" }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
+  let(:parsed_response) { JSON.parse(response.body) }
 
   before { default_headers[:Authorization] = bearer_token }
 
@@ -20,8 +21,7 @@ RSpec.describe "NPQ Participants API", type: :request do
       let(:npq_course)      { npq_application.npq_course }
 
       describe "JSON Index API" do
-        let(:parsed_response) { JSON.parse(response.body) }
-        let(:npq_course)      { npq_applications.sample.npq_course }
+        let(:npq_course) { npq_applications.sample.npq_course }
 
         it "returns correct jsonapi content type header" do
           get "/api/v2/participants/npq"
@@ -176,6 +176,65 @@ RSpec.describe "NPQ Participants API", type: :request do
         default_headers[:Authorization] = bearer_token
         get "/api/v2/participants/npq"
         expect(response.status).to eq 403
+      end
+    end
+  end
+
+  describe "GET /api/v2/participants/npq/:id", :with_default_schedules do
+    let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
+    let(:npq_participant) { npq_application.profile }
+
+    before do
+      default_headers[:Authorization] = bearer_token
+      get "/api/v2/participants/npq/#{npq_participant.user_id}"
+    end
+
+    context "when authorized" do
+      let(:expected_response) do
+        {
+          "data" => {
+            "id" => npq_participant.user_id,
+            "type" => "npq-participant",
+            "attributes" => {
+              "full_name" => npq_participant.user.full_name,
+              "email" => npq_participant.user.email,
+              "teacher_reference_number" => npq_participant.teacher_profile&.trn,
+              "npq_enrolments" => [
+                {
+                  "course_identifier" => npq_participant.npq_course.identifier,
+                  "schedule_identifier" => npq_participant.schedule.schedule_identifier,
+                  "cohort" => npq_participant.schedule.cohort.start_year.to_s,
+                  "npq_application_id" => npq_participant.npq_application.id,
+                  "eligible_for_funding" => npq_participant.npq_application.eligible_for_funding,
+                  "training_status" => npq_participant.training_status,
+                  "school_urn" => npq_participant.school_urn,
+                  "targeted_delivery_funding_eligibility" => npq_participant.npq_application.targeted_delivery_funding_eligibility,
+                },
+              ],
+              "updated_at" => npq_participant.updated_at.rfc3339,
+            },
+          },
+        }
+      end
+
+      it "returns correct jsonapi content type header" do
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns 200" do
+        expect(response.status).to eq 200
+      end
+
+      it "returns correct data" do
+        expect(parsed_response).to eq(expected_response)
+      end
+    end
+
+    context "when unauthorized" do
+      let(:token) { "wrong_token" }
+
+      it "returns 401 for invalid bearer token" do
+        expect(response.status).to eq 401
       end
     end
   end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -996,6 +996,56 @@
         }
       }
     },
+    "/api/v1/participants/ecf/{id}": {
+      "get": {
+        "summary": "Get a single ECF participant",
+        "operationId": "ecf_participant",
+        "tags": [
+          "ECF participants"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the ECF participant.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single ECF participant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participants/ecf/{id}/defer": {
       "put": {
         "summary": "Notify that an ECF participant is taking a break from their course",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -354,6 +354,56 @@
         }
       }
     },
+    "/api/v1/participants/npq/{id}": {
+      "get": {
+        "summary": "Get a single NPQ participant",
+        "operationId": "npq_participant",
+        "tags": [
+          "NPQ participants"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the NPQ participant.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single NPQ participant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQParticipantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participants/npq/{id}/change-schedule": {
       "put": {
         "summary": "Notify that an NPQ participant is changing training schedule",

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -356,6 +356,56 @@
         }
       }
     },
+    "/api/v2/participants/npq/{id}": {
+      "get": {
+        "summary": "Get a single NPQ participant",
+        "operationId": "npq_participant",
+        "tags": [
+          "NPQ participants"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the NPQ participant.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single NPQ participant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQParticipantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/participants/npq/{id}/change-schedule": {
       "put": {
         "summary": "Notify that an NPQ participant is changing training schedule",
@@ -931,6 +981,56 @@
               "text/csv": {
                 "schema": {
                   "$ref": "#/components/schemas/MultipleECFParticipantsCsvResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/participants/ecf/{id}": {
+      "get": {
+        "summary": "Get a single ECF participant",
+        "operationId": "ecf_participant",
+        "tags": [
+          "ECF participants"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the ECF participant.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single ECF participant",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ECFParticipantResponse"
                 }
               }
             }


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1443](https://dfedigital.atlassian.net/browse/CPDLP-1443)
We want to enable providers to retrieve single participant records via the API, by using the participant's id.

### Changes proposed in this pull request

- Updated the pre-commit git hook to stop falsely reporting AWS keys in the swagger `components/schemas`
- Add API endpoints to retrieve single ECF and NPQ participants
  - GET /api/v1/participants/ecf/:id
  - GET /api/v1/participants/npq/:id 
- Update the swagger V1 API spec

### Guidance to review
1. Retrieve a single ECF participant via the API
2. Retrieve a single NPQ participant via the API
3. Check the changes are reflected in the swagger docs

You can use the index endpoints to retrieve all the ECF/NPQ participants, pick a participant id from the list and then try the new api endpoints to retrieve the participant. Confirm the participant data structure and the values are matching.
