### PR TITLE
Add an emergency banner to the landing pages

### DIFF
--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -71,37 +71,36 @@
     <% end %>
 
     <header class="govuk-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-          <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>
-            <span class="govuk-header__logotype">
-              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
-                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                <image src="<%= asset_pack_path('static/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image"></image>
-              </svg>
-              <span class="govuk-header__logotype-text">
-                GOV.UK
+      <div class="govuk-header__container">
+        <div class="govuk-width-container">
+          <div class="govuk-header__logo">
+            <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>
+              <span class="govuk-header__logotype">
+                <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
+                  <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                  <image src="<%= asset_pack_path('static/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image"></image>
+                </svg>
+                <span class="govuk-header__logotype-text">
+                  GOV.UK
+                </span>
               </span>
-            </span>
-          <% end %>
-        </div>
-        <div class="govuk-header__content">
-          <%= link_to service_name, "/", class: "govuk-header__link govuk-header__link--service-name" %>
-          <% if user_signed_in? %>
-          <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item">
-                <%= link_to "Sign out", destroy_user_session_path, class: "govuk-header__link" %>
-              </li>
-            </ul>
-          </nav>
-          <% end %>
+            <% end %>
+          </div>
+          <div class="govuk-header__content">
+            <%= link_to service_name, "/", class: "govuk-header__link govuk-header__link--service-name" %>
+            <% if user_signed_in? %>
+            <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+            <nav>
+              <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+                <li class="govuk-header__navigation-item">
+                  <%= link_to "Sign out", destroy_user_session_path, class: "govuk-header__link" %>
+                </li>
+              </ul>
+            </nav>
+            <% end %>
+          </div>
         </div>
       </div>
-    </header>
-
-    <% if request.path.in?([root_path, lead_providers_landing_page_path])  %>
       <div class="emergency-banner emergency-banner--notable-death" aria-label="emergency banner" role="region" data-nosnippet="true">
         <div class="govuk-width-container">
           <div class="govuk-grid-row">
@@ -117,7 +116,8 @@
           </div>
         </div>
       </div>
-    <% end %>
+
+    </header>
 
     <%= yield(:nav_bar) %>
 

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -101,6 +101,24 @@
       </div>
     </header>
 
+    <% if request.path.in?([root_path, lead_providers_landing_page_path])  %>
+      <div class="emergency-banner emergency-banner--notable-death" aria-label="emergency banner" role="region" data-nosnippet="true">
+        <div class="govuk-width-container">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <h2 class="emergency-banner__heading">
+                Her Majesty Queen Elizabeth II
+              </h2>
+
+              <p class="emergency-banner__description">21 April 1926 to 8 September 2022</p>
+
+              <a href="https://www.gov.uk/government/topical-events/her-majesty-queen-elizabeth-ii" class="emergency-banner__link">Read about the arrangements following The Queen’s death</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <%= yield(:nav_bar) %>
 
     <% if wide_container_view? %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -12,6 +12,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "~govuk-frontend/govuk/all";
 @import "~accessible-autocomplete";
 
+@import "emergency_banner";
 @import "notification_banner";
 @import "app_task_list";
 @import "vendor/components/step-by-step-header";

--- a/app/webpacker/styles/emergency_banner.scss
+++ b/app/webpacker/styles/emergency_banner.scss
@@ -1,3 +1,9 @@
+.govuk-header {
+  .govuk-header__container {
+    border-bottom: 2px solid white;
+  }
+}
+
 .emergency-banner {
   @include govuk-font(19);
   background-color: govuk-colour("mid-grey");

--- a/app/webpacker/styles/emergency_banner.scss
+++ b/app/webpacker/styles/emergency_banner.scss
@@ -1,0 +1,76 @@
+.emergency-banner {
+  @include govuk-font(19);
+  background-color: govuk-colour("mid-grey");
+  color: govuk-colour("white");
+  margin-top: 2px;
+  padding: govuk-spacing(3) 0;
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(6) 0;
+  }
+}
+
+.emergency-banner--homepage {
+  border-bottom: govuk-spacing(1) solid govuk-colour("white");
+  border-top: govuk-spacing(1) solid govuk-colour("white");
+  margin-bottom: govuk-spacing(-2);
+  margin-top: 0;
+  position: relative;
+  z-index: 10;
+}
+
+.emergency-banner__heading {
+  @include govuk-font(24, $weight: bold);
+  margin: 0;
+}
+
+.emergency-banner__heading--homepage {
+  @include govuk-font(48, $weight: bold);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(4);
+  }
+}
+
+.emergency-banner__description {
+  @include govuk-font(19);
+  color: govuk-colour("white");
+  margin-top: 0;
+  margin-bottom: govuk-spacing(4);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.emergency-banner__description--homepage {
+  margin: govuk-spacing(4) 0;
+}
+
+.emergency-banner__link {
+  @include govuk-font(19);
+}
+
+.emergency-banner__link:link,
+.emergency-banner__link:visited {
+  color: govuk-colour("white");
+}
+
+.emergency-banner__link:focus {
+  @include govuk-focused-text;
+}
+
+.emergency-banner--notable-death {
+  background-color: govuk-colour("black");
+}
+
+.emergency-banner--national-emergency {
+  // Not using govuk-colour("red") aka #d4351c as that's a slightly different red.
+  background-color: #b10e1e;
+}
+
+.emergency-banner--local-emergency {
+  // Not using govuk-colour("turquoise") for background colour as
+  // the contrast was too low with white text
+  background-color: #00847d;
+}


### PR DESCRIPTION
### Context

Add an emergency banner beneath the header on the landing pages.

Markup lifted from GOV.UK, styles lifted from [the publishing components gem](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/_emergency-banner.scss).

![image](https://user-images.githubusercontent.com/128088/189316225-61d1e0ac-7498-4f36-94c3-2dedf6d405f4.png)
