### PR TITLE
[CPDLP-1550] Add missing NPQ related changes to API v2

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index create]
       resources :ecf_users, only: %i[index create], path: "ecf-users"
       resources :participant_validation, only: %i[create], path: "participant-validation"
-      resources :npq_applications, only: :index, path: "npq-applications" do
+      resources :npq_applications, only: %i[index show], path: "npq-applications" do
         member do
           post :accept
           post :reject

--- a/spec/docs/v2/npq_applications_spec.rb
+++ b/spec/docs/v2/npq_applications_spec.rb
@@ -90,6 +90,38 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
     end
   end
 
+  path "/api/v2/npq-applications/{id}" do
+    get "Get a single NPQ application" do
+      operationId :npq_application
+      tags "NPQ applications"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The ID of the NPQ application."
+
+      response "200", "A single NPQ application" do
+        let(:id) { npq_application.id }
+
+        schema({ "$ref": "#/components/schemas/NPQApplicationResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:id) { npq_application.id }
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+
   path "/api/v2/npq-applications/{id}/accept" do
     post "Accept an NPQ application" do
       operationId :npq_applications_accept

--- a/spec/docs/v2/npq_participants_spec.rb
+++ b/spec/docs/v2/npq_participants_spec.rb
@@ -7,7 +7,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:Authorization) { "Bearer #{token}" }
-  let!(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:) }
+  let!(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
 
   path "/api/v2/participants/npq" do
     get "Retrieve multiple NPQ participants" do

--- a/spec/requests/api/v1/npq_participants_spec.rb
+++ b/spec/requests/api/v1/npq_participants_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "NPQ Participants API", type: :request do
         expect(response.status).to eq 200
       end
 
-      it "returns correct data" do
+      it "returns correct data", travel_to: Time.zone.local(2022, 8, 4, 10, 0, 0) do
         expect(parsed_response).to eq(expected_response)
       end
     end

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -53,25 +53,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
           expect(parsed_response["data"][0]["id"]).to be_in(NPQApplication.pluck(:id))
 
           npq_application = NPQApplication.find(parsed_response["data"][0]["id"])
-          user = User.find(parsed_response["data"][0]["attributes"]["participant_id"])
-
-          expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
-          expect(parsed_response["data"][0]["attributes"]["email"]).to eql(user.email)
-          expect(parsed_response["data"][0]["attributes"]["email_validated"]).to eql(true)
-          expect(parsed_response["data"][0]["attributes"]["school_urn"]).to eql(npq_application.school_urn)
-          expect(parsed_response["data"][0]["attributes"]["school_ukprn"]).to eql(npq_application.school_ukprn)
-          expect(parsed_response["data"][0]["attributes"]["private_childcare_provider_urn"]).to eql(npq_application.private_childcare_provider_urn)
-          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number"]).to eql(npq_application.teacher_reference_number)
-          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number_validated"]).to eql(npq_application.teacher_reference_number_verified)
-          expect(parsed_response["data"][0]["attributes"]["eligible_for_funding"]).to eql(npq_application.eligible_for_funding)
-          expect(parsed_response["data"][0]["attributes"]["course_identifier"]).to eql(npq_application.npq_course.identifier)
-          expect(parsed_response["data"][0]["attributes"]["status"]).to eql("accepted")
-          expect(parsed_response["data"][0]["attributes"]["works_in_school"]).to eql(npq_application.works_in_school)
-          expect(parsed_response["data"][0]["attributes"]["employment_role"]).to eql(npq_application.employment_role)
-          expect(parsed_response["data"][0]["attributes"]["employer_name"]).to eql(npq_application.employer_name)
-          expect(parsed_response["data"][0]["attributes"]["private_childcare_provider_urn"]).to eql(npq_application.private_childcare_provider_urn)
-          expect(parsed_response["data"][0]["attributes"]["cohort"]).to eql(npq_application.cohort.start_year.to_s)
-          expect(parsed_response["data"][0]["attributes"]["targeted_delivery_funding_eligibility"]).to eql(npq_application.targeted_delivery_funding_eligibility)
+          expect(parsed_response["data"][0]).to eql single_json_v2_application(npq_application:)
         end
 
         it "can return paginated data" do
@@ -229,6 +211,39 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
     end
   end
 
+  describe "GET /api/v2/npq-applications/:id" do
+    let(:npq_application) { create(:npq_application, npq_lead_provider:) }
+
+    before do
+      default_headers[:Authorization] = bearer_token
+      get "/api/v2/npq-applications/#{npq_application.id}"
+    end
+
+    context "when authorized" do
+      let(:expected_response) { expected_single_json_v2_response(npq_application:) }
+
+      it "returns correct jsonapi content type header" do
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns 200" do
+        expect(response.status).to eq 200
+      end
+
+      it "returns correct data" do
+        expect(parsed_response).to eq(expected_response)
+      end
+    end
+
+    context "when unauthorized" do
+      let(:token) { "wrong_token" }
+
+      it "returns 401 for invalid bearer token" do
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
   describe "POST /api/v2/npq-applications/:id/reject" do
     let(:npq_profile) { create(:npq_application, npq_lead_provider:) }
 
@@ -329,4 +344,42 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
       end
     end
   end
+end
+
+def expected_single_json_v2_response(npq_application:)
+  {
+    "data" =>
+        single_json_v2_application(npq_application:),
+  }
+end
+
+def single_json_v2_application(npq_application:)
+  {
+    "id" => npq_application.id,
+    "type" => "npq_application",
+    "attributes" => {
+      "course_identifier" => npq_application.npq_course.identifier,
+      "email" => npq_application.user.email,
+      "email_validated" => true,
+      "employer_name" => npq_application.employer_name,
+      "employment_role" => npq_application.employment_role,
+      "full_name" => npq_application.user.full_name,
+      "funding_choice" => npq_application.funding_choice,
+      "headteacher_status" => npq_application.headteacher_status,
+      "ineligible_for_funding_reason" => npq_application.ineligible_for_funding_reason,
+      "participant_id" => npq_application.participant_identity.external_identifier,
+      "private_childcare_provider_urn" => npq_application.private_childcare_provider_urn,
+      "teacher_reference_number" => npq_application.teacher_reference_number,
+      "teacher_reference_number_validated" => npq_application.teacher_reference_number_verified,
+      "school_urn" => npq_application.school_urn,
+      "school_ukprn" => npq_application.school_ukprn,
+      "status" => npq_application.lead_provider_approval_status,
+      "works_in_school" => npq_application.works_in_school,
+      "created_at" => npq_application.created_at.rfc3339,
+      "updated_at" => npq_application.updated_at.rfc3339,
+      "cohort" => npq_application.cohort.start_year.to_s,
+      "eligible_for_funding" => npq_application.eligible_for_funding,
+      "targeted_delivery_funding_eligibility" => npq_application.targeted_delivery_funding_eligibility,
+    },
+  }
 end

--- a/spec/requests/api/v2/npq_participants_spec.rb
+++ b/spec/requests/api/v2/npq_participants_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe "NPQ Participants API", type: :request do
         expect(response.status).to eq 200
       end
 
-      it "returns correct data" do
+      it "returns correct data", travel_to: Time.zone.local(2022, 8, 4, 10, 0, 0) do
         expect(parsed_response).to eq(expected_response)
       end
     end

--- a/spec/requests/api/v2/npq_participants_spec.rb
+++ b/spec/requests/api/v2/npq_participants_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "NPQ Participants API", type: :request do
 
   describe "GET /api/v2/participants/npq", :with_default_schedules do
     let!(:npq_applications) do
-      create_list(:npq_application, 3, :accepted, npq_lead_provider:, school_urn: "123456")
+      create_list(:npq_application, 3, :accepted, :with_started_declaration, npq_lead_provider:, school_urn: "123456")
     end
 
     context "when authorized" do
@@ -105,25 +105,39 @@ RSpec.describe "NPQ Participants API", type: :request do
         end
       end
 
-      it_behaves_like "a participant withdraw action endpoint" do
+      describe "JSON Participant Withdrawal" do
         let(:course_identifier) { npq_course.identifier }
         let(:url) { "/api/v2/participants/npq/#{npq_application.user.id}/withdraw" }
         let(:params) do
-          { data: { attributes: { course_identifier: npq_course.identifier, reason: Participants::Withdraw::NPQ.reasons.sample } } }
+          { data: { attributes: { course_identifier:, reason: Participants::Withdraw::NPQ.reasons.sample } } }
         end
 
-        before do
-          participant_profile = npq_application.profile
-          user = npq_application.user
+        context "when there is a started declaration" do
+          it_behaves_like "a participant withdraw action endpoint" do
+            before do
+              participant_profile = npq_application.profile
+              user = npq_application.user
 
-          create(:npq_participant_declaration, participant_profile:, course_identifier:, user:)
+              create(:npq_participant_declaration, participant_profile:, course_identifier:, user:)
+            end
+
+            it "changes the training status of a participant to withdrawn" do
+              put url, params: params
+
+              expect(response).to be_successful
+              expect(npq_application.reload.profile.training_status).to eql("withdrawn")
+            end
+          end
         end
 
-        it "changes the training status of a participant to withdrawn" do
-          put url, params: params
+        context "when there are no started declarations" do
+          let(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:, school_urn: "123456") }
 
-          expect(response).to be_successful
-          expect(npq_application.reload.profile.training_status).to eql("withdrawn")
+          it "returns an error message" do
+            put url, params: params
+
+            expect(response.status).to eq(422)
+          end
         end
       end
 

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -140,6 +140,56 @@
         }
       }
     },
+    "/api/v2/npq-applications/{id}": {
+      "get": {
+        "summary": "Get a single NPQ application",
+        "operationId": "npq_application",
+        "tags": [
+          "NPQ applications"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The ID of the NPQ application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single NPQ application",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQApplicationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/npq-applications/{id}/accept": {
       "post": {
         "summary": "Accept an NPQ application",


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1550](https://dfedigital.atlassian.net/browse/CPDLP-1550)

This is a follow up PR to the #2323, #2335 PRs, in order to add missing changes to API v2.

### Changes proposed in this pull request

- Added missing API v2 specs for the NPQ withdrawals
- Added the API v2 endpoint for retrieving single NPQ applications. Also, I added some specs

### Guidance to review

