### PR TITLE
[CPDLP-1707] Can post 2022 declarations

### DIFF
--- a/app/components/finance/statements/ecf_statement_selector.html.erb
+++ b/app/components/finance/statements/ecf_statement_selector.html.erb
@@ -8,6 +8,15 @@
     form_group: { class: "govuk-form-group govuk-!-width-one-third" }
   %>
 
+  <%= f.govuk_collection_select :cohort_year,
+    cohorts,
+    :start_year,
+    :start_year,
+    label: { text: "View a different cohort" },
+    options: { selected: current_statement.cohort.start_year },
+    form_group: { class: "govuk-form-group" }
+  %>
+
   <%= f.govuk_collection_select :statement,
     statements,
     :id,

--- a/app/components/finance/statements/ecf_statement_selector.rb
+++ b/app/components/finance/statements/ecf_statement_selector.rb
@@ -3,10 +3,11 @@
 module Finance
   module Statements
     class ECFStatementSelector < BaseComponent
-      attr_reader :current_statement
+      attr_reader :current_statement, :cohorts
 
-      def initialize(current_statement:)
+      def initialize(current_statement:, cohorts:)
         @current_statement = current_statement
+        @cohorts = cohorts
       end
 
       def lead_providers

--- a/app/components/finance/statements/npq_statement_selector.html.erb
+++ b/app/components/finance/statements/npq_statement_selector.html.erb
@@ -8,6 +8,15 @@
     form_group: { class: "govuk-form-group govuk-!-width-one-third" }
   %>
 
+  <%= f.govuk_collection_select :cohort_year,
+    cohorts,
+    :start_year,
+    :start_year,
+    label: { text: "View a different cohort" },
+    options: { selected: current_statement.cohort.start_year },
+    form_group: { class: "govuk-form-group" }
+  %>
+
   <%= f.govuk_collection_select :statement,
     statements,
     :id,

--- a/app/components/finance/statements/npq_statement_selector.rb
+++ b/app/components/finance/statements/npq_statement_selector.rb
@@ -3,10 +3,11 @@
 module Finance
   module Statements
     class NPQStatementSelector < BaseComponent
-      attr_reader :current_statement
+      attr_reader :current_statement, :cohorts
 
-      def initialize(current_statement:)
+      def initialize(current_statement:, cohorts:)
         @current_statement = current_statement
+        @cohorts = cohorts
       end
 
       def npq_lead_providers

--- a/app/controllers/finance/ecf/participant_declarations/voided_controller.rb
+++ b/app/controllers/finance/ecf/participant_declarations/voided_controller.rb
@@ -7,7 +7,7 @@ module Finance
         def show
           @ecf_lead_provider = LeadProvider.find(params[:payment_breakdown_id])
           @cpd_lead_provider = @ecf_lead_provider.cpd_lead_provider
-          @statement = @ecf_lead_provider.statements.find_by_humanised_name(params[:statement_id])
+          @statement = @ecf_lead_provider.statements.find(params[:statement_id])
           @voided_declarations = @statement.participant_declarations.voided
         end
       end

--- a/app/controllers/finance/ecf/statements_controller.rb
+++ b/app/controllers/finance/ecf/statements_controller.rb
@@ -5,15 +5,11 @@ module Finance
     class StatementsController < BaseController
       def show
         @ecf_lead_provider = lead_provider_scope.find(params[:payment_breakdown_id])
-        @statement = @ecf_lead_provider.statements.find_by(name: identifier_to_name)
+        @statement = @ecf_lead_provider.statements.find(params[:id])
         @calculator = StatementCalculator.new(statement: @statement)
       end
 
     private
-
-      def identifier_to_name
-        params[:id].humanize.gsub("-", " ")
-      end
 
       def lead_provider_scope
         policy_scope(LeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/npq/participant_declarations/voided_controller.rb
+++ b/app/controllers/finance/npq/participant_declarations/voided_controller.rb
@@ -7,7 +7,7 @@ module Finance
         def show
           @npq_lead_provider   = lead_provider_scope.find(params[:lead_provider_id])
           @cpd_lead_provider   = @npq_lead_provider.cpd_lead_provider
-          @statement           = @cpd_lead_provider.npq_lead_provider.statements.find_by_humanised_name(params[:statement_id])
+          @statement           = @cpd_lead_provider.npq_lead_provider.statements.find(params[:statement_id])
           @voided_declarations = @statement.participant_declarations.voided
         end
 

--- a/app/controllers/finance/npq/statements_controller.rb
+++ b/app/controllers/finance/npq/statements_controller.rb
@@ -6,7 +6,7 @@ module Finance
       def show
         @npq_lead_provider = lead_provider_scope.find(params[:lead_provider_id])
         @cpd_lead_provider = @npq_lead_provider.cpd_lead_provider
-        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find_by(name: identifier_to_name)
+        @statement         = @cpd_lead_provider.npq_lead_provider.statements.find(params[:id])
         @statements        = @npq_lead_provider.statements.upto_current.order(payment_date: :desc)
         @npq_contracts     = @npq_lead_provider.npq_contracts.where(version: @statement.contract_version).order(course_identifier: :asc)
 
@@ -14,10 +14,6 @@ module Finance
       end
 
     private
-
-      def identifier_to_name
-        params[:id].humanize.gsub("-", " ")
-      end
 
       def lead_provider_scope
         policy_scope(NPQLeadProvider, policy_scope_class: FinanceProfilePolicy::Scope)

--- a/app/controllers/finance/payment_breakdowns_controller.rb
+++ b/app/controllers/finance/payment_breakdowns_controller.rb
@@ -46,17 +46,19 @@ module Finance
     end
 
     def choose_npq_statement
+      cohort = Cohort.find_by(start_year: params[:cohort_year])
       npq_lead_provider = NPQLeadProvider.find(params[:npq_lead_provider])
       statement_name = params[:statement].humanize.gsub("-", " ")
-      statement = npq_lead_provider.statements.find_by(name: statement_name)
+      statement = npq_lead_provider.statements.find_by(cohort:, name: statement_name)
 
       redirect_to finance_npq_lead_provider_statement_path(npq_lead_provider.id, statement)
     end
 
     def choose_ecf_statement
+      cohort = Cohort.find_by(start_year: params[:cohort_year])
       lead_provider = LeadProvider.find(params[:lead_provider])
       statement_name = params[:statement].humanize.gsub("-", " ")
-      statement = lead_provider.statements.find_by(name: statement_name)
+      statement = lead_provider.statements.find_by(cohort:, name: statement_name)
 
       redirect_to finance_ecf_payment_breakdown_statement_path(lead_provider.id, statement)
     end

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -47,10 +47,6 @@ class Finance::Statement < ApplicationRecord
     def current
       with_future_deadline_date.order(deadline_date: :asc).first
     end
-
-    def attach(participant_declaration)
-      Finance::DeclarationStatementAttacher.new(participant_declaration).call
-    end
   end
 
   def open?

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -44,10 +44,6 @@ class Finance::Statement < ApplicationRecord
   }
 
   class << self
-    def find_by_humanised_name(humanised_name)
-      find_by(name: humanised_name.humanize.gsub("-", " "))
-    end
-
     def current
       with_future_deadline_date.order(deadline_date: :asc).first
     end
@@ -67,10 +63,6 @@ class Finance::Statement < ApplicationRecord
 
   def current?
     payment_date > Time.current && deadline_date > Time.current
-  end
-
-  def to_param
-    name.downcase.gsub(" ", "-")
   end
 
   def previous_statements

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -81,6 +81,16 @@ class ParticipantProfile < ApplicationRecord
         .first
     end
 
+    def schedule_for(cpd_lead_provider:)
+      lead_provider = cpd_lead_provider.lead_provider
+
+      induction_records
+        .joins(induction_programme: { partnership: [:lead_provider] })
+        .where(induction_programmes: { partnerships: { lead_provider: } })
+        .latest
+        .schedule
+    end
+
   private
 
     def update_analytics

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -52,6 +52,10 @@ class ParticipantProfile < ApplicationRecord
       npq_application&.eligible_for_dfe_funding
     end
 
+    def schedule_for(*)
+      schedule
+    end
+
   private
 
     def push_profile_to_big_query

--- a/app/services/finance/declaration_statement_attacher.rb
+++ b/app/services/finance/declaration_statement_attacher.rb
@@ -23,7 +23,11 @@ module Finance
     attr_accessor :participant_declaration
 
     def cohort
-      participant_declaration.participant_profile.schedule.cohort
+      participant_declaration.participant_profile.schedule_for(cpd_lead_provider:).cohort
+    end
+
+    def cpd_lead_provider
+      participant_declaration.cpd_lead_provider
     end
 
     def statement

--- a/app/services/finance/npq/statement_calculator.rb
+++ b/app/services/finance/npq/statement_calculator.rb
@@ -102,12 +102,11 @@ module Finance
         contracts.map { |contract| PaymentCalculator::NPQ::ServiceFees.call(contract:) }.compact
       end
 
-      # WARNING: this does not scope to a cohort
-      # when cohorts are designed for scoping needs to be added here
       def contracts
         npq_lead_provider
           .npq_contracts
           .where(version: statement.contract_version)
+          .where(cohort: statement.cohort)
           .order(course_identifier: :asc)
       end
 

--- a/app/services/importers/npq_contracts.rb
+++ b/app/services/importers/npq_contracts.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Importers
+  # Given a CSV with correct data
+  # Find or create NPQContract
+  class NPQContracts
+    attr_reader :path_to_csv, :errors
+
+    def initialize(path_to_csv:)
+      @path_to_csv = path_to_csv
+      @errors = []
+    end
+
+    def call
+      check_headers
+
+      rows.each do |row|
+        cohort = Cohort.find_by!(start_year: row["cohort_year"])
+        cpd_lead_provider = CpdLeadProvider.find_by!(name: row["provider_name"])
+        npq_lead_provider = cpd_lead_provider.npq_lead_provider
+        course = NPQCourse.where("name ilike '%#{row['course_name']}%'").first
+
+        contract = NPQContract.find_or_initialize_by(
+          cohort:,
+          npq_lead_provider:,
+          course_identifier: course.identifier,
+        )
+
+        contract.update!(
+          recruitment_target: row["recruitment_target"].to_i,
+          per_participant: row["per_participant"],
+          service_fee_installments: row["service_fee_installments"].to_i,
+          number_of_payment_periods: number_of_payment_periods_for(course:),
+          service_fee_percentage: service_fee_percentage_for(course:),
+          output_payment_percentage: output_payment_percentage_for(course:),
+        )
+      end
+    end
+
+  private
+
+    def number_of_payment_periods_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQLeadership::IDENTIFIERS
+        Finance::Schedule::NPQLeadership.default.milestones.count
+      when *Finance::Schedule::NPQSpecialist::IDENTIFIERS
+        Finance::Schedule::NPQSpecialist.default.milestones.count
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        Finance::Schedule::NPQSupport.default.milestones.count
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        Finance::Schedule::NPQEhco.default.milestones.count
+      else
+        raise ArgumentError, "Invalid course identifier"
+      end
+    end
+
+    def service_fee_percentage_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        0
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        0
+      else
+        40
+      end
+    end
+
+    def output_payment_percentage_for(course:)
+      case course.identifier
+      when *Finance::Schedule::NPQSupport::IDENTIFIERS
+        100
+      when *Finance::Schedule::NPQEhco::IDENTIFIERS
+        100
+      else
+        60
+      end
+    end
+
+    def check_headers
+      unless rows.headers == %w[provider_name cohort_year course_name recruitment_target per_participant service_fee_installments]
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true, skip_blanks: true)
+    end
+  end
+end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -39,7 +39,9 @@ class RecordDeclaration
     ParticipantDeclaration.transaction do
       set_eligibility
 
-      Finance::Statement.attach(participant_declaration) unless participant_declaration.submitted?
+      unless participant_declaration.submitted?
+        Finance::DeclarationStatementAttacher.new(participant_declaration).call
+      end
 
       declaration_attempt.update!(participant_declaration:)
     end

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-l"><%= @ecf_lead_provider.name %></span>
     <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 
-    <%= render Finance::Statements::ECFStatementSelector.new(current_statement: @statement) %>
+    <%= render Finance::Statements::ECFStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
   </div>
 </div>
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -7,7 +7,7 @@
       <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
       <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 
-      <%= render Finance::Statements::NPQStatementSelector.new(current_statement: @statement) %>
+      <%= render Finance::Statements::NPQStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
 
       <div class="app-application__panel__summary">
         <div class="govuk-!-margin-right-4">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,6 +375,9 @@ en:
     npq-headship: Headship course breakdown
     npq-executive-leadership: Executive Leadership course breakdown
     npq-additional-support-offer: Additional Support Offer course breakdown
+    npq-early-headship-coaching-offer: Early Headship Coaching Offer
+    npq-early-years-leadership: Early Years Leadership
+    npq-leading-literacy: Leading Literacy
   courses:
     npq:
       npq-leading-teaching: Leading Teaching

--- a/db/seeds/call_off_contracts.rb
+++ b/db/seeds/call_off_contracts.rb
@@ -4,26 +4,28 @@ module Seeds
   class CallOffContracts
     def call
       LeadProvider.all.each do |lp|
-        sample_call_off_contract = CallOffContract.find_or_create_by!(
-          lead_provider: lp,
-          version: example_contract_data[:version] || "0.0.1",
-          uplift_target: example_contract_data[:uplift_target],
-          uplift_amount: example_contract_data[:uplift_amount],
-          recruitment_target: example_contract_data[:recruitment_target],
-          revised_target: example_contract_data[:revised_target],
-          set_up_fee: example_contract_data[:set_up_fee],
-          raw: example_contract_data.to_json,
-          cohort: cohort_2021,
-        )
-
-        %i[band_a band_b band_c band_d].each do |band|
-          src = example_contract_data[band]
-          ParticipantBand.find_or_create_by!(
-            call_off_contract: sample_call_off_contract,
-            min: src[:min],
-            max: src[:max],
-            per_participant: src[:per_participant],
+        [cohort_2021, cohort_2022].each do |cohort|
+          sample_call_off_contract = CallOffContract.find_or_create_by!(
+            lead_provider: lp,
+            version: example_contract_data[:version] || "0.0.1",
+            uplift_target: example_contract_data[:uplift_target],
+            uplift_amount: example_contract_data[:uplift_amount],
+            recruitment_target: example_contract_data[:recruitment_target],
+            revised_target: example_contract_data[:revised_target],
+            set_up_fee: example_contract_data[:set_up_fee],
+            raw: example_contract_data.to_json,
+            cohort:,
           )
+
+          %i[band_a band_b band_c band_d].each do |band|
+            src = example_contract_data[band]
+            ParticipantBand.find_or_create_by!(
+              call_off_contract: sample_call_off_contract,
+              min: src[:min],
+              max: src[:max],
+              per_participant: src[:per_participant],
+            )
+          end
         end
       end
     end
@@ -32,6 +34,10 @@ module Seeds
 
     def cohort_2021
       @cohort_2021 ||= Cohort.find_or_create_by!(start_year: 2021)
+    end
+
+    def cohort_2022
+      @cohort_2022 ||= Cohort.find_or_create_by!(start_year: 2022)
     end
 
     def example_contract_data

--- a/db/seeds/npq_contracts/fake-2021.csv
+++ b/db/seeds/npq_contracts/fake-2021.csv
@@ -1,0 +1,78 @@
+provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments
+Ambition Institute,2021,NPQ Leading Teaching ,1000,900,12
+Ambition Institute,2021,NPQ Leading Behaviour and Culture,1001,901,13
+Ambition Institute,2021,NPQ Leading Teacher Development,1002,902,14
+Ambition Institute,2021,NPQ for Senior Leadership,1003,903,15
+Ambition Institute,2021,NPQ for Headship,1004,904,16
+Ambition Institute,2021,NPQ for Executive Leadership,1005,905,17
+Ambition Institute,2021,NPQ Leading Literacy,1006,906,18
+Ambition Institute,2021,NPQ Early Years Leadership,1007,907,19
+Best Practice Network,2021,NPQ Leading Teaching ,1008,908,20
+Best Practice Network,2021,NPQ Leading Behaviour and Culture,1009,909,21
+Best Practice Network,2021,NPQ Leading Teacher Development,1010,910,22
+Best Practice Network,2021,NPQ for Senior Leadership,1011,911,23
+Best Practice Network,2021,NPQ for Headship,1012,912,24
+Best Practice Network,2021,NPQ for Executive Leadership,1013,913,25
+Church of England,2021,NPQ Leading Teaching ,1014,914,26
+Church of England,2021,NPQ Leading Behaviour and Culture,1015,915,27
+Church of England,2021,NPQ Leading Teacher Development,1016,916,28
+Church of England,2021,NPQ for Senior Leadership,1017,917,29
+Church of England,2021,NPQ for Headship,1018,918,30
+Church of England,2021,NPQ for Executive Leadership,1019,919,31
+Education Development Trust,2021,NPQ Leading Teaching ,1020,920,32
+Education Development Trust,2021,NPQ Leading Behaviour and Culture,1021,921,33
+Education Development Trust,2021,NPQ Leading Teacher Development,1022,922,34
+Education Development Trust,2021,NPQ for Senior Leadership,1023,923,35
+Education Development Trust,2021,NPQ for Headship,1024,924,36
+Education Development Trust,2021,NPQ for Executive Leadership,1025,925,37
+Education Development Trust,2021,NPQ Leading Literacy,1026,926,38
+Education Development Trust,2021,NPQ Early Years Leadership,1027,927,39
+School-Led Network,2021,NPQ Leading Teaching ,1028,928,40
+School-Led Network,2021,NPQ Leading Behaviour and Culture,1029,929,41
+School-Led Network,2021,NPQ Leading Teacher Development,1030,930,42
+School-Led Network,2021,NPQ for Senior Leadership,1031,931,43
+School-Led Network,2021,NPQ for Headship,1032,932,44
+School-Led Network,2021,NPQ for Executive Leadership,1033,933,45
+School-Led Network,2021,NPQ Leading Literacy,1034,934,46
+School-Led Network,2021,NPQ Early Years Leadership,1035,935,47
+Leadership Learning South East,2021,NPQ Leading Teaching ,1036,936,48
+Leadership Learning South East,2021,NPQ Leading Behaviour and Culture,1037,937,49
+Leadership Learning South East,2021,NPQ Leading Teacher Development,1038,938,50
+Leadership Learning South East,2021,NPQ for Senior Leadership,1039,939,51
+Leadership Learning South East,2021,NPQ for Headship,1040,940,52
+Leadership Learning South East,2021,NPQ for Executive Leadership,1041,941,53
+Leadership Learning South East,2021,NPQ Leading Literacy,1042,942,54
+Leadership Learning South East,2021,NPQ Early Years Leadership,1043,943,55
+Teach First,2021,NPQ Leading Teaching ,1044,944,56
+Teach First,2021,NPQ Leading Behaviour and Culture,1045,945,57
+Teach First,2021,NPQ Leading Teacher Development,1046,946,58
+Teach First,2021,NPQ for Senior Leadership,1047,947,59
+Teach First,2021,NPQ for Headship,1048,948,60
+Teach First,2021,NPQ for Executive Leadership,1049,949,61
+Teach First,2021,NPQ Leading Literacy,1050,950,62
+Teach First,2021,NPQ Early Years Leadership,1051,951,63
+Teacher Development Trust,2021,NPQ Leading Teaching ,1052,952,64
+Teacher Development Trust,2021,NPQ Leading Behaviour and Culture,1053,953,65
+Teacher Development Trust,2021,NPQ Leading Teacher Development,1054,954,66
+Teacher Development Trust,2021,NPQ for Senior Leadership,1055,955,67
+Teacher Development Trust,2021,NPQ for Headship,1056,956,68
+Teacher Development Trust,2021,NPQ for Executive Leadership,1057,957,69
+Teacher Development Trust,2021,NPQ Leading Literacy,1058,958,70
+Teacher Development Trust,2021,NPQ Early Years Leadership,1059,959,71
+UCL Institute of Education,2021,NPQ Leading Teaching ,1060,960,72
+UCL Institute of Education,2021,NPQ Leading Behaviour and Culture,1061,961,73
+UCL Institute of Education,2021,NPQ Leading Teacher Development,1062,962,74
+UCL Institute of Education,2021,NPQ for Senior Leadership,1063,963,75
+UCL Institute of Education,2021,NPQ for Headship,1064,964,76
+UCL Institute of Education,2021,NPQ for Executive Leadership,1065,965,77
+UCL Institute of Education,2021,NPQ Leading Literacy,1066,966,78
+UCL Institute of Education,2021,NPQ Early Years Leadership,1067,967,79
+Ambition Institute,2021,The Early Headship Coaching Offer,300,800,0
+Best Practice Network,2021,The Early Headship Coaching Offer,300,800,0
+Church of England,2021,The Early Headship Coaching Offer,300,800,0
+Education Development Trust,2021,The Early Headship Coaching Offer,300,800,0
+School-Led Network,2021,The Early Headship Coaching Offer,300,800,0
+Leadership Learning South East,2021,The Early Headship Coaching Offer,300,800,0
+Teach First,2021,The Early Headship Coaching Offer,300,800,0
+Teacher Development Trust,2021,The Early Headship Coaching Offer,300,800,0
+UCL Institute of Education,2021,The Early Headship Coaching Offer,300,800,0

--- a/db/seeds/npq_contracts/fake-2022.csv
+++ b/db/seeds/npq_contracts/fake-2022.csv
@@ -1,0 +1,78 @@
+provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments
+Ambition Institute,2022,NPQ Leading Teaching ,1000,100,12
+Ambition Institute,2022,NPQ Leading Behaviour and Culture,1001,101,13
+Ambition Institute,2022,NPQ Leading Teacher Development,1002,102,14
+Ambition Institute,2022,NPQ for Senior Leadership,1003,103,15
+Ambition Institute,2022,NPQ for Headship,1004,104,16
+Ambition Institute,2022,NPQ for Executive Leadership,1005,105,17
+Ambition Institute,2022,NPQ Leading Literacy,1006,106,18
+Ambition Institute,2022,NPQ Early Years Leadership,1007,107,19
+Best Practice Network,2022,NPQ Leading Teaching ,1008,108,20
+Best Practice Network,2022,NPQ Leading Behaviour and Culture,1009,109,21
+Best Practice Network,2022,NPQ Leading Teacher Development,1010,110,22
+Best Practice Network,2022,NPQ for Senior Leadership,1011,111,23
+Best Practice Network,2022,NPQ for Headship,1012,112,24
+Best Practice Network,2022,NPQ for Executive Leadership,1013,113,25
+Church of England,2022,NPQ Leading Teaching ,1014,114,26
+Church of England,2022,NPQ Leading Behaviour and Culture,1015,115,27
+Church of England,2022,NPQ Leading Teacher Development,1016,116,28
+Church of England,2022,NPQ for Senior Leadership,1017,117,29
+Church of England,2022,NPQ for Headship,1018,118,30
+Church of England,2022,NPQ for Executive Leadership,1019,119,31
+Education Development Trust,2022,NPQ Leading Teaching ,1020,120,32
+Education Development Trust,2022,NPQ Leading Behaviour and Culture,1021,121,33
+Education Development Trust,2022,NPQ Leading Teacher Development,1022,122,34
+Education Development Trust,2022,NPQ for Senior Leadership,1023,123,35
+Education Development Trust,2022,NPQ for Headship,1024,124,36
+Education Development Trust,2022,NPQ for Executive Leadership,1025,125,37
+Education Development Trust,2022,NPQ Leading Literacy,1026,126,38
+Education Development Trust,2022,NPQ Early Years Leadership,1027,127,39
+School-Led Network,2022,NPQ Leading Teaching ,1028,128,40
+School-Led Network,2022,NPQ Leading Behaviour and Culture,1029,129,41
+School-Led Network,2022,NPQ Leading Teacher Development,1030,130,42
+School-Led Network,2022,NPQ for Senior Leadership,1031,131,43
+School-Led Network,2022,NPQ for Headship,1032,132,44
+School-Led Network,2022,NPQ for Executive Leadership,1033,133,45
+School-Led Network,2022,NPQ Leading Literacy,1034,134,46
+School-Led Network,2022,NPQ Early Years Leadership,1035,135,47
+Leadership Learning South East,2022,NPQ Leading Teaching ,1036,136,48
+Leadership Learning South East,2022,NPQ Leading Behaviour and Culture,1037,137,49
+Leadership Learning South East,2022,NPQ Leading Teacher Development,1038,138,50
+Leadership Learning South East,2022,NPQ for Senior Leadership,1039,139,51
+Leadership Learning South East,2022,NPQ for Headship,1040,140,52
+Leadership Learning South East,2022,NPQ for Executive Leadership,1041,141,53
+Leadership Learning South East,2022,NPQ Leading Literacy,1042,142,54
+Leadership Learning South East,2022,NPQ Early Years Leadership,1043,143,55
+Teach First,2022,NPQ Leading Teaching ,1044,144,56
+Teach First,2022,NPQ Leading Behaviour and Culture,1045,145,57
+Teach First,2022,NPQ Leading Teacher Development,1046,146,58
+Teach First,2022,NPQ for Senior Leadership,1047,147,59
+Teach First,2022,NPQ for Headship,1048,148,60
+Teach First,2022,NPQ for Executive Leadership,1049,149,61
+Teach First,2022,NPQ Leading Literacy,1050,150,62
+Teach First,2022,NPQ Early Years Leadership,1051,151,63
+Teacher Development Trust,2022,NPQ Leading Teaching ,1052,152,64
+Teacher Development Trust,2022,NPQ Leading Behaviour and Culture,1053,153,65
+Teacher Development Trust,2022,NPQ Leading Teacher Development,1054,154,66
+Teacher Development Trust,2022,NPQ for Senior Leadership,1055,155,67
+Teacher Development Trust,2022,NPQ for Headship,1056,156,68
+Teacher Development Trust,2022,NPQ for Executive Leadership,1057,157,69
+Teacher Development Trust,2022,NPQ Leading Literacy,1058,158,70
+Teacher Development Trust,2022,NPQ Early Years Leadership,1059,159,71
+UCL Institute of Education,2022,NPQ Leading Teaching ,1060,160,72
+UCL Institute of Education,2022,NPQ Leading Behaviour and Culture,1061,161,73
+UCL Institute of Education,2022,NPQ Leading Teacher Development,1062,162,74
+UCL Institute of Education,2022,NPQ for Senior Leadership,1063,163,75
+UCL Institute of Education,2022,NPQ for Headship,1064,164,76
+UCL Institute of Education,2022,NPQ for Executive Leadership,1065,165,77
+UCL Institute of Education,2022,NPQ Leading Literacy,1066,166,78
+UCL Institute of Education,2022,NPQ Early Years Leadership,1067,167,79
+Ambition Institute,2022,The Early Headship Coaching Offer,1068,168,0
+Best Practice Network,2022,The Early Headship Coaching Offer,1069,169,0
+Church of England,2022,The Early Headship Coaching Offer,1070,170,0
+Education Development Trust,2022,The Early Headship Coaching Offer,1071,171,0
+School-Led Network,2022,The Early Headship Coaching Offer,1072,172,0
+Leadership Learning South East,2022,The Early Headship Coaching Offer,1073,173,0
+Teach First,2022,The Early Headship Coaching Offer,1074,174,0
+Teacher Development Trust,2022,The Early Headship Coaching Offer,1075,175,0
+UCL Institute of Education,2022,The Early Headship Coaching Offer,1076,176,0

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -8,7 +8,6 @@ include ActiveSupport::Testing::TimeHelpers
 
 DOMAIN = "@digital.education.gov.uk" # Prevent low effort email scraping
 Cohort.find_or_create_by!(start_year: 2021)
-cohort_2022 = Cohort.find_or_create_by!(start_year: 2022)
 cohort_2023 = Cohort.find_or_create_by!(start_year: 2023)
 
 local_authority = LocalAuthority.find_or_create_by!(name: "ZZ Test Local Authority", code: "ZZTEST")
@@ -219,160 +218,6 @@ ProviderRelationship.find_or_create_by!(
 )
 
 Seeds::CallOffContracts.new.call
-
-npq_specifics = [
-  {
-    version: "0.0.1",
-    recruitment_target: 300,
-    course_identifier: "npq-additional-support-offer",
-    number_of_payment_periods: 4,
-    per_participant: 800.00,
-    service_fee_percentage: 0,
-    output_payment_percentage: 100,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.1",
-    recruitment_target: 1000,
-    course_identifier: "npq-leading-teaching",
-    number_of_payment_periods: 3,
-    per_participant: 902.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.1",
-    recruitment_target: 1000,
-    course_identifier: "npq-leading-behaviour-culture",
-    number_of_payment_periods: 3,
-    per_participant: 902.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.1",
-    recruitment_target: 1500,
-    course_identifier: "npq-leading-teaching-development",
-    number_of_payment_periods: 3,
-    per_participant: 902.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.1",
-    recruitment_target: 2000,
-    course_identifier: "npq-senior-leadership",
-    number_of_payment_periods: 4,
-    per_participant: 1149.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 24,
-  },
-  {
-    version: "0.0.1",
-    recruitment_target: 1000,
-    course_identifier: "npq-headship",
-    number_of_payment_periods: 4,
-    per_participant: 1985.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 30,
-  },
-  {
-    version: "0.0.1",
-    recruitment_target: 400,
-    course_identifier: "npq-executive-leadership",
-    number_of_payment_periods: 4,
-    per_participant: 4099.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 24,
-  },
-
-  # Version 0.0.2
-  {
-    version: "0.0.2",
-    recruitment_target: 100,
-    course_identifier: "npq-additional-support-offer",
-    number_of_payment_periods: 4,
-    per_participant: 800.00,
-    service_fee_percentage: 0,
-    output_payment_percentage: 100,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.2",
-    recruitment_target: 1500,
-    course_identifier: "npq-leading-teaching",
-    number_of_payment_periods: 3,
-    per_participant: 902.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.2",
-    recruitment_target: 750,
-    course_identifier: "npq-leading-behaviour-culture",
-    number_of_payment_periods: 3,
-    per_participant: 902.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.2",
-    recruitment_target: 1500,
-    course_identifier: "npq-leading-teaching-development",
-    number_of_payment_periods: 3,
-    per_participant: 902.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 18,
-  },
-  {
-    version: "0.0.2",
-    recruitment_target: 1250,
-    course_identifier: "npq-senior-leadership",
-    number_of_payment_periods: 4,
-    per_participant: 1149.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 24,
-  },
-  {
-    version: "0.0.2",
-    recruitment_target: 750,
-    course_identifier: "npq-headship",
-    number_of_payment_periods: 4,
-    per_participant: 1985.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 30,
-  },
-  {
-    version: "0.0.2",
-    recruitment_target: 100,
-    course_identifier: "npq-executive-leadership",
-    number_of_payment_periods: 4,
-    per_participant: 4099.00,
-    service_fee_percentage: 40,
-    output_payment_percentage: 60,
-    service_fee_installments: 24,
-  },
-]
-
-# NPQ contracts
-NPQLeadProvider.all.each do |npq_lead_provider|
-  npq_specifics.each do |npq_contract|
-    attributes = npq_contract.merge(npq_lead_provider:, cohort: cohort_2022)
-    attributes.merge!(raw: attributes.to_json)
-    NPQContract.create!(attributes)
-  end
-end
 
 # FIP ECT
 user = User.find_or_create_by!(email: "fip-ect@example.com") do |u|
@@ -919,6 +764,11 @@ create_npq_declarations = lambda {
     count: 10,
   ]
 end
+
+service = Importers::NPQContracts.new(
+  path_to_csv: Rails.root.join("db/seeds/npq_contracts/fake-2021.csv"),
+)
+service.call
 
 service = Importers::NPQContracts.new(
   path_to_csv: Rails.root.join("db/seeds/npq_contracts/fake-2022.csv"),

--- a/db/seeds/test_data.rb
+++ b/db/seeds/test_data.rb
@@ -919,3 +919,8 @@ create_npq_declarations = lambda {
     count: 10,
   ]
 end
+
+service = Importers::NPQContracts.new(
+  path_to_csv: Rails.root.join("db/seeds/npq_contracts/fake-2022.csv"),
+)
+service.call

--- a/spec/components/finance/statements/ecf_statement_selector_spec.rb
+++ b/spec/components/finance/statements/ecf_statement_selector_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Finance::Statements::ECFStatementSelector, type: :component do
   let!(:ecf_statement) { create(:ecf_statement) }
   let!(:other_ecf_statement) { create(:ecf_statement) }
 
-  let(:rendered) { render_inline(described_class.new(current_statement: ecf_statement)) }
+  let(:cohorts) { Cohort.where(start_year: 2021..) }
+
+  let(:rendered) { render_inline(described_class.new(current_statement: ecf_statement, cohorts:)) }
 
   it "has a form that PUTs to correct action" do
     expect(rendered).to have_selector("form[method=post][action='/finance/payment-breakdowns/choose-ecf-statement']")

--- a/spec/components/finance/statements/npq_statement_selector_spec.rb
+++ b/spec/components/finance/statements/npq_statement_selector_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Finance::Statements::NPQStatementSelector, type: :component do
   let(:npq_lead_provider)    { cpd_lead_provider.npq_lead_provider }
   let!(:npq_statement)       { create(:npq_statement, cpd_lead_provider:) }
   let!(:other_npq_statement) { create(:npq_statement) }
+  let(:cohorts) { Cohort.where(start_year: 2021..) }
 
-  let(:rendered) { render_inline(described_class.new(current_statement: npq_statement)) }
+  let(:rendered) { render_inline(described_class.new(current_statement: npq_statement, cohorts:)) }
 
   it "has a form that PUTs to correct action" do
     expect(rendered).to have_selector("form[method=post][action='/finance/payment-breakdowns/choose-npq-statement']")

--- a/spec/factories/finance/schedules.rb
+++ b/spec/factories/finance/schedules.rb
@@ -6,12 +6,48 @@ FactoryBot.define do
       after(:create) do |schedule|
         start_year = schedule.cohort.start_year
         [
-          { name: "Output 1 - Participant Start", start_date: Date.new(start_year, 9, 1), milestone_date: Date.new(2021, 11, 30), payment_date: Date.new(2021, 11, 30), declaration_type: "started" },
-          { name: "Output 2 - Retention Point 1", start_date: Date.new(start_year, 11, 1), milestone_date: Date.new(2022, 1, 31), payment_date: Date.new(2022, 2, 28), declaration_type: "retained-1" },
-          { name: "Output 3 - Retention Point 2", start_date: Date.new(start_year, 2, 1), milestone_date: Date.new(2022, 4, 30), payment_date: Date.new(2022, 5, 31), declaration_type: "retained-2" },
-          { name: "Output 4 - Retention Point 3", start_date: Date.new(start_year, 5, 1), milestone_date: Date.new(2022, 9, 30), payment_date: Date.new(2022, 10, 31), declaration_type: "retained-3" },
-          { name: "Output 5 - Retention Point 4", start_date: Date.new(start_year, 10, 1), milestone_date: Date.new(2023, 1, 31), payment_date: Date.new(2023, 2, 28), declaration_type: "retained-4" },
-          { name: "Output 6 - Participant Completion", start_date: Date.new(start_year + 1, 2, 1), milestone_date: Date.new(start_year + 1, 4, 30), payment_date: Date.new(start_year + 1, 5, 31), declaration_type: "completed" },
+          {
+            name: "Output 1 - Participant Start",
+            start_date: Date.new(start_year, 9, 1),
+            milestone_date: Date.new(start_year, 11, 30),
+            payment_date: Date.new(start_year, 11, 30),
+            declaration_type: "started",
+          },
+          {
+            name: "Output 2 - Retention Point 1",
+            start_date: Date.new(start_year, 11, 1),
+            milestone_date: Date.new(start_year + 1, 1, 31),
+            payment_date: Date.new(start_year + 1, 2, 28),
+            declaration_type: "retained-1",
+          },
+          {
+            name: "Output 3 - Retention Point 2",
+            start_date: Date.new(start_year + 1, 2, 1),
+            milestone_date: Date.new(start_year + 1, 4, 30),
+            payment_date: Date.new(start_year + 1, 5, 31),
+            declaration_type: "retained-2",
+          },
+          {
+            name: "Output 4 - Retention Point 3",
+            start_date: Date.new(start_year + 1, 5, 1),
+            milestone_date: Date.new(start_year + 1, 9, 30),
+            payment_date: Date.new(start_year + 1, 10, 31),
+            declaration_type: "retained-3",
+          },
+          {
+            name: "Output 5 - Retention Point 4",
+            start_date: Date.new(start_year + 1, 10, 1),
+            milestone_date: Date.new(start_year + 2, 1, 31),
+            payment_date: Date.new(start_year + 2, 2, 28),
+            declaration_type: "retained-4",
+          },
+          {
+            name: "Output 6 - Participant Completion",
+            start_date: Date.new(start_year + 2, 2, 1),
+            milestone_date: Date.new(start_year + 2, 4, 30),
+            payment_date: Date.new(start_year + 2, 5, 31),
+            declaration_type: "completed",
+          },
         ].each do |hash|
           Finance::Milestone.find_or_create_by!(
             schedule:,

--- a/spec/factories/npq_courses.rb
+++ b/spec/factories/npq_courses.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     identifier { (Finance::Schedule::NPQLeadership::IDENTIFIERS + Finance::Schedule::NPQSpecialist::IDENTIFIERS).sample }
   end
 
-  factory :npq_leadship_course, class: "NPQCourse" do
+  factory :npq_leadership_course, class: "NPQCourse" do
     sequence(:name) { |n| "NPQ Leadership Course #{n}" }
     identifier { Finance::Schedule::NPQLeadership::IDENTIFIERS.sample }
   end

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -37,6 +37,7 @@ FactoryBot.define do
 
     initialize_with do
       participant_id = participant_profile.ecf? ? participant_profile.participant_identity.user_id : participant_profile.npq_application.participant_identity.user_id
+
       params = {
         participant_id:,
         course_identifier:,

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe NPQApplication, type: :model do
   end
 
   describe "#eligible_for_dfe_funding" do
-    let(:npq_course) { create(:npq_leadship_course) }
+    let(:npq_course) { create(:npq_leadership_course) }
     let(:different_npq_course) { create(:npq_specialist_course) }
 
     before do
@@ -146,7 +146,7 @@ RSpec.describe NPQApplication, type: :model do
     end
 
     context "when it is the only accepted application" do
-      let(:course) { create(:npq_leadship_course) }
+      let(:course) { create(:npq_leadership_course) }
 
       subject { create(:npq_application, eligible_for_funding: true, npq_course: course) }
 
@@ -180,7 +180,7 @@ RSpec.describe NPQApplication, type: :model do
     end
 
     context "when there is a previously accepted application" do
-      let(:npq_course) { create(:npq_leadship_course) }
+      let(:npq_course) { create(:npq_leadership_course) }
 
       subject { create(:npq_application, eligible_for_funding: true, npq_course:) }
 

--- a/spec/requests/finance/payment_breakdowns_spec.rb
+++ b/spec/requests/finance/payment_breakdowns_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::PaymentBreakdownsController do
+  let(:user) { create(:user, :finance) }
+
+  let(:cohort_2021) { Cohort.current || create(:cohort, :current) }
+  let(:cohort_2022) { Cohort.next || create(:cohort, :next) }
+
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+
+  before do
+    sign_in user
+  end
+
+  describe "POST #choose_ecf_statement", with_feature_flags: { multiple_cohorts: "active" } do
+    let!(:statement_2021) { create(:ecf_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2021) }
+    let!(:statement_2022) { create(:ecf_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2022) }
+
+    it "redirects to correctly to 2021 statement" do
+      post "/finance/payment-breakdowns/choose-ecf-statement", params: {
+        lead_provider: lead_provider.id,
+        cohort_year: cohort_2021.start_year,
+        statement: statement_2021.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/ecf/payment_breakdowns/#{lead_provider.id}/statements/#{statement_2021.id}")
+    end
+
+    it "redirects to correctly to 2022 statement" do
+      post "/finance/payment-breakdowns/choose-ecf-statement", params: {
+        lead_provider: lead_provider.id,
+        cohort_year: cohort_2022.start_year,
+        statement: statement_2022.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/ecf/payment_breakdowns/#{lead_provider.id}/statements/#{statement_2022.id}")
+    end
+  end
+
+  describe "POST #choose_npq_statement", with_feature_flags: { multiple_cohorts: "active" } do
+    let!(:statement_2021) { create(:npq_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2021) }
+    let!(:statement_2022) { create(:npq_statement, cpd_lead_provider:, name: "November 2022", cohort: cohort_2022) }
+
+    it "redirects to correctly to 2021 statement" do
+      post "/finance/payment-breakdowns/choose-npq-statement", params: {
+        npq_lead_provider: npq_lead_provider.id,
+        cohort_year: cohort_2021.start_year,
+        statement: statement_2021.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/npq/payment-overviews/#{npq_lead_provider.id}/statements/#{statement_2021.id}")
+    end
+
+    it "redirects to correctly to 2022 statement" do
+      post "/finance/payment-breakdowns/choose-npq-statement", params: {
+        npq_lead_provider: npq_lead_provider.id,
+        cohort_year: cohort_2022.start_year,
+        statement: statement_2022.name.downcase.gsub(" ", "-"),
+      }
+
+      expect(response).to redirect_to("/finance/npq/payment-overviews/#{npq_lead_provider.id}/statements/#{statement_2022.id}")
+    end
+  end
+end

--- a/spec/services/finance/clawback_declaration_spec.rb
+++ b/spec/services/finance/clawback_declaration_spec.rb
@@ -4,12 +4,24 @@ require "rails_helper"
 
 RSpec.describe Finance::ClawbackDeclaration, :with_default_schedules do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
 
   let!(:participant_declaration) { create(:ect_participant_declaration, :paid, cpd_lead_provider:) }
+  let(:participant_profile) { participant_declaration.participant_profile }
 
-  let!(:next_statement) { create(:ecf_statement, :output_fee, cpd_lead_provider:, deadline_date: 3.months.from_now) }
+  let!(:next_statement) { create(:ecf_statement, :next_output_fee, cpd_lead_provider:, deadline_date: 3.months.from_now) }
+
+  let(:cohort) { Cohort.current }
+  let(:school) { create(:school) }
+  let(:school_cohort) { create(:school_cohort, school:, cohort:) }
+  let(:partnership) { create(:partnership, school:, lead_provider:, cohort:) }
+  let(:induction_programme) { create(:induction_programme, partnership:) }
 
   subject { described_class.new(participant_declaration) }
+
+  before do
+    Induction::Enrol.call(participant_profile:, induction_programme:)
+  end
 
   describe "#call" do
     it "mutates state of delaration to awaiting_clawback" do

--- a/spec/services/finance/declaration_statement_attacher_spec.rb
+++ b/spec/services/finance/declaration_statement_attacher_spec.rb
@@ -1,30 +1,89 @@
 # frozen_string_literal: true
 
 RSpec.describe Finance::DeclarationStatementAttacher, :with_default_schedules do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:cohort_2021) { Cohort.find_by(start_year: 2021) || create(:cohort, :current) }
+  let(:cohort_2022) { Cohort.find_by(start_year: 2022) || create(:cohort, :next) }
 
-  let(:declaration) do
-    create(:ect_participant_declaration, :eligible, cpd_lead_provider:)
-  end
+  let(:schedule_2021) { create(:ecf_schedule, cohort: cohort_2021) }
+  let(:schedule_2022) { create(:ecf_schedule, cohort: cohort_2022) }
+  let(:npq_schedule_2022) { create(:npq_leadership_schedule, cohort: cohort_2022) }
 
-  let!(:statement) do
-    create(:ecf_statement, output_fee: true, deadline_date: 2.months.from_now, cpd_lead_provider:)
-  end
+  let(:declaration) { create(:ect_participant_declaration, cpd_lead_provider:, participant_profile:, state: "eligible") }
+
+  let(:ecf_statement_2021) { create(:ecf_statement, output_fee: true, cpd_lead_provider:, deadline_date: 2.months.from_now) }
+  let(:ecf_statement_2022) { create(:ecf_statement, output_fee: true, cpd_lead_provider:, deadline_date: 2.months.from_now, cohort: cohort_2022) }
+
+  let(:npq_statement_2022) { create(:npq_statement, output_fee: true, cpd_lead_provider:, deadline_date: 2.months.from_now, cohort: cohort_2022) }
+
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:school) { create(:school) }
+
+  let(:school_cohort)    { create(:school_cohort, school:, cohort:) }
+  let(:partnership)      { create(:partnership, school: school_cohort.school, lead_provider:, cohort:) }
+  let(:induction_programme) { create(:induction_programme, partnership:) }
+  let(:participant_profile) { create(:ect_participant_profile, school_cohort:, cohort:, schedule:) }
 
   subject { described_class.new(declaration) }
 
   describe "#call" do
-    it "creates line item" do
-      expect {
+    context "when cohort 2021" do
+      let!(:statement) { ecf_statement_2021 }
+      let!(:schedule) { schedule_2021 }
+      let(:cohort) { cohort_2021 }
+
+      before do
+        Induction::Enrol.call(participant_profile:, induction_programme:)
+      end
+
+      it "creates line item" do
+        expect {
+          subject.call
+        }.to change { statement.reload.statement_line_items.count }.by(1)
+      end
+
+      it "create line item with same state as declaration" do
         subject.call
-      }.to change { statement.reload.statement_line_items.count }.by(1)
+
+        line_item = Finance::StatementLineItem.last
+        expect(line_item.state).to eql(declaration.state)
+      end
     end
 
-    it "create line item with same state as declaration" do
-      subject.call
+    context "when cohort 2022" do
+      let(:cohort) { cohort_2022 }
 
-      line_item = Finance::StatementLineItem.last
-      expect(line_item.state).to eql(declaration.state)
+      context "ECF" do
+        let!(:schedule) { schedule_2022 }
+        let!(:statement) { ecf_statement_2022 }
+
+        before do
+          Induction::Enrol.call(participant_profile:, induction_programme:)
+        end
+
+        it "attaches to 2022 statement" do
+          subject.call
+
+          expect(statement.participant_declarations).to include(declaration)
+        end
+      end
+
+      context "NPQ" do
+        let!(:statement) { npq_statement_2022 }
+        let(:schedule) { npq_schedule_2022 }
+        let(:participant_profile) { declaration.participant_profile }
+        let(:declaration) { create(:npq_participant_declaration, cpd_lead_provider:, state: "eligible") }
+
+        before do
+          participant_profile.update! schedule:
+        end
+
+        it "attaches to 2022 statement" do
+          subject.call
+
+          expect(statement.participant_declarations).to include(declaration)
+        end
+      end
     end
   end
 end

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -197,20 +197,18 @@ RSpec.describe Finance::NPQ::StatementCalculator, :with_default_schedules do
     let!(:statement_2022) { create(:npq_statement, cpd_lead_provider:, cohort: cohort_2022) }
 
     before do
-      declarations = create_list(
-        :npq_participant_declaration, 1,
+      declaration = create(
+        :npq_participant_declaration,
         state: "eligible",
         course_identifier: npq_course.identifier,
-        npq_course:
+        npq_course:,
       )
 
-      declarations.each do |dec|
-        Finance::StatementLineItem.create!(
-          statement: statement_2022,
-          participant_declaration: dec,
-          state: dec.state,
-        )
-      end
+      Finance::StatementLineItem.create!(
+        statement: statement_2022,
+        participant_declaration: declaration,
+        state: declaration.state,
+      )
     end
 
     it "only includes declarations for the related cohort" do

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Finance::NPQ::StatementCalculator, :with_default_schedules do
   let(:participant_profile) { create(:npq_application, :accepted, :eligible_for_funding, npq_course:, npq_lead_provider:).profile }
   let(:milestone)           { participant_profile.schedule.milestones.find_by!(declaration_type:) }
   let(:declaration_type)    { "started" }
-
-  before { create(:npq_contract, npq_lead_provider:) }
+  let!(:contract) { create(:npq_contract, npq_lead_provider:) }
 
   subject { described_class.new(statement:) }
 

--- a/spec/services/finance/npq/statement_calculator_spec.rb
+++ b/spec/services/finance/npq/statement_calculator_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Finance::NPQ::StatementCalculator, :with_default_schedules do
   let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }
-  let!(:npq_course)         { create(:npq_leadship_course, identifier: "npq-leading-teaching") }
+  let!(:npq_course)         { create(:npq_leadership_course, identifier: "npq-leading-teaching") }
   let(:statement)           { create(:npq_statement, cpd_lead_provider:) }
   let(:participant_profile) { create(:npq_application, :accepted, :eligible_for_funding, npq_course:, npq_lead_provider:).profile }
   let(:milestone)           { participant_profile.schedule.milestones.find_by!(declaration_type:) }

--- a/spec/services/importers/npq_contracts_spec.rb
+++ b/spec/services/importers/npq_contracts_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Importers::NPQContracts do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:path_to_csv) { csv.path }
+
+  let!(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider, name: "Ambition Institute") }
+  let!(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+
+  let!(:cohort) { create(:cohort, :next) }
+
+  let!(:npq_specialist_course) { create(:npq_specialist_course, name: "NPQ Leading Teaching (NPQLT)") }
+  let!(:npq_leadership_course) { create(:npq_leadership_course, name: "NPQ for Headship (NPQH)") }
+  let!(:npq_ehco_course) { create(:npq_ehco_course, name: "The Early Headship Coaching Offer") }
+
+  subject { described_class.new(path_to_csv:) }
+
+  before do
+    allow(Finance::Schedule::NPQLeadership).to receive_message_chain(:default, :milestones, :count) { 4 }
+    allow(Finance::Schedule::NPQSpecialist).to receive_message_chain(:default, :milestones, :count) { 3 }
+    allow(Finance::Schedule::NPQSupport).to receive_message_chain(:default, :milestones, :count) { 4 }
+    allow(Finance::Schedule::NPQEhco).to receive_message_chain(:default, :milestones, :count) { 4 }
+  end
+
+  describe "#call" do
+    context "when headers are incorrect" do
+      before do
+        csv.write "foo,bar"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "throws an error" do
+        expect { subject.call }.to raise_error(NameError)
+      end
+    end
+
+    context "when new contract" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ Leading Teaching,123,456.78,13"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates a new contract with correct values" do
+        expect { subject.call }.to change { NPQContract.count }.by(1)
+
+        contract = NPQContract.last
+
+        expect(contract.npq_lead_provider).to eql(npq_lead_provider)
+        expect(contract.recruitment_target).to eql(123)
+        expect(contract.course_identifier).to eql(npq_specialist_course.identifier)
+        expect(contract.service_fee_installments).to eql(13)
+        expect(contract.service_fee_percentage).to eql(40)
+        expect(contract.output_payment_percentage).to eql(60)
+        expect(contract.per_participant).to eql(456.78)
+        expect(contract.number_of_payment_periods).to eql(3)
+        expect(contract.cohort).to eql(cohort)
+      end
+    end
+
+    context "code is run more than once" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ Leading Teaching,123,456.78,13"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "is idempotent" do
+        expect {
+          subject.call
+          subject.call
+        }.to change { NPQContract.count }.by(1)
+      end
+    end
+
+    context "when existing contract" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ Leading Teaching,123,456.78,13"
+        csv.write "\n"
+        csv.close
+
+        NPQContract.create!(
+          npq_lead_provider:,
+          cohort:,
+          course_identifier: npq_specialist_course.identifier,
+          recruitment_target: 100,
+          per_participant: 100,
+          service_fee_installments: 100,
+          number_of_payment_periods: 100,
+        )
+      end
+
+      it "updates the contract" do
+        expect {
+          subject.call
+        }.not_to change { NPQContract.count }
+
+        contract = NPQContract.last
+
+        expect(contract.recruitment_target).to eql(123)
+        expect(contract.per_participant).to eql(456.78)
+        expect(contract.service_fee_installments).to eql(13)
+        expect(contract.number_of_payment_periods).to eql(3)
+      end
+    end
+
+    context "when a leadership course" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,NPQ for Headship,321,654.87,14"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates a new contract with correct values" do
+        expect { subject.call }.to change { NPQContract.count }.by(1)
+
+        contract = NPQContract.last
+
+        expect(contract.npq_lead_provider).to eql(npq_lead_provider)
+        expect(contract.recruitment_target).to eql(321)
+        expect(contract.course_identifier).to eql(npq_leadership_course.identifier)
+        expect(contract.service_fee_installments).to eql(14)
+        expect(contract.service_fee_percentage).to eql(40)
+        expect(contract.output_payment_percentage).to eql(60)
+        expect(contract.per_participant).to eql(654.87)
+        expect(contract.number_of_payment_periods).to eql(4)
+        expect(contract.cohort).to eql(cohort)
+      end
+    end
+
+    context "when EHCO course" do
+      before do
+        csv.write "provider_name,cohort_year,course_name,recruitment_target,per_participant,service_fee_installments"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022,The Early Headship Coaching Offer,789,111.22,15"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates a new contract with correct values" do
+        expect { subject.call }.to change { NPQContract.count }.by(1)
+
+        contract = NPQContract.last
+
+        expect(contract.npq_lead_provider).to eql(npq_lead_provider)
+        expect(contract.recruitment_target).to eql(789)
+        expect(contract.course_identifier).to eql(npq_ehco_course.identifier)
+        expect(contract.service_fee_installments).to eql(15)
+        expect(contract.service_fee_percentage).to eql(0)
+        expect(contract.output_payment_percentage).to eql(100)
+        expect(contract.per_participant).to eql(111.22)
+        expect(contract.number_of_payment_periods).to eql(4)
+        expect(contract.cohort).to eql(cohort)
+      end
+    end
+  end
+end

--- a/spec/services/npq/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
+++ b/spec/services/npq/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NPQ::Ehco::TargetedDeliveryFundingEligibilityUpdater do
   let!(:application_with_targeted_funding_set)     { create(:npq_application, applicable_application_hash) }
   let!(:application_with_targeted_funding_set_two) { create(:npq_application, applicable_application_hash) }
   let!(:application_before_cutoff)                 { create(:npq_application, applicable_application_hash.merge(created_at: described_class::REOPEN_DATE - 1.day)) }
-  let!(:application_wrong_course)                  { create(:npq_application, applicable_application_hash.merge(npq_course: create(:npq_leadship_course))) }
+  let!(:application_wrong_course)                  { create(:npq_application, applicable_application_hash.merge(npq_course: create(:npq_leadership_course))) }
   let!(:application_not_marked_for_funding)        { create(:npq_application, applicable_application_hash.merge(targeted_delivery_funding_eligibility: false)) }
 
   it "updates the targeted_delivery_funding_eligibility flag for applicable records" do

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -205,6 +205,26 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
       it_behaves_like "validates the course_identifier, cpd_lead_provider, participant_id"
       it_behaves_like "validates existing declarations"
       it_behaves_like "validates the participant milestone"
+
+      context "for 2022 cohort", :with_default_schedules, with_feature_flags: { multiple_cohorts: "active" } do
+        let!(:schedule) { create(:ecf_schedule, cohort:) }
+        let!(:statement) { create(:ecf_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider:, cohort:) }
+
+        let(:cohort) { Cohort.next || create(:cohort, :next) }
+        let(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, lead_provider:, cohort:) }
+        let(:lead_provider) { cpd_lead_provider.lead_provider }
+        let(:participant_profile) { create(:ect, :eligible_for_funding, school_cohort:, lead_provider:) }
+        let(:declaration_date) { schedule.milestones.find_by(declaration_type: "started").start_date }
+
+        it "creates declaration to 2022 statement" do
+          expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
+
+          declaration = ParticipantDeclaration.last
+
+          expect(declaration).to be_eligible
+          expect(declaration.statements).to include(statement)
+        end
+      end
     end
 
     context "when the participant is a Mentor" do
@@ -231,6 +251,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
       create(:npq_participant_profile, *traits, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)
     end
     let(:course_identifier) { npq_course.identifier }
+
     before do
       create(:npq_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider:)
     end
@@ -243,6 +264,25 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
     it_behaves_like "validates the course_identifier, cpd_lead_provider, participant_id"
     it_behaves_like "validates existing declarations"
     it_behaves_like "validates the participant milestone"
+
+    context "for 2022 cohort", :with_default_schedules, with_feature_flags: { multiple_cohorts: "active" } do
+      let!(:schedule) { create(:npq_specialist_schedule, cohort:) }
+      let!(:statement) { create(:npq_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider:, cohort:) }
+
+      let(:cohort) { Cohort.next || create(:cohort, :next) }
+      let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+      let(:participant_profile) { create(:npq_participant_profile, :eligible_for_funding, npq_lead_provider:, npq_course:, schedule:) }
+      let(:declaration_date) { schedule.milestones.find_by(declaration_type: "started").start_date }
+
+      it "creates declaration to 2022 statement" do
+        expect { service.call }.to change { ParticipantDeclaration.count }.by(1)
+
+        declaration = ParticipantDeclaration.last
+
+        expect(declaration).to be_eligible
+        expect(declaration.statements).to include(statement)
+      end
+    end
   end
 
   context "when user is for 2020 cohort" do

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
   context "when the participant is an NPQ" do
     let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
     let(:declaration_date)      { schedule.milestones.find_by(declaration_type: "started").start_date }
-    let(:npq_course) { create(:npq_leadship_course) }
+    let(:npq_course) { create(:npq_leadership_course) }
     let(:traits)     { [] }
     let(:participant_profile) do
       create(:npq_participant_profile, *traits, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1707
- Also covers https://dfedigital.atlassian.net/browse/CPDLP-1644
- This enables providers to post 2022 declarations
- Able to import NPQ contracts from CSV

### Changes proposed in this pull request

- When viewing statements, added cohort filter so finance users can switch between cohorts for statements
- Added new method `schedule_for` to be able to find schedule from a given profile
- Added class to be able to import `NPQContract`s from CSV
- Seeding process now automatically adds 2022 statements, ecf contracts and npq contracts
- Pruned `Finance::Statement.attach` in favour of calling `DeclarationStatementAttacher` directly
- `DeclarationStatementAttacher` now correctly determines the cohort and therefore attaches declarations to correct statements

### Guidance to review

- When viewing a statement these do not conform to the current designs. Extra work needs to be applied to add LHS filtering system
- When viewing a statement the filtering system at the moment does not use javascript. Therefore it is possible to select an invalid statement. Extra work needs to be applied so when cohort is changed this updates the dropdown for possible statements that are selectable