### PR TITLE
Allow admins to change induction start date

### DIFF
--- a/app/controllers/admin/participants/change_induction_start_date_controller.rb
+++ b/app/controllers/admin/participants/change_induction_start_date_controller.rb
@@ -12,10 +12,13 @@ module Admin::Participants
     def update
       @participant_profile = retrieve_participant_profile
       @participant_profile_form = ChangeInductionStartDateForm.new(change_induction_start_date_params)
+      induction_start_date = @participant_profile_form.induction_start_date
 
-      if @participant_profile_form.valid?
-        induction_start_date = @participant_profile_form.induction_start_date
-        ChangeInductionStartDate.call(@participant_profile, induction_start_date:)
+      if @participant_profile_form.valid? && ChangeInductionStartDate.call(@participant_profile, induction_start_date:)
+        flash[:success] = {
+          title: "Induction start date changed successfully",
+          content: "#{@participant_profile.user.full_name}'s induction start date was changed to #{induction_start_date.to_formatted_s(:govuk)}",
+        }
 
         redirect_to(admin_participant_path(@participant_profile))
       else

--- a/app/controllers/admin/participants/change_induction_start_date_controller.rb
+++ b/app/controllers/admin/participants/change_induction_start_date_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class ChangeInductionStartDateController < Admin::BaseController
+    def edit
+      @participant_profile = retrieve_participant_profile
+      @participant_profile_form = ChangeInductionStartDateForm.new(
+        induction_start_date: @participant_profile.induction_start_date,
+      )
+    end
+
+    def update
+      @participant_profile = retrieve_participant_profile
+      @participant_profile_form = ChangeInductionStartDateForm.new(change_induction_start_date_params)
+
+      if @participant_profile_form.valid?
+        induction_start_date = @participant_profile_form.induction_start_date
+        ChangeInductionStartDate.call(@participant_profile, induction_start_date:)
+
+        redirect_to(admin_participant_path(@participant_profile))
+      else
+        render(:edit)
+      end
+    end
+
+  private
+
+    def retrieve_participant_profile
+      policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
+        authorize participant_profile, policy_class: participant_profile.policy_class
+      end
+    end
+
+    def change_induction_start_date_params
+      params.require(:admin_participants_change_induction_start_date_form).permit(:induction_start_date)
+    end
+  end
+end

--- a/app/forms/admin/participants/change_induction_start_date_form.rb
+++ b/app/forms/admin/participants/change_induction_start_date_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class ChangeInductionStartDateForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ::ActiveRecord::AttributeAssignment
+
+    attribute :induction_start_date, :date
+
+    validates :induction_start_date, presence: true
+
+    def to_h
+      { induction_start_date: }
+    end
+  end
+end

--- a/app/policies/induction_record_policy.rb
+++ b/app/policies/induction_record_policy.rb
@@ -5,6 +5,10 @@ class InductionRecordPolicy < ApplicationPolicy
     admin?
   end
 
+  def edit?
+    admin?
+  end
+
   def validate?
     admin?
   end

--- a/app/services/admin/participants/change_induction_start_date.rb
+++ b/app/services/admin/participants/change_induction_start_date.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class ChangeInductionStartDate < BaseService
+    attr_reader :participant_profile, :induction_start_date
+
+    def initialize(participant_profile, induction_start_date:)
+      @participant_profile = participant_profile
+      @induction_start_date = induction_start_date
+    end
+
+    def call
+      participant_profile.update!(induction_start_date:)
+    end
+  end
+end

--- a/app/views/admin/participants/_details.html.erb
+++ b/app/views/admin/participants/_details.html.erb
@@ -27,6 +27,10 @@
   sl.row do |row|
     row.key(text: "Induction start date")
     row.value(text: latest_induction_record.participant_profile&.induction_start_date&.to_s(:govuk))
+    row.action(
+      href: edit_admin_participant_change_induction_start_date_path(participant_profile),
+      visually_hidden_text: "induction start date"
+    )
   end
 
   if @participant_profile.teacher_profile

--- a/app/views/admin/participants/change_cohort/edit.html.erb
+++ b/app/views/admin/participants/change_cohort/edit.html.erb
@@ -1,14 +1,18 @@
-<%= form_for(@amend_participant_cohort, url: admin_participant_change_cohort_path(@participant_profile), method: "put") do |f| %>
-  <%= f.govuk_error_summary %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@amend_participant_cohort, url: admin_participant_change_cohort_path(@participant_profile), method: "put") do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <%= f.govuk_collection_select(
-    :target_cohort_start_year,
-    Cohort.where(start_year: 2021..),
-    :start_year,
-    :start_year,
-    label: { text: "Change #{@participant_profile.user.full_name}'s cohort", tag: "h1", size: "l" },
-    hint: { text: "Their current cohort is: #{@latest_induction_record.cohort.start_year}" },
-  ) %>
+      <%= f.govuk_collection_select(
+        :target_cohort_start_year,
+        Cohort.where(start_year: 2021..),
+        :start_year,
+        :start_year,
+        label: { text: "Change #{@participant_profile.user.full_name}'s cohort", tag: "h1", size: "l" },
+        hint: { text: "Their current cohort is: #{@latest_induction_record.cohort.start_year}" },
+      ) %>
 
-  <%= f.govuk_submit %>
-<% end %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/change_induction_start_date/edit.html.erb
+++ b/app/views/admin/participants/change_induction_start_date/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@participant_profile_form, url: admin_participant_change_induction_start_date_path(@participant_profile), method: "put") do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_date_field(
+        :induction_start_date,
+        legend: { text: "What is #{@participant_profile.user.full_name}'s new induction start date?" },
+        hint: { text: "For example, 14 9 #{Date.today.year}" }
+      ) do %>
+        <p class="govuk-body">
+          This is the date when the ECT's induction programme
+          formally starts. It may be different to their contract start date.
+        </p>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <%= govuk_tabs(title: 'Contents') do |component| %>
         <% component.tab(label: 'Details') do %>
-          <%= render partial: 'details', locals: { latest_induction_record: @latest_induction_record } %>
+          <%= render partial: 'details', locals: { participant_profile: @participant_profile, latest_induction_record: @latest_induction_record } %>
         <% end %>
         <% component.tab(label: 'School') do %>
           <%= render partial: 'school', locals: { latest_induction_record: @latest_induction_record } %>
@@ -25,7 +25,7 @@
           <%= render partial: 'history', locals: { historical_induction_records: @historical_induction_records, latest_induction_record: @latest_induction_record } %>
         <% end %>
         <% component.tab(label: 'Induction records') do %>
-          <%= render partial: 'induction_records', locals: { induction_records: @induction_records } %>
+          <%= render partial: 'induction_records', locals: { participant_profile: @participant_profile, induction_records: @induction_records } %>
         <% end %>
         <% component.tab(label: 'Cohorts') do %>
           <%= render partial: 'cohorts', locals: { latest_induction_record: @latest_induction_record } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,6 +362,10 @@ en:
           attributes:
             delivery_partner_id:
               inclusion: Choose an organisation
+        admin/participants/change_induction_start_date_form:
+          attributes:
+            induction_start_date:
+              blank: Enter an induction start date
 
   page_titles:
     lead_providers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,8 @@ Rails.application.routes.draw do
       resource :npq_change_full_name, only: %i[edit update], controller: "participants/npq/change_full_name"
       resource :npq_change_email, only: %i[edit update], controller: "participants/npq/change_email"
 
+      resource :change_induction_start_date, only: %i[edit update], controller: "participants/change_induction_start_date"
+
       resource :school_transfer, path: "school-transfer", only: [], controller: "participants/school_transfer" do
         member do
           get "select-school", action: :select_school, as: :select_school

--- a/spec/forms/admin/participants/change_induction_start_date_form_spec.rb
+++ b/spec/forms/admin/participants/change_induction_start_date_form_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Participants::ChangeInductionStartDateForm, type: :model do
+  let(:induction_start_date) { 3.weeks.from_now.to_date }
+  subject { described_class.new(induction_start_date:) }
+
+  describe "initializing with an induction_start_date 3 weeks in the future" do
+    it { is_expected.to have_attributes(induction_start_date:) }
+    it { is_expected.to validate_presence_of(:induction_start_date).with_message("Enter an induction start date") }
+  end
+
+  describe "#to_h" do
+    it "returns a hash containing the induction_start_date" do
+      expect(subject.to_h).to eql({ induction_start_date: })
+    end
+  end
+end

--- a/spec/requests/admin/participants/change_cohort_spec.rb
+++ b/spec/requests/admin/participants/change_cohort_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
     end
   end
 
-  describe "PUT /admin/participants/:participant_id/change_cohort/edit" do
+  describe "PUT /admin/participants/:participant_id/change_cohort" do
     let(:params) { { induction_amend_participant_cohort: { target_cohort_start_year: 2022 } } }
 
     it "initializes an Induction::AmendParticipantCohort" do

--- a/spec/requests/admin/participants/change_induction_start_date_spec.rb
+++ b/spec/requests/admin/participants/change_induction_start_date_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
+  let(:admin_user) { create(:user, :admin) }
+  let(:old_date) { 2.weeks.ago.to_date }
+
+  let!(:ect_profile) { create(:ect, induction_start_date: old_date) }
+
+  before { sign_in(admin_user) }
+
+  describe "GET /admin/participants/:participant_id/change_induction_start_date/edit" do
+    before { get("/admin/participants/#{ect_profile.id}/change_induction_start_date/edit") }
+
+    it "renders the edit form for a participant's induction start date" do
+      expect(response).to render_template("admin/participants/change_induction_start_date/edit")
+      expect(response.body).to match(%r{<form.*action="/admin/participants/#{ect_profile.id}/change_induction_start_date"})
+      expect(response.body).to match(/<button.*class="govuk-button"/)
+    end
+
+    it "has the correct heading" do
+      expect(response.body).to match(/What is #{ect_profile.user.full_name}.* new induction start date/)
+    end
+  end
+
+  describe "GET /admin/participants/:participant_id/change_induction_start_date" do
+    let(:new_date) { 3.weeks.from_now.to_date }
+
+    # Rails multiparameter attributes for dates:
+    let(:params) do
+      {
+        admin_participants_change_induction_start_date_form: {
+          "induction_start_date(3i)" => new_date.day,
+          "induction_start_date(2i)" => new_date.month,
+          "induction_start_date(1i)" => new_date.year,
+        },
+      }
+    end
+
+    it "updates the induction_start_date for the given profile" do
+      expect(ect_profile.induction_start_date).to eql(old_date)
+
+      put("/admin/participants/#{ect_profile.id}/change_induction_start_date", params:)
+
+      expect(ect_profile.reload.induction_start_date).to eql(new_date)
+    end
+
+    context "when invalid" do
+      let(:params) do
+        {
+          admin_participants_change_induction_start_date_form: {
+            "induction_start_date(3i)" => "",
+            "induction_start_date(2i)" => "",
+            "induction_start_date(1i)" => "",
+          },
+        }
+      end
+
+      it "renders :edit" do
+        put("/admin/participants/#{ect_profile.id}/change_induction_start_date", params:)
+
+        expect(response).to render_template("admin/participants/change_induction_start_date/edit")
+      end
+    end
+  end
+end

--- a/spec/services/admin/participants/change_induction_start_date_spec.rb
+++ b/spec/services/admin/participants/change_induction_start_date_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Participants::ChangeInductionStartDate do
+  let(:participant_profile) { double(ParticipantProfile, update!: true) }
+  let(:induction_start_date) { 3.weeks.from_now }
+
+  subject { described_class.new(participant_profile, induction_start_date:) }
+
+  describe "#initialize" do
+    it "can be initialized with a participant profile and a date" do
+      expect(subject).to be_a(described_class)
+
+      expect(subject.participant_profile).to eql(participant_profile)
+      expect(subject.induction_start_date).to eql(induction_start_date)
+    end
+  end
+
+  describe "#call" do
+    it "updates the participant profile's induction_start_date field with the supplied date when called" do
+      subject.call
+
+      expect(participant_profile).to have_received(:update!).with(induction_start_date:)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?assignee=5e1dba26b5771b0ca44142ee&selectedIssue=CST-871

### Changes proposed in this pull request

* Add a 'change' link to the details tab so the induction start date can be changed
* Add a form object to validate the change and a regular service object
* Create a form based on the designs in the ticket to update the induction start date

| Details tab | Change induction date form | Success |
| ----------- | -------------------------- | ------------------- |
| ![Screenshot from 2022-09-27 11-35-43](https://user-images.githubusercontent.com/128088/192559292-3a916f05-e191-48ac-9d9c-30ddceecbebc.png) |  ![image](https://user-images.githubusercontent.com/128088/192570720-37d14896-8b9e-41c8-8f8e-276683e86d08.png) | ![image](https://user-images.githubusercontent.com/128088/192572014-d6deb9cc-dc8c-41ec-873f-bd135e973bd2.png) |


### Guidance to review

Do we need additional validation on the start date field? I assume we do but am not sure exactly how it should work (hence the `TODO`)