### PR TITLE
[CPDLP-1827] - Ensure partnership report sets cohort to FIP and migrates participants

### DIFF
--- a/app/services/induction/change_partnership.rb
+++ b/app/services/induction/change_partnership.rb
@@ -28,6 +28,8 @@ class Induction::ChangePartnership < BaseService
           school_cohort.update!(default_induction_programme: programme)
         end
       end
+    else
+      Induction::SetCohortInductionProgramme.call(school_cohort:, programme_choice: "full_induction_programme")
     end
   end
 

--- a/app/services/partnerships/report.rb
+++ b/app/services/partnerships/report.rb
@@ -22,7 +22,7 @@ module Partnerships
 
         partnership.challenge_reason = partnership.challenged_at = nil
         partnership.delivery_partner_id = delivery_partner_id
-        partnership.pending = delay_partnership?
+        partnership.pending = false
         partnership.challenge_deadline = CHALLENGE_WINDOW.from_now
         partnership.report_id = SecureRandom.uuid
         partnership.save!
@@ -42,22 +42,11 @@ module Partnerships
           report_id: partnership.report_id,
         )
 
-        if partnership.pending?
-          PartnershipActivationJob.set(wait_until: partnership.challenge_deadline).perform_later(
-            partnership:,
-            report_id: partnership.report_id,
-          )
-        end
-
         partnership
       end
     end
 
   private
-
-    def delay_partnership?
-      !school_cohort.full_induction_programme?
-    end
 
     attr_reader :cohort_id, :school_id, :lead_provider_id, :delivery_partner_id
 


### PR DESCRIPTION
### Context

- Ticket: [JIRA](https://dfedigital.atlassian.net/browse/CPDLP-1827)

### Changes proposed in this pull request
Update `Induction::ChangePartnership` to call `Induction::SetCohortInductionProgramme` service when existing cohort programme is not a FIP.
No longer use `pending` for partnerships, reporting a partnership should immediately switch cohort default to FIP and migrate participants to the new FIP programme.
Remove call to queue `PartnershipActivationJob` which is outdated (we should remove the job code once deployed and queues empty)

### Guidance to review

