### PR TITLE
Ensure we time travel when setting up test scenarios

### DIFF
--- a/spec/features/scenarios/changes_of_circumstance_scenario.rb
+++ b/spec/features/scenarios/changes_of_circumstance_scenario.rb
@@ -30,7 +30,7 @@ class ChangesOfCircumstanceScenario
     scenario = fixture_data.to_h.with_indifferent_access.freeze
 
     @number = num
-    @statement_name = "February 2023"
+    @statement_name = "November 2021"
     @participant_email = "the-participant-#{num}@example.com"
     @participant_trn = rand(1..9_999_999).to_s.rjust(7, "0")
     @participant_dob = Date.new(1972, 2, 10)

--- a/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "CIP to FIP - Onboard a deferred participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -79,8 +82,10 @@ RSpec.feature "CIP to FIP - Onboard a deferred participant",
         given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "FIP to CIP - Onboard a deferred participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -79,8 +82,10 @@ RSpec.feature "FIP to CIP - Onboard a deferred participant",
         given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "FIP to FIP with different provider - Onboard a deferred participa
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -80,8 +83,10 @@ RSpec.feature "FIP to FIP with different provider - Onboard a deferred participa
         given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
@@ -52,22 +52,25 @@ RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -80,8 +83,10 @@ RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
         given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -79,8 +82,10 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
         given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -79,8 +82,10 @@ RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
         given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -80,8 +83,10 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
         given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -79,8 +82,10 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
         given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -51,22 +51,25 @@ RSpec.feature "CIP to CIP - Transfer a participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -78,8 +81,10 @@ RSpec.feature "CIP to CIP - Transfer a participant",
       before do
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -50,22 +50,25 @@ RSpec.feature "CIP to FIP - Transfer a participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -78,8 +81,10 @@ RSpec.feature "CIP to FIP - Transfer a participant",
         given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "CIP"
 

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -50,22 +50,25 @@ RSpec.feature "FIP to CIP - Transfer a participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -78,8 +81,10 @@ RSpec.feature "FIP to CIP - Transfer a participant",
         given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -50,22 +50,25 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -79,8 +82,10 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
         given_lead_providers_contracted_to_deliver_ecf "New Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -50,22 +50,25 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
       cohort
     end
     let!(:schedule) do
-      schedule = create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+      create(:ecf_schedule, name: "ECF September standard 2021", schedule_identifier: "ecf-standard-september", cohort:)
+    end
+    let!(:milestone_started) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 1 - Participant Start",
              start_date: Date.new(2021, 9, 1),
              milestone_date: Date.new(2021, 11, 30),
              payment_date: Date.new(2021, 11, 30),
              declaration_type: "started"
+    end
+    let!(:milestone_retained_1) do
       create :milestone,
-             schedule: schedule,
+             schedule:,
              name: "Output 2 - Retention Point 1",
              start_date: Date.new(2021, 11, 1),
              milestone_date: Date.new(2022, 1, 31),
              payment_date: Date.new(2022, 2, 28),
              declaration_type: "retained-1"
-      schedule
     end
     let!(:privacy_policy) do
       privacy_policy = create(:privacy_policy)
@@ -78,8 +81,10 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
         given_lead_providers_contracted_to_deliver_ecf "Original Lead Provider"
         given_lead_providers_contracted_to_deliver_ecf "Another Lead Provider"
 
-        Seeds::CallOffContracts.new.call
-        Importers::SeedStatements.new.call
+        travel_to(milestone_started.milestone_date - 2.months) do
+          Seeds::CallOffContracts.new.call
+          Importers::SeedStatements.new.call
+        end
 
         and_sit_at_pupil_premium_school_reported_programme "Original SIT", "FIP"
         and_lead_provider_reported_partnership "Original Lead Provider", "Original SIT"

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -101,10 +101,10 @@ module Steps
       milestone = participant_profile.schedule.milestones
                                      .where(declaration_type: declaration_type.to_s.gsub("_", "-"))
                                      .first
-
-      next_ideal_time milestone.milestone_date - 2.days
+      before_milestone_timestamp = milestone.milestone_date - 2.months
+      next_ideal_time before_milestone_timestamp
       travel_to(@timestamp) do
-        event_date = milestone.milestone_date - 4.days
+        event_date = before_milestone_timestamp - 4.days
         declarations_endpoint = APIs::PostParticipantDeclarationsEndpoint.load(tokens[lead_provider_name])
         declarations_endpoint.post_training_declaration participant_profile.user.id, course_identifier, declaration_type, event_date
 


### PR DESCRIPTION
### Context
Scenarios started failing as we've passed the deadline date on one of the statements (30 September)
Although we are time travelling in the scenarios, we aren't time travelling when creating the statements, which means we are still attaching the declaration to the latest statement which keeps shifting as we go forward.
We fixed that by changing the statement name and pushed it forward.

However, we need to fix this permanently to avoid those failures again after we pass another deadline.

- Ticket: n/a

### Changes proposed in this pull request

Create statements when time travelling, and change expected statement to the past, so it never changes again.
Also shift the timestamp we travel to by 2 months to avoid declarations being attached to two statements, and to adhere to the current test setup and expectations.

### Guidance to review

