### PR TITLE
CST-1067: refactor AmendParticipantCohort

### DIFF
--- a/app/controllers/admin/participants/change_cohort_controller.rb
+++ b/app/controllers/admin/participants/change_cohort_controller.rb
@@ -4,14 +4,14 @@ module Admin::Participants
   class ChangeCohortController < Admin::BaseController
     def edit
       @participant_profile = retrieve_participant_profile
-      @latest_induction_record = retrieve_latest_induction_record(@participant_profile)
+      @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new
     end
 
     def update
       @participant_profile = retrieve_participant_profile
-      @latest_induction_record = retrieve_latest_induction_record(@participant_profile)
+      @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new(
         { **default_amend_participant_cohort_attributes, **amend_participant_cohort_params }.symbolize_keys,
@@ -32,7 +32,7 @@ module Admin::Participants
 
     def default_amend_participant_cohort_attributes
       {
-        email: @latest_induction_record.preferred_identity.email,
+        participant_profile: @participant_profile,
         source_cohort_start_year: @latest_induction_record.cohort.start_year,
       }
     end
@@ -45,10 +45,6 @@ module Admin::Participants
       policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
         authorize participant_profile, policy_class: participant_profile.policy_class
       end
-    end
-
-    def retrieve_latest_induction_record(participant_profile)
-      participant_profile.induction_records.order(created_at: "desc").first
     end
   end
 end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -49,6 +49,10 @@ class ParticipantProfile < ApplicationRecord
 
   delegate :full_name, :user_description, to: :user
 
+  def latest_induction_record
+    induction_records.latest
+  end
+
   def state
     participant_profile_state&.state
   end

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -4,11 +4,20 @@ module Induction
   class AmendParticipantCohort
     include ActiveModel::Model
 
+    class ActiveValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        record.errors.add(attribute, I18n.t("errors.participant_profile.not_active")) unless active?(value)
+      end
+
+      def active?(participant_profile)
+        participant_profile && participant_profile.active_record? && participant_profile.training_status_active?
+      end
+    end
+
     ECF_FIRST_YEAR = 2020
 
-    attr_accessor :email, :source_cohort_start_year, :target_cohort_start_year
+    attr_accessor :participant_profile, :source_cohort_start_year, :target_cohort_start_year
 
-    validates :email, notify_email: true
     validates :source_cohort_start_year,
               numericality: {
                 only_integer: true,
@@ -33,7 +42,8 @@ module Induction
                   I18n.t("errors.cohort.blank", year: form.target_cohort_start_year, where: "the service")
                 end,
               }
-    validates :participant_profile, presence: { message: I18n.t("errors.participant_profile.blank") }
+    validates :participant_profile, presence: { message: I18n.t("errors.participant_profile.blank") },
+                                    active: true
     validates :participant_declarations, absence: { message: I18n.t("errors.participant_declarations.exist") }
     validates :induction_record,
               presence: {
@@ -78,18 +88,6 @@ module Induction
                                       .not_voided
                                       .declared_as_between(source_cohort_start_date, source_cohort_end_date)
                                       .exists?
-    end
-
-    def participant_identity
-      @participant_identity ||= ParticipantIdentity.find_by_email(email)
-    end
-
-    def participant_profile
-      return unless participant_identity
-
-      @participant_profile ||= ParticipantProfile::ECF.training_status_active
-                                                      .active_record
-                                                      .find_by(participant_identity:)
     end
 
     def persisted?

--- a/app/services/induction/amend_participants_cohort.rb
+++ b/app/services/induction/amend_participants_cohort.rb
@@ -1,48 +1,50 @@
 # frozen_string_literal: true
 
-# Given a list of participant email addresses, a source year and a target year,
+# Given a list of participant ids, a source year and a target year,
 # move the participants from the cohort starting the source year to the one
 # starting the target year.
 # Meant to be run after SITs enroll participants in the wrong school cohort:
 #
-#   emails = %w[email_1 email_2 email_3 email_4]
-#   Induction::AmendParticipantsCohort.call(*emails,
+#   participant_profile_ids = %w[id_1 id_2 id_3 id_4]
+#   Induction::AmendParticipantsCohort.call(*participant_profile_ids,
 #                                           source_cohort_start_year: 2021,
 #                                           target_cohort_start_year: 2022)
 #
 #   Returns a hash like this:
 #     {
-#       success: [email_1, email_3],
+#       success: [id_1, id_3],
 #       fail: {
-#         email_2 => "Error after processing email_2",
-#         email_4 => "Error after processing email_4",
+#         id_2 => "Error after processing id_2",
+#         id_4 => "Error after processing id_4",
 #       }
 #     }
 class Induction::AmendParticipantsCohort < BaseService
-  attr_reader :emails, :result, :source_cohort_start_year, :target_cohort_start_year
+  attr_reader :participant_profile_ids, :participant_profiles, :result, :source_cohort_start_year, :target_cohort_start_year
 
   def call
-    process_emails
+    process_participants
     result
   end
 
 private
 
-  def initialize(*emails, source_cohort_start_year:, target_cohort_start_year:)
-    @emails = emails.select(&:present?)
+  def initialize(*participant_profile_ids, source_cohort_start_year:, target_cohort_start_year:)
+    @participant_profile_ids = participant_profile_ids
+    @participant_profiles = ParticipantProfile.where(id: participant_profile_ids).to_a
     @source_cohort_start_year = source_cohort_start_year
     @target_cohort_start_year = target_cohort_start_year
   end
 
-  def failed(email:, error:)
-    result[:fail].merge!(email => { error.attribute => error.message })
+  def failed(participant_profile_id:, error:)
+    result[:fail].merge!(participant_profile_id => { error.attribute => error.message })
   end
 
-  def process_emails
+  def process_participants
     setup
-    emails.each do |email|
-      form = Induction::AmendParticipantCohort.new(email:, source_cohort_start_year:, target_cohort_start_year:)
-      form.save ? success(email:) : failed(email:, error: form.errors.first)
+    participant_profile_ids.each do |participant_profile_id|
+      participant_profile = participant_profiles.detect { |pp| pp.id == participant_profile_id }
+      form = Induction::AmendParticipantCohort.new(participant_profile:, source_cohort_start_year:, target_cohort_start_year:)
+      form.save ? success(participant_profile_id) : failed(participant_profile_id:, error: form.errors.first)
     end
   end
 
@@ -50,7 +52,7 @@ private
     @result = { success: [], fail: {} }
   end
 
-  def success(email:)
-    result[:success] << email
+  def success(participant_profile_id)
+    result[:success] << participant_profile_id
   end
 end

--- a/app/views/admin/participants/_declarations_history.erb
+++ b/app/views/admin/participants/_declarations_history.erb
@@ -36,6 +36,11 @@
       end
 
       sl.row do |row|
+        row.key(text: "Delivery parner")
+        row.value(text: participant_declaration.delivery_partner&.name)
+      end
+
+      sl.row do |row|
         row.key(text: "State")
         row.value(text: participant_declaration.state)
       end
@@ -54,12 +59,6 @@
         row.key(text: "Pupil premium uplift")
         row.value(text: participant_declaration.pupil_premium_uplift)
       end
-
-      sl.row do |row|
-        row.key(text: "Delivery parner")
-        row.value(text: participant_declaration.delivery_partner&.name)
-      end
     end
   %>
-
 <% end %>

--- a/app/views/admin/participants/_induction_records.html.erb
+++ b/app/views/admin/participants/_induction_records.html.erb
@@ -6,6 +6,31 @@
   <%=
     govuk_summary_list do |sl|
       sl.row do |row|
+        row.key(text: "Cohort")
+        row.value(text: induction_record.cohort.start_year)
+      end
+
+      sl.row do |row|
+        row.key(text: "School name")
+        row.value do
+          govuk_link_to(
+            induction_record.school_name,
+            admin_school_path(induction_record.school.friendly_id)
+          )
+        end
+      end
+
+      sl.row do |row|
+        row.key(text: "School URN")
+        row.value(text: induction_record.school_urn)
+      end
+
+      sl.row do |row|
+        row.key(text: "Preferred email")
+        row.value(text: induction_record.participant_email)
+      end
+
+      sl.row do |row|
         row.key(text: "Training programme")
         row.value(text: induction_programme_friendly_name(induction_record.training_programme))
       end
@@ -18,16 +43,6 @@
       sl.row do |row|
         row.key(text: "Delivery partner")
         row.value(text: induction_record.delivery_partner_name || "No delivery partner")
-      end
-
-      sl.row do |row|
-        row.key(text: "School URN")
-        row.value(text: induction_record.school_urn)
-      end
-
-      sl.row do |row|
-        row.key(text: "Preferred email")
-        row.value(text: induction_record.participant_email)
       end
 
       sl.row do |row|
@@ -46,16 +61,6 @@
       end
 
       sl.row do |row|
-        row.key(text: "Start date")
-        row.value(text: induction_record.start_date.to_formatted_s(:govuk))
-      end
-
-      sl.row do |row|
-        row.key(text: "End date")
-        row.value(text: induction_record.end_date&.to_s(:govuk))
-      end
-
-      sl.row do |row|
         row.key(text: "Mentor")
         row.value(text: induction_record.mentor_full_name)
       end
@@ -68,6 +73,16 @@
       sl.row do |row|
         row.key(text: "Appropriate body")
         row.value(text: induction_record.appropriate_body_name)
+      end
+
+      sl.row do |row|
+        row.key(text: "Start date")
+        row.value(text: induction_record.start_date.to_formatted_s(:govuk))
+      end
+
+      sl.row do |row|
+        row.key(text: "End date")
+        row.value(text: induction_record.end_date&.to_s(:govuk))
       end
     end
   %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,8 @@ en:
     participant_declarations:
       exist: "The participant must have no declarations"
     participant_profile:
-      blank: "Not registered or not active"
+      blank: "Not registered"
+      not_active: "Not active"
     programme:
       blank: "Please select programme type"
     provider:

--- a/spec/requests/admin/participants/change_cohort_spec.rb
+++ b/spec/requests/admin/participants/change_cohort_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
   let(:admin_user) { create(:user, :admin) }
-  let(:user)                          { create :user, full_name: "Elza Smith" }
-  let!(:mentor_profile)               { create :mentor, user: }
-  let!(:ect_profile)                  { create :ect, mentor_profile_id: mentor_profile.id }
+  let(:user) { create :user, full_name: "Elza Smith" }
+  let!(:mentor_profile) { create :mentor, user: }
+  let!(:ect_profile) { create :ect, mentor_profile_id: mentor_profile.id }
 
   before { sign_in(admin_user) }
 
@@ -40,7 +40,7 @@ RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
       expect(Induction::AmendParticipantCohort).to have_received(:new).with(
         source_cohort_start_year: 2021,
         target_cohort_start_year: "2022", # string because this one is passed in from the form
-        email: mentor_profile.user.email,
+        participant_profile: mentor_profile,
       )
 
       expect(response).to redirect_to(admin_participant_path(mentor_profile))

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -2,22 +2,12 @@
 
 RSpec.describe Induction::AmendParticipantCohort do
   describe "#save" do
-    let(:email) { "participant@school.org" }
+    let(:participant_profile) {}
     let(:source_cohort_start_year) { 2021 }
     let(:target_cohort_start_year) { 2022 }
 
     subject(:form) do
-      described_class.new(email:, source_cohort_start_year:, target_cohort_start_year:)
-    end
-
-    context "when the email is not valid" do
-      let(:email) { "invalid_email_address" }
-
-      it "returns false and set errors" do
-        expect(form.save).to be_falsey
-        expect(form.errors.first.attribute).to eq(:email)
-        expect(form.errors.first.message).to eq("Enter an email address in the correct format, like name@example.com")
-      end
+      described_class.new(participant_profile:, source_cohort_start_year:, target_cohort_start_year:)
     end
 
     context "when the source_cohort_start_year is not an integer" do
@@ -109,20 +99,18 @@ RSpec.describe Induction::AmendParticipantCohort do
         create(:ect_participant_profile, training_status: :active, school_cohort: source_school_cohort)
       end
 
-      let(:email) { participant_profile.participant_identity.email }
-
       before do
         Induction::SetCohortInductionProgramme.call(school_cohort: source_school_cohort,
                                                     programme_choice: source_school_cohort.induction_programme_choice)
       end
 
-      context "when there is no participant with the provided email address" do
-        let(:email) { "no_participant@school.org" }
+      context "when their is no participant" do
+        let(:participant_profile) {}
 
         it "returns false and set errors" do
           expect(form.save).to be_falsey
           expect(form.errors.first.attribute).to eq(:participant_profile)
-          expect(form.errors.first.message).to eq("Not registered or not active")
+          expect(form.errors.first.message).to eq("Not registered")
         end
       end
 
@@ -134,7 +122,7 @@ RSpec.describe Induction::AmendParticipantCohort do
         it "returns false and set errors" do
           expect(form.save).to be_falsey
           expect(form.errors.first.attribute).to eq(:participant_profile)
-          expect(form.errors.first.message).to eq("Not registered or not active")
+          expect(form.errors.first.message).to eq("Not active")
         end
       end
 

--- a/spec/services/induction/amend_participants_cohort_spec.rb
+++ b/spec/services/induction/amend_participants_cohort_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Induction::AmendParticipantsCohort do
     let!(:school_cohort_22) { create(:school_cohort, :fip, school: school_cohort_21.school, cohort: cohort_22) }
     let!(:successful_participant) { create(:ect_participant_profile, school_cohort: school_cohort_21) }
     let!(:failed_participant) { create(:ect_participant_profile, school_cohort: school_cohort_21) }
-    let!(:emails) { [successful_participant.user.email, failed_participant.user.email] }
+    let!(:participant_profile_ids) { [successful_participant.id, failed_participant.id] }
 
     subject(:service) do
-      described_class.new(*emails, source_cohort_start_year: 2021, target_cohort_start_year: 2022)
+      described_class.new(*participant_profile_ids, source_cohort_start_year: 2021, target_cohort_start_year: 2022)
     end
 
     before do
@@ -24,12 +24,12 @@ RSpec.describe Induction::AmendParticipantsCohort do
                             induction_programme: school_cohort_21.default_induction_programme)
     end
 
-    it "returns a list of successfully processed emails" do
-      expect(service.call[:success]).to match_array([successful_participant.user.email])
+    it "returns a list of successfully processed participants" do
+      expect(service.call[:success]).to match_array([successful_participant.id])
     end
 
-    it "returns a hash of emails failing and their error message" do
-      expect(service.call[:fail]).to match(failed_participant.user.email => {
+    it "returns a hash of ids failing and their error message" do
+      expect(service.call[:fail]).to match(failed_participant.id => {
         induction_record: "The participant is not enrolled on the cohort starting on 2021",
       })
     end


### PR DESCRIPTION
### Context
Some participants can't be moved to another cohort when it should. 
Admin console displays error messages in this cases.

Ticket:  [1067](https://dfedigital.atlassian.net/browse/CST-1067)

### Changes proposed in this pull request

- Refactor amend participant cohort feature to depend on participant_profile rather than one of their emails. 
   That was causing some cases to be failing when the email provided is not the participant_profile's email.
- Display cohort if induction records in admin console
- Reorder some fields displayed in admin console.

### Guidance to review