### PR TITLE
Remove any remaining calls to #titleize names

### DIFF
--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -44,10 +44,6 @@ class NominateInductionTutorForm
     existing_user.full_name
   end
 
-  def full_name_to_display
-    full_name + (full_name[-1..].downcase == "s" ? "’" : "’s")
-  end
-
 private
 
   def email_is_not_in_use

--- a/app/forms/nominate_induction_tutor_form.rb
+++ b/app/forms/nominate_induction_tutor_form.rb
@@ -45,7 +45,7 @@ class NominateInductionTutorForm
   end
 
   def full_name_to_display
-    full_name.split("-").map(&:titleize).join("-") << (full_name[-1..].downcase == "s" ? "’" : "’s")
+    full_name + (full_name[-1..].downcase == "s" ? "’" : "’s")
   end
 
 private

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -322,7 +322,7 @@ module Schools
     end
 
     def display_name
-      type == :self ? "your" : "#{full_name&.titleize}’s"
+      type == :self ? "your" : "#{full_name}’s"
     end
 
     def formatted_nino

--- a/app/forms/schools/transferring_participant_form.rb
+++ b/app/forms/schools/transferring_participant_form.rb
@@ -34,16 +34,12 @@ module Schools
       }
     end
 
-    def formatted_full_name
-      full_name.split("-").map(&:titleize).join("-")
-    end
-
     def formatted_trn
       TeacherReferenceNumber.new(trn).formatted_trn
     end
 
     def full_name_to_display
-      formatted_full_name << (full_name[-1..].downcase == "s" ? "’" : "’s")
+      full_name << (full_name[-1..].downcase == "s" ? "’" : "’s")
     end
 
     def schools_current_programme_choices

--- a/app/forms/schools/transferring_participant_form.rb
+++ b/app/forms/schools/transferring_participant_form.rb
@@ -38,10 +38,6 @@ module Schools
       TeacherReferenceNumber.new(trn).formatted_trn
     end
 
-    def full_name_to_display
-      full_name << (full_name[-1..].downcase == "s" ? "’" : "’s")
-    end
-
     def schools_current_programme_choices
       [
         OpenStruct.new(id: "yes", name: "Yes"),

--- a/app/views/nominations/nominate_induction_coordinator/email.html.erb
+++ b/app/views/nominations/nominate_induction_coordinator/email.html.erb
@@ -12,7 +12,9 @@
         <%= form_for @nominate_induction_tutor_form, url: { action: :check_email }, method: :put do |f| %>
         <%= f.govuk_error_summary %>
             <div class="govuk-form-group">
-                <%= f.govuk_text_field(:email, label: { text: "What’s #{@nominate_induction_tutor_form.full_name_to_display} email address?",
+              <%= f.govuk_text_field(
+                :email,
+                label: { text: "What’s #{possessive_name(@nominate_induction_tutor_form.full_name)} email address?",
                 tag: "h1",
                 size: "xl" },
                 width: "two-thirds") do %>

--- a/app/views/schools/transfer_out/complete.html.erb
+++ b/app/views/schools/transfer_out/complete.html.erb
@@ -1,4 +1,4 @@
-<% title = "#{@profile.user.full_name&.titleize}’s leaving date has been submitted" %>
+<% title = "#{@profile.user.full_name}’s leaving date has been submitted" %>
 
 <% content_for :title, title %>
 
@@ -8,7 +8,7 @@
         <%= govuk_panel title_text: title, text: nil, classes: "govuk-!-margin-bottom-7" %>
 
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We’ll tell <%= @profile.user.full_name&.titleize %> that you’ve reported their transfer. They’ll appear in the ’moving schools’
+        <p class="govuk-body">We’ll tell <%= @profile.user.full_name %> that you’ve reported their transfer. They’ll appear in the ’moving schools’
         section of your dashboard until their leaving date.</p>
 
         <p class="govuk-body">They should continue with their current training programme until their leaving date.
@@ -17,7 +17,7 @@
         <h2 class="govuk-heading-m">Remember to:</h2>
 
         <ol class="govuk-list govuk-list--number">
-          <li>Report this transfer to your appropriate body. They need to complete some checks and update <%= @profile.user.full_name&.titleize %>’s record with the Teaching Regulation Agency (TRA).</li>
+          <li>Report this transfer to your appropriate body. They need to complete some checks and update <%= @profile.user.full_name %>’s record with the Teaching Regulation Agency (TRA).</li>
           <li>If you work with a training provider, let them know that this person is transferring to another school.</li>
         </ol>
 

--- a/app/views/schools/transferring_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/transferring_participants/cannot_find_their_details.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "We cannot find #{@transferring_participant_form.full_name_to_display}" %>
+<% content_for :title, "We cannot find #{possessive_name(@transferring_participant_form.full_name)}" %>
 
 <% content_for :before_content, govuk_back_link( text: "Back", href: { action: @transferring_participant_form.previous_step }) %>
 
@@ -6,8 +6,8 @@
 	<div class="govuk-grid-column-two-thirds">
 
     	<span class="govuk-caption-xl"><%= @school.name %></span>
-    	<h1 class="govuk-heading-xl">We cannot find <%= @transferring_participant_form.full_name_to_display %> record</h1>
-    	
+    	<h1 class="govuk-heading-xl">We cannot find <%= possessive_name(@transferring_participant_form.full_name) %> record</h1>
+
 		<p class="govuk-body">Check the information you’ve entered is correct.</p>
     	<p class="govuk-body">We need to find <%= @transferring_participant_form.full_name %> in the Teaching Regulation Agency records so we can transfer their record to your school.</p>
 
@@ -43,7 +43,7 @@
             		<%= govuk_link_to dob_schools_transferring_participant_path do %>
               		Change <span class="govuk-visually-hidden">date of birth</span>
             		<% end %>
-        		</dd>				
+        		</dd>
       		</div>
     	</dl>
 

--- a/app/views/schools/transferring_participants/check_answers.html.erb
+++ b/app/views/schools/transferring_participants/check_answers.html.erb
@@ -10,7 +10,7 @@
     <%= govuk_summary_list do |summary_list| %>
       <% summary_list.row do |row| %>
         <% row.key { "Name" } %>
-        <% row.value { @transferring_participant_form.formatted_full_name } %>
+        <% row.value { @transferring_participant_form.full_name } %>
         <% row.action(text: :none) %>
       <% end %>
 

--- a/app/views/schools/transferring_participants/choose_mentor.html.erb
+++ b/app/views/schools/transferring_participants/choose_mentor.html.erb
@@ -1,4 +1,4 @@
-<% title = "Who will #{@transferring_participant_form.full_name_to_display} mentor be?" %>
+<% title = "Who will #{possessive_name(@transferring_participant_form.full_name)} mentor be?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/transferring_participants/complete.html.erb
+++ b/app/views/schools/transferring_participants/complete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "transfer added" %>
-<% participant_name = @transferring_participant_form.formatted_full_name %>
+<% participant_name = @transferring_participant_form.full_name %>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -29,7 +29,7 @@
         <% end %>
         <p class="govuk-body">Contact us if you need to make any changes: <%= render MailToSupportComponent.new %></p>
         <% end %>
-        
+
         <%= govuk_link_to "View your ECTs and mentors", schools_participants_path, class: "govuk-link govuk-link--no-visited-state" %>
 
     </div>

--- a/app/views/schools/transferring_participants/dob.html.erb
+++ b/app/views/schools/transferring_participants/dob.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{@transferring_participant_form.full_name_to_display } date of birth?" %>
+<% title = "What’s #{possessive_name(@transferring_participant_form.full_name) } date of birth?" %>
 
 <% content_for :title, title %>
 
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
         <h1 class="govuk-heading-xl"><%= title %></h1>
 

--- a/app/views/schools/transferring_participants/email.html.erb
+++ b/app/views/schools/transferring_participants/email.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{@transferring_participant_form.full_name_to_display } email address?" %>
+<% title = "What’s #{possessive_name(@transferring_participant_form.full_name)} email address?" %>
 
 <% content_for :title, title%>
 
@@ -6,12 +6,12 @@
 
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
-    	
+
 		<span class="govuk-caption-xl"><%= @school.name %></span>
     	<h1 class="govuk-heading-xl"><%= title %></h1>
 
 		<p class="govuk-body">You can enter their personal or school email address.</p>
-    	
+
 		<%= form_for @transferring_participant_form, url: { action: :email }, method: :put do |f| %>
       		<%= f.govuk_text_field :email, label: { hidden: true }, width: "two-thirds" %>
 

--- a/app/views/schools/transferring_participants/teacher_start_date.html.erb
+++ b/app/views/schools/transferring_participants/teacher_start_date.html.erb
@@ -1,10 +1,10 @@
-<% title = "What’s #{@transferring_participant_form.full_name_to_display} start date at your school?" %>
+<% title = "What’s #{possessive_name(@transferring_participant_form.full_name)} start date at your school?" %>
 <% content_for :title, title %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: { action:  @transferring_participant_form.previous_step }) %>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
         <h1 class="govuk-heading-xl"><%= title %></h1>
 
@@ -12,7 +12,7 @@
             <%= f.govuk_date_field :start_date,
                 start_date: true,
                 width: "two-thirds",
-                legend: { text: "#{@transferring_participant_form.full_name_to_display} start date", class: "govuk-visually-hidden" },
+                legend: { text: "#{possessive_name(@transferring_participant_form.full_name)} start date", class: "govuk-visually-hidden" },
                 hint: { text: "For example, 14 7 2023"}
             %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transferring_participants/trn.html.erb
+++ b/app/views/schools/transferring_participants/trn.html.erb
@@ -1,4 +1,4 @@
-<% title = "What’s #{@transferring_participant_form.full_name_to_display} teacher reference number (TRN)?" %>
+<% title = "What’s #{possessive_name(@transferring_participant_form.full_name)} teacher reference number (TRN)?" %>
 
 <% content_for :title, title %>
 
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
+
         <span class="govuk-caption-xl"><%= @school.name %></span>
         <h1 class="govuk-heading-xl"><%= title %></h1>
 


### PR DESCRIPTION
### Context

- Ticket: 

### Changes proposed in this pull request

Follows on from #2616. Didn't pick these up on the first sweep asI only looked in views.

I also removed a couple of overlapping apostrophe-adding methods, everything now uses the `#possessive_name` helper.