### PR TITLE
[Bug fix] Prevent duplicate start_dates in induction records

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -9,7 +9,7 @@ SecureHeaders::Configuration.default do |config|
   config.x_permitted_cross_domain_policies = "none"
   config.referrer_policy = %w[origin-when-cross-origin strict-origin-when-cross-origin]
 
-  google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
+  google_analytics = %w[*.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
 
   config.csp = SecureHeaders::OPT_OUT
 


### PR DESCRIPTION
### Context

The change process for an `InductionRecord` involves duplicating the existing record and applying the changes to the duplicate and updating the existing one with a `changing` status and an `end_date`.  When a record has a future `start_date` we need to preserve it and so this creates records with duplicate `start_date`s. This becomes an issue when trying to sort on `start_date` or when trying to traverse InductionRecords by start and end dates. As there is no real need to preserve the history of future events that haven't happened, we can prevent this and just update a future record instead of creating a new successor record.

### Changes proposed in this pull request

Update `Induction::ChangeInductionRecord` to handle future induction records.

### Guidance to review

