### PR TITLE
Remove User#cohort

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,11 +121,6 @@ class User < ApplicationRecord
     end
   end
 
-  def cohort
-    return early_career_teacher_profile.cohort if early_career_teacher?
-    return mentor_profile.cohort if mentor?
-  end
-
   def school
     return early_career_teacher_profile.school if early_career_teacher?
     return mentor_profile.school if mentor?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -246,27 +246,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#cohort" do
-    it "is expected to return mentor cohort for mentor users" do
-      cohort = create(:cohort)
-      user = create(:mentor_participant_profile, cohort:).user
-
-      expect(user.cohort).to eq cohort
-    end
-
-    it "is expected to return ect cohort for ect users" do
-      cohort = create(:cohort)
-      user = create(:ect_participant_profile, cohort:).user
-
-      expect(user.cohort).to eq cohort
-    end
-
-    it "is expected to return nil when no cohort" do
-      user = create(:user)
-      expect(user.cohort).to be_nil
-    end
-  end
-
   describe "#school" do
     it "is expected to return mentor school for mentor users" do
       school = create(:school)


### PR DESCRIPTION
### Context

- Ticket: n/a

### Changes proposed in this pull request

- Remove `User#cohort`
- this conceptually no longer makes sense. as someone could be in multiple cohorts via different enrolments. eg. ECT in 2021 then 2022 for an NPQ
- also does not appear to be used anywhere

### Guidance to review

- This is some legwork as I try to hammer in `ParticipantProfile#cohort` to become the source of truth for the cohort