### PR TITLE
CPDLP-1655-npqs-training-status

### DIFF
--- a/app/views/finance/change_training_statuses/new.html.erb
+++ b/app/views/finance/change_training_statuses/new.html.erb
@@ -13,7 +13,11 @@
       <p>
         <strong>Training status</strong>
         <br/>
-        <%= @participant_profile.training_status %>
+        <% if @participant_profile.npq? %>
+          <%= @participant_profile.state %>
+        <% else %>
+          <%= @participant_profile.training_status %>
+        <% end %>
       </p>
     </div>
 

--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -43,7 +43,7 @@
 
   <% summary_list.row do |row| %>
     <% row.key { "Training status" } %>
-    <% row.value { pp.training_status } %>
+    <% row.value { pp.state } %>
     <% row.action(
       text: "Change",
       visually_hidden_text: "training status",

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -37,6 +37,12 @@ FactoryBot.define do
         participant_profile.schedule = schedule
         participant_profile.npq_course = npq_application.npq_course
       end
+
+      trait :with_participant_profile_state do
+        after(:build) do |participant_profile|
+          participant_profile.participant_profile_states << build(:participant_profile_state, state: participant_profile.training_status)
+        end
+      end
     end
 
     trait :sparsity_uplift do

--- a/spec/features/finance/change_training_status_spec.rb
+++ b/spec/features/finance/change_training_status_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Finance users participant change training status", type: :feature
   end
 
   describe "NPQ" do
-    let!(:participant_profile) { create(:npq_participant_profile, training_status: "active") }
+    let!(:participant_profile) { create(:npq_participant_profile, :with_participant_profile_state, training_status: "active") }
     let!(:user) { participant_profile.user }
     let!(:participant_declaration) { create(:npq_participant_declaration, participant_profile:, user:) }
 


### PR DESCRIPTION
The drilldown page is using the cached training_status value from the
participant profile record to display the participant training status
for NPQ participants, when the API is using the latest participant profile
state record. These two can go out of sync and cause issues and confusion.

Replacing the ParticipantProfile training_status in the drilldown page with the 
ParticipantProfile state method ensures the correct state is always displayed.

Eventually the InductionRecord will replace both the training_status and the 
ParticipantProfileState. ECF participants already using the InductionRecord,
but the NPQ ones not just yet.

### Context

- Ticket: CPDLP-1655

### Changes proposed in this pull request
I changed the drilldown page to display the `ParticipantProfile.state` instead of the `training_status`, but only for the NPQs

### Guidance to review

