### PR TITLE
do not allow participants to be assigned to an induction programme fr…

### DIFF
--- a/app/models/induction_programme.rb
+++ b/app/models/induction_programme.rb
@@ -25,7 +25,8 @@ class InductionProgramme < ApplicationRecord
   has_one :lead_provider, through: :partnership
   has_one :delivery_partner, through: :partnership
   has_one :cpd_lead_provider, through: :lead_provider
-  delegate :cohort, :school, to: :school_cohort
+
+  delegate :cohort, :cohort_id, :school, to: :school_cohort
 
   after_commit :touch_induction_records
 

--- a/app/services/induction/change_programme.rb
+++ b/app/services/induction/change_programme.rb
@@ -23,14 +23,21 @@ private
     @start_date = start_date
     @end_date = end_date
     @mentor_profile = mentor_profile
+    check_cohorts!
+  end
+
+  def check_cohorts!
+    raise("Given induction programme is not in the cohort of the participant!") unless compatible_cohorts?
+  end
+
+  def compatible_cohorts?
+    return true if participant_profile.schedule.nil?
+
+    new_induction_programme.cohort_id == participant_profile.schedule.cohort_id
   end
 
   def current_induction_record
     participant_profile.current_induction_record
-  end
-
-  def current_induction_programme
-    participant_profile.current_induction_record&.induction_programme
   end
 
   def preferred_email


### PR DESCRIPTION
…om a different cohort

### Context
  We have induction_records whose schedule doesn't match that of the participant profile.
  Induction::ChangeProgramme is a service object invoked by devs in the runbook that might cause this issue to happen.

- Ticket: [CST-1068](https://dfedigital.atlassian.net/browse/CST-1068)

### Changes proposed in this pull request
  Raise error when a participant is to be changed to an induction programme in a cohort other than the current one of the participant.

### Guidance to review