### PR TITLE
[CST-904] Ensure transferring participants appear in the admin view for a school

### DIFF
--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def index
       @participant_profiles = policy_scope(ParticipantProfile::ECF, policy_scope_class: ParticipantProfilePolicy::Scope)
-        .where(id: school.current_induction_records.select(:participant_profile_id))
+        .where(id: InductionRecord.for_school(school).current_or_transferring_in.select(:participant_profile_id))
         .includes(participant_identity: :user)
         .order("users.full_name")
     end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -65,6 +65,8 @@ class InductionRecord < ApplicationRecord
   scope :transferring_in, -> { active_induction_status.merge(start_date_in_future.and(school_transfer)) }
   scope :transferring_out, -> { leaving_induction_status.merge(end_date_in_future.and(school_transfer)) }
 
+  scope :current_or_transferring_in, -> { current.or(transferring_in) }
+
   scope :claimed_by_another_school, -> { leaving_induction_status.merge(not_school_transfer.and(end_date_in_future)) }
   scope :transferred, -> { leaving_induction_status.merge(end_date_in_past) }
 

--- a/spec/features/admin/schools/view_school_participants_spec.rb
+++ b/spec/features/admin/schools/view_school_participants_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Admin viewing participants", js: true, rutabaga: false do
+  scenario "Admin can see all current and transferring in/out participants" do
+    given_there_is_a_school_with_current_and_transferring_participants
+    and_i_am_signed_in_as_an_admin
+    when_i_visit the_school_participants_page
+    then_i_should_see_all_the_current_and_transferring_participants
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named("Admin school participants listing page")
+  end
+
+private
+
+  def given_there_is_a_school_with_current_and_transferring_participants
+    @school = create(:school, name: "Test school")
+    cohort = create(:cohort, start_year: 2021)
+    school_cohort = create(:school_cohort, :fip, school: @school, cohort:)
+
+    charlie = create(:ect_participant_profile, school_cohort:, user: create(:user, full_name: "Charlie Current"))
+    theresa = create(:ect_participant_profile, user: create(:user, full_name: "Theresa Transfer-In"))
+    linda = create(:ect_participant_profile, school_cohort:, user: create(:user, full_name: "Linda Leaving"))
+
+    programme = create(:induction_programme, :fip, school_cohort:)
+    school_cohort.update!(default_induction_programme: programme)
+
+    programme2 = create(:induction_programme, :fip, school_cohort: theresa.school_cohort)
+    induction_record = Induction::Enrol.call(participant_profile: theresa, induction_programme: programme2, start_date: Date.new(2021, 9, 1))
+    induction_record.leaving!(2.months.from_now)
+    Induction::Enrol.call(participant_profile: charlie, induction_programme: programme, start_date: Date.new(2021, 12, 1))
+    Induction::Enrol.call(participant_profile: linda, induction_programme: programme, start_date: Date.new(2021, 9, 1))
+    Induction::Enrol.call(participant_profile: theresa, induction_programme: programme, start_date: induction_record.end_date, school_transfer: true)
+    linda.current_induction_record.leaving!(1.week.from_now)
+  end
+
+  def the_school_participants_page
+    admin_school_participants_path(school_id: @school.slug)
+  end
+
+  def then_i_should_see_all_the_current_and_transferring_participants
+    expect(page).to have_content "Charlie Current"
+    expect(page).to have_content "Theresa Transfer-In"
+    expect(page).to have_content "Linda Leaving"
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-904)

Participants that are transferring in/out should be listed in the admin console when viewing a school's participant list

![image](https://user-images.githubusercontent.com/333931/183370593-9ef92a4e-667d-4de5-9fb2-4a04afaeacac.png)

### Changes proposed in this pull request
Additional scope on `InductionRecord` for `current_or_transferring_in`
Changes to participants query in the admin schools participants controller.

### Guidance to review

