### PR TITLE
[CN-422] Fix whitespace and case issues in CSV parser

### DIFF
--- a/app/services/admin/npq_applications/eligibility_import/csv_parser.rb
+++ b/app/services/admin/npq_applications/eligibility_import/csv_parser.rb
@@ -41,9 +41,9 @@ module Admin
 
             OpenStruct.new(
               csv_row:,
-              ecf_id: row["ecf_id"],
-              eligible_for_funding: row["eligible_for_funding"] == "TRUE",
-              funding_eligiblity_status_code: row["funding_eligiblity_status_code"],
+              ecf_id: row["ecf_id"].strip,
+              eligible_for_funding: row["eligible_for_funding"].strip.upcase == "TRUE",
+              funding_eligiblity_status_code: row["funding_eligiblity_status_code"].strip,
             )
           end
         end

--- a/spec/jobs/admin/npq_applications/eligibility_import_job_spec.rb
+++ b/spec/jobs/admin/npq_applications/eligibility_import_job_spec.rb
@@ -22,10 +22,12 @@ RSpec.describe Admin::NPQApplications::EligibilityImportJob do
     let(:csv_file_contents) do
       CSV.generate do |csv|
         csv << csv_headers
-        csv << [npq_application_to_mark_funded.id, "TRUE", "funded"]
-        csv << [npq_application_to_mark_unfunded.id, "FALSE", "ineligible_establishment_type"]
-        csv << [npq_application_to_mark_other.id, "no", "previously_funded"]
-        csv << [npq_application_to_mark_invalid_status_code.id, "no", "not funded"]
+        # The array sample is to check that different cases of true all resolve to the boolean value true
+        # We also in various other values add padding to check that whitespace is being stripped out
+        csv << [npq_application_to_mark_funded.id, ["TRUE", "true", "TRue", " TRUE"].sample, "funded"]
+        csv << [npq_application_to_mark_unfunded.id, "FALSE", "ineligible_establishment_type  "]
+        csv << ["#{npq_application_to_mark_other.id} ", " no", "previously_funded"]
+        csv << [npq_application_to_mark_invalid_status_code.id, "false", "not funded"]
         csv << [fake_ecf_id, "TRUE", "funded"]
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CN-422

### Changes proposed in this pull request

This makes sure that “TRUE”, “true”, “TRue”, and “ TRUE” all resolve to true. It also ensures whitespace in other columns does not prevent the importer working correctly.
