### PR TITLE
CST-1051: update schools S41 approved from GIAS

### DIFF
--- a/app/services/data_stage/update_staged_schools.rb
+++ b/app/services/data_stage/update_staged_schools.rb
@@ -120,7 +120,8 @@ module DataStage
 
     def eligible_row?(row)
       english_district_code?(row.fetch("DistrictAdministrative (code)")) &&
-        eligible_establishment_code?(row.fetch("TypeOfEstablishment (code)").to_i)
+        (eligible_establishment_code?(row.fetch("TypeOfEstablishment (code)").to_i) ||
+          row.fetch("Section41Approved (name)") == "Approved")
     end
 
     def extract_values_from(changes_hash)

--- a/spec/services/data_stage/update_staged_schools_spec.rb
+++ b/spec/services/data_stage/update_staged_schools_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DataStage::UpdateStagedSchools do
 
   describe ".call" do
     it "imports each school_data_file row as a DataStage::School" do
-      expect { service.call(**files) }.to change { DataStage::School.count }.by 3
+      expect { service.call(**files) }.to change { DataStage::School.count }.by 4
 
       imported_school = DataStage::School.find_by(urn: 20_001)
       expect(imported_school.name).to eql("The Starship Children's Centre")
@@ -41,11 +41,11 @@ RSpec.describe DataStage::UpdateStagedSchools do
     end
 
     it "ensures the local authority is created" do
-      expect { service.call(**files) }.to change { LocalAuthority.count }.by 3
+      expect { service.call(**files) }.to change { LocalAuthority.count }.by 4
     end
 
     it "ensures the local authority district is created" do
-      expect { service.call(**files) }.to change { LocalAuthorityDistrict.count }.by 3
+      expect { service.call(**files) }.to change { LocalAuthorityDistrict.count }.by 4
     end
 
     context "when the school already exists" do


### PR DESCRIPTION
### Context

- Ticket: [CST-1051](https://dfedigital.atlassian.net/browse/CST-1051)

We are not updating all schools coming from GIAS.
We ignore non-eligible schools.
However we need to extend the definition of eligible-schools to include those whose field `Section41-approval` has changed to `"Approved"` (the are eligible now)

### Changes proposed in this pull request
  Do not ignore school changes coming from GIAS when the school `Section41-approval` is now `"Approved"`

### Guidance to review

