### PR TITLE
Stop challenge window check fail on nil deadline

### DIFF
--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -44,6 +44,8 @@ class Partnership < ApplicationRecord
   end
 
   def in_challenge_window?
+    return false if challenge_deadline.blank?
+
     challenge_deadline > Time.zone.now
   end
 

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -90,6 +90,12 @@ RSpec.describe Partnership, type: :model do
 
       expect(partnership).not_to be_in_challenge_window
     end
+
+    it "returns false when the challenge_deadline is blank" do
+      partnership = create(:partnership, challenge_deadline: nil)
+
+      expect(partnership).not_to be_in_challenge_window
+    end
   end
 
   describe "scope :active" do


### PR DESCRIPTION
### Context

The `#in_challenge_window?` method expects `challenge_deadline` is set. When it's `nil` we're throwing an error.

If there is no deadline I assume we cannot be in a window.
