### PR TITLE
[CPDLP-1797] bugfix when ECT and NPQ resolve profile correctly

### DIFF
--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -3,6 +3,7 @@
 class ParticipantIdentity < ApplicationRecord
   belongs_to :user, touch: true
   has_many :participant_profiles
+  has_many :npq_participant_profiles, class_name: "ParticipantProfile::NPQ"
   has_many :npq_applications
   has_many :induction_records, through: :participant_profiles
 

--- a/app/services/participant_profile_resolver.rb
+++ b/app/services/participant_profile_resolver.rb
@@ -19,10 +19,10 @@ class ParticipantProfileResolver
           .first
       elsif NPQCourse.identifiers.include?(course_identifier)
         participant_identity
-          .participant_profiles
-          .joins(participant_identity: { npq_applications: [:npq_course, { npq_lead_provider: :cpd_lead_provider }] })
+          .npq_participant_profiles
+          .joins(npq_application: [:npq_course, { npq_lead_provider: :cpd_lead_provider }])
           .where(npq_courses: { identifier: course_identifier })
-          .where(npq_applications: { npq_lead_providers: { cpd_lead_provider: } })
+          .where(npq_application: { npq_lead_providers: { cpd_lead_provider: } })
           .first
       end
     end

--- a/spec/services/participant_profile_resolver_spec.rb
+++ b/spec/services/participant_profile_resolver_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantProfileResolver, :with_default_schedules do
+  describe "#call" do
+    context "when participant has both ECT and NPQ profiles" do
+      let!(:ect_profile) { create(:ect) }
+      let!(:npq_application) { create(:npq_application, :accepted, user:) }
+
+      let(:npq_profile) { npq_application.profile }
+      let(:user) { ect_profile.user }
+      let(:participant_identity) { user.participant_identities.first }
+      let(:course_identifier) { npq_application.npq_course.identifier }
+      let(:cpd_lead_provider) { npq_application.npq_lead_provider.cpd_lead_provider }
+
+      it "correctly selects NPQ profile" do
+        result = described_class.call(
+          participant_identity:,
+          course_identifier:,
+          cpd_lead_provider:,
+        )
+
+        expect(result).to eql(npq_profile)
+      end
+    end
+  end
+end


### PR DESCRIPTION

### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1797
- this bug is when a user has both ECF and NPQ profiles
- when selecting the NPQ profile it would return the ECF profile


### Changes proposed in this pull request

- when attempting to resolve an NPQ profile should now return correct profile

### Guidance to review

- none