### PR TITLE
[CPDLP-1744] - add guard clauses so that double profile can not be created

### DIFF
--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -13,6 +13,8 @@ module EarlyCareerTeachers
 
         create_teacher_profile
 
+        raise ParticipantProfileExistsError if participant_profile_exists?
+
         profile = if year_2020
                     ParticipantProfile::ECT.create!({
                       teacher_profile:,
@@ -20,8 +22,6 @@ module EarlyCareerTeachers
                       participant_identity: Identity::Create.call(user:),
                     }.merge(ect_attributes))
                   else
-                    raise ParticipantProfileExistsError if participant_profile_exists?
-
                     ParticipantProfile::ECT.create!({
                       teacher_profile:,
                       schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort),

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -3,19 +3,15 @@
 module EarlyCareerTeachers
   class Create < BaseService
     include SchoolCohortDelegator
+    ParticipantProfileExistsError = Class.new(RuntimeError)
 
     def call
       profile = nil
       ActiveRecord::Base.transaction do
         # Retain the original name if the user already exists
-        user = User.find_or_create_by!(email:) do |ect|
-          ect.full_name = full_name
-        end
         user.update!(full_name:) unless user.participant_profiles&.active_record&.any? || user.npq_registered?
 
-        teacher_profile = TeacherProfile.find_or_create_by!(user:) do |teacher|
-          teacher.school = school_cohort.school
-        end
+        create_teacher_profile
 
         profile = if year_2020
                     ParticipantProfile::ECT.create!({
@@ -24,6 +20,8 @@ module EarlyCareerTeachers
                       participant_identity: Identity::Create.call(user:),
                     }.merge(ect_attributes))
                   else
+                    raise ParticipantProfileExistsError if participant_profile_exists?
+
                     ParticipantProfile::ECT.create!({
                       teacher_profile:,
                       schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort),
@@ -76,8 +74,25 @@ module EarlyCareerTeachers
       }
     end
 
+    def teacher_profile
+      @teacher_profile ||= TeacherProfile.find_or_create_by!(user:) do |teacher|
+        teacher.school = school_cohort.school
+      end
+    end
+    alias_method :create_teacher_profile, :teacher_profile
+
+    def user
+      @user ||= User.find_or_create_by!(email:) do |ect|
+        ect.full_name = full_name
+      end
+    end
+
     def mentor_profile
       ParticipantProfile::Mentor.find(mentor_profile_id) if mentor_profile_id.present?
+    end
+
+    def participant_profile_exists?
+      teacher_profile.participant_profiles.ects.exists? || user.participant_identities.joins(:participant_profiles).where(participant_profiles: { type: "ParticipantProfile::ECT" }).exists?
     end
   end
 end

--- a/spec/requests/admin/schools/cohort_2020_spec.rb
+++ b/spec/requests/admin/schools/cohort_2020_spec.rb
@@ -84,37 +84,11 @@ RSpec.describe "Admin::Schools::Cohort2020", type: :request do
       let(:email) { participant_profile.user.email }
 
       it "adds an NQT+1 profile to the user" do
-        expect(EarlyCareerTeachers::Create).to receive(:call).with({
-          full_name: name,
-          email:,
-          school_cohort:,
-          mentor_profile_id: nil,
-          year_2020: true,
-        }).and_call_original
-
-        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
-          user: { full_name: name, email: },
-        }
-
-        expect(User.find_by(email:).participant_profiles.count).to eql 2
-      end
-
-      it "changes the name on the user" do
-        other_name = "Other Name"
-
-        expect(EarlyCareerTeachers::Create).to receive(:call).with({
-          full_name: other_name,
-          email:,
-          school_cohort:,
-          mentor_profile_id: nil,
-          year_2020: true,
-        }).and_call_original
-
-        post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
-          user: { full_name: other_name, email: },
-        }
-
-        expect(User.find_by(email:).full_name).to eql other_name
+        expect {
+          post "/admin/schools/#{school_cohort.school.slug}/cohort2020", params: {
+            user: { full_name: name, email: },
+          }
+        }.to raise_error EarlyCareerTeachers::Create::ParticipantProfileExistsError
       end
     end
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
       end
 
       ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record = ParticipantProfile::ECT.first
-      create(:ect, :withdrawn_record, user: ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record.user, school_cohort:)
+      create(:ect, :withdrawn_record, school_cohort:).tap do |pp|
+        pp.update!(teacher_profile: ect_teacher_profile_with_one_active_and_one_withdrawn_profile_record.teacher_profile)
+      end
     end
 
     let!(:withdrawn_ect_profile_record) do

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -19,16 +19,9 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
 
   let!(:ect_profile) { create :ect, mentor_profile_id: mentor_profile.id, school_cohort:, lead_provider: cpd_lead_provider.lead_provider }
   let!(:withdrawn_ect_profile) do
-    withdrawn_ect = create :ect, mentor_profile_id: mentor_profile.id, school_cohort: school_cohort, lead_provider: cpd_lead_provider.lead_provider
-
-    create(
-      :ect,
-      :withdrawn_record,
-      user: withdrawn_ect.user,
-      school_cohort:,
-    )
-
-    withdrawn_ect
+    create(:ect, mentor_profile_id: mentor_profile.id, school_cohort:, lead_provider: cpd_lead_provider.lead_provider).tap do |withdrawn_ect|
+      create(:ect, :withdrawn_record, school_cohort:).update!(teacher_profile: withdrawn_ect.teacher_profile)
+    end
   end
 
   let!(:withdrawn_ect_profile_record) { create(:ect, :eligible_for_funding, :withdrawn_record, school_cohort:, lead_provider: cpd_lead_provider.lead_provider) }

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe EarlyCareerTeachers::Create, :with_default_schedules do
         mentor_profile_id: mentor_profile.id,
       )
     }.to change { ParticipantProfile::ECT.count }.by(1)
-           .and not_change { User.count }
-                  .and change { TeacherProfile.count }.by(1)
+     .and not_change { User.count }
+     .and change { TeacherProfile.count }.by(1)
   end
 
   it "uses the existing teacher profile record" do
@@ -30,8 +30,8 @@ RSpec.describe EarlyCareerTeachers::Create, :with_default_schedules do
         school_cohort:,
       )
     }.to change { ParticipantProfile::ECT.count }.by(1)
-           .and not_change { User.count }
-                  .and not_change { TeacherProfile.count }
+     .and not_change { User.count }
+     .and not_change { TeacherProfile.count }
   end
 
   it "creates a new user and teacher profile" do
@@ -42,8 +42,8 @@ RSpec.describe EarlyCareerTeachers::Create, :with_default_schedules do
         school_cohort:,
       )
     }.to change { ParticipantProfile::ECT.count }.by(1)
-           .and change { User.count }.by(1)
-                  .and change { TeacherProfile.count }.by(1)
+     .and change { User.count }.by(1)
+     .and change { TeacherProfile.count }.by(1)
   end
 
   it "updates the users name" do
@@ -234,6 +234,6 @@ RSpec.describe EarlyCareerTeachers::Create, :with_default_schedules do
         mentor_profile_id: mentor_profile.id,
       )
     }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob)
-           .with(participant_profile: instance_of(ParticipantProfile::ECT))
+     .with(participant_profile: instance_of(ParticipantProfile::ECT))
   end
 end

--- a/spec/services/identity/create_spec.rb
+++ b/spec/services/identity/create_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Identity::Create do
       context "when the existing profiles belong to another identity" do
         let(:ect)                { create(:mentor, :eligible_for_funding, user:) }
         let(:exisiting_identity) { ect.participant_identities.first }
-        let!(:mentor_profile)    { create(:mentor, :eligible_for_funding, trn: ect.teacher_profile.trn, user:) }
+        let!(:mentor_profile)    { create(:mentor, :eligible_for_funding, trn: ect.teacher_profile.trn).tap { |pp| pp.update!(teacher_profile: ect.teacher_profile) } }
         let(:npq_profile)        { create(:npq_participant_profile,       trn: ect.teacher_profile.trn, user:) }
 
         it "does not add the profiles to the new identity" do

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -152,18 +152,36 @@ RSpec.describe Mentors::Create, :with_default_schedules do
   end
 
   context "when the user has an active participant profile" do
-    before do
-      create(:ecf_participant_profile, teacher_profile: create(:teacher_profile, user:))
+    context "when the profile is attached to teacher_profile" do
+      before do
+        create(:mentor_participant_profile, teacher_profile: create(:teacher_profile, user:))
+      end
+
+      it "raises an error" do
+        expect {
+          described_class.call(
+            email: user.email,
+            full_name: Faker::Name.name,
+            school_cohort:,
+          )
+        }.to raise_error(described_class::ParticipantProfileExistsError)
+      end
     end
 
-    it "does not update the users name" do
-      expect {
-        described_class.call(
-          email: user.email,
-          full_name: Faker::Name.name,
-          school_cohort:,
-        )
-      }.not_to change { user.reload.full_name }
+    context "when the profile is attached to participant identities" do
+      before do
+        create(:mentor_participant_profile).update!(participant_identity: create(:participant_identity, user:))
+      end
+
+      it "raises an error" do
+        expect {
+          described_class.call(
+            email: user.email,
+            full_name: Faker::Name.name,
+            school_cohort:,
+          )
+        }.to raise_error(described_class::ParticipantProfileExistsError)
+      end
     end
   end
 


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CPDLP-1744) 

### Changes proposed in this pull request

This change aims at preventing creation of duplicate profile whilst we resolve and soft delete the existing duplicate profiles

### Guidance to review

