### PR TITLE
Correcting typo - progamme

### DIFF
--- a/app/views/schools/transferring_participants/cannot_add.html.erb
+++ b/app/views/schools/transferring_participants/cannot_add.html.erb
@@ -12,7 +12,7 @@
         <p class="govuk-body">This could be because:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>the information does not match their Teaching Regulation Agency record</li>
-            <li>they’re not registered on an ECF-based training progamme yet</li>
+            <li>they’re not registered on an ECF-based training programme yet</li>
         </ul>
 
 


### PR DESCRIPTION
### Context

Noticed typo "progamme" in live content. Changed to "programme". 

### Changes proposed in this pull request

### Guidance to review

