### PR TITLE
Exclude the v3 doc specs by default

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -136,4 +136,6 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.exclude_pattern = "spec/docs/v3/**/*_spec.rb" unless ENV["WITH_V3_DOC_SPECS"]
 end


### PR DESCRIPTION
### Context
Ignore the v3 doc specs by default unless explicitly included.

This matches our current CI flow that [ignores the v3 doc specs](https://github.com/DFE-Digital/early-careers-framework/blob/26d34db96b48d94f6aff10719a4868d1f0da17c2/bin/rspec_ci#L8), because their are still in progress.

- Ticket: N/A

### Changes proposed in this pull request
- added an `exclude_pattern` configuration in `rails_helper.rb` to ignore the specs
- added the `WITH_V3_DOC_SPECS` env var for the API team to allow them to run the specs as they build the v3 api

### Guidance to review
In your CLI, run:
- `rspec spec/docs/` - shouldn't run the v3 doc specs
- `WITH_V3_DOC_SPECS=true rspec spec/docs/` - should run the v3 doc specs