### PR TITLE
[CPDLP-1476] add extra 2022 ECF schedules

### DIFF
--- a/app/controllers/finance/schedules_controller.rb
+++ b/app/controllers/finance/schedules_controller.rb
@@ -3,7 +3,7 @@
 module Finance
   class SchedulesController < BaseController
     def index
-      @schedules = Finance::Schedule.includes(:cohort, :milestones).order(:schedule_identifier)
+      @cohorts = Cohort.order(start_year: :asc)
     end
 
     def show

--- a/app/views/finance/schedules/index.html.erb
+++ b/app/views/finance/schedules/index.html.erb
@@ -2,28 +2,29 @@
 
 <h1 class="govuk-heading-xl">Schedules</h1>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Identifier</th>
-      <th scope="col" class="govuk-table__header">Cohort</th>
-      <th scope="col" class="govuk-table__header">Milestones</th>
-    </tr>
-  </thead>
+<% @cohorts.each do |cohort| %>
+  <h2>Cohort: <%= cohort.start_year %></h2>
 
-  <tbody class="govuk-table__body">
-    <% @schedules.each do |schedule| %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header">
-          <%= govuk_link_to schedule.schedule_identifier, finance_schedule_path(schedule) %>
-        </th>
-        <td class="govuk-table__cell">
-          <%= schedule.cohort.start_year %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= schedule.milestones.size %>
-        </td>
+        <th scope="col" class="govuk-table__header">Identifier</th>
+        <th scope="col" class="govuk-table__header">Milestones</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% cohort.schedules.each do |schedule| %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            <%= govuk_link_to schedule.schedule_identifier, finance_schedule_path(schedule) %>
+          </th>
+
+          <td class="govuk-table__cell">
+            <%= schedule.milestones.size %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/db/seeds/schedules/ecf_extended.csv
+++ b/db/seeds/schedules/ecf_extended.csv
@@ -20,3 +20,24 @@ ecf-extended-april,ECF Extended April,2021,Output 3 - Retention Point 2,retained
 ecf-extended-april,ECF Extended April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
 ecf-extended-april,ECF Extended April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
 ecf-extended-april,ECF Extended April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
+,,,,,,,
+ecf-extended-september,ECF Extended September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
+ecf-extended-september,ECF Extended September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
+ecf-extended-september,ECF Extended September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
+ecf-extended-september,ECF Extended September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
+ecf-extended-september,ECF Extended September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
+ecf-extended-september,ECF Extended September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
+,,,,,,,
+ecf-extended-january,ECF Extended January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
+ecf-extended-january,ECF Extended January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
+ecf-extended-january,ECF Extended January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
+ecf-extended-january,ECF Extended January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
+ecf-extended-january,ECF Extended January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
+ecf-extended-january,ECF Extended January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
+,,,,,,,
+ecf-extended-april,ECF Extended April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
+ecf-extended-april,ECF Extended April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
+ecf-extended-april,ECF Extended April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
+ecf-extended-april,ECF Extended April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
+ecf-extended-april,ECF Extended April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
+ecf-extended-april,ECF Extended April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023

--- a/db/seeds/schedules/ecf_reduced.csv
+++ b/db/seeds/schedules/ecf_reduced.csv
@@ -20,3 +20,24 @@ ecf-reduced-april,ECF Reduced April,2021,Output 3 - Retention Point 2,retained-2
 ecf-reduced-april,ECF Reduced April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
 ecf-reduced-april,ECF Reduced April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
 ecf-reduced-april,ECF Reduced April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
+,,,,,,,
+ecf-reduced-september,ECF Reduced September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
+ecf-reduced-september,ECF Reduced September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
+ecf-reduced-september,ECF Reduced September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
+ecf-reduced-september,ECF Reduced September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
+ecf-reduced-september,ECF Reduced September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
+ecf-reduced-september,ECF Reduced September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
+,,,,,,,
+ecf-reduced-january,ECF Reduced January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
+ecf-reduced-january,ECF Reduced January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
+ecf-reduced-january,ECF Reduced January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
+ecf-reduced-january,ECF Reduced January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
+ecf-reduced-january,ECF Reduced January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
+ecf-reduced-january,ECF Reduced January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
+,,,,,,,
+ecf-reduced-april,ECF Reduced April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
+ecf-reduced-april,ECF Reduced April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
+ecf-reduced-april,ECF Reduced April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
+ecf-reduced-april,ECF Reduced April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
+ecf-reduced-april,ECF Reduced April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
+ecf-reduced-april,ECF Reduced April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023

--- a/db/seeds/schedules/ecf_replacement.csv
+++ b/db/seeds/schedules/ecf_replacement.csv
@@ -20,3 +20,24 @@ ecf-replacement-april,ECF Replacement April,2021,Output 3 - Retention Point 2,re
 ecf-replacement-april,ECF Replacement April,2021,Output 4 - Retention Point 3,retained-3,01/04/2022,,01/04/2022
 ecf-replacement-april,ECF Replacement April,2021,Output 5 - Retention Point 4,retained-4,01/04/2022,,01/04/2022
 ecf-replacement-april,ECF Replacement April,2021,Output 6 - Participant Completion,completed,01/04/2022,,01/04/2022
+,,,,,,,
+ecf-replacement-september,ECF Replacement September,2022,Output 1 - Participant Start,started,01/09/2022,,01/09/2022
+ecf-replacement-september,ECF Replacement September,2022,Output 2 - Retention Point 1,retained-1,01/09/2022,,01/09/2022
+ecf-replacement-september,ECF Replacement September,2022,Output 3 - Retention Point 2,retained-2,01/09/2022,,01/09/2022
+ecf-replacement-september,ECF Replacement September,2022,Output 4 - Retention Point 3,retained-3,01/09/2022,,01/09/2022
+ecf-replacement-september,ECF Replacement September,2022,Output 5 - Retention Point 4,retained-4,01/09/2022,,01/09/2022
+ecf-replacement-september,ECF Replacement September,2022,Output 6 - Participant Completion,completed,01/09/2022,,01/09/2022
+,,,,,,,
+ecf-replacement-january,ECF Replacement January,2022,Output 1 - Participant Start,started,01/01/2023,,01/01/2023
+ecf-replacement-january,ECF Replacement January,2022,Output 2 - Retention Point 1,retained-1,01/01/2023,,01/01/2023
+ecf-replacement-january,ECF Replacement January,2022,Output 3 - Retention Point 2,retained-2,01/01/2023,,01/01/2023
+ecf-replacement-january,ECF Replacement January,2022,Output 4 - Retention Point 3,retained-3,01/01/2023,,01/01/2023
+ecf-replacement-january,ECF Replacement January,2022,Output 5 - Retention Point 4,retained-4,01/01/2023,,01/01/2023
+ecf-replacement-january,ECF Replacement January,2022,Output 6 - Participant Completion,completed,01/01/2023,,01/01/2023
+,,,,,,,
+ecf-replacement-april,ECF Replacement April,2022,Output 1 - Participant Start,started,01/04/2023,,01/04/2023
+ecf-replacement-april,ECF Replacement April,2022,Output 2 - Retention Point 1,retained-1,01/04/2023,,01/04/2023
+ecf-replacement-april,ECF Replacement April,2022,Output 3 - Retention Point 2,retained-2,01/04/2023,,01/04/2023
+ecf-replacement-april,ECF Replacement April,2022,Output 4 - Retention Point 3,retained-3,01/04/2023,,01/04/2023
+ecf-replacement-april,ECF Replacement April,2022,Output 5 - Retention Point 4,retained-4,01/04/2023,,01/04/2023
+ecf-replacement-april,ECF Replacement April,2022,Output 6 - Participant Completion,completed,01/04/2023,,01/04/2023

--- a/spec/features/finance/schedules_spec.rb
+++ b/spec/features/finance/schedules_spec.rb
@@ -12,9 +12,10 @@ RSpec.feature "Finance users payment breakdowns", type: :feature do
     then_i_see("Schedules")
     and_see_table_with_schedule
 
-    within page.find("table tbody tr", text: /#{schedule.schedule_identifier} #{schedule.cohort.start_year}/) do
+    within page.find("table tbody tr", text: /#{schedule.schedule_identifier}/) do
       when_i_click(schedule.schedule_identifier)
     end
+
     then_i_see("Milestones")
     and_see_table_of_milestones_for_schedule
   end

--- a/spec/models/finance/schedule/ecf_spec.rb
+++ b/spec/models/finance/schedule/ecf_spec.rb
@@ -29,25 +29,29 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
     end
   end
 
-  it "seeds ecf schedules and milestones" do
-    schedule = described_class.find_by(schedule_identifier: "ecf-standard-april")
+  context "for 2021 cohort" do
+    let(:cohort) { Cohort.find_by(start_year: 2021) }
 
-    expect(schedule).to be_present
-    expect(schedule.milestones.count).to eql(6)
+    it "seeds ecf schedules and milestones" do
+      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-standard-april")
 
-    schedule = described_class.find_by(schedule_identifier: "ecf-reduced-april")
+      expect(schedule).to be_present
+      expect(schedule.milestones.count).to eql(6)
 
-    expect(schedule).to be_present
-    expect(schedule.milestones.count).to eql(6)
+      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-reduced-april")
 
-    schedule = described_class.find_by(schedule_identifier: "ecf-extended-april")
+      expect(schedule).to be_present
+      expect(schedule.milestones.count).to eql(6)
 
-    expect(schedule).to be_present
-    expect(schedule.milestones.count).to eql(6)
+      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-april")
 
-    schedule = described_class.find_by(schedule_identifier: "ecf-replacement-april")
+      expect(schedule).to be_present
+      expect(schedule.milestones.count).to eql(6)
 
-    expect(schedule).to be_present
-    expect(schedule.milestones.count).to eql(6)
+      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-replacement-april")
+
+      expect(schedule).to be_present
+      expect(schedule.milestones.count).to eql(6)
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1476

### Changes proposed in this pull request

- Add missing 2022 extended, reduced and replacement schedules for ECF
- In finance area split schedules by cohort for improved readabilty

### Guidance to review

- none