### PR TITLE
[CPDLP-1552] Show the correct participant role in the delivery partners check data service

### DIFF
--- a/app/components/delivery_partners/participants/table_row.html.erb
+++ b/app/components/delivery_partners/participants/table_row.html.erb
@@ -9,7 +9,7 @@
     <%= teacher_profile.trn %>
   </td>
   <td class="govuk-table__cell">
-    <%= user_description %>
+    <%= role %>
   </td>
   <td class="govuk-table__cell">
     <%= lead_provider_name %>

--- a/app/components/delivery_partners/participants/table_row.rb
+++ b/app/components/delivery_partners/participants/table_row.rb
@@ -8,9 +8,10 @@ module DeliveryPartners
       delegate :user,
                :teacher_profile,
                :cohort,
+               :role,
                to: :participant_profile
 
-      delegate :full_name, :user_description,
+      delegate :full_name,
                to: :user
 
       delegate :training_status,

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -110,6 +110,10 @@ class ParticipantProfile < ApplicationRecord
   def policy_class
     ParticipantProfilePolicy
   end
+
+  def role
+    raise "Not implemented"
+  end
 end
 
 require "participant_profile/npq"

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -79,15 +79,6 @@ class ParticipantProfile < ApplicationRecord
         .first
     end
 
-    def role
-      case participant_type
-      when :ect
-        "Early career teacher"
-      when :mentor
-        "Mentor"
-      end
-    end
-
   private
 
     def update_analytics

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -79,6 +79,15 @@ class ParticipantProfile < ApplicationRecord
         .first
     end
 
+    def role
+      case participant_type
+      when :ect
+        "Early career teacher"
+      when :mentor
+        "Mentor"
+      end
+    end
+
   private
 
     def update_analytics

--- a/app/models/participant_profile/ect.rb
+++ b/app/models/participant_profile/ect.rb
@@ -12,5 +12,9 @@ class ParticipantProfile < ApplicationRecord
     def participant_type
       :ect
     end
+
+    def role
+      "Early career teacher"
+    end
   end
 end

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -20,5 +20,9 @@ class ParticipantProfile < ApplicationRecord
     def participant_type
       :mentor
     end
+
+    def role
+      "Mentor"
+    end
   end
 end

--- a/app/serializers/delivery_partners/participants_serializer.rb
+++ b/app/serializers/delivery_partners/participants_serializer.rb
@@ -43,9 +43,7 @@ module DeliveryPartners
       participant_profile.teacher_profile.trn
     end
 
-    attribute :role do |participant_profile|
-      participant_profile.user.user_description
-    end
+    attribute :role, &:role
 
     attribute :lead_provider do |participant_profile, params|
       induction_record(participant_profile, params[:delivery_partner])&.induction_programme&.partnership&.lead_provider&.name

--- a/spec/components/delivery_partners/participants/table_row_spec.rb
+++ b/spec/components/delivery_partners/participants/table_row_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe DeliveryPartners::Participants::TableRow, type: :view_component d
   context "mentor with multiple profiles" do
     let(:school_cohort) { create(:school_cohort) }
 
+    before do
+      participant_profile.reload
+    end
+
     context "when the primary profile is eligible" do
       let(:participant_profile) { create(:mentor_participant_profile, :primary_profile, school_cohort:) }
       let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :eligible, participant_profile:) }
-
-      before do
-        participant_profile.reload
-      end
 
       it { is_expected.to have_text("Training or eligible for training") }
     end
@@ -63,11 +63,14 @@ RSpec.describe DeliveryPartners::Participants::TableRow, type: :view_component d
       let(:participant_profile) { create(:mentor_participant_profile, :secondary_profile, school_cohort:) }
       let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :ineligible, participant_profile:) }
 
-      before do
-        participant_profile.reload
-      end
-
       it { is_expected.to have_text("Training or eligible for training") }
+    end
+
+    context "when participant is Mentor and Induction Tutor" do
+      let(:participant_profile) { create(:mentor_participant_profile, school_cohort:) }
+      let(:induction_coordinator_profile) { create(:induction_coordinator_profile, user: participant_profile.user) }
+
+      it { is_expected.to have_text("Mentor") }
     end
   end
 

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -210,4 +210,22 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       end
     end
   end
+
+  describe "#role" do
+    context "when participant is Mentor" do
+      let(:profile) { create(:mentor_participant_profile) }
+
+      it "returns Mentor" do
+        expect(profile.role).to eq("Mentor")
+      end
+    end
+
+    context "when participant is ECT" do
+      let(:profile) { create(:ect_participant_profile) }
+
+      it "returns Early career teacher" do
+        expect(profile.role).to eq("Early career teacher")
+      end
+    end
+  end
 end

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -64,4 +64,10 @@ RSpec.describe ParticipantProfile, type: :model do
     it { is_expected.to belong_to(:school).optional }
     it { is_expected.to be_versioned }
   end
+
+  describe "#role" do
+    it "should fail with 'Not implemented'" do
+      expect { subject.role }.to raise_error("Not implemented")
+    end
+  end
 end

--- a/spec/serializers/delivery_partners/participants_serializer_spec.rb
+++ b/spec/serializers/delivery_partners/participants_serializer_spec.rb
@@ -36,7 +36,7 @@ module DeliveryPartners
           full_name: participant_profile.user.full_name,
           email_address: participant_profile.user.email,
           trn: participant_profile.teacher_profile.trn,
-          role: participant_profile.user.user_description,
+          role: participant_profile.role,
           lead_provider: lead_provider.name,
           school: school.name,
           school_unique_reference_number: school.urn,
@@ -44,6 +44,16 @@ module DeliveryPartners
           training_status: "withdrawn",
           status: "No longer being trained",
         )
+      end
+
+      context "when participant is Mentor and Induction Tutor" do
+        let(:participant_profile) { create(:mentor_participant_profile, school_cohort:) }
+
+        it "returns Mentor" do
+          create(:induction_coordinator_profile, user: participant_profile.user)
+
+          expect(subject.serializable_hash[:data][:attributes][:role]).to eq("Mentor")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1552](https://dfedigital.atlassian.net/browse/CPDLP-1552)

The check data service shows wrong participant roles in the UI and csv extract, when users are both Mentors and Induction Tutors.

### Changes proposed in this pull request

- I created the `role` method in the `ParticipantProfile::ECF` model to determine the participant's role based on their participant type
- Replaced the `User#user_description` method that shows the wrong role in both the UI and CSV serializer, with the `ParticipantProfile::ECF#role`

### Guidance to review
