### PR TITLE
Stop full name and date of birth from being logged

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -17,4 +17,6 @@ Rails.application.config.filter_parameters += %i[
   nino
   full_name
   date_of_birth
+  trn
+  teacher_reference_number
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -15,4 +15,6 @@ Rails.application.config.filter_parameters += %i[
   ssn
   national_insurance_number
   nino
+  full_name
+  date_of_birth
 ]


### PR DESCRIPTION
### Context

I noticed some detail we probably shouldn't be logging while hunting down an error in the logs.

Added the immediate offenders here:

* [x] `full_name`
* [x] `date_of_birth`

Others that _might_ be worth filtering:

* [x] `trn` (_potentially_ identifiable)
