### PR TITLE
[CPDLP-1810] Return validation error if wrong cohort passed in

### DIFF
--- a/app/services/participants/change_schedule/ecf.rb
+++ b/app/services/participants/change_schedule/ecf.rb
@@ -66,7 +66,7 @@ module Participants
 
       def validate_cannot_change_cohort
         if relevant_induction_record &&
-            relevant_induction_record.schedule.cohort.start_year != cohort.start_year
+            relevant_induction_record.schedule.cohort.start_year != cohort&.start_year
           errors.add(:cohort, I18n.t("cannot_change_cohort"))
         end
       end
@@ -159,6 +159,7 @@ module Participants
 
       def validate_new_schedule_valid_with_existing_declarations
         return if user.blank? || user_profile.blank?
+        return unless schedule
 
         user_profile.participant_declarations.each do |declaration|
           next unless %w[submitted eligible payable paid].include?(declaration.state)

--- a/app/services/participants/change_schedule/npq.rb
+++ b/app/services/participants/change_schedule/npq.rb
@@ -95,6 +95,8 @@ module Participants
       end
 
       def schedule_valid_with_pending_declarations
+        return unless schedule
+
         user_profile&.participant_declarations&.each do |declaration|
           if declaration.changeable?
             milestone = schedule.milestones.find_by(declaration_type: declaration.declaration_type)

--- a/spec/services/participants/change_schedule/ecf_spec.rb
+++ b/spec/services/participants/change_schedule/ecf_spec.rb
@@ -125,6 +125,33 @@ RSpec.describe Participants::ChangeSchedule::ECF, :with_default_schedules do
         expect(subject.errors.full_messages.join(",")).to include("The property '#/course_identifier' must be an available course to '#/participant_id'")
       end
     end
+
+    context "with incorrect cohort" do
+      let(:user)     { profile.user }
+      let(:profile)  { create(:mentor, lead_provider: cpd_lead_provider.lead_provider) }
+      let(:schedule) { Finance::Schedule::ECF.default_for(cohort: Cohort.current) }
+      let!(:participant_declaration) do
+        create(:participant_declaration,
+               user:,
+               cpd_lead_provider:,
+               participant_profile: profile,
+               course_identifier: "ecf-mentor")
+      end
+
+      subject do
+        Participants::ChangeSchedule::ECF.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: user.id,
+          course_identifier: "ecf-mentor",
+          cpd_lead_provider:,
+          cohort: 2018,
+        })
+      end
+
+      it "should have an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing, /must be present and correspond to a valid schedule/)
+      end
+    end
   end
 
   describe "changing to a soft schedules with previous declarations", :with_default_schedules do

--- a/spec/services/participants/change_schedule/npq_spec.rb
+++ b/spec/services/participants/change_schedule/npq_spec.rb
@@ -72,7 +72,33 @@ RSpec.describe Participants::ChangeSchedule::NPQ, :with_default_schedules do
         })
       end
 
-      it "should not have an error" do
+      it "should have an error" do
+        expect { subject.call }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
+    context "with incorrect cohort" do
+      let!(:declaration) do
+        create(
+          :npq_participant_declaration,
+          participant_profile: profile,
+          course_identifier: profile.npq_course.identifier,
+          declaration_date: schedule.milestones.find_by(declaration_type: "started").start_date + 1.day,
+          cpd_lead_provider:,
+        )
+      end
+
+      subject do
+        described_class.new(params: {
+          schedule_identifier: schedule.schedule_identifier,
+          participant_id: user.id,
+          course_identifier: profile.npq_course.identifier,
+          cpd_lead_provider:,
+          cohort: 2018,
+        })
+      end
+
+      it "should have an error" do
         expect { subject.call }.to raise_error(ActionController::ParameterMissing)
       end
     end


### PR DESCRIPTION
### Context
If the wrong cohort is passed in on change schedule, make sure validation completes successfully rather than raising a 500 error due to the schedule not being found

https://sentry.io/organizations/dfe-teacher-services/issues/3491823308/?environment=sandbox&project=5748989&query=is%3Aunresolved

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1810?focusedCommentId=49783&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-49783

### Changes proposed in this pull request
Return early in validation if schedule not present to avoid hitting a 500

### Guidance to review

