### PR TITLE
Remove Percy from testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,6 @@ jobs:
       ANALYTICS_DB_PASSWORD: ''
       ANALYTICS_DB_HOSTNAME: 127.0.0.1
       ANALYTICS_DB_PORT: 5432
-      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-      PERCY_PARALLEL_NONCE: ${{ needs.create-nonce.outputs.nonce }}
-      PERCY_PARALLEL_TOTAL: 12
       CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       CI_NODE_INDEX: ${{ matrix.ci_node_index }}
 
@@ -74,7 +71,7 @@ jobs:
         run: bin/rails db:create db:schema:load
 
       - name: Run tests
-        run: yarn percy exec --parallel -- bundle exec bin/rspec_ci
+        run: bundle exec bin/rspec_ci
 
   e2e-scenarios:
     name: Run end to end scenarios
@@ -195,18 +192,12 @@ jobs:
       - name: Webpacker
         run: bin/webpacker
 
-      # Percy stuff is from https://dev.to/digitaledawn/github-action-cypress-and-percy-parallelisation-setup-484a
       - name: Run Cypress
         uses: cypress-io/github-action@v2
         with:
           start: bundle exec rails server -e test -p 5017
           wait-on: 'http://localhost:5017/'
-          command: npx percy exec --parallel -- ${{ github.workspace }}/bin/cypress_ci
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          COMMIT_INFO_BRANCH: ${{ github.head_ref }}
-          PERCY_PARALLEL_NONCE: ${{ needs.create-nonce.outputs.nonce }}
-          PERCY_PARALLEL_TOTAL: 12
+          command: ${{ github.workspace }}/bin/cypress_ci
 
   rspec_and_cypress_success:
     name: Rspec and Cypress success

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,4 +1,0 @@
-version: 2
-snapshot:
-  widths:
-    - 1280

--- a/Gemfile
+++ b/Gemfile
@@ -167,7 +167,6 @@ group :test do
   gem "capybara", "~> 3.37"
   gem "jsonapi-rspec"
   gem "launchy"
-  gem "percy-capybara"
   gem "pundit-matchers", "~> 1.7.0"
   gem "rails-controller-testing", "~> 1.0.5"
   gem "rspec-default_http_header", "~> 0.0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,8 +349,6 @@ GEM
       parallel
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    percy-capybara (5.0.0)
-      capybara (>= 3)
     pg (1.4.1)
     pretender (0.4.0)
       actionpack (>= 5.2)
@@ -676,7 +674,6 @@ DEPENDENCIES
   pagy (~> 5.10, >= 5.10.1)
   paper_trail
   parallel_tests
-  percy-capybara
   pg (~> 1.4)
   pretender (>= 0.4.0)
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Tests](https://github.com/DFE-Digital/early-careers-framework/workflows/Test/badge.svg)
-[![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/c72bbcf6/early-careers-framework)
 
 # Early careers framework
 
@@ -134,7 +133,7 @@ Please note: `--fail-fast` is recommended when running scenarios locally due to 
 
 ## End to end browser testing
 
-We use Cypress for end-to-end tests. This integrates with Axe for automated accessibility tests, and Percy for snapshot testing.
+We use Cypress for end-to-end tests. This integrates with Axe for automated accessibility tests.
 
 We aim to have an accessibility and snapshot test for every page on the service.
 

--- a/documentation/cypress_cucumber.md
+++ b/documentation/cypress_cucumber.md
@@ -69,7 +69,6 @@ Exceptions are for steps that aren't from the point of the user, such as:
 
 - `Given scenario "user_cip" has been run`
 - `Then the page should be accessible`
-- `Then percy should be sent snapshot`
 
 #### Reuse step definitions where possible
 
@@ -105,23 +104,14 @@ following in your spec:
 
 - `Given scenario "test_scenario" has been run`
 
-#### Visual and accessibility testing
+#### Accessibility testing
 
-We use [Percy] for visual testing and [cypress-axe] for basic automated
+We use [cypress-axe] for basic automated
 accessibility testing. Every time you add a test for a new page (or significant
 state change to an existing page), add the following lines to your spec:
 
 ```
 Then the page should be accessible
-And percy should be sent snapshot
-```
-
-Note that percy snapshot names should be unique. By default they take the name
-of the feature + scenario, but if you have more than one percy snapshot in the
-same test you'll need to give it a name manually:
-
-```
-And percy should be sent snapshot called "page name"
 ```
 
 When the accessibility tests fail, the error logged to the console won't say
@@ -169,5 +159,4 @@ the last scenario in a file, or comment out all the tests below it.
 [cypress-cucumber-preprocessor]: https://github.com/TheBrainFamily/cypress-cucumber-preprocessor
 [Gherkin syntax]: https://cucumber.io/docs/gherkin/reference/
 [Cypress best practices]: https://docs.cypress.io/guides/references/best-practices
-[Percy]: https://percy.io/
 [cypress-axe]: https://github.com/component-driven/cypress-axe

--- a/documentation/feature_testing.md
+++ b/documentation/feature_testing.md
@@ -6,7 +6,6 @@ The feature tests in this repository are written using the following gems:
 - [Page objects]
 - [Chromedriver]
 - [Axe]
-- [Percy]
 
 The feature tests are used to test service features and user journeys to avoid
 repetitive manual testing. They use Given-When-Then syntax so that they 
@@ -253,7 +252,6 @@ using active voice and first-person. for example;
 Exceptions are for steps that aren't from the point of the user, such as:
 
 - `and_the_page_is_accessible`
-- `and_percy_is_sent_a_snapshot_called "School Participant Dashboard"`
 
 The language of steps should be definite rather than speculative, so `Then I am on` 
 rather than `Then I should be on`.
@@ -274,29 +272,19 @@ definitions in the future.
 
 
 
-#### Visual and accessibility testing
+#### Accessibility testing
 
-We use [Percy] for visual testing and [Axe] for basic automated
+We use [Axe] for basic automated
 accessibility testing. Every time you add a test for a new page (or significant
 state change to an existing page), add the following lines to your spec:
 
 ```
 then_the_page_is_accessible
-and_percy_is_sent_a_snapshot
-```
-
-Note that percy snapshot names should be unique. By default they take the name
-of the feature, but if you have more than one percy snapshot in the
-same test you'll need to give it a name manually:
-
-```
-and_percy_is_sent_a_snapshot_called "unique screenshot description name"
 ```
 
 [Capybara]: http://teamcapybara.github.io/capybara/
 [Chromedriver]: https://github.com/titusfortner/webdrivers
 [Axe]: https://www.deque.com/axe/
-[Percy]: https://docs.percy.io/
 [Capybara cheatsheet]: https://devhints.io/capybara
 [Page objects]: https://github.com/site-prism/site_prism
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "whatwg-fetch": "^3.6.1"
   },
   "devDependencies": {
-    "@percy/cli": "^1.0.8",
-    "@percy/cypress": "^3.1.1",
     "axe-core": "^4.3.5",
     "cypress": "9.7.0",
     "cypress-axe": "^0.14.0",

--- a/spec/cypress/integration/accessibility.js
+++ b/spec/cypress/integration/accessibility.js
@@ -7,7 +7,6 @@ describe("Accessibility", () => {
   it("Login should be accessible", () => {
     cy.visit("/users/sign_in");
     cy.checkA11y();
-    cy.percySnapshot("Login page");
 
     // School not registered page
     cy.get('[name="user[email]"]').type("doesntexist@example.com{enter}");
@@ -27,7 +26,6 @@ describe("Accessibility", () => {
     cy.get('[type="submit"]').contains("Sign in").click();
     cy.titleShouldEqual("Check email");
     cy.checkA11y();
-    cy.percySnapshot("Check email page");
 
     cy.get("@userData").then(([user]) => {
       cy.verifySignInEmailSentToUser(user);
@@ -43,7 +41,6 @@ describe("Accessibility", () => {
         cy.visit(`/users/confirm_sign_in?login_token=${user.login_token}`);
       });
     cy.checkA11y();
-    cy.percySnapshot("Confirm sign in page");
 
     cy.get('[action="/users/sign_in_with_token"] [name="commit"]').click();
     cy.get("h1").should("contain", "You cannot use this service yet");
@@ -51,12 +48,10 @@ describe("Accessibility", () => {
 
     cy.logout();
     cy.checkA11y();
-    cy.percySnapshot("Logout page");
   });
 
   it("Login link invalid page should be accessible", () => {
     cy.visit("/users/link-invalid");
     cy.checkA11y();
-    cy.percySnapshot();
   });
 });

--- a/spec/cypress/integration/admin/AdminManagement.feature
+++ b/spec/cypress/integration/admin/AdminManagement.feature
@@ -10,14 +10,12 @@ Feature: Admin user modifying admin users
     When I click on "create admin button"
     Then I should be on "admin creation" page
     And the page should be accessible
-    And percy should be sent snapshot called "Admin creation page"
 
     When I type "John Smith" into "name input"
     And I type "j.smith@example.com" into "email input"
     And I click the submit button
     Then I should be on "admin confirm creation" page
     And the page should be accessible
-    And percy should be sent snapshot called "Admin confirm creation page"
     And "page body" should contain "John Smith"
     And "page body" should contain "j.smith@example.com"
 
@@ -34,13 +32,11 @@ Feature: Admin user modifying admin users
     When I click on "edit admin link" containing "Emma Dow"
     Then "page body" should contain "Edit user details"
     And the page should be accessible
-    And percy should be sent snapshot called "Edit admin page"
 
     When I click on "delete button"
     Then "page body" should contain "Do you want to delete this user?"
     And "page body" should contain "Admin user: Emma Dow"
     And the page should be accessible
-    And percy should be sent snapshot called "Delete admin page"
 
     When I click on "delete button"
     Then "page body" should not contain "Emma Dow"

--- a/spec/cypress/integration/admin/DeliveryPartnerManagement.feature
+++ b/spec/cypress/integration/admin/DeliveryPartnerManagement.feature
@@ -10,19 +10,16 @@ Feature: Admin user modifying delivery partners
     When I click on "create delivery partner button"
     Then I should be on "choose new delivery partner name" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose new deivery partner name page"
 
     When I type "New delivery partner" into "delivery partner name input"
     And I click the submit button
     Then I should be on "choose new delivery partner lead providers" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose new delivery partner lead providers page"
 
     When I click on "Lead Provider 1" label
     And I click the submit button
     Then I should be on "choose delivery partner cohorts" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose delivery partner cohorts page"
 
     When I click on "2021" label
     And I click the submit button
@@ -31,14 +28,12 @@ Feature: Admin user modifying delivery partners
     And "page body" should contain "Lead Provider 1"
     And "page body" should contain "2021"
     And the page should be accessible
-    And percy should be sent snapshot called "New delivery partner review page"
 
     When I click the submit button
     Then I should be on "delivery partner index" page
     And "page body" should contain "New delivery partner"
     And "notification banner" should contain "Delivery partner created"
     And the page should be accessible
-    And percy should be sent snapshot called "New delivery partner index page"
 
   Scenario: It should remember details when navigating backwards in creation process
     When I click on "create delivery partner button"
@@ -83,7 +78,6 @@ Feature: Admin user modifying delivery partners
     Then I should be on "delivery partner edit" page
     And "delivery partner name input" should have value "Delivery Partner 1"
     # And the page should be accessible
-    And percy should be sent snapshot called "Delivery partner edit page"
 
     When I clear "delivery partner name input"
     And I type "New delivery partner" into "delivery partner name input"
@@ -105,7 +99,6 @@ Feature: Admin user modifying delivery partners
     And I click on "delete button"
     Then I should be on "delivery partner delete" page
     And the page should be accessible
-    And percy should be sent snapshot called "Delivery partner delete page"
 
     When I click on "delete button"
     Then I should be on "delivery partner index" page

--- a/spec/cypress/integration/admin/InductionCoordinatorManagment.feature
+++ b/spec/cypress/integration/admin/InductionCoordinatorManagment.feature
@@ -16,7 +16,6 @@ Feature: Admin user creating induction tutor
     When I click on "link" containing "Add induction tutor"
     Then I should be on "new admin school induction coordinator" page
     And the page should be accessible
-    And percy should be sent snapshot called "Admin add induction coordinator page"
 
     Given user was created as "induction_coordinator" with email "existing_induction_coordinator@example.com" and full_name "Existing User"
     When I type "John Smith" into "name input"
@@ -24,7 +23,6 @@ Feature: Admin user creating induction tutor
     And I click the submit button
     Then "page body" should contain "The name you entered does not match our records"
     And the page should be accessible
-    And percy should be sent snapshot called "Admin add induction coordinator name different"
 
     When I click on "link" containing "Change name"
     And I type "John Smith" into "name input"
@@ -50,7 +48,6 @@ Feature: Admin user creating induction tutor
     When I click on "link" containing "Change"
     Then I should be on "choose replace or update induction tutor" page
     And the page should be accessible
-    And percy should be sent snapshot called "choose replace or update induction tutor"
 
     When I click on "update induction tutor" 
     And I click the submit button
@@ -58,7 +55,6 @@ Feature: Admin user creating induction tutor
     And "name input" should have value "Brenda Walsh"
     And "email input" should have value "brenda.walsh@school.org"
     And the page should be accessible
-    And percy should be sent snapshot called "update induction tutor"
 
     When I clear "name input"
     And I type "Brenda Jones" into "name input"

--- a/spec/cypress/integration/admin/LeadProviderUserManagement.feature
+++ b/spec/cypress/integration/admin/LeadProviderUserManagement.feature
@@ -11,28 +11,24 @@ Feature: Admin user modifying lead provider users
     When I click on "create supplier user button"
     Then I should be on "new lead provider user" page
     And the page should be accessible
-    And percy should be sent snapshot called "New lead provider user page"
 
     When I type "Lead" into "supplier name input"
     And I click on "autocomplete dropdown item" containing "Lead Provider 1"
     And I click the submit button
     Then I should be on "new lead provider user details" page
     And the page should be accessible
-    And percy should be sent snapshot called "New lead provider user details page"
 
     When I type "John Smith" into "name input"
     And I type "j.s@example.com" into "email input"
     And I click the submit button
     Then I should be on "new lead provider user review" page
     And the page should be accessible
-    And percy should be sent snapshot called "New lead provider user review page"
     And "page body" should contain "John Smith"
     And "page body" should contain "j.s@example.com"
 
     When I click the submit button
     Then I should be on "lead provider users index" page
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider users index page"
     And "page body" should contain "John Smith"
     And "page body" should contain "j.s@example.com"
     And "page body" should contain "Lead Provider 1"
@@ -68,7 +64,6 @@ Feature: Admin user modifying lead provider users
     And I click on "delete button"
     Then I should be on "lead provider user delete" page
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider user delete page"
     Then "page body" should contain "Do you want to delete this user?"
     And "page body" should contain "Supplier user: John Wick"
 

--- a/spec/cypress/integration/admin/ParticipantManagment.feature
+++ b/spec/cypress/integration/admin/ParticipantManagment.feature
@@ -10,7 +10,6 @@ Feature: Admin user managing participants
     Then the table should have 7 rows
     And "page body" should contain "Enter the participant’s name, school’s name or URN"
     And the page should be accessible
-    And percy should be sent snapshot
 
     When I type "Test school" into "search box"
     And I press enter in "search box"
@@ -26,12 +25,10 @@ Feature: Admin user managing participants
     Then I should be on "admin participant" page
     And "page body" should contain "DOB entered"
     And the page should be accessible
-    And percy should be sent snapshot called "NPQ participant admin profile"
 
     When I click on "link" containing "View identity confirmation"
     Then I should be on "admin participant identity" page
     And the page should be accessible
-    And percy should be sent snapshot called "NPQ participant admin empty identity validation"
 
     When I click the submit button
     Then "page body" should contain "can't be blank"

--- a/spec/cypress/integration/admin/SchoolManagment.feature
+++ b/spec/cypress/integration/admin/SchoolManagment.feature
@@ -25,13 +25,11 @@ Feature: Admin user managing schools
     And "page body" should contain "CIP Programme 1"
     And "page body" should contain "CIP Programme 2"
     And the page should be accessible
-    And percy should be sent snapshot
 
   Scenario: Viewing a list of schools
     Then the table should have 9 rows
     And "page body" should contain "Enter the school’s name, URN or tutor email"
     And the page should be accessible
-    And percy should be sent snapshot
 
     When I type "include" into "search box"
     And I press enter in "search box"

--- a/spec/cypress/integration/admin/ViewSchoolParticipants.feature
+++ b/spec/cypress/integration/admin/ViewSchoolParticipants.feature
@@ -12,7 +12,6 @@ Feature: Admin users viewing school participants
     Then "page body" should contain "ECT User 1"
     And "page body" should not contain "Unrelated user 1"
     Then the page should be accessible
-    And percy should be sent snapshot called "Admin school participants index page"
 
   Scenario: Admins should be able to click through to individual participants
     When I click on "link" containing "ECT User 1"
@@ -21,18 +20,15 @@ Feature: Admin users viewing school participants
 
     # Once there is more participants functionality this should be moved to there
     And the page should be accessible
-    And percy should be sent snapshot called "Admin view participant"
 
     # Move this to ParticipantManagement.feature once the links work
     When I click on "link" containing "Delete participant"
     Then I should be on "admin delete participant" page
     And the page should be accessible
-    And percy should be sent snapshot called "Admin delete participant"
 
     When I click the submit button
     Then "page body" should contain "has been deleted"
     And the page should be accessible
-    And percy should be sent snapshot called "Admin delete participant success"
 
     When I click on "link" containing "View participant listing"
     Then I should be on "admin participants" page

--- a/spec/cypress/integration/lead_providers/PartnershipGuidance.feature
+++ b/spec/cypress/integration/lead_providers/PartnershipGuidance.feature
@@ -2,11 +2,9 @@ Feature: Lead Providers Partnership Management
   Scenario: Visiting the Lead Providers landing page
     Given I am on "the Lead Provider landing page" page
     Then the page should be accessible
-    And percy should be sent snapshot
 
   Scenario: Learning how to manage partnerships
     Given I am on "the Lead Provider landing page" page
     When I click on "link" containing "Learn to manage ECF partnerships"
     Then I should be on "Partnership guidance" page
     And the page should be accessible
-    And percy should be sent snapshot

--- a/spec/cypress/integration/lead_providers/ReportSchools.feature
+++ b/spec/cypress/integration/lead_providers/ReportSchools.feature
@@ -12,7 +12,6 @@ Feature: Report Schools flow
     Then I should be on "lead providers report schools start" page
     And "page body" should contain "2022"
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider report schools start page"
 
   Scenario: Selecting a delivery partner and upload csv
     And I am on "lead providers report schools start" page
@@ -21,18 +20,15 @@ Feature: Report Schools flow
     And "page body" should contain "Choose the delivery partner"
     And "page body" should contain "Delivery Partner 1"
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider report schools choose delivery partner page"
     When I click on the delivery partner radio button
     And I click the submit button
     Then I should be on "partnership csv uploads" page
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider report schools upload csv page"
 
     When I add a school urn csv with errors to the file input
     And I click the submit button
     Then I should be on "csv errors" page
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider report schools csv error page"
 
     When I click on "input" containing "Continue"
     Then I should be on "confirm partnerships" page
@@ -45,7 +41,6 @@ Feature: Report Schools flow
     Then I should be on "confirm partnerships" page
     And the table should have 2 rows
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider report schools confirm"
 
     When I click on first "remove button"
     Then I should be on "confirm partnerships" page
@@ -55,4 +50,3 @@ Feature: Report Schools flow
     When I click on "input" containing "Confirm"
     Then I should be on "partnerships success" page
     And the page should be accessible
-    And percy should be sent snapshot called "Lead provider report schools success"

--- a/spec/cypress/integration/lead_providers/YourSchools.feature
+++ b/spec/cypress/integration/lead_providers/YourSchools.feature
@@ -18,7 +18,6 @@ Feature: Your schools flow
     And "page body" should contain "Middle School"
     And "page body" should contain "Small School"
     And the page should be accessible
-    And percy should be sent snapshot
 
     When I am on "dashboard" page
     And I click on "link" containing "Check your schools"
@@ -70,7 +69,6 @@ Feature: Your schools flow
     And "page body" should contain "Pupil premium above 40%"
     And "page body" should contain "induction.tutor_1@example.com"
     And the page should be accessible
-    And percy should be sent snapshot called "Lead providers school with pupil premium uplift details"
 
   Scenario: Viewing school with sparsity uplift
     When I click on "link" containing "Middle School"
@@ -81,7 +79,6 @@ Feature: Your schools flow
     And "page body" should contain "Remote school"
     And "page body" should contain "induction.tutor_2@example.com"
     And the page should be accessible
-    And percy should be sent snapshot called "Lead providers school with sparsity uplift details"
 
   Scenario: Viewing school with pupil premium and sparsity uplifts
     When I click on "link" containing "Small School"
@@ -92,4 +89,3 @@ Feature: Your schools flow
     And "page body" should contain "Pupil premium above 40% and Remote school"
     And "page body" should contain "induction.tutor_3@example.com"
     And the page should be accessible
-    And percy should be sent snapshot called "Lead providers school with pupil premium and sparsity uplift details"

--- a/spec/cypress/integration/nominations/ResendNominations.feature
+++ b/spec/cypress/integration/nominations/ResendNominations.feature
@@ -5,26 +5,22 @@ Feature: Resend nominations flow
     Given scenario "school_with_local_authority" has been run
     And I am on "resend nominations start" page
     Then the page should be accessible
-    And percy should be sent snapshot called "Resend nominations start page"
 
     When I click on "link" containing "Continue"
     Then I should be on "resend nominations choose location" page
     And the page should be accessible
-    And percy should be sent snapshot called "Resend nominations choose location page"
 
     When I type "test" into "location input"
     And I click on "autocomplete dropdown item" containing "Test"
     And I click the submit button
     Then I should be on "resend nominations choose school" page
     And the page should be accessible
-    And percy should be sent snapshot called "Resend nominations choose school page"
 
     When I type "test" into "school input"
     And I click on "autocomplete dropdown item" containing "Test"
     And I click the submit button
     Then I should be on "resend nominations review" page
     And the page should be accessible
-    And percy should be sent snapshot called "Resend nominations review page"
 
     # Clicking change school link should reset location input
     When I click on "change school link"
@@ -41,16 +37,13 @@ Feature: Resend nominations flow
     When I click the submit button
     Then I should be on "resend nominations success" page
     And the page should be accessible
-    And percy should be sent snapshot called "Resend nominations success page"
 
   Scenario: Failure pages should be accessible
     When I am on "resend nominations not eligible" page
     Then the page should be accessible
-    And percy should be sent snapshot called "Resend nominations not eligible page"
 
     When I am on "resend nominations already nominated" page
     Then the page should be accessible
-    And percy should be sent snapshot called "Resend nominations already nominated page"
 
   Scenario: Resending limits
     Given scenario "school_with_local_authority" has been run
@@ -66,4 +59,3 @@ Feature: Resend nominations flow
 
     Then I should be on "resend nominations limit reached" page
     Then the page should be accessible
-    And percy should be sent snapshot called "Resend nominations limit reached page"

--- a/spec/cypress/integration/schools/ChooseProgramme.feature
+++ b/spec/cypress/integration/schools/ChooseProgramme.feature
@@ -8,14 +8,12 @@ Feature: Induction tutors choosing programmes
     And I am logged in as an induction coordinator for created school
     Then I should be on "choose programme" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose training programme page"
 
   Scenario: Choosing Core Induction Programme
     When I click on "accredited materials" label
     And I click the submit button
     Then I should be on "choose programme confirm" page
     And the page should be accessible
-    And percy should be sent snapshot called "Confirm materials CIP page"
 
     When I click the submit button
     Then I should be on "have you appointed an appropriate body" page
@@ -24,26 +22,22 @@ Feature: Induction tutors choosing programmes
     And I click the submit button
     Then I should be on "choose programme success" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose materials success"
 
     When I click on "link" containing "Continue"
     Then I should be on "school cohorts" page
     And the page should be accessible
-    And percy should be sent snapshot called "CIP schools page"
 
     When I navigate to "choose programme" page with school_id "test-school" and cohort_id "2021"
     Then I should have been redirected to "school cohorts" page
     And the page should be accessible
     And "page body" should contain "Manage your training"
     And "page body" should contain "Add your early career teacher and mentor details"
-    And percy should be sent snapshot called "Manage your training page"
 
   Scenario: Choosing Full Induction Programme
     When I click on "training provider" label
     And I click the submit button
     Then I should be on "choose programme confirm" page
     And the page should be accessible
-    And percy should be sent snapshot called "Confirm materials FIP page"
 
     When I click the submit button
     Then I should be on "have you appointed an appropriate body" page
@@ -57,14 +51,12 @@ Feature: Induction tutors choosing programmes
     And the page should be accessible
     And "page body" should contain "Manage your training"
     And "page body" should contain "Add your early career teacher and mentor details"
-    And percy should be sent snapshot called "FIP schools page"
 
   Scenario: Choosing to design and deliver our own programme
     When I click on "design and deliver our own programme radio button"
     And I click the submit button
     Then I should be on "choose programme confirm" page
     And the page should be accessible
-    And percy should be sent snapshot called "Confirm materials DIY page"
 
     When I click the submit button
     Then I should be on "have you appointed an appropriate body" page
@@ -72,7 +64,6 @@ Feature: Induction tutors choosing programmes
     And I click the submit button
     Then I should be on "choose programme success" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose design and deliver success"
 
   Scenario: Choosing there are no early career teachers for this year
     When I click on "no early career teachers radio button"
@@ -80,9 +71,7 @@ Feature: Induction tutors choosing programmes
 
     Then I should be on "choose programme confirm" page
     And the page should be accessible
-    And percy should be sent snapshot called "Confirm materials no ECT page"
 
     When I click the submit button
     Then I should be on "choose programme success" page
     And the page should be accessible
-    And percy should be sent snapshot called "Choose no early career teachers success"

--- a/spec/cypress/integration/schools/ChooseProgrammeCIPOnly.feature
+++ b/spec/cypress/integration/schools/ChooseProgrammeCIPOnly.feature
@@ -11,7 +11,6 @@ Feature: Induction tutors choosing programmes - CIP only
     And I click the submit button
     Then I should be on "choose programme confirm" page
     And the page should be accessible
-    And percy should be sent snapshot called "Confirm school funded fip page"
 
     When I click the submit button
     Then I should be on "have you appointed an appropriate body" page
@@ -20,4 +19,3 @@ Feature: Induction tutors choosing programmes - CIP only
     And I click the submit button
     Then I should be on "choose programme success" page
     And the page should be accessible
-    And percy should be sent snapshot called "school funded fip success"

--- a/spec/cypress/integration/schools/ViewPartnerships.feature
+++ b/spec/cypress/integration/schools/ViewPartnerships.feature
@@ -10,7 +10,6 @@ Feature: Induction tutors viewing partnerships
     Then I should be on "2021 school partnerships" page
     And "page body" should contain "Signing up with a training provider"
     And the page should be accessible
-    And percy should be sent snapshot
 
   Scenario: View confirmed with provider page
     Given I am logged in as existing user with email "signed-up-provider@example.com"
@@ -20,4 +19,3 @@ Feature: Induction tutors viewing partnerships
     And "page body" should contain "Test delivery partner"
     And "page body" should contain "Test lead provider"
     And the page should be accessible
-    And percy should be sent snapshot

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -1,4 +1,3 @@
-import "@percy/cypress";
 import OnRails from "./on-rails";
 import "cypress-file-upload";
 

--- a/spec/cypress/support/step_definitions/misc.js
+++ b/spec/cypress/support/step_definitions/misc.js
@@ -4,14 +4,6 @@ Then("the page should be accessible", () => {
   cy.checkA11y();
 });
 
-Then("percy should be sent snapshot", () => {
-  cy.percySnapshot();
-});
-
-Then("percy should be sent snapshot called {string}", (name) => {
-  cy.percySnapshot(name);
-});
-
 Then("the Swagger documentation should be visible", () => {
   cy.get("section.models").should("be.visible");
 });

--- a/spec/features/accessibility_statement_page_spec.rb
+++ b/spec/features/accessibility_statement_page_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Accessibility statement page", type: :feature, js: true, rutabaga
   scenario "Accessibility statement is accessible" do
     given_i_am_on_the_accessibility_statement_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Accessibility statement page"
   end
 
   scenario "Reading the accessibility statement" do

--- a/spec/features/admin/schools/challenging_partnerships_spec.rb
+++ b/spec/features/admin/schools/challenging_partnerships_spec.rb
@@ -12,14 +12,12 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
 
     then_i_should_be_on the_challenge_partnership_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin challenge partnership page")
 
     when_i_select_mistake
     and_i_click_the_continue_button
     then_i_should_be_on the_confirm_page
     and_the_page_should_contain_lead_provider_name
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin confirm challenge partnership page")
 
     when_i_click_the_continue_button
     then_i_should_be_on the_school_cohorts_page

--- a/spec/features/admin/schools/changing_provision_spec.rb
+++ b/spec/features/admin/schools/changing_provision_spec.rb
@@ -10,13 +10,11 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
     and_i_click_the_link_containing "Change"
     then_i_should_be_on the_change_programme_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin choose programme page")
 
     when_i_select_cip
     and_i_click_the_continue_button
     then_i_should_be_on the_confirm_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin confirm programme page")
 
     when_i_click_the_continue_button
     then_i_should_be_on the_school_cohorts_page

--- a/spec/features/admin/schools/changing_training_materials_spec.rb
+++ b/spec/features/admin/schools/changing_training_materials_spec.rb
@@ -11,13 +11,11 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
     and_i_click_the_change_materials_link
     then_i_should_be_on the_change_materials_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin change materials page")
 
     when_i_select_ambition
     and_i_click_the_continue_button
     then_i_should_be_on the_confirm_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin confirm change materials page")
 
     when_i_click_the_continue_button
     then_i_should_be_on the_school_cohorts_page

--- a/spec/features/admin/schools/managing_2020_participants_spec.rb
+++ b/spec/features/admin/schools/managing_2020_participants_spec.rb
@@ -8,12 +8,10 @@ RSpec.feature "Admin managing 2020 participants", js: true, rutabaga: false do
     and_i_am_signed_in_as_an_admin
     when_i_visit the_school_2020_cohort_page
     then_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin NQT+1 listing page")
 
     when_i_click_the_link_containing "Add new"
     then_i_should_be_on the_add_nqt_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin add new NQT+1 page")
 
     when_i_fill_the_form_in
     and_i_click_the_save_button

--- a/spec/features/admin/schools/view_school_participants_spec.rb
+++ b/spec/features/admin/schools/view_school_participants_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature "Admin viewing participants", js: true, rutabaga: false do
     when_i_visit the_school_participants_page
     then_i_should_see_all_the_current_and_transferring_participants
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Admin school participants listing page")
   end
 
 private

--- a/spec/features/check_have_account_page_spec.rb
+++ b/spec/features/check_have_account_page_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Check you have an account page", type: :feature, js: true, rutaba
   scenario "Check you have an account page is accessible" do
     given_i_am_on_the_check_account_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Check you have an account page"
   end
 
   scenario "Visiting the Check you have an account page" do

--- a/spec/features/cookies_policy_page_spec.rb
+++ b/spec/features/cookies_policy_page_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature "Cookie policy page", type: :feature, js: true do
     given_i_am_on_the_cookie_policy_page
 
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Cookie policy page"
   end
 
   scenario "Reading the cookie policy" do
@@ -38,7 +37,6 @@ RSpec.feature "Cookie policy page", type: :feature, js: true do
 
     then_i_confirm_cookie_consent_is_given_on_the_cookie_policy_page
     and_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Cookie consent page"
   end
 
   scenario "Not consenting to the cookie policy" do
@@ -48,7 +46,6 @@ RSpec.feature "Cookie policy page", type: :feature, js: true do
 
     then_i_confirm_cookie_consent_is_not_given_on_the_cookie_policy_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Cookie dissent page"
   end
 
   scenario "Changing consent to the cookie policy" do

--- a/spec/features/error_pages_spec.rb
+++ b/spec/features/error_pages_spec.rb
@@ -6,18 +6,15 @@ RSpec.feature "Error pages", type: :feature, js: true, rutabaga: false do
   scenario "Page Not Found page is accessible" do
     given_i_am_on_the_page_not_found_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Page Not Found page"
   end
 
   scenario "Internal Server Error page is accessible" do
     given_i_am_on_the_internal_server_error_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Internal Server Error page"
   end
 
   scenario "Forbidden page is accessible" do
     given_i_am_on_the_forbidden_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Forbidden page"
   end
 end

--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -43,7 +43,6 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     then_i_should_see_correct_service_fee_payment_breakdown
     then_i_should_see_the_correct_total
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Course overview per lead provider")
 
     when_i_click_on_view_within_statement_summary
     then_i_see_voided_declarations
@@ -51,7 +50,6 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
     when_i_click_on_view_contract
     then_i_see_contract_information
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Contract information per NPQ lead provider")
   end
 
   def create_accepted_application(user, npq_course, npq_lead_provider)

--- a/spec/features/finance/payment_breakdown_spec.rb
+++ b/spec/features/finance/payment_breakdown_spec.rb
@@ -49,12 +49,10 @@ RSpec.feature "Finance users payment breakdowns", :with_default_schedules, type:
     and_voided_payable_declarations_are_submitted
     when_i_click_on_payment_breakdown_header
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named("Payment breakdown select programme")
 
     when_i_select_ecf
     and_i_click_the_continue_button
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named("Payment breakdown select ECF provider")
 
     when_i_select_a_provider
     and_i_click_the_continue_button

--- a/spec/features/inducation_nomination_spec.rb
+++ b/spec/features/inducation_nomination_spec.rb
@@ -34,7 +34,6 @@ RSpec.feature "Nominating tutors", :with_default_schedules, :js do
       expect(page).to have_css("h1", text: "The name you entered does not match our records")
 
       and_the_page_should_be_accessible
-      and_percy_should_be_sent_a_snapshot_named "Start nominations name different"
 
       click_on "Change the name"
 
@@ -47,7 +46,6 @@ RSpec.feature "Nominating tutors", :with_default_schedules, :js do
       expect(page).to have_css("h1", text: "The email address is being used by another school")
 
       and_the_page_should_be_accessible
-      and_percy_should_be_sent_a_snapshot_named "Start nominations email already used"
 
       click_on "Change email address"
 
@@ -74,7 +72,6 @@ RSpec.feature "Nominating tutors", :with_default_schedules, :js do
       expect(page).to have_css(".govuk-panel--confirmation", text: "Induction tutor nominated")
 
       and_the_page_should_be_accessible
-      and_percy_should_be_sent_a_snapshot_named "Start nominations email already used again"
 
       expect(SchoolMailer)
         .to have_received(:nomination_confirmation_email)

--- a/spec/features/induction_tutor_materials_pages_spec.rb
+++ b/spec/features/induction_tutor_materials_pages_spec.rb
@@ -8,42 +8,35 @@ RSpec.feature "Induction Tutor Materials", type: :feature, js: true, rutabaga: f
   scenario "Ambition Year One Induction Tutor materials are accessible" do
     given_i_am_on_the_ambition_year_one_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "ambition year one induction materials"
   end
 
   scenario "Ambition Year Two Induction Tutor materials are accessible" do
     given_i_am_on_the_ambition_year_two_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "ambition year two induction materials"
   end
 
   scenario "EDT Year One Induction Tutor materials are accessible" do
     given_i_am_on_the_edt_year_one_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "edt year one induction materials"
   end
 
   scenario "EDT Year Two Induction Tutor materials are accessible" do
     given_i_am_on_the_edt_year_two_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "edt year two induction materials"
   end
 
   scenario "Teach First Year One and Two Induction Tutor materials are accessible" do
     given_i_am_on_the_teach_first_year_one_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "teach first year one and two induction materials"
   end
 
   scenario "UCL Year One Induction Tutor materials are accessible" do
     given_i_am_on_the_ucl_year_one_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "ucl year one induction materials"
   end
 
   scenario "UCL Year Two Induction Tutor materials are accessible" do
     given_i_am_on_the_ucl_year_two_induction_tutor_materials_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "ucl year two induction materials"
   end
 end

--- a/spec/features/lead_providers/dashboard_page_spec.rb
+++ b/spec/features/lead_providers/dashboard_page_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
     and_i_confirm_lead_provider_name_on_the_lead_provider_dashboard lead_provider_name
 
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Lead Provider Dashboard"
   end
 
   scenario "Visiting the Lead provider dashboard" do

--- a/spec/features/nominations/choose_how_to_continue_spec.rb
+++ b/spec/features/nominations/choose_how_to_continue_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     when_i_click_the_link_to_nominate_a_sit
     then_i_should_be_on_the_choose_how_to_continue_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Select how to continue SIT nomination"
   end
 
   scenario "School expects ECTs to join in the current academic year" do
@@ -19,7 +18,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_on_the_start_nomination_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Start SIT nomination - yes"
   end
 
   scenario "School does not expect any early career teachers to join in the current academic year" do
@@ -27,7 +25,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_redirected_to_the_choice_saved_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Start SIT nomination - Opt out choice saved"
   end
 
   scenario "School does not know whether they will have an early career teachers join in the current academic year" do
@@ -35,6 +32,5 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_on_the_start_nomination_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Start SIT nomination - we do not know"
   end
 end

--- a/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
+++ b/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
@@ -11,18 +11,15 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     when_i_click_the_link_to_nominate_a_sit
     then_i_should_be_on_the_choose_how_to_continue_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Choose how to continue"
 
     when_i_select "yes"
     click_on "Continue"
     then_i_should_be_on_the_start_nomination_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Start SIT nomination"
 
     click_on "Continue"
     then_i_should_be_on_the_nominations_full_name_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Add SIT name"
 
     click_on "Continue"
     then_i_should_receive_a_full_name_error_message
@@ -31,7 +28,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_on_the_nominations_email_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Add SIT email"
 
     click_on "Continue"
     then_i_should_receive_a_blank_email_error_message
@@ -47,7 +43,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Confirm and nominate"
     then_i_should_be_on_the_nominate_sit_success_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Nominate SIT completed"
   end
 
   scenario "Expired nomination link was sent" do
@@ -56,7 +51,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     when_i_click_the_link_to_nominate_a_sit
     then_i_should_be_redirected_to_the_link_expired_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Nominate a SIT link expired"
   end
 
   scenario "Nomination Link was sent for which Induction Tutor was already nominated for the same school" do
@@ -64,7 +58,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     when_i_click_the_link_to_nominate_a_sit
     then_i_should_be_redirected_to_the_induction_tutor_already_nominated_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "SIT already nominated"
   end
 
   scenario "Nominating an induction tutor with name and email that do not match" do
@@ -72,13 +65,11 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     when_i_click_the_link_to_nominate_a_sit
     then_i_should_be_on_the_choose_how_to_continue_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "How to continue"
 
     when_i_select "yes"
     click_on "Continue"
     then_i_should_be_on_the_start_nomination_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Start school induction tutor nomination"
 
     click_on "Continue"
     then_i_should_be_on_the_nominations_full_name_page
@@ -87,13 +78,11 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_on_the_nominations_email_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "SIT email does not match name"
 
     when_i_fill_in_using_an_email_that_is_already_being_used
     click_on "Continue"
     then_i_should_be_redirected_to_name_different_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Different name page"
 
     click_on "Change the name"
     then_i_should_be_on_the_nominations_full_name_page
@@ -106,12 +95,10 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_on_the_check_details_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Check details"
 
     click_on "Confirm and nominate"
     then_i_should_be_on_the_nominate_sit_success_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Nominate SIT success"
   end
 
   scenario "Nominating an induction tutor with an email already in use by another school", :with_default_schedules do
@@ -133,7 +120,6 @@ RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
     click_on "Continue"
     then_i_should_be_on_the_email_already_used_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "SIT nomination - Email already in use"
 
     when_i_click "Change email address"
     then_i_should_be_on_the_nominations_full_name_page

--- a/spec/features/participants/participant_registration_start_page_spec.rb
+++ b/spec/features/participants/participant_registration_start_page_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature "Participant registration start page",
     given_i_am_on_the_participant_registration_start_page
 
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participants start registration landing page"
   end
 
   scenario "Participant can begin registration" do

--- a/spec/features/participants/participant_validation_spec.rb
+++ b/spec/features/participants/participant_validation_spec.rb
@@ -78,54 +78,43 @@ RSpec.feature "Participant validation journey",
     given_i_sign_in_as_the_user_with_the_full_name ect_full_name
     and_i_am_on_the_participant_registration_wizard
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: trn"
 
     when_i_add_teacher_reference_number_to_the_participant_registration_wizard "1234567"
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: dob"
 
     when_i_add_date_of_birth_to_the_participant_registration_wizard Date.new(1983, 2, 28)
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: no-match after trn"
 
     when_i_choose_add_your_national_insurance_number_on_the_participant_registration_wizard
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: nino"
 
     when_i_add_national_insurance_number_to_the_participant_registration_wizard "AB123456C"
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: no-match after trn and nino"
 
     when_i_choose_confirm_your_name_on_the_participant_registration_wizard
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: name changed"
 
     when_i_choose_last_name_has_changed_on_the_participant_registration_wizard
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: name"
 
     when_i_add_full_name_to_the_participant_registration_wizard "Correct Name"
     then_i_am_on_the_participant_registration_no_match_page
     and_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: no-match after trn, nino and name change"
 
     when_i_continue_on_the_participant_registration_no_match_page
     then_i_am_on_the_participant_registration_manual_check_required_page
     and_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Participant validation journey: manual check required"
   end
 
   scenario "Mentor validation journey without TRN is accessible" do
     given_i_sign_in_as_the_user_with_the_full_name mentor_full_name
     and_i_am_on_the_mentor_registration_wizard
     and_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Mentor validation journey: trn"
 
     when_i_confirm_do_not_have_trn_on_the_mentor_registration_wizard
 
     then_i_am_on_the_get_a_trn_page
     and_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Mentor validation journey: trn guidance"
   end
 
   scenario "Mentor validates their details with trn" do

--- a/spec/features/privacy_policy_page_spec.rb
+++ b/spec/features/privacy_policy_page_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "Privacy policy page", type: :feature, js: true, rutabaga: false d
   scenario "Privacy policy is accessible" do
     given_i_am_on_the_privacy_policy_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Privacy policy page"
   end
 
   scenario "Visiting the Privacy policy" do

--- a/spec/features/sandbox_landing_page_spec.rb
+++ b/spec/features/sandbox_landing_page_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Sandbox landing page", type: :feature, js: true, rutabaga: false 
   scenario "Sandbox landing page is accessible" do
     given_i_am_on_the_sandbox_landing_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Sandbox landing page"
   end
 
   scenario "Continuing as a Lead Provider" do

--- a/spec/features/schools/challenge_partnership_spec.rb
+++ b/spec/features/schools/challenge_partnership_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature "Reporting an error with a partnership", type: :feature, js: true,
 
       then_i_am_on_the_report_incorrect_partnership_page_with_token "abc1234"
       and_the_page_is_accessible
-      and_percy_is_sent_a_snapshot_named "challenge options"
     end
 
     scenario "Can challenge a partnership from an email link" do
@@ -29,7 +28,6 @@ RSpec.feature "Reporting an error with a partnership", type: :feature, js: true,
 
       then_i_am_on_the_report_incorrect_partnership_success_page
       and_the_page_is_accessible
-      and_percy_is_sent_a_snapshot_named "challenge success"
     end
 
     scenario "Cannot challenge a partnership twice from an email link" do
@@ -39,7 +37,6 @@ RSpec.feature "Reporting an error with a partnership", type: :feature, js: true,
 
       then_i_am_on_the_report_incorrect_partnership_already_challenged_page
       and_the_page_is_accessible
-      and_percy_is_sent_a_snapshot_named "already challenged"
     end
 
     scenario "Cannot challenge an expired challenge from an email link" do
@@ -49,7 +46,6 @@ RSpec.feature "Reporting an error with a partnership", type: :feature, js: true,
 
       then_i_am_on_the_report_incorrect_partnership_link_expired_page
       and_the_page_is_accessible
-      and_percy_is_sent_a_snapshot_named "challenge link expired"
     end
   end
 

--- a/spec/features/schools/change_sit/change_sit_spec.rb
+++ b/spec/features/schools/change_sit/change_sit_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "Change a school induction tutor (SIT) as a SIT", js: true do
     click_on "Change"
     then_i_should_be_on_the_change_sit_name_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "SIT adds new SITs name"
 
     click_on "Continue"
     then_i_should_receive_a_full_name_error_message
@@ -22,7 +21,6 @@ RSpec.describe "Change a school induction tutor (SIT) as a SIT", js: true do
     click_on "Continue"
     then_i_should_be_on_the_change_sit_email_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "SIT adds new SITs email"
 
     click_on "Continue"
     then_i_should_receive_a_blank_email_error_message
@@ -38,12 +36,10 @@ RSpec.describe "Change a school induction tutor (SIT) as a SIT", js: true do
     click_on "Accept and continue"
     then_i_should_be_on_confirm_sit_change_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Confirm new SIT details"
 
     click_on "Confirm and replace"
     then_i_should_be_on_the_nominate_sit_success_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Replace SIT completed"
 
     visit "/schools"
     then_i_should_have_been_signed_out_of_the_service

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -78,7 +78,6 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
     then_i_am_on_the_school_funded_fip_training_submitted_page
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "School funded fip training submitted"
     and_i_can_get_guidance_about_an_arrangement_with_a_training_provider_on_the_school_funded_fip_training_submitted_page
     and_i_can_email_cpd_for_help_on_the_school_funded_fip_training_submitted_page
 

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -112,43 +112,33 @@ RSpec.describe "Reporting participants with a known TRN",
     given_i_sign_in_as_the_user_with_the_full_name "Fip induction tutor"
     when_i_view_participant_details_on_the_school_dashboard_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "ECF roles information"
 
     when_i_choose_to_add_an_ect_or_mentor_on_the_school_participants_dashboard_page
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor adds ECT and mentors"
 
     and_i_choose_to_add_a_new_ect_on_the_school_add_participant_wizard
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor adds ECT name"
 
     when_i_add_full_name_to_the_school_add_participant_wizard participant_data[:full_name]
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor adds ECT do you know teachers TRN"
 
     when_i_add_teacher_reference_number_to_the_school_add_participant_wizard participant_data[:full_name], participant_data[:trn]
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor adds ECT date of birth"
 
     when_i_add_date_of_birth_to_the_school_add_participant_wizard participant_data[:date_of_birth]
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor adds ECT email"
 
     when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email]
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor selects ECT induction start date"
 
     when_i_add_start_date_to_the_school_add_participant_wizard participant_data[:start_date]
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor selects ECTs mentor"
 
     when_i_choose_a_mentor_from_the_school_add_participant_wizard "Billy Mentor"
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor checks ECT details"
 
     when_i_confirm_and_add_on_the_school_add_participant_wizard
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor receives add ECT Confirmation"
 
     then_i_am_on_the_school_add_participant_completed_page
     and_i_confirm_has_full_name_on_the_school_add_participant_completed_page participant_data[:full_name]
@@ -162,7 +152,6 @@ RSpec.describe "Reporting participants with a known TRN",
     when_i_choose_to_add_an_ect_or_mentor_from_the_school_participants_dashboard_page
     and_i_choose_to_add_a_new_mentor_on_the_school_add_participant_wizard
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor adds mentor name"
 
     when_i_add_full_name_to_the_school_add_participant_wizard participant_data[:full_name]
     when_i_add_teacher_reference_number_to_the_school_add_participant_wizard participant_data[:full_name], participant_data[:trn]
@@ -170,11 +159,9 @@ RSpec.describe "Reporting participants with a known TRN",
 
     when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email]
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor checks mentor details"
 
     when_i_confirm_and_add_on_the_school_add_participant_wizard
     then_the_page_is_accessible
-    then_percy_is_sent_a_snapshot_named "Induction tutor receives add mentor Confirmation"
 
     then_i_am_on_the_school_add_participant_completed_page
     and_i_confirm_has_full_name_on_the_school_add_participant_completed_page participant_data[:full_name]

--- a/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/happy_path_sit_adds_self_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/happy_path_sit_adds_self_as_mentor_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     when_i_click_on_add_myself_as_mentor
     then_i_am_taken_to_are_you_sure_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor check"
 
     when_i_click_on_check_what_each_role_needs_to_do
     then_i_am_taken_to_roles_page
@@ -50,6 +49,5 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     when_i_sign_back_in
     then_i_am_taken_to_fip_induction_dashboard
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor confirmation"
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/unhappy_path_sit_adds_themselves_as_mentor.rb
+++ b/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/unhappy_path_sit_adds_themselves_as_mentor.rb
@@ -25,7 +25,6 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     when_i_click_on_add_myself_as_mentor
     then_i_am_taken_to_are_you_sure_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor check"
 
     when_i_click_on_check_what_each_role_needs_to_do
     then_i_am_taken_to_roles_page
@@ -50,6 +49,5 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     when_i_sign_back_in
     then_i_should_be_asked_to_validate
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor add yourself as mentor confirmation"
   end
 end

--- a/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
     then_i_am_on_the_school_add_participant_still_cannot_find_their_details_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor still cannot validate a participant with their nino"
     then_i_cant_add_participant_on_the_school_add_participant_still_cannot_find_their_details_page
     then_i_can_view_my_etcs_and_mentors_on_the_school_add_participant_still_cannot_find_their_details_page
   end
@@ -48,7 +47,6 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
     then_i_am_on_the_school_add_participant_still_cannot_find_their_details_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor still cannot validate a participant with their nino"
     then_i_cant_add_participant_on_the_school_add_participant_still_cannot_find_their_details_page
     then_i_can_view_my_etcs_and_mentors_on_the_school_add_participant_still_cannot_find_their_details_page
   end

--- a/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_email_taken_spec.rb
@@ -47,6 +47,5 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     when_i_click_on_continue
     then_i_am_taken_to_email_already_taken_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor receives the email taken page"
   end
 end

--- a/spec/features/schools/participants/remove_from_cohort_spec.rb
+++ b/spec/features/schools/participants/remove_from_cohort_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe "SIT removing participants from the cohort", js: true, with_featu
       .to have_content("Confirm you want to remove #{mentor_profile.user.full_name}")
       .and be_accessible
 
-    page.percy_snapshot("Confirm participant removal")
-
     expect { click_on "Confirm and remove" }
       .to change { mentor_profile.reload.status }.from("active").to("withdrawn")
       .and change { ect_profile.reload.mentor_profile }.from(mentor_profile).to(nil)
@@ -47,8 +45,6 @@ RSpec.describe "SIT removing participants from the cohort", js: true, with_featu
     expect(page)
       .to have_content("#{mentor_profile.user.full_name} has been removed from this cohort")
       .and be_accessible
-
-    page.percy_snapshot("Induction coordinator removing participant")
 
     click_on "Return to your ECTs and mentors"
     expect(page).to have_no_content mentor_profile.user.full_name

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -55,14 +55,12 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
         then_i_should_be_taken_to_the_teachers_current_programme_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - teachers current programme"
 
         when_i_select "No"
         click_on "Continue"
 
         then_i_should_be_taken_to_the_schools_current_programme_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - schools current programme"
 
         when_i_select "Yes"
         click_on "Continue"

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -21,18 +21,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         when_i_click_to_add_an_ect_or_mentor
         then_i_should_be_on_the_who_to_add_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - who to add"
 
         when_i_select_transfer_teacher_option
         click_on "Continue"
         then_i_should_be_on_what_we_need_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - what we need"
 
         click_on "Continue"
         then_i_should_be_on_full_name_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - full name"
 
         click_on "Continue"
         then_i_receive_a_missing_name_error_message
@@ -41,7 +38,6 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         click_on "Continue"
         then_i_should_be_on_trn_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - trn"
 
         click_on "Continue"
         then_i_should_see_a_enter_trn_error_message
@@ -54,7 +50,6 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         click_on "Continue"
         then_i_should_be_on_the_date_of_birth_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - dob"
 
         click_on "Continue"
         then_i_should_see_enter_date_of_birth_error_message
@@ -68,7 +63,6 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
         then_i_should_be_on_the_teacher_start_date_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - teacher start date"
 
         click_on "Continue"
         then_i_should_see_enter_start_date_error_message
@@ -85,7 +79,6 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
         then_i_should_be_on_the_add_email_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - email"
 
         click_on "Continue"
         then_i_should_see_blank_email_date_error_message
@@ -98,7 +91,6 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         click_on "Continue"
         then_i_should_be_on_the_select_mentor_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - select mentor"
         and_it_should_list_the_schools_mentors
 
         click_on "Continue"
@@ -109,12 +101,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
         then_i_should_be_taken_to_the_check_your_answers_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - check answers"
 
         click_on "Confirm and add"
         then_i_should_be_on_the_complete_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - transfer complete"
         and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
         and_the_schools_current_provider_is_notified_with(:provider_existing_school_transfer_notification)
 

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -40,12 +40,10 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
         then_i_should_be_taken_to_the_cannot_find_their_details
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - cannot find their details"
         click_on "Confirm and continue"
 
         then_i_should_be_taken_to_the_cannot_add_page
         then_the_page_should_be_accessible
-        then_percy_should_be_sent_a_snapshot_named "Transfer journey - cannot add"
       end
 
       # given

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe "Update participants details", js: true do
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     then_i_am_taken_to_add_mentor_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor chooses mentor for ECT"
 
     when_i_choose_a_mentor
     when_i_click_on_continue
@@ -80,13 +79,11 @@ RSpec.describe "Update participants details", js: true do
     click_on "Not training"
     then_it_should_show_the_withdrawn_participant
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Withdrawn participant shown on dashboard"
 
     when_i_click_on_the_participants_name "Sally Teacher"
     then_i_am_taken_to_view_details_page
     and_it_should_not_allow_a_sit_to_edit_the_participant_details
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Participant details without change links"
   end
 
   scenario "Induction tutor can't change ECT / mentor name or email for a participant contacted for info" do
@@ -98,18 +95,15 @@ RSpec.describe "Update participants details", js: true do
     given_the_ect_has_been_validated
     when_i_view_ects_from_the_school_participants_dashboard_page "Sally Teacher"
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor sees ECT profile"
 
     when_i_click_on_change_name
     then_i_am_on_the_reason_to_change_school_participant_name_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Why do you need to edit ect name"
     and_i_confirm_the_participant_on_the_reason_to_change_school_participant_name_page_with_name "Sally Teacher"
 
     when_i_choose_they_have_changed_their_name_from_the_reason_to_change_school_participant_name_page
     then_i_am_on_the_edit_school_participant_name_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor edits the name of a participant"
     and_i_confirm_the_participant_on_the_edit_school_participant_name_page_with_name "Sally Teacher"
 
     when_i_set_a_blank_name_on_the_edit_school_participant_name_page
@@ -118,7 +112,6 @@ RSpec.describe "Update participants details", js: true do
     when_i_set_the_name_on_the_edit_school_participant_name_page_with_new_name "Jane Teacher"
     then_i_see_a_confirmation_message_on_the_school_participant_name_updated_page_with_old_name_and_new_name "Sally Teacher", "Jane Teacher"
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor completed the change of a participant's name"
 
     when_i_return_to_the_participant_profile_from_the_school_participant_name_updated_page
     then_i_confirm_the_participant_on_the_school_participant_details_page_with_name "Sally Teacher"
@@ -146,7 +139,6 @@ RSpec.describe "Update participants details", js: true do
     when_i_choose_should_not_be_registered_from_the_reason_to_change_school_participant_name_page
     then_i_cant_edit_the_participant_name_on_the_school_participant_should_not_have_been_registered_page "Sally Teacher"
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor can't edit the name of a participant because they should not have been registered"
   end
 
   scenario "Induction tutor can't replace an ECT / mentor by changing their name in participant profile page" do
@@ -156,7 +148,6 @@ RSpec.describe "Update participants details", js: true do
     when_i_choose_replaced_by_a_different_person_from_the_reason_to_change_school_participant_name_page
     then_i_cant_edit_the_participant_name_on_the_school_participant_replaced_by_a_different_person_page "Sally Teacher"
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor can't replace a participant's name with that of a different person"
     then_i_can_add_a_participant_from_the_school_participant_replaced_by_a_different_person_page "ECT"
   end
 
@@ -166,7 +157,6 @@ RSpec.describe "Update participants details", js: true do
     when_i_click_on_change_email
     then_i_am_on_the_edit_school_participant_email_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor edits the email of a participant"
     and_i_confirm_the_participant_on_the_edit_school_participant_email_page_with_name "Sally Teacher"
 
     when_i_set_a_blank_email_on_the_edit_school_participant_email_page
@@ -178,7 +168,6 @@ RSpec.describe "Update participants details", js: true do
     when_i_set_the_email_on_the_edit_school_participant_email_page_with_new_email "jane@school.com"
     then_i_see_a_confirmation_message_on_the_school_participant_email_updated_page_with_name "Sally Teacher"
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Induction tutor completed the change of a participant's email"
 
     when_i_return_to_the_participant_profile_from_the_school_participant_email_updated_page
     then_i_confirm_the_participant_on_the_school_participant_details_page_with_name "Sally Teacher"

--- a/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_cip_training_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Manage CIP training", js: true do
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_am_taken_to_cip_induction_dashboard
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "CIP induction dashboard without materials"
 
     when_i_click_on_add_your_early_career_teacher_and_mentor_details
     then_i_am_taken_to_roles_page
@@ -20,7 +19,6 @@ RSpec.describe "Manage CIP training", js: true do
     when_i_click_on_view_details
     then_i_am_taken_to_cip_programme_choice_info_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "CIP programme info"
   end
 
   scenario "CIP Induction Mentor with materials chosen" do
@@ -32,14 +30,12 @@ RSpec.describe "Manage CIP training", js: true do
     when_i_click_on_continue
     then_i_am_taken_to_course_choice_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Course choice"
 
     when_i_choose_materials
     when_i_click_on_continue
     when_i_visit_manage_training_dashboard
     then_i_can_view_the_added_materials
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "CIP induction dashboard with materials"
   end
 
   scenario "CIP Induction Mentor who has not added ECT or mentors" do
@@ -62,8 +58,7 @@ RSpec.describe "Manage CIP training", js: true do
     and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
                                                         "Deliver your own programme using DfE accredited materials",
                                                         "We do not expect any early career teachers to join"],
-                                               choice: "Deliver your own programme using DfE accredited materials",
-                                               snapshot: "Design Our Own - change programme options")
+                                               choice: "Deliver your own programme using DfE accredited materials")
 
     expect(page).to have_text "You’ve submitted your training information"
   end

--- a/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_design_our_own_training_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Manage Design Our Own training", js: true do
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_view_the_design_our_own_induction_dashboard
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Design Our Own dashboard"
   end
 
   scenario "Change induction programme to Design Your Own" do
@@ -21,8 +20,7 @@ RSpec.describe "Manage Design Our Own training", js: true do
     and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
                                                         "Deliver your own programme using DfE accredited materials"],
 
-                                               choice: "Design and deliver your own programme based on the Early Career Framework (ECF)",
-                                               snapshot: "Design Your Own - change programme")
+                                               choice: "Design and deliver your own programme based on the Early Career Framework (ECF)")
 
     expect(page).to have_text "You’ve submitted your training information"
   end

--- a/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_fip_training_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021,
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_am_taken_to_fip_induction_dashboard
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "FIP dashboard with partnership"
 
     when_i_click_on_add_your_early_career_teacher_and_mentor_details
     then_i_am_taken_to_roles_page
@@ -20,7 +19,6 @@ RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021,
     when_i_click_on_view_details
     then_i_am_taken_to_fip_programme_choice_info_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "FIP programme info"
   end
 
   scenario "FIP Induction Coordinator without training provider" do
@@ -28,12 +26,10 @@ RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021,
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_view_the_fip_induction_dashboard_without_partnership_details
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "FIP dashboard without partnership"
 
     when_i_click_on_sign_up
     then_i_am_taken_to_sign_up_to_training_provider_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "Sign up to training provider"
   end
 
   scenario "Change induction programme to FIP" do
@@ -42,8 +38,7 @@ RSpec.describe "Manage FIP training", js: true, travel_to: Time.zone.local(2021,
     then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
     and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
                                                         "Deliver your own programme using DfE accredited materials"],
-                                               choice: "Use a training provider, funded by the DfE",
-                                               snapshot: "FIP - change programme options")
+                                               choice: "Use a training provider, funded by the DfE")
 
     expect(page).to have_text "You’ve submitted your training information"
   end

--- a/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_no_ect_training_spec.rb
@@ -11,12 +11,10 @@ RSpec.describe "Manage No ECT training", js: true do
     and_i_am_signed_in_as_an_induction_coordinator
     then_i_can_view_the_no_ect_induction_dashboard
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "No ECT dashboard"
 
     when_i_click_on_change_programme
     then_i_am_taken_to_change_how_you_run_programme_page
     then_the_page_should_be_accessible
-    then_percy_should_be_sent_a_snapshot_named "No ECT training info"
   end
 
   scenario "Change induction programme to No ECTs" do
@@ -25,8 +23,7 @@ RSpec.describe "Manage No ECT training", js: true do
     then_i_should_see_the_program_and_click_to_change_it(program_label: "Design and deliver your own programme")
     and_see_the_other_programs_before_choosing(labels: ["Use a training provider, funded by the DfE",
                                                         "Deliver your own programme using DfE accredited materials"],
-                                               choice: "We do not expect any early career teachers to join",
-                                               snapshot: "Design Your Own - change programme options")
+                                               choice: "We do not expect any early career teachers to join")
 
     expect(page).to have_text "You’ve submitted your training information"
   end

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
     then_i_am_on_schools_page
     and_i_should_see_multiple_schools
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "Induction Coordinator Select School"
 
     given_i_click_on_test_school_1
     then_i_should_be_on_school_cohorts_1_page
@@ -27,7 +26,6 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
     then_i_should_be_on_school_cohorts_2_page
     and_i_should_see_school_2_data
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named "School Cohorts with Breadcrumbs"
   end
 
   context "Multiple cohorts when the new cohort is open for registrations", with_feature_flags: { multiple_cohorts: "active" }, travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0) do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -332,7 +332,7 @@ module ManageTrainingSteps
     sign_in_as induction_coordinator
   end
 
-  def and_see_the_other_programs_before_choosing(labels:, choice:, snapshot:)
+  def and_see_the_other_programs_before_choosing(labels:, choice:)
     expect(page).to have_text "Change how you run your training programme"
     expect(page).to be_accessible
     click_on "Check the other options available"
@@ -340,7 +340,6 @@ module ManageTrainingSteps
     expect(page).to have_text "How do you want to run your training"
     labels.each { |label| expect(page).to have_selector(:label, text: label) }
     expect(page).to be_accessible
-    page.percy_snapshot(snapshot)
 
     choose choice
     click_on "Continue"

--- a/spec/features/schools/year_2020_spec.rb
+++ b/spec/features/schools/year_2020_spec.rb
@@ -8,24 +8,20 @@ RSpec.describe "School leaders adding 2020 participants", :with_default_schedule
   scenario "Adding a 2020 participant" do
     when_i_visit start_schools_year_2020_path(school_id: school.slug)
     then_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 start page")
 
     click_on "Choose a provider"
     then_i_should_be_on choose_core_induction_programme_schools_year_2020_path(school_id: school.slug)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 CIP Choice page")
 
     when_i_select "Awesome induction course"
     and_i_click_the_continue_button
     then_i_should_be_on add_teacher_schools_year_2020_path(school_id: school.slug)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 add teacher page")
 
     when_i_add_first_teacher_details
     and_i_click_the_continue_button
     then_i_should_be_on check_your_answers_schools_year_2020_path(school_id: school.slug)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 check your answers page")
 
     click_on "Add another teacher"
     then_i_should_be_on add_teacher_schools_year_2020_path(school_id: school.slug)
@@ -34,34 +30,28 @@ RSpec.describe "School leaders adding 2020 participants", :with_default_schedule
     and_i_click_the_continue_button
     then_i_should_be_on check_your_answers_schools_year_2020_path(school_id: school.slug)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 check your answers page with two teachers")
 
     click_on "Change personal details", match: :first
     then_i_should_be_on edit_teacher_schools_year_2020_path(school_id: school.slug, index: 1)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 edit teacher")
 
     fill_in "Full name", with: "James Bond 2"
     and_i_click_the_continue_button
     then_i_should_be_on check_your_answers_schools_year_2020_path(school_id: school.slug)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 check your answers page with two teachers edited")
 
     click_on "Delete", match: :first
     then_i_should_be_on remove_teacher_schools_year_2020_path(school_id: school.slug, index: 1)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 remove teacher")
 
     click_button "Delete", class: "govuk-button", type: "submit"
     then_i_should_be_on check_your_answers_schools_year_2020_path(school_id: school.slug)
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 check your answers page with a deleted teacher")
 
     click_button "Confirm", class: "govuk-button", type: "submit"
     then_there_should_be_a_success_panel
     and_a_confirmation_email_should_be_sent
     and_the_page_should_be_accessible
-    and_percy_should_be_sent_a_snapshot_named("Year 2020 ect participant added")
   end
 
   def when_i_add_first_teacher_details

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Start user journey", type: :feature, js: true, rutabaga: false do
   scenario "Start page is accessible" do
     given_i_am_on_the_start_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Start page"
   end
 
   scenario "Root URL should be the Start page" do

--- a/spec/features/user_research_pages_spec.rb
+++ b/spec/features/user_research_pages_spec.rb
@@ -6,18 +6,15 @@ RSpec.feature "User research pages", js: true, rutabaga: false do
   scenario "Viewing the page as a mentor" do
     given_i_am_on_the_user_research_page_with_mentor true
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Mentor user research page"
   end
 
   scenario "Viewing the page as an ECT" do
     given_i_am_on_the_user_research_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "ECT user research page"
   end
 
   scenario "Viewing the page when the sessions are fully booked" do
     given_i_am_on_the_user_research_page
     then_the_page_is_accessible
-    and_percy_is_sent_a_snapshot_named "Fully booked user research page"
   end
 end

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -4,7 +4,6 @@ require "capybara"
 require "capybara/rspec"
 require "axe-rspec"
 require "webdrivers/chromedriver"
-require "percy/capybara"
 require "site_prism"
 require "site_prism/all_there" # Optional but needed to perform more complex matching
 
@@ -23,7 +22,7 @@ Capybara.javascript_driver = :chrome_headless
 Capybara.automatic_label_click = true
 
 RSpec.configure do |config|
-  config.include AxeAndPercyHelper, type: :feature
+  config.include AxeHelper, type: :feature
   config.include FeatureFlagHelper, type: :feature
   config.include InteractionHelper, type: :feature
   config.include PageAssertionsHelper, type: :feature
@@ -31,7 +30,7 @@ RSpec.configure do |config|
 
   config.include Steps::GenericPageObjectSteps, type: :feature
 
-  # need this for percy and axe
+  # need this for axe
   config.before(:each, type: :feature) do
     WebMock.disable_net_connect!(allow_localhost: true,
                                  allow: "chromedriver.storage.googleapis.com")

--- a/spec/support/features/axe_helper.rb
+++ b/spec/support/features/axe_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AxeAndPercyHelper
+module AxeHelper
   extend RSpec::Matchers::DSL
 
   define :be_accessible do
@@ -13,24 +13,9 @@ module AxeAndPercyHelper
     expect(page).to be_accessible
   end
 
-  def and_percy_is_sent_a_snapshot_named(name)
-    page.percy_snapshot(name)
-  end
-
   alias_method :then_the_page_is_accessible, :and_the_page_is_accessible
-  alias_method :then_percy_is_sent_a_snapshot_named, :and_percy_is_sent_a_snapshot_named
 
   # TODO: old speculative syntax to be removed
   alias_method :and_the_page_should_be_accessible, :then_the_page_is_accessible
   alias_method :then_the_page_should_be_accessible, :then_the_page_is_accessible
-  alias_method :and_percy_should_be_sent_a_snapshot_named, :then_percy_is_sent_a_snapshot_named
-  alias_method :then_percy_should_be_sent_a_snapshot_named, :then_percy_is_sent_a_snapshot_named
-
-  module SilentPercy
-    def log(*)
-      super if ENV["PERCY_TOKEN"]
-    end
-
-    ::Capybara::Session.include(self)
-  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,161 +1102,6 @@
   resolved "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@nodelib/fs.scandir@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
-  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
-  dependencies:
-    "@nodelib/fs.stat" "2.0.5"
-    run-parallel "^1.1.9"
-
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.5"
-  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
-  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.walk@^1.2.3":
-  version "1.2.8"
-  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
-  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
-  dependencies:
-    "@nodelib/fs.scandir" "2.1.5"
-    fastq "^1.6.0"
-
-"@percy/cli-build@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.8.tgz"
-  integrity sha512-taCq+2s8aa6q2IiiMXC49f+3keepgXCFNEGQBdlozFOe8hTFWkvYvsoFEBCMlfoWOUEbG/ZZx/bqexPPfiFt7Q==
-  dependencies:
-    "@percy/cli-command" "1.0.8"
-
-"@percy/cli-command@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.8.tgz"
-  integrity sha512-xbq9aIGGFs74K/Xwa21O/QUP9U7Q9OfbOmyuZeJLMtQZiDcyCijFWqIa18JsSGiUcsdWVR2tC5ORxsg6vrvZzQ==
-  dependencies:
-    "@percy/config" "1.0.8"
-    "@percy/core" "1.0.8"
-    "@percy/logger" "1.0.8"
-
-"@percy/cli-config@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.8.tgz"
-  integrity sha512-ydIexY5H4+usvbPb99ADrcKczDJi10rhluBHPU9h91NYgCQ7IximsALzJpv/lQVYN2tmPDY5EcbSso0vFSVS1g==
-  dependencies:
-    "@percy/cli-command" "1.0.8"
-
-"@percy/cli-exec@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.8.tgz"
-  integrity sha512-jmGQh19X8wkcamLhX2uagbqqgH/BubEwdzx6d5aADPM4yeBfKfd6iYol+HTvqWbKP1gqVN7vwBlOD6GABR+8qQ==
-  dependencies:
-    "@percy/cli-command" "1.0.8"
-    cross-spawn "^7.0.3"
-    which "^2.0.2"
-
-"@percy/cli-snapshot@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.8.tgz"
-  integrity sha512-GborzpMqGnZFi+ljTgM75X7RG9jTHc5gIA06+fX4qmf8MtZ+tqfcI/nCiXfovAnBWPQA0Tkn3gt0dXE1Jhd9ng==
-  dependencies:
-    "@percy/cli-command" "1.0.8"
-    yaml "^2.0.0"
-
-"@percy/cli-upload@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.8.tgz"
-  integrity sha512-gsP1QI5obB91BFUwr2/jrDyNl0QaTHIPYKAu3qiQlBEcy08/PE6sLFPc76Xf8wAcxu2kgLFpa0/SED7FarzlAQ==
-  dependencies:
-    "@percy/cli-command" "1.0.8"
-    fast-glob "^3.2.11"
-    image-size "^1.0.0"
-
-"@percy/cli@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/cli/-/cli-1.0.8.tgz"
-  integrity sha512-5c8DitDuAV261MjJTbJ9W0+5TYHP1BChdGbb/poRjodKVyKMu/Bb3uAEffHvHah91PNKFByNjRZwfufka1kiPg==
-  dependencies:
-    "@percy/cli-build" "1.0.8"
-    "@percy/cli-command" "1.0.8"
-    "@percy/cli-config" "1.0.8"
-    "@percy/cli-exec" "1.0.8"
-    "@percy/cli-snapshot" "1.0.8"
-    "@percy/cli-upload" "1.0.8"
-    "@percy/client" "1.0.8"
-    "@percy/logger" "1.0.8"
-
-"@percy/client@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/client/-/client-1.0.8.tgz"
-  integrity sha512-k4a46azsVDUQQDClP9dY4fmS5G71kWcOdHJMUQCayWM3hzJto9f+fA+K1BDUxFNzkLlPkXJ0D/oak18H2KcggA==
-  dependencies:
-    "@percy/env" "1.0.8"
-    "@percy/logger" "1.0.8"
-
-"@percy/config@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/config/-/config-1.0.8.tgz"
-  integrity sha512-WufbOoxl2q/Gti+IGeG3qjUL/Poa4vLe5G/+kkL0naXHN51AfoPoTdC8PszIDbm7mnh+3x6FCkyy5eb0dKt9tA==
-  dependencies:
-    "@percy/logger" "1.0.8"
-    ajv "^8.6.2"
-    cosmiconfig "^7.0.0"
-    yaml "^2.0.0"
-
-"@percy/core@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/core/-/core-1.0.8.tgz"
-  integrity sha512-ari1d0mMDHopS85q9fmkWg3utJSYGm4SWuZz+ERIrcsbhMkSjwazsVoGPgDdl5+D1caPplIbH+DjRgl3nsm23w==
-  dependencies:
-    "@percy/client" "1.0.8"
-    "@percy/config" "1.0.8"
-    "@percy/dom" "1.0.8"
-    "@percy/logger" "1.0.8"
-    content-disposition "^0.5.4"
-    cross-spawn "^7.0.3"
-    extract-zip "^2.0.1"
-    fast-glob "^3.2.11"
-    micromatch "^4.0.4"
-    mime-types "^2.1.34"
-    path-to-regexp "^6.2.0"
-    rimraf "^3.0.2"
-    ws "^8.0.0"
-
-"@percy/cypress@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@percy/cypress/-/cypress-3.1.1.tgz"
-  integrity sha512-khvWmCOJW7pxwDZPB5ovvbSe11FfNtH8Iyq8PHRYLD9ibAkiAWHZVs07bLK5wju1Q9X8s7zg5uj2yWxIlB1yjA==
-  dependencies:
-    "@percy/sdk-utils" "^1.0.0-beta.44"
-
-"@percy/dom@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/dom/-/dom-1.0.8.tgz"
-  integrity sha512-5AdVVcFaV2kBFp30tEhbx4vCDrdv/4hF/s2lP3TBXKA+feSMB50xLQ3Vc1KJQ1HoOecFgBZdLwEsJM2gR5vgWw==
-
-"@percy/env@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/env/-/env-1.0.8.tgz"
-  integrity sha512-MRXxxMWWMMHj8Sgl1EQmhwhtMV7VhOIKBkWzqZKmQMoe1LhEkHaEQxc/kWdxYGZD5fVETQZcvoXRGSd7f22FDg==
-
-"@percy/logger@1.0.0-beta.76":
-  version "1.0.0-beta.76"
-  resolved "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.76.tgz"
-  integrity sha512-v5zIMNv1xqdcWBAOK5A6ZEO99ZBwzWS3phLEfkKbIlGIUxvjkJHSfZv/k1dnt2RRfpDNkM6X5pMg2yI8j1+d+g==
-
-"@percy/logger@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@percy/logger/-/logger-1.0.8.tgz"
-  integrity sha512-uHIk6YW7iJGcl/y/QHRl1R8t4NavyTZwji6oe1WW0BUGpR4xE6WjzXqSWv6UezfLLvZGV0AI8vrFqD95d8LLXg==
-
-"@percy/sdk-utils@^1.0.0-beta.44":
-  version "1.0.0-beta.76"
-  resolved "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.0.0-beta.76.tgz"
-  integrity sha512-5B070+VlTiCjxmwHU5Q8+ow1dGdmOkukY8TkSBkkbSs2OE4IPcYBlb+t/hGhpw7D34znPXc2dmUrZrbXwkRd2A==
-  dependencies:
-    "@percy/logger" "1.0.0-beta.76"
-
 "@sentry/browser@^6.19.7":
   version "6.19.7"
   resolved "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.7.tgz"
@@ -1755,16 +1600,6 @@ ajv@^8.0.0, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^8.6.2:
-  version "8.10.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz"
-  integrity sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz"
@@ -2118,7 +1953,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -2737,7 +2572,7 @@ constants-browserify@~1.0.0:
   resolved "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-content-disposition@0.5.4, content-disposition@^0.5.4:
+content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -3851,7 +3686,7 @@ extend@~3.0.2:
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-extract-zip@2.0.1, extract-zip@^2.0.1:
+extract-zip@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -3877,17 +3712,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11:
-  version "3.2.11"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz"
-  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
@@ -3907,13 +3731,6 @@ fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
-
-fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
-  dependencies:
-    reusify "^1.0.4"
 
 faye-websocket@^0.11.3:
   version "0.11.4"
@@ -4157,19 +3974,19 @@ gherkin@^5.0.0, gherkin@^5.1.0:
   resolved "https://registry.npmjs.org/gherkin/-/gherkin-5.1.0.tgz"
   integrity sha1-aEu7A63STq9731RPWAM+so+zxtU=
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-parent@^6.0.1:
   version "6.0.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -4403,13 +4220,6 @@ ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
-
-image-size@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz"
-  integrity sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==
-  dependencies:
-    queue "6.0.2"
 
 immutable@^4.0.0:
   version "4.0.0"
@@ -5133,11 +4943,6 @@ merge-stream@^2.0.0:
   resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
@@ -5150,14 +4955,6 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
-
-micromatch@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz"
-  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.2.3"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -5172,7 +4969,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.34, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5666,11 +5463,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz"
-  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
-
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
@@ -5707,7 +5499,7 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -6080,18 +5872,6 @@ querystring@0.2.0:
   resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-queue-microtask@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
-  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-queue@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz"
-  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
-  dependencies:
-    inherits "~2.0.3"
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
@@ -6289,11 +6069,6 @@ retry@^0.13.1:
   resolved "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
-reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
 rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz"
@@ -6313,13 +6088,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-run-parallel@^1.1.9:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
-  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
-  dependencies:
-    queue-microtask "^1.2.2"
 
 rxjs@^7.5.1:
   version "7.5.5"
@@ -7439,7 +7207,7 @@ which-typed-array@^1.1.2:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.7"
 
-which@^2.0.1, which@^2.0.2:
+which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -7484,7 +7252,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^8.0.0, ws@^8.4.2:
+ws@^8.4.2:
   version "8.5.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz"
   integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
@@ -7508,11 +7276,6 @@ yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-2.0.0.tgz"
-  integrity sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
### Context
As per https://ukgovernmentdfe.slack.com/archives/G01F7SE8TLY/p1661936151860109 we have decided to remove Percy from our builds due to the complexity it adds
- Ticket: N/A

### Changes proposed in this pull request
Remove Percy as a visual testing tool from feature and Cypress tests. Also remove from documentation.

### Guidance to review
Commit by commit. If all is well the only thing left is to remove the `PERCY_TOKEN` from secrets