### PR TITLE
[CPDLP-1798] Inject monthly service fee into contracts

### DIFF
--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -148,7 +148,7 @@ module Finance
       end
 
       def service_fee
-        PaymentCalculator::ECF::ServiceFees.new(contract:).call.sum { |hash| hash[:monthly] }
+        contract.monthly_service_fee || calculated_service_fee
       end
 
       def output_fee
@@ -158,6 +158,10 @@ module Finance
       end
 
     private
+
+      def calculated_service_fee
+        PaymentCalculator::ECF::ServiceFees.new(contract:).call.sum { |hash| hash[:monthly] }
+      end
 
       def output_calculator
         @output_calculator ||= OutputCalculator.new(statement:)

--- a/app/services/finance/npq/course_statement_calculator.rb
+++ b/app/services/finance/npq/course_statement_calculator.rb
@@ -100,7 +100,7 @@ module Finance
       end
 
       def service_fees_per_participant
-        service_fees[:per_participant]
+        calculated_service_fee_per_participant_derived_from_monthly_service_fee || calculated_service_fee_per_participant
       end
 
       def monthly_service_fees
@@ -112,6 +112,16 @@ module Finance
       end
 
     private
+
+      def calculated_service_fee_per_participant_derived_from_monthly_service_fee
+        return unless contract.monthly_service_fee
+
+        contract.monthly_service_fee / contract.recruitment_target
+      end
+
+      def calculated_service_fee_per_participant
+        service_fees[:per_participant]
+      end
 
       def calculated_service_fee
         service_fees[:monthly]

--- a/app/services/finance/npq/course_statement_calculator.rb
+++ b/app/services/finance/npq/course_statement_calculator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "payment_calculator/npq/service_fees"
+
 module Finance
   module NPQ
     class CourseStatementCalculator
@@ -102,11 +104,7 @@ module Finance
       end
 
       def monthly_service_fees
-        service_fees[:monthly]
-      end
-
-      def service_fees
-        @service_fees ||= PaymentCalculator::NPQ::ServiceFees.call(contract:)
+        contract.monthly_service_fee || calculated_service_fee
       end
 
       def course_total
@@ -114,6 +112,14 @@ module Finance
       end
 
     private
+
+      def calculated_service_fee
+        service_fees[:monthly]
+      end
+
+      def service_fees
+        @service_fees ||= PaymentCalculator::NPQ::ServiceFees.call(contract:)
+      end
 
       def course
         @course ||= contract.npq_course

--- a/db/migrate/20220929102011_add_monthly_service_fee_to_contracts.rb
+++ b/db/migrate/20220929102011_add_monthly_service_fee_to_contracts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMonthlyServiceFeeToContracts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :call_off_contracts, :monthly_service_fee, :decimal
+  end
+end

--- a/db/migrate/20220929104505_add_npq_monthly_service_fee.rb
+++ b/db/migrate/20220929104505_add_npq_monthly_service_fee.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNPQMonthlyServiceFee < ActiveRecord::Migration[6.1]
+  def change
+    add_column :npq_contracts, :monthly_service_fee, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_15_142750) do
+ActiveRecord::Schema.define(version: 2022_09_29_102011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -128,6 +128,7 @@ ActiveRecord::Schema.define(version: 2022_09_15_142750) do
     t.uuid "lead_provider_id", default: -> { "gen_random_uuid()" }, null: false
     t.integer "revised_target"
     t.uuid "cohort_id", null: false
+    t.decimal "monthly_service_fee"
     t.index ["cohort_id"], name: "index_call_off_contracts_on_cohort_id"
     t.index ["lead_provider_id"], name: "index_call_off_contracts_on_lead_provider_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_29_102011) do
+ActiveRecord::Schema.define(version: 2022_09_29_104505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -569,6 +569,7 @@ ActiveRecord::Schema.define(version: 2022_09_29_102011) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "cohort_id", null: false
+    t.decimal "monthly_service_fee"
     t.index ["cohort_id"], name: "index_npq_contracts_on_cohort_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_contracts_on_npq_lead_provider_id"
   end

--- a/spec/factories/call_off_contract.rb
+++ b/spec/factories/call_off_contract.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
       }.to_json
     end
 
+    trait :with_monthly_service_fee do
+      monthly_service_fee { 123.45 }
+    end
+
     after(:build) do |contract, evaluator|
       contract.lead_provider = evaluator.lead_provider
     end

--- a/spec/factories/npq_contracts.rb
+++ b/spec/factories/npq_contracts.rb
@@ -61,4 +61,8 @@ FactoryBot.define do
     per_participant { 850.00 }
     service_fee_installments { 25 }
   end
+
+  trait :with_monthly_service_fee do
+    monthly_service_fee { 543.21 }
+  end
 end

--- a/spec/factories/npq_contracts.rb
+++ b/spec/factories/npq_contracts.rb
@@ -63,6 +63,6 @@ FactoryBot.define do
   end
 
   trait :with_monthly_service_fee do
-    monthly_service_fee { 543.21 }
+    monthly_service_fee { 5432.10 }
   end
 end

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -631,4 +631,20 @@ RSpec.describe Finance::ECF::StatementCalculator, :with_default_schedules do
       end
     end
   end
+
+  describe "#service_fee" do
+    let(:contract) { create(:call_off_contract, lead_provider:) }
+
+    it "returns calculated calculated service fee" do
+      expect(subject.service_fee).to eql(BigDecimal("0.75943068965517241379310344827586206896551e5"))
+    end
+
+    context "when monthly_service_fee is set on contract" do
+      let(:contract) { create(:call_off_contract, :with_monthly_service_fee, lead_provider:) }
+
+      it "uses monthly_service_fee" do
+        expect(subject.service_fee).to eql(123.45)
+      end
+    end
+  end
 end

--- a/spec/services/finance/npq/course_statement_calculator_spec.rb
+++ b/spec/services/finance/npq/course_statement_calculator_spec.rb
@@ -218,7 +218,31 @@ RSpec.describe Finance::NPQ::CourseStatementCalculator, :with_default_schedules,
       end
 
       it "returns monthly_service_fee from contract" do
-        expect(subject.monthly_service_fees).to eql(543.21)
+        expect(subject.monthly_service_fees).to eql(5432.10)
+      end
+    end
+  end
+
+  describe "#service_fees_per_participant" do
+    it "returns calculated service_fees_per_participant" do
+      expect(subject.service_fees_per_participant).to eql(BigDecimal("0.16842105263157894736842105263157894737e2"))
+    end
+
+    context "when monthly_service_fee present on contract" do
+      let(:contract) do
+        create(
+          :npq_contract,
+          :with_monthly_service_fee,
+          npq_lead_provider:,
+          course_identifier: npq_course.identifier,
+          recruitment_target: 438,
+        )
+      end
+
+      it "returns value calulated from monthly_service_fee from contract" do
+        expected = BigDecimal("0.12402054794520547945205479452054794521e2")
+
+        expect(subject.service_fees_per_participant).to eql(expected)
       end
     end
   end

--- a/spec/services/finance/npq/course_statement_calculator_spec.rb
+++ b/spec/services/finance/npq/course_statement_calculator_spec.rb
@@ -201,4 +201,25 @@ RSpec.describe Finance::NPQ::CourseStatementCalculator, :with_default_schedules,
       end
     end
   end
+
+  describe "#monthly_service_fees" do
+    it "returns calculated service fee" do
+      expect(subject.monthly_service_fees).to eql(BigDecimal("0.1212631578947368421052631578947368421064e4"))
+    end
+
+    context "when monthly_service_fee present on contract" do
+      let(:contract) do
+        create(
+          :npq_contract,
+          :with_monthly_service_fee,
+          npq_lead_provider:,
+          course_identifier: npq_course.identifier,
+        )
+      end
+
+      it "returns monthly_service_fee from contract" do
+        expect(subject.monthly_service_fees).to eql(543.21)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1798
- Stakeholders wish to be able to specify ad-hoc monthly service fees that are not derived from other numbers such as recruitment targets

### Changes proposed in this pull request

- On a contract one can now set `monthly_service_fee`
- If this is not set it uses the previous mechanism for calculating this value
- If set we use this figure instead when presenting thru statements
- This feature is available to both ECF and NPQ

### Guidance to review

- none