### PR TITLE
hardcode Cohort.current to 2021

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -8,12 +8,7 @@ class Cohort < ApplicationRecord
   has_many :npq_contracts
 
   def self.current
-    # TODO: Register and Partner 262: Figure out how to update current year
-    if FeatureFlag.active?(:multiple_cohorts)
-      where("academic_year_start_date <= ?", Time.zone.now).order(start_year: :desc).first
-    else
-      find_by(start_year: 2021)
-    end
+    find_by(start_year: 2021)
   end
 
   def self.next


### PR DESCRIPTION
### Context

- Ticket: n/a
- `Cohort.current` is now referring to `2022` whereas there is reference code that expects this to be `2021`

### Changes proposed in this pull request

- Hardcode `Cohort.current` to `2021`
- This is in place whilst we fix references to `Cohort.current` to select the desired cohort
- Once that work is complete we should be able to revert this change

### Guidance to review

- none