### PR TITLE
Use --autocorrect instead of --auto-correct

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -41,7 +41,7 @@ git apply -R unstaged.diff
 CHANGED_RUBY_FILES=$(git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$')
 
 echo "$CHANGED_RUBY_FILES"
-if [[ -n "$CHANGED_RUBY_FILES" ]]; then echo "$CHANGED_RUBY_FILES" | xargs rubocop --force-exclusion --fail-fast --auto-correct ; fi
+if [[ -n "$CHANGED_RUBY_FILES" ]]; then echo "$CHANGED_RUBY_FILES" | xargs rubocop --force-exclusion --fail-fast --autocorrect ; fi
 RUBOCOP_EXIT_CODE="$?"
 CHANGED_JS_FILES=$(git diff --name-only --cached | xargs ls -1 2>/dev/null | grep 'app\|spec' | grep '\.js$')
 if [[ -n "$CHANGED_JS_FILES" ]]; then echo "$CHANGED_JS_FILES" | xargs yarn run prettier --write ; fi


### PR DESCRIPTION
### Context

```
> rubocop --auto-correct
--auto-correct is deprecated; use --autocorrect instead.
```

https://github.com/rubocop/rubocop/issues/10095

### Changes proposed in this pull request

Swap --auto-correct to --autocorrect.