### PR TITLE
[CPDLP-1804] Add service to amend an NPQ application cohort

### DIFF
--- a/app/services/npq/amend_participant_cohort.rb
+++ b/app/services/npq/amend_participant_cohort.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module NPQ
+  class AmendParticipantCohort
+    include ActiveModel::Validations
+
+    attr_accessor :npq_application_id, :target_cohort_start_year
+
+    validates :npq_application_id, :target_cohort_start_year, presence: true
+    validates :npq_application,
+              presence: { message: I18n.t("errors.npq_application.blank") }
+    validates :target_cohort,
+              presence: {
+                message: lambda do |form, _|
+                  I18n.t("errors.cohort.blank", year: form.target_cohort_start_year, where: "the service")
+                end,
+              }
+    validate :participant_profile_has_no_declarations
+    validate :source_cohort_different_to_target_cohort
+
+    def initialize(npq_application_id:, target_cohort_start_year:)
+      @npq_application_id = npq_application_id
+      @target_cohort_start_year = target_cohort_start_year
+    end
+
+    def call
+      return if invalid?
+
+      ActiveRecord::Base.transaction do
+        npq_application.update!(cohort: target_cohort)
+        participant_profile.update!(schedule: target_schedule) if participant_profile
+      end
+    end
+
+  private
+
+    def source_cohort
+      @source_cohort ||= npq_application.cohort
+    end
+
+    def target_cohort
+      @target_cohort ||= Cohort.find_by(start_year: target_cohort_start_year)
+    end
+
+    def npq_application
+      @npq_application ||= NPQApplication.find_by(id: npq_application_id)
+    end
+
+    def participant_profile
+      @participant_profile ||= npq_application&.profile
+    end
+
+    def participant_declarations
+      @participant_declarations ||= participant_profile.participant_declarations
+    end
+
+    def source_schedule
+      @source_schedule ||= participant_profile.schedule
+    end
+
+    def target_schedule
+      Finance::Schedule::NPQ.find_by(cohort: target_cohort, name: source_schedule.name, schedule_identifier: source_schedule.schedule_identifier, type: source_schedule.type)
+    end
+
+    def source_cohort_different_to_target_cohort
+      return unless npq_application
+
+      if npq_application.cohort == target_cohort
+        errors.add(:target_cohort_start_year, I18n.t("errors.cohort.excluded_start_year", year: source_cohort.start_year))
+      end
+    end
+
+    def participant_profile_has_no_declarations
+      return unless participant_profile
+
+      if participant_declarations.any?
+        errors.add(:base, I18n.t("errors.participant_declarations.exist"))
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,8 @@ en:
     teacher_reference_number_personalised:
       <<: *trn_error_messages
       blank: Enter your teacher reference number (TRN)
+    npq_application:
+      blank: Enter a valid NPQ application ID
 
   activerecord:
     attributes:

--- a/spec/services/npq/amend_participant_cohort_spec.rb
+++ b/spec/services/npq/amend_participant_cohort_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::AmendParticipantCohort, :with_default_schedules, type: :model do
+  let(:npq_application) { create(:npq_application) }
+  let(:npq_application_id) { npq_application.id }
+
+  let!(:cohort_2022) { create(:cohort, :next) }
+  let(:cohort_2021) { Cohort.find_by(start_year: 2021) }
+
+  let(:target_cohort_start_year) { cohort_2021.start_year }
+  subject do
+    described_class.new(
+      npq_application_id:,
+      target_cohort_start_year:,
+    )
+  end
+
+  describe "validations" do
+    context "when the NPQ application id is blank" do
+      let(:npq_application_id) {}
+      it { is_expected.to validate_presence_of(:npq_application_id) }
+    end
+
+    context "when the NPQ application id does not exist" do
+      let(:npq_application_id) { "does-not-exist" }
+
+      it "returns an error message" do
+        expect(subject).to be_invalid
+        expect(subject.errors.messages_for(:npq_application)).to include("Enter a valid NPQ application ID")
+      end
+    end
+
+    context "when the target_cohort_start_year is blank" do
+      let(:target_cohort_start_year) {}
+      it { is_expected.to validate_presence_of(:target_cohort_start_year) }
+    end
+
+    context "when the target_cohort does not exist for the start year" do
+      let(:target_cohort_start_year) { 2018 }
+
+      it "returns an error message" do
+        expect(subject).to be_invalid
+        expect(subject.errors.messages_for(:target_cohort)).to include("Cohort starting on 2018 not setup on the service")
+      end
+    end
+
+    context "when there are declarations set on the profile" do
+      let!(:npq_application) { create(:npq_application, :accepted, :with_started_declaration) }
+      it "returns an error message" do
+        expect(subject).to be_invalid
+        expect(subject.errors.messages_for(:base)).to include("The participant must have no declarations")
+      end
+    end
+
+    context "when the target cohort is already set on the NPQ application" do
+      it "returns an error message" do
+        expect(subject).to be_invalid
+        expect(subject.errors.messages_for(:target_cohort_start_year)).to include("Invalid value. Must be different to 2021")
+      end
+    end
+  end
+
+  describe "#call" do
+    let(:npq_application) { create(:npq_application, cohort: cohort_2022) }
+
+    context "when invalid" do
+      let(:target_cohort_start_year) {}
+
+      it "does not update the application" do
+        expect { subject.call }.not_to change(npq_application, :cohort)
+      end
+    end
+
+    context "when valid" do
+      it "updates the cohort on the NPQ application to the target cohort" do
+        expect { subject.call }.to change { npq_application.reload.cohort }.from(cohort_2022).to(cohort_2021)
+      end
+
+      context "when a profile is attached to an NPQ application" do
+        let(:npq_course) { create(:npq_course, identifier: "npq-leading-teaching") }
+        let(:npq_application) { create(:npq_application, :accepted, cohort: cohort_2022, npq_course:) }
+        let!(:source_schedule) { create(:npq_specialist_schedule, cohort: cohort_2022) }
+        let!(:target_schedule) { Finance::Schedule::NPQSpecialist.find_by(cohort: cohort_2021) }
+
+        it "updates the cohort on the NPQ application to the target cohort" do
+          expect { subject.call }.to change { npq_application.reload.cohort }.from(cohort_2022).to(cohort_2021)
+        end
+
+        it "updates the schedule on the profile to the target cohort schedule" do
+          participant_profile = npq_application.profile
+
+          expect { subject.call }.to change { participant_profile.reload.schedule }.from(source_schedule).to(target_schedule)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

### Context
NPQ applications might have been moved incorrectly to cohort 2022, add a service to amend that fixes that, with the correct validations in place.

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1804

### Changes proposed in this pull request
Add a service which could later be plugged into the FE to amend an NPQ participant's cohort

### Guidance to review
Did I miss anything?