### PR TITLE
Add partnership challenging to the admin pages

### DIFF
--- a/app/components/admin/schools/cohorts/cip_info.html.erb
+++ b/app/components/admin/schools/cohorts/cip_info.html.erb
@@ -26,4 +26,6 @@
       <span class="govuk-visually-hidden"> training materials</span>
     </dd>
   </div>
+
+  <%= content %>
 </dl>

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -1,4 +1,20 @@
 <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
   <%= cohort.display_name %> cohort
 </h3>
+
 <%= render cohort_info %>
+
+<% if partnerships.present? %>
+  <h4>Partnerships</h4>
+
+  <ul>
+    <% partnerships.each do |p| %>
+      <li class="govuk-!-padding-bottom-5">
+        <%= "#{p.delivery_partner.name} (#{p.lead_provider.name})" %><br>
+        <%= govuk_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, p)) do %>
+          Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -2,19 +2,28 @@
   <%= cohort.display_name %> cohort
 </h3>
 
-<%= render cohort_info %>
-
-<% if partnerships.present? %>
-  <h4>Partnerships</h4>
-
-  <ul>
-    <% partnerships.each do |p| %>
-      <li class="govuk-!-padding-bottom-5">
-        <%= "#{p.delivery_partner.name} (#{p.lead_provider.name})" %><br>
-        <%= govuk_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, p)) do %>
-          Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
-        <% end %>
-      </li>
+<%= render cohort_info do %>
+  <% if partnerships.present? %>
+     <% partnerships.each do |p| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <% if not p.relationship %>
+            Default Partnership
+          <% else %>
+            Relationship
+          <% end %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <strong>Delivery partner:</strong> <%= p.delivery_partner.name %><br>
+          <strong>Lead provider:</strong> <%= p.lead_provider.name %>
+          </ul>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= govuk_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, p)) do %>
+            Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
+          <% end %>
+        </dd>
+      </div>
     <% end %>
-  </ul>
+  <% end %>
 <% end %>

--- a/app/components/admin/schools/cohorts/cohort.rb
+++ b/app/components/admin/schools/cohorts/cohort.rb
@@ -16,11 +16,11 @@ module Admin
 
         attr_reader :cohort, :school_cohort
 
-        def cohort_info
+        def cohort_info(&block)
           case school_cohort&.induction_programme_choice
-          when "core_induction_programme" then CipInfo.new(school_cohort:)
-          when "full_induction_programme" then FipInfo.new(school_cohort:)
-          else OtherInfo.new(school_cohort:, cohort:)
+          when "core_induction_programme" then CipInfo.new(school_cohort:, &block)
+          when "full_induction_programme" then FipInfo.new(school_cohort:, &block)
+          else OtherInfo.new(school_cohort:, cohort:, &block)
           end
         end
       end

--- a/app/components/admin/schools/cohorts/cohort.rb
+++ b/app/components/admin/schools/cohorts/cohort.rb
@@ -4,9 +4,12 @@ module Admin
   module Schools
     module Cohorts
       class Cohort < BaseComponent
-        def initialize(cohort:, school_cohort:)
+        attr_reader :partnerships
+
+        def initialize(cohort:, school_cohort:, partnerships: [])
           @cohort = cohort
           @school_cohort = school_cohort
+          @partnerships = partnerships
         end
 
       private

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -32,4 +32,6 @@
     </dd>
     <dd class="govuk-summary-list__actions"></dd>
   </div>
+
+  <%= content %>
 </dl>

--- a/app/components/admin/schools/cohorts/other_info.html.erb
+++ b/app/components/admin/schools/cohorts/other_info.html.erb
@@ -11,4 +11,6 @@
       <span class="govuk-visually-hidden"> induction programme</span>
     </dd>
   </div>
+
+  <%= content %>
 </dl>

--- a/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
+++ b/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
@@ -9,9 +9,9 @@ module Admin
 
         def new
           school = School.friendly.find params[:school_id]
-          cohort = ::Cohort.find_by(start_year: params[:id])
-          partnership = Partnership.find_by(school:, cohort:)
+          partnership = Partnership.find(params[:partnership_id])
           authorize partnership, :update?
+
           @challenge_partnership_form = ChallengePartnershipForm.new(
             school_name: school.name,
             partnership_id: partnership.id,

--- a/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
+++ b/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
@@ -26,7 +26,7 @@ module Admin
         def create
           authorize @challenge_partnership_form.partnership, :update?
           @challenge_partnership_form.challenge!
-          set_success_message heading: "Induction programme has been changed"
+          set_success_message heading: "Induction programme has been challenged"
           redirect_to admin_school_cohorts_path
         end
 

--- a/app/controllers/admin/schools/cohorts_controller.rb
+++ b/app/controllers/admin/schools/cohorts_controller.rb
@@ -18,7 +18,8 @@ module Admin
     private
 
       def set_school
-        @school = School.friendly.find params[:school_id]
+        @school = School.eager_load(:active_partnerships).friendly.find(params[:school_id])
+        @partnerships_by_cohort = @school.active_partnerships.group_by(&:cohort_id)
       end
     end
   end

--- a/app/views/admin/participants/_school.html.erb
+++ b/app/views/admin/participants/_school.html.erb
@@ -26,7 +26,6 @@
   sl.row do |row|
     row.key(text: "Lead provider")
     row.value(text: latest_induction_record.school_cohort.lead_provider&.name)
-    row.action(text: "Challenge", visually_hidden_text: "lead provider", href: "#") if lead_provider
   end
 
   sl.row do |row|

--- a/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
@@ -4,6 +4,8 @@
       You are reporting an incorrect partnership
     </h1>
 
+    <%= govuk_warning_text(text: "Has this been authorised by the Policy Engagement Team?") %>
+
     <%= govuk_summary_list do |sl|
       sl.row do |row|
         row.key(text: "Cohort")

--- a/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-xl">
       You are choosing to change course report and remove: <%= @challenge_partnership_form.lead_provider_name %>
     </h1>
-    <%= form_for @challenge_partnership_form, url: admin_school_challenge_partnership_path do |f| %>
+    <%= form_for @challenge_partnership_form, url: admin_school_partnership_challenge_partnership_path do |f| %>
       <%= f.hidden_field :partnership_id %>
       <%= f.hidden_field :challenge_reason %>
       <%= f.govuk_submit "Continue" %>

--- a/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
@@ -1,12 +1,29 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl">
-      You are choosing to change course report and remove: <%= @challenge_partnership_form.lead_provider_name %>
+      You are reporting an incorrect partnership
     </h1>
+
+    <%= govuk_summary_list do |sl|
+      sl.row do |row|
+        row.key(text: "Cohort")
+        row.value(text: @challenge_partnership_form.partnership.cohort.start_year)
+      end
+
+      sl.row do |row|
+        row.key(text: "Lead Provider")
+        row.value(text: @challenge_partnership_form.partnership.lead_provider.name)
+      end
+
+      sl.row do |row|
+        row.key(text: "Delivery partner")
+        row.value(text: @challenge_partnership_form.partnership.delivery_partner.name)
+      end
+    end %>
     <%= form_for @challenge_partnership_form, url: admin_school_partnership_challenge_partnership_path do |f| %>
       <%= f.hidden_field :partnership_id %>
       <%= f.hidden_field :challenge_reason %>
-      <%= f.govuk_submit "Continue" %>
+      <%= f.govuk_submit "Challenge" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
@@ -4,8 +4,25 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Report that <%= @challenge_partnership_form.school_name %> has been signed up incorrectly</h1>
 
-    <%= form_for @challenge_partnership_form, url: confirm_admin_school_challenge_partnership_path do |f| %>
-      <%= f.hidden_field :partnership_id %>
+    <%= govuk_summary_list do |sl|
+      sl.row do |row|
+        row.key(text: "Cohort")
+        row.value(text: @challenge_partnership_form.partnership.cohort.start_year)
+      end
+
+      sl.row do |row|
+        row.key(text: "Lead Provider")
+        row.value(text: @challenge_partnership_form.partnership.lead_provider.name)
+      end
+
+      sl.row do |row|
+        row.key(text: "Delivery partner")
+        row.value(text: @challenge_partnership_form.partnership.delivery_partner.name)
+      end
+    end %>
+
+    <%= form_for @challenge_partnership_form, url: confirm_admin_school_partnership_challenge_partnership_path do |f| %>
+      <%= f.hidden_field :partnership_id, value: @challenge_partnership_form.partnership_id %>
       <%= f.govuk_collection_radio_buttons(
             :challenge_reason,
             @challenge_partnership_form.challenge_reason_options,

--- a/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
@@ -2,7 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Report that <%= @challenge_partnership_form.school_name %> has been signed up incorrectly</h1>
+    <h1 class="govuk-heading-xl">
+      Report an incorrect partnership
+    </h1>
 
     <%= govuk_summary_list do |sl|
       sl.row do |row|
@@ -28,7 +30,7 @@
             @challenge_partnership_form.challenge_reason_options,
             :id,
             :name,
-            legend: { text: "Tell us why", size: "m" }) %>
+            legend: { text: "Tell us why this is not the right partnership", size: "m" }) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/admin/schools/cohorts/index.html.erb
+++ b/app/views/admin/schools/cohorts/index.html.erb
@@ -6,7 +6,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% @cohorts.each do |cohort| %>
-      <%= render Admin::Schools::Cohorts::Cohort.new(school_cohort: @school_cohorts.find_by(cohort: cohort), cohort: cohort) %>
+      <%= render Admin::Schools::Cohorts::Cohort.new(
+        school_cohort: @school_cohorts.find_by(cohort: cohort),
+        cohort: cohort,
+        partnerships: @partnerships_by_cohort[cohort.id],
+      ) %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,12 +223,14 @@ Rails.application.routes.draw do
           resource :change_programme, only: %i[show update], path: "change-programme", controller: "schools/cohorts/change_programme" do
             post :confirm
           end
-          resource :challenge_partnership, only: %i[new create], path: "challenge-partnership", controller: "schools/cohorts/challenge_partnership" do
-            post :confirm
-          end
           resource :change_training_materials, only: %i[show update], path: "change-training-materials", controller: "schools/cohorts/change_training_materials" do
             post :confirm
           end
+        end
+      end
+      resources :partnerships, only: [] do
+        resource :challenge_partnership, only: %i[new create], path: "challenge-partnership", controller: "schools/cohorts/challenge_partnership" do
+          post :confirm
         end
       end
       resources :participants, controller: "schools/participants", only: :index

--- a/spec/components/admin/schools/cohorts/cip_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/cip_info_spec.rb
@@ -1,26 +1,36 @@
 # frozen_string_literal: true
 
-RSpec.describe Admin::Schools::Cohorts::CipInfo, type: :view_component do
-  let(:school) { create(:school, slug: "test-school") }
-  let(:school_cohort) { FactoryBot.create :school_cohort, :cip, school:, core_induction_programme: programme }
+RSpec.describe Admin::Schools::Cohorts::CipInfo, type: :component do
+  let(:school) { FactoryBot.create :school }
   let(:programme) { FactoryBot.create :core_induction_programme }
+  let(:school_cohort) { FactoryBot.create :school_cohort, :cip, school:, core_induction_programme: programme }
 
-  component { described_class.new school_cohort: }
-
-  it "has the correct content" do
+  subject! do
     with_request_url "/schools/test-school" do
-      expect(rendered).to have_content "Use the DfE accredited materials"
-      expect(rendered).to have_content programme.name
+      render_inline(described_class.new(school_cohort:))
     end
   end
 
-  context "when no programme is selected" do
-    let(:programme) { nil }
+  it "has the correct content" do
+    with_request_url "/schools/test-school" do
+      expect(rendered_component).to have_content "Use the DfE accredited materials"
+      expect(rendered_component).to have_content programme.name
+    end
+  end
 
-    it "renders" do
+  context "when a block is passed in" do
+    let(:block_content) { "extra content" }
+
+    subject! do
       with_request_url "/schools/test-school" do
-        expect(rendered).to render
+        render_inline(described_class.new(school_cohort:)) do
+          block_content
+        end
       end
+    end
+
+    it "renders the block" do
+      expect(rendered_component).to have_content(block_content)
     end
   end
 end

--- a/spec/components/admin/schools/cohorts/fip_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/fip_info_spec.rb
@@ -1,20 +1,44 @@
 # frozen_string_literal: true
 
-RSpec.describe Admin::Schools::Cohorts::FipInfo, type: :view_component do
-  let(:school_cohort) { FactoryBot.create :school_cohort, :fip }
+RSpec.describe Admin::Schools::Cohorts::FipInfo, type: :component do
+  let(:school) { FactoryBot.create :school }
+  let(:school_cohort) { FactoryBot.create(:school_cohort, :fip, school:) }
   let(:lead_provider) { FactoryBot.create :lead_provider }
 
   before do
-    FactoryBot.create :partnership, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider:
+    FactoryBot.create(
+      :partnership,
+      school: school_cohort.school,
+      cohort: school_cohort.cohort,
+      lead_provider:,
+    )
   end
 
-  component { described_class.new school_cohort: }
+  subject! do
+    with_request_url "/schools/test-school" do
+      render_inline(described_class.new(school_cohort:))
+    end
+  end
 
   it "has the correct content" do
-    with_request_url "/schools/test-school" do
-      expect(rendered).to have_content "Use an approved training provider"
-      expect(rendered).to have_content lead_provider.name
-      expect(rendered).to have_content school_cohort.delivery_partner.name
+    expect(rendered_component).to have_content "Use an approved training provider"
+    expect(rendered_component).to have_content lead_provider.name
+    expect(rendered_component).to have_content school_cohort.delivery_partner.name
+  end
+
+  context "when a block is passed in" do
+    let(:block_content) { "extra content" }
+
+    subject! do
+      with_request_url "/schools/test-school" do
+        render_inline(described_class.new(school_cohort:)) do
+          block_content
+        end
+      end
+    end
+
+    it "renders the block" do
+      expect(rendered_component).to have_content(block_content)
     end
   end
 end

--- a/spec/components/admin/schools/cohorts/other_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/other_info_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe Admin::Schools::Cohorts::OtherInfo, type: :view_component do
+RSpec.describe Admin::Schools::Cohorts::OtherInfo, type: :component do
   let(:cohort) { instance_double Cohort, start_year: rand(2020..2030) }
   let(:school_cohort) { instance_double(SchoolCohort, induction_programme_choice: Faker::Lorem.words.join("_")) if rand < 0.5 }
-
-  component { described_class.new cohort:, school_cohort: }
 
   before do
     url_options[:school_id] = 1
     allow(controller).to receive(:url_options).and_return(controller.url_options.merge(school_id: 1))
   end
 
+  before { render_inline(described_class.new(cohort:, school_cohort:)) }
+
   it { is_expected.to have_link "Change", href: admin_school_change_programme_path(id: cohort.start_year) }
+
+  subject { rendered_component }
 
   context "without school cohort" do
     let(:school_cohort) { nil }

--- a/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
+++ b/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
 
       expect(response).to redirect_to "/admin/schools/#{school.slug}/cohorts"
       follow_redirect!
-      expect(response.body).to include "Induction programme has been changed"
+      expect(response.body).to include "Induction programme has been challenged"
     end
   end
 end

--- a/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
+++ b/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
@@ -13,17 +13,16 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
 
   describe "GET /admin/schools/:school_slug/cohorts/:id/challenge-partnership/new" do
     it "renders the new template" do
-      get "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership/new"
+      get "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/new"
       expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
     end
   end
 
   describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership/confirm" do
     it "shows an error message if no reason is selected" do
-      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership/confirm", params: {
+      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/confirm", params: {
         challenge_partnership_form: {
           partnership_id: partnership.id,
-          lead_provider_name: partnership.lead_provider.name,
           challenge_reason: "",
         },
       }
@@ -33,7 +32,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
     end
 
     it "shows a confirmation message" do
-      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership/confirm", params: {
+      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/confirm", params: {
         challenge_partnership_form: {
           partnership_id: partnership.id,
           lead_provider_name: partnership.lead_provider.name,
@@ -49,7 +48,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
     it "call Partnerships::Challenge with the correct arguments" do
       expect(Partnerships::Challenge).to receive(:call).with(partnership:, challenge_reason: "mistake")
 
-      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership", params: {
+      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership", params: {
         challenge_partnership_form: {
           partnership_id: partnership.id,
           challenge_reason: "mistake",
@@ -58,7 +57,7 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
     end
 
     it "redirects to the cohorts page and shows a success message" do
-      post "/admin/schools/#{school.slug}/cohorts/#{cohort.start_year}/challenge-partnership", params: {
+      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership", params: {
         challenge_partnership_form: {
           partnership_id: partnership.id,
           challenge_reason: "mistake",


### PR DESCRIPTION
### Context

- Ticket: 

### Summary

* make the existing partnership challenging functionality partner-centric
* display the partnership details on the form (so it's clear what we're challening)
* display all the partnerships for each cohort beneath the listing with a 'challenge' link

The partnership challenging controller appeared to be written in a way that assumes there's only one partnership per cohort per school. I don't think this is necessarily always the case (it certainly isn't in the seed data).

Now instead of grabbing the partnership based on the school and cohort, the partnership id is a URL param.

Because multiple partnerships might be available to edit I've added the relevant details to the top of the challenge form too.

| Parterships list | Challenge form | Confirmation screen | Notification |
| ------------- | --------------- | ----------------- | -------------------- |
| ![image](https://user-images.githubusercontent.com/128088/194907466-4467e4a9-5d64-4102-a611-76e169363bb5.png) | ![image](https://user-images.githubusercontent.com/128088/194907599-1cd9d2d9-d300-4f94-99b4-183d4e50eb5f.png) | ![Screenshot from 2022-10-10 16-58-53](https://user-images.githubusercontent.com/128088/194907924-b45325f3-fa12-4c80-b5e3-c92bafb6506e.png) | ![image](https://user-images.githubusercontent.com/128088/194907822-c42e8d37-b43b-4460-b7de-f0209b4d2407.png) |

