### PR TITLE
[CPDNPQ-422] Copy GOOGLE_DRIVE_NPQ_DOWNLOAD_FOLDER_ID to ENV

### DIFF
--- a/config/initializers/google_drive_credentials.rb
+++ b/config/initializers/google_drive_credentials.rb
@@ -8,6 +8,7 @@
   GOOGLE_ACCOUNT_TYPE
   GOOGLE_PRIVATE_KEY
   GOOGLE_DRIVE_NPQ_UPLOAD_FOLDER_ID
+  GOOGLE_DRIVE_NPQ_DOWNLOAD_FOLDER_ID
 ].each do |identifier|
   next if ENV.key?(identifier.to_s)
 


### PR DESCRIPTION
### Context

- Ticket: [CPDNPQ-422](https://dfedigital.atlassian.net/browse/CPDNPQ-422)

### Changes proposed in this pull request

This needs to be followed up with a PR that moves the lookups for GOOGLE_DRIVE_NPQ_UPLOAD_FOLDER_ID and GOOGLE_DRIVE_NPQ_DOWNLOAD_FOLDER_ID to use the credentials file. I'm doing this here so that we can get things working so that records can be updated immediately.
