### PR TITLE
[CPDLP-1244] Allow a DfE user to change the status of an NPQ application from the support page

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def reject
-        if npq_application.update(lead_provider_approval_status: "rejected")
+        if NPQ::Reject.call(npq_application:)
           render json: json_serializer_class.new(npq_application).serializable_hash
         else
           render json: { errors: Api::ErrorFactory.new(model: npq_application).call }, status: :bad_request

--- a/app/controllers/finance/change_lead_provider_approval_statuses_controller.rb
+++ b/app/controllers/finance/change_lead_provider_approval_statuses_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Finance
+  class ChangeLeadProviderApprovalStatusesController < BaseController
+    before_action :set_npq_application
+
+    def new
+      @change_lead_provider_approval_status_form = Finance::ChangeLeadProviderApprovalStatusForm.new
+    end
+
+    def create
+      @change_lead_provider_approval_status_form = Finance::ChangeLeadProviderApprovalStatusForm.new(change_lead_provider_approval_status_form_params)
+      @change_lead_provider_approval_status_form.npq_application = @npq_application
+
+      if @change_lead_provider_approval_status_form.save
+        redirect_to finance_participant_path(@change_lead_provider_approval_status_form.profile.user)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def set_npq_application
+      @npq_application = NPQApplication.find(params[:npq_application_id])
+    end
+
+    def change_lead_provider_approval_status_form_params
+      return {} unless params.key?(:finance_change_lead_provider_approval_status_form)
+
+      params.require(:finance_change_lead_provider_approval_status_form).permit(
+        :change_status_to_pending,
+      )
+    end
+  end
+end

--- a/app/forms/finance/change_lead_provider_approval_status_form.rb
+++ b/app/forms/finance/change_lead_provider_approval_status_form.rb
@@ -17,7 +17,10 @@ module Finance
       return false unless valid?
       return true if change_status_to_pending == "no"
 
-      ::NPQ::ChangeToPending.call(npq_application:)
+      unless ::NPQ::ChangeToPending.call(npq_application:)
+        errors.add(:change_status_to_pending, npq_application.errors[:lead_provider_approval_status].first)
+        return false
+      end
 
       true
     end

--- a/app/forms/finance/change_lead_provider_approval_status_form.rb
+++ b/app/forms/finance/change_lead_provider_approval_status_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Finance
+  class ChangeLeadProviderApprovalStatusForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :npq_application
+    attribute :change_status_to_pending
+
+    validates :change_status_to_pending, inclusion: { in: %w[yes no] }
+
+    delegate :profile,
+             to: :npq_application
+
+    def save
+      return false unless valid?
+      return true if change_status_to_pending == "no"
+
+      ::NPQ::ChangeToPending.call(npq_application:)
+
+      true
+    end
+  end
+end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -36,9 +36,6 @@ class NPQApplication < ApplicationRecord
     rejected: "rejected",
   }
 
-  validate :validate_rejected_status_cannot_change
-  validate :validate_accepted_status_cannot_change
-
   validates :eligible_for_funding_before_type_cast, inclusion: { in: [true, false, "true", "false"] }
 
   delegate :start_year, to: :cohort, prefix: true, allow_nil: true
@@ -48,18 +45,6 @@ class NPQApplication < ApplicationRecord
 
   delegate :id, :name, to: :npq_course, prefix: true
   delegate :id, :name, to: :npq_lead_provider, prefix: true
-
-  def validate_rejected_status_cannot_change
-    if lead_provider_approval_status_changed?(from: "rejected")
-      errors.add(:lead_provider_approval_status, :invalid, message: "Once rejected an application cannot change state")
-    end
-  end
-
-  def validate_accepted_status_cannot_change
-    if lead_provider_approval_status_changed?(from: "accepted")
-      errors.add(:lead_provider_approval_status, :invalid, message: "Once accepted an application cannot change state")
-    end
-  end
 
   # this builds upon #eligible_for_funding
   # eligible_for_funding is solely based on what NPQ app knows

--- a/app/services/npq/accept.rb
+++ b/app/services/npq/accept.rb
@@ -25,6 +25,11 @@ module NPQ
         return false
       end
 
+      if npq_application.rejected?
+        npq_application.errors.add(:lead_provider_approval_status, :cannot_change_from_rejected)
+        return false
+      end
+
       ApplicationRecord.transaction do
         teacher_profile.update!(trn: npq_application.teacher_reference_number) if npq_application.teacher_reference_number_verified?
         participant_profile

--- a/app/services/npq/change_to_pending.rb
+++ b/app/services/npq/change_to_pending.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module NPQ
+  class ChangeToPending
+    class << self
+      def call(npq_application:)
+        new(npq_application:).call
+      end
+    end
+
+    attr_reader :npq_application
+
+    def initialize(npq_application:)
+      @npq_application = npq_application
+    end
+
+    def call
+      return if npq_application.pending?
+
+      npq_application.update!(lead_provider_approval_status: "pending")
+    end
+  end
+end

--- a/app/services/npq/change_to_pending.rb
+++ b/app/services/npq/change_to_pending.rb
@@ -10,14 +10,37 @@ module NPQ
 
     attr_reader :npq_application
 
+    delegate :profile,
+             to: :npq_application
+
     def initialize(npq_application:)
       @npq_application = npq_application
     end
 
     def call
-      return if npq_application.pending?
+      return true if npq_application.pending?
 
-      npq_application.update!(lead_provider_approval_status: "pending")
+      if declarations_exist?
+        npq_application.errors.add(:lead_provider_approval_status, :declarations_exist)
+        return false
+      end
+
+      ActiveRecord::Base.transaction do
+        if profile
+          profile.participant_profile_states.destroy_all
+          profile.participant_declarations.destroy_all
+          profile.destroy!
+        end
+        npq_application.update!(lead_provider_approval_status: "pending")
+      end
+
+      true
+    end
+
+    def declarations_exist?
+      return false unless profile
+
+      profile.participant_declarations.where.not(state: %w[submitted voided ineligible]).any?
     end
   end
 end

--- a/app/services/npq/reject.rb
+++ b/app/services/npq/reject.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module NPQ
+  class Reject
+    class << self
+      def call(npq_application:)
+        new(npq_application:).call
+      end
+    end
+
+    attr_reader :npq_application
+
+    def initialize(npq_application:)
+      @npq_application = npq_application
+    end
+
+    def call
+      if npq_application.rejected?
+        npq_application.errors.add(:lead_provider_approval_status, :has_already_been_rejected)
+        return false
+      end
+
+      if npq_application.accepted?
+        npq_application.errors.add(:lead_provider_approval_status, :cannot_change_from_accepted)
+        return false
+      end
+
+      npq_application.update!(lead_provider_approval_status: "rejected")
+
+      true
+    end
+  end
+end

--- a/app/views/finance/change_lead_provider_approval_statuses/new.html.erb
+++ b/app/views/finance/change_lead_provider_approval_statuses/new.html.erb
@@ -15,7 +15,7 @@
     <%= form_for @change_lead_provider_approval_status_form, url: finance_npq_application_change_lead_provider_approval_status_path(@npq_application) do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset :training_status, legend: { text: "Change the status to pending?", tag: 'h1', size: 'm' } do %>
-        <%= f.govuk_radio_button :change_status_to_pending, "yes", label: { text: "Yes" }, link_erorrs: true %>
+        <%= f.govuk_radio_button :change_status_to_pending, "yes", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :change_status_to_pending, "no", label: { text: "No" } %>
       <% end %>
       <%= f.govuk_submit "Continue" %>

--- a/app/views/finance/change_lead_provider_approval_statuses/new.html.erb
+++ b/app/views/finance/change_lead_provider_approval_statuses/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: finance_participant_path(@npq_application.profile.user)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Are you sure you want to change the status to pending?</h1>
+
+    <div class="govuk-inset-text">
+      <p>
+        <strong>Lead provider approval status</strong>
+        <br/>
+        <%= @npq_application.lead_provider_approval_status %>
+      </p>
+    </div>
+
+    <%= form_for @change_lead_provider_approval_status_form, url: finance_npq_application_change_lead_provider_approval_status_path(@npq_application) do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :training_status, legend: { text: "Change the status to pending?", tag: 'h1', size: 'm' } do %>
+        <%= f.govuk_radio_button :change_status_to_pending, "yes", label: { text: "Yes" }, link_erorrs: true %>
+        <%= f.govuk_radio_button :change_status_to_pending, "no", label: { text: "No" } %>
+      <% end %>
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -2,45 +2,62 @@
   <% summary_list.row do |row| %>
     <% row.key { "Application ID" } %>
     <% row.value { govuk_link_to application.id, finance_participant_path(application.id) } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Lead Provider" } %>
     <% row.value { application.npq_lead_provider.name } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Lead Provider approval status" } %>
     <% row.value { application.lead_provider_approval_status } %>
+    <% if application.lead_provider_approval_status == "pending" %>
+      <% row.action(text: :none) %>
+    <% else %>
+      <% row.action(
+        text: "Change to pending",
+        visually_hidden_text: "",
+        href: new_finance_npq_application_change_lead_provider_approval_status_path(application))
+      %>
+    <% end %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "NPQ course" } %>
     <% row.value { application.npq_course.name } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "School URN" } %>
     <% row.value { application.school_urn } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "School UKPRN" } %>
     <% row.value { application.school_ukprn } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Targeted support funding eligibility" } %>
     <% row.value { bool_to_tag(application.targeted_delivery_funding_eligibility) } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Created at" } %>
     <% row.value { application.created_at.to_s(:govuk) } %>
+    <% row.action(text: :none) %>
   <% end %>
 
   <% summary_list.row do |row| %>
     <% row.key { "Updated at" } %>
     <% row.value { application.updated_at.to_s(:govuk) } %>
+    <% row.action(text: :none) %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,6 +176,9 @@ en:
             lead_provider_approval_status:
               has_another_accepted_application: The participant already has an accepted application for this course
               has_already_been_accepted: This NPQ application has already been accepted
+              has_already_been_rejected: This NPQ application has already been rejected
+              cannot_change_from_accepted: Once accepted an application cannot change state
+              cannot_change_from_rejected: Once rejected an application cannot change state
 
   activemodel:
     errors:
@@ -308,6 +311,10 @@ en:
               inclusion: Choose a valid training status
             reason:
               inclusion: Choose a valid reason for training status
+        finance/change_lead_provider_approval_status_form:
+          attributes:
+            confirmation:
+              inclusion: Choose yes or no
 
   page_titles:
     lead_providers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
               has_already_been_rejected: This NPQ application has already been rejected
               cannot_change_from_accepted: Once accepted an application cannot change state
               cannot_change_from_rejected: Once rejected an application cannot change state
+              declarations_exist: There are already declarations for this participant on this course, please ask provider to void and/or clawback any declarations they have made before attempting to reset the application.
 
   activemodel:
     errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -338,6 +338,9 @@ Rails.application.routes.draw do
     resources :participant_profiles, only: [] do
       resource :change_training_status, only: %i[new create]
     end
+    resources :npq_applications, only: [] do
+      resource :change_lead_provider_approval_status, only: %i[new create]
+    end
 
     namespace :banding_tracker, path: "banding-tracker" do
       resources :providers, only: %i[show]

--- a/spec/features/finance/change_lead_provider_approval_status_spec.rb
+++ b/spec/features/finance/change_lead_provider_approval_status_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Finance users NPQ application change lead_provider_approval_status", type: :feature do
+  let!(:cohort) { create :cohort }
+  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+  let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
+  let(:npq_lead_provider) { create :npq_lead_provider }
+
+  before do
+    given_i_am_logged_in_as_a_finance_user
+    when_i_visit_the_finance_participant_drilldown_page
+    then_i_see("Participant")
+  end
+
+  describe "accepted to pending" do
+    let(:npq_application) do
+      create(
+        :npq_application, :accepted,
+        npq_lead_provider:,
+        npq_course:,
+        cohort:
+      )
+    end
+    let!(:user) { npq_application.user }
+
+    scenario "Change status to pending" do
+      then_table_value_is(label: "Lead Provider approval status", value: "accepted")
+      and_i_click_on("Change to pending")
+      then_i_see("Are you sure you want to change the status to pending?")
+      and_i_see("Change the status to pending?")
+      when_i_choose("Yes")
+      and_i_click_on("Continue")
+      then_table_value_is(label: "Lead Provider approval status", value: "pending")
+    end
+  end
+
+  def when_i_visit_the_finance_participant_drilldown_page
+    visit("/finance/participants/#{user.id}")
+  end
+
+  def and_i_click_on(string)
+    page.click_on(string)
+  end
+
+  def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  def and_i_see(string)
+    then_i_see(string)
+  end
+
+  def when_i_choose(text)
+    page.choose text
+  end
+
+  def then_table_value_is(label:, value:)
+    label_field = page.find(".govuk-summary-list__key", text: label)
+    expect(label_field).to have_sibling(".govuk-summary-list__value", text: value)
+  end
+end

--- a/spec/forms/finance/change_lead_provider_approval_status_form_spec.rb
+++ b/spec/forms/finance/change_lead_provider_approval_status_form_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Finance::ChangeLeadProviderApprovalStatusForm, type: :model do
+  subject(:form) { described_class.new(params) }
+
+  let(:params) { { npq_application:, change_status_to_pending: "yes" } }
+
+  let!(:cohort) { create :cohort }
+  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+  let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
+  let(:npq_lead_provider) { create :npq_lead_provider }
+
+  describe "accepted to pending" do
+    let(:npq_application) do
+      create(
+        :npq_application, :accepted,
+        npq_lead_provider:,
+        npq_course:,
+        cohort:
+      )
+    end
+    it { is_expected.to validate_inclusion_of(:change_status_to_pending).in_array(%w[yes no]) }
+
+    describe ".save" do
+      context "valid params" do
+        it "should change status" do
+          expect(form.save).to be true
+          expect(npq_application.reload).to be_pending
+        end
+      end
+
+      context "invalid params" do
+        let(:params) { { npq_application:, change_status_to_pending: "" } }
+
+        it "should not change status" do
+          expect(form.save).to be false
+          expect(npq_application.reload).to be_accepted
+        end
+      end
+    end
+  end
+
+  describe "rejected to pending" do
+    let(:npq_application) do
+      create(
+        :npq_application, :rejected,
+        npq_lead_provider:,
+        npq_course:,
+        cohort:
+      )
+    end
+    it { is_expected.to validate_inclusion_of(:change_status_to_pending).in_array(%w[yes no]) }
+
+    describe ".save" do
+      context "valid params" do
+        it "should change status" do
+          expect(form.save).to be true
+          expect(npq_application.reload).to be_pending
+        end
+      end
+
+      context "invalid params" do
+        let(:params) { { npq_application:, change_status_to_pending: "" } }
+
+        it "should not change status" do
+          expect(form.save).to be false
+          expect(npq_application.reload).to be_rejected
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
 
         expect(parsed_response["errors"][0].key?("title")).to be_truthy
         expect(parsed_response["errors"][0].key?("detail")).to be_truthy
-        expect(parsed_response["errors"][0]["title"]).to eql("Status invalid")
+        expect(parsed_response["errors"][0]["title"]).to eql("Status cannot change from accepted")
         expect(parsed_response["errors"][0]["detail"]).to eql("Once accepted an application cannot change state")
       end
     end
@@ -336,7 +336,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
 
         expect(parsed_response["errors"][0].key?("title")).to be_truthy
         expect(parsed_response["errors"][0].key?("detail")).to be_truthy
-        expect(parsed_response["errors"][0]["title"]).to eql("Status invalid")
+        expect(parsed_response["errors"][0]["title"]).to eql("Status cannot change from rejected")
         expect(parsed_response["errors"][0]["detail"]).to eql("Once rejected an application cannot change state")
       end
     end

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
 
         expect(parsed_response["errors"][0].key?("title")).to be_truthy
         expect(parsed_response["errors"][0].key?("detail")).to be_truthy
-        expect(parsed_response["errors"][0]["title"]).to eql("Status invalid")
+        expect(parsed_response["errors"][0]["title"]).to eql("Status cannot change from accepted")
         expect(parsed_response["errors"][0]["detail"]).to eql("Once accepted an application cannot change state")
       end
     end
@@ -339,7 +339,7 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
 
         expect(parsed_response["errors"][0].key?("title")).to be_truthy
         expect(parsed_response["errors"][0].key?("detail")).to be_truthy
-        expect(parsed_response["errors"][0]["title"]).to eql("Status invalid")
+        expect(parsed_response["errors"][0]["title"]).to eql("Status cannot change from rejected")
         expect(parsed_response["errors"][0]["detail"]).to eql("Once rejected an application cannot change state")
       end
     end

--- a/spec/services/npq/accept_spec.rb
+++ b/spec/services/npq/accept_spec.rb
@@ -241,9 +241,9 @@ RSpec.describe NPQ::Accept do
       end
 
       it "cannot then be accepted" do
-        expect {
-          subject.call
-        }.not_to change { npq_application.reload.lead_provider_approval_status }
+        subject.call
+        expect(npq_application.reload).to be_rejected
+        expect(npq_application.errors[:lead_provider_approval_status]).to be_present
       end
     end
 

--- a/spec/services/npq/change_to_pending_spec.rb
+++ b/spec/services/npq/change_to_pending_spec.rb
@@ -3,47 +3,107 @@
 require "rails_helper"
 
 RSpec.describe NPQ::ChangeToPending do
+  let!(:cohort) { create :cohort }
+  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+  let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
+  let(:npq_lead_provider) { create :npq_lead_provider }
+
+  let!(:npq_application) do
+    create(
+      :npq_application,
+      application_status,
+      npq_lead_provider:,
+      npq_course:,
+      cohort:,
+    )
+  end
+
+  let!(:participant_profile) { npq_application.profile }
+
+  let!(:participant_declaration) do
+    create(
+      :npq_participant_declaration,
+      declaration_type: "started",
+      user: npq_application.user,
+      participant_profile:,
+      course_identifier: npq_course.identifier,
+      state: "submitted",
+    )
+  end
+
   subject do
     described_class.new(npq_application:)
   end
 
   describe "#call" do
-    let(:cohort_2021) { Cohort.current }
-    let(:user) { create(:user) }
-    let(:identity) { create(:participant_identity, user:) }
-    let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
-    let(:npq_lead_provider) { create(:npq_lead_provider) }
-
-    let(:npq_application) do
-      NPQApplication.new(
-        participant_identity: identity,
-        npq_course:,
-        npq_lead_provider:,
-        cohort: cohort_2021,
-      )
-    end
-
     context "when application has already been accepted" do
-      before do
-        npq_application.lead_provider_approval_status = "accepted"
-        npq_application.save!
-      end
+      let(:application_status) { :accepted }
 
       it "changes to pending" do
         subject.call
-        expect(npq_application.reload).to be_pending
+        npq_application.reload
+        expect(npq_application).to be_pending
+        expect(npq_application.profile).to be_nil
       end
     end
 
     context "when application has already been rejected" do
-      before do
-        npq_application.lead_provider_approval_status = "rejected"
-        npq_application.save!
-      end
+      let(:application_status) { :rejected }
+      let!(:participant_profile) { create(:npq_participant_profile, npq_application:) }
 
       it "changes to pending" do
         subject.call
-        expect(npq_application.reload).to be_pending
+        npq_application.reload
+        expect(npq_application).to be_pending
+        expect(npq_application.profile).to be_nil
+      end
+    end
+
+    # Should fail
+    %w[eligible payable paid awaiting_clawback].each do |dec_state|
+      context "accepted application with #{dec_state} declaration" do
+        let(:application_status) { :accepted }
+        let!(:participant_declaration) do
+          create(
+            :npq_participant_declaration,
+            declaration_type: "started",
+            user: npq_application.user,
+            participant_profile:,
+            course_identifier: npq_course.identifier,
+            state: dec_state,
+          )
+        end
+
+        it "returns error" do
+          subject.call
+          npq_application.reload
+          expect(npq_application).to be_accepted
+          expect(npq_application.errors[:lead_provider_approval_status]).to include("There are already declarations for this participant on this course, please ask provider to void and/or clawback any declarations they have made before attempting to reset the application.")
+        end
+      end
+    end
+
+    #  Should succeed
+    %w[submitted voided ineligible].each do |dec_state|
+      context "accepted application with #{dec_state} declaration" do
+        let(:application_status) { :accepted }
+        let!(:participant_declaration) do
+          create(
+            :npq_participant_declaration,
+            declaration_type: "started",
+            user: npq_application.user,
+            participant_profile:,
+            course_identifier: npq_course.identifier,
+            state: dec_state,
+          )
+        end
+
+        it "changes to pending" do
+          subject.call
+          npq_application.reload
+          expect(npq_application).to be_pending
+          expect(npq_application.errors[:lead_provider_approval_status]).to_not be_present
+        end
       end
     end
   end

--- a/spec/services/npq/change_to_pending_spec.rb
+++ b/spec/services/npq/change_to_pending_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::ChangeToPending do
+  subject do
+    described_class.new(npq_application:)
+  end
+
+  describe "#call" do
+    let(:cohort_2021) { Cohort.current }
+    let(:user) { create(:user) }
+    let(:identity) { create(:participant_identity, user:) }
+    let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
+    let(:npq_lead_provider) { create(:npq_lead_provider) }
+
+    let(:npq_application) do
+      NPQApplication.new(
+        participant_identity: identity,
+        npq_course:,
+        npq_lead_provider:,
+        cohort: cohort_2021,
+      )
+    end
+
+    context "when application has already been accepted" do
+      before do
+        npq_application.lead_provider_approval_status = "accepted"
+        npq_application.save!
+      end
+
+      it "changes to pending" do
+        subject.call
+        expect(npq_application.reload).to be_pending
+      end
+    end
+
+    context "when application has already been rejected" do
+      before do
+        npq_application.lead_provider_approval_status = "rejected"
+        npq_application.save!
+      end
+
+      it "changes to pending" do
+        subject.call
+        expect(npq_application.reload).to be_pending
+      end
+    end
+  end
+end

--- a/spec/services/npq/reject_spec.rb
+++ b/spec/services/npq/reject_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::Reject do
+  subject do
+    described_class.new(npq_application:)
+  end
+
+  describe "#call" do
+    let(:cohort_2021) { Cohort.current }
+    let(:user) { create(:user) }
+    let(:identity) { create(:participant_identity, user:) }
+    let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
+    let(:npq_lead_provider) { create(:npq_lead_provider) }
+
+    let(:npq_application) do
+      NPQApplication.new(
+        participant_identity: identity,
+        npq_course:,
+        npq_lead_provider:,
+        cohort: cohort_2021,
+      )
+    end
+
+    context "when application has already been accepted" do
+      before do
+        npq_application.lead_provider_approval_status = "accepted"
+        npq_application.save!
+      end
+
+      it "cannot then be rejected" do
+        subject.call
+        expect(npq_application.reload).to be_accepted
+        expect(npq_application.errors[:lead_provider_approval_status]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1244

### Changes proposed in this pull request

* New "Change to pending" link added to participant drill down support page

### Guidance to review

* Login as `finance@example.com`
* Go to the participant drill down page
* Enter participant id with NPQ Application

