### PR TITLE
Add RSpec filter to avoid running API v3 specs

### DIFF
--- a/bin/rspec_ci
+++ b/bin/rspec_ci
@@ -5,7 +5,6 @@ ci_node_index = ENV["CI_NODE_INDEX"] || "0"
 github_sha = ENV['GITHUB_SHA'] || "fake-sha-123"
 
 tests = Dir["spec/**/*_spec.rb"]
-  .reject { |path| path.match?(/spec\/docs\/v3/) }
   .sort
   # Add randomization seed based on SHA of each commit
   .shuffle(random: Random.new(github_sha.to_i(16)))

--- a/spec/docs/v3/ecf_delivery_partners_spec.rb
+++ b/spec/docs/v3/ecf_delivery_partners_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   path "/api/v3/delivery-partners" do
     get "Retrieve delivery partners" do
       operationId :delivery_patrners_get

--- a/spec/docs/v3/ecf_partnerships_spec.rb
+++ b/spec/docs/v3/ecf_partnerships_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   path "/api/v3/partnerships/ecf" do
     get "Retrieve multiple ECF partnerships" do
       operationId :partnerships_ecf_get

--- a/spec/docs/v3/npq_applications_spec.rb
+++ b/spec/docs/v3/npq_applications_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
+describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/docs/v3/npq_outcomes_spec.rb
+++ b/spec/docs/v3/npq_outcomes_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   path "/api/v3/participants/npq/{id}/outcomes" do
     get "Retrieve NPQ outcomes for the specified participant" do
       operationId :npq_outcome_get

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
+describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/docs/v3/participant_declarations_spec.rb
+++ b/spec/docs/v3/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "Participant Declarations", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
+RSpec.describe "Participant Declarations", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   let(:ect_profile) { create(:ect) }
   let(:ect_declaration_date) { ect_profile.schedule.milestones.find_by(declaration_type: "started").start_date }
   let(:user) { ect_profile.user }

--- a/spec/docs/v3/participants_ecf_spec.rb
+++ b/spec/docs/v3/participants_ecf_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+describe "API", type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }
   let(:Authorization) { bearer_token }

--- a/spec/docs/v3/statements_spec.rb
+++ b/spec/docs/v3/statements_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
   path "/api/v3/statements" do
     get "Retrieve financial statements" do
       operationId :statements_get

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,6 @@ RSpec.configure do |config|
   # order to prevent clashes with cypress features and confusion with capybara
   # conventions.
   config.pattern += ",**/turnip_features/**/*.feature"
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
@@ -107,6 +106,8 @@ RSpec.configure do |config|
   config.extend WithModel
 
   config.bisect_runner = :shell
+
+  config.filter_run_excluding api_v3: true
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
### Context
V3 API tests are excluded in our CI runs, however locally they fail unless manually excluded

- Ticket: n/a

### Changes proposed in this pull request
- Add filter to config
- Add this new filter to all specs to ignore
- Remove exclusion from rspec ci now its no longer needed

### Guidance to review
When we add endpoints we will start removing those filters one by one, whilst also setting the API feature flag to true
This is based off @leoapost work in https://github.com/DFE-Digital/early-careers-framework/pull/2640