### PR TITLE
[CPDLP-1580] Access management - Switch between deliver partners

### DIFF
--- a/app/controllers/appropriate_bodies/base_controller.rb
+++ b/app/controllers/appropriate_bodies/base_controller.rb
@@ -6,7 +6,6 @@ module AppropriateBodies
 
     before_action :authenticate_user!
     before_action :ensure_appropriate_body
-    before_action :set_appropriate_body
 
     layout "appropriate_bodies"
 
@@ -14,12 +13,6 @@ module AppropriateBodies
 
     def ensure_appropriate_body
       raise Pundit::NotAuthorizedError, I18n.t(:forbidden) unless current_user.appropriate_body?
-    end
-
-    def set_appropriate_body
-      return if params[:appropriate_body_id].blank?
-
-      @appropriate_body = current_user.appropriate_bodies.find(params[:appropriate_body_id])
     end
   end
 end

--- a/app/controllers/appropriate_bodies/participants_controller.rb
+++ b/app/controllers/appropriate_bodies/participants_controller.rb
@@ -2,6 +2,14 @@
 
 module AppropriateBodies
   class ParticipantsController < BaseController
-    def index; end
+    def index
+      appropriate_body
+    end
+
+  private
+
+    def appropriate_body
+      @appropriate_body ||= current_user.appropriate_bodies.find(params[:appropriate_body_id])
+    end
   end
 end

--- a/app/controllers/delivery_partners/delivery_partners_controller.rb
+++ b/app/controllers/delivery_partners/delivery_partners_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-module AppropriateBodies
-  class AppropriateBodiesController < BaseController
+module DeliveryPartners
+  class DeliveryPartnersController < BaseController
     layout "application"
 
     def index
       if choose_organisation_form.only_one
-        redirect_to appropriate_body_participants_path(choose_organisation_form.appropriate_body)
+        redirect_to delivery_partner_participants_path(choose_organisation_form.delivery_partner)
       end
     end
 
@@ -14,7 +14,7 @@ module AppropriateBodies
       choose_organisation_form.assign_attributes(choose_organisation_form_params)
 
       if choose_organisation_form.valid?
-        redirect_to appropriate_body_participants_path(choose_organisation_form.appropriate_body)
+        redirect_to delivery_partner_participants_path(choose_organisation_form.delivery_partner)
       else
         render :index
       end
@@ -27,8 +27,8 @@ module AppropriateBodies
     end
 
     def choose_organisation_form_params
-      params.fetch(:appropriate_bodies_choose_organisation_form, {}).permit(
-        :appropriate_body_id,
+      params.fetch(:delivery_partners_choose_organisation_form, {}).permit(
+        :delivery_partner_id,
       )
     end
   end

--- a/app/controllers/delivery_partners/participants_controller.rb
+++ b/app/controllers/delivery_partners/participants_controller.rb
@@ -11,7 +11,7 @@ module DeliveryPartners
         induction_records: {
           induction_programme: {
             partnerships: {
-              delivery_partner: current_user.delivery_partner_profile.delivery_partner,
+              delivery_partner:,
               challenged_at: nil,
               challenge_reason: nil,
               pending: false,
@@ -35,7 +35,7 @@ module DeliveryPartners
           serializer = DeliveryPartners::ParticipantsSerializer.new(
             @filter.scope.order(updated_at: :desc),
             params: {
-              delivery_partner: current_user.delivery_partner_profile.delivery_partner,
+              delivery_partner:,
             },
           )
           render body: to_csv(serializer.serializable_hash)
@@ -44,6 +44,12 @@ module DeliveryPartners
     end
 
   private
+
+    def delivery_partner
+      @delivery_partner ||= current_user.delivery_partners.find(params[:delivery_partner_id])
+    end
+
+    helper_method :delivery_partner
 
     def to_csv(hash)
       return "" if hash[:data].empty?

--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -32,7 +32,7 @@ class ChooseRoleForm
     when "finance"
       helpers.finance_landing_page_path
     when "delivery_partner"
-      helpers.delivery_partners_participants_path
+      helpers.delivery_partners_path
     when "appropriate_body"
       helpers.appropriate_bodies_path
     when "induction_coordinator_and_mentor"

--- a/app/forms/delivery_partners/choose_organisation_form.rb
+++ b/app/forms/delivery_partners/choose_organisation_form.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module DeliveryPartners
+  class ChooseOrganisationForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :user
+    attribute :delivery_partner_id
+
+    validates :delivery_partner_id, inclusion: { in: :valid_ids }
+
+    def delivery_partner_options
+      @delivery_partner_options ||= user.delivery_partners.each_with_object({}) do |ab, sum|
+        sum[ab.id] = ab.name
+      end
+    end
+
+    def delivery_partner
+      return if delivery_partner_id.blank?
+
+      user.delivery_partners.find(delivery_partner_id)
+    end
+
+    def only_one
+      return false if user.delivery_partners.count > 1
+
+      self.delivery_partner_id = user.delivery_partners.first.id
+      true
+    end
+
+  private
+
+    def valid_ids
+      delivery_partner_options.keys
+    end
+  end
+end

--- a/app/forms/delivery_partners/create_user_form.rb
+++ b/app/forms/delivery_partners/create_user_form.rb
@@ -26,7 +26,10 @@ module DeliveryPartners
   private
 
     def email_not_taken
-      if Identity.find_user_by(email:)&.delivery_partner?
+      return if delivery_partner_id.blank?
+      return unless (user = Identity.find_user_by(email:))
+
+      if DeliveryPartnerProfile.where(user:, delivery_partner:).exists?
         errors.add(:email, :unique, message: I18n.t("errors.email.taken"))
       end
     end

--- a/app/mailers/delivery_partner_profile_mailer.rb
+++ b/app/mailers/delivery_partner_profile_mailer.rb
@@ -11,7 +11,7 @@ class DeliveryPartnerProfileMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         name: delivery_partner_profile.user.full_name,
-        delivery_partners_url: delivery_partners_url(**UTMService.email(:delivery_partner_profile_welcome)),
+        delivery_partners_url: start_delivery_partners_url(**UTMService.email(:delivery_partner_profile_welcome)),
       },
     ).tag(:delivery_partner_profile_welcome).associate_with(delivery_partner_profile, as: :delivery_partner_profile)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,8 @@ class User < ApplicationRecord
 
   has_one :teacher_profile, dependent: :destroy
 
-  has_one :delivery_partner_profile, dependent: :destroy
+  has_many :delivery_partner_profiles, dependent: :destroy
+  has_many :delivery_partners, through: :delivery_partner_profiles
 
   has_many :appropriate_body_profiles, dependent: :destroy
   has_many :appropriate_bodies, through: :appropriate_body_profiles
@@ -56,7 +57,7 @@ class User < ApplicationRecord
   end
 
   def delivery_partner?
-    delivery_partner_profile.present?
+    delivery_partner_profiles.any?
   end
 
   def appropriate_body?
@@ -153,7 +154,6 @@ class User < ApplicationRecord
   scope :for_lead_provider, -> { includes(:lead_provider).joins(:lead_provider) }
   scope :admins, -> { joins(:admin_profile) }
   scope :finance_users, -> { joins(:finance_profile) }
-  scope :delivery_partner_users, -> { joins(:delivery_partner_profile) }
 
   scope :changed_since, lambda { |timestamp|
     if timestamp.present?

--- a/app/views/admin/delivery_partners/users/delete.html.erb
+++ b/app/views/admin/delivery_partners/users/delete.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, "Delete user" %>
 <h1>Do you want to delete this user?</h1>
-<p class="govuk-!-font-weight-bold">Supplier user: <span class="govuk-!-font-weight-regular"><%= @user.full_name %></span></p>
-<%= form_for :confirmation, url: admin_delivery_partners_user_path(@user), method: :delete do |f| %>
+<p class="govuk-!-font-weight-bold">Supplier user: <span class="govuk-!-font-weight-regular"><%= @delivery_partner_profile.user.full_name %></span></p>
+<%= form_for :confirmation, url: admin_delivery_partners_user_path(@delivery_partner_profile), method: :delete do |f| %>
   <div class="govuk-button-group">
     <%= f.govuk_submit "Delete", classes: "govuk-button--warning", "data-test": "delete-button" %>
-    <%= govuk_button_link_to "Back", edit_admin_delivery_partners_user_path(@user), class: "govuk-button--secondary" %>
+    <%= govuk_button_link_to "Back", edit_admin_delivery_partners_user_path(@delivery_partner_profile), class: "govuk-button--secondary" %>
   </div>
 <% end %>

--- a/app/views/admin/delivery_partners/users/edit.html.erb
+++ b/app/views/admin/delivery_partners/users/edit.html.erb
@@ -8,13 +8,14 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Edit user details</h1>
 
-    <%= form_with model: @delivery_partners_user_form, scope: :delivery_partners_user_form, url: admin_delivery_partners_user_path(@user) do |f| %>
+    <%= form_with model: @delivery_partners_user_form, scope: :delivery_partners_user_form, url: admin_delivery_partners_user_path(@delivery_partner_profile) do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_collection_select(:delivery_partner_id, DeliveryPartner.name_order, :id, :name, label: { text: "Delivery partner" }, options: { include_blank: true }, class: ["js-location-select"]) %>
       <%= f.govuk_text_field(:full_name, label: { text: "Full name" }) %>
       <%= f.govuk_email_field(:email, label: { text: "Email" }) %>
       <div class="govuk-button-group">
         <%= f.govuk_submit "Save" %>
-        <%= govuk_button_link_to "Delete", delete_admin_delivery_partners_user_path(@user), class: "govuk-button--warning", "data-test"=> "delete-button" %>
+        <%= govuk_button_link_to "Delete", delete_admin_delivery_partners_user_path(@delivery_partner_profile), class: "govuk-button--warning" %>
       </div>
     <% end %>
   </div>

--- a/app/views/admin/delivery_partners/users/index.html.erb
+++ b/app/views/admin/delivery_partners/users/index.html.erb
@@ -12,13 +12,14 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @users.each do |user| %>
+    <% @delivery_partner_profiles.each do |delivery_partner_profile| %>
+      <% user = delivery_partner_profile.user %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= govuk_link_to user.full_name, edit_admin_delivery_partners_user_path(user) %></td>
+        <td class="govuk-table__cell"><%= govuk_link_to user.full_name, edit_admin_delivery_partners_user_path(delivery_partner_profile) %></td>
         <td class="govuk-table__cell"><%= user.email %></td>
-        <td class="govuk-table__cell"><%= user.delivery_partner_profile.delivery_partner.name %></td>
+        <td class="govuk-table__cell"><%= delivery_partner_profile.delivery_partner.name %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
-<%== govuk_paginate @users, @pagy %>
+<%== govuk_paginate @delivery_partner_profiles, @pagy %>

--- a/app/views/admin/delivery_partners/users/new.html.erb
+++ b/app/views/admin/delivery_partners/users/new.html.erb
@@ -9,6 +9,7 @@
     <h1 class="govuk-heading-l">Add a new delivery partner user</h1>
 
     <%= form_with model: @delivery_partners_user_form, scope: :delivery_partners_user_form, url: admin_delivery_partners_users_path do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_collection_select(:delivery_partner_id, DeliveryPartner.name_order, :id, :name, label: { text: "Delivery partner" }, options: { include_blank: true }, class: ["js-location-select"]) %>
       <%= f.govuk_text_field(:full_name, label: { text: "Full name" }) %>
       <%= f.govuk_email_field(:email, label: { text: "Email" }) %>

--- a/app/views/delivery_partners/delivery_partners/index.html.erb
+++ b/app/views/delivery_partners/delivery_partners/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: choose_role_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @choose_organisation_form, url: delivery_partners_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset :delivery_partner_id, legend: { text: "What organisation do you want to view?", tag: 'h1', size: 'xl' }, caption: { text: "Delivery partner", tag: "span", size: "xl" } do %>
+        <p>Choose an organisation to view its participants.</p>
+
+        <% @choose_organisation_form.delivery_partner_options.each_with_index do |(val, name), n| %>
+          <%= f.govuk_radio_button :delivery_partner_id, val, label: { text: name }, link_errors: n.zero? %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/delivery_partners/participants/index.html.erb
+++ b/app/views/delivery_partners/participants/index.html.erb
@@ -1,7 +1,8 @@
-<h1 class="govuk-heading-xl">Participants</h1>
+<span class="govuk-caption-xl">Delivery partner</span>
+<h1 class="govuk-heading-xl"><%= delivery_partner.name %> Participants</h1>
 
-<p class="govuk-body">
-  <%= govuk_link_to "Download (csv)", delivery_partners_participants_path(params.permit(:query, :role, :academic_year, :status).merge({format: :csv})) %>
+<p class="govuk-body govuk-!-text-align-right">
+  <%= govuk_link_to "Download (csv)", delivery_partner_participants_path(params.permit(:query, :role, :academic_year, :status).merge({format: :csv})) %>
 </p>
 
 <%= render SearchBox.new(
@@ -47,7 +48,7 @@
 
   <tbody class="govuk-table__body">
     <% if @participant_profiles.any? %>
-      <%= render DeliveryPartners::Participants::TableRow.with_collection(@participant_profiles, delivery_partner: current_user.delivery_partner_profile.delivery_partner) %>
+      <%= render DeliveryPartners::Participants::TableRow.with_collection(@participant_profiles, delivery_partner: delivery_partner) %>
     <% else %>
       <tr class="govuk-table__row">
         <td colspan="10" class="govuk-table__cell">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,10 @@ en:
           attributes:
             appropriate_body_id:
               inclusion: Choose an organisation
+        delivery_partners/choose_organisation_form:
+          attributes:
+            delivery_partner_id:
+              inclusion: Choose an organisation
 
   page_titles:
     lead_providers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -576,9 +576,11 @@ Rails.application.routes.draw do
     end
   end
 
-  get "/delivery-partners", to: "start#delivery_partners", as: :delivery_partners
-  namespace :delivery_partners, path: "delivery-partners" do
-    resources :participants, only: %i[index]
+  get "/delivery-partners/start", to: "start#delivery_partners", as: :start_delivery_partners
+  scope module: "delivery_partners" do
+    resources :delivery_partners, path: "delivery-partners", only: %i[index create] do
+      resources :participants, only: %i[index]
+    end
   end
 
   scope module: "appropriate_bodies" do

--- a/spec/factories/delivery_partners.rb
+++ b/spec/factories/delivery_partners.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :delivery_partner do
-    name  { "Delivery Partner" }
+    sequence :name do |n|
+      "Delivery Partner #{n}"
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -53,7 +53,9 @@ FactoryBot.define do
     end
 
     trait :delivery_partner do
-      delivery_partner_profile
+      after(:create) do |u|
+        create(:delivery_partner_profile, user: u)
+      end
     end
 
     trait :appropriate_body do

--- a/spec/features/delivery_partners/delivery_partners_spec.rb
+++ b/spec/features/delivery_partners/delivery_partners_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Delivery partner choose organisations page", type: :feature do
+  let(:delivery_partner_user) { create(:user) }
+  let(:delivery_partner_profile1) { create(:delivery_partner_profile, user: delivery_partner_user) }
+  let(:delivery_partner_profile2) { create(:delivery_partner_profile, user: delivery_partner_user) }
+  let(:delivery_partner_profile3) { create(:delivery_partner_profile, user: delivery_partner_user) }
+
+  scenario "User with one delivery partner" do
+    given_user_with_one_delivery_partner_exists
+    and_i_am_logged_in_as_delivery_partner_user
+
+    when_i_visit_the_delivery_partners_page
+
+    then_i_see("Participants")
+    and_i_see(delivery_partner_profile1.delivery_partner.name)
+  end
+
+  scenario "User with multiple delivery partners" do
+    given_user_with_multiple_delivery_partner_exists
+    and_i_am_logged_in_as_delivery_partner_user
+
+    when_i_visit_the_delivery_partners_page
+
+    then_i_see("What organisation do you want to view?")
+    and_i_see_multiple_delivery_partners
+
+    when_i_choose(delivery_partner_profile2.delivery_partner.name)
+    and_i_click_on("Continue")
+
+    then_i_see("Participants")
+    and_i_see(delivery_partner_profile2.delivery_partner.name)
+  end
+
+  def given_user_with_one_delivery_partner_exists
+    delivery_partner_profile1
+  end
+
+  def given_user_with_multiple_delivery_partner_exists
+    delivery_partner_profile1
+    delivery_partner_profile2
+    delivery_partner_profile3
+  end
+
+  def and_i_am_logged_in_as_delivery_partner_user
+    sign_in_as(delivery_partner_user)
+  end
+
+  def when_i_visit_the_delivery_partners_page
+    visit("/delivery-partners")
+  end
+
+  def then_i_see(string)
+    expect(page).to have_content(string)
+  end
+
+  alias_method :and_i_see, :then_i_see
+
+  def and_i_see_multiple_delivery_partners
+    expect(page).to have_css(".govuk-radios__item", text: delivery_partner_profile1.delivery_partner.name)
+    expect(page).to have_css(".govuk-radios__item", text: delivery_partner_profile2.delivery_partner.name)
+    expect(page).to have_css(".govuk-radios__item", text: delivery_partner_profile3.delivery_partner.name)
+  end
+
+  def when_i_choose(string)
+    page.choose string
+  end
+
+  def when_i_click_on(string)
+    page.click_on(string)
+  end
+
+  alias_method :and_i_click_on, :when_i_click_on
+end

--- a/spec/features/delivery_partners/participants_spec.rb
+++ b/spec/features/delivery_partners/participants_spec.rb
@@ -8,11 +8,12 @@ RSpec.feature "Delivery partner users participants", type: :feature do
   let(:participant_profile) { create(:ect_participant_profile, school_cohort:, training_status: "withdrawn") }
 
   let(:delivery_partner_user) { create(:user, :delivery_partner) }
+  let(:delivery_partner) { delivery_partner_user.delivery_partners.first }
   let(:partnership) do
     create(
       :partnership,
       school:,
-      delivery_partner: delivery_partner_user.delivery_partner_profile.delivery_partner,
+      delivery_partner:,
       challenged_at: nil,
       challenge_reason: nil,
       pending: false,
@@ -122,7 +123,7 @@ RSpec.feature "Delivery partner users participants", type: :feature do
   end
 
   def when_i_visit_the_delivery_partners_participants_page
-    visit("/delivery-partners/participants")
+    visit("/delivery-partners/#{delivery_partner.id}/participants")
   end
 
   def then_i_see(string)

--- a/spec/forms/choose_role_form_spec.rb
+++ b/spec/forms/choose_role_form_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe ChooseRoleForm, type: :model do
 
       describe "param with delivery_partner role" do
         let(:form_role) { "delivery_partner" }
-        let(:helpers) { Struct.new(:delivery_partners_participants_path).new("/delivery-partners") }
+        let(:helpers) { Struct.new(:delivery_partners_path).new("/delivery-partners") }
 
         it "should be valid" do
           expect(form.valid?).to be true
         end
 
         it "returns correct redirect_path" do
-          expect(form.redirect_path(helpers:)).to be helpers.delivery_partners_participants_path
+          expect(form.redirect_path(helpers:)).to be helpers.delivery_partners_path
         end
       end
 

--- a/spec/forms/delivery_partners/choose_organisation_form_spec.rb
+++ b/spec/forms/delivery_partners/choose_organisation_form_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe DeliveryPartners::ChooseOrganisationForm, type: :model do
+  subject(:form) { described_class.new(params) }
+
+  let(:params) { { user:, delivery_partner_id: form_delivery_partner_id } }
+  let(:form_delivery_partner_id) { nil }
+  let(:user) { create(:user) }
+
+  describe "#delivery_partner" do
+    let!(:delivery_partner_profile) { create(:delivery_partner_profile, user:) }
+    let(:form_delivery_partner_id) { delivery_partner_profile.delivery_partner.id }
+
+    it "returns delivery_partner" do
+      expect(form.delivery_partner).to eql(delivery_partner_profile.delivery_partner)
+    end
+  end
+
+  describe "#only_one" do
+    describe "one appropriate body" do
+      let!(:delivery_partner_profile1) { create(:delivery_partner_profile, user:) }
+
+      it "returns true" do
+        expect(form.only_one).to be true
+        expect(form.delivery_partner).to eql(delivery_partner_profile1.delivery_partner)
+      end
+    end
+
+    describe "multiple appropriate bodies" do
+      let!(:delivery_partner_profile1) { create(:delivery_partner_profile, user:) }
+      let!(:delivery_partner_profile2) { create(:delivery_partner_profile, user:) }
+      let!(:delivery_partner_profile3) { create(:delivery_partner_profile, user:) }
+
+      it "returns false" do
+        expect(form.only_one).to be false
+      end
+    end
+  end
+
+  describe "#delivery_partner_options" do
+    let!(:delivery_partner_profile1) { create(:delivery_partner_profile, user:) }
+    let!(:delivery_partner_profile2) { create(:delivery_partner_profile, user:) }
+    let!(:delivery_partner_profile3) { create(:delivery_partner_profile, user:) }
+
+    it "returns form options" do
+      expect(form.delivery_partner_options).to include(
+        delivery_partner_profile1.delivery_partner.id => delivery_partner_profile1.delivery_partner.name,
+        delivery_partner_profile2.delivery_partner.id => delivery_partner_profile2.delivery_partner.name,
+        delivery_partner_profile3.delivery_partner.id => delivery_partner_profile3.delivery_partner.name,
+      )
+    end
+  end
+end

--- a/spec/forms/delivery_partners/update_user_form_spec.rb
+++ b/spec/forms/delivery_partners/update_user_form_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe DeliveryPartners::UpdateUserForm, type: :model do
-  let(:delivery_partner_user) { create(:user, :delivery_partner) }
-  let(:delivery_partner) { create(:delivery_partner) }
-  let(:params) { { full_name: "Test 1", email: "test@example.com", delivery_partner_id: delivery_partner.id } }
+  let(:user) { create(:user, full_name: "Example Name", email: "madeup@example.com") }
+  let(:delivery_partner_1) { create(:delivery_partner) }
+  let(:delivery_partner_2) { create(:delivery_partner) }
 
-  subject(:form) { described_class.new(delivery_partner_user) }
+  let(:delivery_partner_profile) { create(:delivery_partner_profile, user:, delivery_partner: delivery_partner_1) }
+
+  let(:params) { { full_name: "Test 1", email: "test@example.com", delivery_partner_id: delivery_partner_2.id } }
+
+  subject(:form) { described_class.new(delivery_partner_profile:) }
 
   it { is_expected.to validate_presence_of(:full_name).on(:name).with_message("Enter a full name") }
   it { is_expected.to validate_presence_of(:email).on(:email).with_message("Enter an email") }
@@ -13,19 +17,18 @@ RSpec.describe DeliveryPartners::UpdateUserForm, type: :model do
 
   describe ".update" do
     context "valid params" do
-      before do
-        expect(delivery_partner_user).to receive(:update!).with(
-          full_name: params[:full_name],
-          email: params[:email],
-        ).and_return(true)
+      it "should change delivery partner user details" do
+        delivery_partner_profile.reload
+        expect(delivery_partner_profile.user.full_name).to eql("Example Name")
+        expect(delivery_partner_profile.user.email).to eql("madeup@example.com")
+        expect(delivery_partner_profile.delivery_partner).to eql(delivery_partner_1)
 
-        expect(delivery_partner_user.delivery_partner_profile).to receive(:update!).with(
-          delivery_partner:,
-        ).and_return(true)
-      end
-
-      it "should create delivery partner user" do
         expect(form.update(params)).to be true
+
+        delivery_partner_profile.reload
+        expect(delivery_partner_profile.user.full_name).to eql("Test 1")
+        expect(delivery_partner_profile.user.email).to eql("test@example.com")
+        expect(delivery_partner_profile.delivery_partner).to eql(delivery_partner_2)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:participant_profiles) }
     it { is_expected.to have_one(:admin_profile) }
     it { is_expected.to have_one(:finance_profile) }
-    it { is_expected.to have_one(:delivery_partner_profile) }
+    it { is_expected.to have_many(:delivery_partner_profiles) }
     it { is_expected.to have_many(:appropriate_body_profiles) }
     it { is_expected.to have_one(:induction_coordinator_profile) }
     it { is_expected.to have_many(:schools).through(:induction_coordinator_profile) }
@@ -372,7 +372,7 @@ RSpec.describe User, type: :model do
 
   describe "#user_roles" do
     it "returns delivery_partner role" do
-      expect(build(:user, :delivery_partner).user_roles).to eq(%w[delivery_partner])
+      expect(create(:user, :delivery_partner).user_roles).to eq(%w[delivery_partner])
     end
 
     it "returns appropriate_body role" do
@@ -400,11 +400,11 @@ RSpec.describe User, type: :model do
     end
 
     it "returns induction_coordinator and delivery_partner role" do
-      expect(build(:user, :induction_coordinator, :delivery_partner).user_roles.sort).to eq(%w[delivery_partner induction_coordinator].sort)
+      expect(create(:user, :induction_coordinator, :delivery_partner).user_roles.sort).to eq(%w[delivery_partner induction_coordinator].sort)
     end
 
     it "returns teacher, induction_coordinator and delivery_partner role" do
-      expect(build(:user, :teacher, :induction_coordinator, :delivery_partner).user_roles.sort).to eq(%w[delivery_partner induction_coordinator teacher].sort)
+      expect(create(:user, :teacher, :induction_coordinator, :delivery_partner).user_roles.sort).to eq(%w[delivery_partner induction_coordinator teacher].sort)
     end
   end
 end

--- a/spec/requests/delivery_partners/participants_spec.rb
+++ b/spec/requests/delivery_partners/participants_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe "DeliveryPartners::Participants", type: :request do
   let(:user) { create(:user, :delivery_partner) }
+  let(:delivery_partner) { user.delivery_partners.first }
 
   before do
     sign_in user
@@ -11,7 +12,7 @@ RSpec.describe "DeliveryPartners::Participants", type: :request do
 
   describe "GET delivery-partners/participants" do
     it "renders the index participants template" do
-      get "/delivery-partners/participants"
+      get "/delivery-partners/#{delivery_partner.id}/participants"
       expect(response).to render_template "delivery_partners/participants/index"
     end
   end
@@ -21,7 +22,7 @@ RSpec.describe "DeliveryPartners::Participants", type: :request do
 
     it "raises not authorised error" do
       expect {
-        get "/delivery-partners/participants"
+        get "/delivery-partners"
       }.to raise_error Pundit::NotAuthorizedError
     end
   end

--- a/spec/serializers/delivery_partners/participants_serializer_spec.rb
+++ b/spec/serializers/delivery_partners/participants_serializer_spec.rb
@@ -10,7 +10,7 @@ module DeliveryPartners
 
     let(:lead_provider) { create(:lead_provider) }
     let(:delivery_partner_user) { create(:user, :delivery_partner) }
-    let(:delivery_partner) { delivery_partner_user.delivery_partner_profile.delivery_partner }
+    let(:delivery_partner) { delivery_partner_user.delivery_partners.first }
     let(:partnership) do
       create(
         :partnership,


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1580

### Changes proposed in this pull request

* DP participants page updated to allow for multiple organisations and switching between them
* DP choose organisation page
* Login as `delivery-partner@example.com`
  * If the user only has one DP partner role, it will redirect to the participants
  * If more than one, will redirect to choose organisation page

### Guidance to review

