### PR TITLE
Sort applications by id to ensure order matches CSV

### DIFF
--- a/spec/jobs/admin/npq_applications/export_job_spec.rb
+++ b/spec/jobs/admin/npq_applications/export_job_spec.rb
@@ -53,10 +53,16 @@ RSpec.describe Admin::NPQApplications::ExportJob do
     end
 
     let(:expected_csv) do
+      applications = [
+        npq_application_created_within_date_range,
+        npq_application_created_on_final_day,
+      ].sort_by(&:id)
+
       CSV.generate do |csv|
         csv << expected_columns
-        csv << expected_columns.map { |csv_column| npq_application_created_within_date_range.send(csv_column) }
-        csv << expected_columns.map { |csv_column| npq_application_created_on_final_day.send(csv_column) }
+        applications.each do |application|
+          csv << expected_columns.map { |csv_column| application.send(csv_column) }
+        end
       end
     end
 

--- a/spec/requests/admin/participants/change_cohort_spec.rb
+++ b/spec/requests/admin/participants/change_cohort_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
   let(:admin_user) { create(:user, :admin) }
-
-  let!(:mentor_profile)               { create :mentor }
+  let(:user)                          { create :user, full_name: "Elza Smith" }
+  let!(:mentor_profile)               { create :mentor, user: }
   let!(:ect_profile)                  { create :ect, mentor_profile_id: mentor_profile.id }
 
   before { sign_in(admin_user) }


### PR DESCRIPTION
### Context
When inserting records into the CSV, we are using `find_each` which adheres to the asc ID order. This means that the UIID of the first record could end up coming in later in the CSV.

This is causing the test to be flakey due to the order of the records. Ensure order is respected by sorting by the ID in the expected CSV.

- Ticket: n/a

### Changes proposed in this pull request
- Sort expected records before inserting into the CSV by ascending ID.

### Guidance to review
example of failure
https://github.com/DFE-Digital/early-careers-framework/actions/runs/3144801621/jobs/5111482559#step:8:1528
Ran multiple times locally and hasn't failed yet