### PR TITLE
Add has_paper_trail to ProviderRelationship

### DIFF
--- a/app/models/provider_relationship.rb
+++ b/app/models/provider_relationship.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ProviderRelationship < DiscardableRecord
+  has_paper_trail
+
   belongs_to :cohort
   belongs_to :lead_provider
   belongs_to :delivery_partner


### PR DESCRIPTION
### Context

Being able to see provider relationship events would be useful when diagnosing problems. Recently some have been unexpectedly changed and we've not been able to work out how/why.
