### PR TITLE
[CPDLP-1772] Add new service to transfer an NPQ participant between lead providers

### DIFF
--- a/app/services/transfers/npq_participants.rb
+++ b/app/services/transfers/npq_participants.rb
@@ -26,7 +26,7 @@ module Transfers
     end
 
     def npq_lead_provider
-      @npq_lead_provider ||= NPQLeadProvider.find_by(id: new_npq_lead_provider_id)
+      @npq_lead_provider ||= NPQLeadProvider.find_by!(id: new_npq_lead_provider_id)
     end
 
     def participant_profile
@@ -34,11 +34,11 @@ module Transfers
         ParticipantProfile::NPQ
           .active_record
           .joins(participant_identity: { npq_applications: :npq_course })
-          .find_by(participant_identity:, npq_courses: { identifier: course_identifier })
+          .find_by!(participant_identity:, npq_courses: { identifier: course_identifier })
     end
 
     def participant_identity
-      @participant_identity ||= ParticipantIdentity.find_by(external_identifier:)
+      @participant_identity ||= ParticipantIdentity.find_by!(external_identifier:)
     end
 
     def npq_application

--- a/app/services/transfers/npq_participants.rb
+++ b/app/services/transfers/npq_participants.rb
@@ -2,9 +2,12 @@
 
 module Transfers
   class NPQParticipants
-    def initialize(external_identifier:, new_npq_lead_provider_id:)
+    attr_reader :external_identifier, :new_npq_lead_provider_id, :course_identifier
+
+    def initialize(external_identifier:, new_npq_lead_provider_id:, course_identifier:)
       @external_identifier = external_identifier
       @new_npq_lead_provider_id = new_npq_lead_provider_id
+      @course_identifier = course_identifier
     end
 
     def call
@@ -14,8 +17,6 @@ module Transfers
     end
 
   private
-
-    attr_reader :external_identifier, :new_npq_lead_provider_id
 
     def transfer_participant
       return unless participant_profile && npq_application
@@ -31,9 +32,9 @@ module Transfers
     def participant_profile
       @participant_profile ||=
         ParticipantProfile::NPQ
-          .npqs
           .active_record
-          .find_by(participant_identity:)
+          .joins(participant_identity: { npq_applications: :npq_course })
+          .find_by(participant_identity:, npq_courses: { identifier: course_identifier })
     end
 
     def participant_identity

--- a/app/services/transfers/npq_participants.rb
+++ b/app/services/transfers/npq_participants.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Transfers
+  class NPQParticipants
+    def initialize(external_identifier:, new_npq_lead_provider_id:)
+      @external_identifier = external_identifier
+      @new_npq_lead_provider_id = new_npq_lead_provider_id
+    end
+
+    def call
+      return unless npq_lead_provider && participant_identity
+
+      transfer_participant
+    end
+
+  private
+
+    attr_reader :external_identifier, :new_npq_lead_provider_id
+
+    def transfer_participant
+      return unless participant_profile && npq_application
+
+      npq_application.update!(npq_lead_provider:)
+      Rails.logger.info "Participant (#{external_identifier}) was transferred to (#{npq_lead_provider.name}) successfully"
+    end
+
+    def npq_lead_provider
+      @npq_lead_provider ||= NPQLeadProvider.find_by(id: new_npq_lead_provider_id)
+    end
+
+    def participant_profile
+      @participant_profile ||=
+        ParticipantProfile::NPQ
+          .npqs
+          .active_record
+          .find_by(participant_identity:)
+    end
+
+    def participant_identity
+      @participant_identity ||= ParticipantIdentity.find_by(external_identifier:)
+    end
+
+    def npq_application
+      @npq_application ||= participant_profile.npq_application
+    end
+  end
+end

--- a/spec/services/transfers/npq_participants_spec.rb
+++ b/spec/services/transfers/npq_participants_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe Transfers::NPQParticipants, :with_default_schedules do
 
   let(:external_identifier) { participant_profile.participant_identity.external_identifier }
   let(:npq_application) { participant_profile.npq_application }
+  let(:course_identifier) { participant_profile.npq_application.npq_course.identifier }
 
   subject do
     described_class.new(
       external_identifier:,
       new_npq_lead_provider_id:,
+      course_identifier:,
     )
   end
 
@@ -41,6 +43,13 @@ RSpec.describe Transfers::NPQParticipants, :with_default_schedules do
 
     context "when participant does not have an active NPQ profile" do
       let!(:participant_profile) { create(:npq_participant_profile, :withdrawn_record, npq_lead_provider:) }
+      it "does not update the NPQ lead provider on the participant application" do
+        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+      end
+    end
+
+    context "when course_identifier is different than one attached to the profile" do
+      let(:course_identifier) { "some-other-identifier" }
       it "does not update the NPQ lead provider on the participant application" do
         expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
       end

--- a/spec/services/transfers/npq_participants_spec.rb
+++ b/spec/services/transfers/npq_participants_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Transfers::NPQParticipants, :with_default_schedules do
+  let!(:new_cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:new_npq_lead_provider_id) { new_cpd_lead_provider.npq_lead_provider.id }
+
+  let(:cpd_lead_provider)      { create(:cpd_lead_provider, :with_npq_lead_provider, :with_lead_provider) }
+  let(:npq_lead_provider)      { cpd_lead_provider.npq_lead_provider }
+  let!(:participant_profile)   { create(:npq_participant_profile, npq_lead_provider:) }
+
+  let(:external_identifier) { participant_profile.participant_identity.external_identifier }
+  let(:npq_application) { participant_profile.npq_application }
+
+  subject do
+    described_class.new(
+      external_identifier:,
+      new_npq_lead_provider_id:,
+    )
+  end
+
+  describe "#call" do
+    it "transfers the participant application to the new NPQ lead provider" do
+      expect { subject.call }.to change { npq_application.reload.npq_lead_provider_id }.from(npq_lead_provider.id).to(new_npq_lead_provider_id)
+    end
+
+    context "when NPQ lead provider does not exist" do
+      let(:new_npq_lead_provider_id) { "does-not-exist" }
+      it "does not update the NPQ lead provider on the participant application" do
+        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+      end
+    end
+
+    context "when participant does not exist" do
+      let(:external_identifier) { "does-not-exist" }
+      it "does not update the NPQ lead provider on the participant application" do
+        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+      end
+    end
+
+    context "when participant does not have an active NPQ profile" do
+      let!(:participant_profile) { create(:npq_participant_profile, :withdrawn_record, npq_lead_provider:) }
+      it "does not update the NPQ lead provider on the participant application" do
+        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+      end
+    end
+  end
+end

--- a/spec/services/transfers/npq_participants_spec.rb
+++ b/spec/services/transfers/npq_participants_spec.rb
@@ -30,28 +30,36 @@ RSpec.describe Transfers::NPQParticipants, :with_default_schedules do
     context "when NPQ lead provider does not exist" do
       let(:new_npq_lead_provider_id) { "does-not-exist" }
       it "does not update the NPQ lead provider on the participant application" do
-        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+        expect { subject.call }
+          .to raise_error(ActiveRecord::RecordNotFound)
+          .and not_change { npq_application.reload.npq_lead_provider_id }
       end
     end
 
     context "when participant does not exist" do
       let(:external_identifier) { "does-not-exist" }
       it "does not update the NPQ lead provider on the participant application" do
-        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+        expect { subject.call }
+          .to raise_error(ActiveRecord::RecordNotFound)
+          .and not_change { npq_application.reload.npq_lead_provider_id }
       end
     end
 
     context "when participant does not have an active NPQ profile" do
       let!(:participant_profile) { create(:npq_participant_profile, :withdrawn_record, npq_lead_provider:) }
       it "does not update the NPQ lead provider on the participant application" do
-        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+        expect { subject.call }
+          .to raise_error(ActiveRecord::RecordNotFound)
+          .and not_change { npq_application.reload.npq_lead_provider_id }
       end
     end
 
     context "when course_identifier is different than one attached to the profile" do
       let(:course_identifier) { "some-other-identifier" }
       it "does not update the NPQ lead provider on the participant application" do
-        expect { subject.call }.not_to change { npq_application.reload.npq_lead_provider_id }
+        expect { subject.call }
+          .to raise_error(ActiveRecord::RecordNotFound)
+          .and not_change { npq_application.reload.npq_lead_provider_id }
       end
     end
   end


### PR DESCRIPTION
### Context
A task to move an NPQ participant between lead providers prompted creating a service to wrap the logic and test it 
- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1772

### Changes proposed in this pull request

Using the external identifier of the participant and the ID of the new NPQ lead provider, the participant's application should move to the new NPQ lead provider. The new provider can now make declarations to this participant

### Guidance to review
I think(?) this isn't the right place to add this service, as this hierarchy is used differently for inheritance purposes. Happy to move to `services/npq` or as a standalone service class, any thoughts welcome
