### PR TITLE
[CST-1001] ensure programme changes are added correctly

### DIFF
--- a/app/forms/challenge_partnership_form.rb
+++ b/app/forms/challenge_partnership_form.rb
@@ -14,7 +14,7 @@ class ChallengePartnershipForm
   end
 
   def challenge!
-    Partnerships::Challenge.call(partnership, challenge_reason)
+    Partnerships::Challenge.call(partnership:, challenge_reason:)
   end
 
   def partnership

--- a/app/models/induction_programme.rb
+++ b/app/models/induction_programme.rb
@@ -23,14 +23,18 @@ class InductionProgramme < ApplicationRecord
   has_many :participant_profiles, through: :active_induction_records
   has_many :current_participant_profiles, through: :current_induction_records, source: :participant_profile
   has_one :lead_provider, through: :partnership
+  has_one :delivery_partner, through: :partnership
   has_one :cpd_lead_provider, through: :lead_provider
   delegate :school, to: :school_cohort
-  delegate :lead_provider_name, to: :partnership, allow_nil: true
 
   after_commit :touch_induction_records
 
-  def delivery_partner
-    partnership&.delivery_partner
+  def lead_provider_name
+    lead_provider&.name unless partnership&.challenged?
+  end
+
+  def delivery_partner_name
+    delivery_partner&.name unless partnership&.challenged?
   end
 
 private

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -80,8 +80,9 @@ class InductionRecord < ApplicationRecord
     order(created_at: :asc).last
   end
 
-  delegate :lead_provider, to: :induction_programme, allow_nil: true
-  delegate :lead_provider_name, to: :induction_programme, allow_nil: true
+  # NOTE: these will return nil if the partnership is challenged
+  delegate :lead_provider_name, to: :induction_programme
+  delegate :delivery_partner_name, to: :induction_programme
 
   after_save :update_analytics
 

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -33,23 +33,19 @@ class Partnership < ApplicationRecord
 
   scope :in_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
   scope :unchallenged, -> { where(challenged_at: nil, challenge_reason: nil) }
+  scope :active, -> { unchallenged.where(pending: false) }
   scope :relationships, -> { where(relationship: true) }
 
   delegate :name, to: :lead_provider, allow_nil: true, prefix: true
 
-  def challenge!(reason)
-    raise ArgumentError if reason.blank?
-
-    update!(challenge_reason: reason, challenged_at: Time.zone.now)
-  end
+  # NOTE: challenge! has been moved to a service Partnerships::Challenge as there
+  # are now many side affects that need to be considered.
 
   def in_challenge_window?
     return false if challenge_deadline.blank?
 
     challenge_deadline > Time.zone.now
   end
-
-  scope :active, -> { unchallenged.where(pending: false) }
 
   def active?
     challenged_at.nil? && challenge_reason.nil? && pending == false

--- a/app/services/induction/change_cohort_induction_programme.rb
+++ b/app/services/induction/change_cohort_induction_programme.rb
@@ -14,12 +14,12 @@ class Induction::ChangeCohortInductionProgramme < BaseService
                                                   opt_out_of_updates: programme_choice == "no_early_career_teachers",
                                                   core_induction_programme:)
 
-      new_programme = school_cohort.default_induction_programme
-
-      if previous_programme.present? && new_programme.present?
-        Induction::MigrateParticipantsToNewProgramme.call(from_programme: previous_programme,
-                                                          to_programme: new_programme)
-      end
+      # new_programme = school_cohort.default_induction_programme
+      #
+      # if previous_programme.present? && new_programme.present?
+      #   Induction::MigrateParticipantsToNewProgramme.call(from_programme: previous_programme,
+      #                                                     to_programme: new_programme)
+      # end
     end
   end
 

--- a/app/services/induction/change_cohort_induction_programme.rb
+++ b/app/services/induction/change_cohort_induction_programme.rb
@@ -13,13 +13,6 @@ class Induction::ChangeCohortInductionProgramme < BaseService
                                                   programme_choice:,
                                                   opt_out_of_updates: programme_choice == "no_early_career_teachers",
                                                   core_induction_programme:)
-
-      # new_programme = school_cohort.default_induction_programme
-      #
-      # if previous_programme.present? && new_programme.present?
-      #   Induction::MigrateParticipantsToNewProgramme.call(from_programme: previous_programme,
-      #                                                     to_programme: new_programme)
-      # end
     end
   end
 

--- a/app/services/induction/set_cohort_induction_programme.rb
+++ b/app/services/induction/set_cohort_induction_programme.rb
@@ -12,9 +12,13 @@ class Induction::SetCohortInductionProgramme < BaseService
       programme = nil
 
       if InductionProgramme.training_programmes.keys.include? programme_choice
-        # NOTE: we could move any participants in the old default programme (if present)
-        # over to the new one here but not sure that would always be required?
         programme = InductionProgramme.create!(programme_attrs)
+
+        if school_cohort.default_induction_programme.present?
+          # move users to the new programme
+          Induction::MigrateParticipantsToNewProgramme.call(from_programme: school_cohort.default_induction_programme,
+                                                            to_programme: programme)
+        end
       end
 
       school_cohort.default_induction_programme = programme
@@ -30,6 +34,7 @@ private
                  opt_out_of_updates: false,
                  core_induction_programme: nil,
                  delivery_partner_to_be_confirmed: false)
+
     # NOTE: this is mainly called during addition of a school_cohort and the model may not
     # be persisted as yet
     @school_cohort = school_cohort

--- a/app/services/partnerships/challenge.rb
+++ b/app/services/partnerships/challenge.rb
@@ -1,33 +1,45 @@
 # frozen_string_literal: true
 
 module Partnerships
-  class Challenge
-    def self.call(partnership, challenge_reason)
-      new(partnership, challenge_reason).call
-    end
-
-    def initialize(partnership, challenge_reason)
-      @partnership = partnership
-      @challenge_reason = challenge_reason
-    end
-
+  class Challenge < ::BaseService
     def call
       ActiveRecord::Base.transaction do
-        partnership.challenge!(challenge_reason)
-        partnership.event_logs.create!(
-          event: :challenged,
-          data: {
-            reason: challenge_reason,
-          },
-        )
-
-        if partnership.no_ects?
-          school_cohort = partnership.school.school_cohorts.find_by(cohort: partnership.cohort)
-          school_cohort.update!(induction_programme_choice: :no_early_career_teachers,
-                                opt_out_of_updates: true)
-        end
+        challenge_partnership!
+        update_school_cohort_for_no_ects! if partnership.no_ects?
       end
 
+      send_notification_emails if notify_provider
+    end
+
+  private
+
+    attr_reader :partnership, :challenge_reason, :notify_provider
+
+    def initialize(partnership:, challenge_reason:, notify_provider: true)
+      @partnership = partnership
+      @challenge_reason = challenge_reason
+      @notify_provider = notify_provider
+    end
+
+    def challenge_partnership!
+      raise ArgumentError if challenge_reason.blank?
+
+      partnership.update!(challenge_reason: challenge_reason, challenged_at: Time.zone.now)
+      partnership.event_logs.create!(
+        event: :challenged,
+        data: {
+          reason: challenge_reason,
+        },
+      )
+    end
+
+    def update_school_cohort_for_no_ects!
+      school_cohort.update!(induction_programme_choice: :no_early_career_teachers,
+                            default_induction_programme: nil,
+                            opt_out_of_updates: true)
+    end
+
+    def send_notification_emails
       partnership.lead_provider.users.each do |lead_provider_user|
         LeadProviderMailer.partnership_challenged_email(
           partnership:,
@@ -36,8 +48,8 @@ module Partnerships
       end
     end
 
-  private
-
-    attr_reader :partnership, :challenge_reason
+    def school_cohort
+      partnership.school.school_cohorts.find_by(cohort: partnership.cohort)
+    end
   end
 end

--- a/app/services/partnerships/challenge.rb
+++ b/app/services/partnerships/challenge.rb
@@ -24,7 +24,7 @@ module Partnerships
     def challenge_partnership!
       raise ArgumentError if challenge_reason.blank?
 
-      partnership.update!(challenge_reason: challenge_reason, challenged_at: Time.zone.now)
+      partnership.update!(challenge_reason:, challenged_at: Time.zone.now)
       partnership.event_logs.create!(
         event: :challenged,
         data: {

--- a/app/views/admin/participants/_induction_records.html.erb
+++ b/app/views/admin/participants/_induction_records.html.erb
@@ -12,7 +12,7 @@
 
       sl.row do |row|
         row.key(text: "Lead provider")
-        row.value(text: induction_record&.lead_provider&.name || "No lead provider")
+        row.value(text: induction_record&.lead_provider_name || "No lead provider")
       end
 
       sl.row do |row|

--- a/spec/forms/challenge_partnership_form_spec.rb
+++ b/spec/forms/challenge_partnership_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ChallengePartnershipForm, type: :model do
     subject { described_class.new(partnership_id: partnership.id, challenge_reason: reason) }
 
     it "calls Partnerships::Challenge" do
-      expect(Partnerships::Challenge).to receive(:call).with(partnership, reason)
+      expect(Partnerships::Challenge).to receive(:call).with(partnership:, challenge_reason: reason)
       subject.challenge!
     end
   end

--- a/spec/models/induction_programme_spec.rb
+++ b/spec/models/induction_programme_spec.rb
@@ -36,4 +36,72 @@ RSpec.describe InductionProgramme, type: :model do
     it { is_expected.to have_many(:current_induction_records) }
     it { is_expected.to have_many(:current_participant_profiles).through(:current_induction_records).source(:participant_profile) }
   end
+
+  describe "#lead_provider_name" do
+    let(:lead_provider) { create(:lead_provider, name: "Big Provider") }
+    let(:partnership) { create(:partnership, lead_provider:) }
+    subject(:induction_programme) { create(:induction_programme, :fip, partnership:) }
+
+    it "returns the name of the lead provider" do
+      expect(induction_programme.lead_provider_name).to eq "Big Provider"
+    end
+
+    context "when a partnership has not been reported" do
+      let(:partnership) { nil }
+
+      it "returns nil" do
+        expect(induction_programme.lead_provider_name).to be_nil
+      end
+    end
+
+    context "when the partnership is challenged" do
+      let(:partnership) { create(:partnership, :challenged) }
+
+      it "returns nil" do
+        expect(induction_programme.lead_provider_name).to be_nil
+      end
+    end
+
+    context "when not a FIP programme" do
+      subject(:induction_programme) { create(:induction_programme, :cip) }
+
+      it "returns nil" do
+        expect(induction_programme.lead_provider_name).to be_nil
+      end
+    end
+  end
+
+  describe "#delivery_partner_name" do
+    let(:delivery_partner) { create(:delivery_partner, name: "Big Partner Inc.") }
+    let(:partnership) { create(:partnership, delivery_partner:) }
+    subject(:induction_programme) { create(:induction_programme, :fip, partnership:) }
+
+    it "returns the name of the delivery partner" do
+      expect(induction_programme.delivery_partner_name).to eq "Big Partner Inc."
+    end
+
+    context "when a partnership has not been reported" do
+      let(:partnership) { nil }
+
+      it "returns nil" do
+        expect(induction_programme.delivery_partner_name).to be_nil
+      end
+    end
+
+    context "when the partnership is challenged" do
+      let(:partnership) { create(:partnership, :challenged) }
+
+      it "returns nil" do
+        expect(induction_programme.delivery_partner_name).to be_nil
+      end
+    end
+
+    context "when not a FIP programme" do
+      subject(:induction_programme) { create(:induction_programme, :cip) }
+
+      it "returns nil" do
+        expect(induction_programme.delivery_partner_name).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -56,28 +56,6 @@ RSpec.describe Partnership, type: :model do
     end
   end
 
-  describe "#challenge!" do
-    it "sets the challenge reason and challenged at time" do
-      freeze_time
-      partnership.challenge!("mistake")
-
-      expect(partnership.challenge_reason).to eql "mistake"
-      expect(partnership.challenged_at).to eql Time.zone.now
-    end
-
-    it "raises an error when given a bad argument" do
-      expect {
-        partnership.challenge!("bad_argument")
-      }.to raise_error ArgumentError
-    end
-
-    it "raises an error when given a blank argument" do
-      expect {
-        partnership.challenge!("")
-      }.to raise_error ArgumentError
-    end
-  end
-
   describe "#in_challenge_window?" do
     it "returns true when the challenge deadline is ahead" do
       partnership = create(:partnership, challenge_deadline: rand(1..100).days.from_now)

--- a/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
+++ b/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
 
   describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership" do
     it "call Partnerships::Challenge with the correct arguments" do
-      expect(Partnerships::Challenge).to receive(:call).with(partnership, "mistake")
+      expect(Partnerships::Challenge).to receive(:call).with(partnership:, challenge_reason: "mistake")
 
       post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership", params: {
         challenge_partnership_form: {


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1001)
Ensure changes to partnership are reflected in the service.


### Changes proposed in this pull request

* When a partnership is challenged: do not display provider/partner names in the UI
* When a new partnership is added: add new programme and move users in existing cohort default programme to it.
* Removed the `Partnership#challenge!` method and moved functionality to the existing `Partnerships::Challenge` service

### Guidance to review

