### PR TITLE
[CPDLP-1489] allow DfE user to change training status

### DIFF
--- a/app/controllers/finance/change_training_statuses_controller.rb
+++ b/app/controllers/finance/change_training_statuses_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Finance
+  class ChangeTrainingStatusesController < BaseController
+    before_action :set_participant_profile
+
+    def new
+      @change_training_status_form = Finance::ChangeTrainingStatusForm.new(
+        participant_profile: @participant_profile,
+      )
+    end
+
+    def create
+      @change_training_status_form = Finance::ChangeTrainingStatusForm.new(change_training_status_form_params)
+      @change_training_status_form.participant_profile = @participant_profile
+
+      if @change_training_status_form.save
+        set_success_message(heading: "Training status updated successfully.")
+        redirect_to finance_participant_path(@change_training_status_form.participant_profile.user)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def set_participant_profile
+      @participant_profile = ParticipantProfile.find(params[:participant_profile_id])
+    end
+
+    def change_training_status_form_params
+      return {} unless params.key?(:finance_change_training_status_form)
+
+      params.require(:finance_change_training_status_form).permit(
+        :training_status,
+        :reason,
+      )
+    end
+  end
+end

--- a/app/forms/finance/change_training_status_form.rb
+++ b/app/forms/finance/change_training_status_form.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Finance
+  class ChangeTrainingStatusForm
+    include ActiveModel::Model
+
+    TRAINING_STATUS_OPTIONS = ParticipantProfile.defined_enums["training_status"].freeze
+
+    attr_accessor :participant_profile, :training_status, :reason
+
+    validates :training_status, presence: true, inclusion: TRAINING_STATUS_OPTIONS.keys
+    validates :reason, inclusion: { in: :valid_training_status_reasons }, if: :reason_required?
+
+    delegate :ecf?, :npq?,
+             to: :participant_profile
+
+    def training_status_options
+      opts = TRAINING_STATUS_OPTIONS.dup
+      opts.delete(participant_profile.training_status)
+      opts
+    end
+
+    def reason_required?
+      training_status.present? && training_status != "active"
+    end
+
+    def reason_options
+      opts =
+        if ecf?
+          {
+            "active" => [],
+            "deferred" => Participants::Defer::ECF.reasons,
+            "withdrawn" => Participants::Withdraw::ECF.reasons,
+          }
+        elsif npq?
+          {
+            "active" => [],
+            "deferred" => Participants::Defer::NPQ.reasons,
+            "withdrawn" => Participants::Withdraw::NPQ.reasons,
+          }
+        end
+
+      opts.delete(participant_profile.training_status)
+      opts
+    end
+
+    def valid_training_status_reasons
+      reason_options[training_status]
+    end
+
+    def participant_class_name
+      case participant_profile.participant_type
+      when :npq
+        "NPQ"
+      when :ect
+        "EarlyCareerTeacher"
+      when :mentor
+        "Mentor"
+      else
+        raise "Participant type not recognised"
+      end
+    end
+
+    def action_class_name
+      case training_status
+      when "active"
+        "Resume"
+      when "deferred"
+        "Defer"
+      when "withdrawn"
+        "Withdraw"
+      else
+        raise "Class name not recognised"
+      end
+    end
+
+    def cpd_lead_provider
+      @cpd_lead_provider ||=
+        if ecf?
+          participant_profile.school_cohort.school.active_partnerships[0].lead_provider.cpd_lead_provider
+        elsif npq?
+          participant_profile.npq_application.npq_lead_provider.cpd_lead_provider
+        end
+    end
+
+    def course_identifier
+      @course_identifier ||=
+        case participant_profile.participant_type
+        when :mentor
+          "ecf-mentor"
+        when :ect
+          "ecf-induction"
+        when :npq
+          participant_profile.npq_application.npq_course.identifier
+        end
+    end
+
+    def save
+      return false unless valid?
+
+      # Nothing to change if training_status is same
+      return true if training_status == participant_profile.training_status
+
+      klass = "Participants::#{action_class_name}::#{participant_class_name}".constantize
+      klass.call(
+        params: {
+          cpd_lead_provider:,
+          course_identifier:,
+          participant_id: participant_profile.participant_identity.external_identifier,
+          reason:,
+          force_training_status_change: true,
+        },
+      )
+
+      true
+    end
+  end
+end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -28,7 +28,9 @@ class InductionRecord < ApplicationRecord
 
   validates :start_date, presence: true
 
-  validate :cannot_resume_from_withdrawn
+  attr_accessor :force_training_status_change
+
+  validate :cannot_resume_from_withdrawn, unless: :force_training_status_change
 
   enum induction_status: {
     active: "active",

--- a/app/services/participants/base.rb
+++ b/app/services/participants/base.rb
@@ -8,6 +8,7 @@ module Participants
     include ProfileAttributes
     include AbstractInterface
     implement_class_method :valid_courses
+    attr_accessor :force_training_status_change
 
     class << self
       def call(params:)
@@ -32,6 +33,7 @@ module Participants
       self.participant_id = params[:participant_id]
       self.course_identifier = params[:course_identifier]
       self.cpd_lead_provider = params[:cpd_lead_provider]
+      self.force_training_status_change = params[:force_training_status_change]
     end
 
     def validate_provider!

--- a/app/services/participants/defer/validate_and_change_state.rb
+++ b/app/services/participants/defer/validate_and_change_state.rb
@@ -10,7 +10,7 @@ module Participants
         attr_accessor :reason
 
         validates :reason, inclusion: { in: reasons }
-        validate :not_already_withdrawn
+        validate :not_already_withdrawn, unless: :force_training_status_change
         validate :not_already_deferred
       end
 
@@ -19,7 +19,7 @@ module Participants
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:deferred], cpd_lead_provider:, reason:)
           user_profile.training_status_deferred!
 
-          relevant_induction_record.update!(training_status: "deferred") if relevant_induction_record
+          relevant_induction_record.update!(training_status: "deferred", force_training_status_change:) if relevant_induction_record
         end
 
         user_profile

--- a/app/services/participants/profile_attributes.rb
+++ b/app/services/participants/profile_attributes.rb
@@ -7,6 +7,7 @@ module Participants
 
     included do
       attr_accessor :course_identifier, :participant_id, :cpd_lead_provider
+      attr_accessor :force_training_status_change
 
       validates :course_identifier, presence: { message: I18n.t(:missing_course_identifier) }
       validates :participant_id, presence: { message: I18n.t(:missing_participant_id) }

--- a/app/services/participants/resume/validate_and_change_state.rb
+++ b/app/services/participants/resume/validate_and_change_state.rb
@@ -8,14 +8,14 @@ module Participants
 
       included do
         validate :not_already_active
-        validate :not_already_withdrawn
+        validate :not_already_withdrawn, unless: :force_training_status_change
       end
 
       def perform_action!
         ActiveRecord::Base.transaction do
           ParticipantProfileState.create!(participant_profile: user_profile, state: ParticipantProfileState.states[:active], cpd_lead_provider:)
           user_profile.training_status_active!
-          relevant_induction_record.update!(training_status: "active") if relevant_induction_record
+          relevant_induction_record.update!(training_status: "active", force_training_status_change:) if relevant_induction_record
         end
 
         user_profile

--- a/app/services/participants/withdraw/validate_and_change_state.rb
+++ b/app/services/participants/withdraw/validate_and_change_state.rb
@@ -21,7 +21,7 @@ module Participants
                                           reason:)
 
           user_profile.training_status_withdrawn!
-          relevant_induction_record.update!(training_status: "withdrawn") if relevant_induction_record
+          relevant_induction_record.update!(training_status: "withdrawn", force_training_status_change:) if relevant_induction_record
         end
 
         unless user_profile.npq?

--- a/app/views/finance/change_training_statuses/new.html.erb
+++ b/app/views/finance/change_training_statuses/new.html.erb
@@ -1,0 +1,42 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_participant_path(@participant_profile.user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change training status</h1>
+
+    <div class="govuk-inset-text">
+      <p>
+        <strong>User ID / Participant ID</strong>
+        <br/>
+        <%= @participant_profile.user.id %>
+      </p>
+      <p>
+        <strong>Training status</strong>
+        <br/>
+        <%= @participant_profile.training_status %>
+      </p>
+    </div>
+
+    <%= form_for @change_training_status_form, url: finance_participant_profile_change_training_status_path(@participant_profile) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :training_status, legend: { text: "Choose a different training status", tag: 'h1', size: 'm' } do %>
+        <% @change_training_status_form.training_status_options.each do |val, text| %>
+          <%= f.govuk_radio_button :training_status, val, label: { text: text } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_select(:reason, label: { text: "Reason for change", tag: 'h1', size: 'm' }, hint: { text: "Required for deferred or withdrawn" }, options: { include_blank: true }) do %>
+        <% @change_training_status_form.reason_options.each do |group, items| %>
+          <optgroup label="<%= group %>">
+            <% items.each do |item| %>
+              <option value="<%= item %>" data-tags="<%= item %>" <%= "selected" if item == @change_training_status_form.reason %>><%= item %></option>
+            <% end %>
+          </optgroup>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -2,56 +2,71 @@
   <% summary_list.row do |row| %>
     <% row.key { "User ID / Participant ID" } %>
     <% row.value { @user.id } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Profile ID" } %>
     <% row.value { pp.id } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Eligible for funding" } %>
     <% row.value { pp.fundable?.to_s.upcase } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Lead provider" } %>
     <% row.value { pp&.school_cohort&.school&.active_partnerships[0]&.lead_provider&.name } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "School URN" } %>
     <% row.value { pp&.school_cohort&.school&.urn } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Status" } %>
     <% row.value { pp.status } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Training status" } %>
     <% row.value { pp.training_status } %>
+    <% row.action(
+      text: "Change",
+      visually_hidden_text: "training status",
+      href: new_finance_participant_profile_change_training_status_path(pp))
+    %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Schedule identifier" } %>
     <% row.value { pp.schedule&.schedule_identifier } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Schedule cohort" } %>
     <% row.value { pp.schedule&.cohort&.start_year&.to_s } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Created at" } %>
     <% row.value { pp.created_at.to_s(:govuk) } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Updated at" } %>
     <% row.value { pp.updated_at.to_s(:govuk) } %>
+    <% row.action(text: :none) %>
   <% end %>
 <% end %>
 

--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -2,61 +2,77 @@
   <% summary_list.row do |row| %>
     <% row.key { "User ID / Participant ID" } %>
     <% row.value { @user.id } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Profile ID" } %>
     <% row.value { pp.id } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Eligible for funding" } %>
     <% row.value { pp.fundable?.to_s.upcase } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "NPQ course" } %>
     <% row.value { pp.npq_course&.name } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Lead provider" } %>
     <% row.value { pp.npq_application&.npq_lead_provider&.name } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "School URN" } %>
     <% row.value { pp.npq_application&.school_urn } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Status" } %>
     <% row.value { pp.status } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Training status" } %>
     <% row.value { pp.training_status } %>
+    <% row.action(
+      text: "Change",
+      visually_hidden_text: "training status",
+      href: new_finance_participant_profile_change_training_status_path(pp))
+    %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Schedule identifier" } %>
     <% row.value { pp.schedule&.schedule_identifier } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Schedule cohort" } %>
     <% row.value { pp.schedule&.cohort&.start_year&.to_s } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Created at" } %>
     <% row.value { pp.created_at.to_s(:govuk) } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Updated at" } %>
     <% row.value { pp.updated_at.to_s(:govuk) } %>
+    <% row.action(text: :none) %>
   <% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,6 +293,13 @@ en:
               blank: "Choose an appropriate body type"
             appropriate_body:
               blank: "Choose an appropriate body"
+        finance/change_training_status_form:
+          attributes:
+            training_status:
+              blank: Choose training status
+              inclusion: Choose a valid training status
+            reason:
+              inclusion: Choose a valid reason for training status
 
   page_titles:
     lead_providers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -332,6 +332,9 @@ Rails.application.routes.draw do
     resource :landing_page, only: :show, path: "manage-cpd-contracts", controller: "landing_page"
 
     resources :participants, only: %i[index show]
+    resources :participant_profiles, only: [] do
+      resource :change_training_status, only: %i[new create]
+    end
 
     namespace :banding_tracker, path: "banding-tracker" do
       resources :providers, only: %i[show]

--- a/spec/features/finance/change_training_status_spec.rb
+++ b/spec/features/finance/change_training_status_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Finance users participant change training status", type: :feature do
+  before do
+    given_i_am_logged_in_as_a_finance_user
+    when_i_visit_the_finance_participant_drilldown_page
+    then_i_see("Participant")
+  end
+
+  describe "NPQ" do
+    let!(:participant_profile) { create(:npq_participant_profile, training_status: "active") }
+    let!(:user) { participant_profile.user }
+    let!(:participant_declaration) { create(:npq_participant_declaration, participant_profile:, user:) }
+
+    scenario "Change training status to deferred" do
+      then_table_value_is(label: "Training status", value: "active")
+      and_i_click_on("Change training status")
+      then_i_see("Change training status")
+      and_i_see("Choose a different training status")
+      when_i_choose("deferred")
+      and_i_select("bereavement", "finance-change-training-status-form-reason-field")
+      and_i_click_on("Continue")
+      then_i_see("Training status updated successfully")
+      then_table_value_is(label: "Training status", value: "deferred")
+    end
+  end
+
+  describe "ECF" do
+    let(:school_cohort) { participant_profile.school_cohort }
+    let!(:partnership) do
+      create(
+        :partnership,
+        school: school_cohort.school,
+        cohort: school_cohort.cohort,
+        challenged_at: nil,
+        challenge_reason: nil,
+        pending: false,
+      )
+    end
+    let(:induction_programme) { create(:induction_programme, partnership:, school_cohort:) }
+    let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
+
+    describe "EarlyCareerTeacher" do
+      let!(:participant_profile) { create(:ect_participant_profile, training_status: "active") }
+      let!(:user) { participant_profile.user }
+      let!(:participant_declaration) { create(:ect_participant_declaration, participant_profile:, user:) }
+
+      scenario "Change training status to deferred" do
+        then_table_value_is(label: "Training status", value: "active")
+        and_i_click_on("Change training status")
+        then_i_see("Change training status")
+        and_i_see("Choose a different training status")
+        when_i_choose("deferred")
+        and_i_select("bereavement", "finance-change-training-status-form-reason-field")
+        and_i_click_on("Continue")
+        then_i_see("Training status updated successfully")
+        then_table_value_is(label: "Training status", value: "deferred")
+      end
+    end
+
+    describe "Mentor" do
+      let!(:participant_profile) { create(:mentor_participant_profile, training_status: "active") }
+      let!(:user) { participant_profile.user }
+      let!(:participant_declaration) { create(:mentor_participant_declaration, participant_profile:, user:) }
+
+      scenario "Change training status to deferred" do
+        then_table_value_is(label: "Training status", value: "active")
+        and_i_click_on("Change training status")
+        then_i_see("Change training status")
+        and_i_see("Choose a different training status")
+        when_i_choose("deferred")
+        and_i_select("bereavement", "finance-change-training-status-form-reason-field")
+        and_i_click_on("Continue")
+        then_i_see("Training status updated successfully")
+        then_table_value_is(label: "Training status", value: "deferred")
+      end
+    end
+  end
+
+  def when_i_visit_the_finance_participant_drilldown_page
+    visit("/finance/participants/#{user.id}")
+  end
+
+  def and_i_click_on(string)
+    page.click_on(string)
+  end
+
+  def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def and_i_see(string)
+    then_i_see(string)
+  end
+
+  def when_i_fill_in(selector, with:)
+    page.fill_in selector, with:
+  end
+
+  def when_i_choose(text)
+    page.choose text
+  end
+
+  def and_i_select(option, dropdown)
+    page.select option, from: dropdown
+  end
+
+  def then_table_value_is(label:, value:)
+    table_values =
+      page.all("dl.govuk-summary-list .govuk-summary-list__row").each_with_object({}) do |row, sum|
+        key = row.find(".govuk-summary-list__key").text.to_s.strip
+        val = row.find(".govuk-summary-list__value").text.to_s.strip
+        if key.present?
+          sum[key] = val
+        end
+      end
+    expect(table_values[label]).to eql(value)
+  end
+
+  def and_an_ect_user_with_profile_and_declarations
+    ect_user
+    ect_profile
+    ect_declaration
+  end
+end

--- a/spec/forms/finance/change_training_status_form_spec.rb
+++ b/spec/forms/finance/change_training_status_form_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ChangeTrainingStatusForm, type: :model do
+  subject(:form) { described_class.new(params) }
+
+  describe "NPQ" do
+    let(:participant_profile) { create(:npq_participant_profile, training_status: "active") }
+    let(:params) { { participant_profile:, training_status: "deferred", reason: "bereavement" } }
+
+    it { is_expected.to validate_presence_of(:training_status) }
+    it { is_expected.to validate_inclusion_of(:reason).in_array(Participants::Defer::NPQ.reasons) }
+
+    describe ".participant_class_name" do
+      it "returns participant correct class name" do
+        expect(form.participant_class_name).to eql("NPQ")
+      end
+    end
+
+    describe ".action_class_name" do
+      it "returns correct action name" do
+        expect(form.action_class_name).to eql("Defer")
+      end
+    end
+
+    describe ".save" do
+      context "valid params" do
+        it "should change training status" do
+          expect(form.save).to be true
+          expect(participant_profile.reload.training_status).to eql("deferred")
+        end
+      end
+
+      context "invalid params" do
+        let(:params) { { participant_profile:, training_status: nil, reason: nil } }
+
+        it "should not change training status" do
+          expect(form.save).to be false
+          expect(participant_profile.reload.training_status).to eql("active")
+        end
+      end
+    end
+  end
+
+  describe "ECF" do
+    let(:school_cohort) { participant_profile.school_cohort }
+    let!(:partnership) do
+      create(
+        :partnership,
+        school: school_cohort.school,
+        cohort: school_cohort.cohort,
+        challenged_at: nil,
+        challenge_reason: nil,
+        pending: false,
+      )
+    end
+    let(:induction_programme) { create(:induction_programme, partnership:, school_cohort:) }
+    let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
+    let(:params) { { participant_profile:, training_status: "deferred", reason: "bereavement" } }
+
+    describe "EarlyCareerTeacher" do
+      let!(:participant_declaration) { create(:ect_participant_declaration, participant_profile:, user: participant_profile.user) }
+      let(:participant_profile) { create(:ect_participant_profile, training_status: "active") }
+
+      it { is_expected.to validate_presence_of(:training_status) }
+      it { is_expected.to validate_inclusion_of(:reason).in_array(Participants::Defer::ECF.reasons) }
+
+      describe ".participant_class_name" do
+        it "returns participant correct class name" do
+          expect(form.participant_class_name).to eql("EarlyCareerTeacher")
+        end
+      end
+
+      describe ".action_class_name" do
+        it "returns correct action name" do
+          expect(form.action_class_name).to eql("Defer")
+        end
+      end
+
+      describe ".save" do
+        context "valid params" do
+          it "should change training status" do
+            expect(form.save).to be true
+            expect(participant_profile.reload.training_status).to eql("deferred")
+          end
+        end
+
+        context "invalid params" do
+          let(:params) { { participant_profile:, training_status: nil, reason: nil } }
+
+          it "should not change training status" do
+            expect(form.save).to be false
+            expect(participant_profile.reload.training_status).to eql("active")
+          end
+        end
+      end
+    end
+
+    describe "Mentor" do
+      let!(:participant_declaration) { create(:mentor_participant_declaration, participant_profile:, user: participant_profile.user) }
+      let(:participant_profile) { create(:mentor_participant_profile, training_status: "active") }
+
+      it { is_expected.to validate_presence_of(:training_status) }
+      it { is_expected.to validate_inclusion_of(:reason).in_array(Participants::Defer::ECF.reasons) }
+
+      describe ".participant_class_name" do
+        it "returns participant correct class name" do
+          expect(form.participant_class_name).to eql("Mentor")
+        end
+      end
+
+      describe ".action_class_name" do
+        it "returns correct action name" do
+          expect(form.action_class_name).to eql("Defer")
+        end
+      end
+
+      describe ".save" do
+        context "valid params" do
+          it "should change training status" do
+            expect(form.save).to be true
+            expect(participant_profile.reload.training_status).to eql("deferred")
+          end
+        end
+
+        context "invalid params" do
+          let(:params) { { participant_profile:, training_status: nil, reason: nil } }
+
+          it "should not change training status" do
+            expect(form.save).to be false
+            expect(participant_profile.reload.training_status).to eql("active")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: 
- https://dfedigital.atlassian.net/browse/CPDLP-1489
- https://dfedigital.atlassian.net/browse/CPDLP-1490
- https://dfedigital.atlassian.net/browse/CPDLP-1522

### Changes proposed in this pull request

* Added new form to allow changing of `training_status`
* Updated validation to allow admin user to change status

### Guidance to review

* Login as finance role
* Go to finance drill down page
* Click change on participant profile
* https://ecf-review-pr-2362.london.cloudapps.digital/finance/participants/9956f5f2-030c-4bdf-90be-784621dfc49e
* https://ecf-review-pr-2362.london.cloudapps.digital/finance/participants/3ee6c188-9586-44f6-a271-4933295fec05