### PR TITLE
[CST-891] Accept slashes and letters in TRN input

### DIFF
--- a/app/controllers/schools/transferring_participants_controller.rb
+++ b/app/controllers/schools/transferring_participants_controller.rb
@@ -286,7 +286,7 @@ module Schools
 
     def check_against_dqt?
       @transferring_participant_form.full_name.present? &&
-        @transferring_participant_form.trn.present? &&
+        @transferring_participant_form.formatted_trn.present? &&
         @transferring_participant_form.date_of_birth.present?
     end
 
@@ -300,14 +300,14 @@ module Schools
       @participant_profile ||= ParticipantProfile::ECF.joins(:ecf_participant_validation_data)
           .where("full_name ILIKE ? AND trn = ? AND date_of_birth = ?",
                  "#{first_name} %",
-                 @transferring_participant_form.trn,
+                 @transferring_participant_form.formatted_trn,
                  @transferring_participant_form.date_of_birth).first
     end
 
     def dqt_record
       ParticipantValidationService.validate(
         full_name: @transferring_participant_form.full_name,
-        trn: @transferring_participant_form.trn,
+        trn: @transferring_participant_form.formatted_trn,
         date_of_birth: @transferring_participant_form.date_of_birth,
         nino: nil,
         config: {

--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -51,9 +51,7 @@ module Participants
       attribute :no_trn, :boolean, default: false
 
       validates :trn,
-                presence: true,
-                format: { with: /\A\d+\z/ },
-                length: { within: 5..7 },
+                teacher_reference_number: { message_scope: "errors.teacher_reference_number_personalised" },
                 unless: :no_trn
 
       before_complete { check_eligibility! if dob.present? && !no_trn }
@@ -129,7 +127,7 @@ module Participants
     def check_eligibility!
       self.dqt_response = ParticipantValidationService.validate(
         full_name:,
-        trn:,
+        trn: formatted_trn,
         date_of_birth: dob,
         nino:,
         config: {
@@ -162,7 +160,7 @@ module Participants
       StoreValidationResult.call(
         participant_profile:,
         validation_data: {
-          trn:,
+          trn: formatted_trn,
           nino:,
           full_name:,
           dob:,
@@ -188,6 +186,10 @@ module Participants
 
     def additional_step
       (EXTRA_STEPS - completed_steps).first || :manual_check
+    end
+
+    def formatted_trn
+      TeacherReferenceNumber.new(trn).formatted_trn
     end
 
     def call(save_validation_data_without_match: true)

--- a/app/forms/schools/transferring_participant_form.rb
+++ b/app/forms/schools/transferring_participant_form.rb
@@ -9,11 +9,7 @@ module Schools
     attr_accessor :full_name, :trn, :date_of_birth, :start_date, :email, :mentor_id, :schools_current_programme_choice, :teachers_current_programme_choice, :same_programme, :current_step, :steps
 
     validates :full_name, presence: true, on: :full_name
-    validates :trn,
-              presence: true,
-              format: { with: /\A\d+\z/ },
-              length: { within: 5..7 },
-              on: :trn
+    validates :trn, teacher_reference_number: true, on: :trn
     validates :email, presence: true, notify_email: true, on: :email
     validates :mentor_id, presence: true, on: :choose_mentor
     validate :schools_programme_choice, on: :schools_current_programme
@@ -40,6 +36,10 @@ module Schools
 
     def formatted_full_name
       full_name.split("-").map(&:titleize).join("-")
+    end
+
+    def formatted_trn
+      TeacherReferenceNumber.new(trn).formatted_trn
     end
 
     def full_name_to_display

--- a/app/lib/teacher_reference_number.rb
+++ b/app/lib/teacher_reference_number.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class TeacherReferenceNumber
+  MIN_UNPADDED_TRN_LENGTH = 5
+  PADDED_TRN_LENGTH = 7
+
+  attr_reader :trn, :format_error
+
+  def initialize(trn)
+    @trn = trn
+    @format_error = nil
+  end
+
+  def formatted_trn
+    @formatted_trn ||= extract_trn_value
+  end
+
+  def valid?
+    formatted_trn.present?
+  end
+
+private
+
+  def extract_trn_value
+    @format_error = :blank and return if trn.blank?
+
+    # remove any characters that are not digits
+    only_digits = trn.to_s.gsub(/[^\d]/, "")
+
+    @format_error = :invalid and return if only_digits.blank?
+    @format_error = :too_short and return if only_digits.length < MIN_UNPADDED_TRN_LENGTH
+    @format_error = :too_long and return if only_digits.length > PADDED_TRN_LENGTH
+
+    only_digits.rjust(PADDED_TRN_LENGTH, "0")
+  end
+end

--- a/app/validators/teacher_reference_number_validator.rb
+++ b/app/validators/teacher_reference_number_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TeacherReferenceNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    trn = TeacherReferenceNumber.new(value)
+    unless trn.valid?
+      message_scope = (options[:message_scope] || "errors.teacher_reference_number")
+      record.errors.add(attribute, (options[:message] || I18n.t(trn.format_error, scope: message_scope)))
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,6 +138,14 @@ en:
       blank: "Please select programme type"
     provider:
       blank: "Please select a provider"
+    teacher_reference_number: &trn_error_messages
+      blank: Enter the teacher reference number (TRN)
+      too_short: Teacher reference number contains at least 5 digits
+      too_long: Teacher reference number contains at most 7 digits
+      invalid: Teacher reference number is not the correct format (for example, RP99/12345)
+    teacher_reference_number_personalised:
+      <<: *trn_error_messages
+      blank: Enter your teacher reference number (TRN)
 
   activerecord:
     attributes:

--- a/spec/features/participants/participant_validation_spec.rb
+++ b/spec/features/participants/participant_validation_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Participant validation journey",
 
     when_i_am_on_the_participant_registration_wizard
     click_on "Continue"
-    then_i_see_an_error_message "Enter your teacher reference number"
+    then_i_see_an_error_message "Enter your teacher reference number (TRN)"
 
     when_i_add_teacher_reference_number_to_the_participant_registration_wizard "1234567"
     click_on "Continue"

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Reporting participants with a known TRN",
 
     when_i_choose_i_know_the_participants_trn_to_the_school_add_participant_wizard
     click_on "Continue"
-    then_i_see_an_error_message "Enter the teacher reference number (TRN) for the teacher you are adding"
+    then_i_see_an_error_message "Enter the teacher reference number (TRN)"
 
     when_i_add_teacher_reference_number_to_the_school_add_participant_wizard participant_data[:full_name], participant_data[:trn]
     click_on "Continue"

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -267,11 +267,11 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def then_i_should_see_a_enter_trn_error_message
-        expect(page).to have_text("Enter the teachers TRN (teacher reference number)")
+        expect(page).to have_text("Enter the teacher reference number (TRN)")
       end
 
       def then_i_should_see_invalid_trn_message
-        expect(page).to have_text("Teacher reference number is at least 5 digits long")
+        expect(page).to have_text("Teacher reference number contains at least 5 digits")
       end
 
       def then_i_should_see_enter_date_of_birth_error_message

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
   describe "steps" do
     describe "STEP trn" do
       context "when no_trn flag is not set" do
-        it { is_expected.to validate_presence_of(:trn).on(:trn).with_message("Enter your TRN (teacher reference number)") }
+        it { is_expected.to validate_presence_of(:trn).on(:trn).with_message("Enter your teacher reference number (TRN)") }
 
         it "validates the TRN has at least 5 digits" do
           form.trn = "RP22/12"

--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -64,8 +64,19 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
   describe "steps" do
     describe "STEP trn" do
       context "when no_trn flag is not set" do
-        it { is_expected.to validate_presence_of(:trn).on(:trn) }
-        it { is_expected.to validate_length_of(:trn).is_at_least(5).is_at_most(7) }
+        it { is_expected.to validate_presence_of(:trn).on(:trn).with_message("Enter your TRN (teacher reference number)") }
+
+        it "validates the TRN has at least 5 digits" do
+          form.trn = "RP22/12"
+          expect(form).not_to be_valid
+          expect(form.errors[:trn]).to include "Teacher reference number contains at least 5 digits"
+        end
+
+        it "validates the TRN has at most 7 digits" do
+          form.trn = "RP22/1234567"
+          expect(form).not_to be_valid
+          expect(form.errors[:trn]).to include "Teacher reference number contains at most 7 digits"
+        end
       end
 
       context "when no_trn flag is set" do

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
   it { is_expected.to validate_presence_of(:transfer).on(:transfer) }
 
   describe "when a SIT knows the teachers trn" do
-    it { is_expected.to validate_presence_of(:trn).on(:trn).with_message("Enter the teacher reference number (TRN) for the teacher you are adding") }
+    it { is_expected.to validate_presence_of(:trn).on(:trn).with_message("Enter the teacher reference number (TRN)") }
     it { is_expected.to validate_presence_of(:do_you_know_teachers_trn).on(:do_you_know_teachers_trn).with_message("Select whether you know the teacher reference number (TRN) for the teacher you are adding") }
     it { is_expected.to validate_presence_of(:date_of_birth).on(:dob) }
 

--- a/spec/forms/schools/transferring_participant_form_spec.rb
+++ b/spec/forms/schools/transferring_participant_form_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Schools::TransferringParticipantForm, type: :model do
       it "returns false" do
         form.trn = ""
         expect(form.valid?(:trn)).to be false
-        expect(form.errors[:trn]).to include "Enter the teachers TRN (teacher reference number)"
+        expect(form.errors[:trn]).to include "Enter the teacher reference number (TRN)"
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Schools::TransferringParticipantForm, type: :model do
       it "returns false when TRN is less than 5 digits" do
         form.trn = "1234"
         expect(form.valid?(:trn)).to be false
-        expect(form.errors[:trn]).to include "Teacher reference number is at least 5 digits long"
+        expect(form.errors[:trn]).to include "Teacher reference number contains at least 5 digits"
       end
     end
 
@@ -55,15 +55,15 @@ RSpec.describe Schools::TransferringParticipantForm, type: :model do
       it "returns false when TRN is more than 7 digits" do
         form.trn = "12345678"
         expect(form.valid?(:trn)).to be false
-        expect(form.errors[:trn]).to include "Teacher reference number is at most 7 digits long"
+        expect(form.errors[:trn]).to include "Teacher reference number contains at most 7 digits"
       end
     end
 
-    context "when trn contains non-digits" do
+    context "when trn contains no digits" do
       it "returns false" do
-        form.trn = "ABCD123"
+        form.trn = "ABCD/EFGH"
         expect(form.valid?(:trn)).to be false
-        expect(form.errors[:trn]).to include "Teacher reference number must only contain numbers"
+        expect(form.errors[:trn]).to include "Teacher reference number is not the correct format (for example, RP99/12345)"
       end
     end
   end

--- a/spec/lib/teacher_reference_number_spec.rb
+++ b/spec/lib/teacher_reference_number_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherReferenceNumber do
+  describe "valid?" do
+    context "when the original value contains the correct number of digits" do
+      it "returns true" do
+        expect(described_class.new("RP99/12345")).to be_valid
+        expect(described_class.new("12345")).to be_valid
+        expect(described_class.new("1234567")).to be_valid
+      end
+    end
+
+    context "when the original value is blank" do
+      subject(:trn) { described_class.new("") }
+
+      it "returns false" do
+        expect(trn).not_to be_valid
+      end
+
+      it "sets the format_error to :blank" do
+        trn.valid?
+        expect(trn.format_error).to eq(:blank)
+      end
+    end
+
+    context "when the original value contains fewer than 5 digits" do
+      subject(:trn) { described_class.new("R12WWS/ 2") }
+
+      it "returns false" do
+        expect(trn).not_to be_valid
+      end
+
+      it "sets the format_error to :too_short" do
+        trn.valid?
+        expect(trn.format_error).to eq(:too_short)
+      end
+    end
+
+    context "when the original value contains more than 7 digits" do
+      subject(:trn) { described_class.new("RP11/12345678") }
+
+      it "returns false" do
+        expect(trn).not_to be_valid
+      end
+
+      it "sets the format_error to :too_long" do
+        trn.valid?
+        expect(trn.format_error).to eq(:too_long)
+      end
+    end
+  end
+
+  describe "#formatted_trn" do
+    it "removes non-numeric characters" do
+      expect(described_class.new("RP22/ 21 1 33").formatted_trn).to eq("2221133")
+    end
+
+    it "zero pads the value to 7-digits" do
+      expect(described_class.new("RP99/123").formatted_trn).to eq("0099123")
+    end
+
+    context "when the original value is not valid" do
+      it "returns nil" do
+        expect(described_class.new("QWERTY123").formatted_trn).to be_nil
+      end
+    end
+  end
+end

--- a/spec/validators/teacher_reference_number_validator_spec.rb
+++ b/spec/validators/teacher_reference_number_validator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotifyEmailValidator do
+  with_model :teacher do
+    table do |t|
+      t.string :trn
+    end
+
+    model do
+      validates :trn, teacher_reference_number: true
+    end
+  end
+
+  it "correctly identifies valid TRNs" do
+    valid_trns = ["12345", "RP99/12345", "RP / 1234567", "  R P 99 / 1234", "ZZ-123445 "]
+
+    valid_trns.each do |trn|
+      expect(Teacher.new(trn:)).to be_valid
+    end
+  end
+
+  it "correctly identifies invalid TRNs" do
+    invalid_trns = {
+      too_short: "1234",
+      too_long: "RP99/123457",
+      invalid: "No-numbers",
+      blank: "",
+    }
+
+    invalid_trns.each do |k, v|
+      teacher = Teacher.new(trn: v)
+      expect(teacher).not_to be_valid
+      expect(teacher.errors[:trn]).to include(I18n.t(k, scope: "errors.teacher_reference_number"))
+    end
+  end
+end

--- a/spec/validators/teacher_reference_number_validator_spec.rb
+++ b/spec/validators/teacher_reference_number_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NotifyEmailValidator do
+RSpec.describe TeacherReferenceNumberValidator do
   with_model :teacher do
     table do |t|
       t.string :trn


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-891)

Allow SITs and participants to enter TRNs as per the guidance on the forms and handle the stripping of the unwanted characters.
TRN could contain letters and slashes e.g. RP99/12345
Once stripped of everything except numerical digits:
* TRN should be between 5 and 7 digits long
* We should pad with zeros on the left to make the TRN 7 digits long if not e.g. "123456" becomes "0123456"

### Changes proposed in this pull request
Adds a `TeacherReferenceNumber` class that handles the formatting
Adds a `TeacherReferenceNumberValidator` to simplify validation of TRN entry.
Modify forms that add, transfer or validate participants to use these new classes

### Guidance to review

