### PR TITLE
Fix Change full name and ECF API flaky tests

### DIFF
--- a/spec/requests/admin/participants/npq/change_email_spec.rb
+++ b/spec/requests/admin/participants/npq/change_email_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe "Admin::Participants::NPQ::ChangeEmailController", :with_default_schedules do
   let(:admin_user) { create(:user, :admin) }
 
-  let(:npq_profile) { create(:npq_participant_profile) }
+  let(:user) { create :user, full_name: "Roland Reilly" }
+  let(:npq_profile) { create(:npq_participant_profile, user:) }
 
   before { sign_in(admin_user) }
 

--- a/spec/requests/admin/participants/npq/change_full_name_spec.rb
+++ b/spec/requests/admin/participants/npq/change_full_name_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe "Admin::Participants::NPQ::ChangeFullNameController", :with_default_schedules do
   let(:admin_user) { create(:user, :admin) }
 
-  let(:npq_profile) { create(:npq_participant_profile) }
+  let(:user) { create :user, full_name: "Roland Reilly" }
+  let(:npq_profile) { create(:npq_participant_profile, user:) }
 
   before { sign_in(admin_user) }
 


### PR DESCRIPTION
### Context
Flakey specs: 
- `spec/requests/admin/participants/npq/change_full_name_spec.rb`: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3205886126/jobs/5238956665

- ` spec/requests/api/v2/ecf_participants_spec.rb`: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3203146889/jobs/5232896436

- Ticket: n/a

### Changes proposed in this pull request
- Use explicit name to avoid failure in regex expectation in spec
- Explicitly set ECT profile user with mentor in spec

### Guidance to review

