### PR TITLE
Allow creating `ApiRequest`s on API versions past v1

### DIFF
--- a/app/middlewares/api_request_middleware.rb
+++ b/app/middlewares/api_request_middleware.rb
@@ -70,6 +70,6 @@ private
   end
 
   def vendor_api_path?
-    @request.path =~ /^\/api\/v1\/.*$/
+    @request.path =~ /^\/api\/v\d+\/.*$/
   end
 end

--- a/spec/middlewares/api_request_middleware_spec.rb
+++ b/spec/middlewares/api_request_middleware_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe ApiRequestMiddleware do
     end
   end
 
+  describe "#call on a different version API path" do
+    it "fires an ApiRequestJob" do
+      request.get "/api/v3/participants/ecf", params: { foo: "bar" }
+
+      expect(ApiRequestJob).to have_received(:perform_async).with(
+        hash_including("path" => "/api/v3/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything
+      )
+    end
+  end
+
   describe "#call on an API path with POST data" do
     it "fires an ApiRequestJob including post data" do
       request.post "/api/v1/participant-declarations", as: :json, params: { foo: "bar" }.to_json


### PR DESCRIPTION
### Context
We currently only create `ApiRequests` if the API version is 1. However we now support v2 and will be supporting v3 soon. 

- Ticket: N/A

### Changes proposed in this pull request
Allow multiple versions to create `ApiRequest`s

### Guidance to review
I went with only `\d{1}` could go with `\d+` so we don't have to worry about this anymore, thoughts?
