### PR TITLE
allow cohort transfers when the participant declarations are not bill…

### DIFF
--- a/app/models/induction_programme.rb
+++ b/app/models/induction_programme.rb
@@ -25,7 +25,7 @@ class InductionProgramme < ApplicationRecord
   has_one :lead_provider, through: :partnership
   has_one :delivery_partner, through: :partnership
   has_one :cpd_lead_provider, through: :lead_provider
-  delegate :school, to: :school_cohort
+  delegate :cohort, :school, to: :school_cohort
 
   after_commit :touch_induction_records
 

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -103,6 +103,7 @@ class ParticipantDeclaration < ApplicationRecord
   scope :paid_uplift_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).uplift }
 
   scope :billable, -> { where(state: %w[eligible payable paid]) }
+  scope :billable_or_changeable, -> { billable.or(changeable) }
 
   before_create :build_initial_declaration_state
 

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -44,7 +44,7 @@ module Induction
               }
     validates :participant_profile, presence: { message: I18n.t("errors.participant_profile.blank") },
                                     active: true
-    validates :participant_declarations, absence: { message: I18n.t("errors.participant_declarations.exist") }
+    validates :participant_declarations, absence: { message: I18n.t("errors.participant_declarations.billable_or_submitted") }
     validates :induction_record,
               presence: {
                 message: lambda do |form, _|

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -10,7 +10,7 @@ module Induction
       end
 
       def active?(participant_profile)
-        participant_profile && participant_profile.active_record? && participant_profile.training_status_active?
+        participant_profile&.active_record? && participant_profile&.training_status_active?
       end
     end
 
@@ -33,7 +33,7 @@ module Induction
                 message: I18n.t("errors.cohort.invalid_start_year", start: ECF_FIRST_YEAR, end: Date.current.year),
               },
               exclusion: {
-                within: ->(form) { [form.source_cohort_start_year] },
+                within: ->(form) { [form.source_cohort_start_year.to_s, form.source_cohort_start_year.to_i] },
                 message: ->(form, _) { I18n.t("errors.cohort.excluded_start_year", year: form.source_cohort_start_year) },
               }
     validates :target_cohort,
@@ -85,7 +85,7 @@ module Induction
 
       @participant_declarations ||= participant_profile
                                       .participant_declarations
-                                      .not_voided
+                                      .billable_or_changeable
                                       .declared_as_between(source_cohort_start_date, source_cohort_end_date)
                                       .exists?
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,7 @@ en:
     induction_record:
       blank: "The participant is not enrolled on the cohort starting on %{year}"
     participant_declarations:
-      exist: "The participant must have no declarations"
+      exist: "The participant has billable or submitted declarations in the current cohort"
     participant_profile:
       blank: "Not registered"
       not_active: "Not active"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,8 @@ en:
     induction_record:
       blank: "The participant is not enrolled on the cohort starting on %{year}"
     participant_declarations:
-      exist: "The participant has billable or submitted declarations in the current cohort"
+      exist: "The participant must have no declarations"
+      billable_or_submitted: "The participant has billable or submitted declarations in the current cohort"
     participant_profile:
       blank: "Not registered"
       not_active: "Not active"

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -190,21 +190,41 @@ RSpec.describe Induction::AmendParticipantCohort do
           end
         end
 
-        it "returns true and set no errors" do
-          expect(form.save).to be_truthy
-          expect(form.errors).to be_empty
+        context "when the participant has no declarations" do
+          it "returns true and set no errors" do
+            expect(form.save).to be_truthy
+            expect(form.errors).to be_empty
+          end
+
+          it "enrolls the participant in the target programme" do
+            expect(form.save).to be_truthy
+
+            induction_record = participant_profile.reload.induction_records.latest
+
+            expect(induction_record.induction_programme).to eq(target_school_cohort.default_induction_programme)
+            expect(induction_record.start_date).to eq(target_cohort.academic_year_start_date)
+            expect(induction_record.schedule).to eq(Finance::Schedule::ECF.default_for(cohort: target_cohort))
+            expect(participant_profile.school_cohort).to eq(target_school_cohort)
+            expect(participant_profile.schedule).to eq(Finance::Schedule::ECF.default_for(cohort: target_cohort))
+          end
         end
 
-        it "enrolls the participant in the target programme" do
-          expect(form.save).to be_truthy
+        %i[voided ineligible awaiting_clawback clawed_back].each do |declaration_state|
+          context "when the participant has #{declaration_state} declarations and no billable or changeable declarations" do
+            before do
+              participant_profile.participant_declarations.create!(declaration_date: Date.new(2021, 10, 10),
+                                                                   declaration_type: :started,
+                                                                   state: declaration_state,
+                                                                   course_identifier: "ecf-induction",
+                                                                   cpd_lead_provider: create(:cpd_lead_provider),
+                                                                   user: participant_profile.user)
+            end
 
-          induction_record = participant_profile.reload.induction_records.latest
-
-          expect(induction_record.induction_programme).to eq(target_school_cohort.default_induction_programme)
-          expect(induction_record.start_date).to eq(target_cohort.academic_year_start_date)
-          expect(induction_record.schedule).to eq(Finance::Schedule::ECF.default_for(cohort: target_cohort))
-          expect(participant_profile.school_cohort).to eq(target_school_cohort)
-          expect(participant_profile.schedule).to eq(Finance::Schedule::ECF.default_for(cohort: target_cohort))
+            it "executes the transfer, returns true and set no errors" do
+              expect(form.save).to be_truthy
+              expect(form.errors).to be_empty
+            end
+          end
         end
       end
     end

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -126,15 +126,22 @@ RSpec.describe Induction::AmendParticipantCohort do
         end
       end
 
-      context "when the participant has declarations" do
-        before do
-          allow_any_instance_of(described_class).to receive(:participant_declarations).and_return(true)
-        end
+      %i[submitted eligible payable paid].each do |declaration_state|
+        context "when the participant has #{declaration_state} declarations for the current cohort" do
+          before do
+            participant_profile.participant_declarations.create!(declaration_date: Date.new(2021, 10, 10),
+                                                                 declaration_type: :started,
+                                                                 state: declaration_state,
+                                                                 course_identifier: "ecf-induction",
+                                                                 cpd_lead_provider: create(:cpd_lead_provider),
+                                                                 user: participant_profile.user)
+          end
 
-        it "returns false and set errors" do
-          expect(form.save).to be_falsey
-          expect(form.errors.first.attribute).to eq(:participant_declarations)
-          expect(form.errors.first.message).to eq("The participant must have no declarations")
+          it "returns false and set errors" do
+            expect(form.save).to be_falsey
+            expect(form.errors.first.attribute).to eq(:participant_declarations)
+            expect(form.errors.first.message).to eq("The participant has billable or submitted declarations in the current cohort")
+          end
         end
       end
 


### PR DESCRIPTION
…able or submitted

### Context
  Admin cohort transfer tool reject transfers when the participant has declarations in their current cohort.
  This should not be the case when there are no billable or submitted declarations.
  This PR fixes it.

- Ticket: [1075](https://dfedigital.atlassian.net/browse/CST-1075)

### Changes proposed in this pull request
  

### Guidance to review

