### PR TITLE
[CST-1072] Ensure school mentors are available at the right school

### DIFF
--- a/app/views/admin/participants/_school.html.erb
+++ b/app/views/admin/participants/_school.html.erb
@@ -33,5 +33,18 @@
     row.key(text: "Delivery partner")
     row.value(text: latest_induction_record.school_cohort.delivery_partner&.name)
   end
+
+  if latest_induction_record.participant_profile.mentor?
+    sl.row do |row|
+      row.key(text: "Mentoring at")
+      row.value do
+        ["<ul class='govuk-list govuk-list--bullet'>",
+        latest_induction_record.participant_profile.school_mentors.map do |school_mentor|
+          "<li>#{govuk_link_to(school_mentor.school.name, admin_school_path(school_mentor.school.friendly_id))}</li>"
+        end,
+        "</ul>"].flatten.join.html_safe
+      end
+    end
+  end
 end %>
 <%= govuk_link_to "Transfer to another school", select_school_admin_participant_school_transfer_path(@participant_profile) %>


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1072)

In the transfer services we were missing setting/correcting the mentors `SchoolMentor` records which enable them to appear in the mentor selection form shown to SITs. This has been fixed previously but there were still instances of mentors at schools without a `SchoolMentor` record.  I have updated the data in prod to ensure all active mentors have a `SchoolMentor` record for their school.
This PR adds a list of schools the mentor is mentoring at to the schools tab in the admin UI to enable support to diagnose mentoring availability questions more easily.

### Changes proposed in this pull request
Adds a list of "Mentoring at" schools to the School tab as links to those schools

### Guidance to review

![image](https://user-images.githubusercontent.com/333931/194870813-f87bb46c-218d-4705-805b-39e7f19b413c.png)
