### PR TITLE
Add policy specific funding status codes

### DIFF
--- a/app/services/admin/npq_applications/eligibility_import/application_updater.rb
+++ b/app/services/admin/npq_applications/eligibility_import/application_updater.rb
@@ -15,6 +15,8 @@ module Admin
           early_years_outside_catchment
           not_on_early_years_register
           early_years_invalid_npq
+          marked_funded_by_policy
+          marked_ineligible_by_policy
         ].freeze
 
         attr_reader :application_updates, :user, :update_errors, :updated_records, :eligibility_import


### PR DESCRIPTION
### Context

Policy are uploading funding eligibility files and it'd be really useful if they had a specific status code that indicated that it was them who marked an application as funded or ineligible.

### Changes proposed in this pull request

- Add in funding eligibility status codes for policy to use
