### PR TITLE
Use explicit name to avoid failure in regex expectation

### DIFF
--- a/spec/components/admin/npq/applications/analysis/table_row_spec.rb
+++ b/spec/components/admin/npq/applications/analysis/table_row_spec.rb
@@ -2,8 +2,9 @@
 
 RSpec.describe Admin::NPQ::Applications::Analysis::TableRow, :with_default_schedules, type: :view_component do
   let(:npq_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider).npq_lead_provider }
+  let(:user) { create(:user, full_name: "John Doe") }
   let(:npq_application) do
-    create(:npq_application, :funded, :accepted, npq_lead_provider:)
+    create(:npq_application, :funded, :accepted, npq_lead_provider:, user:)
   end
 
   before do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.unique.safe_email }
-    full_name { Faker::Name.name }
+    sequence(:full_name) { |n| "John Doe #{n}" }
     login_token { Faker::Alphanumeric.alpha(number: 10) }
     login_token_valid_until { 12.hours.from_now }
 
@@ -62,6 +62,10 @@ FactoryBot.define do
       after(:create) do |u|
         create(:appropriate_body_profile, user: u)
       end
+    end
+
+    trait :random_name do
+      full_name { Faker::Name.name }
     end
   end
 end

--- a/spec/requests/admin/participants/change_induction_start_date_spec.rb
+++ b/spec/requests/admin/participants/change_induction_start_date_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:old_date) { 2.weeks.ago.to_date }
 
-  let!(:ect_profile) { create(:ect, induction_start_date: old_date) }
+  let(:user) { create(:user, full_name: "John Doe") }
+  let!(:ect_profile) { create(:ect, induction_start_date: old_date, user:) }
 
   before { sign_in(admin_user) }
 


### PR DESCRIPTION
### Context
When checking for the following in the page:
```
/What is #{ect_profile.user.full_name}.*/
```
Names such as: Elza O'Reilly will fail that regex because they are formatted differently on the page. 
- Ticket: n/a

### Changes proposed in this pull request
Set the user name explicitly to avoid failures on random names.

### Guidance to review
example of failure: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3295940164/jobs/5435027414
