### PR TITLE
refactor amend participant cohort feature

### DIFF
--- a/app/controllers/admin/participants/change_cohort_controller.rb
+++ b/app/controllers/admin/participants/change_cohort_controller.rb
@@ -4,14 +4,14 @@ module Admin::Participants
   class ChangeCohortController < Admin::BaseController
     def edit
       @participant_profile = retrieve_participant_profile
-      @latest_induction_record = retrieve_latest_induction_record(@participant_profile)
+      @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new
     end
 
     def update
       @participant_profile = retrieve_participant_profile
-      @latest_induction_record = retrieve_latest_induction_record(@participant_profile)
+      @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new(
         { **default_amend_participant_cohort_attributes, **amend_participant_cohort_params }.symbolize_keys,
@@ -32,7 +32,7 @@ module Admin::Participants
 
     def default_amend_participant_cohort_attributes
       {
-        email: @latest_induction_record.preferred_identity.email,
+        participant_profile: @participant_profile,
         source_cohort_start_year: @latest_induction_record.cohort.start_year,
       }
     end
@@ -45,10 +45,6 @@ module Admin::Participants
       policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
         authorize participant_profile, policy_class: participant_profile.policy_class
       end
-    end
-
-    def retrieve_latest_induction_record(participant_profile)
-      participant_profile.induction_records.order(created_at: "desc").first
     end
   end
 end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -49,6 +49,10 @@ class ParticipantProfile < ApplicationRecord
 
   delegate :full_name, :user_description, to: :user
 
+  def latest_induction_record
+    induction_records.latest
+  end
+
   def state
     participant_profile_state&.state
   end

--- a/app/services/induction/move_participants_to_another_programme.rb
+++ b/app/services/induction/move_participants_to_another_programme.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Induction::MoveParticipantsToAnotherProgramme < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      from_programme.active_induction_records.each do |induction_record|
+        Induction::ChangeInductionRecord.call(induction_record:,
+                                              changes: { induction_programme_id: to_programme.id })
+      end
+    end
+  end
+
+private
+
+  attr_reader :from_programme, :to_programme
+
+  def initialize(from_programme:, to_programme:)
+    @from_programme = from_programme
+    @to_programme = to_programme
+  end
+end

--- a/app/views/admin/participants/_declarations_history.erb
+++ b/app/views/admin/participants/_declarations_history.erb
@@ -36,6 +36,11 @@
       end
 
       sl.row do |row|
+        row.key(text: "Delivery parner")
+        row.value(text: participant_declaration.delivery_partner&.name)
+      end
+
+      sl.row do |row|
         row.key(text: "State")
         row.value(text: participant_declaration.state)
       end
@@ -54,12 +59,6 @@
         row.key(text: "Pupil premium uplift")
         row.value(text: participant_declaration.pupil_premium_uplift)
       end
-
-      sl.row do |row|
-        row.key(text: "Delivery parner")
-        row.value(text: participant_declaration.delivery_partner&.name)
-      end
     end
   %>
-
 <% end %>

--- a/app/views/admin/participants/_induction_records.html.erb
+++ b/app/views/admin/participants/_induction_records.html.erb
@@ -6,6 +6,31 @@
   <%=
     govuk_summary_list do |sl|
       sl.row do |row|
+        row.key(text: "Cohort")
+        row.value(text: induction_record.cohort.start_year)
+      end
+
+      sl.row do |row|
+        row.key(text: "School name")
+        row.value do
+          govuk_link_to(
+            induction_record.school_name,
+            admin_school_path(induction_record.school.friendly_id)
+          )
+        end
+      end
+
+      sl.row do |row|
+        row.key(text: "School URN")
+        row.value(text: induction_record.school_urn)
+      end
+
+      sl.row do |row|
+        row.key(text: "Preferred email")
+        row.value(text: induction_record.participant_email)
+      end
+
+      sl.row do |row|
         row.key(text: "Training programme")
         row.value(text: induction_programme_friendly_name(induction_record.training_programme))
       end
@@ -18,16 +43,6 @@
       sl.row do |row|
         row.key(text: "Delivery partner")
         row.value(text: induction_record.delivery_partner_name || "No delivery partner")
-      end
-
-      sl.row do |row|
-        row.key(text: "School URN")
-        row.value(text: induction_record.school_urn)
-      end
-
-      sl.row do |row|
-        row.key(text: "Preferred email")
-        row.value(text: induction_record.participant_email)
       end
 
       sl.row do |row|
@@ -46,16 +61,6 @@
       end
 
       sl.row do |row|
-        row.key(text: "Start date")
-        row.value(text: induction_record.start_date.to_formatted_s(:govuk))
-      end
-
-      sl.row do |row|
-        row.key(text: "End date")
-        row.value(text: induction_record.end_date&.to_s(:govuk))
-      end
-
-      sl.row do |row|
         row.key(text: "Mentor")
         row.value(text: induction_record.mentor_full_name)
       end
@@ -68,6 +73,16 @@
       sl.row do |row|
         row.key(text: "Appropriate body")
         row.value(text: induction_record.appropriate_body_name)
+      end
+
+      sl.row do |row|
+        row.key(text: "Start date")
+        row.value(text: induction_record.start_date.to_formatted_s(:govuk))
+      end
+
+      sl.row do |row|
+        row.key(text: "End date")
+        row.value(text: induction_record.end_date&.to_s(:govuk))
       end
     end
   %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,7 @@ en:
     participant_declarations:
       exist: "The participant must have no declarations"
     participant_profile:
-      blank: "Not registered or not active"
+      not_active: "Not active"
     programme:
       blank: "Please select programme type"
     provider:

--- a/spec/requests/admin/participants/change_cohort_spec.rb
+++ b/spec/requests/admin/participants/change_cohort_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
-  let(:admin_user) { create(:user, :admin) }
-  let(:user)                          { create :user, full_name: "Elza Smith" }
-  let!(:mentor_profile)               { create :mentor, user: }
-  let!(:ect_profile)                  { create :ect, mentor_profile_id: mentor_profile.id }
+  let(:admin_user)            { create(:user, :admin) }
+  let(:user)                  { create :user, full_name: "Elza Smith" }
+  let!(:mentor_profile) { create :mentor, user: }
+  let!(:ect_profile)    { create :ect, mentor_profile_id: mentor_profile.id }
 
   before { sign_in(admin_user) }
 
@@ -40,7 +40,7 @@ RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
       expect(Induction::AmendParticipantCohort).to have_received(:new).with(
         source_cohort_start_year: 2021,
         target_cohort_start_year: "2022", # string because this one is passed in from the form
-        email: mentor_profile.user.email,
+        participant_profile: mentor_profile,
       )
 
       expect(response).to redirect_to(admin_participant_path(mentor_profile))

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -2,22 +2,12 @@
 
 RSpec.describe Induction::AmendParticipantCohort do
   describe "#save" do
-    let(:email) { "participant@school.org" }
+    let(:participant_profile) { }
     let(:source_cohort_start_year) { 2021 }
     let(:target_cohort_start_year) { 2022 }
 
     subject(:form) do
-      described_class.new(email:, source_cohort_start_year:, target_cohort_start_year:)
-    end
-
-    context "when the email is not valid" do
-      let(:email) { "invalid_email_address" }
-
-      it "returns false and set errors" do
-        expect(form.save).to be_falsey
-        expect(form.errors.first.attribute).to eq(:email)
-        expect(form.errors.first.message).to eq("Enter an email address in the correct format, like name@example.com")
-      end
+      described_class.new(participant_profile:, source_cohort_start_year:, target_cohort_start_year:)
     end
 
     context "when the source_cohort_start_year is not an integer" do
@@ -109,21 +99,9 @@ RSpec.describe Induction::AmendParticipantCohort do
         create(:ect_participant_profile, training_status: :active, school_cohort: source_school_cohort)
       end
 
-      let(:email) { participant_profile.participant_identity.email }
-
       before do
         Induction::SetCohortInductionProgramme.call(school_cohort: source_school_cohort,
                                                     programme_choice: source_school_cohort.induction_programme_choice)
-      end
-
-      context "when there is no participant with the provided email address" do
-        let(:email) { "no_participant@school.org" }
-
-        it "returns false and set errors" do
-          expect(form.save).to be_falsey
-          expect(form.errors.first.attribute).to eq(:participant_profile)
-          expect(form.errors.first.message).to eq("Not registered or not active")
-        end
       end
 
       context "when the participant is not active" do
@@ -134,7 +112,7 @@ RSpec.describe Induction::AmendParticipantCohort do
         it "returns false and set errors" do
           expect(form.save).to be_falsey
           expect(form.errors.first.attribute).to eq(:participant_profile)
-          expect(form.errors.first.message).to eq("Not registered or not active")
+          expect(form.errors.first.message).to eq("Not active")
         end
       end
 


### PR DESCRIPTION
### Context
  

- Refactor amend participant cohort feature to depend on participant_profile rather than one of their emails. 
   That was causing some cases to be failing when the email provided is not the participant_profile's email.
- Display cohort if induction records in admin console
- Reorder some fields displayed in admin console.

Ticket:  

### Changes proposed in this pull request

### Guidance to review

