### PR TITLE
Expose shared interface for Participant profiles

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -21,9 +21,9 @@ module Api
 
   private
 
-    def render_from_service(service, serializer)
+    def render_from_service(service, serializer, params: {})
       if service.valid?
-        render json: serializer.new(service.call).serializable_hash
+        render json: serializer.new(service.call, params:).serializable_hash
       else
         render json: Api::V1::ActiveModelErrorsSerializer.from(service), status: :unprocessable_entity
       end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -85,6 +85,7 @@ class ParticipantProfile < ApplicationRecord
         .order(start_date: :desc)
         .first
     end
+    alias_method :record_to_serialize_for, :relevant_induction_record
 
     def schedule_for(cpd_lead_provider:)
       lead_provider = cpd_lead_provider.lead_provider

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -96,6 +96,14 @@ class ParticipantProfile < ApplicationRecord
         .schedule
     end
 
+    def withdrawn_for?(cpd_lead_provider:)
+      !!latest_induction_record_for(cpd_lead_provider:)&.training_status_withdrawn?
+    end
+
+    def deferred_for?(cpd_lead_provider:)
+      !!latest_induction_record_for(cpd_lead_provider:)&.training_status_deferred?
+    end
+
   private
 
     def update_analytics

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -56,6 +56,14 @@ class ParticipantProfile < ApplicationRecord
       schedule
     end
 
+    def withdrawn_for?(*)
+      training_status_withdrawn?
+    end
+
+    def deferred_for?(*)
+      training_status_deferred?
+    end
+
     def latest_induction_record_for(*)
       nil
     end

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -64,6 +64,10 @@ class ParticipantProfile < ApplicationRecord
       training_status_deferred?
     end
 
+    def record_to_serialize_for(*)
+      user
+    end
+
     def latest_induction_record_for(*)
       nil
     end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -296,4 +296,20 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       it { is_expected.not_to be_deferred_for(cpd_lead_provider:) }
     end
   end
+
+  describe "#record_to_serialize_for", :with_default_schedules do
+    let(:lead_provider) do
+      subject
+        .induction_records
+        .latest
+        .cpd_lead_provider
+        .lead_provider
+    end
+
+    subject { create(:ect) }
+
+    it "returns the relevant induction record for that profile" do
+      expect(subject.record_to_serialize_for(lead_provider:)).to eq(subject.induction_records.latest.reload)
+    end
+  end
 end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -252,4 +252,48 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       end
     end
   end
+
+  describe "#withdrawn_for", :with_default_schedules do
+    let(:cpd_lead_provider) { subject.induction_records.latest&.cpd_lead_provider }
+
+    context "when participant is withdrawn" do
+      subject { create(:ect, :withdrawn) }
+
+      it { is_expected.to be_withdrawn_for(cpd_lead_provider:) }
+    end
+
+    context "when participant is not withdrawn" do
+      subject { create(:ect) }
+
+      it { is_expected.not_to be_withdrawn_for(cpd_lead_provider:) }
+    end
+
+    context "when participant has no induction records" do
+      subject { create(:ecf_participant_profile) }
+
+      it { is_expected.not_to be_withdrawn_for(cpd_lead_provider:) }
+    end
+  end
+
+  describe "#deferred_for", :with_default_schedules do
+    let(:cpd_lead_provider) { subject.induction_records.latest&.cpd_lead_provider }
+
+    context "when participant is deferred" do
+      subject { create(:ect, :deferred) }
+
+      it { is_expected.to be_deferred_for(cpd_lead_provider:) }
+    end
+
+    context "when participant is not deferred" do
+      subject { create(:ect) }
+
+      it { is_expected.not_to be_deferred_for(cpd_lead_provider:) }
+    end
+
+    context "when participant has no induction records" do
+      subject { create(:ecf_participant_profile) }
+
+      it { is_expected.not_to be_deferred_for(cpd_lead_provider:) }
+    end
+  end
 end

--- a/spec/models/participant_profile/npq_spec.rb
+++ b/spec/models/participant_profile/npq_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ParticipantProfile::NPQ, :with_default_schedules, type: :model do
     end
   end
 
-  describe "#withdrawn_for", :with_default_schedules do
+  describe "#withdrawn_for" do
     let(:cpd_lead_provider) { subject.npq_application.npq_lead_provider.cpd_lead_provider }
 
     context "when participant is withdrawn" do
@@ -47,7 +47,7 @@ RSpec.describe ParticipantProfile::NPQ, :with_default_schedules, type: :model do
     end
   end
 
-  describe "#deferred_for", :with_default_schedules do
+  describe "#deferred_for" do
     let(:cpd_lead_provider) { subject.npq_application.npq_lead_provider.cpd_lead_provider }
 
     context "when participant is deferred" do
@@ -64,6 +64,18 @@ RSpec.describe ParticipantProfile::NPQ, :with_default_schedules, type: :model do
       it "returns false" do
         expect(subject.reload.deferred_for?(cpd_lead_provider:)).to be false
       end
+    end
+  end
+
+  describe "#record_to_serialize_for" do
+    let(:lead_provider) do
+      subject.npq_application.npq_lead_provider
+    end
+
+    subject { create(:npq_participant_profile) }
+
+    it "returns the relevant induction record for that profile" do
+      expect(subject.record_to_serialize_for(lead_provider:)).to eq(subject.user)
     end
   end
 end

--- a/spec/models/participant_profile/npq_spec.rb
+++ b/spec/models/participant_profile/npq_spec.rb
@@ -26,4 +26,44 @@ RSpec.describe ParticipantProfile::NPQ, :with_default_schedules, type: :model do
       end
     end
   end
+
+  describe "#withdrawn_for", :with_default_schedules do
+    let(:cpd_lead_provider) { subject.npq_application.npq_lead_provider.cpd_lead_provider }
+
+    context "when participant is withdrawn" do
+      subject { create(:npq_participant_profile, :withdrawn) }
+
+      it "returns true" do
+        expect(subject.reload.withdrawn_for?(cpd_lead_provider:)).to be true
+      end
+    end
+
+    context "when participant is not withdrawn" do
+      subject { create(:npq_participant_profile) }
+
+      it "returns false" do
+        expect(subject.reload.withdrawn_for?(cpd_lead_provider:)).to be false
+      end
+    end
+  end
+
+  describe "#deferred_for", :with_default_schedules do
+    let(:cpd_lead_provider) { subject.npq_application.npq_lead_provider.cpd_lead_provider }
+
+    context "when participant is deferred" do
+      subject { create(:npq_participant_profile, :deferred) }
+
+      it "returns true" do
+        expect(subject.reload.deferred_for?(cpd_lead_provider:)).to be true
+      end
+    end
+
+    context "when participant is not deferred" do
+      subject { create(:npq_participant_profile) }
+
+      it "returns false" do
+        expect(subject.reload.deferred_for?(cpd_lead_provider:)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
This is an unblocker PR as we are refactoring multiple endpoints at the same time

- Ticket: n/a

### Changes proposed in this pull request
- Add shared methods for both NPQ and ECF profiles to be used in action endpoints refactor

### Guidance to review

based off https://github.com/DFE-Digital/early-careers-framework/pull/2610