### PR TITLE
Add Makefile to ease analytics exporting

### DIFF
--- a/analytics_queries/Makefile
+++ b/analytics_queries/Makefile
@@ -1,0 +1,7 @@
+flatten_queries: 
+	mkdir -p /tmp/exports
+	rm -f /tmp/exports/*.sql
+	cat declarations.sql | tr --delete '\n' > /tmp/exports/declarations.sql
+	cat participants.sql | tr --delete '\n' > /tmp/exports/participants.sql
+	cat partnerships.sql | tr --delete '\n' > /tmp/exports/partnerships.sql
+	cat schools.sql      | tr --delete '\n' > /tmp/exports/schools.sql

--- a/analytics_queries/README
+++ b/analytics_queries/README
@@ -3,3 +3,18 @@ These queries select the data used for analysis by TAD/IES/BMG. They can be used
 cf conduit ecf-postgres-sandbox -- psql -c "\copy (SELECT pd.id, pd.user_id, pd.declaration_type, pd.declaration_date, (pd.state = 'voided') as voided, pd.evidence_held FROM participant_declarations pd WHERE course_identifier in ('ecf-induction', 'ecf-mentor')) to 'declarations.csv' csv header"
 
 Substitute the database name and query as appropriate. Nathan Easey is the point of contact for questions around this.
+
+Note, the above process has been streamlined by moving the `\copy` command into the SQL files. Now we can run the `Makefile` to build the queries and run them one by one:
+ * change to `$APP/analytics_queries`
+ * run `make`
+ * it creates a directory in /tmp/exports
+ * then copies each of the queries into /tmp/exports and removes any \n characters
+
+Now we can `cd /tmp/exports` and run the ones we need:
+
+cf conduit ecf-postgres-sandbox -- psql < /tmp/exports/declarations.sql
+cf conduit ecf-postgres-sandbox -- psql < /tmp/exports/participants.sql
+cf conduit ecf-postgres-sandbox -- psql < /tmp/exports/partnerships.sql
+cf conduit ecf-postgres-sandbox -- psql < /tmp/exports/schools.sql
+
+The CSV files will be deposited in our `/tmp/exports` folder. We can zip, password and upload them as normal.

--- a/analytics_queries/declarations.sql
+++ b/analytics_queries/declarations.sql
@@ -6,8 +6,10 @@
           (pd.state = 'voided') as voided,
           pd.evidence_held,
           pd.state,
-          pds.state_reason
+          pds.state_reason,
+          clp.name as cpd_lead_provider_name
     FROM participant_declarations pd
     LEFT JOIN declaration_states pds on pd.id = pds.participant_declaration_id and pd.state = pds.state
+    LEFT JOIN cpd_lead_providers clp on pd.cpd_lead_provider_id = clp.id
     WHERE course_identifier in ('ecf-induction', 'ecf-mentor')
 ) to '/tmp/exports/declarations.csv' with csv header;

--- a/analytics_queries/declarations.sql
+++ b/analytics_queries/declarations.sql
@@ -1,11 +1,13 @@
-SELECT pd.id,
-       pd.user_id,
-       pd.declaration_type,
-       pd.declaration_date,
-       (pd.state = 'voided') as voided,
-       pd.evidence_held,
-       pd.state,
-       pds.state_reason
-FROM participant_declarations pd
-LEFT JOIN declaration_states pds on pd.id = pds.participant_declaration_id and pd.state = pds.state
-WHERE course_identifier in ('ecf-induction', 'ecf-mentor');
+\copy (
+    SELECT pd.id,
+          pd.user_id,
+          pd.declaration_type,
+          pd.declaration_date,
+          (pd.state = 'voided') as voided,
+          pd.evidence_held,
+          pd.state,
+          pds.state_reason
+    FROM participant_declarations pd
+    LEFT JOIN declaration_states pds on pd.id = pds.participant_declaration_id and pd.state = pds.state
+    WHERE course_identifier in ('ecf-induction', 'ecf-mentor')
+) to '/tmp/exports/declarations.csv' with csv header;

--- a/analytics_queries/participants.sql
+++ b/analytics_queries/participants.sql
@@ -1,42 +1,44 @@
-SELECT u.id                                                    as participant_id,
-       pi.external_identifier                                  as external_id,
-       pp.created_at                                           as added_at,
-       sch.urn                                                 as school_urn,
-       u.full_name                                             as name,
-       u.email                                                 as email,
-       SPLIT_PART(pp.type, '::', 2)                            as type,
-       (SELECT u2.id
-        FROM participant_profiles pp2
-                 JOIN teacher_profiles tp2 on pp2.teacher_profile_id = tp2.id
-                 JOIN users u2 on tp2.user_id = u2.id
-        WHERE pp2.id = pp.mentor_profile_id)                   as mentor_id,
-       c.start_year                                            as cohort,
-       pp.status                                               as status,
-       pp.training_status                                      as training_status,
-       pps.reason                                              as training_status_reason,
-       s.name                                                  as schedule,
-       s.schedule_identifier                                   as schedule_identifier,
-       tp.trn                                                  as trn,
-       epvd.created_at                                         as trn_provided_at,
-       (epe.status IN ('eligible', 'matched'))                 as trn_validated,
-       epe.reason                                              as trn_validated_reason,
-       (epe.manually_validated OR epe.status = 'manual_check') as manual_validation_required,
-       (CASE
-            WHEN epe.status = 'eligible' THEN true
-            WHEN epe.status = 'ineligible' THEN false
-           END)                                                as eligible_for_funding
-FROM participant_profiles pp
-         JOIN school_cohorts sc on pp.school_cohort_id = sc.id
-         JOIN cohorts c on sc.cohort_id = c.id
-         JOIN schools sch on sc.school_id = sch.id
-         JOIN schedules s on pp.schedule_id = s.id
-         JOIN teacher_profiles tp on pp.teacher_profile_id = tp.id
-         JOIN users u on tp.user_id = u.id
-         JOIN participant_identities pi on pp.participant_identity_id = pi.id
-         LEFT OUTER JOIN ecf_participant_validation_data epvd on pp.id = epvd.participant_profile_id
-         LEFT OUTER JOIN ecf_participant_eligibilities epe on pp.id = epe.participant_profile_id
-         LEFT OUTER JOIN participant_profile_states pps on pp.id = pps.participant_profile_id AND pps.id = (
-          SELECT id from participant_profile_states _pps WHERE _pps.participant_profile_id = pp.id AND _pps.state = pp.training_status ORDER BY created_at desc LIMIT 1
-         )
-WHERE pp.type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
-  AND c.start_year > 2020;
+\copy (
+    SELECT u.id                                                    as participant_id,
+          pi.external_identifier                                  as external_id,
+          pp.created_at                                           as added_at,
+          sch.urn                                                 as school_urn,
+          u.full_name                                             as name,
+          u.email                                                 as email,
+          SPLIT_PART(pp.type, '::', 2)                            as type,
+          (SELECT u2.id
+            FROM participant_profiles pp2
+                    JOIN teacher_profiles tp2 on pp2.teacher_profile_id = tp2.id
+                    JOIN users u2 on tp2.user_id = u2.id
+            WHERE pp2.id = pp.mentor_profile_id)                   as mentor_id,
+          c.start_year                                            as cohort,
+          pp.status                                               as status,
+          pp.training_status                                      as training_status,
+          pps.reason                                              as training_status_reason,
+          s.name                                                  as schedule,
+          s.schedule_identifier                                   as schedule_identifier,
+          tp.trn                                                  as trn,
+          epvd.created_at                                         as trn_provided_at,
+          (epe.status IN ('eligible', 'matched'))                 as trn_validated,
+          epe.reason                                              as trn_validated_reason,
+          (epe.manually_validated OR epe.status = 'manual_check') as manual_validation_required,
+          (CASE
+                WHEN epe.status = 'eligible' THEN true
+                WHEN epe.status = 'ineligible' THEN false
+              END)                                                as eligible_for_funding
+    FROM participant_profiles pp
+            JOIN school_cohorts sc on pp.school_cohort_id = sc.id
+            JOIN cohorts c on sc.cohort_id = c.id
+            JOIN schools sch on sc.school_id = sch.id
+            JOIN schedules s on pp.schedule_id = s.id
+            JOIN teacher_profiles tp on pp.teacher_profile_id = tp.id
+            JOIN users u on tp.user_id = u.id
+            JOIN participant_identities pi on pp.participant_identity_id = pi.id
+            LEFT OUTER JOIN ecf_participant_validation_data epvd on pp.id = epvd.participant_profile_id
+            LEFT OUTER JOIN ecf_participant_eligibilities epe on pp.id = epe.participant_profile_id
+            LEFT OUTER JOIN participant_profile_states pps on pp.id = pps.participant_profile_id AND pps.id = (
+              SELECT id from participant_profile_states _pps WHERE _pps.participant_profile_id = pp.id AND _pps.state = pp.training_status ORDER BY created_at desc LIMIT 1
+            )
+    WHERE pp.type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      AND c.start_year > 2020
+) to '/tmp/exports/participants.csv' with csv header;

--- a/analytics_queries/partnerships.sql
+++ b/analytics_queries/partnerships.sql
@@ -1,10 +1,12 @@
-SELECT s.urn        as school_urn,
-       lp.name      as lead_provider_name,
-       dp.name      as delivery_partner_name,
-       p.created_at AS partnership_reported_at,
-       p.challenge_reason,
-       p.challenged_at
-FROM partnerships p
-         JOIN lead_providers lp on lp.id = p.lead_provider_id
-         JOIN delivery_partners dp on p.delivery_partner_id = dp.id
-         JOIN schools s on p.school_id = s.id;
+\copy (
+    SELECT s.urn        as school_urn,
+          lp.name      as lead_provider_name,
+          dp.name      as delivery_partner_name,
+          p.created_at AS partnership_reported_at,
+          p.challenge_reason,
+          p.challenged_at
+    FROM partnerships p
+            JOIN lead_providers lp on lp.id = p.lead_provider_id
+            JOIN delivery_partners dp on p.delivery_partner_id = dp.id
+            JOIN schools s on p.school_id = s.id
+) to '/tmp/exports/partnerships.csv' with csv header;

--- a/analytics_queries/schools.sql
+++ b/analytics_queries/schools.sql
@@ -1,26 +1,28 @@
-SELECT DISTINCT s.urn,
-                sc.induction_programme_choice,
-                (p.id IS NOT NULL)                 as in_partnership,
-                lp.name                            as lead_provider_name,
-                dp.name                            as delivery_partner_name,
-                (icp.id IS NOT NULL)               as tutor_nominated,
-                icp.created_at                     as tutor_nominated_at,
-                (u.current_sign_in_at IS NOT NULL) as tutor_signed_in,
-                u.full_name                        as tutor_name,
-                u.email                            as tutor_email,
-                (pp.id IS NOT NULL)                as sit_mentor,
-                u.id                              as sit_mentor_id
+\copy (
+    SELECT DISTINCT s.urn,
+                    sc.induction_programme_choice,
+                    (p.id IS NOT NULL)                 as in_partnership,
+                    lp.name                            as lead_provider_name,
+                    dp.name                            as delivery_partner_name,
+                    (icp.id IS NOT NULL)               as tutor_nominated,
+                    icp.created_at                     as tutor_nominated_at,
+                    (u.current_sign_in_at IS NOT NULL) as tutor_signed_in,
+                    u.full_name                        as tutor_name,
+                    u.email                            as tutor_email,
+                    (pp.id IS NOT NULL)                as sit_mentor,
+                    u.id                              as sit_mentor_id
 
-FROM schools s
-         LEFT OUTER JOIN school_cohorts sc on s.id = sc.school_id
-         LEFT OUTER JOIN cohorts c on sc.cohort_id = c.id
-         LEFT OUTER JOIN partnerships p on s.id = p.school_id
-         LEFT OUTER JOIN lead_providers lp on p.lead_provider_id = lp.id
-         LEFT OUTER JOIN delivery_partners dp on p.delivery_partner_id = dp.id
-         LEFT OUTER JOIN induction_coordinator_profiles_schools icps on s.id = icps.school_id
-         LEFT OUTER JOIN induction_coordinator_profiles icp on icps.induction_coordinator_profile_id = icp.id
-         LEFT OUTER JOIN users u on icp.user_id = u.id
-         LEFT OUTER JOIN teacher_profiles tp on u.id = tp.user_id
-         LEFT OUTER JOIN participant_profiles pp on tp.id = pp.teacher_profile_id and pp.status = 'active' and
-                                                    pp.type = 'ParticipantProfile::Mentor'
-WHERE (c.start_year > 2020 OR c.id IS NULL);
+    FROM schools s
+            LEFT OUTER JOIN school_cohorts sc on s.id = sc.school_id
+            LEFT OUTER JOIN cohorts c on sc.cohort_id = c.id
+            LEFT OUTER JOIN partnerships p on s.id = p.school_id
+            LEFT OUTER JOIN lead_providers lp on p.lead_provider_id = lp.id
+            LEFT OUTER JOIN delivery_partners dp on p.delivery_partner_id = dp.id
+            LEFT OUTER JOIN induction_coordinator_profiles_schools icps on s.id = icps.school_id
+            LEFT OUTER JOIN induction_coordinator_profiles icp on icps.induction_coordinator_profile_id = icp.id
+            LEFT OUTER JOIN users u on icp.user_id = u.id
+            LEFT OUTER JOIN teacher_profiles tp on u.id = tp.user_id
+            LEFT OUTER JOIN participant_profiles pp on tp.id = pp.teacher_profile_id and pp.status = 'active' and
+                                                        pp.type = 'ParticipantProfile::Mentor'
+    WHERE (c.start_year > 2020 OR c.id IS NULL)
+) to '/tmp/exports/schools.csv' with csv header;


### PR DESCRIPTION
No code changes here, just streamlining the analyics export.

The process is made easier by:

* moving the `\copy` statement inside the SQL files
* adding a `Makefile` that creates an export directory and moves the queries to the right location
* automatically strips `\n` from the SQL files so they work with `\copy`

## Review guidance

Would recommend disabling whitespace to review, most of the changes are adding indentation as we're wrapping the queries in `\copy ( ... )`.
