### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/forms/participants/participant_validation_form_spec.rb
+++ b/spec/forms/participants/participant_validation_form_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Participants::ParticipantValidationForm, type: :model do
             expect(ParticipantValidationService).to have_received(:validate).with(
               hash_including(
                 date_of_birth: form.dob,
-                trn: form.trn,
+                trn: form.formatted_trn,
               ),
             )
           end


### PR DESCRIPTION
### Context

Fix intermittent spec fail, spec uses random length TRN, we are now formatting those with padded zero to send to validation, however spec expects unformatted version so fails when TRN length < 7.

### Changes proposed in this pull request
Change spec to expect `formatted_trn` from the form object.

### Guidance to review

