### PR TITLE
[CPDLP-1538] Return all cohorts past 2021 when querying participant induction records

### DIFF
--- a/app/services/participants/ecf.rb
+++ b/app/services/participants/ecf.rb
@@ -19,7 +19,7 @@ module Participants
         .joins(:participant_profile, induction_programme: { school_cohort: [:cohort], partnership: [:lead_provider] })
         .where(participant_profile: user_profile)
         .where(induction_programme: { partnerships: { lead_provider: } })
-        .where(induction_programme: { school_cohorts: { cohort: Cohort.current } })
+        .where(induction_programme: { school_cohorts: { cohort: Cohort.where(start_year: 2021..) } })
         .order(start_date: :desc)
         .first
     end

--- a/spec/services/participants/ecf_spec.rb
+++ b/spec/services/participants/ecf_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::ECF, with_feature_flags: { multiple_cohorts: "active" } do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:cohort) { create(:cohort) }
+  let(:partnership) { create(:partnership, lead_provider:, cohort:) }
+  let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort:) }
+  let(:induction_programme) { create(:induction_programme, school_cohort:, partnership:) }
+  let(:user_profile) { create(:ecf_participant_profile, school_cohort:) }
+  let!(:induction_record) { create(:induction_record, participant_profile: user_profile, induction_programme:) }
+
+  let(:test_ecf_participants) do
+    Class.new do
+      include Participants::ECF
+
+      attr_reader :cpd_lead_provider, :user_profile
+
+      def initialize(cpd_lead_provider:, user_profile:)
+        @cpd_lead_provider = cpd_lead_provider
+        @user_profile = user_profile
+      end
+    end
+  end
+
+  before do
+    stub_const("TestECFParticipants", test_ecf_participants)
+  end
+
+  describe "#matches_lead_provider?" do
+    it "returns true if induction record exists for lead provider" do
+      service = TestECFParticipants.new(cpd_lead_provider:, user_profile:)
+
+      expect(service.matches_lead_provider?).to be(true)
+    end
+
+    it "returns false if induction record does not exist for lead provider" do
+      another_cpd_lead_provider = create(:cpd_lead_provider, :with_lead_provider)
+      service = TestECFParticipants.new(cpd_lead_provider: another_cpd_lead_provider, user_profile:)
+
+      expect(service.matches_lead_provider?).to be(false)
+    end
+  end
+
+  describe "#relevant_induction_record" do
+    let(:service) { TestECFParticipants.new(cpd_lead_provider:, user_profile:) }
+
+    context "when cohort start year is the same year as induction programme start" do
+      it "returns the induction record matching user, cohort and lead provider" do
+        expect(service.relevant_induction_record).to eq(induction_record)
+      end
+    end
+    context "when another cohort exists with with start year ahead of the induction programme start" do
+      let(:cohort) { create(:cohort, :next) }
+
+      it "returns the induction record matching user, cohort and lead provider" do
+        expect(service.relevant_induction_record).to eq(induction_record)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

A provider is using the header: `X-With-Server-Date` to time travel on sandbox to test different declarations.
They are getting a 422 when attempting to set milestones that occur in the subsequent year (eg `retain-3`)

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1538

### Changes proposed in this pull request

For an ECF participant, when retrieving induction records, we are only returning records from the current cohort. The current cohort is dependant on the time of year if the `multiple_cohorts` flag has been activated. This means when we attempt to return induction records for a cohort with milestones in the next year, we end up querying the incorrect cohort (current cohort will return 2022 although the one we need is 2021). Trying to tie induction records to the wrong cohort will return no records, meaning a 422 is returned incorrectly.

Allow multiple cohorts to be queried to return the correct records instead of only looking at current which could be incorrect.

### Guidance to review
Did I miss anything? Also keen to hear about where is the best place to test this if anyone has any better ideas

To test this POST to `api/v1/participant-declarations/` with a declaration type past started and declaration date in the future where the milestone is in the next year. Also set the `X-With-Server-Date` as well to after that milestone date.
