### PR TITLE
[CPDLP-1613] ECF statements: uplift fees in own separate table

### DIFF
--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -4,6 +4,8 @@ module FinanceHelper
   include ActionView::Helpers::NumberHelper
 
   def number_to_pounds(number)
+    number = 0 if number.zero?
+
     number_to_currency number, precision: 2, unit: "£"
   end
 

--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -132,7 +132,7 @@ module Finance
       end
 
       def adjustments_total
-        total_for_uplift - clawback_deductions
+        -clawback_deductions
       end
 
       def clawback_deductions
@@ -142,7 +142,7 @@ module Finance
       end
 
       def total(with_vat: false)
-        sum = service_fee + output_fee + adjustments_total + statement.reconcile_amount
+        sum = service_fee + output_fee + total_for_uplift + adjustments_total + statement.reconcile_amount
         sum += vat if with_vat
         sum
       end

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -28,6 +28,10 @@
           </p>
 
           <p class="govuk-body-s govuk-!-margin-bottom-2">
+            Uplift fees <span><%= number_to_pounds(@calculator.total_for_uplift) %></span>
+          </p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
             Adjustments <span><%= number_to_pounds(@calculator.adjustments_total) %></span>
           </p>
 
@@ -149,6 +153,28 @@
 
     <div class="finance-panel finance-panel__adjustments govuk-!-margin-top-5 govuk-!-margin-bottom-5">
       <%= govuk_table do |table| %>
+        <% table.caption(size: "m", text: "Uplift fees") %>
+
+        <% table.head do |head| %>
+          <% head.row do |row| %>
+            <% row.cell(header: true, text: "Number of participants") %>
+            <% row.cell(header: true, text: "Fee per participant") %>
+            <% row.cell(header: true, text: "Payments", numeric: true) %>
+          <% end %>
+
+          <% table.body do |body| %>
+            <% body.row do |row| %>
+              <% row.cell(text: @calculator.uplift_additions_count) %>
+              <% row.cell(text: number_to_pounds(@calculator.uplift_fee_per_declaration)) %>
+              <% row.cell(text: number_to_pounds(@calculator.uplift_additions_count * @calculator.uplift_fee_per_declaration), numeric: true) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="finance-panel finance-panel__adjustments govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+      <%= govuk_table do |table| %>
         <% table.caption(size: "m", text: "Adjustments") %>
 
         <% table.head do |head| %>
@@ -160,13 +186,6 @@
           <% end %>
 
           <% table.body do |body| %>
-            <% body.row do |row| %>
-              <% row.cell(text: "Uplift fee") %>
-              <% row.cell(text: @calculator.uplift_additions_count) %>
-              <% row.cell(text: number_to_pounds(@calculator.uplift_fee_per_declaration)) %>
-              <% row.cell(text: number_to_pounds(@calculator.uplift_additions_count * @calculator.uplift_fee_per_declaration), numeric: true) %>
-            <% end %>
-
             <% body.row do |row| %>
               <% row.cell(text: "Uplift clawbacks") %>
               <% row.cell(text: @calculator.uplift_deductions_count) %>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -151,7 +151,7 @@
       </div>
     </div>
 
-    <div class="finance-panel finance-panel__adjustments govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+    <div class="finance-panel finance-panel__uplifts govuk-!-margin-top-5 govuk-!-margin-bottom-5">
       <%= govuk_table do |table| %>
         <% table.caption(size: "m", text: "Uplift fees") %>
 

--- a/spec/helpers/finance_helper_spec.rb
+++ b/spec/helpers/finance_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FinanceHelper do
+  describe "#number_to_pounds" do
+    context "when negative zero" do
+      it "returns unsigned zero" do
+        expect(helper.number_to_pounds(BigDecimal("-0"))).to eql("£0.00")
+      end
+    end
+  end
+end

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Finance::ECF::StatementCalculator, :with_default_schedules do
         allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
       end
 
-      it "includes uplift adjustments" do
-        expect(subject.adjustments_total).to eql(200)
+      it "does not include uplift adjustments" do
+        expect(subject.adjustments_total).to eql(0)
       end
     end
 

--- a/spec/support/features/pages/finance/finance_payment_breakdown_report.rb
+++ b/spec/support/features/pages/finance/finance_payment_breakdown_report.rb
@@ -3,6 +3,7 @@
 require_relative "../../sections/statement_selector"
 require_relative "../../sections/summary_finance_panel"
 require_relative "../../sections/output_payments_finance_panel"
+require_relative "../../sections/uplifts_finance_panel"
 require_relative "../../sections/adjustments_finance_panel"
 require_relative "../../sections/contract_information_finance_panel"
 
@@ -14,6 +15,7 @@ module Pages
     section :statement_selector, Sections::StatementSelector
     section :summary_panel, Sections::SummaryFinancePanel
     section :output_payments_panel, Sections::OutputPaymentsFinancePanel
+    section :uplifts_panel, Sections::UpliftsFinancePanel
     section :adjustments_panel, Sections::AdjustmentsFinancePanel
     section :contract_information_panel, Sections::ContractInformationFinancePanel
 
@@ -51,7 +53,7 @@ module Pages
     end
 
     def has_other_fees_table?(num_ects: 0, num_mentors: 0)
-      adjustments_panel.has_uplift_payments? num_ects + num_mentors
+      uplifts_panel.has_uplift_payments? num_ects + num_mentors
     end
   end
 end

--- a/spec/support/features/sections/uplifts_finance_panel.rb
+++ b/spec/support/features/sections/uplifts_finance_panel.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../sections/base_section"
+
+module Sections
+  class UpliftsFinancePanel < Sections::BaseSection
+    set_default_search_arguments ".finance-panel__uplifts"
+
+    # cols: Number of trainees, Fee per trainee, Payments
+    elements :adjustments, "table tbody > tr"
+
+    def has_uplift_payments?(num_participants = 0)
+      element_has_content? adjustments[0], num_participants
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1613
- Uplift fees are not considered adjustments

### Changes proposed in this pull request

- Uplift fees has it's own row in the summary breakdown
- Uplift fees no longer in the adjustments table and now lives in it's own table

### Guidance to review

- none