### PR TITLE
release note for 2022 non standard ecf schedules

### DIFF
--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -9,6 +9,27 @@ weight: 8
   If you have any questions or comments about these notes, please contact DfE via Slack or email.
 </p>
 
+<h2 class="govuk-heading-l" id="17-8-2022">17th August 2022</h2>
+<p class="govuk-body-m">
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Added non-standard ECF schedules to 2022 cohort:</li>
+    <li>
+      <ul>
+        <li>ecf-extended-september</li>
+        <li>ecf-extended-january</li>
+        <li>ecf-extended-april</li>
+        <li>ecf-reduced-september</li>
+        <li>ecf-reduced-january</li>
+        <li>ecf-reduced-april</li>
+        <li>ecf-replacement-september</li>
+        <li>ecf-replacement-january</li>
+        <li>ecf-replacement-april</li>
+      </ul>
+    </li>
+    <li>These non-standard schedules start on the first day of the month of the given schedule name. For example ecf-extended-january starts on 1st January 2023</li>
+  </ul>
+</p>
+
 <h2 class="govuk-heading-l" id="9-8-2022">9th August 2022</h2>
 <p class="govuk-body-m">
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
### Context

- Ticket: n/a

### Changes proposed in this pull request

- Add release notes for newly added non-standard ECF schedules for 2022 cohort
- See https://ecf-review-pr-2404.london.cloudapps.digital/api-reference/release-notes.html#17-8-2022

### Guidance to review

- none