### PR TITLE
Improve the admin school overview

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -40,4 +40,10 @@ module AdminHelper
 
     short ? short_names.fetch(name) : long_names.fetch(name)
   end
+
+  def format_address(*parts)
+    return if parts.blank?
+
+    safe_join(parts.compact_blank, tag.br)
+  end
 end

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -12,35 +12,51 @@
                       "data-test": "impersonate-button") { 'Impersonate induction tutor' } %>
 <% end %>
 
-<table class="govuk-table">
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Induction tutor</td>
-      <td class="govuk-table__cell">
-        <% if @induction_coordinator %>
-          <%= @induction_coordinator.full_name %><br>
-          <%= govuk_mail_to @induction_coordinator.email, @induction_coordinator.email  %>
-        <% end %>
-      </td>
-      <td class="govuk-table__cell">
-        <% if @induction_coordinator %>
-          <%= govuk_link_to "Change", admin_school_replace_or_update_induction_tutor_path(@school) %>
-        <% else %>
-          <%= govuk_link_to "Add induction tutor", new_admin_school_induction_coordinator_path(@school) %>
-        <% end %>
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Local authority</td>
-      <td class="govuk-table__cell"><%=@school.local_authority&.name%></td>
-      <td class="govuk-table__cell"></td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Establishment group</td>
-      <td class="govuk-table__cell"></td>
-      <td class="govuk-table__cell"></td>
-    </tr>
-  </tbody>
-</table>
+<%=
+  govuk_summary_list do |sl|
+    sl.row do |row|
+      row.key(text: "URN")
+      row.value(text: @school.urn)
+      if @school.urn.present?
+        row.action(
+          text: "Open in GIAS",
+          href: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@school.urn}",
+        )
+      end
+    end
+
+    sl.row do |row|
+      row.key(text: "Induction tutor")
+      row.value do
+        if @induction_coordinator.present?
+          safe_join([@induction_coordinator.full_name, tag.br, govuk_mail_to(@induction_coordinator.email, @induction_coordinator.email)])
+        end
+      end
+
+      if @induction_coordinator.present?
+        row.action(text: "Change", visually_hidden_text: "induction tutor", href: admin_school_replace_or_update_induction_tutor_path(@school))
+      else
+        row.action(text: "Add", visually_hidden_text: "induction tutor", href: new_admin_school_induction_coordinator_path(@school))
+      end
+    end
+
+    sl.row do |row|
+      row.key(text: "Local authority")
+      row.value(text: @school.local_authority&.name)
+    end
+
+    sl.row do |row|
+      row.key(text: "Address")
+      row.value(
+        text: format_address(
+          @school.address_line1,
+          @school.address_line2,
+          @school.address_line3,
+          @school.postcode,
+        )
+      )
+    end
+  end
+%>
 
 <%= govuk_link_to @link_text_2020, @link_2020 %>

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -75,4 +75,16 @@ RSpec.describe AdminHelper, type: :helper do
       end
     end
   end
+
+  describe "#format_address" do
+    it "returns nil when nothing is passed in" do
+      expect(format_address).to be_nil
+    end
+
+    it "joins the elements with <br> when multiple are passed in" do
+      expect(format_address("a")).to eql("a")
+      expect(format_address("a", "b")).to eql("a<br>b")
+      expect(format_address("a", "b", "c")).to eql("a<br>b<br>c")
+    end
+  end
 end

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Admin::Schools", type: :request do
 
         expect(response).to render_template("admin/schools/show")
         expect(response.body).to include(CGI.escapeHTML(school.name))
-        expect(response.body).to include("Add induction tutor")
+        expect(response.body).to include(%(Add <span class="govuk-visually-hidden">induction tutor</span>))
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe "Admin::Schools", type: :request do
 
         expect(response).to render_template("admin/schools/show")
         expect(response.body).to include(CGI.escapeHTML(school.name))
-        expect(response.body).to include("Add induction tutor")
+        expect(response.body).to include(%(Add <span class="govuk-visually-hidden">induction tutor</span>))
       end
     end
 


### PR DESCRIPTION
### Context

This was created in direct collaboration with the support team. The following fields have been added to school overview:

* URN
* Address
* A direct link to the corresponding page on GIAS
