### PR TITLE
Fix listing of date of birth for NPQ participants

### DIFF
--- a/app/components/admin/npq/participants/details.html.erb
+++ b/app/components/admin/npq/participants/details.html.erb
@@ -23,7 +23,7 @@
 
     sl.row do |row|
       row.key(text: "Date of birth")
-      row.value(text: ni_number)
+      row.value(text: date_of_birth)
     end
   end
 

--- a/spec/components/admin/npq/participants/details_spec.rb
+++ b/spec/components/admin/npq/participants/details_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type:
       expect(rendered).to have_contents(
         profile.user.full_name,
         profile.user.email,
+        profile.npq_application.nino,
+        profile.npq_application.date_of_birth.to_formatted_s(:govuk),
         profile.npq_application.teacher_reference_number,
         profile.npq_application.school_urn,
         t(:npq, scope: "schools.participants.type"),


### PR DESCRIPTION
### Context

Small fix where the national insurance number was displayed instead of the date of birth.
