### PR TITLE
[CPDLP-1692] Add API V3 Statements endpoint

### DIFF
--- a/app/controllers/api/v3/finance/statements_controller.rb
+++ b/app/controllers/api/v3/finance/statements_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    class Finance::StatementsController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include ApiPagination
+      include ApiFilter
+
+      def index
+        render json: Finance::StatementSerializer.new(paginate(finance_statements)).serializable_hash.to_json
+      end
+
+    private
+
+      def finance_statements
+        @finance_statements ||= finance_statements_query.statements
+      end
+
+      def finance_statements_query
+        Finance::Statements::Index.new(
+          cpd_lead_provider: current_user,
+          params: statement_params,
+        )
+      end
+
+      def statement_params
+        params.permit(filter: %i[cohort type])
+      end
+    end
+  end
+end

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -43,6 +43,8 @@ class Finance::Statement < ApplicationRecord
       .where("deadline_date >= ?", Date.current)
   }
 
+  STATEMENT_TYPES = %w[ecf npq].freeze
+
   class << self
     def current
       with_future_deadline_date.order(deadline_date: :asc).first

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -53,6 +53,10 @@ class Finance::Statement < ApplicationRecord
     true
   end
 
+  def paid?
+    false
+  end
+
   def past_deadline_date?
     participant_declarations.any?
   end

--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -3,6 +3,8 @@
 class Finance::Statement::ECF < Finance::Statement
   has_one :lead_provider, through: :cpd_lead_provider
 
+  STATEMENT_TYPE = "ecf"
+
   def contract
     CallOffContract.find_by!(
       version: contract_version,

--- a/app/models/finance/statement/ecf/paid.rb
+++ b/app/models/finance/statement/ecf/paid.rb
@@ -4,4 +4,8 @@ class Finance::Statement::ECF::Paid < Finance::Statement::ECF
   def open?
     false
   end
+
+  def paid?
+    true
+  end
 end

--- a/app/models/finance/statement/npq.rb
+++ b/app/models/finance/statement/npq.rb
@@ -3,6 +3,8 @@
 class Finance::Statement::NPQ < Finance::Statement
   has_one :npq_lead_provider, through: :cpd_lead_provider
 
+  STATEMENT_TYPE = "npq"
+
   def payable!
     update!(type: "Finance::Statement::NPQ::Payable")
   end

--- a/app/models/finance/statement/npq/paid.rb
+++ b/app/models/finance/statement/npq/paid.rb
@@ -4,4 +4,8 @@ class Finance::Statement::NPQ::Paid < Finance::Statement::NPQ
   def open?
     false
   end
+
+  def paid?
+    true
+  end
 end

--- a/app/serializers/api/v3/finance/statement_serializer.rb
+++ b/app/serializers/api/v3/finance/statement_serializer.rb
@@ -21,12 +21,7 @@ module Api
         end
 
         attribute :type do |statement|
-          case statement
-          when ::Finance::Statement::ECF
-            "ecf"
-          when ::Finance::Statement::NPQ
-            "npq"
-          end
+          statement.class::STATEMENT_TYPE
         end
 
         attribute :cohort do |statement|

--- a/app/serializers/api/v3/finance/statement_serializer.rb
+++ b/app/serializers/api/v3/finance/statement_serializer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "jsonapi/serializer/instrumentation"
+
+module Api
+  module V3
+    module Finance
+      class StatementSerializer
+        include JSONAPI::Serializer
+        include JSONAPI::Serializer::Instrumentation
+
+        set_id :id
+        set_type :statement
+
+        attribute :month do |statement|
+          statement.name[/([^\s]+)/]
+        end
+
+        attribute :year do |statement|
+          statement.name[/(\d+)/]
+        end
+
+        attribute :type do |statement|
+          case statement
+          when ::Finance::Statement::ECF
+            "ecf"
+          when ::Finance::Statement::NPQ
+            "npq"
+          end
+        end
+
+        attribute :cohort do |statement|
+          statement.cohort.start_year.to_s
+        end
+
+        attribute :cut_off_date do |statement|
+          statement.deadline_date.rfc3339
+        end
+
+        attribute :payment_date do |statement|
+          statement.payment_date.rfc3339
+        end
+
+        attribute :paid, &:paid?
+      end
+    end
+  end
+end

--- a/app/services/api/v3/finance/statements/index.rb
+++ b/app/services/api/v3/finance/statements/index.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    module Finance
+      module Statements
+        class Index
+          attr_reader :cpd_lead_provider, :params
+
+          def initialize(cpd_lead_provider:, params:)
+            @cpd_lead_provider = cpd_lead_provider
+            @params = params
+          end
+
+          def statements
+            statement_class
+              .includes(:cohort)
+              .where(
+                cpd_lead_provider:,
+                cohort_id: with_cohorts.map(&:id),
+              ).order(created_at: :asc)
+          end
+
+        private
+
+          def filter
+            params[:filter] ||= {}
+          end
+
+          def with_cohorts
+            return Cohort.where(start_year: filter[:cohort].split(",")) if filter[:cohort].present?
+
+            Cohort.where("start_year > 2020")
+          end
+
+          def statement_class
+            return ::Finance::Statement if filter[:type].blank?
+
+            case filter[:type]
+            when "ecf"
+              ::Finance::Statement::ECF
+            when "npq"
+              ::Finance::Statement::NPQ
+            else
+              ::Finance::Statement.none
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/finance/statements/index.rb
+++ b/app/services/api/v3/finance/statements/index.rb
@@ -36,11 +36,8 @@ module Api
           def statement_class
             return ::Finance::Statement if filter[:type].blank?
 
-            case filter[:type]
-            when "ecf"
-              ::Finance::Statement::ECF
-            when "npq"
-              ::Finance::Statement::NPQ
+            if ::Finance::Statement::STATEMENT_TYPES.include?(filter[:type])
+              "::Finance::Statement::#{filter[:type].classify}".constantize
             else
               ::Finance::Statement.none
             end

--- a/app/services/api/v3/finance/statements/index.rb
+++ b/app/services/api/v3/finance/statements/index.rb
@@ -18,7 +18,7 @@ module Api
               .where(
                 cpd_lead_provider:,
                 cohort_id: with_cohorts.map(&:id),
-              ).order(created_at: :asc)
+              ).order(payment_date: :asc)
           end
 
         private
@@ -35,12 +35,9 @@ module Api
 
           def statement_class
             return ::Finance::Statement if filter[:type].blank?
+            return ::Finance::Statement.none unless ::Finance::Statement::STATEMENT_TYPES.include?(filter[:type])
 
-            if ::Finance::Statement::STATEMENT_TYPES.include?(filter[:type])
-              "::Finance::Statement::#{filter[:type].classify}".constantize
-            else
-              ::Finance::Statement.none
-            end
+            "::Finance::Statement::#{filter[:type].classify}".constantize
           end
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
     end
 
     namespace :v3, constraints: ->(_request) { FeatureFlag.active?(:api_v3) } do
+      resources :statements, only: %i[index], controller: "finance/statements"
     end
   end
 

--- a/spec/factories/finance/statements.rb
+++ b/spec/factories/finance/statements.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
 
     factory :ecf_statement, class: "Finance::Statement::ECF" do
       cpd_lead_provider { association :cpd_lead_provider, :with_lead_provider }
+
+      factory :ecf_paid_statement, class: "Finance::Statement::ECF::Paid" do
+        paid
+      end
     end
 
     trait :output_fee do

--- a/spec/models/finance/statement/ecf/paid_spec.rb
+++ b/spec/models/finance/statement/ecf/paid_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::Statement::ECF::Paid do
+  subject { create(:ecf_paid_statement) }
+
+  describe "#paid?" do
+    it { is_expected.to be_paid }
+  end
+end

--- a/spec/models/finance/statement/npq/paid_spec.rb
+++ b/spec/models/finance/statement/npq/paid_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::Statement::NPQ::Paid do
+  subject { create(:npq_paid_statement) }
+
+  describe "#paid?" do
+    it { is_expected.to be_paid }
+  end
+end

--- a/spec/models/finance/statement_spec.rb
+++ b/spec/models/finance/statement_spec.rb
@@ -4,4 +4,10 @@ require "rails_helper"
 
 RSpec.describe Finance::Statement do
   it { is_expected.to belong_to(:cohort) }
+
+  describe "#paid?" do
+    subject { create(:ecf_statement) }
+
+    it { is_expected.not_to be_paid }
+  end
 end

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "statements endpoint spec", type: :request do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider) }
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
+  let(:bearer_token) { "Bearer #{token}" }
+
+  let(:cohort_2021) { create(:cohort, :current) }
+  let(:cohort_2022) { create(:cohort, :next) }
+  let!(:ecf_statement_cohort_2022) do
+    create(
+      :ecf_statement,
+      cpd_lead_provider:,
+      cohort: cohort_2022,
+    )
+  end
+  let!(:ecf_statement_cohort_2021) do
+    create(
+      :ecf_statement,
+      cpd_lead_provider:,
+      cohort: cohort_2021,
+    )
+  end
+  let!(:npq_statement_cohort_2022) do
+    create(
+      :npq_statement,
+      cpd_lead_provider:,
+      cohort: cohort_2022,
+    )
+  end
+  let!(:npq_statement_cohort_2021) do
+    create(
+      :npq_statement,
+      cpd_lead_provider:,
+      cohort: cohort_2021,
+    )
+  end
+
+  let(:parsed_response) { JSON.parse(response.body) }
+  let(:params) { {} }
+
+  describe "GET /statements" do
+    before do
+      default_headers[:Authorization] = bearer_token
+      default_headers[:CONTENT_TYPE] = "application/json"
+    end
+
+    context "with API V3 flag disabled" do
+      it "returns a 404" do
+        expect { get "/api/v3/statements", params: }.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "with API V3 flag active", with_feature_flags: { api_v3: "active" } do
+      it "returns correct jsonapi content type header" do
+        get("/api/v3/statements", params:)
+
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns a list of all statements" do
+        get("/api/v3/statements", params:)
+        expect(parsed_response["data"].count).to eq(4)
+      end
+
+      it "returns correct type" do
+        get("/api/v3/statements", params:)
+
+        expect(parsed_response["data"][0]).to have_type("statement")
+      end
+
+      it "returns statement IDs" do
+        get("/api/v3/statements", params:)
+
+        expect(parsed_response["data"][0]["id"]).to be_in(Finance::Statement.pluck(:id))
+      end
+
+      it "has correct attributes" do
+        get("/api/v3/statements", params:)
+
+        expect(parsed_response["data"][0]).to have_jsonapi_attributes(
+          :month,
+          :year,
+          :type,
+          :cohort,
+          :cut_off_date,
+          :payment_date,
+          :paid,
+        ).exactly
+      end
+
+      it "returns the right number of statements per page" do
+        get "/api/v3/statements", params: { page: { per_page: 3, page: 1 } }
+
+        expect(parsed_response["data"].size).to eql(3)
+      end
+
+      it "returns different statements for second page" do
+        get "/api/v3/statements", params: { page: { per_page: 3, page: 2 } }
+
+        expect(parsed_response["data"].size).to eql(1)
+      end
+
+      context "with cohort filter" do
+        let(:params) { { filter: { cohort: "2021" } } }
+        it "returns statements within filter cohort" do
+          get("/api/v3/statements", params:)
+
+          expect(parsed_response["data"].size).to eql(2)
+        end
+      end
+
+      context "with type filter" do
+        let(:params) { { filter: { type: "ecf" } } }
+        it "returns statements within filter type" do
+          get("/api/v3/statements", params:)
+
+          expect(parsed_response["data"].size).to eql(2)
+        end
+      end
+
+      context "when unauthorized" do
+        let(:token) { "incorrect-token" }
+        it "returns 401" do
+          get("/api/v3/statements", params:)
+
+          expect(response.status).to eq 401
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v3/finance/statement_serializer_spec.rb
+++ b/spec/serializers/api/v3/finance/statement_serializer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  module V3
+    module Finance
+      RSpec.describe StatementSerializer do
+        describe "serialization" do
+          let(:cohort) { create(:cohort, :next) }
+          let(:statement) { create(:ecf_statement, name: "January 2022", cohort:) }
+          subject(:serialiser) { described_class.new(statement) }
+
+          it "returns the month" do
+            expect(serialiser.serializable_hash[:data][:attributes][:month]).to eq("January")
+          end
+
+          it "returns the year" do
+            expect(serialiser.serializable_hash[:data][:attributes][:year]).to eq("2022")
+          end
+
+          it "returns the cohort start year" do
+            expect(serialiser.serializable_hash[:data][:attributes][:cohort]).to eq("2022")
+          end
+
+          it "returns the cut off dates" do
+            expect(serialiser.serializable_hash[:data][:attributes][:cut_off_date]).to eq(statement.deadline_date.rfc3339)
+          end
+
+          it "returns the payment dates" do
+            expect(serialiser.serializable_hash[:data][:attributes][:payment_date]).to eq(statement.payment_date.rfc3339)
+          end
+
+          context "with an ECF statement" do
+            it "returns the type" do
+              expect(serialiser.serializable_hash[:data][:attributes][:type]).to eq("ecf")
+            end
+
+            it "returns the paid status of the statement" do
+              expect(serialiser.serializable_hash[:data][:attributes][:paid]).to be(false)
+            end
+
+            context "when paid" do
+              let(:statement) { create(:ecf_paid_statement) }
+
+              it "returns the paid status of the statement" do
+                expect(serialiser.serializable_hash[:data][:attributes][:paid]).to be(true)
+              end
+            end
+          end
+
+          context "with an NPQ statement" do
+            let(:statement) { create(:npq_statement) }
+
+            it "returns the type" do
+              expect(serialiser.serializable_hash[:data][:attributes][:type]).to eq("npq")
+            end
+
+            it "returns the paid status of the statement" do
+              expect(serialiser.serializable_hash[:data][:attributes][:paid]).to be(false)
+            end
+
+            context "when paid" do
+              let(:statement) { create(:npq_paid_statement) }
+
+              it "returns the paid status of the statement" do
+                expect(serialiser.serializable_hash[:data][:attributes][:paid]).to be(true)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/finance/statements/index_spec.rb
+++ b/spec/services/api/v3/finance/statements/index_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V3::Finance::Statements::Index do
+  describe "#statements" do
+    let(:cohort_2021) { create(:cohort, :current) }
+    let(:cohort_2022) { create(:cohort, :next) }
+
+    let(:cpd_lead_provider) { create(:cpd_lead_provider) }
+
+    let!(:ecf_statement_cohort_another_lead_provider) { create(:ecf_statement, cohort: cohort_2022) }
+    let!(:ecf_statement_cohort_2022) do
+      create(
+        :ecf_statement,
+        cpd_lead_provider:,
+        cohort: cohort_2022,
+        created_at: 4.days.ago,
+      )
+    end
+    let!(:ecf_statement_cohort_2021) do
+      create(
+        :ecf_statement,
+        cpd_lead_provider:,
+        cohort: cohort_2021,
+        created_at: 3.days.ago,
+      )
+    end
+    let!(:npq_statement_cohort_2022) do
+      create(
+        :npq_statement,
+        cpd_lead_provider:,
+        cohort: cohort_2022,
+        created_at: 2.days.ago,
+      )
+    end
+    let!(:npq_statement_cohort_2021) do
+      create(
+        :npq_statement,
+        cpd_lead_provider:,
+        cohort: cohort_2021,
+        created_at: 1.day.ago,
+      )
+    end
+
+    let(:params) { {} }
+
+    subject { described_class.new(cpd_lead_provider:, params:) }
+
+    it "returns all statements for the cpd provider ordered by created_at" do
+      expect(subject.statements).to eq([
+        ecf_statement_cohort_2022,
+        ecf_statement_cohort_2021,
+        npq_statement_cohort_2022,
+        npq_statement_cohort_2021,
+      ])
+    end
+
+    context "with correct cohort filter" do
+      let(:params) { { filter: { cohort: "2021" } } }
+
+      it "returns all statements for the specific cohort" do
+        expect(subject.statements).to eq([
+          ecf_statement_cohort_2021,
+          npq_statement_cohort_2021,
+        ])
+      end
+    end
+
+    context "with multiple cohort filter" do
+      let(:params) { { filter: { cohort: "2021,2022" } } }
+
+      it "returns all statements for the specific cohort" do
+        expect(subject.statements).to eq([
+          ecf_statement_cohort_2022,
+          ecf_statement_cohort_2021,
+          npq_statement_cohort_2022,
+          npq_statement_cohort_2021,
+        ])
+      end
+    end
+
+    context "with incorrect cohort filter" do
+      let(:params) { { filter: { cohort: "2017" } } }
+
+      it "returns no statements" do
+        expect(subject.statements).to be_empty
+      end
+    end
+
+    context "with ecf type filter" do
+      let(:params) { { filter: { type: "ecf" } } }
+
+      it "returns all ecf statements" do
+        expect(subject.statements).to eq([
+          ecf_statement_cohort_2022,
+          ecf_statement_cohort_2021,
+        ])
+      end
+    end
+
+    context "with npq type filter" do
+      let(:params) { { filter: { type: "npq" } } }
+
+      it "returns all npq statements" do
+        expect(subject.statements).to eq([
+          npq_statement_cohort_2022,
+          npq_statement_cohort_2021,
+        ])
+      end
+
+      context "with incorrect type filter" do
+        let(:params) { { filter: { type: "does-not-exist" } } }
+
+        it "returns no statements" do
+          expect(subject.statements).to be_empty
+        end
+      end
+
+      context "with an ecf and cohort filter" do
+        let(:params) { { filter: { type: "ecf", cohort: "2021" } } }
+
+        it "returns ecf statement that belongs to the cohort" do
+          expect(subject.statements).to contain_exactly(ecf_statement_cohort_2021)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/finance/statements/index_spec.rb
+++ b/spec/services/api/v3/finance/statements/index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V3::Finance::Statements::Index do
         :ecf_statement,
         cpd_lead_provider:,
         cohort: cohort_2022,
-        created_at: 4.days.ago,
+        payment_date: 4.days.ago,
       )
     end
     let!(:ecf_statement_cohort_2021) do
@@ -23,7 +23,7 @@ RSpec.describe Api::V3::Finance::Statements::Index do
         :ecf_statement,
         cpd_lead_provider:,
         cohort: cohort_2021,
-        created_at: 3.days.ago,
+        payment_date: 3.days.ago,
       )
     end
     let!(:npq_statement_cohort_2022) do
@@ -31,7 +31,7 @@ RSpec.describe Api::V3::Finance::Statements::Index do
         :npq_statement,
         cpd_lead_provider:,
         cohort: cohort_2022,
-        created_at: 2.days.ago,
+        payment_date: 2.days.ago,
       )
     end
     let!(:npq_statement_cohort_2021) do
@@ -39,7 +39,7 @@ RSpec.describe Api::V3::Finance::Statements::Index do
         :npq_statement,
         cpd_lead_provider:,
         cohort: cohort_2021,
-        created_at: 1.day.ago,
+        payment_date: 1.day.ago,
       )
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Api::V3::Finance::Statements::Index do
 
     subject { described_class.new(cpd_lead_provider:, params:) }
 
-    it "returns all statements for the cpd provider ordered by created_at" do
+    it "returns all statements for the cpd provider ordered by payment_date" do
       expect(subject.statements).to eq([
         ecf_statement_cohort_2022,
         ecf_statement_cohort_2021,


### PR DESCRIPTION
### Context
Add API V3 statements endpoint

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1692

### Changes proposed in this pull request
- Add Statements serialiser
- Add `paid?` methods to subclasses to make it easier to calculate paid statements
- Add Statements query service to parse params and return correct statements
- Add API v3 statements route and controller

### Guidance to review
To test:

enable the feature flag: `FeatureFlag.activate("api_v3")`
GET the following endpoint: `/api/v3/statements`
To use different filters: `/api/v3/statements?filter[type]=npq&filter[cohort]=2021,2022`


