### PR TITLE
CST-1029: fix bug setup AB for a participant

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -289,8 +289,6 @@ module Schools
     end
 
     def save!
-      return if dqt_record.blank?
-
       profile = nil
       ActiveRecord::Base.transaction do
         profile = creators[participant_type].call(

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -206,26 +206,6 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
         allow(ParticipantMailer).to receive(:sit_has_added_and_validated_participant).and_call_original
       end
 
-      context "When no DQT record has been returned" do
-        before do
-          form.dqt_record = nil
-        end
-
-        it "does not create a new participant record" do
-          expect { form.save! }.not_to change(ParticipantProfile::ECF, :count)
-        end
-
-        it "does not create ecf validation data" do
-          expect { form.save! }.not_to change(ECFParticipantValidationData, :count)
-        end
-
-        it "does not send a participant any email" do
-          form.save!
-          expect(ParticipantMailer).not_to have_received(:sit_has_added_and_validated_participant)
-          expect(ParticipantMailer).not_to have_received(:participant_added)
-        end
-      end
-
       context "When participant details validated against the DQT" do
         it "creates new participant record" do
           expect { form.save! }.to change(ParticipantProfile::ECF, :count).by 1


### PR DESCRIPTION
### Context
  Fix bug when changing a participant's AB

- Ticket:  [1029](https://dfedigital.atlassian.net/browse/CST-1029)

### Changes proposed in this pull request

  Remove security check before saving new participant form after making TRN mandatory

### Guidance to review

