### PR TITLE
[CPDLP-1811] CourseValidator now uses user for profiles

### DIFF
--- a/app/validators/course_validator.rb
+++ b/app/validators/course_validator.rb
@@ -10,9 +10,9 @@ class CourseValidator < ActiveModel::Validator
 private
 
   def has_profile_for_course_given_course_identitfier?(record)
-    return unless record.participant_identity
+    return unless record.participant_identity&.user
 
-    record.participant_identity.participant_profiles.active_record.any? do |participant_profile|
+    record.participant_identity.user.participant_profiles.active_record.any? do |participant_profile|
       participant_profile.class::COURSE_IDENTIFIERS.include?(record.course_identifier)
     end
   end

--- a/spec/validators/course_validator_spec.rb
+++ b/spec/validators/course_validator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CourseValidator, :with_default_schedules do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      validates :course_identifier, course: true
+
+      attr_reader :participant_identity, :course_identifier
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "temp")
+      end
+
+      def initialize(participant_identity:, course_identifier:)
+        @participant_identity = participant_identity
+        @course_identifier = course_identifier
+      end
+    end
+  end
+
+  describe "#validate" do
+    context "NPQ user" do
+      let(:profile) { create(:npq_participant_profile) }
+      let(:user) { profile.user }
+      let(:participant_identity) { profile.participant_identity }
+      let(:course_identifier) { profile.npq_application.npq_course.identifier }
+
+      subject { klass.new(participant_identity:, course_identifier:) }
+
+      context "with one identity" do
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "with multiple identities" do
+        let(:second_email) { "#{rand(99_999)}@example.com" }
+        let(:second_external_identifier) { SecureRandom.uuid }
+
+        let(:participant_identity) do
+          create(
+            :participant_identity,
+            user:,
+            email: second_email,
+            external_identifier: second_external_identifier,
+          )
+        end
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/course_validator_spec.rb
+++ b/spec/validators/course_validator_spec.rb
@@ -55,6 +55,56 @@ RSpec.describe CourseValidator, :with_default_schedules do
           expect(subject).to be_valid
         end
       end
+
+      context "with different course_identifier" do
+        let(:course_identifier) { "incorrect-course-identifier" }
+
+        it "is invalid" do
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
+    context "ECF user" do
+      let(:declaration) { create(:ect_participant_declaration) }
+      let(:profile) { declaration.participant_profile }
+      let(:user) { profile.user }
+      let(:participant_identity) { profile.participant_identity }
+      let(:course_identifier) { declaration.course_identifier }
+
+      subject { klass.new(participant_identity:, course_identifier:) }
+
+      context "with one identity" do
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "with multiple identities" do
+        let(:second_email) { "#{rand(99_999)}@example.com" }
+        let(:second_external_identifier) { SecureRandom.uuid }
+
+        let(:participant_identity) do
+          create(
+            :participant_identity,
+            user:,
+            email: second_email,
+            external_identifier: second_external_identifier,
+          )
+        end
+
+        it "is valid" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "with different course_identifier" do
+        let(:course_identifier) { "incorrect-course-identifier" }
+
+        it "is invalid" do
+          expect(subject).to be_invalid
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1811
- There are validation issues when attempting to change schedule for users with more than one identity with regards to the `CourseValidator`

### Changes proposed in this pull request

- This handles cases where there may be more than one participant identity for a user

### Guidance to review

- none