### PR TITLE
[CPLD-1860] Amend Participant Identity lookup in assurance reports

### DIFF
--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -56,7 +56,7 @@ module Finance
             JOIN participant_profiles pp   ON pd.participant_profile_id = pp.id
             LEFT OUTER JOIN participant_profile_states pps ON pps.participant_profile_id = pp.id AND pps.cpd_lead_provider_id = clp.id AND pps.state = 'withdrawn'
             JOIN participant_identities pi ON pp.participant_identity_id = pi.id
-            JOIN users u                   ON u.id = pi.external_identifier
+            JOIN users u                   ON u.id = pi.user_id
             JOIN teacher_profiles tp       ON tp.id = pp.teacher_profile_id
             JOIN (
                  SELECT

--- a/app/services/finance/npq/assurance_report/query.rb
+++ b/app/services/finance/npq/assurance_report/query.rb
@@ -48,7 +48,7 @@ module Finance
             JOIN npq_applications a             ON a.id = pp.id
             JOIN npq_courses c                  ON c.id = a.npq_course_id
             JOIN participant_identities pi      ON pp.participant_identity_id = pi.id
-            JOIN users u                        ON u.id = pi.external_identifier
+            JOIN users u                        ON u.id = pi.user_id
             JOIN teacher_profiles tp            ON tp.id = pp.teacher_profile_id
             JOIN schedules sch                  ON sch.id = pp.schedule_id
             LEFT OUTER JOIN schools sc          ON sc.urn = pp.school_urn

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, :with_default_schedules do
 
   let(:uplifts)                   { [] }
   let(:participant_profile)       { create(:ect, :eligible_for_funding, uplifts:, lead_provider: cpd_lead_provider.lead_provider) }
+  let(:participant_identity)      { participant_profile.participant_identity }
   let!(:participant_declaration)  { travel_to(statement.deadline_date) { create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:) } }
 
   let(:other_statement)                { create(:ecf_statement, cpd_lead_provider:, deadline_date: statement.deadline_date + 1.day) }
@@ -24,6 +25,31 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, :with_default_schedules do
   describe "#participant_declarations" do
     it "includes the declaration" do
       expect(query.participant_declarations).to eq([participant_declaration])
+    end
+
+    it "surfaces the preferred external identifier" do
+      participant_declarations = query.participant_declarations
+      expect(participant_declarations.first.participant_id).to eq(participant_identity.external_identifier)
+    end
+
+    context "with multiple participant identities" do
+      let(:induction_record) { participant_profile.induction_records.latest }
+      let(:new_participant_identity) { ParticipantIdentity.find_by!(email: "second_email@example.com") }
+      before do
+        Induction::ChangePreferredEmail.call(induction_record:, preferred_email: "second_email@example.com")
+        # We ideally should not update the existing participant identity on a profile when a new one is added
+        # however, some of the data has this incorrect shape, so we should account for it.
+        participant_profile.update!(participant_identity: new_participant_identity)
+      end
+
+      it "includes the declaration" do
+        expect(query.participant_declarations).to eq([participant_declaration])
+      end
+
+      it "surfaces the preferred external identifier" do
+        participant_declarations = query.participant_declarations
+        expect(participant_declarations.first.participant_id).to eq(participant_identity.external_identifier)
+      end
     end
   end
 


### PR DESCRIPTION
### Context
Some participant profiles are incorrectly attached to new participant identities where the user.id does not equate to the external identifier of the identity.

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1860

### Changes proposed in this pull request
User the `user_id` to make sure we always find the user

### Guidance to review

