### PR TITLE
Fix relevant induction record lookup

### DIFF
--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -81,7 +81,7 @@ class ParticipantProfile < ApplicationRecord
       induction_records
         .joins(induction_programme: { school_cohort: [:cohort], partnership: [:lead_provider] })
         .where(induction_programme: { partnerships: { lead_provider: } })
-        .where(induction_programme: { school_cohorts: { cohort: Cohort.current } })
+        .where(induction_programme: { school_cohorts: { cohort: Cohort.where(start_year: 2021..) } })
         .order(start_date: :desc)
         .first
     end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -228,4 +228,28 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       end
     end
   end
+
+  describe "#relevant_induction_record" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+    let(:lead_provider) { cpd_lead_provider.lead_provider }
+    let(:cohort) { create(:cohort, :next) }
+    let(:partnership) { create(:partnership, lead_provider:, cohort:) }
+    let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort:) }
+    let(:induction_programme) { create(:induction_programme, school_cohort:, partnership:) }
+    let(:profile) { create(:ecf_participant_profile, school_cohort:) }
+    let!(:induction_record_older) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 2.days.ago) }
+    let!(:induction_record_latest) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 1.day.ago) }
+
+    it "finds the most recent induction record" do
+      expect(profile.relevant_induction_record(lead_provider:)).to eq(induction_record_latest)
+    end
+
+    context "when participant is in an older cohort" do
+      let(:cohort) { create(:cohort, :current) }
+
+      it "finds the most recent induction record" do
+        expect(profile.relevant_induction_record(lead_provider:)).to eq(induction_record_latest)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

ECF Action participant endpoints such as defer/resume/withdraw, find the relevant induction record for a lead provider to serialise a response in the API: https://github.com/DFE-Digital/early-careers-framework/blob/7ab4cbc54985cbcdcb85e0736c1bd11bc56a71f5/app/controllers/concerns/api/v1/participant_actions.rb#L32

When we lookup those induction records we are currently only scoping them to the current cohort i.e. 2022. So if an action is attempted for participants with induction record in older cohorts they get an empty body in the API response as no induction record is returned

- Ticket: n/a


### Changes proposed in this pull request

We should return induction records for all cohorts, and not just the current cohort for a lead provider.

### Guidance to review
Did I miss anything?
