### PR TITLE
Just log percy snapshot error when build finalized

### DIFF
--- a/spec/support/features/axe_and_percy_helper.rb
+++ b/spec/support/features/axe_and_percy_helper.rb
@@ -15,6 +15,10 @@ module AxeAndPercyHelper
 
   def and_percy_is_sent_a_snapshot_named(name)
     page.percy_snapshot(name)
+  rescue StandardError => e
+    raise e unless e.message =~ /Can only finalize pending builds/
+
+    Rails.logger.error(e.message)
   end
 
   alias_method :then_the_page_is_accessible, :and_the_page_is_accessible


### PR DESCRIPTION
### Context and changes

We have a few flaky tests and occasionally need to re-run part of the suite. While this isn't ideal, sometimes they pass on the second run but are reported as failed because Percy can't add new screenshots to a build that's already been finalized. [Here's an example](https://github.com/DFE-Digital/early-careers-framework/actions/runs/2903242442) where the build should be green but isn't.

In this instance Percy shouldn't cause the build to fail, so we'll detect finalized build errors and just log them, but `raise` on everything else.

The error message will still be logged.
