### PR TITLE
[CST-1078] additional functionality for admin transfer

### DIFF
--- a/app/controllers/admin/participants/school_transfer_controller.rb
+++ b/app/controllers/admin/participants/school_transfer_controller.rb
@@ -11,6 +11,8 @@ module Admin::Participants
     def select_school
       step = if @school_transfer_form.cannot_transfer_to_new_school?
                :cannot_transfer
+             elsif @school_transfer_form.skip_transfer_options?
+               :start_date
              else
                :transfer_options
              end

--- a/app/forms/admin/school_transfer_form.rb
+++ b/app/forms/admin/school_transfer_form.rb
@@ -76,7 +76,7 @@ class Admin::SchoolTransferForm
   end
 
   def cannot_transfer_to_new_school?
-    cannot_transfer_reason.present?
+    no_programmes_to_transfer_into_or_continue?
   end
 
   def cannot_transfer_reason
@@ -90,7 +90,7 @@ class Admin::SchoolTransferForm
     programme_count = new_school_cohort&.induction_programmes&.count || 0
 
     choice = if latest_induction_record.present?
-               if programme_count == 0
+               if programme_count.zero?
                  "continue"
                elsif programme_count == 1 && latest_induction_record.induction_programme.same_induction_as?(new_school_cohort.induction_programmes.first)
                  new_school_cohort.induction_programmes.first.id

--- a/app/models/induction_programme.rb
+++ b/app/models/induction_programme.rb
@@ -38,6 +38,14 @@ class InductionProgramme < ApplicationRecord
     delivery_partner&.name unless partnership&.challenged?
   end
 
+  def same_induction_as?(other)
+    school_cohort.cohort == other.school_cohort.cohort &&
+      training_programme == other.training_programme &&
+      lead_provider == other.lead_provider &&
+      delivery_partner == other.delivery_partner &&
+      core_induction_programme == other.core_induction_programme
+  end
+
 private
 
   def touch_induction_records

--- a/app/services/induction/create_relationship.rb
+++ b/app/services/induction/create_relationship.rb
@@ -12,18 +12,27 @@ class Induction::CreateRelationship < BaseService
                                    cohort: school_cohort.cohort,
                                    lead_provider:,
                                    delivery_partner:) do |partnership|
-      partnership.relationship = true
-      partnership.challenge_deadline = Time.zone.now
+      partnership.relationship = !treat_as_partnership
+      partnership.challenge_deadline = challenge_deadline
     end
   end
 
 private
 
-  attr_reader :school_cohort, :lead_provider, :delivery_partner
+  attr_reader :school_cohort, :lead_provider, :delivery_partner, :treat_as_partnership
 
-  def initialize(school_cohort:, lead_provider:, delivery_partner: nil)
+  def initialize(school_cohort:, lead_provider:, delivery_partner: nil, treat_as_partnership: false)
     @school_cohort = school_cohort
     @lead_provider = lead_provider
     @delivery_partner = delivery_partner
+    @treat_as_partnership = treat_as_partnership
+  end
+
+  def challenge_deadline
+    if treat_as_partnership
+      Partnerships::Report::CHALLENGE_WINDOW.from_now
+    else
+      Time.zone.now
+    end
   end
 end

--- a/app/services/induction/transfer_and_continue_existing_programme.rb
+++ b/app/services/induction/transfer_and_continue_existing_programme.rb
@@ -85,7 +85,8 @@ private
     if lead_provider.present?
       Induction::CreateRelationship.call(school_cohort:,
                                          lead_provider:,
-                                         delivery_partner:)
+                                         delivery_partner:,
+                                         treat_as_partnership: @make_default_programme)
     end
   end
 

--- a/app/views/admin/participants/school_transfer/transfer_options.html.erb
+++ b/app/views/admin/participants/school_transfer/transfer_options.html.erb
@@ -11,7 +11,9 @@
           <% @school_transfer_form.transfer_options.each do |option| %>
             <%= f.govuk_radio_button :transfer_choice, option.id, label: { text: option.description } %>
           <% end %>
-          <%= f.govuk_radio_divider %>
+          <% if @school_transfer_form.transfer_options.any? %>
+            <%= f.govuk_radio_divider %>
+          <% end %>
           <%= f.govuk_radio_button :transfer_choice, "continue", label: { text: "Current #{@school_transfer_form.current_programme_description}" } %>
       <% end %>
       <%= f.govuk_submit %>

--- a/spec/services/induction/create_relationship_spec.rb
+++ b/spec/services/induction/create_relationship_spec.rb
@@ -5,31 +5,36 @@ RSpec.describe Induction::CreateRelationship do
     let(:school_cohort) { create :school_cohort }
     let(:lead_provider) { create(:lead_provider) }
     let(:delivery_partner) { create(:delivery_partner) }
+    let(:treat_as_partnership) { false }
 
-    subject(:service) { described_class }
+    subject(:service_call) { described_class.call(school_cohort:, lead_provider:, delivery_partner:, treat_as_partnership:) }
 
     it "adds a new Partnership record" do
-      expect {
-        service.call(school_cohort:,
-                     lead_provider:,
-                     delivery_partner:)
-      }.to change { school_cohort.school.partnerships.count }.by 1
+      expect { service_call }.to change { school_cohort.school.partnerships.count }.by 1
     end
 
     it "sets the relationship flag on the Partnership" do
-      service.call(school_cohort:,
-                   lead_provider:,
-                   delivery_partner:)
-
+      service_call
       expect(school_cohort.school.partnerships.last).to be_relationship
     end
 
-    it "the Partnership doesn't have a challenge window" do
-      service.call(school_cohort:,
-                   lead_provider:,
-                   delivery_partner:)
-
+    it "doesn't have a challenge window in the Partnership" do
+      service_call
       expect(school_cohort.school.partnerships.last).not_to be_in_challenge_window
+    end
+
+    context "when treat_as_partnership is true" do
+      let(:treat_as_partnership) { true }
+
+      it "does not set the relationship flag" do
+        service_call
+        expect(school_cohort.school.partnerships.last).not_to be_relationship
+      end
+
+      it "doesn't have a challenge window in the Partnership" do
+        service_call
+        expect(school_cohort.school.partnerships.last).to be_in_challenge_window
+      end
     end
   end
 end

--- a/spec/services/induction/transfer_and_continue_existing_programme_spec.rb
+++ b/spec/services/induction/transfer_and_continue_existing_programme_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe Induction::TransferAndContinueExistingProgramme, :with_default_sc
       expect { service_call }.to change { participant_profile.induction_records.count }.by 1
     end
 
+    context "when there is no school cohort at the new school" do
+      let(:school_2) { create(:school) }
+      let!(:school_cohort_2) { nil }
+      let!(:mentor_profile_2) { nil }
+
+      it "creates a new school cohort" do
+        expect { service_call }.to change { school_2.school_cohorts.count }.by(1)
+      end
+
+      it "sets the induction programme choice on the school cohort" do
+        service_call
+        expect(school_2.school_cohorts.first).to be_full_induction_programme
+      end
+
+      it "sets the default induction programme on the school cohort to be the new programme" do
+        service_call
+        expect(school_2.school_cohorts.first.default_induction_programme).to eq school_2.school_cohorts.first.induction_programmes.first
+      end
+    end
+
     context "when the original programme is a FIP" do
       it "creates a relationship partnership at the transferring in school" do
         expect { service_call }.to change { school_2.partnerships.relationships.count }.by 1


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1078)

Extra functionality for the admin school transfers when there is no school cohort at the destination school or the school has chosen "no ECTs" for the cohort.

In these cases the transfer will add a school cohort and set it up the same as the transferring in participants programme.
Also remove the transfer choice page when there is no choice available (no programmes at destination or only 1 that matches the participants current programme).

### Changes proposed in this pull request

### Guidance to review

