### PR TITLE
Add feature flag for API v3 endpoints

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -20,6 +20,7 @@ class FeatureFlag
     eligibility_notifications
     change_of_circumstances
     multiple_cohorts
+    api_v3
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,9 @@ Rails.application.routes.draw do
         get "/school-rollout", to: "school_rollout#index"
       end
     end
+
+    namespace :v3, constraints: ->(_request) { FeatureFlag.active?(:api_v3) } do
+    end
   end
 
   scope :nominations, module: :nominations do


### PR DESCRIPTION
### Context

Hide API V3 endpoints behind a feature flag

- Ticket: n/a

### Changes proposed in this pull request
Add a new feature flag `v3_api` to allow development of API v3

### Guidance to review
Will add tests later when we have endpoints
