### PR TITLE
[CPDLP-1541] Validation error when passing in wrong course-identifier

### DIFF
--- a/app/services/participants/change_schedule/ecf.rb
+++ b/app/services/participants/change_schedule/ecf.rb
@@ -9,7 +9,7 @@ module Participants
 
       delegate :school_cohort, to: :user_profile, allow_nil: true
 
-      validates :course_identifier, presence: { message: I18n.t(:missing_course_identifier) }
+      validates :course_identifier, course: true, presence: { message: I18n.t(:missing_course_identifier) }
       validates :participant_id, presence: { message: I18n.t(:missing_participant_id) }
       validates :cpd_lead_provider, presence: { message: I18n.t(:missing_cpd_lead_provider) }
       validates :schedule, presence: { message: I18n.t(:invalid_schedule) }
@@ -58,6 +58,10 @@ module Participants
         user_profile
       end
 
+      def participant_identity
+        @participant_identity ||= ParticipantIdentity.find_by(external_identifier: participant_id)
+      end
+
     private
 
       def validate_cannot_change_cohort
@@ -69,10 +73,6 @@ module Participants
 
       def participant_has_user_profile
         errors.add(:participant_id, I18n.t(:invalid_participant)) if user && user_profile.blank?
-      end
-
-      def participant_identity
-        @participant_identity ||= ParticipantIdentity.find_by(external_identifier: participant_id)
       end
 
       def user

--- a/app/services/participants/defer/validate_and_change_state.rb
+++ b/app/services/participants/defer/validate_and_change_state.rb
@@ -26,17 +26,21 @@ module Participants
       end
 
       def not_already_withdrawn
+        return unless user_profile
+
         if user_profile.ecf?
           errors.add(:induction_record, I18n.t(:invalid_withdrawal)) if relevant_induction_record&.training_status_withdrawn?
-        elsif user_profile&.training_status_withdrawn?
+        elsif user_profile.training_status_withdrawn?
           errors.add(:participant_profile, I18n.t(:invalid_withdrawal))
         end
       end
 
       def not_already_deferred
+        return unless user_profile
+
         if user_profile.ecf?
           errors.add(:induction_record, I18n.t(:invalid_deferral)) if relevant_induction_record&.training_status_deferred?
-        elsif user_profile&.training_status_deferred?
+        elsif user_profile.training_status_deferred?
           errors.add(:participant_profile, I18n.t(:invalid_deferral))
         end
       end

--- a/app/services/participants/profile_attributes.rb
+++ b/app/services/participants/profile_attributes.rb
@@ -9,7 +9,7 @@ module Participants
       attr_accessor :course_identifier, :participant_id, :cpd_lead_provider
       attr_accessor :force_training_status_change
 
-      validates :course_identifier, presence: { message: I18n.t(:missing_course_identifier) }
+      validates :course_identifier, course: true, presence: { message: I18n.t(:missing_course_identifier) }
       validates :participant_id, presence: { message: I18n.t(:missing_participant_id) }
       validates :cpd_lead_provider, presence: { message: I18n.t(:missing_cpd_lead_provider) }
       validates :participant_id, format: /\A[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z/, allow_blank: true
@@ -29,11 +29,11 @@ module Participants
       errors.add(:participant_id, I18n.t(:invalid_participant)) if user_profile.blank?
     end
 
-  private
-
     def participant_identity
       @participant_identity ||= ParticipantIdentity.find_by(external_identifier: participant_id)
     end
+
+  private
 
     def user
       @user ||= participant_identity&.user

--- a/app/services/participants/resume/validate_and_change_state.rb
+++ b/app/services/participants/resume/validate_and_change_state.rb
@@ -22,17 +22,21 @@ module Participants
       end
 
       def not_already_active
+        return unless user_profile
+
         if user_profile.ecf?
           errors.add(:induction_record, I18n.t(:already_active)) if relevant_induction_record&.training_status_active?
-        elsif user_profile&.training_status_active?
+        elsif user_profile.training_status_active?
           errors.add(:participant_profile, I18n.t(:already_active))
         end
       end
 
       def not_already_withdrawn
+        return unless user_profile
+
         if user_profile.ecf?
           errors.add(:induction_record, I18n.t(:invalid_resume)) if relevant_induction_record&.training_status_withdrawn?
-        elsif user_profile&.training_status_withdrawn?
+        elsif user_profile.training_status_withdrawn?
           errors.add(:participant_profile, I18n.t(:invalid_resume))
         end
       end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -107,6 +107,8 @@ private
   end
 
   def validate_milestone_exists
+    return unless participant_profile
+
     if milestone.blank?
       errors.add(:declaration_type, I18n.t(:mismatch_declaration_type_for_schedule))
     end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
 
             expect(response).not_to be_successful
             expect(response).to have_http_status(:unprocessable_entity)
-            expect(parsed_response["errors"]).to include({ "title" => "declaration_type", "detail" => "The property '#/declaration_type does not exist for this schedule" })
+            expect(parsed_response["errors"]).to include({ "title" => "course_identifier", "detail" => "The property '#/course_identifier' must be an available course to '#/participant_id'" })
           end
         end
 
@@ -417,7 +417,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
             .to eq(
               [
                 { "title" => "declaration_date",  "detail" => "can't be blank" },
-                { "title" => "declaration_type",  "detail" => "can't be blank, The property '#/declaration_type does not exist for this schedule" },
+                { "title" => "declaration_type",  "detail" => "can't be blank" },
                 { "title" => "participant_id",    "detail" => "The property '#/participant_id' must be a valid Participant ID" },
                 { "title" => "course_identifier", "detail" => "The property '#/course_identifier' must be an available course to '#/participant_id'" },
               ],

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -197,8 +197,8 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
         expect(response).to have_http_status(:unprocessable_entity)
         expect(parsed_response["errors"])
           .to include(
-            "title" => "declaration_type",
-            "detail" => "The property '#/declaration_type does not exist for this schedule",
+            "title" => "course_identifier",
+            "detail" => "The property '#/course_identifier' must be an available course to '#/participant_id'",
           )
       end
 
@@ -210,7 +210,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
           .to eq(
             [
               { "title" => "declaration_date", "detail" => "can't be blank" },
-              { "title" => "declaration_type", "detail" => "can't be blank, The property '#/declaration_type does not exist for this schedule" },
+              { "title" => "declaration_type", "detail" => "can't be blank" },
               { "title" => "participant_id", "detail" => "The property '#/participant_id' must be a valid Participant ID" },
               { "title" => "course_identifier", "detail" => "The property '#/course_identifier' must be an available course to '#/participant_id'" },
             ],

--- a/spec/services/participants/change_schedule/early_career_teacher_spec.rb
+++ b/spec/services/participants/change_schedule/early_career_teacher_spec.rb
@@ -71,6 +71,25 @@ RSpec.describe Participants::ChangeSchedule::ECF, :with_default_schedules do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing)
       end
     end
+
+    context "with incorrect course_identifier" do
+      let!(:declaration) { create(:ect_participant_declaration, participant_profile: profile, cpd_lead_provider:) }
+      let(:schedule) { create(:schedule, :soft) }
+
+      subject do
+        described_class.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: user.id,
+          course_identifier: "ecf-mentor",
+          cpd_lead_provider:,
+          cohort: schedule.cohort.start_year,
+        })
+      end
+
+      it "should have an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
   end
 
   describe "changing to a soft schedules with previous declarations" do

--- a/spec/services/participants/change_schedule/ecf_spec.rb
+++ b/spec/services/participants/change_schedule/ecf_spec.rb
@@ -106,6 +106,25 @@ RSpec.describe Participants::ChangeSchedule::ECF, :with_default_schedules do
         expect(subject.errors.full_messages.join(",")).to include("Participant The property '#/participant_id' must be a valid Participant ID")
       end
     end
+
+    context "with incorrect course_identifier" do
+      let(:schedule) { create(:schedule, :soft, cohort: Cohort.current) }
+      let(:profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+
+      subject do
+        described_class.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: profile.user_id,
+          course_identifier: "ecf-mentor",
+          cpd_lead_provider:,
+        })
+      end
+
+      it "returns error with invalid course identifier" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing)
+        expect(subject.errors.full_messages.join(",")).to include("The property '#/course_identifier' must be an available course to '#/participant_id'")
+      end
+    end
   end
 
   describe "changing to a soft schedules with previous declarations", :with_default_schedules do

--- a/spec/services/participants/change_schedule/npq_spec.rb
+++ b/spec/services/participants/change_schedule/npq_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe Participants::ChangeSchedule::NPQ, :with_default_schedules do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing)
       end
     end
+
+    context "with incorrect course_identifier" do
+      subject do
+        described_class.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: user.id,
+          course_identifier: "ecf-mentor",
+          cpd_lead_provider:,
+        })
+      end
+
+      it "should not have an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
   end
 
   describe "changing to a soft schedules with previous declarations", :with_default_schedules do

--- a/spec/services/participants/defer/early_career_teacher_spec.rb
+++ b/spec/services/participants/defer/early_career_teacher_spec.rb
@@ -92,5 +92,13 @@ RSpec.describe Participants::Defer::EarlyCareerTeacher, :with_default_schedules 
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
+
+    context "with incorrect course" do
+      let!(:participant_profile) { create(:mentor, lead_provider: cpd_lead_provider.lead_provider) }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
+      end
+    end
   end
 end

--- a/spec/services/participants/defer/mentor_spec.rb
+++ b/spec/services/participants/defer/mentor_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
-  let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_lead_provider) }
-  let(:lead_provider)       { cpd_lead_provider.lead_provider }
-  let!(:profile)            { create(:mentor, lead_provider:) }
-  let(:user)                { profile.user }
+  let(:cpd_lead_provider)    { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider)        { cpd_lead_provider.lead_provider }
+  let!(:participant_profile) { create(:mentor, lead_provider:) }
+  let(:user)                 { participant_profile.user }
 
   subject do
     described_class.new(
@@ -20,8 +20,8 @@ RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
   end
 
   describe "#call" do
-    it "updates profile training_status to deferred" do
-      expect { subject.call }.to change { profile.reload.training_status }.from("active").to("deferred")
+    it "updates the participant profile training_status to deferred" do
+      expect { subject.call }.to change { participant_profile.reload.training_status }.from("active").to("deferred")
     end
 
     it "creates a ParticipantProfileState" do
@@ -29,7 +29,7 @@ RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
     end
 
     it "updates induction_record training_status" do
-      expect { subject.call }.to change { profile.current_induction_record.reload.training_status }.from("active").to("deferred")
+      expect { subject.call }.to change { participant_profile.current_induction_record.reload.training_status }.from("active").to("deferred")
     end
 
     context "when already deferred" do
@@ -51,14 +51,14 @@ RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
 
     context "when status is withdrawn" do
       before do
-        ParticipantProfileState.create!(participant_profile: profile, state: "withdrawn")
-        profile.update!(status: "withdrawn")
+        ParticipantProfileState.create!(participant_profile:, state: "withdrawn")
+        participant_profile.update!(status: "withdrawn")
       end
 
       xit "returns an error and does not update training_status" do
         # TODO: there is a gap and bug here
-        # it should return a useful error
-        # but throws an error as we scope to active profiles only and therefore never find the record
+        # it should return a useful error but throws an error as we scope to
+        # active participant profiles only and therefore never find the record
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
       end
 
       it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
 
@@ -91,12 +91,12 @@ RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
       end
 
       it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
 
     context "with incorrect course" do
-      let!(:profile) { create(:ect, lead_provider:) }
+      let!(:participant_profile) { create(:ect, lead_provider:) }
 
       it "raises an error and does not create a ParticipantProfileState" do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }

--- a/spec/services/participants/defer/mentor_spec.rb
+++ b/spec/services/participants/defer/mentor_spec.rb
@@ -94,5 +94,13 @@ RSpec.describe Participants::Defer::Mentor, :with_default_schedules do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
       end
     end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:ect, lead_provider:) }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
+      end
+    end
   end
 end

--- a/spec/services/participants/defer/npq_spec.rb
+++ b/spec/services/participants/defer/npq_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Participants::Defer::NPQ, :with_default_schedules do
     end
 
     context "with incorrect course" do
-      let!(:profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+      let!(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
       let(:course_identifier) { "ecf-induction" }
 
       it "raises an error and does not create a ParticipantProfileState" do

--- a/spec/services/participants/defer/npq_spec.rb
+++ b/spec/services/participants/defer/npq_spec.rb
@@ -3,17 +3,17 @@
 require "rails_helper"
 
 RSpec.describe Participants::Defer::NPQ, :with_default_schedules do
-  let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:cpd_lead_provider)   { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
   let(:npq_lead_provider)   { cpd_lead_provider.npq_lead_provider }
   let!(:participant_profile) { create(:npq_participant_profile, npq_lead_provider:) }
   let(:user)                { participant_profile.user }
-  let(:npq_course)          { participant_profile.npq_course }
+  let(:course_identifier) { participant_profile.npq_course.identifier }
 
   subject do
     described_class.new(
       params: {
         participant_id: user.id,
-        course_identifier: npq_course.identifier,
+        course_identifier:,
         cpd_lead_provider:,
         reason: "bereavement",
       },
@@ -34,7 +34,7 @@ RSpec.describe Participants::Defer::NPQ, :with_default_schedules do
         described_class.new(
           params: {
             participant_id: user.id,
-            course_identifier: npq_course.identifier,
+            course_identifier:,
             cpd_lead_provider:,
             reason: "bereavement",
           },
@@ -68,7 +68,7 @@ RSpec.describe Participants::Defer::NPQ, :with_default_schedules do
         described_class.new(
           params: {
             participant_id: user.id,
-            course_identifier: npq_course.identifier,
+            course_identifier:,
             cpd_lead_provider:,
           },
         )
@@ -84,7 +84,7 @@ RSpec.describe Participants::Defer::NPQ, :with_default_schedules do
         described_class.new(
           params: {
             participant_id: user.id,
-            course_identifier: npq_course.identifier,
+            course_identifier:,
             cpd_lead_provider:,
             reason: "foo",
           },
@@ -93,6 +93,15 @@ RSpec.describe Participants::Defer::NPQ, :with_default_schedules do
 
       it "returns an error and does not update training_status" do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
+      end
+    end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+      let(:course_identifier) { "ecf-induction" }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
   end

--- a/spec/services/participants/resume/early_career_teacher_spec.rb
+++ b/spec/services/participants/resume/early_career_teacher_spec.rb
@@ -59,5 +59,13 @@ RSpec.describe Participants::Resume::EarlyCareerTeacher, :with_default_schedules
         # but throws an error as we scope to active profiles only and therefore never find the record
       end
     end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:mentor, :deferred, lead_provider:) }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
+      end
+    end
   end
 end

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -2,34 +2,15 @@
 
 require "rails_helper"
 
-RSpec.describe Participants::Resume::Mentor do
+RSpec.describe Participants::Resume::Mentor, :with_default_schedules do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
-  let(:profile) { create(:mentor_participant_profile, training_status: "deferred") }
-  let(:user) { profile.user }
-  let(:school) { profile.school_cohort.school }
-  let(:cohort) { profile.school_cohort.cohort }
-  let(:induction_programme) { create(:induction_programme, :fip, partnership:) }
-
-  let!(:induction_record) do
-    Induction::Enrol
-      .call(participant_profile: profile, induction_programme:)
-      .tap { |ir| ir.update!(training_status: "deferred") }
-  end
-
-  let!(:partnership) do
-    create(
-      :partnership,
-      school:,
-      lead_provider:,
-      cohort:,
-    )
-  end
+  let!(:profile) { create(:mentor, :deferred, lead_provider:) }
 
   subject do
     described_class.new(
       params: {
-        participant_id: user.id,
+        participant_id: profile.user_id,
         course_identifier: "ecf-mentor",
         cpd_lead_provider:,
       },
@@ -42,7 +23,7 @@ RSpec.describe Participants::Resume::Mentor do
     end
 
     it "updates induction_record training_status to active" do
-      expect { subject.call }.to change { induction_record.reload.training_status }.from("deferred").to("active")
+      expect { subject.call }.to change { profile.induction_records.first.training_status }.from("deferred").to("active")
     end
 
     it "creates a ParticipantProfileState" do
@@ -53,7 +34,7 @@ RSpec.describe Participants::Resume::Mentor do
       before do
         described_class.new(
           params: {
-            participant_id: user.id,
+            participant_id: profile.user_id,
             course_identifier: "ecf-mentor",
             cpd_lead_provider:,
           },
@@ -75,6 +56,14 @@ RSpec.describe Participants::Resume::Mentor do
         # TODO: there is a gap and bug here
         # it should return a useful error
         # but throws an error as we scope to active profiles only and therefore never find the record
+      end
+    end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:ect, :deferred, lead_provider:) }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
   end

--- a/spec/services/participants/resume/mentor_spec.rb
+++ b/spec/services/participants/resume/mentor_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Participants::Resume::Mentor, :with_default_schedules do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
-  let!(:profile) { create(:mentor, :deferred, lead_provider:) }
+  let!(:participant_profile) { create(:mentor, :deferred, lead_provider:) }
 
   subject do
     described_class.new(
       params: {
-        participant_id: profile.user_id,
+        participant_id: participant_profile.user_id,
         course_identifier: "ecf-mentor",
         cpd_lead_provider:,
       },
@@ -18,12 +18,12 @@ RSpec.describe Participants::Resume::Mentor, :with_default_schedules do
   end
 
   describe "#call" do
-    it "updates profile training_status to active" do
-      expect { subject.call }.to change { profile.reload.training_status }.from("deferred").to("active")
+    it "updates the participant profile training_status to active" do
+      expect { subject.call }.to change { participant_profile.reload.training_status }.from("deferred").to("active")
     end
 
     it "updates induction_record training_status to active" do
-      expect { subject.call }.to change { profile.induction_records.first.training_status }.from("deferred").to("active")
+      expect { subject.call }.to change { participant_profile.induction_records.latest.training_status }.from("deferred").to("active")
     end
 
     it "creates a ParticipantProfileState" do
@@ -34,7 +34,7 @@ RSpec.describe Participants::Resume::Mentor, :with_default_schedules do
       before do
         described_class.new(
           params: {
-            participant_id: profile.user_id,
+            participant_id: participant_profile.user_id,
             course_identifier: "ecf-mentor",
             cpd_lead_provider:,
           },
@@ -48,19 +48,19 @@ RSpec.describe Participants::Resume::Mentor, :with_default_schedules do
 
     context "when status is withdrawn" do
       before do
-        ParticipantProfileState.create!(participant_profile: profile, state: "withdrawn")
-        profile.update!(status: "withdrawn")
+        ParticipantProfileState.create!(participant_profile:, state: "withdrawn")
+        participant_profile.update!(status: "withdrawn")
       end
 
       xit "returns an error and does not update training_status" do
         # TODO: there is a gap and bug here
-        # it should return a useful error
-        # but throws an error as we scope to active profiles only and therefore never find the record
+        # it should return a useful error but throws an error as we scope to
+        # active participant profiles only and therefore never find the record
       end
     end
 
     context "with incorrect course" do
-      let!(:profile) { create(:ect, :deferred, lead_provider:) }
+      let!(:participant_profile) { create(:ect, :deferred, lead_provider:) }
 
       it "raises an error and does not create a ParticipantProfileState" do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }

--- a/spec/services/participants/resume/npq_spec.rb
+++ b/spec/services/participants/resume/npq_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Participants::Resume::NPQ, :with_default_schedules do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
-  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
-  let!(:profile)          { create(:npq_participant_profile, :deferred, npq_lead_provider:) }
-  let(:user)              { profile.user }
-  let(:course_identifier) { profile.npq_course.identifier }
+  let(:cpd_lead_provider)    { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
+  let(:npq_lead_provider)    { cpd_lead_provider.npq_lead_provider }
+  let!(:participant_profile) { create(:npq_participant_profile, :deferred, npq_lead_provider:) }
+  let(:user)                 { participant_profile.user }
+  let(:course_identifier)    { participant_profile.npq_course.identifier }
 
   subject do
     described_class.new(
@@ -20,8 +20,8 @@ RSpec.describe Participants::Resume::NPQ, :with_default_schedules do
   end
 
   describe "#call" do
-    it "updates profile training_status to active" do
-      expect { subject.call }.to change { profile.reload.training_status }.from("deferred").to("active")
+    it "updates the participant profile training_status to active" do
+      expect { subject.call }.to change { participant_profile.reload.training_status }.from("deferred").to("active")
     end
 
     it "creates a ParticipantProfileState" do
@@ -46,19 +46,19 @@ RSpec.describe Participants::Resume::NPQ, :with_default_schedules do
 
     context "when status is withdrawn" do
       before do
-        ParticipantProfileState.create!(participant_profile: profile, state: "withdrawn")
-        profile.update!(status: "withdrawn")
+        ParticipantProfileState.create!(participant_profile:, state: "withdrawn")
+        participant_profile.update!(status: "withdrawn")
       end
 
       xit "returns an error and does not update training_status" do
         # TODO: there is a gap and bug here
-        # it should return a useful error
-        # but throws an error as we scope to active profiles only and therefore never find the record
+        # it should return a useful error but throws an error as we scope to
+        # active participant profiles only and therefore never find the record
       end
     end
 
     context "with incorrect course" do
-      let!(:profile) { create(:ect, :deferred, lead_provider: cpd_lead_provider.lead_provider) }
+      let!(:participant_profile) { create(:ect, :deferred, lead_provider: cpd_lead_provider.lead_provider) }
       let(:course_identifier) { "ecf-induction" }
 
       it "raises an error and does not create a ParticipantProfileState" do

--- a/spec/services/participants/withdraw/early_career_teacher_spec.rb
+++ b/spec/services/participants/withdraw/early_career_teacher_spec.rb
@@ -107,5 +107,13 @@ RSpec.describe Participants::Withdraw::EarlyCareerTeacher, :with_default_schedul
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
       end
     end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:mentor, lead_provider:) }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
+      end
+    end
   end
 end

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
-  let(:profile) { create(:mentor, lead_provider:) }
-  let(:user) { profile.user }
-  let(:school) { profile.school_cohort.school }
-  let(:cohort) { profile.school_cohort.cohort }
+  let(:participant_profile) { create(:mentor, lead_provider:) }
+  let(:user) { participant_profile.user }
+  let(:school) { participant_profile.school_cohort.school }
+  let(:cohort) { participant_profile.school_cohort.cohort }
 
   let!(:induction_coordinator_profile) do
     create(
@@ -29,12 +29,12 @@ RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
   end
 
   describe "#call" do
-    it "updates profile training_status to withdrawn" do
-      expect { subject.call }.to change { profile.reload.training_status }.from("active").to("withdrawn")
+    it "updates the participant profile training_status to withdrawn" do
+      expect { subject.call }.to change { participant_profile.reload.training_status }.from("active").to("withdrawn")
     end
 
     it "updates induction record training_status to withdrawn" do
-      expect { subject.call }.to change { profile.reload.current_induction_record.reload.training_status }.from("active").to("withdrawn")
+      expect { subject.call }.to change { participant_profile.reload.current_induction_record.reload.training_status }.from("active").to("withdrawn")
     end
 
     it "creates a ParticipantProfileState" do
@@ -48,7 +48,7 @@ RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
       subject.call
 
       expect(SchoolMailer).to have_received(:fip_provider_has_withdrawn_a_participant).with(
-        withdrawn_participant: profile,
+        withdrawn_participant: participant_profile,
         induction_coordinator: induction_coordinator_profile,
       )
     end
@@ -72,14 +72,14 @@ RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
 
     context "when status is withdrawn" do
       before do
-        ParticipantProfileState.create!(participant_profile: profile, state: "withdrawn")
-        profile.update!(status: "withdrawn")
+        ParticipantProfileState.create!(participant_profile:, state: "withdrawn")
+        participant_profile.update!(status: "withdrawn")
       end
 
       xit "returns an error and does not update training_status" do
         # TODO: there is a gap and bug here
-        # it should return a useful error
-        # but throws an error as we scope to active profiles only and therefore never find the record
+        # it should return a useful error but throws an error as we scope to
+        # active participant profiles only and therefore never find the record
       end
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
       end
 
       it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
 
@@ -112,12 +112,12 @@ RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
       end
 
       it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
 
     context "with incorrect course" do
-      let!(:profile) { create(:ect, lead_provider:) }
+      let!(:participant_profile) { create(:ect, lead_provider:) }
 
       it "raises an error and does not create a ParticipantProfileState" do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }

--- a/spec/services/participants/withdraw/mentor_spec.rb
+++ b/spec/services/participants/withdraw/mentor_spec.rb
@@ -115,5 +115,13 @@ RSpec.describe Participants::Withdraw::Mentor, :with_default_schedules do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
       end
     end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:ect, lead_provider:) }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
+      end
+    end
   end
 end

--- a/spec/services/participants/withdraw/npq_spec.rb
+++ b/spec/services/participants/withdraw/npq_spec.rb
@@ -3,12 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
-  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
-  let!(:profile)          { create(:npq_participant_profile, npq_lead_provider:) }
-  let(:npq_application)   { profile.npq_application }
-  let(:user)              { profile.user }
-  let(:course_identifier) { profile.npq_course.identifier }
+  let(:cpd_lead_provider)    { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
+  let(:npq_lead_provider)    { cpd_lead_provider.npq_lead_provider }
+  let!(:participant_profile) { create(:npq_participant_profile, npq_lead_provider:) }
+  let(:npq_application)      { participant_profile.npq_application }
+  let(:user)                 { participant_profile.user }
+  let(:course_identifier)    { participant_profile.npq_course.identifier }
 
   subject do
     described_class.new(
@@ -22,8 +22,8 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
   end
 
   describe "#call" do
-    it "updates profile training_status to withdrawn" do
-      expect { subject.call }.to change { profile.reload.training_status }.from("active").to("withdrawn")
+    it "updates the participant profile training_status to withdrawn" do
+      expect { subject.call }.to change { participant_profile.reload.training_status }.from("active").to("withdrawn")
     end
 
     it "creates a ParticipantProfileState" do
@@ -49,14 +49,14 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
 
     context "when status is withdrawn" do
       before do
-        ParticipantProfileState.create!(participant_profile: profile, state: "withdrawn")
-        profile.update!(status: "withdrawn")
+        ParticipantProfileState.create!(participant_profile:, state: "withdrawn")
+        participant_profile.update!(status: "withdrawn")
       end
 
       xit "returns an error and does not update training_status" do
         # TODO: there is a gap and bug here
-        # it should return a useful error
-        # but throws an error as we scope to active profiles only and therefore never find the record
+        # it should return a useful error but throws an error as we scope to
+        # active participant profiles only and therefore never find the record
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
       end
 
       it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
 
@@ -89,12 +89,12 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
       end
 
       it "returns an error and does not update training_status" do
-        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { participant_profile.reload.training_status }
       end
     end
 
     context "with incorrect course" do
-      let!(:profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+      let!(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
       let(:course_identifier) { "ecf-induction" }
 
       it "raises an error and does not create a ParticipantProfileState" do

--- a/spec/services/participants/withdraw/npq_spec.rb
+++ b/spec/services/participants/withdraw/npq_spec.rb
@@ -3,18 +3,18 @@
 require "rails_helper"
 
 RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
   let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
   let!(:profile)          { create(:npq_participant_profile, npq_lead_provider:) }
   let(:npq_application)   { profile.npq_application }
   let(:user)              { profile.user }
-  let(:npq_course)        { profile.npq_course }
+  let(:course_identifier) { profile.npq_course.identifier }
 
   subject do
     described_class.new(
       params: {
         participant_id: user.id,
-        course_identifier: npq_course.identifier,
+        course_identifier:,
         cpd_lead_provider:,
         reason: "insufficient-capacity-to-undertake-programme",
       },
@@ -35,7 +35,7 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
         described_class.new(
           params: {
             participant_id: user.id,
-            course_identifier: npq_course.identifier,
+            course_identifier:,
             cpd_lead_provider:,
             reason: "insufficient-capacity-to-undertake-programme",
           },
@@ -65,7 +65,7 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
         described_class.new(
           params: {
             participant_id: user.id,
-            course_identifier: npq_course.identifier,
+            course_identifier:,
             cpd_lead_provider:,
           },
         )
@@ -81,7 +81,7 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
         described_class.new(
           params: {
             participant_id: user.id,
-            course_identifier: npq_course.identifier,
+            course_identifier:,
             cpd_lead_provider:,
             reason: "foo",
           },
@@ -90,6 +90,15 @@ RSpec.describe Participants::Withdraw::NPQ, :with_default_schedules do
 
       it "returns an error and does not update training_status" do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { profile.reload.training_status }
+      end
+    end
+
+    context "with incorrect course" do
+      let!(:profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+      let(:course_identifier) { "ecf-induction" }
+
+      it "raises an error and does not create a ParticipantProfileState" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing).and not_change { ParticipantProfileState.count }
       end
     end
   end


### PR DESCRIPTION
### Context
On different endpoints, if we pass in a course identifier that exists but is not associated to the participant, we raise a 500 rather than a 422 error with the correct message

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1541

### Changes proposed in this pull request
- Reuse the course validation added for record declarations in Profile attribute validations which are used across resume/defer/withdraw actions. Expose private method `participant_identity` to allow validation to complete
- Skip validations if user profile does not exist (as it won't if the course identifier is incorrect)
- Ensure change schedule ECF validates course identifier as well
- To tidy up validations and avoid raising unnecessary ones validate milestone on declarations if `participant_profile` exists, otherwise we'll raise an unnecessary error 

### Guidance to review
We are still raising missing participant errors and need more tidy up to avoid those. Now we at least raise course identifier errors to point to the issue. This is most prominent in participant declarations
