### PR TITLE
[CST-965] update registration journeys for cip only schools setting up their 2022 23 cohort

### DIFF
--- a/app/helpers/schools/dashboard_helper.rb
+++ b/app/helpers/schools/dashboard_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Schools
+  module DashboardHelper
+    def manage_ects_and_mentors?(school_cohort)
+      !(school_cohort.school.cip_only? || school_cohort.school_chose_diy?)
+    end
+  end
+end

--- a/app/helpers/schools/dashboard_helper.rb
+++ b/app/helpers/schools/dashboard_helper.rb
@@ -3,7 +3,7 @@
 module Schools
   module DashboardHelper
     def manage_ects_and_mentors?(school_cohort)
-      !(school_cohort.school.cip_only? || school_cohort.school_chose_diy?)
+      school_cohort.full_induction_programme? || school_cohort.core_induction_programme?
     end
   end
 end

--- a/app/helpers/schools/setup_school_cohort_helper.rb
+++ b/app/helpers/schools/setup_school_cohort_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Schools
+  module SetupSchoolCohortHelper
+    TRAINING_CONFIRMATION_TEMPLATES = {
+      full_induction_programme: :training_confirmation_fip,
+      core_induction_programme: :training_confirmation_cip,
+      school_funded_fip: :training_confirmation_school_funded_fip,
+      design_our_own: :training_confirmation_diy,
+    }.freeze
+
+    def training_confirmation_template(training_choice)
+      TRAINING_CONFIRMATION_TEMPLATES[training_choice.to_sym].to_s
+    end
+  end
+end

--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -17,23 +17,27 @@
     <% row.value(text: "2 years")  %>
     <% row.action(text: :none) %>
   <% end %>
-  <% unless school_cohort.school_chose_diy? %>
+
+  <% if manage_ects_and_mentors?(school_cohort) %>
     <% list.row do |row| %>
       <% row.key(text: "ECTs and mentors") %>
       <% row.value(text: ects_count) %>
       <% row.action(text: ects_count.zero? ? "Add" : "Manage", href: schools_participants_path(cohort_id: school_cohort.cohort.start_year)) %>
     <% end %>
   <% end %>
+
   <% list.row do |row| %>
     <% row.key(text: "Induction tutor") %>
     <% row.value(text: school_cohort.school.induction_coordinators.first.full_name) %>
     <% row.action(text: "Change", href: name_schools_change_sit_path, visually_hidden_text: "induction tutor") %>
   <% end %>
+
   <% list.row do |row| %>
     <% row.key(text: "Programme") %>
     <% row.value(text: t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes])) %>
     <% row.action(text: "Change", href: change_programme_schools_cohort_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "induction programme choice") %>
   <% end %>
+
   <% if school_cohort.full_induction_programme? %>
     <% list.row do |row| %>
       <% row.key(text: "Training provider") %>
@@ -44,6 +48,7 @@
       <% end %>
       <% row.action(text: :none) %>
     <% end %>
+
     <% list.row do |row| %>
       <% row.key(text: "Delivery partner") %>
       <% if latest_partnership&.challenged? == true %>
@@ -78,7 +83,6 @@
       <% row.action(text: "Add", href: add_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
     <% end %>
   <% end %>
-
 <% end %>
 
 <% if latest_partnership&.challenged? == false %>
@@ -88,7 +92,13 @@
     </p>
   <% else %>
     <p class="govuk-body">
-    If this does not look right, contact: <%= render MailToSupportComponent.new %>
+      If this does not look right, contact: <%= render MailToSupportComponent.new %>
     </p>
   <% end %>
+<% end %>
+
+<% if school_cohort.school.cip_only? %>
+  <p class="govuk-body">
+    You do not need to add information about your ECTs and mentors to this service.
+  </p>
 <% end %>

--- a/app/views/schools/setup_school_cohort/_training_confirmation_school_funded_fip.html.erb
+++ b/app/views/schools/setup_school_cohort/_training_confirmation_school_funded_fip.html.erb
@@ -1,0 +1,17 @@
+<h2 class="govuk-heading-m">What to do next</h2>
+<p class="govuk-body">
+  You need to <%= govuk_link_to "make your own arrangements with a training provider (opens in a new tab)",
+                                "https://www.gov.uk/guidance/funding-and-eligibility-for-ecf-based-training",
+                                class: "govuk-link govuk-link--no-visited-state",
+                                rel: "noreferrer noopener",
+                                target: "_blank" %>, approved by the DfE.
+</p>
+
+<p class="govuk-body">
+  You do not need to add information about your ECTs and mentors to this service.
+</p>
+
+<p class="govuk-body">
+  If you change your mind about how you want to run your training, email
+  <%= govuk_mail_to("continuing-professional-development@digital.education.gov.uk") %>.
+</p>

--- a/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
+++ b/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
@@ -16,14 +16,14 @@
 
       <%= f.govuk_collection_radio_buttons(
         :how_will_you_run_training_choice,
-        @setup_school_cohort_form.how_will_you_run_training_choices,
+        @setup_school_cohort_form.how_will_you_run_training_choices(cip_only: @school.cip_only?),
         :id, :name,
         legend: { text: title, tag: 'h1', size: 'xl' }) do %>
 
         <p class="govuk-body">This choice will only apply for ECTs and mentors starting in the <%= registration_cohort %> academic year.</p>
         <p class="govuk-body">
           Read our guidance to
-          <%= govuk_link_to 'check your options (opens in new tab)', 
+          <%= govuk_link_to 'check your options (opens in new tab)',
           "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training",
           target: :_blank,
           rel: "noopener noreferrer" %>.

--- a/app/views/schools/setup_school_cohort/programme_confirmation.html.erb
+++ b/app/views/schools/setup_school_cohort/programme_confirmation.html.erb
@@ -22,6 +22,8 @@
                 <li>choose your training materials</li>
                 <li>add your ECTs and mentors</li>
             </ul>
+        <% elsif @setup_school_cohort_form.attributes[:how_will_you_run_training_choice] == 'school_funded_fip' %>
+            <p class="govuk-body">You‘ve chosen to use a training provider funded by your school.</p>
         <% end %>
 
         <% if @setup_school_cohort_form.attributes[:how_will_you_run_training_choice] == 'design_our_own' %>

--- a/app/views/schools/setup_school_cohort/training_confirmation.html.erb
+++ b/app/views/schools/setup_school_cohort/training_confirmation.html.erb
@@ -3,21 +3,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <% academic_year = Cohort.active_registration_cohort.description %>
     <%= govuk_panel title_text: title, classes: "govuk-!-margin-bottom-7" do %>
       Academic year<br/>
-      <strong><%= academic_year %></strong>
+      <strong><%= Cohort.active_registration_cohort.description %></strong>
     <% end %>
 
-    <% if @setup_school_cohort_form.attributes[:how_will_you_run_training_choice] == 'full_induction_programme' %>
-      <%= render 'training_confirmation_fip' %>
-    <% elsif @setup_school_cohort_form.attributes[:how_will_you_run_training_choice] == 'core_induction_programme' %>
-      <%= render 'training_confirmation_cip' %>
-    <% elsif @setup_school_cohort_form.attributes[:how_will_you_run_training_choice] == 'design_our_own' %>
-      <%= render 'training_confirmation_diy' %>
-    <% end %>
-    <%= govuk_link_to "Return to manage your training", schools_dashboard_path, class: "govuk-link govuk-link--no-visited-state" %>
+    <%= render training_confirmation_template(@setup_school_cohort_form.attributes[:how_will_you_run_training_choice]) %>
 
+    <%= govuk_link_to "Return to manage your training",
+                      schools_dashboard_path,
+                      class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -54,6 +54,38 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
     and_i_see_add_ects_link
   end
 
+  scenario "A CIT-only school chooses ECTs expected in next academic year and training school funded" do
+    given_a_school_with_no_chosen_programme_for_next_academic_year(cip_only: true)
+    and_i_am_signed_in_as_an_induction_coordinator
+
+    when_i_start_programme_selection_for_next_cohort
+    then_i_am_taken_to_ects_expected_in_next_academic_year_page
+    and_the_page_should_be_accessible
+
+    when_i_choose_ects_expected
+    and_i_click_continue
+    then_i_am_taken_to_the_how_will_you_run_training_page
+
+    when_i_choose_use_a_training_provider_funded_by_your_school
+    and_i_click_continue
+    then_i_am_taken_to_the_training_confirmation_page
+
+    when_i_click_the_confirm_button
+    then_i_am_taken_to_the_appropriate_body_appointed_page
+
+    when_i_choose_no
+    and_i_click_continue
+
+    then_i_am_on_the_school_funded_fip_training_submitted_page
+    and_the_page_should_be_accessible
+    and_percy_should_be_sent_a_snapshot_named "School funded fip training submitted"
+    and_i_can_get_guidance_about_an_arrangement_with_a_training_provider_on_the_school_funded_fip_training_submitted_page
+    and_i_can_email_cpd_for_help_on_the_school_funded_fip_training_submitted_page
+
+    when_i_click_on_the_return_to_your_training_link
+    then_i_am_taken_to_the_manage_your_training_page
+  end
+
   scenario "A school chooses ECTs expected in next academic year and deliver own programme" do
     given_a_school_with_no_chosen_programme_for_next_academic_year
     and_i_am_signed_in_as_an_induction_coordinator

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -5,10 +5,11 @@ module ChooseProgrammeSteps
 
   # Given steps
 
-  def given_a_school_with_no_chosen_programme_for_next_academic_year
+  def given_a_school_with_no_chosen_programme_for_next_academic_year(cip_only: false)
+    name = "NoECTsSchool"
     @previous_cohort = create(:cohort, start_year: 2021)
     @cohort = create(:cohort, start_year: 2022)
-    @school = create(:school, name: "NoECTsSchool")
+    @school = cip_only ? create(:school, :cip_only, name:) : create(:school, name:)
     create(:school_cohort, :cip, school: @school, cohort: @previous_cohort)
   end
 
@@ -277,6 +278,10 @@ module ChooseProgrammeSteps
     click_on("Return to manage your training")
   end
 
+  def when_i_click_the_confirm_button
+    click_on("Confirm")
+  end
+
   def when_i_choose_ects_expected
     choose("Yes")
   end
@@ -285,16 +290,16 @@ module ChooseProgrammeSteps
     choose("Use a training provider, funded by the DfE")
   end
 
-  def when_i_click_the_confirm_button
-    click_on("Confirm")
-  end
-
   def when_i_choose_deliver_your_own_programme
     choose("Deliver your own programme using DfE-accredited materials")
   end
 
   def when_i_choose_design_and_deliver_your_own_material
     choose("Design and deliver you own programme based on the early career framework (ECF)")
+  end
+
+  def when_i_choose_use_a_training_provider_funded_by_your_school
+    choose("Use a training provider funded by your school")
   end
 
   def when_i_choose_to_leave_lead_provider

--- a/spec/forms/schools/setup_school_cohort_form_spec.rb
+++ b/spec/forms/schools/setup_school_cohort_form_spec.rb
@@ -10,12 +10,16 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
 
   describe ".PROGRAMME_CHOICES_MAP" do
     it "returns a hash with the user programme choices and their respective programme types" do
-      expect(described_class::PROGRAMME_CHOICES_MAP).to eq({
-        "change_lead_provider" => "full_induction_programme",
-        "change_delivery_partner" => "full_induction_programme",
-        "change_to_core_induction_programme" => "core_induction_programme",
-        "change_to_design_our_own" => "design_our_own",
-      })
+      expect(described_class::PROGRAMME_CHOICES_MAP).to(
+        eq(
+          {
+            change_lead_provider: :full_induction_programme,
+            change_delivery_partner: :full_induction_programme,
+            change_to_core_induction_programme: :core_induction_programme,
+            change_to_design_our_own: :design_our_own,
+          },
+        ),
+      )
     end
   end
 
@@ -25,46 +29,83 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
     end
 
     it "returns the user form choices" do
-      choices = { expect_any_ects_choice: "yes",
-                  how_will_you_run_training_choice: "core_induction_programme",
-                  change_provider_choice: "yes",
-                  what_changes_choice: "change_lead_provider",
-                  use_different_delivery_partner_choice: "yes" }
+      choices = {
+        expect_any_ects_choice: "yes",
+        how_will_you_run_training_choice: "core_induction_programme",
+        change_provider_choice: "yes",
+        what_changes_choice: "change_lead_provider",
+        use_different_delivery_partner_choice: "yes",
+      }
+
       expect(described_class.new(choices).attributes).to eq(choices)
     end
   end
 
   describe "#expect_any_ects_choices" do
     it "returns an Array with the correct choices" do
-      expect(described_class.new.expect_any_ects_choices).to match_array(
-        [
-          have_attributes(class: OpenStruct, id: "yes", name: "Yes"),
-          have_attributes(class: OpenStruct, id: "no", name: "No"),
-        ],
+      expect(described_class.new.expect_any_ects_choices).to(
+        match_array(
+          [
+            have_attributes(class: OpenStruct, id: "yes", name: "Yes"),
+            have_attributes(class: OpenStruct, id: "no", name: "No"),
+          ],
+        ),
       )
     end
   end
 
   describe "#use_different_delivery_partner_choices" do
     it "returns an Array with the correct choices" do
-      expect(described_class.new.use_different_delivery_partner_choices).to match_array(
-        [
-          have_attributes(class: OpenStruct, id: "yes", name: "Yes"),
-          have_attributes(class: OpenStruct, id: "no", name: "No"),
-        ],
+      expect(described_class.new.use_different_delivery_partner_choices).to(
+        match_array(
+          [
+            have_attributes(class: OpenStruct, id: "yes", name: "Yes"),
+            have_attributes(class: OpenStruct, id: "no", name: "No"),
+          ],
+        ),
       )
     end
   end
 
   describe "#how_will_you_run_training_choices" do
-    it "returns an Array with the correct choices" do
-      expect(described_class.new.how_will_you_run_training_choices).to match_array(
-        [
-          have_attributes(class: OpenStruct, id: "full_induction_programme", name: "Use a training provider, funded by the DfE"),
-          have_attributes(class: OpenStruct, id: "core_induction_programme", name: "Deliver your own programme using DfE-accredited materials"),
-          have_attributes(class: OpenStruct, id: "design_our_own", name: "Design and deliver you own programme based on the early career framework (ECF)"),
-        ],
-      )
+    context "when the school is CIP-only" do
+      it "returns an Array with the correct choices" do
+        expect(described_class.new.how_will_you_run_training_choices(cip_only: true)).to(
+          match_array(
+            [
+              have_attributes(class: OpenStruct,
+                              id: "core_induction_programme",
+                              name: "Deliver your own programme using DfE-accredited materials"),
+              have_attributes(class: OpenStruct,
+                              id: "school_funded_fip",
+                              name: "Use a training provider funded by your school"),
+              have_attributes(class: OpenStruct,
+                              id: "design_our_own",
+                              name: "Design and deliver you own programme based on the early career framework (ECF)"),
+            ],
+          ),
+        )
+      end
+    end
+
+    context "when the school is not CIP-only" do
+      it "returns an Array with the correct choices" do
+        expect(described_class.new.how_will_you_run_training_choices).to(
+          match_array(
+            [
+              have_attributes(class: OpenStruct,
+                              id: "full_induction_programme",
+                              name: "Use a training provider, funded by the DfE"),
+              have_attributes(class: OpenStruct,
+                              id: "core_induction_programme",
+                              name: "Deliver your own programme using DfE-accredited materials"),
+              have_attributes(class: OpenStruct,
+                              id: "design_our_own",
+                              name: "Design and deliver you own programme based on the early career framework (ECF)"),
+            ],
+          ),
+        )
+      end
     end
   end
 
@@ -73,13 +114,19 @@ RSpec.describe Schools::SetupSchoolCohortForm, type: :model do
       lead_provider_name = "lead provider"
       delivery_partner_name = "delivery partner"
 
-      expect(described_class.new.what_changes_choices(lead_provider_name, delivery_partner_name)).to match_array(
-        [
-          OpenStruct.new(id: "change_lead_provider", name: "Leave #{lead_provider_name} and use a different lead provider"),
-          OpenStruct.new(id: "change_delivery_partner", name: "Stay with #{lead_provider_name} but change your delivery partner, #{delivery_partner_name}"),
-          OpenStruct.new(id: "change_to_core_induction_programme", name: "Deliver your own programme using DfE-accredited materials"),
-          OpenStruct.new(id: "change_to_design_our_own", name: "Design and deliver you own programme based on the Early Career Framework (ECF)"),
-        ],
+      expect(described_class.new.what_changes_choices(lead_provider_name, delivery_partner_name)).to(
+        match_array(
+          [
+            OpenStruct.new(id: "change_lead_provider",
+                           name: "Leave #{lead_provider_name} and use a different lead provider"),
+            OpenStruct.new(id: "change_delivery_partner",
+                           name: "Stay with #{lead_provider_name} but change your delivery partner, #{delivery_partner_name}"),
+            OpenStruct.new(id: "change_to_core_induction_programme",
+                           name: "Deliver your own programme using DfE-accredited materials"),
+            OpenStruct.new(id: "change_to_design_our_own",
+                           name: "Design and deliver you own programme based on the Early Career Framework (ECF)"),
+          ],
+        ),
       )
     end
   end

--- a/spec/support/features/pages/schools/choose_programme/school_funded_fip_training_submitted_page.rb
+++ b/spec/support/features/pages/schools/choose_programme/school_funded_fip_training_submitted_page.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../../base_page"
+
+module Pages
+  class SchoolFundedFipTrainingSubmittedPage < ::Pages::BasePage
+    set_url "/schools/{slug}/cohorts/{cohort}/register-programme/training-confirmation"
+    set_primary_heading(/\AYou’ve submitted your training information\z/)
+
+    def can_get_guidance_about_an_arrangement_with_a_training_provider
+      has_link?("make your own arrangements with a training provider (opens in a new tab)")
+    end
+
+    def can_email_cpd_for_help
+      has_link?(href: "mailto:continuing-professional-development@digital.education.gov.uk")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Update registration journeys for CIP-only schools setting up their 2022/23 cohort](https://dfedigital.atlassian.net/browse/CST-965)

### Changes proposed in this pull request
- Remove "ects and mentors" row from the school dashboard for CIP-only schools, so they can't manage participants.
- Add copy saying it at the botom.
- Do not show FIP choice when a CIP-only school is choosing an induction programme
- Customize the confirmation screen for schools that choose a school funded fip programme.

### Guidance to review

