### PR TITLE
Fix cohort issue for NQT+1 check

### DIFF
--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -41,7 +41,8 @@ private
     return true if validation_data["induction"]["completion_date"].present?
     return false if validation_data["induction"]["start_date"].nil?
 
-    validation_data["induction"]["start_date"] < ActiveSupport::TimeZone["London"].local(Cohort.current.start_year, 9, 1)
+    # this should always be a check against 2021 not Cohort.current.start_year
+    validation_data["induction"]["start_date"] < ActiveSupport::TimeZone["London"].local(2021, 9, 1)
   end
 
   def check_first_name_only?

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
-      context "when the participant has an induction start date before September this year" do
+      context "when the participant has an induction start date before September 2021" do
         let(:induction_start_date) { Time.zone.parse("2021-08-31T22:59:59Z") }
         let(:induction_completion_date) { nil }
         let(:induction) do


### PR DESCRIPTION
### Context

The participant validation service was using `Cohort.current.start_year` in its check for a previous induction. This check is only meant to catch pre-Sept 2021 start dates and is now wrongly flagging participants as being NQT+1

### Changes proposed in this pull request

Fix the date being checked against to 1/9/2021

### Guidance to review

