### PR TITLE
Improve the admin participant search

### DIFF
--- a/app/components/admin/participants/table.html.erb
+++ b/app/components/admin/participants/table.html.erb
@@ -4,6 +4,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Full name</th>
         <th scope="col" class="govuk-table__header">Role</th>
+        <th scope="col" class="govuk-table__header">TRN</th>
         <th scope="col" class="govuk-table__header">School</th>
         <th scope="col" class="govuk-table__header">School URN</th>
         <th scope="col" class="govuk-table__header">Date added</th>

--- a/app/components/admin/participants/table_row.html.erb
+++ b/app/components/admin/participants/table_row.html.erb
@@ -11,6 +11,10 @@
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">School</span>
+    <%= profile.teacher_profile.trn %>
+  </td>
+  <td class="govuk-table__cell nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">School</span>
     <%= school&.name %>
   </td>
   <td class="govuk-table__cell nhsuk-table__cell">

--- a/app/components/admin/participants/table_row.rb
+++ b/app/components/admin/participants/table_row.rb
@@ -20,7 +20,7 @@ module Admin
       def induction_record
         return unless @profile.ect? || @profile.mentor?
 
-        @induction_record ||= @profile.current_induction_record || @profile.induction_records.latest
+        @induction_record ||= @profile.latest_current_induction_record
       end
 
       def school

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -13,21 +13,11 @@ module Admin
     def show; end
 
     def index
-      if FeatureFlag.active?(:change_of_circumstances)
-        @participant_profiles = search
-      else
-        school_cohort_ids = SchoolCohort.ransack(school_name_or_school_urn_cont: params[:query]).result.pluck(:id)
-        query = "%#{(params[:query] || '').downcase}%"
-        @participant_profiles = policy_scope(ParticipantProfile).joins(:user)
-                                                                .active_record
-                                                                .includes(:validation_decisions)
-                                                                .where("lower(users.full_name) LIKE ? OR school_cohort_id IN (?)", query, school_cohort_ids)
-                                                                .order("DATE(users.created_at) asc, users.full_name")
+      search_term = params[:query]
+      type        = params[:type]
 
-        if params[:type].present?
-          @participant_profiles = @participant_profiles.where(type: params[:type])
-        end
-      end
+      @participant_profiles = Admin::Participants::Search
+        .call(policy_scope(ParticipantProfile), search_term:, type:)
     end
 
     def edit_name; end
@@ -77,37 +67,6 @@ module Admin
         .eager_load(:teacher_profile).find(params[:id])
 
       authorize @participant_profile, policy_class: @participant_profile.policy_class
-    end
-
-    def search
-      scope = policy_scope(ParticipantProfile)
-        .eager_load(
-          :participant_identity,
-          :ecf_participant_eligibility,
-          :ecf_participant_validation_data,
-          :validation_decisions,
-          current_induction_records: :school,
-          participant_identity: :user,
-        )
-
-      if params[:type].present?
-        scope = scope.where(type: params[:type])
-      end
-
-      if params[:query].present?
-        query = "%#{params.fetch(:query).downcase}%"
-        profile_ids = InductionRecord.current.ransack(induction_programme_school_cohort_school_name_or_induction_programme_school_cohort_school_urn_i_cont: params[:query]).result.pluck(:participant_profile_id)
-        scope = scope.where(
-          <<~CONDITIONS, profile_ids, query, query, query
-            participant_profiles.id IN (?)
-            OR users.full_name ILIKE ?
-            OR users.email ILIKE ?
-            OR participant_identities.email ILIKE ?
-          CONDITIONS
-        )
-      end
-
-      scope.order("DATE(users.created_at) ASC, users.full_name")
     end
 
     def induction_records

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -80,7 +80,14 @@ module Admin
     end
 
     def search
-      scope = policy_scope(ParticipantProfile).joins(participant_identity: :user)
+      scope = policy_scope(ParticipantProfile)
+        .eager_load(
+          :ecf_participant_eligibility,
+          :ecf_participant_validation_data,
+          :validation_decisions,
+          current_induction_records: :school,
+          participant_identity: :user,
+        )
 
       if params[:type].present?
         scope = scope.where(type: params[:type])

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -76,8 +76,11 @@ class InductionRecord < ApplicationRecord
 
   scope :for_school, ->(school) { joins(:school).where(school: { id: school.id }) }
 
+  scope :oldest_first, -> { order(created_at: :asc) }
+  scope :newest_first, -> { order(created_at: :desc) }
+
   def self.latest
-    order(created_at: :asc).last
+    newest_first.first
   end
 
   # NOTE: these will return nil if the partnership is challenged

--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -17,4 +17,10 @@ class ParticipantIdentity < ApplicationRecord
 
   scope :original, -> { where("participant_identities.external_identifier = participant_identities.user_id") }
   scope :transferred, -> { where("participant_identities.external_identifier != participant_identities.user_id") }
+
+  def self.email_matches(search_term)
+    return none if search_term.blank?
+
+    where("participant_identities.email like ?", "%#{search_term}%")
+  end
 end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -15,6 +15,8 @@ class ParticipantProfile < ApplicationRecord
 
   has_many :induction_records
   has_many :current_induction_records, -> { current }, class_name: "InductionRecord"
+  has_one :ecf_participant_eligibility
+  has_one :ecf_participant_validation_data
 
   has_many :participant_profile_states
   has_one :participant_profile_state, lambda {

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -118,6 +118,10 @@ class ParticipantProfile < ApplicationRecord
   def role
     raise "Not implemented"
   end
+
+  def latest_current_induction_record
+    current_induction_records.first
+  end
 end
 
 require "participant_profile/npq"

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -11,8 +11,6 @@ class ParticipantProfile < ApplicationRecord
 
     has_one :school, through: :school_cohort
     has_one :cohort, through: :school_cohort
-    has_one :ecf_participant_eligibility, foreign_key: :participant_profile_id
-    has_one :ecf_participant_validation_data, foreign_key: :participant_profile_id
 
     belongs_to :mentor_profile, -> { where(id: 0) }, class_name: "Mentor", optional: true
     has_one :mentor, through: :mentor_profile, source: :user

--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -17,4 +17,10 @@ class TeacherProfile < ApplicationRecord
 
   has_many :npq_profiles, class_name: "ParticipantProfile::NPQ"
   # end: TODO
+
+  def self.trn_matches(search_term)
+    return none if search_term.blank?
+
+    where("teacher_profiles.trn like ?", "%#{search_term}%")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,18 @@ class User < ApplicationRecord
     joins(:participant_profiles).merge(ParticipantProfile.active_record)
   }
 
+  def self.full_name_matches(search_term)
+    return none if search_term.blank?
+
+    where("users.full_name ilike ?", "%#{search_term}%")
+  end
+
+  def self.email_matches(search_term)
+    return none if search_term.blank?
+
+    where("users.email like ?", "%#{search_term}%")
+  end
+
 private
 
   def strip_whitespace

--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Admin::Participants::Search < BaseService
-  class NoScopeError < StandardError; end
   attr_reader :scope, :search_term, :type
 
   def initialize(scope = ParticipantProfile, search_term: nil, type: nil)

--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -13,8 +13,9 @@ class Admin::Participants::Search < BaseService
   end
 
   def call
-    scope
-      .active_record
+    adjusted_scope = FeatureFlag.active?(:change_of_circumstances) ? scope : scope.active_record
+
+    adjusted_scope
       .eager_load(*left_outer_joins)
       .merge(search_conditions)
       .merge(type_conditions)

--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class Admin::Participants::Search < BaseService
+  class NoScopeError < StandardError; end
+  attr_reader :scope, :search_term, :type
+
+  def initialize(scope = ParticipantProfile, search_term: nil, type: nil)
+    # make the scope overrideable so we can pass in one that's been
+    # checked by Pundit from the controller
+    @scope       = scope
+    @search_term = search_term
+    @type        = type
+  end
+
+  def call
+    scope
+      .active_record
+      .eager_load(*left_outer_joins)
+      .merge(search_conditions)
+      .merge(type_conditions)
+      .order(order)
+  end
+
+private
+
+  def search_conditions
+    if search_term.present?
+      User
+        .full_name_matches(search_term)
+        .or(User.email_matches(search_term))
+        .or(ParticipantIdentity.email_matches(search_term))
+        .or(TeacherProfile.trn_matches(search_term))
+    else
+      User.all
+    end
+  end
+
+  def type_conditions
+    if type.present?
+      ParticipantProfile.where(type:)
+    else
+      ParticipantProfile.all
+    end
+  end
+
+  def left_outer_joins
+    [
+      :participant_identity,
+      :ecf_participant_eligibility,
+      :ecf_participant_validation_data,
+      :validation_decisions,
+      { current_induction_records: :school },
+      { participant_identity: { user: :teacher_profile } },
+    ]
+  end
+
+  def order
+    "DATE(users.created_at) ASC, users.full_name"
+  end
+end

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -3,7 +3,7 @@
 <%= render SearchBox.new(
   query: params[:query],
   title: "Search participants",
-  hint: "Enter the participant’s name, school’s name or URN",
+  hint: "Enter the participant’s name, school’s name, email address or URN",
   filters: [
     {
       field: :type,

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -3,7 +3,7 @@
 <%= render SearchBox.new(
   query: params[:query],
   title: "Search participants",
-  hint: "Enter the participant’s name, school’s name, email address or URN",
+  hint: "Enter the participant’s name, email address or TRN",
   filters: [
     {
       field: :type,

--- a/spec/cypress/integration/admin/ParticipantManagment.feature
+++ b/spec/cypress/integration/admin/ParticipantManagment.feature
@@ -11,9 +11,9 @@ Feature: Admin user managing participants
     And "page body" should contain "Enter the participant’s name, email address or TRN"
     And the page should be accessible
 
-    When I type "Test school" into "search box"
+    When I type "example" into "search box"
     And I press enter in "search box"
-    Then the table should have 4 rows
+    Then the table should have 5 rows
 
     When I clear "search box"
     And I type "Unrelated" into "search box"

--- a/spec/cypress/integration/admin/ParticipantManagment.feature
+++ b/spec/cypress/integration/admin/ParticipantManagment.feature
@@ -8,7 +8,7 @@ Feature: Admin user managing participants
 
   Scenario: Viewing a list of participants
     Then the table should have 7 rows
-    And "page body" should contain "Enter the participant’s name, school’s name, email address or URN"
+    And "page body" should contain "Enter the participant’s name, email address or TRN"
     And the page should be accessible
 
     When I type "Test school" into "search box"

--- a/spec/cypress/integration/admin/ParticipantManagment.feature
+++ b/spec/cypress/integration/admin/ParticipantManagment.feature
@@ -8,7 +8,7 @@ Feature: Admin user managing participants
 
   Scenario: Viewing a list of participants
     Then the table should have 7 rows
-    And "page body" should contain "Enter the participant’s name, school’s name or URN"
+    And "page body" should contain "Enter the participant’s name, school’s name, email address or URN"
     And the page should be accessible
 
     When I type "Test school" into "search box"

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -264,6 +264,20 @@ RSpec.describe InductionRecord, :with_default_schedules, type: :model do
         end
       end
     end
+
+    describe "ordering" do
+      describe ".oldest_first" do
+        it "orders by created_at asc" do
+          expect(described_class.oldest_first.to_sql).to match(%(ORDER BY "induction_records"."created_at" ASC))
+        end
+      end
+
+      describe ".newest_first" do
+        it "orders by created_at desc" do
+          expect(described_class.newest_first.to_sql).to match(%(ORDER BY "induction_records"."created_at" DESC))
+        end
+      end
+    end
   end
 
   describe "enums" do

--- a/spec/models/participant_identity_spec.rb
+++ b/spec/models/participant_identity_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe ParticipantIdentity, type: :model do
       expect(participant_identity.user.reload.updated_at).to be_within(1.second).of participant_identity.updated_at
     end
   end
+
+  describe "scopes" do
+    describe "#email_matches" do
+      it "adds a wildcarded condition on email" do
+        # we don't need to worry about case sensitivity here because the email
+        # address column is citext
+        expect(described_class.email_matches("xyz").to_sql).to include("participant_identities.email like '%xyz%'")
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe "#full_name_matches" do
+      it "adds a case-insensitive wildcarded condition on full name" do
+        expect(described_class.full_name_matches("xyz").to_sql).to include("users.full_name ilike '%xyz%'")
+      end
+    end
+
+    describe "#email_matches" do
+      it "adds a wildcarded condition on email" do
+        # we don't need to worry about case sensitivity here because the email
+        # address column is citext
+        expect(described_class.email_matches("xyz").to_sql).to include("users.email like '%xyz%'")
+      end
+    end
+  end
+
   describe "before_validation" do
     let(:user) { build(:user, full_name: "\t  Gordon \tBanks \n", email: " \tgordo@example.com \n ") }
 

--- a/spec/services/admin/participants/search_spec.rb
+++ b/spec/services/admin/participants/search_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Participants::Search, :with_default_schedules do
+  let(:search) { Admin::Participants::Search }
+
+  describe "searching" do
+    let!(:user_1) { create(:user, full_name: "Andrew Armstrong", email: "aaaa@example.com") }
+    let!(:user_2) { create(:user, full_name: "Bonnie Benson", email: "bbbb@example.com") }
+    let!(:user_3) { create(:user, full_name: "Charles Cross", email: "cccc@example.com") }
+
+    let!(:pp_1) { create(:ecf_participant_profile, user: user_1) }
+    let!(:pp_2) { create(:ecf_participant_profile, user: user_2) }
+    let!(:pp_3) { create(:npq_participant_profile, user: user_3) }
+
+    context "when searching with a string" do
+      describe "matching by name (case insensitively)" do
+        let(:results) { search.call(ParticipantProfile, search_term: "ben") }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_2)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_1, pp_3)
+        end
+      end
+
+      describe "matching by user email (case insensitively)" do
+        let(:results) { search.call(ParticipantProfile, search_term: "ccc") }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_3)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_1, pp_2)
+        end
+      end
+
+      describe "matching by participant identity email (case insensitively)" do
+        before do
+          pp_2.participant_identity.update(email: "dddd@example.com")
+        end
+
+        let(:results) { search.call(ParticipantProfile, search_term: "ddd") }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_2)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_1, pp_3)
+        end
+      end
+
+      describe "matching by TRN" do
+        before { pp_3.teacher_profile.update(trn: "123456") }
+
+        let(:results) { search.call(ParticipantProfile, search_term: "1234") }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_3)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_1, pp_2)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The search/index page wasn't eager loading the results causing a large number of queries. These have been optimised into a couple and some of the scope logic reworked. Participants can now be found by email address too.

### Changes proposed in this pull request

- Add scopes for sorting induction records by create
- Eager load relations used in participants table
- Extend the search so it covers email addresses
