### PR TITLE
Comment out 'change' link for induction start date in the admin console

### DIFF
--- a/app/views/admin/participants/_details.html.erb
+++ b/app/views/admin/participants/_details.html.erb
@@ -27,10 +27,10 @@
   sl.row do |row|
     row.key(text: "Induction start date")
     row.value(text: latest_induction_record.participant_profile&.induction_start_date&.to_s(:govuk))
-    row.action(
-      href: edit_admin_participant_change_induction_start_date_path(participant_profile),
-      visually_hidden_text: "induction start date"
-    )
+    # row.action(
+    #   href: edit_admin_participant_change_induction_start_date_path(participant_profile),
+    #   visually_hidden_text: "induction start date"
+    # )
   end
 
   if @participant_profile.teacher_profile


### PR DESCRIPTION
### Context and changes proposed

The ParticipantProfile#induction_start_date is a column belonging to a piece of work yet to be finished. It will store the first starting date of an induction, but before it's used we need to backfill the existing profiles and surface the date in various places in the UI.

Until those things are done this 'Change' link is likely to cause confusion, so we'll temporarily hide it.

This change was requested by Nicola.
