### PR TITLE
[CST-998] Add mentors to new school and remove from old when transferring

### DIFF
--- a/app/jobs/remove_school_mentor_job.rb
+++ b/app/jobs/remove_school_mentor_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveSchoolMentorJob < ApplicationJob
+  def perform
+    SchoolMentor.to_be_removed.find_each do |school_mentor|
+      Mentors::RemoveFromSchool.call(mentor_profile: school_mentor.participant_profile, school: school_mentor.school)
+    end
+  end
+end

--- a/app/models/school_mentor.rb
+++ b/app/models/school_mentor.rb
@@ -4,4 +4,6 @@ class SchoolMentor < ApplicationRecord
   belongs_to :school
   belongs_to :participant_profile, class_name: "ParticipantProfile::Mentor"
   belongs_to :preferred_identity, class_name: "ParticipantIdentity"
+
+  scope :to_be_removed, -> { where(remove_from_school_on: ..Time.zone.today) }
 end

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -4,6 +4,8 @@ class Induction::TransferAndContinueExistingFip < BaseService
   def call
     check_fip_induction_and_different_school!
 
+    induction_record = nil
+
     ActiveRecord::Base.transaction do
       # we haven't already been informed this person is leaving
       if latest_induction_record.active_induction_status?
@@ -17,12 +19,12 @@ class Induction::TransferAndContinueExistingFip < BaseService
                                              school_cohort:,
                                              partnership: create_relationship)
 
-      Induction::Enrol.call(participant_profile:,
-                            induction_programme: programme,
-                            start_date:,
-                            preferred_email: email,
-                            mentor_profile:,
-                            school_transfer: true)
+      induction_record = Induction::Enrol.call(participant_profile:,
+                                               induction_programme: programme,
+                                               start_date:,
+                                               preferred_email: email,
+                                               mentor_profile:,
+                                               school_transfer: true)
 
       if participant_profile.mentor?
         Mentors::ChangeSchool.call(mentor_profile: participant_profile,
@@ -32,6 +34,8 @@ class Induction::TransferAndContinueExistingFip < BaseService
                                    preferred_email: email)
       end
     end
+
+    induction_record
   end
 
 private

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -10,6 +10,8 @@ class Induction::TransferAndContinueExistingFip < BaseService
         latest_induction_record.leaving!(end_date)
       end
 
+      old_school = latest_induction_record.school
+
       # create a special programme to support the transferring participant
       programme = InductionProgramme.create!(training_programme: :full_induction_programme,
                                              school_cohort:,
@@ -21,6 +23,14 @@ class Induction::TransferAndContinueExistingFip < BaseService
                             preferred_email: email,
                             mentor_profile:,
                             school_transfer: true)
+
+      if participant_profile.mentor?
+        Mentors::ChangeSchool.call(mentor_profile: participant_profile,
+                                   from_school: old_school,
+                                   to_school: school_cohort.school,
+                                   remove_on_date: start_date,
+                                   preferred_email: email)
+      end
     end
   end
 

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -9,6 +9,7 @@ class Induction::TransferToSchoolsProgramme < BaseService
       if latest_induction_record.active_induction_status?
         latest_induction_record.leaving!(end_date)
       end
+      old_school = latest_induction_record.school
 
       Induction::Enrol.call(participant_profile:,
                             induction_programme:,
@@ -16,6 +17,14 @@ class Induction::TransferToSchoolsProgramme < BaseService
                             preferred_email: email,
                             mentor_profile:,
                             school_transfer: true)
+
+      if participant_profile.mentor?
+        Mentors::ChangeSchool.call(mentor_profile: participant_profile,
+                                   from_school: old_school,
+                                   to_school: induction_programme.school,
+                                   remove_on_date: start_date,
+                                   preferred_email: email)
+      end
     end
   end
 

--- a/app/services/induction/transfer_to_schools_programme.rb
+++ b/app/services/induction/transfer_to_schools_programme.rb
@@ -4,6 +4,8 @@ class Induction::TransferToSchoolsProgramme < BaseService
   def call
     check_different_school!
 
+    induction_record = nil
+
     ActiveRecord::Base.transaction do
       # we haven't already been informed this person is leaving
       if latest_induction_record.active_induction_status?
@@ -11,12 +13,12 @@ class Induction::TransferToSchoolsProgramme < BaseService
       end
       old_school = latest_induction_record.school
 
-      Induction::Enrol.call(participant_profile:,
-                            induction_programme:,
-                            start_date:,
-                            preferred_email: email,
-                            mentor_profile:,
-                            school_transfer: true)
+      induction_record = Induction::Enrol.call(participant_profile:,
+                                               induction_programme:,
+                                               start_date:,
+                                               preferred_email: email,
+                                               mentor_profile:,
+                                               school_transfer: true)
 
       if participant_profile.mentor?
         Mentors::ChangeSchool.call(mentor_profile: participant_profile,
@@ -26,6 +28,8 @@ class Induction::TransferToSchoolsProgramme < BaseService
                                    preferred_email: email)
       end
     end
+
+    induction_record
   end
 
 private

--- a/app/services/mentors/change_school.rb
+++ b/app/services/mentors/change_school.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Mentors
+  class ChangeSchool < BaseService
+    def call
+      ActiveRecord::Base.transaction do
+        AddToSchool.call(mentor_profile:, school: to_school, preferred_email:)
+        RemoveFromSchool.call(mentor_profile:, school: from_school, remove_on_date:)
+      end
+    end
+
+  private
+
+    attr_reader :mentor_profile, :from_school, :to_school, :remove_on_date, :preferred_email
+
+    def initialize(mentor_profile:, from_school:, to_school:, preferred_email: nil, remove_on_date: nil)
+      @mentor_profile = mentor_profile
+      @from_school = from_school
+      @to_school = to_school
+      @preferred_email = preferred_email
+      @remove_on_date = remove_on_date
+    end
+  end
+end

--- a/app/services/mentors/remove_from_school.rb
+++ b/app/services/mentors/remove_from_school.rb
@@ -3,16 +3,37 @@
 module Mentors
   class RemoveFromSchool < BaseService
     def call
-      school.school_mentors.find_by(participant_profile: mentor_profile)&.destroy
+      if remove_on_date.present? && remove_on_date > Time.zone.now
+        store_removal_date!
+      else
+        ActiveRecord::Base.transaction do
+          # remove from mentors list at the school
+          school_mentor&.destroy!
+
+          # remove from mentees at the school
+          InductionRecord.for_school(school).ects.current.where(mentor_profile:).each do |induction_record|
+            Induction::ChangeMentor.call(induction_record:)
+          end
+        end
+      end
     end
 
   private
 
-    attr_reader :mentor_profile, :school
+    attr_reader :mentor_profile, :school, :remove_on_date
 
-    def initialize(mentor_profile:, school:)
+    def initialize(mentor_profile:, school:, remove_on_date: nil)
       @mentor_profile = mentor_profile
       @school = school
+      @remove_on_date = remove_on_date
+    end
+
+    def school_mentor
+      school.school_mentors.find_by(participant_profile: mentor_profile)
+    end
+
+    def store_removal_date!
+      school_mentor&.update!(remove_from_school_on: remove_on_date)
     end
   end
 end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -29,3 +29,7 @@ transition_statements_to_payable:
   cron: "@daily"
   class: "Finance::Statements::MarkAsPayable"
   queue: default
+remove_school_mentor_job:
+  cron: "45 4 * * *"
+  class: "RemoveSchoolMentorJob"
+  queue: default

--- a/db/migrate/20220909081139_add_remove_from_school_on_to_school_mentors.rb
+++ b/db/migrate/20220909081139_add_remove_from_school_on_to_school_mentors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRemoveFromSchoolOnToSchoolMentors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :school_mentors, :remove_from_school_on, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_01_105322) do
+ActiveRecord::Schema.define(version: 2022_09_09_081139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -873,6 +873,7 @@ ActiveRecord::Schema.define(version: 2022_09_01_105322) do
     t.uuid "preferred_identity_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "remove_from_school_on"
     t.index ["participant_profile_id", "school_id"], name: "index_school_mentors_on_participant_profile_id_and_school_id", unique: true
     t.index ["participant_profile_id"], name: "index_school_mentors_on_participant_profile_id"
     t.index ["preferred_identity_id"], name: "index_school_mentors_on_preferred_identity_id"

--- a/spec/jobs/remove_school_mentor_job_spec.rb
+++ b/spec/jobs/remove_school_mentor_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RemoveSchoolMentorJob, :with_default_schedules do
+  describe "#perform" do
+    subject(:job) { described_class }
+    let(:school_cohort) { create(:school_cohort, :fip) }
+    let(:school) { school_cohort.school }
+    let(:remove_on_date) { Time.zone.today }
+    let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
+
+    before do
+      Mentors::AddToSchool.call(mentor_profile:, school:)
+      school.school_mentors.first.update!(remove_from_school_on: remove_on_date)
+    end
+
+    context "when there are school mentors to be removed" do
+      it "removes the school mentor records" do
+        expect { job.perform_now }.to change { SchoolMentor.count }.by(-1)
+      end
+    end
+
+    context "when there are school mentors to be removed in the future" do
+      let(:remove_on_date) { 1.day.from_now.to_date }
+
+      it "does not remove the school mentors records" do
+        expect { job.perform_now }.not_to change { SchoolMentor.count }
+      end
+    end
+  end
+end

--- a/spec/models/school_mentor_spec.rb
+++ b/spec/models/school_mentor_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SchoolMentor, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:participant_profile) }
+    it { is_expected.to belong_to(:preferred_identity) }
+  end
+
+  describe ".to_be_removed" do
+    let(:mentor_profiles) { create_list(:mentor_participant_profile, 4) }
+
+    before do
+      mentor_profiles.each do |mentor_profile|
+        Mentors::AddToSchool.call(mentor_profile:, school: mentor_profile.school)
+      end
+      mentor_profiles[1].school_mentors.first.update!(remove_from_school_on: 1.day.ago)
+      mentor_profiles[2].school_mentors.first.update!(remove_from_school_on: Time.zone.today)
+      mentor_profiles[3].school_mentors.first.update!(remove_from_school_on: 1.day.from_now)
+    end
+
+    it "returns records that have a removed_from_school_on date <= today" do
+      expected_school_mentors = mentor_profiles[1..2].map { |mp| mp.school_mentors.first }
+      expect(described_class.to_be_removed).to match_array expected_school_mentors
+    end
+  end
+end

--- a/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_fip_spec.rb
@@ -87,5 +87,25 @@ RSpec.describe Induction::TransferAndContinueExistingFip, :with_default_schedule
         expect(original_induction.reload.end_date).to be_within(1.second).of Time.zone.now
       end
     end
+
+    context "when the participant is a mentor" do
+      before do
+        Mentors::AddToSchool.call(mentor_profile: mentor_profile_1, school: school_cohort_1.school)
+      end
+
+      it "calls the Mentors::ChangeSchool service" do
+        expect(Mentors::ChangeSchool).to receive(:call).with(mentor_profile: mentor_profile_1,
+                                                             from_school: school_cohort_1.school,
+                                                             to_school: school_cohort_2.school,
+                                                             remove_on_date: start_date,
+                                                             preferred_email: new_email_address)
+
+        service.call(participant_profile: mentor_profile_1,
+                     school_cohort: school_cohort_2,
+                     email: new_email_address,
+                     start_date:,
+                     end_date:)
+      end
+    end
   end
 end

--- a/spec/services/induction/transfer_to_schools_programme_spec.rb
+++ b/spec/services/induction/transfer_to_schools_programme_spec.rb
@@ -79,5 +79,25 @@ RSpec.describe Induction::TransferToSchoolsProgramme, :with_default_schedules do
         expect(original_induction.reload.end_date).to be_within(1.second).of Time.zone.now
       end
     end
+
+    context "when the participant is a mentor" do
+      before do
+        Mentors::AddToSchool.call(mentor_profile: mentor_profile_1, school: school_cohort_1.school)
+      end
+
+      it "calls the Mentors::ChangeSchool service" do
+        expect(Mentors::ChangeSchool).to receive(:call).with(mentor_profile: mentor_profile_1,
+                                                             from_school: school_cohort_1.school,
+                                                             to_school: school_cohort_2.school,
+                                                             remove_on_date: start_date,
+                                                             preferred_email: new_email_address)
+
+        service.call(participant_profile: mentor_profile_1,
+                     induction_programme: induction_programme_2,
+                     email: new_email_address,
+                     start_date:,
+                     end_date:)
+      end
+    end
   end
 end

--- a/spec/services/mentors/change_school_spec.rb
+++ b/spec/services/mentors/change_school_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Mentors::ChangeSchool do
+  let(:cohort) { create(:cohort, start_year: 2021) }
+  let(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, cohort:) }
+  let(:old_school) { school_cohort.school }
+  let(:new_school) { create(:school) }
+  let(:induction_programme) { school_cohort.default_induction_programme }
+  let(:preferred_email) { nil }
+  let(:remove_on_date) { nil }
+  let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
+  let!(:mentee_profile) { create(:ect_participant_profile, school_cohort:) }
+
+  before do
+    Mentors::AddToSchool.call(mentor_profile:, school: old_school)
+    Induction::Enrol.call(participant_profile: mentee_profile, induction_programme:, mentor_profile:, start_date: 9.months.ago)
+    described_class.call(mentor_profile:, from_school: old_school, to_school: new_school, preferred_email:, remove_on_date:)
+  end
+
+  it "adds the mentor to the mentor pool at the new school" do
+    expect(new_school.mentor_profiles).to include mentor_profile
+  end
+
+  it "removes the mentor from the mentor pool at the old school" do
+    expect(new_school.mentor_profiles).to include mentor_profile
+  end
+
+  it "removes the mentor from their mentees at the old school" do
+    expect(mentee_profile.current_induction_record.mentor_profile).to be_blank
+  end
+
+  context "when a preferred email is supplied" do
+    let(:preferred_email) { "micky.mentor@example.com" }
+
+    it "sets the preferred email on the new school mentor record" do
+      expect(new_school.school_mentors.first.preferred_identity.email).to eq preferred_email
+    end
+  end
+
+  context "when a future remove_on_date is specified" do
+    let(:remove_on_date) { 1.week.from_now.to_date }
+
+    it "adds the mentor to the mentor pool at the new school" do
+      expect(new_school.mentor_profiles).to include mentor_profile
+    end
+
+    it "does not remove the mentor from the old school's mentor pool" do
+      expect(old_school.mentor_profiles).to include mentor_profile
+    end
+
+    it "does not remove the mentor from their mentees at the old school" do
+      expect(mentee_profile.current_induction_record.mentor_profile).to eq mentor_profile
+    end
+
+    it "stores the remove_on_date" do
+      expect(old_school.school_mentors.first.remove_from_school_on).to eq remove_on_date
+    end
+  end
+end

--- a/spec/services/mentors/remove_from_school_spec.rb
+++ b/spec/services/mentors/remove_from_school_spec.rb
@@ -2,23 +2,40 @@
 
 RSpec.describe Mentors::RemoveFromSchool do
   let(:cohort) { create(:cohort, start_year: 2021) }
-  let(:school_cohort) { create(:school_cohort, cohort:) }
+  let(:school_cohort) { create(:school_cohort, :fip, :with_induction_programme, cohort:) }
   let(:school) { school_cohort.school }
+  let(:induction_programme) { school_cohort.default_induction_programme }
+  let(:remove_on_date) { nil }
   let!(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
+  let!(:mentee_profile) { create(:ect_participant_profile, school_cohort:) }
 
   before do
     Mentors::AddToSchool.call(mentor_profile:, school:)
-  end
-
-  it "removes the school mentor record" do
-    expect {
-      described_class.call(mentor_profile:, school:)
-    }.to change { SchoolMentor.count }.by(-1)
+    Induction::Enrol.call(participant_profile: mentee_profile, induction_programme:, mentor_profile:, start_date: 9.months.ago)
+    described_class.call(mentor_profile:, school:, remove_on_date:)
   end
 
   it "removes the mentor from the school's mentor pool" do
-    described_class.call(mentor_profile:, school:)
-
     expect(school.mentor_profiles).not_to include mentor_profile
+  end
+
+  it "removes the mentor from their mentees" do
+    expect(mentee_profile.current_induction_record.mentor_profile).to be_blank
+  end
+
+  context "when a future remove_on_date is specified" do
+    let(:remove_on_date) { 1.week.from_now.to_date }
+
+    it "does not remove the mentor from the school's mentor pool" do
+      expect(school.mentor_profiles).to include mentor_profile
+    end
+
+    it "does not remove the mentor from their mentees" do
+      expect(mentee_profile.current_induction_record.mentor_profile).to eq mentor_profile
+    end
+
+    it "stores the remove_on_date" do
+      expect(school.school_mentors.first.remove_from_school_on).to eq remove_on_date
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-998)
When a mentor is transferred to a different school, we are not adding/removing `SchoolMentor` records so that the mentor can appear in the list of mentors at the new school (and be removed from the list at the old school)
Also need to ensure that the mentees are disassociated.
There is a complication in that a transfer can happen with a future date. In this case we need to defer removing from the old school and mentees until the transfer date.  I've added a `Date` field to `SchoolMentor` named `remove_from_school_on` that can be used for this, in conjunction with a daily cron job.

### Changes proposed in this pull request
Add new column `remove_from_school_on` to `school_mentors`
Add new service `Mentors::ChangeSchool`
Update school transfer services to call `Mentors::ChangeSchool` if participant is a mentor.
Add job `RemoveSchoolMentorJob` and daily cron schedule

### Guidance to review

