### PR TITLE
[CST-1063] Cannot add participant from different school message

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -360,7 +360,7 @@ module Schools
     end
 
     def existing_participant_profile_same_school?
-      existing_participant_profile&.school == school_cohort.school
+      existing_participant_profile&.current_induction_record&.school == school_cohort.school
     end
   end
 end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -360,7 +360,7 @@ module Schools
     end
 
     def existing_participant_profile_same_school?
-      existing_participant_profile&.induction_records.latest&.school == school_cohort.school
+      existing_participant_profile&.induction_records&.latest&.school == school_cohort.school
     end
   end
 end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -360,7 +360,7 @@ module Schools
     end
 
     def existing_participant_profile_same_school?
-      existing_participant_profile&.current_induction_record&.school == school_cohort.school
+      existing_participant_profile&.induction_records.latest&.school == school_cohort.school
     end
   end
 end

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -358,5 +358,9 @@ module Schools
     rescue ActiveRecord::RecordNotFound
       nil
     end
+
+    def existing_participant_profile_same_school?
+      existing_participant_profile&.school == school_cohort.school
+    end
   end
 end

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -7,7 +7,11 @@
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name.titleize %></h1>
 
-    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at a different school</p>
+    <% if add_participant_form.existing_participant_profile_same_school? %>
+      <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at this school</p>
+    <% else %>
+      <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at a different school</p>
+    <% end %>
 
     <p class="govuk-body">Contact us for help to register this person at your school:
     <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -7,12 +7,8 @@
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name.titleize %></h1>
 
-    <% message = "Our records show this person is already registered on an ECF-based training programme" %>
-    <% if add_participant_form.existing_participant_profile_same_school? %>
-      <p class="govuk-body"><%= message %> at this school</p>
-    <% else %>
-      <p class="govuk-body"><%= message %> at a different school</p>
-    <% end %>
+    <% which_school = add_participant_form.existing_participant_profile_same_school? ? "this" : "a different" %>
+    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at <%= which_school %> school" %></p>
 
     <p class="govuk-body">Contact us for help to register this person at your school:
     <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -8,7 +8,7 @@
     <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name.titleize %></h1>
 
     <% which_school = add_participant_form.existing_participant_profile_same_school? ? "this" : "a different" %>
-    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at <%= which_school %> school" %></p>
+    <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at <%= which_school %> school %></p>
 
     <p class="govuk-body">Contact us for help to register this person at your school:
     <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %></p>

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -7,10 +7,11 @@
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name.titleize %></h1>
 
+    <% message = "Our records show this person is already registered on an ECF-based training programme" %>
     <% if add_participant_form.existing_participant_profile_same_school? %>
-      <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at this school</p>
+      <p class="govuk-body"><%= message %> at this school</p>
     <% else %>
-      <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at a different school</p>
+      <p class="govuk-body"><%= message %> at a different school</p>
     <% end %>
 
     <p class="govuk-body">Contact us for help to register this person at your school:

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
 
       when_i_select "No"
       when_i_click_on_continue
-      then_i_am_taken_to_the_cannot_add_page
+      then_i_am_taken_to_the_cannot_add_page_same_school
     end
   end
 
@@ -114,6 +114,38 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
       and_a_participant_from_a_different_school_is_already_on_ecf
     end
 
+    scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do
+      when_i_click_on_add_your_early_career_teacher_and_mentor_details
+      then_i_am_taken_to_roles_page
 
+      when_i_click_on_continue
+      then_i_am_taken_to_your_ect_and_mentors_page
+
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
+
+      when_i_select_to_add_a "A new ECT"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_from_you_page
+
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
+
+      when_i_add_ect_or_mentor_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
+
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
+
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_are_they_a_transfer_page
+
+      when_i_select "No"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_cannot_add_page_different_school
+    end
   end
 end

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -17,7 +17,47 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
 
   context "When participant already on ECF from the same school" do
     before do
-      and_a_participant_is_already_on_ecf
+      given_a_participant_from_the_same_school_is_already_on_ecf
+    end
+
+    scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do
+      when_i_click_on_add_your_early_career_teacher_and_mentor_details
+      then_i_am_taken_to_roles_page
+
+      when_i_click_on_continue
+      then_i_am_taken_to_your_ect_and_mentors_page
+
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
+
+      when_i_select_to_add_a "A new ECT"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_from_you_page
+
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
+
+      when_i_add_ect_or_mentor_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
+
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
+
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_are_they_a_transfer_page
+
+      when_i_select "No"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_cannot_add_page_same_school
+    end
+  end
+
+  context "When participant already on ECF from a different school" do
+    before do
+      given_a_participant_from_a_different_school_is_already_on_ecf
     end
 
     scenario "Induction tutor tries to add ppt that's already on ECF, redirects to transfer journey" do
@@ -72,46 +112,6 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
       when_i_click_confirm_and_add
 
       then_i_should_be_on_the_complete_page
-    end
-
-    scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do
-      when_i_click_on_add_your_early_career_teacher_and_mentor_details
-      then_i_am_taken_to_roles_page
-
-      when_i_click_on_continue
-      then_i_am_taken_to_your_ect_and_mentors_page
-
-      when_i_click_to_add_a_new_ect_or_mentor
-      then_i_should_be_on_the_who_to_add_page
-
-      when_i_select_to_add_a "A new ECT"
-      when_i_click_on_continue
-      then_i_am_taken_to_the_what_we_need_from_you_page
-
-      when_i_click_on_continue
-      then_i_am_taken_to_add_ect_name_page
-
-      when_i_add_ect_or_mentor_name
-      when_i_click_on_continue
-      then_i_am_taken_to_add_teachers_trn_page
-
-      when_i_add_the_trn
-      when_i_click_on_continue
-      then_i_am_taken_to_add_date_of_birth_page
-
-      when_i_add_a_date_of_birth
-      when_i_click_on_continue
-      then_i_am_taken_to_are_they_a_transfer_page
-
-      when_i_select "No"
-      when_i_click_on_continue
-      then_i_am_taken_to_the_cannot_add_page_same_school
-    end
-  end
-
-  context "When participant already on ECF from a different school" do
-    before do
-      given_a_participant_from_a_different_school_is_already_on_ecf
     end
 
     scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -9,98 +9,111 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
   before do
     given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator
-    and_a_participant_is_already_on_ecf
     and_i_have_added_a_mentor
     then_i_am_taken_to_fip_induction_dashboard
     set_participant_data
     set_dqt_validation_result
   end
 
-  scenario "Induction tutor tries to add ppt that's already on ECF, redirects to transfer journey" do
-    when_i_click_on_add_your_early_career_teacher_and_mentor_details
-    then_i_am_taken_to_roles_page
+  context "When participant already on ECF from the same school" do
+    before do
+      and_a_participant_is_already_on_ecf
+    end
 
-    when_i_click_on_continue
-    then_i_am_taken_to_your_ect_and_mentors_page
+    scenario "Induction tutor tries to add ppt that's already on ECF, redirects to transfer journey" do
+      when_i_click_on_add_your_early_career_teacher_and_mentor_details
+      then_i_am_taken_to_roles_page
 
-    when_i_click_to_add_a_new_ect_or_mentor
-    then_i_should_be_on_the_who_to_add_page
+      when_i_click_on_continue
+      then_i_am_taken_to_your_ect_and_mentors_page
 
-    when_i_select_to_add_a "A new ECT"
-    when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_you_page
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
 
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
+      when_i_select_to_add_a "A new ECT"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_from_you_page
 
-    when_i_add_ect_or_mentor_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
 
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
+      when_i_add_ect_or_mentor_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
 
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_are_they_a_transfer_page
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
 
-    when_i_select "Yes"
-    when_i_click_on_continue
-    then_i_am_taken_to_teacher_start_date_page
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_are_they_a_transfer_page
 
-    when_i_add_a_start_date
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_or_mentor_email_page
+      when_i_select "Yes"
+      when_i_click_on_continue
+      then_i_am_taken_to_teacher_start_date_page
 
-    when_i_add_ect_or_mentor_email
-    when_i_click_on_continue
-    then_i_am_taken_choose_mentor_in_transfer_page
+      when_i_add_a_start_date
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_select_a_mentor
-    when_i_click_on_continue
+      when_i_add_ect_or_mentor_email
+      when_i_click_on_continue
+      then_i_am_taken_choose_mentor_in_transfer_page
 
-    then_i_should_be_taken_to_the_teachers_current_programme_page
-    when_i_select "Yes"
-    when_i_click_on_continue
+      when_i_select_a_mentor
+      when_i_click_on_continue
 
-    then_i_am_taken_to_check_details_page
-    when_i_click_confirm_and_add
+      then_i_should_be_taken_to_the_teachers_current_programme_page
+      when_i_select "Yes"
+      when_i_click_on_continue
 
-    then_i_should_be_on_the_complete_page
+      then_i_am_taken_to_check_details_page
+      when_i_click_confirm_and_add
+
+      then_i_should_be_on_the_complete_page
+    end
+
+    scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do
+      when_i_click_on_add_your_early_career_teacher_and_mentor_details
+      then_i_am_taken_to_roles_page
+
+      when_i_click_on_continue
+      then_i_am_taken_to_your_ect_and_mentors_page
+
+      when_i_click_to_add_a_new_ect_or_mentor
+      then_i_should_be_on_the_who_to_add_page
+
+      when_i_select_to_add_a "A new ECT"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_what_we_need_from_you_page
+
+      when_i_click_on_continue
+      then_i_am_taken_to_add_ect_name_page
+
+      when_i_add_ect_or_mentor_name
+      when_i_click_on_continue
+      then_i_am_taken_to_add_teachers_trn_page
+
+      when_i_add_the_trn
+      when_i_click_on_continue
+      then_i_am_taken_to_add_date_of_birth_page
+
+      when_i_add_a_date_of_birth
+      when_i_click_on_continue
+      then_i_am_taken_to_are_they_a_transfer_page
+
+      when_i_select "No"
+      when_i_click_on_continue
+      then_i_am_taken_to_the_cannot_add_page
+    end
   end
 
-  scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do
-    when_i_click_on_add_your_early_career_teacher_and_mentor_details
-    then_i_am_taken_to_roles_page
+  context "When participant already on ECF from a different school" do
+    before do
+      and_a_participant_from_a_different_school_is_already_on_ecf
+    end
 
-    when_i_click_on_continue
-    then_i_am_taken_to_your_ect_and_mentors_page
 
-    when_i_click_to_add_a_new_ect_or_mentor
-    then_i_should_be_on_the_who_to_add_page
-
-    when_i_select_to_add_a "A new ECT"
-    when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_you_page
-
-    when_i_click_on_continue
-    then_i_am_taken_to_add_ect_name_page
-
-    when_i_add_ect_or_mentor_name
-    when_i_click_on_continue
-    then_i_am_taken_to_add_teachers_trn_page
-
-    when_i_add_the_trn
-    when_i_click_on_continue
-    then_i_am_taken_to_add_date_of_birth_page
-
-    when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_are_they_a_transfer_page
-
-    when_i_select "No"
-    when_i_click_on_continue
-    then_i_am_taken_to_the_cannot_add_page
   end
 end

--- a/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_already_on_ecf_training_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
 
   context "When participant already on ECF from a different school" do
     before do
-      and_a_participant_from_a_different_school_is_already_on_ecf
+      given_a_participant_from_a_different_school_is_already_on_ecf
     end
 
     scenario "Induction tutor tries to add ppt that's already on ECF, does NOT continue onto transfer journey" do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -220,15 +220,11 @@ module ManageTrainingSteps
                                               start_date: 2.months.from_now)
   end
 
-  def and_a_participant_is_already_on_ecf
-    @school_two = create(:school, name: "Fip School 2")
-    @school_cohort_two = create(:school_cohort, school: @school_two, cohort: @cohort, induction_programme_choice: "full_induction_programme")
-    @induction_programme_two = create(:induction_programme, :fip, school_cohort: @school_cohort_two)
-
+  def given_a_participant_from_the_same_school_is_already_on_ecf
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
     teacher_profile = create(:teacher_profile, user:)
     @participant_profile_ect = create(:ect_participant_profile, teacher_profile:, school_cohort: @school_cohort)
-    Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_two)
+    Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme)
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1234567", date_of_birth: Date.new(1998, 3, 22))
   end
 

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -122,15 +122,6 @@ module ManageTrainingSteps
     set_updated_participant_data
   end
 
-  def given_i_am_signed_in_as_an_induction_coordinator_from_a_different_school
-    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort_two.school], user: create(:user, full_name: "Carl Coordinator Two"))
-    privacy_policy = create(:privacy_policy)
-    privacy_policy.accept!(@induction_coordinator_profile.user)
-    sign_in_as @induction_coordinator_profile.user
-    set_participant_data
-    set_updated_participant_data
-  end
-
   def and_i_have_added_an_ect
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
     teacher_profile = create(:teacher_profile, user:)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -241,7 +241,7 @@ module ManageTrainingSteps
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1234567", date_of_birth: Date.new(1998, 3, 22))
   end
 
-  def and_a_participant_from_a_different_school_is_already_on_ecf
+  def given_a_participant_from_a_different_school_is_already_on_ecf
     @school_three = create(:school, name: "Fip School 3")
     @school_cohort_three = create(:school_cohort, school: @school_three, cohort: @cohort, induction_programme_choice: "full_induction_programme")
     @induction_programme_three = create(:induction_programme, :fip, school_cohort: @school_cohort_three)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1011,9 +1011,14 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "What’s Sally Teacher’s start date at your school?")
   end
 
-  def then_i_am_taken_to_the_cannot_add_page
+  def then_i_am_taken_to_the_cannot_add_page_same_school
     expect(page).to have_selector("h1", text: "You cannot add Sally Teacher")
     expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at this school")
+  end
+
+  def then_i_am_taken_to_the_cannot_add_page_different_school
+    expect(page).to have_selector("h1", text: "You cannot add Sally Teacher")
+    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at a different school")
   end
 
   def then_i_am_taken_choose_mentor_in_transfer_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -122,6 +122,15 @@ module ManageTrainingSteps
     set_updated_participant_data
   end
 
+  def given_i_am_signed_in_as_an_induction_coordinator_from_a_different_school
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school_cohort_two.school], user: create(:user, full_name: "Carl Coordinator Two"))
+    privacy_policy = create(:privacy_policy)
+    privacy_policy.accept!(@induction_coordinator_profile.user)
+    sign_in_as @induction_coordinator_profile.user
+    set_participant_data
+    set_updated_participant_data
+  end
+
   def and_i_have_added_an_ect
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
     teacher_profile = create(:teacher_profile, user:)
@@ -229,6 +238,18 @@ module ManageTrainingSteps
     teacher_profile = create(:teacher_profile, user:)
     @participant_profile_ect = create(:ect_participant_profile, teacher_profile:, school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_two)
+    create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1234567", date_of_birth: Date.new(1998, 3, 22))
+  end
+
+  def and_a_participant_from_a_different_school_is_already_on_ecf
+    @school_three = create(:school, name: "Fip School 3")
+    @school_cohort_three = create(:school_cohort, school: @school_three, cohort: @cohort, induction_programme_choice: "full_induction_programme")
+    @induction_programme_three = create(:induction_programme, :fip, school_cohort: @school_cohort_three)
+
+    user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
+    teacher_profile = create(:teacher_profile, user:)
+    @participant_profile_ect = create(:ect_participant_profile, teacher_profile:, school_cohort: @school_cohort_three)
+    Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_three)
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1234567", date_of_birth: Date.new(1998, 3, 22))
   end
 
@@ -992,7 +1013,7 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_the_cannot_add_page
     expect(page).to have_selector("h1", text: "You cannot add Sally Teacher")
-    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at a different school")
+    expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at this school")
   end
 
   def then_i_am_taken_choose_mentor_in_transfer_page


### PR DESCRIPTION
### Context

- Ticket: CST-1063

### Changes proposed in this pull request
The "cannot add" logic checks whether the existing participant is in the same school of the new participant.
The message shown changes based on whether the above condition is true or not.


