### PR TITLE
Intermittent Failure - Use correct updated_at for expected_json

### DIFF
--- a/spec/serializers/api/v1/participant_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_serializer_spec.rb
@@ -82,7 +82,7 @@ module Api
                   sparsity_uplift: ect_profile.sparsity_uplift,
                   training_status: ect_profile.training_status,
                   schedule_identifier: ect_profile.schedule.schedule_identifier,
-                  updated_at: ect_profile.updated_at.rfc3339,
+                  updated_at: ect_profile.user.updated_at.rfc3339,
                 },
               },
             }.to_json


### PR DESCRIPTION
### Context

The serializer was using the user and the expectation was using the profile. This lead to intermittent failures due to possible rounding differences between the two.



### Changes proposed in this pull request

Use the correct updated_at column

https://github.com/DFE-Digital/early-careers-framework/blob/develop/app/serializers/api/v1/participant_serializer.rb#L88