### PR TITLE
remove aasm gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,9 +70,6 @@ gem "savon", "~> 2.13"
 # Strong migration checker for database migrations
 gem "strong_migrations", "~> 1.3"
 
-# Acts as State Machine for participant and declaration states
-gem "aasm"
-
 # Pagination
 gem "pagy", "~> 5.10", ">= 5.10.1"
 
@@ -150,9 +147,6 @@ group :development do
 
   # autocompletion backend for development
   gem "solargraph"
-
-  # State machine diagrams - https://github.com/Katee/aasm-diagram
-  gem "aasm-diagram"
 
   # Profiling
   gem "memory_profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (5.3.1)
-      concurrent-ruby (~> 1.0)
-    aasm-diagram (0.1.3)
-      aasm (~> 5.0, >= 4.12)
-      ruby-graphviz (~> 1.2)
     actioncable (6.1.7)
       actionpack (= 6.1.7)
       activesupport (= 6.1.7)
@@ -450,8 +445,6 @@ GEM
       rubocop (~> 1.0)
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -604,8 +597,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm
-  aasm-diagram
   activerecord-session_store (~> 2.0)
   ar-uuid (~> 0.2.3)
   aws-sdk-s3


### PR DESCRIPTION

### Context

- Ticket: n/a

### Changes proposed in this pull request

- Remove `aasm` and related gem as does not appear to be used anywhere

### Guidance to review

- none
