### PR TITLE
[CPDLP-1770] Remove different declaration date validation

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -29,7 +29,6 @@ class RecordDeclaration
 
   validate :validate_milestone_exists
   validate :validates_billable_slot_available
-  validate :record_does_not_exists_with_different_declaration_date
 
   attr_reader :raw_declaration_date
 
@@ -175,37 +174,5 @@ private
     return ParticipantDeclaration::NPQ if participant_profile.is_a?(ParticipantProfile::NPQ)
 
     ParticipantDeclaration::ECF
-  end
-
-  def record_does_not_exists_with_different_declaration_date
-    return unless participant_profile
-
-    declaration = participant_profile
-                    .participant_declarations
-                    .not_voided
-                    .find_by(
-                      user: participant_identity.user,
-                      course_identifier:,
-                      declaration_type:,
-                    )
-
-    return unless declaration.present? && \
-      (similar_declaration_for_same_lead_provider?(declaration) || same_declaration_for_a_different_lead_provider?(declaration))
-
-    errors.add(
-      :declaration_date,
-      I18n.t(
-        :declaration_with_another_date_already_exists,
-        declaration_date: declaration.declaration_date.rfc3339,
-      ),
-    )
-  end
-
-  def similar_declaration_for_same_lead_provider?(declaration)
-    declaration.declaration_date != declaration_date && declaration.cpd_lead_provider == cpd_lead_provider
-  end
-
-  def same_declaration_for_a_different_lead_provider?(declaration)
-    declaration.cpd_lead_provider != cpd_lead_provider
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,6 @@ en:
   missing_participant_id: "The property '#/participant_id' must be present"
   missing_cpd_lead_provider: "The property '#/cpd_lead_provider' must be present"
   declaration_already_exists: There already exists a declaration that will be or has been paid for this event
-  declaration_with_another_date_already_exists: A declaration with the date of %{declaration_date} already exists.
   already_active: The participant is already active
   invalid_withdrawal: The participant is already withdrawn
   invalid_resume: Cannot resume a withdrawn participant

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -150,7 +150,6 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
           expect(parsed_response)
             .to eq({ "errors" => [
               { "title" => "base", "detail" => "There already exists a declaration that will be or has been paid for this event" },
-              { "title" => "declaration_date", "detail" => "A declaration with the date of #{milestone_start_date.in_time_zone.rfc3339} already exists." },
             ] })
         end
       end
@@ -274,7 +273,6 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
                   .to eq(
                     [
                       { "title" => "base", "detail" => "There already exists a declaration that will be or has been paid for this event" },
-                      { "title" => "declaration_date", "detail" => "A declaration with the date of #{old_provider_declaration.dig('data', 'attributes', 'declaration_date')} already exists." },
                     ],
                   )
               end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1770
- There is a regression whereby providers cannot re-post for a declaration after it has been clawed back. ie the original declaration is in `awaiting_clawback` or `clawed_back` state

### Changes proposed in this pull request

- This removes the validation `record_does_not_exists_with_different_declaration_date`
- I'm not sure why we have this validation and what purposes it serves so I have removed it as it blocking providers from reposting
- There already exists the validation `validates_billable_slot_available` which checks there is open slot available otherwise prevents the declaration from getting through
- This should be enough for our needs to my understanding

### Guidance to review

- none