### PR TITLE
[CPDLP-1707] Can post 2022 declarations

### DIFF
--- a/app/components/finance/statements/ecf_statement_selector.html.erb
+++ b/app/components/finance/statements/ecf_statement_selector.html.erb
@@ -8,6 +8,15 @@
     form_group: { class: "govuk-form-group govuk-!-width-one-third" }
   %>
 
+  <%= f.govuk_collection_select :cohort_year,
+    cohorts,
+    :start_year,
+    :start_year,
+    label: { text: "View a different cohort" },
+    options: { selected: current_statement.cohort.start_year },
+    form_group: { class: "govuk-form-group" }
+  %>
+
   <%= f.govuk_collection_select :statement,
     statements,
     :id,

--- a/app/components/finance/statements/ecf_statement_selector.rb
+++ b/app/components/finance/statements/ecf_statement_selector.rb
@@ -31,6 +31,10 @@ module Finance
 
     private
 
+      def cohorts
+        Cohort.where(start_year: 2021..)
+      end
+
       def i18n_scope
         %i[components finance statements ecf_statement_selector]
       end

--- a/app/components/finance/statements/ecf_statement_selector.rb
+++ b/app/components/finance/statements/ecf_statement_selector.rb
@@ -3,10 +3,11 @@
 module Finance
   module Statements
     class ECFStatementSelector < BaseComponent
-      attr_reader :current_statement
+      attr_reader :current_statement, :cohorts
 
-      def initialize(current_statement:)
+      def initialize(current_statement:, cohorts:)
         @current_statement = current_statement
+        @cohorts = cohorts
       end
 
       def lead_providers
@@ -30,10 +31,6 @@ module Finance
       end
 
     private
-
-      def cohorts
-        Cohort.where(start_year: 2021..)
-      end
 
       def i18n_scope
         %i[components finance statements ecf_statement_selector]

--- a/app/components/finance/statements/npq_statement_selector.html.erb
+++ b/app/components/finance/statements/npq_statement_selector.html.erb
@@ -8,6 +8,15 @@
     form_group: { class: "govuk-form-group govuk-!-width-one-third" }
   %>
 
+  <%= f.govuk_collection_select :cohort_year,
+    cohorts,
+    :start_year,
+    :start_year,
+    label: { text: "View a different cohort" },
+    options: { selected: current_statement.cohort.start_year },
+    form_group: { class: "govuk-form-group" }
+  %>
+
   <%= f.govuk_collection_select :statement,
     statements,
     :id,

--- a/app/components/finance/statements/npq_statement_selector.rb
+++ b/app/components/finance/statements/npq_statement_selector.rb
@@ -25,7 +25,7 @@ module Finance
           end
       end
 
-      private
+    private
 
       def cohorts
         Cohort.where(start_year: 2021..)

--- a/app/components/finance/statements/npq_statement_selector.rb
+++ b/app/components/finance/statements/npq_statement_selector.rb
@@ -24,6 +24,12 @@ module Finance
             )
           end
       end
+
+      private
+
+      def cohorts
+        Cohort.where(start_year: 2021..)
+      end
     end
   end
 end

--- a/app/controllers/finance/ecf/participant_declarations/voided_controller.rb
+++ b/app/controllers/finance/ecf/participant_declarations/voided_controller.rb
@@ -7,7 +7,7 @@ module Finance
         def show
           @ecf_lead_provider = LeadProvider.find(params[:payment_breakdown_id])
           @cpd_lead_provider = @ecf_lead_provider.cpd_lead_provider
-          @statement = @ecf_lead_provider.statements.find_by_humanised_name(params[:statement_id])
+          @statement = @ecf_lead_provider.statements.find(params[:statement_id])
           @voided_declarations = @statement.participant_declarations.voided
         end
       end

--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -5,15 +5,11 @@ module Finance
     class StatementsController < BaseController
       def show
         @ecf_lead_provider = lead_provider_scope.find(params[:payment_breakdown_id])
-        @statement = @ecf_lead_provider.statements.find_by(name: identifier_to_name)
+        @statement = @ecf_lead_provider.statements.find(params[:id])
         @calculator = StatementCalculator.new(statement: @statement)
       end
 
     private
-
-      def identifier_to_name
-        params[:id].humanize.gsub("-", " ")
-      end
 
       def lead_provider_scope
         policy_scope(LeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/npq/participant_declarations/voided_controller.rb
+++ b/app/controllers/finance/npq/participant_declarations/voided_controller.rb
@@ -7,7 +7,7 @@ module Finance
         def show
           @npq_lead_provider   = lead_provider_scope.find(params[:lead_provider_id])
           @cpd_lead_provider   = @npq_lead_provider.cpd_lead_provider
-          @statement           = @cpd_lead_provider.npq_lead_provider.statements.find_by_humanised_name(params[:statement_id])
+          @statement           = @cpd_lead_provider.npq_lead_provider.statements.find(params[:statement_id])
           @voided_declarations = @statement.participant_declarations.voided
         end
 

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -6,7 +6,7 @@ module Finance
       def show
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
-        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: identifier_to_name)
+        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find(params[:id])
         @statements        = @npq_lead_provider.statements.upto_current.order(payment_date: :desc)
         @npq_contracts     = @npq_lead_provider.npq_contracts.where(version: @statement.contract_version).order(course_identifier: :asc)
 
@@ -14,10 +14,6 @@ module Finance
       end
 
     private
-
-      def identifier_to_name
-        params[:id].humanize.gsub("-", " ")
-      end
 
       def lead_provider_scope
         policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/payment_breakdowns_controller.rb
@@ -46,17 +46,19 @@ module Finance
     end
 
     def choose_npq_statement
+      cohort = Cohort.find_by(start_year: params[:cohort_year])
       npq_lead_provider = NPQLeadProvider.find(params[:npq_lead_provider])
       statement_name = params[:statement].humanize.gsub("-", " ")
-      statement = npq_lead_provider.statements.find_by(name: statement_name)
+      statement = npq_lead_provider.statements.find_by(cohort:, name: statement_name)
 
       redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider.id, statement)
     end
 
     def choose_ecf_statement
+      cohort = Cohort.find_by(start_year: params[:cohort_year])
       lead_provider = LeadProvider.find(params[:lead_provider])
       statement_name = params[:statement].humanize.gsub("-", " ")
-      statement = lead_provider.statements.find_by(name: statement_name)
+      statement = lead_provider.statements.find_by(cohort:, name: statement_name)
 
       redirect_to finance_ecf_payment_breakdown_statement_path(lead_provider.id, statement)
     end

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -47,10 +47,6 @@ class Finance::Statement < ApplicationRecord
     def current
       with_future_deadline_date.order(deadline_date: :asc).first
     end
-
-    def attach(participant_declaration)
-      Finance::DeclarationStatementAttacher.new(participant_declaration:).call
-    end
   end
 
   def open?

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -44,10 +44,6 @@ class Finance::Statement < ApplicationRecord
   }
 
   class << self
-    def find_by_humanised_name(humanised_name)
-      find_by(name: humanised_name.humanize.gsub("-", " "))
-    end
-
     def current
       with_future_deadline_date.order(deadline_date: :asc).first
     end
@@ -67,10 +63,6 @@ class Finance::Statement < ApplicationRecord
 
   def current?
     payment_date > Time.current && deadline_date > Time.current
-  end
-
-  def to_param
-    name.downcase.gsub(" ", "-")
   end
 
   def previous_statements

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -79,6 +79,16 @@ class ParticipantProfile < ApplicationRecord
         .first
     end
 
+    def schedule_for(cpd_lead_provider:)
+      lead_provider = cpd_lead_provider.lead_provider
+
+      induction_records
+        .joins(induction_programme: { partnership: [:lead_provider] })
+        .where(induction_programmes: { partnerships: { lead_provider: } })
+        .latest
+        .schedule
+    end
+
   private
 
     def update_analytics

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -37,6 +37,10 @@ class ParticipantProfile < ApplicationRecord
       npq_application&.eligible_for_dfe_funding
     end
 
+    def schedule_for(*)
+      schedule
+    end
+
   private
 
     def push_profile_to_big_query

--- a/app/services/finance/declaration_statement_attacher.rb
+++ b/app/services/finance/declaration_statement_attacher.rb
@@ -24,7 +24,11 @@ module Finance
   private
 
     def cohort
-      participant_declaration.participant_profile.schedule.cohort
+      participant_declaration.participant_profile.schedule_for(cpd_lead_provider:).cohort
+    end
+
+    def cpd_lead_provider
+      participant_declaration.cpd_lead_provider
     end
 
     def statement

--- a/app/services/finance/npq/statement_calculator.rb
+++ b/app/services/finance/npq/statement_calculator.rb
@@ -102,12 +102,11 @@ module Finance
         contracts.map { |contract| PaymentCalculator::NPQ::ServiceFees.call(contract:) }.compact
       end
 
-      # WARNING: this does not scope to a cohort
-      # when cohorts are designed for scoping needs to be added here
       def contracts
         npq_lead_provider
           .npq_contracts
           .where(version: statement.contract_version)
+          .where(cohort: statement.cohort)
           .order(course_identifier: :asc)
       end
 

--- a/app/services/importers/npq_contracts.rb
+++ b/app/services/importers/npq_contracts.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Importers
+  # Given a CSV with correct data
+  # Find or create NPQContract
+  class NPQContracts
+    attr_reader :path_to_csv, :errors
+
+    def initialize(path_to_csv:)
+      @path_to_csv = path_to_csv
+      @errors = []
+    end
+
+    def call
+      check_headers
+
+      rows.each do |row|
+        cohort = Cohort.find_by!(start_year: row["cohort_year"])
+        cpd_lead_provider = CpdLeadProvider.find_by!(name: row["provider_name"])
+        npq_lead_provider = cpd_lead_provider.npq_lead_provider
+        course = NPQCourse.where("name ilike '%#{row['course_name']}%'").first
+
+        contract = NPQContract.find_or_initialize_by(
+          cohort:,
+          npq_lead_provider:,
+          course_identifier: course.identifier,
+        )
+
+        contract.update!(
+          recruitment_target: row["recruitment_target"].to_i,
+          per_participant: row["per_participant"],
+          service_fee_installments: row["service_fee_installments"].to_i,
+          number_of_payment_periods: number_of_payment_periods_for(course:),
+          service_fee_percentage: service_fee_percentage_for(course:),
+          output_payment_percentage: output_payment_percentage_for(course:),
+        )
+      end
+    end
+
+  private
+
+    def number_of_payment_periods_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQLeadership::IDENTIFIERS
+        4
+      when *Finance::Schedule::NPQSpecialist::IDENTIFIERS
+        3
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        4
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        4
+      else
+        raise ArgumentError, "Invalid course identifier"
+      end
+    end
+
+    def service_fee_percentage_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        0
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        0
+      else
+        40
+      end
+    end
+
+    def output_payment_percentage_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        100
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        100
+      else
+        60
+      end
+    end
+
+    def check_headers
+      unless rows.headers == %w[provider_name cohort_year course_name recruitment_target per_participant service_fee_installments]
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true, skip_blanks: true)
+    end
+  end
+end

--- a/app/services/importers/npq_contracts.rb
+++ b/app/services/importers/npq_contracts.rb
@@ -42,13 +42,13 @@ module Importers
     def number_of_payment_periods_for(course:)
       case course.identifier
       when *Finance::Schedule::NPQLeadership::IDENTIFIERS
-        4
+        Finance::Schedule::NPQLeadership.default.milestones.count
       when *Finance::Schedule::NPQSpecialist::IDENTIFIERS
-        3
+        Finance::Schedule::NPQSpecialist.default.milestones.count
       when *Finance::Schedule::NPQSupport::IDENTIFIERS
-        4
+        Finance::Schedule::NPQSupport.default.milestones.count
       when *Finance::Schedule::NPQEhco::IDENTIFIERS
-        4
+        Finance::Schedule::NPQEhco.default.milestones.count
       else
         raise ArgumentError, "Invalid course identifier"
       end

--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -17,10 +17,14 @@ class Importers::SeedStatements
       cpd_lead_provider = lead_provider.cpd_lead_provider
 
       ecf_statements.each do |statement_data|
+        cohort = Cohort.find_by(start_year: statement_data.cohort)
+
+        next unless cohort
+
         statement = Finance::Statement::ECF.find_by(
           name: statement_data.name,
           cpd_lead_provider:,
-          cohort: statement_data.cohort,
+          cohort:,
         )
 
         next if statement
@@ -28,7 +32,7 @@ class Importers::SeedStatements
         Finance::Statement::ECF.create!(
           name: statement_data.name,
           cpd_lead_provider:,
-          cohort: statement_data.cohort,
+          cohort:,
           deadline_date: statement_data.deadline_date,
           payment_date: statement_data.payment_date,
           output_fee: statement_data.output_fee,
@@ -42,10 +46,14 @@ class Importers::SeedStatements
       cpd_lead_provider = npq_lead_provider.cpd_lead_provider
 
       npq_statements.each do |statement_data|
+        cohort = Cohort.find_by(start_year: statement_data.cohort)
+
+        next unless cohort
+
         statement = Finance::Statement::NPQ.find_by(
           name: statement_data.name,
           cpd_lead_provider:,
-          cohort: statement_data.cohort,
+          cohort:,
         )
 
         next if statement
@@ -55,7 +63,7 @@ class Importers::SeedStatements
           cpd_lead_provider:,
           deadline_date: statement_data.deadline_date,
           payment_date: statement_data.payment_date,
-          cohort: statement_data.cohort,
+          cohort:,
           output_fee: statement_data.output_fee,
           type: class_for(statement_data, namespace: Finance::Statement::NPQ),
           contract_version: statement_data.contract_version,
@@ -80,8 +88,6 @@ private
         Date.parse(value)
       when "output_fee"
         ActiveModel::Type::Boolean.new.cast(value)
-      when "cohort"
-        Cohort.find_by!(start_year: value)
       else
         value
       end

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -38,7 +38,10 @@ module RecordDeclarations
       ParticipantDeclaration.transaction do
         set_eligibility
 
-        Finance::Statement.attach(participant_declaration) unless participant_declaration.submitted?
+        unless participant_declaration.submitted?
+          Finance::DeclarationStatementAttacher.new(participant_declaration:).call
+        end
+
         declaration_attempt.update!(participant_declaration:)
       end
 

--- a/app/services/record_declarations/base.rb
+++ b/app/services/record_declarations/base.rb
@@ -17,6 +17,7 @@ module RecordDeclarations
     validate :validate_milestone_exists
     validate :validates_billable_slot_available
 
+    # TODO: for schedule this should find correct induction record and query there
     delegate :schedule, :participant_declarations, to: :user_profile, allow_nil: true
 
     class << self

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-l"><%= @ecf_lead_provider.name %></span>
     <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 
-    <%= render Finance::Statements::ECFStatementSelector.new(current_statement: @statement) %>
+    <%= render Finance::Statements::ECFStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
   </div>
 </div>
 

--- a/db/seeds/call_off_contracts.rb
+++ b/db/seeds/call_off_contracts.rb
@@ -4,26 +4,28 @@ module Seeds
   class CallOffContracts
     def call
       LeadProvider.all.each do |lp|
-        sample_call_off_contract = CallOffContract.find_or_create_by!(
-          lead_provider: lp,
-          version: example_contract_data[:version] || "0.0.1",
-          uplift_target: example_contract_data[:uplift_target],
-          uplift_amount: example_contract_data[:uplift_amount],
-          recruitment_target: example_contract_data[:recruitment_target],
-          revised_target: example_contract_data[:revised_target],
-          set_up_fee: example_contract_data[:set_up_fee],
-          raw: example_contract_data.to_json,
-          cohort: cohort_2021,
-        )
-
-        %i[band_a band_b band_c band_d].each do |band|
-          src = example_contract_data[band]
-          ParticipantBand.find_or_create_by!(
-            call_off_contract: sample_call_off_contract,
-            min: src[:min],
-            max: src[:max],
-            per_participant: src[:per_participant],
+        [cohort_2021, cohort_2022].each do |cohort|
+          sample_call_off_contract = CallOffContract.find_or_create_by!(
+            lead_provider: lp,
+            version: example_contract_data[:version] || "0.0.1",
+            uplift_target: example_contract_data[:uplift_target],
+            uplift_amount: example_contract_data[:uplift_amount],
+            recruitment_target: example_contract_data[:recruitment_target],
+            revised_target: example_contract_data[:revised_target],
+            set_up_fee: example_contract_data[:set_up_fee],
+            raw: example_contract_data.to_json,
+            cohort:,
           )
+
+          %i[band_a band_b band_c band_d].each do |band|
+            src = example_contract_data[band]
+            ParticipantBand.find_or_create_by!(
+              call_off_contract: sample_call_off_contract,
+              min: src[:min],
+              max: src[:max],
+              per_participant: src[:per_participant],
+            )
+          end
         end
       end
     end
@@ -32,6 +34,10 @@ module Seeds
 
     def cohort_2021
       @cohort_2021 ||= Cohort.find_or_create_by!(start_year: 2021)
+    end
+
+    def cohort_2022
+      @cohort_2022 ||= Cohort.find_or_create_by!(start_year: 2022)
     end
 
     def example_contract_data

--- a/db/seeds/npq_contracts/fake-2022.csv
+++ b/db/seeds/npq_contracts/fake-2022.csv
@@ -1,0 +1,78 @@
+provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments
+Ambition Institute,2022,NPQ Leading Teaching ,1000,100,12
+Ambition Institute,2022,NPQ Leading Behaviour and Culture,1001,101,13
+Ambition Institute,2022,NPQ Leading Teacher Development,1002,102,14
+Ambition Institute,2022,NPQ for Senior Leadership,1003,103,15
+Ambition Institute,2022,NPQ for Headship,1004,104,16
+Ambition Institute,2022,NPQ for Executive Leadership,1005,105,17
+Ambition Institute,2022,NPQ Leading Literacy,1006,106,18
+Ambition Institute,2022,NPQ Early Years Leadership,1007,107,19
+Best Practice Network,2022,NPQ Leading Teaching ,1008,108,20
+Best Practice Network,2022,NPQ Leading Behaviour and Culture,1009,109,21
+Best Practice Network,2022,NPQ Leading Teacher Development,1010,110,22
+Best Practice Network,2022,NPQ for Senior Leadership,1011,111,23
+Best Practice Network,2022,NPQ for Headship,1012,112,24
+Best Practice Network,2022,NPQ for Executive Leadership,1013,113,25
+Church of England,2022,NPQ Leading Teaching ,1014,114,26
+Church of England,2022,NPQ Leading Behaviour and Culture,1015,115,27
+Church of England,2022,NPQ Leading Teacher Development,1016,116,28
+Church of England,2022,NPQ for Senior Leadership,1017,117,29
+Church of England,2022,NPQ for Headship,1018,118,30
+Church of England,2022,NPQ for Executive Leadership,1019,119,31
+Education Development Trust,2022,NPQ Leading Teaching ,1020,120,32
+Education Development Trust,2022,NPQ Leading Behaviour and Culture,1021,121,33
+Education Development Trust,2022,NPQ Leading Teacher Development,1022,122,34
+Education Development Trust,2022,NPQ for Senior Leadership,1023,123,35
+Education Development Trust,2022,NPQ for Headship,1024,124,36
+Education Development Trust,2022,NPQ for Executive Leadership,1025,125,37
+Education Development Trust,2022,NPQ Leading Literacy,1026,126,38
+Education Development Trust,2022,NPQ Early Years Leadership,1027,127,39
+School-Led Network,2022,NPQ Leading Teaching ,1028,128,40
+School-Led Network,2022,NPQ Leading Behaviour and Culture,1029,129,41
+School-Led Network,2022,NPQ Leading Teacher Development,1030,130,42
+School-Led Network,2022,NPQ for Senior Leadership,1031,131,43
+School-Led Network,2022,NPQ for Headship,1032,132,44
+School-Led Network,2022,NPQ for Executive Leadership,1033,133,45
+School-Led Network,2022,NPQ Leading Literacy,1034,134,46
+School-Led Network,2022,NPQ Early Years Leadership,1035,135,47
+Leadership Learning South East,2022,NPQ Leading Teaching ,1036,136,48
+Leadership Learning South East,2022,NPQ Leading Behaviour and Culture,1037,137,49
+Leadership Learning South East,2022,NPQ Leading Teacher Development,1038,138,50
+Leadership Learning South East,2022,NPQ for Senior Leadership,1039,139,51
+Leadership Learning South East,2022,NPQ for Headship,1040,140,52
+Leadership Learning South East,2022,NPQ for Executive Leadership,1041,141,53
+Leadership Learning South East,2022,NPQ Leading Literacy,1042,142,54
+Leadership Learning South East,2022,NPQ Early Years Leadership,1043,143,55
+Teach First,2022,NPQ Leading Teaching ,1044,144,56
+Teach First,2022,NPQ Leading Behaviour and Culture,1045,145,57
+Teach First,2022,NPQ Leading Teacher Development,1046,146,58
+Teach First,2022,NPQ for Senior Leadership,1047,147,59
+Teach First,2022,NPQ for Headship,1048,148,60
+Teach First,2022,NPQ for Executive Leadership,1049,149,61
+Teach First,2022,NPQ Leading Literacy,1050,150,62
+Teach First,2022,NPQ Early Years Leadership,1051,151,63
+Teacher Development Trust,2022,NPQ Leading Teaching ,1052,152,64
+Teacher Development Trust,2022,NPQ Leading Behaviour and Culture,1053,153,65
+Teacher Development Trust,2022,NPQ Leading Teacher Development,1054,154,66
+Teacher Development Trust,2022,NPQ for Senior Leadership,1055,155,67
+Teacher Development Trust,2022,NPQ for Headship,1056,156,68
+Teacher Development Trust,2022,NPQ for Executive Leadership,1057,157,69
+Teacher Development Trust,2022,NPQ Leading Literacy,1058,158,70
+Teacher Development Trust,2022,NPQ Early Years Leadership,1059,159,71
+UCL Institute of Education,2022,NPQ Leading Teaching ,1060,160,72
+UCL Institute of Education,2022,NPQ Leading Behaviour and Culture,1061,161,73
+UCL Institute of Education,2022,NPQ Leading Teacher Development,1062,162,74
+UCL Institute of Education,2022,NPQ for Senior Leadership,1063,163,75
+UCL Institute of Education,2022,NPQ for Headship,1064,164,76
+UCL Institute of Education,2022,NPQ for Executive Leadership,1065,165,77
+UCL Institute of Education,2022,NPQ Leading Literacy,1066,166,78
+UCL Institute of Education,2022,NPQ Early Years Leadership,1067,167,79
+Ambition Institute,2022,The Early Headship Coaching Offer,1068,168,0
+Best Practice Network,2022,The Early Headship Coaching Offer,1069,169,0
+Church of England,2022,The Early Headship Coaching Offer,1070,170,0
+Education Development Trust,2022,The Early Headship Coaching Offer,1071,171,0
+School-Led Network,2022,The Early Headship Coaching Offer,1072,172,0
+Leadership Learning South East,2022,The Early Headship Coaching Offer,1073,173,0
+Teach First,2022,The Early Headship Coaching Offer,1074,174,0
+Teacher Development Trust,2022,The Early Headship Coaching Offer,1075,175,0
+UCL Institute of Education,2022,The Early Headship Coaching Offer,1076,176,0

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -921,3 +921,8 @@ create_npq_declarations = lambda {
     count: 10,
   ]
 end
+
+service = Importers::NPQContracts.new(
+  path_to_csv: Rails.root.join("db/seeds/npq_contracts/fake-2022.csv"),
+)
+service.call

--- a/spec/components/finance/statements/ecf_statement_selector_spec.rb
+++ b/spec/components/finance/statements/ecf_statement_selector_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Finance::Statements::ECFStatementSelector, type: :component do
   let!(:ecf_statement) { create(:ecf_statement) }
   let!(:other_ecf_statement) { create(:ecf_statement) }
 
-  let(:rendered) { render_inline(described_class.new(current_statement: ecf_statement)) }
+  let(:cohorts) { Cohort.where(start_year: 2021..) }
+
+  let(:rendered) { render_inline(described_class.new(current_statement: ecf_statement, cohorts:)) }
 
   it "has a form that PUTs to correct action" do
     expect(rendered).to have_selector("form[method=post][action='/finance/payment-breakdowns/choose-ecf-statement']")

--- a/spec/factories/npq_courses.rb
+++ b/spec/factories/npq_courses.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     identifier { (Finance::Schedule::NPQLeadership::IDENTIFIERS + Finance::Schedule::NPQSpecialist::IDENTIFIERS).sample }
   end
 
-  factory :npq_leadship_course, class: "NPQCourse" do
+  factory :npq_leadership_course, class: "NPQCourse" do
     sequence(:name) { |n| "NPQ Leadership Course #{n}" }
     identifier { Finance::Schedule::NPQLeadership::IDENTIFIERS.sample }
   end

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
                    end
 
         participant_profile.npq_application ||= npq_application
-        participant_profile.schedule = schedule
+        participant_profile.schedule ||= schedule
         participant_profile.npq_course = npq_application.npq_course
       end
 

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe NPQApplication, type: :model do
   end
 
   describe "#eligible_for_dfe_funding" do
-    let(:npq_course) { create(:npq_leadship_course) }
+    let(:npq_course) { create(:npq_leadership_course) }
     let(:different_npq_course) { create(:npq_specialist_course) }
 
     before do
@@ -146,7 +146,7 @@ RSpec.describe NPQApplication, type: :model do
     end
 
     context "when it is the only accepted application" do
-      let(:course) { create(:npq_leadship_course) }
+      let(:course) { create(:npq_leadership_course) }
 
       subject { create(:npq_application, eligible_for_funding: true, npq_course: course) }
 
@@ -180,7 +180,7 @@ RSpec.describe NPQApplication, type: :model do
     end
 
     context "when there is a previously accepted application" do
-      let(:npq_course) { create(:npq_leadship_course) }
+      let(:npq_course) { create(:npq_leadership_course) }
 
       subject { create(:npq_application, eligible_for_funding: true, npq_course:) }
 

--- a/spec/requests/finance/payment_breakdowns_spec.rb
+++ b/spec/requests/finance/payment_breakdowns_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::PaymentBreakdownsController do
+  let(:user) { create(:user, :finance) }
+
+  let(:cohort_2021) { Cohort.current || create(:cohort, :current) }
+  let(:cohort_2022) { Cohort.next || create(:cohort, :next) }
+
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+
+  before do
+    sign_in user
+  end
+
+  describe "POST #choose_ecf_statement", with_feature_flags: { multiple_cohorts: "active" } do
+    let!(:statement_2021) { create(:ecf_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2021) }
+    let!(:statement_2022) { create(:ecf_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2022) }
+
+    it "redirects to correctly to 2021 statement" do
+      post "/finance/payment-breakdowns/choose-ecf-statement", params: {
+        lead_provider: lead_provider.id,
+        cohort_year: cohort_2021.start_year,
+        statement: statement_2021.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/ecf/payment_breakdowns/#{lead_provider.id}/statements/#{statement_2021.id}")
+    end
+
+    it "redirects to correctly to 2022 statement" do
+      post "/finance/payment-breakdowns/choose-ecf-statement", params: {
+        lead_provider: lead_provider.id,
+        cohort_year: cohort_2022.start_year,
+        statement: statement_2022.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/ecf/payment_breakdowns/#{lead_provider.id}/statements/#{statement_2022.id}")
+    end
+  end
+
+  describe "POST #choose_npq_statement", with_feature_flags: { multiple_cohorts: "active" } do
+    let!(:statement_2021) { create(:npq_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2021) }
+    let!(:statement_2022) { create(:npq_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2022) }
+
+    it "redirects to correctly to 2021 statement" do
+      post "/finance/payment-breakdowns/choose-npq-statement", params: {
+        npq_lead_provider: npq_lead_provider.id,
+        cohort_year: cohort_2021.start_year,
+        statement: statement_2021.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/npq/payment-overviews/#{npq_lead_provider.id}/statements/#{statement_2021.id}")
+    end
+
+    it "redirects to correctly to 2022 statement" do
+      post "/finance/payment-breakdowns/choose-npq-statement", params: {
+        npq_lead_provider: npq_lead_provider.id,
+        cohort_year: cohort_2022.start_year,
+        statement: statement_2022.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/npq/payment-overviews/#{npq_lead_provider.id}/statements/#{statement_2022.id}")
+    end
+  end
+end

--- a/spec/services/finance/clawback_declaration_spec.rb
+++ b/spec/services/finance/clawback_declaration_spec.rb
@@ -4,12 +4,24 @@ require "rails_helper"
 
 RSpec.describe Finance::ClawbackDeclaration do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
 
   let(:participant_declaration) { create(:ect_participant_declaration, :paid, cpd_lead_provider:) }
+  let(:participant_profile) { participant_declaration.participant_profile }
 
   let!(:next_statement) { create(:ecf_statement, :output_fee, cpd_lead_provider:, deadline_date: 3.months.from_now) }
 
+  let(:cohort) { Cohort.current }
+  let(:school) { create(:school) }
+  let(:school_cohort) { create(:school_cohort, school:, cohort:) }
+  let(:partnership) { create(:partnership, school:, lead_provider:, cohort:) }
+  let(:induction_programme) { create(:induction_programme, partnership:) }
+
   subject { described_class.new(participant_declaration:) }
+
+  before do
+    Induction::Enrol.call(participant_profile:, induction_programme:)
+  end
 
   describe "#call" do
     it "mutates state of delaration to awaiting_clawback" do

--- a/spec/services/finance/declaration_statement_attacher_spec.rb
+++ b/spec/services/finance/declaration_statement_attacher_spec.rb
@@ -3,24 +3,87 @@
 require "rails_helper"
 
 RSpec.describe Finance::DeclarationStatementAttacher do
-  let(:declaration) { create(:ect_participant_declaration, cpd_lead_provider:) }
-  let(:statement) { create(:ecf_statement, output_fee: true, deadline_date: 2.months.from_now) }
-  let(:cpd_lead_provider) { statement.cpd_lead_provider }
+  let(:cohort_2021) { Cohort.find_by(start_year: 2021) || create(:cohort, :current) }
+  let(:cohort_2022) { Cohort.find_by(start_year: 2022) || create(:cohort, :next) }
+
+  let(:schedule_2021) { create(:ecf_schedule, cohort: cohort_2021) }
+  let(:schedule_2022) { create(:ecf_schedule, cohort: cohort_2022) }
+  let(:npq_schedule_2022) { create(:npq_leadership_schedule, cohort: cohort_2022) }
+
+  let(:declaration) { create(:ect_participant_declaration, cpd_lead_provider:, participant_profile:) }
+
+  let(:ecf_statement_2021) { create(:ecf_statement, output_fee: true, cpd_lead_provider:, deadline_date: 2.months.from_now) }
+  let(:ecf_statement_2022) { create(:ecf_statement, output_fee: true, cpd_lead_provider:, deadline_date: 2.months.from_now, cohort: cohort_2022) }
+
+  let(:npq_statement_2022) { create(:npq_statement, output_fee: true, cpd_lead_provider:, deadline_date: 2.months.from_now, cohort: cohort_2022) }
+
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:school) { create(:school) }
+
+  let(:school_cohort)    { create(:school_cohort, school:, cohort:) }
+  let(:partnership)      { create(:partnership, school: school_cohort.school, lead_provider:, cohort:) }
+  let(:induction_programme) { create(:induction_programme, partnership:) }
+  let(:participant_profile) { create(:ect_participant_profile, school_cohort:, cohort:, schedule:) }
 
   subject { described_class.new(participant_declaration: declaration) }
 
   describe "#call" do
-    it "creates line item" do
-      expect {
+    context "when cohort 2021" do
+      let!(:statement) { ecf_statement_2021 }
+      let!(:schedule) { schedule_2021 }
+      let(:cohort) { cohort_2021 }
+
+      before do
+        Induction::Enrol.call(participant_profile:, induction_programme:)
+      end
+
+      it "creates line item" do
+        expect {
+          subject.call
+        }.to change { statement.reload.statement_line_items.count }.by(1)
+      end
+
+      it "create line item with same state as declaration" do
         subject.call
-      }.to change { statement.reload.statement_line_items.count }.by(1)
+
+        line_item = Finance::StatementLineItem.last
+        expect(line_item.state).to eql(declaration.state)
+      end
     end
 
-    it "create line item with same state as declaration" do
-      subject.call
+    context "when cohort 2022" do
+      let(:cohort) { cohort_2022 }
 
-      line_item = Finance::StatementLineItem.last
-      expect(line_item.state).to eql(declaration.state)
+      context "ECF" do
+        let!(:schedule) { schedule_2022 }
+        let!(:statement) { ecf_statement_2022 }
+
+        before do
+          Induction::Enrol.call(participant_profile:, induction_programme:)
+        end
+
+        it "attaches to 2022 statement" do
+          subject.call
+
+          expect(statement.participant_declarations).to include(declaration)
+        end
+      end
+
+      context "NPQ" do
+        # let(:npq_course) { create(:npq_leadership_course) }
+
+        let!(:statement) { npq_statement_2022 }
+        let(:schedule) { npq_schedule_2022 }
+        let(:participant_profile) { create(:npq_participant_profile, schedule:) }
+        let(:declaration) { create(:npq_participant_declaration, cpd_lead_provider:, participant_profile:) }
+
+        it "attaches to 2022 statement" do
+          subject.call
+
+          expect(statement.participant_declarations).to include(declaration)
+        end
+      end
     end
   end
 end

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Finance::NPQ::StatementCalculator do
   let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
 
-  let!(:npq_course) { create(:npq_leadship_course, identifier: "npq-leading-teaching") }
+  let!(:npq_course) { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
 
   let!(:contract) { create(:npq_contract, npq_lead_provider:) }
 

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -241,4 +241,31 @@ RSpec.describe Finance::NPQ::StatementCalculator do
       end
     end
   end
+
+  context "when there exists contracts over multiple cohorts", with_feature_flags: { multiple_cohorts: "active" } do
+    let!(:cohort_2022) { Cohort.next || create(:cohort, :next) }
+    let!(:contract_2022) { create(:npq_contract, npq_lead_provider:, cohort: cohort_2022) }
+    let!(:statement_2022) { create(:npq_statement, cpd_lead_provider:, cohort: cohort_2022) }
+
+    before do
+      declarations = create_list(
+        :npq_participant_declaration, 1,
+        state: "eligible",
+        course_identifier: npq_course.identifier
+      )
+
+      declarations.each do |dec|
+        Finance::StatementLineItem.create!(
+          statement: statement_2022,
+          participant_declaration: dec,
+          state: dec.state,
+        )
+      end
+    end
+
+    it "only includes declarations for the related cohort" do
+      expect(described_class.new(statement:).total_starts).to be_zero
+      expect(described_class.new(statement: statement_2022).total_starts).to eql(1)
+    end
+  end
 end

--- a/spec/services/importers/npq_contracts_spec.rb
+++ b/spec/services/importers/npq_contracts_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Importers::NPQContracts do
 
   subject { described_class.new(path_to_csv:) }
 
+  before do
+    allow(Finance::Schedule::NPQLeadership).to receive_message_chain(:default, :milestones, :count) { 4 }
+    allow(Finance::Schedule::NPQSpecialist).to receive_message_chain(:default, :milestones, :count) { 3 }
+    allow(Finance::Schedule::NPQSupport).to receive_message_chain(:default, :milestones, :count) { 4 }
+    allow(Finance::Schedule::NPQEhco).to receive_message_chain(:default, :milestones, :count) { 4 }
+  end
+
   describe "#call" do
     context "when headers are incorrect" do
       before do

--- a/spec/services/importers/npq_contracts_spec.rb
+++ b/spec/services/importers/npq_contracts_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Importers::NPQContracts do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:path_to_csv) { csv.path }
+
+  let!(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider, name: "Ambition Institute") }
+  let!(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+
+  let!(:cohort) { create(:cohort, :next) }
+
+  let!(:npq_specialist_course) { create(:npq_specialist_course, name: "NPQ Leading Teaching (NPQLT)") }
+  let!(:npq_leadership_course) { create(:npq_leadership_course, name: "NPQ for Headship (NPQH)") }
+  let!(:npq_ehco_course) { create(:npq_ehco_course, name: "The Early Headship Coaching Offer") }
+
+  subject { described_class.new(path_to_csv:) }
+
+  describe "#call" do
+    context "when headers are incorrect" do
+      before do
+        csv.write "foo,bar"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "throws an error" do
+        expect { subject.call }.to raise_error(NameError)
+      end
+    end
+
+    context "when new contract" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ Leading Teaching,123,456.78,13"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates a new contract with correct values" do
+        expect { subject.call }.to change { NPQContract.count }.by(1)
+
+        contract = NPQContract.last
+
+        expect(contract.npq_lead_provider).to eql(npq_lead_provider)
+        expect(contract.recruitment_target).to eql(123)
+        expect(contract.course_identifier).to eql(npq_specialist_course.identifier)
+        expect(contract.service_fee_installments).to eql(13)
+        expect(contract.service_fee_percentage).to eql(40)
+        expect(contract.output_payment_percentage).to eql(60)
+        expect(contract.per_participant).to eql(456.78)
+        expect(contract.number_of_payment_periods).to eql(3)
+        expect(contract.cohort).to eql(cohort)
+      end
+    end
+
+    context "code is run more than once" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ Leading Teaching,123,456.78,13"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "is idempotent" do
+        expect {
+          subject.call
+          subject.call
+        }.to change { NPQContract.count }.by(1)
+      end
+    end
+
+    context "when existing contract" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ Leading Teaching,123,456.78,13"
+        csv.write "\n"
+        csv.close
+
+        NPQContract.create!(
+          npq_lead_provider:,
+          cohort:,
+          course_identifier: npq_specialist_course.identifier,
+          recruitment_target: 100,
+          per_participant: 100,
+          service_fee_installments: 100,
+          number_of_payment_periods: 100,
+        )
+      end
+
+      it "updates the contract" do
+        expect {
+          subject.call
+        }.not_to change { NPQContract.count }
+
+        contract = NPQContract.last
+
+        expect(contract.recruitment_target).to eql(123)
+        expect(contract.per_participant).to eql(456.78)
+        expect(contract.service_fee_installments).to eql(13)
+        expect(contract.number_of_payment_periods).to eql(3)
+      end
+    end
+
+    context "when a leadership course" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ for Headship,321,654.87,14"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates a new contract with correct values" do
+        expect { subject.call }.to change { NPQContract.count }.by(1)
+
+        contract = NPQContract.last
+
+        expect(contract.npq_lead_provider).to eql(npq_lead_provider)
+        expect(contract.recruitment_target).to eql(321)
+        expect(contract.course_identifier).to eql(npq_leadership_course.identifier)
+        expect(contract.service_fee_installments).to eql(14)
+        expect(contract.service_fee_percentage).to eql(40)
+        expect(contract.output_payment_percentage).to eql(60)
+        expect(contract.per_participant).to eql(654.87)
+        expect(contract.number_of_payment_periods).to eql(4)
+        expect(contract.cohort).to eql(cohort)
+      end
+    end
+
+    context "when EHCO course" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,The Early Headship Coaching Offer,789,111.22,15"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates a new contract with correct values" do
+        expect { subject.call }.to change { NPQContract.count }.by(1)
+
+        contract = NPQContract.last
+
+        expect(contract.npq_lead_provider).to eql(npq_lead_provider)
+        expect(contract.recruitment_target).to eql(789)
+        expect(contract.course_identifier).to eql(npq_ehco_course.identifier)
+        expect(contract.service_fee_installments).to eql(15)
+        expect(contract.service_fee_percentage).to eql(0)
+        expect(contract.output_payment_percentage).to eql(100)
+        expect(contract.per_participant).to eql(111.22)
+        expect(contract.number_of_payment_periods).to eql(4)
+        expect(contract.cohort).to eql(cohort)
+      end
+    end
+  end
+end

--- a/spec/services/npq/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
+++ b/spec/services/npq/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NPQ::Ehco::TargetedDeliveryFundingEligibilityUpdater do
   let!(:application_with_targeted_funding_set)     { create(:npq_application, applicable_application_hash) }
   let!(:application_with_targeted_funding_set_two) { create(:npq_application, applicable_application_hash) }
   let!(:application_before_cutoff)                 { create(:npq_application, applicable_application_hash.merge(created_at: described_class::REOPEN_DATE - 1.day)) }
-  let!(:application_wrong_course)                  { create(:npq_application, applicable_application_hash.merge(npq_course: create(:npq_leadship_course))) }
+  let!(:application_wrong_course)                  { create(:npq_application, applicable_application_hash.merge(npq_course: create(:npq_leadership_course))) }
   let!(:application_not_marked_for_funding)        { create(:npq_application, applicable_application_hash.merge(targeted_delivery_funding_eligibility: false)) }
 
   it "updates the targeted_delivery_funding_eligibility flag for applicable records" do

--- a/spec/services/record_declarations/started/early_career_teacher_spec.rb
+++ b/spec/services/record_declarations/started/early_career_teacher_spec.rb
@@ -324,4 +324,37 @@ RSpec.describe RecordDeclarations::Started::EarlyCareerTeacher do
       expect(declaration).to be_eligible
     end
   end
+
+  context "when declaring for a participant in 2022" do
+    let(:school_cohort) { create(:school_cohort, cohort:) }
+    let(:cohort) { create(:cohort, start_year: 2022) }
+    let(:induction_programme) { create(:induction_programme, :fip, partnership:, school_cohort:) }
+    let(:schedule) { create(:ecf_schedule, cohort:) }
+    let(:profile) { create(:ect_participant_profile, schedule:) }
+
+    before do
+      Induction::Enrol.new(induction_programme:, participant_profile: profile).call
+    end
+
+    let!(:eligibility) { create(:ecf_participant_eligibility, participant_profile: profile) }
+
+    let!(:statement) do
+      create(
+        :ecf_statement,
+        :output_fee,
+        cpd_lead_provider:,
+        deadline_date: 6.months.from_now,
+        payment_date: 7.months.from_now,
+        cohort:,
+      )
+    end
+
+    it "accepts the declaration as eligible" do
+      expect { subject.call }.to change { ParticipantDeclaration.count }.by(1)
+
+      declaration = ParticipantDeclaration.order(created_at: :asc).last
+
+      expect(declaration).to be_eligible
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1707
- Also covers https://dfedigital.atlassian.net/browse/CPDLP-1644
- This enables providers to post 2022 declarations
- Able to import NPQ contracts from CSV

### Changes proposed in this pull request

- When viewing statements, added cohort filter so finance users can switch between cohorts for statements
- Added new method `schedule_for` to be able to find schedule from a given profile
- Added class to be able to import `NPQContract`s from CSV
- Seeding process now automatically adds 2022 statements, ecf contracts and npq contracts
- Pruned `Finance::Statement.attach` in favour of calling `DeclarationStatementAttacher` directly
- `DeclarationStatementAttacher` now correctly determines the cohort and therefore attaches declarations to correct statements

### Guidance to review

- When viewing a statement these do not conform to the current designs. Extra work needs to be applied to add LHS filtering system
- When viewing a statement the filtering system at the moment does not use javascript. Therefore it is possible to select an invalid statement. Extra work needs to be applied so when cohort is changed this updates the dropdown for possible statements that are selectable