### PR TITLE
Ensure that school_cohort combinations are unique

### DIFF
--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -37,6 +37,8 @@ class SchoolCohort < ApplicationRecord
   has_many :transferred_induction_records, through: :induction_programmes, class_name: "InductionRecord"
   has_many :current_participant_profiles, through: :induction_programmes, class_name: "ParticipantProfile::ECF"
 
+  validates :school_id, uniqueness: { scope: :cohort_id }
+
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
 
   delegate :description, :academic_year, :start_year, to: :cohort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,10 @@ en:
               cannot_change_from_accepted: Once accepted an application cannot change state
               cannot_change_from_rejected: Once rejected an application cannot change state
               declarations_exist: There are already declarations for this participant on this course, please ask provider to void and/or clawback any declarations they have made before attempting to reset the application.
+        school_cohort:
+          attributes:
+            school_id:
+              taken: The school is already linked to this cohort
 
   activemodel:
     errors:

--- a/db/migrate/20221012103024_add_unique_index_to_school_cohorts.rb
+++ b/db/migrate/20221012103024_add_unique_index_to_school_cohorts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToSchoolCohorts < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:school_cohorts, %i[school_id cohort_id], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_29_104505) do
+ActiveRecord::Schema.define(version: 2022_10_12_103024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -847,6 +847,7 @@ ActiveRecord::Schema.define(version: 2022_09_29_104505) do
     t.index ["cohort_id"], name: "index_school_cohorts_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_school_cohorts_on_core_induction_programme_id"
     t.index ["default_induction_programme_id"], name: "index_school_cohorts_on_default_induction_programme_id"
+    t.index ["school_id", "cohort_id"], name: "index_school_cohorts_on_school_id_and_cohort_id", unique: true
     t.index ["school_id"], name: "index_school_cohorts_on_school_id"
   end
 

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe SchoolCohort, type: :model do
     it { is_expected.to have_many(:transferring_out_induction_records).through(:induction_programmes) }
   end
 
+  describe "validation" do
+    it "validates the uniqueness of school_id and cohort_id in combination" do
+      school_cohort_1 = create(:school_cohort)
+      school_cohort_2 = school_cohort_1.dup
+
+      expect(school_cohort_2).to be_invalid
+      expect(school_cohort_2.errors.messages[:school_id]).to include("The school is already linked to this cohort")
+    end
+  end
+
   it "updates the updated_at on participant profiles and users when meaningfully updated" do
     freeze_time
     school_cohort = create(:school_cohort)

--- a/spec/policies/participant_profile_policy_spec.rb
+++ b/spec/policies/participant_profile_policy_spec.rb
@@ -34,17 +34,17 @@ RSpec.describe ParticipantProfilePolicy, :with_default_schedules, type: :policy 
     end
 
     context "for an induction coordinator" do
-      let(:schools) { create_list :school, rand(2..3) }
+      let(:schools) { create_list :school, 3 }
       let(:user) { create(:induction_coordinator_profile, schools:).user }
-      let(:ect_profiles_for_stis_schools) { Array.new(rand(3..5)) { create :ect, school_cohort: create(:school_cohort, school: schools.sample) } }
-      let(:mentor_profiles_for_stis_schools) { Array.new(rand(3..5)) { create :mentor, school_cohort: create(:school_cohort, school: schools.sample) } }
-      let(:npq_profiles_for_stis_schools) { Array.new(rand(3..5)) { create :npq_participant_profile, school: schools.sample } }
+      let(:ect_profiles_for_stis_schools) { create :ect, school_cohort: create(:school_cohort, school: schools.first) }
+      let(:mentor_profiles_for_stis_schools) { create :mentor, school_cohort: create(:school_cohort, school: schools.second) }
+      let(:npq_profiles_for_stis_schools) { create :npq_participant_profile, school: schools.third }
       let(:other_participant_profiles) { create_list :ect, rand(2..3) }
 
-      it { is_expected.to include(*ect_profiles_for_stis_schools) }
-      it { is_expected.to include(*mentor_profiles_for_stis_schools) }
-      it { is_expected.not_to include(*npq_profiles_for_stis_schools) }
-      it { is_expected.not_to include(*other_participant_profiles) }
+      it { is_expected.to include(ect_profiles_for_stis_schools) }
+      it { is_expected.to include(mentor_profiles_for_stis_schools) }
+      it { is_expected.not_to include(npq_profiles_for_stis_schools) }
+      it { is_expected.not_to include(other_participant_profiles) }
     end
 
     context "for a regular user" do

--- a/spec/requests/admin/schools/cohorts_spec.rb
+++ b/spec/requests/admin/schools/cohorts_spec.rb
@@ -6,15 +6,18 @@ RSpec.describe "Admin::Schools::Cohorts", type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:school) { create(:school) }
   let(:cip) { create(:core_induction_programme, name: "CIP Programme") }
+  let(:cohorts) { create_list(:cohort, 5) }
+
   let!(:school_cohorts) do
     [
-      create(:school_cohort, school:, core_induction_programme: cip),
-      create(:school_cohort, school:),
-      create(:school_cohort, school:, induction_programme_choice: "full_induction_programme"),
-      create(:school_cohort, school:, induction_programme_choice: "no_early_career_teachers"),
-      create(:school_cohort, school:, induction_programme_choice: "design_our_own"),
+      create(:school_cohort, school:, cohort: cohorts[0], core_induction_programme: cip),
+      create(:school_cohort, school:, cohort: cohorts[1]),
+      create(:school_cohort, school:, cohort: cohorts[2], induction_programme_choice: "full_induction_programme"),
+      create(:school_cohort, school:, cohort: cohorts[3], induction_programme_choice: "no_early_career_teachers"),
+      create(:school_cohort, school:, cohort: cohorts[4], induction_programme_choice: "design_our_own"),
     ]
   end
+
   let!(:cohort_without_programme_chosen) { create(:cohort) }
 
   before do


### PR DESCRIPTION
### Context

We had a case recently where a school had two 2021 cohort records. This should never happen. This change enforces it both at the database and model level.

### Changes proposed in this pull request

* add a unique index to `school_cohorts` on `school_id` and `cohort_id`
* add a unique constraint to the `SchoolCohort` model

### Before merging

**Don't merge this until we have no more duplicates.**

This query should return no results in prod.

```
with dupes as (
  select school_id, cohort_id
  from school_cohorts
  group by school_id, cohort_id
  having count(*) > 1
)
select urn, name, postcode
from schools
join dupes on schools.id = dupes.school_id;
```
