### PR TITLE
Better clawback service with logging of exceptions

### DIFF
--- a/app/services/importers/clawbacks.rb
+++ b/app/services/importers/clawbacks.rb
@@ -26,7 +26,12 @@ module Importers
         end
 
         service = Finance::ClawbackDeclaration.new(participant_declaration:)
-        service.call
+
+        begin
+          service.call
+        rescue StandardError => e
+          errors << "declaration #{row['declaration_id']} has the following errors: #{e}"
+        end
 
         if service.errors.any?
           errors << "declaration #{row['declaration_id']} has the following issues: #{service.errors.full_messages.join(', ')}"


### PR DESCRIPTION
### Context

- Ticket: n/a

### Changes proposed in this pull request

- This improves the class that processes clawbacks in csv format
- If there are any exceptions they are caught and logged and no longer exit the process part way thru

### Guidance to review

- none