### PR TITLE
Fix flaky serializer spec

### DIFF
--- a/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
@@ -33,8 +33,8 @@ module Api
                 challenged_reason: partnership.challenge_reason,
                 induction_tutor_name: school.induction_tutor.full_name,
                 induction_tutor_email: school.contact_email,
-                updated_at: delivery_partner.updated_at.rfc3339,
-                created_at: delivery_partner.created_at.rfc3339,
+                updated_at: partnership.updated_at.rfc3339,
+                created_at: partnership.created_at.rfc3339,
               },
             ])
           end


### PR DESCRIPTION
### Context

Noticed that a intermittently failing spec was due to a timing inconsistency where the wrong object `created_at` and `updated_at` were being compared in this spec.

### Changes proposed in this pull request

### Guidance to review

