### PR TITLE
Stop titleizing full names

### DIFF
--- a/app/views/schools/add_participants/_ect_or_mentor_details_summary.html.erb
+++ b/app/views/schools/add_participants/_ect_or_mentor_details_summary.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_summary_list do |summary_list| %>
   <% summary_list.row do |row| %>
     <% row.key { "Name" } %>
-    <% row.value { add_participant_form.full_name.titleize } %>
+    <% row.value { add_participant_form.full_name } %>
     <% unless add_participant_form.dqt_record %>
       <% row.action text: "Change",
                     visually_hidden_text: "name",

--- a/app/views/schools/add_participants/_sit_confirm_self_details_summary.html.erb
+++ b/app/views/schools/add_participants/_sit_confirm_self_details_summary.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_summary_list do |summary_list| %>
   <% summary_list.row do |row| %>
     <% row.key { "Name" } %>
-    <% row.value { add_participant_form.full_name.titleize } %>
+    <% row.value { add_participant_form.full_name } %>
     <% unless add_participant_form.dqt_record %>
       <% row.action text: "Change",
                     visually_hidden_text: "name",

--- a/app/views/schools/add_participants/cannot_add.html.erb
+++ b/app/views/schools/add_participants/cannot_add.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name.titleize %></h1>
+    <h1 class="govuk-heading-xl"> You cannot add <%= add_participant_form.full_name %></h1>
 
     <% which_school = add_participant_form.existing_participant_profile_same_school? ? "this" : "a different" %>
     <p class="govuk-body">Our records show this person is already registered on an ECF-based training programme at <%= which_school %> school</p>

--- a/app/views/schools/add_participants/cannot_add_mentor_without_trn.html.erb
+++ b/app/views/schools/add_participants/cannot_add_mentor_without_trn.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl">
-      You cannot add <%= add_participant_form.full_name.titleize %> as a mentor without their TRN
+      You cannot add <%= add_participant_form.full_name %> as a mentor without their TRN
     </h1>
 
     <p class="govuk-body">If they:</p>

--- a/app/views/schools/add_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/cannot_find_their_details.html.erb
@@ -1,4 +1,4 @@
-<% title = "We cannot find #{add_participant_form.full_name.titleize}" %>
+<% title = "We cannot find #{add_participant_form.full_name}" %>
 
 <% content_for :title, title %>
 
@@ -8,15 +8,15 @@
     <div class="govuk-grid-column-two-thirds">
 
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">We cannot find <%= add_participant_form.full_name.titleize %>’s record</h1>
+        <h1 class="govuk-heading-xl">We cannot find <%= add_participant_form.full_name %>’s record</h1>
 
         <p class="govuk-body">Check the information you’ve entered is correct.</p>
-        <p class="govuk-body">We need to find <%= add_participant_form.full_name.titleize %> in the Teaching Regulation Agency records to make sure they’re eligible for this funded programme.</p>
+        <p class="govuk-body">We need to find <%= add_participant_form.full_name %> in the Teaching Regulation Agency records to make sure they’re eligible for this funded programme.</p>
 
         <%= govuk_summary_list do |summary_list| %>
             <% summary_list.row do |row| %>
                 <% row.key { "Name" } %>
-                <% row.value { add_participant_form.full_name.titleize } %>
+                <% row.value { add_participant_form.full_name } %>
                 <% row.action(text: "Change",
                     visually_hidden_text: "name",
                     href: url_for( { step: :name } )) %>

--- a/app/views/schools/add_participants/eligibility_confirmation/_exempt_from_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_exempt_from_induction.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_panel title_text: "#{profile.user.full_name.titleize} does not need to serve statutory induction for early career teachers", text: nil, classes: "govuk-!-margin-bottom-8" %>
+<%= govuk_panel title_text: "#{profile.user.full_name} does not need to serve statutory induction for early career teachers", text: nil, classes: "govuk-!-margin-bottom-8" %>
 
 <p>Their Teaching Regulation Agency record shows that they do not need to complete a statutory induction, or take part in ECF-based training.</p>
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_ineligible.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_ineligible.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m"><%= profile.user.full_name.titleize %> eligible for the early career teacher training programme</h2>
+<h2 class="govuk-heading-m"><%= profile.user.full_name %> eligible for the early career teacher training programme</h2>
 
 <h2 class="govuk-heading-m">Why?</h2>
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_manual_check_needed.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_manual_check_needed.html.erb
@@ -1,5 +1,5 @@
 <p>We’re checking this person’s details with the Teaching Regulation Agency.</p>
 
-<p>We may need to contact <%= profile.user.full_name.titleize %> for more information to complete their registration.</p>
+<p>We may need to contact <%= profile.user.full_name %> for more information to complete their registration.</p>
 
-<p>We’ll pass <%= profile.user.full_name.titleize %>’s details to your training provider.</p>
+<p>We’ll pass <%= profile.user.full_name %>’s details to your training provider.</p>

--- a/app/views/schools/add_participants/eligibility_confirmation/_no_qts_reason.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_no_qts_reason.html.erb
@@ -1,2 +1,2 @@
-<p><%= profile.user.full_name.titleize %> does not have qualified teacher status (QTS) yet. They need this to be eligible for funded traning.</p>
+<p><%= profile.user.full_name %> does not have qualified teacher status (QTS) yet. They need this to be eligible for funded traning.</p>
 <p>We’ll keep checking their status and notify you if something changes.</p>

--- a/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-body"><%= profile.user.full_name.titleize %> is not eligible for the early career teacher training programme</p>
+<p class="govuk-body"><%= profile.user.full_name %> is not eligible for the early career teacher training programme</p>
 
 <h2 class="govuk-heading-m">Why?</h2>
 <p class="govuk-body">Our records show they started or completed their statutory induction before 1 September 2021. Teachers are only eligible for the new 2-year funded training if they started their induction after that date.</p>

--- a/app/views/schools/add_participants/start_date.html.erb
+++ b/app/views/schools/add_participants/start_date.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{add_participant_form.full_name.titleize}’s induction start date?" %>
+<% title = "What’s #{add_participant_form.full_name}’s induction start date?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/add_participants/transfer.html.erb
+++ b/app/views/schools/add_participants/transfer.html.erb
@@ -1,4 +1,4 @@
-<% title = "Is #{add_participant_form.full_name.titleize} transferring from another school?" %>
+<% title = "Is #{add_participant_form.full_name} transferring from another school?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/transfer_out/check_answers.html.erb
+++ b/app/views/schools/transfer_out/check_answers.html.erb
@@ -10,7 +10,7 @@
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.row do |row| %>
         <% row.key { "Name" } %>
-        <% row.value { @profile.user.full_name.titleize } %>
+        <% row.value { @profile.user.full_name } %>
         <% row.action(text: :none) %>
       <% end %>
 

--- a/app/views/schools/transfer_out/check_transfer.html.erb
+++ b/app/views/schools/transfer_out/check_transfer.html.erb
@@ -1,4 +1,4 @@
-<% title = "Is #{@profile.user.full_name.titleize} transferring to another school where they’ll continue their induction?" %>
+<% title = "Is #{@profile.user.full_name} transferring to another school where they’ll continue their induction?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/transfer_out/teacher_end_date.html.erb
+++ b/app/views/schools/transfer_out/teacher_end_date.html.erb
@@ -1,4 +1,4 @@
-<% title = "When is #{@profile.user.full_name.titleize} leaving your school?" %>
+<% title = "When is #{@profile.user.full_name} leaving your school?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/transferring_participants/cannot_add.html.erb
+++ b/app/views/schools/transferring_participants/cannot_add.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
         
         <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"> You cannot add <%= @transferring_participant_form.full_name.titleize %></h1>
+        <h1 class="govuk-heading-xl"> You cannot add <%= @transferring_participant_form.full_name %></h1>
 
         <p class="govuk-body">We cannot find this person’s training record based on the information you’ve entered.</p>
         <p class="govuk-body">This could be because:</p>

--- a/app/views/schools/transferring_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/transferring_participants/cannot_find_their_details.html.erb
@@ -9,13 +9,13 @@
     	<h1 class="govuk-heading-xl">We cannot find <%= @transferring_participant_form.full_name_to_display %> record</h1>
     	
 		<p class="govuk-body">Check the information you’ve entered is correct.</p>
-    	<p class="govuk-body">We need to find <%= @transferring_participant_form.full_name.titleize %> in the Teaching Regulation Agency records so we can transfer their record to your school.</p>
+    	<p class="govuk-body">We need to find <%= @transferring_participant_form.full_name %> in the Teaching Regulation Agency records so we can transfer their record to your school.</p>
 
     	<dl class="govuk-summary-list govuk-!-margin-bottom-7">
       		<div class="govuk-summary-list__row">
         		<dt class="govuk-summary-list__key">Name</dt>
         		<dd class="govuk-summary-list__value">
-          			<%= @transferring_participant_form.full_name.titleize %>
+          			<%= @transferring_participant_form.full_name %>
         		</dd>
         		<dd class="govuk-summary-list__actions">
           			<%= govuk_link_to full_name_schools_transferring_participant_path do %>

--- a/app/views/schools/transferring_participants/check_answers.html.erb
+++ b/app/views/schools/transferring_participants/check_answers.html.erb
@@ -45,7 +45,7 @@
       <% if show_mentor? %>
         <% summary_list.row do |row| %>
           <% row.key { "Mentor" } %>
-          <% row.value { @transferring_participant_form.mentor_id.present? ? @transferring_participant_form.mentor.full_name.titleize : "Assign a mentor later" } %>
+          <% row.value { @transferring_participant_form.mentor_id.present? ? @transferring_participant_form.mentor.full_name : "Assign a mentor later" } %>
           <% row.action(text: "Change",
                         visually_hidden_text: "mentor",
                         href: url_for({ action: :choose_mentor})) %>

--- a/app/views/schools/transferring_participants/schools_current_programme.html.erb
+++ b/app/views/schools/transferring_participants/schools_current_programme.html.erb
@@ -1,4 +1,4 @@
-<% title = "Will #{@transferring_participant_form.full_name.titleize } be training with your school’s current providers?" %>
+<% title = "Will #{@transferring_participant_form.full_name } be training with your school’s current providers?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/transferring_participants/teachers_current_programme.html.erb
+++ b/app/views/schools/transferring_participants/teachers_current_programme.html.erb
@@ -1,4 +1,4 @@
-<% title = "Will #{@transferring_participant_form.full_name.titleize } continue with their current training programme?" %>
+<% title = "Will #{@transferring_participant_form.full_name } continue with their current training programme?" %>
 
 <% content_for :title, title %>
 

--- a/documentation/feature_testing.md
+++ b/documentation/feature_testing.md
@@ -8,27 +8,27 @@ The feature tests in this repository are written using the following gems:
 - [Axe]
 
 The feature tests are used to test service features and user journeys to avoid
-repetitive manual testing. They use Given-When-Then syntax so that they 
-are, hopefully understandable (and therefore approvable) by non-technical 
-team members such as analysts, product owners and service owners as well as 
+repetitive manual testing. They use Given-When-Then syntax so that they
+are, hopefully understandable (and therefore approvable) by non-technical
+team members such as analysts, product owners and service owners as well as
 external stakeholders.
 
 ## How to write feature tests
 
 Feature tests are located in the `spec/features/` folder and have a `_spec.rb`
-extension. They're written using Given-When-Then syntax and the step definitions 
+extension. They're written using Given-When-Then syntax and the step definitions
 are defined in `spec/support/features/steps`. Step definitions are designed to
 be reusable so hopefully there will be little need to define your own.
 
 ### Page Objects
 
-Every page is described by a [Page object] located in the 
-`spec/support/features/pages` folder and have a `_page.rb` or `_wizard.rb` 
-extension. Page objects provide helpers for navigating from the page, 
-interacting with form elements on the page, checking the content of the page 
+Every page is described by a [Page object] located in the
+`spec/support/features/pages` folder and have a `_page.rb` or `_wizard.rb`
+extension. Page objects provide helpers for navigating from the page,
+interacting with form elements on the page, checking the content of the page
 and verifying that the expected page has loaded correctly.
 
-Each page object inherits from `::Pages::BasePage` as in this example of the 
+Each page object inherits from `::Pages::BasePage` as in this example of the
 Privacy Policy page object;
 
 ```ruby
@@ -36,19 +36,19 @@ module Pages
   class PrivacyPolicyPage < ::Pages::BasePage
     set_url "/privacy-policy"
     set_primary_heading "Privacy policy"
-  end 
-end 
+  end
+end
 ```
 
 A page object needs to include the following at least;
 
-- `set_url` should be set to the url of the page on load 
+- `set_url` should be set to the url of the page on load
 - `set_primary_heading` should be set to the text contents of the pages `H1` heading
 
 #### Navigation
 
 Navigation methods should use the Capybara action `click_on "Link text"` to interact with
-clickable text within the page and then should call the static `loaded` 
+clickable text within the page and then should call the static `loaded`
 method of the expected pages object to confirm that the correct page has loaded.
 
 Navigation method names should describe the task to be performed by the
@@ -63,27 +63,27 @@ def view_privacy_policy
 end
 ```
 
-The full feature scenario suite should prove that a user can achieve any 
-desired tasks and so at least one scenario should navigate the user from the 
-start page to the appropriate page that the task is required to be performed 
-on. If this navigation is already present then it is possible to use the page 
+The full feature scenario suite should prove that a user can achieve any
+desired tasks and so at least one scenario should navigate the user from the
+start page to the appropriate page that the task is required to be performed
+on. If this navigation is already present then it is possible to use the page
 objects to directly load a specific page, as in;
 
 ```ruby
 Pages::CheckAccountPage.load
 ```
 
-Again the Primary Heading will be checked once the page has been loaded but as 
+Again the Primary Heading will be checked once the page has been loaded but as
 the URL is loaded directly this check is not performed.
 
 #### Interaction
 
-Interaction with the page to fill in form fields and click buttons to submit 
+Interaction with the page to fill in form fields and click buttons to submit
 that information to the server are also handled with page object methods named
 to describe the task.
 
-A page interaction will generally be more than just a single page action such 
-as in the case of a `find` action which will require a value to be entered into 
+A page interaction will generally be more than just a single page action such
+as in the case of a `find` action which will require a value to be entered into
 a form and a button to be clicked in order to submit the query to the server.
 
 ```ruby
@@ -97,7 +97,7 @@ def find(participant_name)
 end
 ```
 
-When filling in fields or selecting/choosing field values we should use the 
+When filling in fields or selecting/choosing field values we should use the
 appropriate label text rather than the HTML element via CSS selectors as this
 is what a user would be doing.
 
@@ -105,7 +105,7 @@ is what a user would be doing.
 
 Every feature scenario should include a way of proving that the user is able to
 understand that the task has been performed correctly. The easiest way to check
-this is to achieve this is to assert that the page is displaying the expect text 
+this is to achieve this is to assert that the page is displaying the expect text
 or information.
 
 Several helper methods are included on the `BasePage` class to help describe any
@@ -124,8 +124,8 @@ def confirm_will_use_dfe_funded_training_provider
 end
 ```
 
-In this case if the exact content is not found within the page then the 
-scenario will fail with an explanation of the expectations; 
+In this case if the exact content is not found within the page then the
+scenario will fail with an explanation of the expectations;
 
 ```bash
 expected to find "Programme Use a training provider funded by the DfE" within
@@ -147,16 +147,16 @@ the page objects to ensure consistent interaction across the suite. Some specifi
 steps may have to defined within the scenario feature itself and should be set as
 `private` to ensure they are not accidentally picked up by another scenario.
 
-If a scenario step method is intended to be shared between multiple scenarios 
+If a scenario step method is intended to be shared between multiple scenarios
 then it should be defined within the `spec/support/features/steps` folder in a
 file with the extension `_steps.rb`.
 
-Hopefully most of the steps within a scenario will be covered by the generic 
+Hopefully most of the steps within a scenario will be covered by the generic
 step helpers which are already defined within the steps files.
 
 #### Loading a page
 
-To use the generic navigation steps you will need to have a page object that 
+To use the generic navigation steps you will need to have a page object that
 describes the page you are currently expected to navigate from. The templates for
 this sort of step are;
 
@@ -166,12 +166,13 @@ given_i_am_on_the_{{page_object}}
 when_i_am_on_the_{{page_object}}_with_{{query_params}}
 ```
 
-These templated steps will use a specific page object to load its url where `page_object` is 
-constantized. If it includes `query_params` then this string is parsed, split 
+These templated steps will use a specific page object to load its url where `page_object` is
+constantized. If it includes `query_params` then this string is parsed, split
 on `_and_` and the arguments passed to `PageObject#load` so;
 
 ```handlebars
-given_i_am_on_the_school_participant_dashboard_page_with_participant_id "ABC-9876"
+given_i_am_on_the_school_participant_dashboard_page_with_participant_id
+"ABC-9876"
 ```
 
 is interpreted as;
@@ -182,7 +183,7 @@ is interpreted as;
 
 #### Validating that a page has loaded
 
-It is also possible to validate that the correct page is now loaded using two 
+It is also possible to validate that the correct page is now loaded using two
 similar templated steps;
 
 ```handlebars
@@ -191,9 +192,9 @@ then_i_am_on_the_{{page_object}}
 and_i_am_on_the_{{page_object}}_with_{{query_params}}
 ```
 
-In these templated steps a specific page object is used to check the page has 
+In these templated steps a specific page object is used to check the page has
 loaded where `page_object` is constantized. Agian, if it includes `query_params`
-then this string is parsed, split on `_and_` and the arguments passed to 
+then this string is parsed, split on `_and_` and the arguments passed to
 `PageObject#loaded` so;
 
 ```handlebars
@@ -209,7 +210,7 @@ is interpreted as;
 #### interacting with a page
 
 To use the generic interaction steps you will need to have a page object that
-describes the page you are currently expected to interact with. Examples of 
+describes the page you are currently expected to interact with. Examples of
 the templates for this sort of step are;
 
 ```handlebars
@@ -223,25 +224,26 @@ and_i_{{method_name}}_from_{{page_object}}_with_{{query_params}}
 ```
 
 These will call a specific action of a specific page object where `method_name`
-and `page_object` are constantized. If it includes `query_params` then this 
-string is parsed, split on `_and_` and the arguments passed to 
+and `page_object` are constantized. If it includes `query_params` then this
+string is parsed, split on `_and_` and the arguments passed to
 `PageObject#method_name` so;
 
 ```handlebars
-given_i_find_a_participant_from_school_participant_dashboard_page_with_participant_name "the Participant"
+given_i_find_a_participant_from_school_participant_dashboard_page_with_participant_name
+"The Participant"
 ```
 
 is interpreted as;
 
 ```ruby
-::Pages::SchoolParticipantDashboardPage.find_a_particiapnt(participant_name: "the Participant")
+::Pages::SchoolParticipantDashboardPage.find_a_particiapnt(participant_name: "The Participant")
 ```
 
 ### Conventions
 
 #### Step definitions
 
-Steps should describe the scenario from the point of view of the user - e.g. 
+Steps should describe the scenario from the point of view of the user - e.g.
 what they do or what they should see - the language should be in present tense,
 using active voice and first-person. for example;
 
@@ -253,24 +255,22 @@ Exceptions are for steps that aren't from the point of the user, such as:
 
 - `and_the_page_is_accessible`
 
-The language of steps should be definite rather than speculative, so `Then I am on` 
+The language of steps should be definite rather than speculative, so `Then I am on`
 rather than `Then I should be on`.
 
 #### Reuse step definitions where possible
 
-Most of the time, you won't need to write specific step definitions as the 
+Most of the time, you won't need to write specific step definitions as the
 page objects should encapsulate all the steps needed to achieve a task.
-instead of `I click on "delete" button` you can write `I delete user "the Participant"` and 
-this will encapsulate all the actions needed to delete the user named 
-"the Participant" and notify us of any action that fails during this task.
+instead of `I click on "delete" button` you can write `I delete user "The Participant"` and
+this will encapsulate all the actions needed to delete the user named
+"The Participant" and notify us of any action that fails during this task.
 
 You must consider this when writing new step definitions - make them as
 reusable as possible so that other people don't have to write similar step
 definitions in the future.
 
 #### Setting up a scenario
-
-
 
 #### Accessibility testing
 
@@ -282,9 +282,8 @@ state change to an existing page), add the following lines to your spec:
 then_the_page_is_accessible
 ```
 
-[Capybara]: http://teamcapybara.github.io/capybara/
-[Chromedriver]: https://github.com/titusfortner/webdrivers
-[Axe]: https://www.deque.com/axe/
-[Capybara cheatsheet]: https://devhints.io/capybara
-[Page objects]: https://github.com/site-prism/site_prism
-
+[capybara]: http://teamcapybara.github.io/capybara/
+[chromedriver]: https://github.com/titusfortner/webdrivers
+[axe]: https://www.deque.com/axe/
+[capybara cheatsheet]: https://devhints.io/capybara
+[page objects]: https://github.com/site-prism/site_prism

--- a/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/cip_to_fip_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "CIP to FIP - Onboard a deferred participant",
         and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -103,12 +103,12 @@ RSpec.feature "CIP to FIP - Onboard a deferred participant",
       context when_context(scenario) do
         before do
           when_developers_transfer_the_deferred_participant "New SIT",
-                                                            "the Participant"
+                                                            "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "New Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_cip_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "FIP to CIP - Onboard a deferred participant",
         and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -105,12 +105,12 @@ RSpec.feature "FIP to CIP - Onboard a deferred participant",
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_deferred_participant "New SIT",
-                                                            "the Participant"
+                                                            "The Participant"
 
           and_eligible_training_declarations_are_made_payable
         end

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_different_provider_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "FIP to FIP with different provider - Onboard a deferred participa
         and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -107,17 +107,17 @@ RSpec.feature "FIP to FIP with different provider - Onboard a deferred participa
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_deferred_participant "New SIT",
-                                                            "the Participant"
+                                                            "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "New Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_deferred_participant/fip_to_fip_with_same_provider_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
         and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -107,17 +107,17 @@ RSpec.feature "FIP to FIP with same provider - Onboard a deferred participant",
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_deferred_participant "New SIT",
-                                                            "the Participant"
+                                                            "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/cip_to_fip_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
         and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -103,12 +103,12 @@ RSpec.feature "CIP to FIP - Onboarding a withdrawn participant",
       context when_context(scenario) do
         before do
           when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "the Participant"
+                                                             "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "New Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_cip_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
         and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -105,12 +105,12 @@ RSpec.feature "FIP to CIP - Onboarding a withdrawn participant",
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "the Participant"
+                                                             "The Participant"
 
           and_eligible_training_declarations_are_made_payable
         end

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_different_provider_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
         and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -107,17 +107,17 @@ RSpec.feature "FIP to FIP with different provider - Onboarding a withdrawn parti
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "the Participant"
+                                                             "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "New Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/onboarding_a_withdrawn_participant/fip_to_fip_with_same_provider_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
         and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -106,17 +106,17 @@ RSpec.feature "FIP to FIP with same provider - Onboarding a withdrawn participan
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_withdrawn_participant "New SIT",
-                                                             "the Participant"
+                                                             "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_cip_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "CIP to CIP - Transfer a participant",
         and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -101,7 +101,7 @@ RSpec.feature "CIP to CIP - Transfer a participant",
       context when_context(scenario) do
         before do
           when_developers_transfer_the_active_participant "New SIT",
-                                                          "the Participant"
+                                                          "The Participant"
 
           and_eligible_training_declarations_are_made_payable
         end

--- a/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/cip_to_fip_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "CIP to FIP - Transfer a participant",
         and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -102,12 +102,12 @@ RSpec.feature "CIP to FIP - Transfer a participant",
       context when_context(scenario) do
         before do
           when_developers_transfer_the_active_participant "New SIT",
-                                                          "the Participant"
+                                                          "The Participant"
 
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "New Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_cip_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "FIP to CIP - Transfer a participant",
         and_sit_at_pupil_premium_school_reported_programme "New SIT", "CIP"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -104,12 +104,12 @@ RSpec.feature "FIP to CIP - Transfer a participant",
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_developers_transfer_the_active_participant "New SIT",
-                                                          "the Participant"
+                                                          "The Participant"
 
           and_eligible_training_declarations_are_made_payable
         end

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_different_provider_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
         and_lead_provider_reported_partnership "New Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -106,12 +106,12 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_school_uses_the_transfer_participant_wizard "New SIT",
-                                                           "the Participant",
+                                                           "The Participant",
                                                            scenario.participant_email,
                                                            scenario.participant_trn,
                                                            scenario.participant_dob,
@@ -120,7 +120,7 @@ RSpec.feature "FIP to FIP with different provider - Transfer a participant",
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "New Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
+++ b/spec/features/scenarios/transfering_a_participant/fip_to_fip_with_same_provider_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
         and_lead_provider_reported_partnership "Original Lead Provider", "New SIT"
 
         and_sit_reported_participant "Original SIT",
-                                     "the Participant",
+                                     "The Participant",
                                      scenario.participant_trn,
                                      scenario.participant_dob,
                                      scenario.participant_email,
@@ -105,12 +105,12 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
           scenario.prior_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 
           when_school_uses_the_transfer_participant_wizard "New SIT",
-                                                           "the Participant",
+                                                           "The Participant",
                                                            scenario.participant_email,
                                                            scenario.participant_trn,
                                                            scenario.participant_dob,
@@ -119,7 +119,7 @@ RSpec.feature "FIP to FIP with same provider - Transfer a participant",
           scenario.new_declarations.each do |declaration_type|
             and_lead_provider_has_made_training_declaration "Original Lead Provider",
                                                             scenario.participant_type,
-                                                            "the Participant",
+                                                            "The Participant",
                                                             declaration_type
           end
 

--- a/spec/forms/schools/add_participant_form_spec.rb
+++ b/spec/forms/schools/add_participant_form_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Schools::AddParticipantForm, type: :model do
 
     it "returns the name of the participant who's being added" do
       form.assign_attributes(type: :mentor, full_name: user.full_name)
-      expect(form.display_name).to eql("#{user.full_name.titleize}’s")
+      expect(form.display_name).to eql("#{user.full_name}’s")
     end
   end
 

--- a/spec/support/features/pages/schools/school_add_participant_wizard.rb
+++ b/spec/support/features/pages/schools/school_add_participant_wizard.rb
@@ -81,7 +81,7 @@ module Pages
     end
 
     def add_teacher_reference_number(full_name, trn)
-      fill_in "What’s #{full_name.titleize}’s teacher reference number (TRN)?", with: trn
+      fill_in "What’s #{full_name}’s teacher reference number (TRN)?", with: trn
       click_on "Continue"
 
       self

--- a/spec/support/features/pages/schools/school_transfer_participant_completed_page.rb
+++ b/spec/support/features/pages/schools/school_transfer_participant_completed_page.rb
@@ -8,7 +8,7 @@ module Pages
     set_primary_heading(/^.* has been registered at your school$/)
 
     def confirm_has_full_name(full_name)
-      element_has_content? header, "#{full_name.titleize} has been added"
+      element_has_content? header, "#{full_name} has been added"
       self
     end
 

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -284,7 +284,7 @@ module Steps
     end
 
     def self.then_sit_cannot_see_context(scenario)
-      "cannot see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      "cannot see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
     end
 
     def then_sit_cannot_see_participant_in_school_portal(sit_name, _scenario = {})
@@ -294,7 +294,7 @@ module Steps
     end
 
     def self.then_sit_can_see_context(scenario, is_training: true)
-      str = "can see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      str = "can see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
       str += "          with the Email address of \"#{scenario.participant_email}\"\n"
       str += "          and with the Training status of \"Eligible to start\"\n"
       str += "          and that they are#{is_training ? '' : ' not'} being trained\n"
@@ -307,15 +307,15 @@ module Steps
       when_i_view_participant_details_from_the_school_dashboard_page
       case scenario.participant_type
       when "ECT"
-        and_i_view_ects_from_the_school_participants_dashboard_page "the Participant"
+        and_i_view_ects_from_the_school_participants_dashboard_page "The Participant"
       when "Mentor"
-        and_i_view_mentors_from_the_school_participants_dashboard_page "the Participant"
+        and_i_view_mentors_from_the_school_participants_dashboard_page "The Participant"
       else
         raise "Participant Type \"#{scenario.participant_type}\" not recognised"
       end
 
-      and_i_confirm_the_participant_on_the_school_participant_details_page_with_name "the Participant"
-      and_i_confirm_full_name_on_the_school_participant_details_page "the Participant"
+      and_i_confirm_the_participant_on_the_school_participant_details_page_with_name "The Participant"
+      and_i_confirm_full_name_on_the_school_participant_details_page "The Participant"
       and_i_confirm_email_address_on_the_school_participant_details_page scenario.participant_email
       and_i_confirm_status_on_the_school_participant_details_page "Eligible to start"
 
@@ -326,10 +326,10 @@ module Steps
       given_i_sign_in_as_the_user_with_the_full_name sit_name
 
       when_i_view_participant_details_from_the_school_dashboard_page
-      and_i_view_not_training_on_the_school_participants_dashboard_page "the Participant"
+      and_i_view_not_training_on_the_school_participants_dashboard_page "The Participant"
 
-      and_i_confirm_the_participant_on_the_school_participant_details_page_with_name "the Participant"
-      and_i_confirm_full_name_on_the_school_participant_details_page "the Participant"
+      and_i_confirm_the_participant_on_the_school_participant_details_page_with_name "The Participant"
+      and_i_confirm_full_name_on_the_school_participant_details_page "The Participant"
       and_i_confirm_email_address_on_the_school_participant_details_page scenario.participant_email
       and_i_confirm_status_on_the_school_participant_details_page "Eligible to start"
 
@@ -337,20 +337,20 @@ module Steps
     end
 
     def self.then_lead_provider_cannot_see_context(scenario)
-      "cannot see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      "cannot see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
     end
 
     def then_lead_provider_cannot_see_participant_in_api(lead_provider_name, _scenario)
       then_ecf_participants_api_does_not_have_participant_details lead_provider_name,
-                                                                  "the Participant"
+                                                                  "The Participant"
 
       then_participant_declarations_api_does_not_have_declarations lead_provider_name,
-                                                                   "the Participant"
+                                                                   "The Participant"
     end
 
     def self.then_lead_provider_can_see_context(scenario, declarations, participant_status = "active", see_prior_school: false)
       school_name = see_prior_school ? "Original SIT's School" : "New SIT's School"
-      str = "can see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      str = "can see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
       str += "          with the participant email as \"#{scenario.participant_email}\"\n"
       str += "          and with the participant trn as \"#{scenario.participant_trn}\"\n"
       str += "          and with the participant status of \"#{participant_status}\"\n"
@@ -361,7 +361,7 @@ module Steps
 
     def then_lead_provider_can_see_participant_in_api(lead_provider_name, scenario, declarations, participant_status = "active", see_prior_school: false)
       then_ecf_participants_api_has_participant_details lead_provider_name,
-                                                        "the Participant",
+                                                        "The Participant",
                                                         scenario.participant_email,
                                                         scenario.participant_trn,
                                                         scenario.participant_type,
@@ -370,7 +370,7 @@ module Steps
                                                         "active"
 
       then_participant_declarations_api_has_declarations lead_provider_name,
-                                                         "the Participant",
+                                                         "The Participant",
                                                          declarations
     end
 
@@ -417,7 +417,7 @@ module Steps
     end
 
     def self.then_finance_user_context(scenario)
-      str = "can see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      str = "can see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
       str += "          with the school as \"New SIT's school\"\n"
       str += "          and with the lead provider as \"#{scenario.new_lead_provider_name}\"\n"
       str += "          and with the participant status as \"active\"\n"
@@ -475,7 +475,7 @@ module Steps
     end
 
     def self.then_admin_user_context(scenario)
-      str = "can see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      str = "can see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
       str += "          with the school as \"New SIT's school\"\n"
       str += "          and with the validation status as \"Eligible to start\"\n"
       str += "          and with the lead provider as \"#{scenario.new_lead_provider_name}\""
@@ -487,9 +487,9 @@ module Steps
 
       and_i_am_on_the_admin_support_portal
       and_i_view_participant_list_from_the_admin_support_portal
-      and_i_view_participant_from_the_admin_support_participant_list "the Participant"
+      and_i_view_participant_from_the_admin_support_participant_list "The Participant"
 
-      then_the_admin_portal_shows_the_current_participant_record "the Participant",
+      then_the_admin_portal_shows_the_current_participant_record "The Participant",
                                                                  "New SIT",
                                                                  scenario.new_lead_provider_name,
                                                                  "Eligible to start"
@@ -512,14 +512,14 @@ module Steps
     end
 
     def self.then_support_service_context(scenario)
-      str = "can see \"the Participant\" as a \"#{scenario.participant_type}\"\n"
+      str = "can see \"The Participant\" as a \"#{scenario.participant_type}\"\n"
       str += "          with the email address as \"#{scenario.participant_email}\"\n"
       str += "          and with the induction programme as \"#{scenario.new_programme == 'CIP' ? 'core_induction_programme' : 'full_induction_programme'}\"\n"
       str
     end
 
     def then_ecf_users_endpoint_shows_the_current_record(scenario)
-      participant_user = find_user "the Participant"
+      participant_user = find_user "The Participant"
 
       participant_type = scenario.participant_type == "ECT" ? "early_career_teacher" : "mentor"
       induction_programme_identifier = scenario.new_programme == "CIP" ? "core_induction_programme" : "full_induction_programme"
@@ -527,7 +527,7 @@ module Steps
       user_endpoint = APIs::ECFUsersEndpoint.load
       user_endpoint.get_user participant_user.id
 
-      expect(user_endpoint).to have_full_name "the Participant"
+      expect(user_endpoint).to have_full_name "The Participant"
       expect(user_endpoint).to have_email scenario.participant_email
       expect(user_endpoint).to have_user_type participant_type
       expect(user_endpoint).to have_core_induction_programme "none"

--- a/spec/support/shared_examples/changes_of_circumstances/cip_to_cip.rb
+++ b/spec/support/shared_examples/changes_of_circumstances/cip_to_cip.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples "CIP to CIP" do |scenario|
        :aggregate_failures do
       given_i_sign_in_as_a_finance_user
 
-      then_the_finance_portal_shows_the_current_participant_record "the Participant",
+      then_the_finance_portal_shows_the_current_participant_record "The Participant",
                                                                    scenario.participant_type,
                                                                    "New SIT",
                                                                    "",
@@ -78,10 +78,10 @@ RSpec.shared_examples "CIP to CIP" do |scenario|
   context "Then the Analytics Dashboards" do
     subject(:analytics_user) { "Analysts" }
 
-    it "is expected to report the correct participant details for \"the Participant\"",
+    it "is expected to report the correct participant details for \"The Participant\"",
        :aggregate_failures,
        skip: "Not yet implemented" do
-      is_expected.to report_correct_participant_details "the Participant"
+      is_expected.to report_correct_participant_details "The Participant"
     end
   end
 end

--- a/spec/support/shared_examples/changes_of_circumstances/cip_to_fip.rb
+++ b/spec/support/shared_examples/changes_of_circumstances/cip_to_fip.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples "CIP to FIP" do |scenario|
 
       if scenario.duplicate_declarations.any?
         scenario.duplicate_declarations.each do |declaration_type|
-          expect(subject).to_not make_duplicate_training_declaration "the Participant",
+          expect(subject).to_not make_duplicate_training_declaration "The Participant",
                                                                      scenario.participant_type,
                                                                      declaration_type
         end
@@ -67,7 +67,7 @@ RSpec.shared_examples "CIP to FIP" do |scenario|
        :aggregate_failures do
       given_i_sign_in_as_a_finance_user
 
-      then_the_finance_portal_shows_the_current_participant_record "the Participant",
+      then_the_finance_portal_shows_the_current_participant_record "The Participant",
                                                                    scenario.participant_type,
                                                                    "New SIT",
                                                                    "New Lead Provider",
@@ -103,10 +103,10 @@ RSpec.shared_examples "CIP to FIP" do |scenario|
   context "Then the Analytics Dashboards" do
     subject(:analytics_user) { "Analysts" }
 
-    it "is expected to report the correct participant details for \"the Participant\"",
+    it "is expected to report the correct participant details for \"The Participant\"",
        :aggregate_failures,
        skip: "Not yet implemented" do
-      is_expected.to report_correct_participant_details "the Participant"
+      is_expected.to report_correct_participant_details "The Participant"
     end
   end
 end

--- a/spec/support/shared_examples/changes_of_circumstances/fip_to_cip.rb
+++ b/spec/support/shared_examples/changes_of_circumstances/fip_to_cip.rb
@@ -61,7 +61,7 @@ RSpec.shared_examples "FIP to CIP" do |scenario, participant_status|
        :aggregate_failures do
       given_i_sign_in_as_a_finance_user
 
-      then_the_finance_portal_shows_the_current_participant_record "the Participant",
+      then_the_finance_portal_shows_the_current_participant_record "The Participant",
                                                                    scenario.participant_type,
                                                                    "New SIT",
                                                                    "",
@@ -97,10 +97,10 @@ RSpec.shared_examples "FIP to CIP" do |scenario, participant_status|
   context "Then the Analytics Dashboards" do
     subject(:analytics_user) { "Analysts" }
 
-    it "is expected to report the correct participant details for \"the Participant\"",
+    it "is expected to report the correct participant details for \"The Participant\"",
        :aggregate_failures,
        skip: "Not yet implemented" do
-      is_expected.to report_correct_participant_details "the Participant"
+      is_expected.to report_correct_participant_details "The Participant"
     end
   end
 end

--- a/spec/support/shared_examples/changes_of_circumstances/fip_to_fip_with_different_provider.rb
+++ b/spec/support/shared_examples/changes_of_circumstances/fip_to_fip_with_different_provider.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples "FIP to FIP with different provider" do |scenario, partici
 
       if scenario.duplicate_declarations.any?
         scenario.duplicate_declarations.each do |declaration_type|
-          expect(subject).to_not make_duplicate_training_declaration "the Participant",
+          expect(subject).to_not make_duplicate_training_declaration "The Participant",
                                                                      scenario.participant_type,
                                                                      declaration_type
         end
@@ -85,7 +85,7 @@ RSpec.shared_examples "FIP to FIP with different provider" do |scenario, partici
        :aggregate_failures do
       given_i_sign_in_as_a_finance_user
 
-      then_the_finance_portal_shows_the_current_participant_record "the Participant",
+      then_the_finance_portal_shows_the_current_participant_record "The Participant",
                                                                    scenario.participant_type,
                                                                    "New SIT",
                                                                    "New Lead Provider",
@@ -130,10 +130,10 @@ RSpec.shared_examples "FIP to FIP with different provider" do |scenario, partici
   context "Then the Analytics Dashboards" do
     subject(:analytics_user) { "Analysts" }
 
-    it "is expected to report the correct participant details for \"the Participant\"",
+    it "is expected to report the correct participant details for \"The Participant\"",
        :aggregate_failures,
        skip: "Not yet implemented" do
-      is_expected.to report_correct_participant_details "the Participant"
+      is_expected.to report_correct_participant_details "The Participant"
     end
   end
 end

--- a/spec/support/shared_examples/changes_of_circumstances/fip_to_fip_with_same_provider.rb
+++ b/spec/support/shared_examples/changes_of_circumstances/fip_to_fip_with_same_provider.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples "FIP to FIP with same provider" do |scenario, participant_
 
       if scenario.duplicate_declarations.any?
         scenario.duplicate_declarations.each do |declaration_type|
-          expect(subject).to_not make_duplicate_training_declaration "the Participant",
+          expect(subject).to_not make_duplicate_training_declaration "The Participant",
                                                                      scenario.participant_type,
                                                                      declaration_type
         end
@@ -74,7 +74,7 @@ RSpec.shared_examples "FIP to FIP with same provider" do |scenario, participant_
        :aggregate_failures do
       given_i_sign_in_as_a_finance_user
 
-      then_the_finance_portal_shows_the_current_participant_record "the Participant",
+      then_the_finance_portal_shows_the_current_participant_record "The Participant",
                                                                    scenario.participant_type,
                                                                    "New SIT",
                                                                    "Original Lead Provider",
@@ -110,10 +110,10 @@ RSpec.shared_examples "FIP to FIP with same provider" do |scenario, participant_
   context "Then the Analytics Dashboards" do
     subject(:analytics_user) { "Analysts" }
 
-    it "is expected to report the correct participant details for \"the Participant\"",
+    it "is expected to report the correct participant details for \"The Participant\"",
        :aggregate_failures,
        skip: "Not yet implemented" do
-      is_expected.to report_correct_participant_details "the Participant"
+      is_expected.to report_correct_participant_details "The Participant"
     end
   end
 end


### PR DESCRIPTION
### JIRA ticket

https://dfedigital.atlassian.net/browse/CST-740

### Changes proposed in this pull request

Some full names will be corrupted by `#titleize`:

```
"Jean-Claude Van Damme" => "Jean Claude Van Damme"
"James McAvoy"          => "James Mc Avoy"
"Leonardo DiCaprio"     => "Leonardo Di Caprio"
"Peter O'Toole"         => "Peter O'toole"
"Guillermo del Toro"    => "Guillermo Del Toro"
```

We should display them in the form they were entered.
