### PR TITLE
Add postcode to filterable school fields

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -13,7 +13,7 @@ module Admin
       @pagy, @schools = pagy(policy_scope(School)
                                .distinct
                                .includes(:induction_coordinators, :local_authority)
-                               .ransack(induction_coordinators_email_or_urn_or_name_cont: @query)
+                               .ransack(induction_coordinators_email_or_urn_or_name_or_postcode_cont: @query)
                                .result
                                .order(:name), page: params[:page], items: 10)
     end

--- a/app/views/admin/schools/index.html.erb
+++ b/app/views/admin/schools/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l">Schools</h1>
-<%= render SearchBox.new(query: @query, title: "Search schools", hint: "Enter the school’s name, URN or tutor email") %>
+<%= render SearchBox.new(query: @query, title: "Search schools", hint: "Enter the school’s name, postcode, URN or tutor email") %>
 
 
 <div class="nhsuk-table-container">

--- a/spec/cypress/integration/admin/SchoolManagment.feature
+++ b/spec/cypress/integration/admin/SchoolManagment.feature
@@ -28,7 +28,7 @@ Feature: Admin user managing schools
 
   Scenario: Viewing a list of schools
     Then the table should have 9 rows
-    And "page body" should contain "Enter the school’s name, URN or tutor email"
+    And "page body" should contain "Enter the school’s name, postcode, URN or tutor email"
     And the page should be accessible
 
     When I type "include" into "search box"

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Admin::Schools", type: :request do
     end
 
     context "filtering the school list" do
-      let!(:included_school) { create(:school, name: "Include Me", urn: "090120") }
+      let!(:included_school) { create(:school, name: "Include Me", urn: "090120", postcode: "M1 2WD") }
       let!(:excluded_school) { create(:school, name: "Exclude Me", urn: "333333") }
 
       it "filters the list of schools by name" do
@@ -44,6 +44,11 @@ RSpec.describe "Admin::Schools", type: :request do
         create(:user, :induction_coordinator, email: "mary@schools.org", schools: [included_school])
 
         get "/admin/schools", params: { query: "mary" }
+        expect(assigns(:schools)).to match_array [included_school]
+      end
+
+      it "filters the list by postcode" do
+        get "/admin/schools", params: { query: "M1" }
         expect(assigns(:schools)).to match_array [included_school]
       end
 


### PR DESCRIPTION
### Context

Allow admins to filter schools by postcode. This helps support agents find schools that share their name with lots of other schools
