### PR TITLE
Fix bug that excluded data on final day of export

### DIFF
--- a/app/services/admin/npq_applications/csv_generator.rb
+++ b/app/services/admin/npq_applications/csv_generator.rb
@@ -40,8 +40,8 @@ module Admin
       attr_reader :start_date, :end_date
 
       def initialize(start_date:, end_date:)
-        @start_date = start_date
-        @end_date = end_date
+        @start_date = start_date.at_beginning_of_day
+        @end_date = end_date.at_end_of_day
       end
 
       def csv

--- a/spec/jobs/admin/npq_applications/export_job_spec.rb
+++ b/spec/jobs/admin/npq_applications/export_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Admin::NPQApplications::ExportJob do
     let!(:npq_application_created_within_date_range) { create(:npq_application, created_at: start_date + 1.day) }
     let!(:npq_application_created_before_date_range) { create(:npq_application, created_at: start_date - 1.day) }
     let!(:npq_application_created_after_date_range) { create(:npq_application, created_at: end_date + 1.day) }
+    let!(:npq_application_created_on_final_day) { create(:npq_application, created_at: end_date + 12.hours) }
 
     let(:expected_columns) do
       %i[
@@ -55,6 +56,7 @@ RSpec.describe Admin::NPQApplications::ExportJob do
       CSV.generate do |csv|
         csv << expected_columns
         csv << expected_columns.map { |csv_column| npq_application_created_within_date_range.send(csv_column) }
+        csv << expected_columns.map { |csv_column| npq_application_created_on_final_day.send(csv_column) }
       end
     end
 


### PR DESCRIPTION
### Context

The NPQ Application Exports allowed you to set the end date for exports. The export was wrongly ending at the start of that day rather than the end, entirely missing out a day of data.

### Changes proposed in this pull request

Set the end date to midnight of the end_date.


