### PR TITLE
[CST-881] fix issues with leaving participants

### DIFF
--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -18,8 +18,7 @@ module Schools
     end
 
     def check_answers
-      @induction_record.leaving_induction_status!
-      @induction_record.update!(end_date: @transfer_out_form.end_date, school_transfer: true)
+      @induction_record.leaving!(@transfer_out_form.end_date, true)
       ParticipantTransferMailer.participant_transfer_out_notification(induction_record: @induction_record).deliver_later
 
       store_form_redirect_to_next_step(:complete)

--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -18,7 +18,7 @@ module Schools
     end
 
     def check_answers
-      @induction_record.leaving!(@transfer_out_form.end_date, true)
+      @induction_record.leaving!(@transfer_out_form.end_date, transferring_out: true)
       ParticipantTransferMailer.participant_transfer_out_notification(induction_record: @induction_record).deliver_later
 
       store_form_redirect_to_next_step(:complete)

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -60,7 +60,7 @@ class InductionRecord < ApplicationRecord
   scope :not_school_transfer, -> { where(school_transfer: false) }
 
   scope :active, -> { active_induction_status.merge(end_date_null.or(end_date_in_future)).and(start_date_in_past.or(not_school_transfer)) }
-  scope :current, -> { active.or(claimed_by_another_school) }
+  scope :current, -> { active.or(transferring_out).or(claimed_by_another_school) }
 
   scope :transferring_in, -> { active_induction_status.merge(start_date_in_future.and(school_transfer)) }
   scope :transferring_out, -> { leaving_induction_status.merge(end_date_in_future.and(school_transfer)) }
@@ -100,8 +100,9 @@ class InductionRecord < ApplicationRecord
     update!(induction_status: :withdrawn, end_date: date_of_change)
   end
 
-  def leaving!(date_of_change = Time.zone.now)
-    update!(induction_status: :leaving, end_date: date_of_change)
+  def leaving!(date_of_change = Time.zone.now, transferring_out = false)
+    # set transferring_out to true if this action originates from the school the participant is leaving
+    update!(induction_status: :leaving, end_date: date_of_change, school_transfer: transferring_out)
   end
 
   def transferring_in?

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -100,7 +100,7 @@ class InductionRecord < ApplicationRecord
     update!(induction_status: :withdrawn, end_date: date_of_change)
   end
 
-  def leaving!(date_of_change = Time.zone.now, transferring_out = false)
+  def leaving!(date_of_change = Time.zone.now, transferring_out: false)
     # set transferring_out to true if this action originates from the school the participant is leaving
     update!(induction_status: :leaving, end_date: date_of_change, school_transfer: transferring_out)
   end

--- a/app/services/coc_set_participant_categories.rb
+++ b/app/services/coc_set_participant_categories.rb
@@ -126,13 +126,6 @@ private
     ).resolve
   end
 
-  # def incoming_induction_records
-  #   InductionRecordPolicy::Scope.new(
-  #     user,
-  #     school_cohort.transferring_in_induction_records,
-  #   ).resolve
-  # end
-
   def fip_eligible_participants
     active_induction_records
       .fip

--- a/app/services/coc_set_participant_categories.rb
+++ b/app/services/coc_set_participant_categories.rb
@@ -99,13 +99,12 @@ private
     ).resolve
   end
 
-  # switch back to active_induction_records once transferring out journey is done
-  # Until this is done we want to show the active and transferring_out in this section
   def active_induction_records
     InductionRecordPolicy::Scope.new(
       user,
       school_cohort
-        .current_induction_records
+        .active_induction_records
+        .or(InductionRecord.claimed_by_another_school)
         .where.not(training_status: :withdrawn)
         .joins(:participant_profile)
         .where(participant_profiles: { type: profile_type.to_s })
@@ -127,12 +126,12 @@ private
     ).resolve
   end
 
-  def incoming_induction_records
-    InductionRecordPolicy::Scope.new(
-      user,
-      school_cohort.transferring_in_induction_records,
-    ).resolve
-  end
+  # def incoming_induction_records
+  #   InductionRecordPolicy::Scope.new(
+  #     user,
+  #     school_cohort.transferring_in_induction_records,
+  #   ).resolve
+  # end
 
   def fip_eligible_participants
     active_induction_records

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -196,38 +196,72 @@ RSpec.describe InductionRecord, type: :model do
       end
     end
 
-    describe ".current_or_transferring_in" do
+    describe "current scopes" do
       let(:induction_programme) { create(:induction_programme, :fip) }
       let(:charlie_current_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
       let(:theresa_transfer_in_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.from_now, school_transfer: true) }
       let(:linda_leaving_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
       let(:tina_transferred_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
       let(:wendy_withdrawn_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:terry_transferring_out_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
 
       before do
         linda_leaving_ir.leaving!(1.month.from_now)
+        terry_transferring_out_ir.leaving!(1.month.from_now, true)
         tina_transferred_ir.leaving!(1.month.ago)
         wendy_withdrawn_ir.withdrawing!(1.day.ago)
       end
 
-      it "includes current users" do
-        expect(induction_programme.induction_records.current_or_transferring_in).to include charlie_current_ir
+      context "when .current" do
+        it "includes current users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include charlie_current_ir
+        end
+
+        it "includes transferring out users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include terry_transferring_out_ir
+        end
+
+        it "includes users leaving for another school" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include linda_leaving_ir
+        end
+
+        it "does not include transferring in users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include theresa_transfer_in_ir
+        end
+
+        it "does not include transferred users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).not_to include tina_transferred_ir
+        end
+
+        it "does not include withdrawn users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).not_to include wendy_withdrawn_ir
+        end
       end
 
-      it "includes transferring in users" do
-        expect(induction_programme.induction_records.current_or_transferring_in).to include theresa_transfer_in_ir
-      end
+      context "when .current_or_transferring_in" do
+        it "includes current users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include charlie_current_ir
+        end
 
-      it "includes transferring out users" do
-        expect(induction_programme.induction_records.current_or_transferring_in).to include linda_leaving_ir
-      end
+        it "includes transferring in users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include theresa_transfer_in_ir
+        end
 
-      it "does not include transferred users" do
-        expect(induction_programme.induction_records.current_or_transferring_in).not_to include tina_transferred_ir
-      end
+        it "includes transferring out users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include terry_transferring_out_ir
+        end
 
-      it "does not include withdrawn users" do
-        expect(induction_programme.induction_records.current_or_transferring_in).not_to include wendy_withdrawn_ir
+        it "includes users leaving for another school" do
+          expect(induction_programme.induction_records.current_or_transferring_in).to include linda_leaving_ir
+        end
+
+        it "does not include transferred users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).not_to include tina_transferred_ir
+        end
+
+        it "does not include withdrawn users" do
+          expect(induction_programme.induction_records.current_or_transferring_in).not_to include wendy_withdrawn_ir
+        end
       end
     end
   end
@@ -311,6 +345,13 @@ RSpec.describe InductionRecord, type: :model do
       it "sets the end_date to the specified date of change" do
         induction_record.leaving!(date_of_change)
         expect(induction_record.end_date).to be_within(1.second).of(date_of_change)
+      end
+
+      context "when transferring_out" do
+        it "sets the school_transfer flag to the specified value" do
+          induction_record.leaving!(date_of_change, true)
+          expect(induction_record).to be_school_transfer
+        end
       end
     end
   end

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe InductionRecord, type: :model do
 
       before do
         linda_leaving_ir.leaving!(1.month.from_now)
-        terry_transferring_out_ir.leaving!(1.month.from_now, true)
+        terry_transferring_out_ir.leaving!(1.month.from_now, transferring_out: true)
         tina_transferred_ir.leaving!(1.month.ago)
         wendy_withdrawn_ir.withdrawing!(1.day.ago)
       end
@@ -349,7 +349,7 @@ RSpec.describe InductionRecord, type: :model do
 
       context "when transferring_out" do
         it "sets the school_transfer flag to the specified value" do
-          induction_record.leaving!(date_of_change, true)
+          induction_record.leaving!(date_of_change, transferring_out: true)
           expect(induction_record).to be_school_transfer
         end
       end

--- a/spec/services/coc_set_participant_categories_spec.rb
+++ b/spec/services/coc_set_participant_categories_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
     let(:fip_withdrawn_ect) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, training_status: "withdrawn", school_cohort:) }
     let(:fip_transferring_in_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:fip_transferring_out_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
+    let(:fip_another_school_claimed_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:fip_transferred_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:fip_transferred_withdrawn_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:fip_ect_no_qts) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
@@ -46,6 +47,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
     let(:cip_withdrawn_ect) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, training_status: "withdrawn", school_cohort:) }
     let(:cip_transferring_in_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:cip_transferring_out_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
+    let(:cip_another_school_claimed_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:cip_transferred_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:cip_transferred_withdrawn_participant) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
     let(:cip_ect_no_qts) { create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, school_cohort:) }
@@ -68,6 +70,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         fip_withdrawn_ect,
         fip_transferring_in_participant,
         fip_transferring_out_participant,
+        fip_another_school_claimed_participant,
         fip_transferred_participant,
         fip_transferred_withdrawn_participant,
         fip_ect_no_qts,
@@ -92,6 +95,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         cip_withdrawn_ect,
         cip_transferring_in_participant,
         cip_transferring_out_participant,
+        cip_another_school_claimed_participant,
         cip_transferred_participant,
         cip_transferred_withdrawn_participant,
         cip_ect_no_qts,
@@ -109,7 +113,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       # NOTE: all categories under one spec as otherwise very slow
       it "returns induction_records in correct category" do
         # eligible
-        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, fip_another_school_claimed_participant].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor].map(&:current_induction_record))
 
         # ineligible
@@ -152,7 +156,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       # NOTE: all categories under one spec as otherwise very slow
       it "returns participants in correct category" do
         # eligible
-        expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts, cip_another_school_claimed_participant].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
 
         # ineligible
@@ -193,7 +197,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
       # NOTE: all categories under one spec as otherwise very slow
       it "returns participants in correct category" do
         # eligible
-        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts].map(&:current_induction_record))
+        expect(@ect_categories.eligible).to match_array([fip_eligible_ect, fip_ero_ect, cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, cip_ect_no_qts, fip_another_school_claimed_participant, cip_another_school_claimed_participant].map(&:current_induction_record))
         expect(@mentor_categories.eligible).to match_array([fip_eligible_mentor, fip_ero_mentor, fip_primary_mentor, fip_secondary_mentor, cip_eligible_mentor, cip_ineligible_mentor, cip_ero_mentor, cip_details_being_checked_mentor, cip_primary_mentor, cip_secondary_mentor, cip_mentor_no_qts].map(&:current_induction_record))
 
         # ineligible
@@ -253,7 +257,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
 
       it "only returns ECTs for the selected school cohort" do
         ect_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::ECT)
-        expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, fip_transferring_in_participant, cip_transferring_in_participant, cip_ect_no_qts].map(&:current_induction_record).compact)
+        expect(ect_categories.eligible).to match_array([cip_eligible_ect, cip_ineligible_ect, cip_ero_ect, cip_details_being_checked_ect, @ects.first, fip_transferring_in_participant, cip_transferring_in_participant, cip_ect_no_qts, cip_another_school_claimed_participant].map(&:current_induction_record).compact)
       end
 
       it "only returns mentors for the selected school cohort" do
@@ -265,29 +269,32 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
   end
 
   def setup_fip_participants
-    school_cohort.update!(induction_programme_choice: :full_induction_programme, default_induction_programme: fip_programme)
-    fip_participants.each do |profile|
-      Induction::Enrol.call(participant_profile: profile, induction_programme: fip_programme)
-    end
-    fip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
-    fip_transferring_out_participant.induction_records.first.update!(school_transfer: true, induction_status: :leaving, end_date: 1.month.from_now)
-    fip_transferred_participant.induction_records.first.leaving!(1.month.ago)
-    fip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
-    fip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!
-    fip_withdrawn_ect.induction_records.first.training_status_withdrawn!
+    ActiveRecord::Base.no_touching do
+      school_cohort.update!(induction_programme_choice: :full_induction_programme, default_induction_programme: fip_programme)
+      fip_participants.each do |profile|
+        Induction::Enrol.call(participant_profile: profile, induction_programme: fip_programme)
+      end
+      fip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
+      fip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now, true)
+      fip_another_school_claimed_participant.induction_records.first.leaving!(1.month.from_now)
+      fip_transferred_participant.induction_records.first.leaving!(1.month.ago)
+      fip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
+      fip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!
+      fip_withdrawn_ect.induction_records.first.training_status_withdrawn!
 
-    fip_ineligible_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
-    fip_ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
-    fip_ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-    fip_ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-    fip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
-    fip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
-    fip_ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-    fip_mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+      fip_ineligible_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+      fip_ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+      fip_ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+      fip_ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+      fip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+      fip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+      fip_ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+      fip_mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
 
-    [fip_primary_mentor, fip_secondary_mentor].each do |profile|
-      profile.ecf_participant_eligibility.determine_status
-      profile.ecf_participant_eligibility.save!
+      [fip_primary_mentor, fip_secondary_mentor].each do |profile|
+        profile.ecf_participant_eligibility.determine_status
+        profile.ecf_participant_eligibility.save!
+      end
     end
 
     @ect_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::ECT)
@@ -295,31 +302,33 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
   end
 
   def setup_cip_participants
-    school_cohort.update!(default_induction_programme: cip_programme)
-    cip_participants.each do |profile|
-      Induction::Enrol.call(participant_profile: profile, induction_programme: cip_programme)
+    ActiveRecord::Base.no_touching do
+      school_cohort.update!(default_induction_programme: cip_programme)
+      cip_participants.each do |profile|
+        Induction::Enrol.call(participant_profile: profile, induction_programme: cip_programme)
+      end
+      cip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
+      cip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now, true)
+      cip_another_school_claimed_participant.induction_records.first.leaving!(1.month.from_now)
+      cip_transferred_participant.induction_records.first.leaving!(1.month.ago)
+      cip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
+      cip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!
+      cip_withdrawn_ect.induction_records.first.training_status_withdrawn!
+
+      cip_ineligible_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+      cip_ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
+      cip_ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+      cip_ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
+      cip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+      cip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
+      cip_ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+      cip_mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
+
+      [cip_primary_mentor, cip_secondary_mentor].each do |profile|
+        profile.ecf_participant_eligibility.determine_status
+        profile.ecf_participant_eligibility.save!
+      end
     end
-    cip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
-    cip_transferring_out_participant.induction_records.first.update!(school_transfer: true, induction_status: :leaving, end_date: 1.month.from_now)
-    cip_transferred_participant.induction_records.first.leaving!(1.month.ago)
-    cip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
-    cip_transferred_withdrawn_participant.induction_records.first.training_status_withdrawn!
-    cip_withdrawn_ect.induction_records.first.training_status_withdrawn!
-
-    cip_ineligible_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
-    cip_ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
-    cip_ero_ect.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-    cip_ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
-    cip_details_being_checked_ect.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
-    cip_details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
-    cip_ect_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-    cip_mentor_no_qts.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
-
-    [cip_primary_mentor, cip_secondary_mentor].each do |profile|
-      profile.ecf_participant_eligibility.determine_status
-      profile.ecf_participant_eligibility.save!
-    end
-
     @ect_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::ECT)
     @mentor_categories = service.call(school_cohort, induction_coordinator.user, ParticipantProfile::Mentor)
   end

--- a/spec/services/coc_set_participant_categories_spec.rb
+++ b/spec/services/coc_set_participant_categories_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         Induction::Enrol.call(participant_profile: profile, induction_programme: fip_programme)
       end
       fip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
-      fip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now, true)
+      fip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now, transferring_out: true)
       fip_another_school_claimed_participant.induction_records.first.leaving!(1.month.from_now)
       fip_transferred_participant.induction_records.first.leaving!(1.month.ago)
       fip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)
@@ -308,7 +308,7 @@ RSpec.describe CocSetParticipantCategories, with_feature_flags: { change_of_circ
         Induction::Enrol.call(participant_profile: profile, induction_programme: cip_programme)
       end
       cip_transferring_in_participant.induction_records.first.update!(start_date: 2.months.from_now, school_transfer: true)
-      cip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now, true)
+      cip_transferring_out_participant.induction_records.first.leaving!(1.month.from_now, transferring_out: true)
       cip_another_school_claimed_participant.induction_records.first.leaving!(1.month.from_now)
       cip_transferred_participant.induction_records.first.leaving!(1.month.ago)
       cip_transferred_withdrawn_participant.induction_records.first.leaving!(1.month.ago)


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-881)
When a SIT tells us a participant is leaving, they should still have a `current` induction record until their leaving date has passed.

Participants claimed by another school should be treated as active participants in their old school's dashboard until they have left the school.


### Changes proposed in this pull request
Fix the `InductionRecord.current` scope
Fix the `CocSetParticipantCategories` service to include the claimed participants with the active induction records.

### Guidance to review

