### PR TITLE
Add methods in ParticipantIdentity to determine its origin

### DIFF
--- a/app/components/admin/participants/identities.rb
+++ b/app/components/admin/participants/identities.rb
@@ -10,10 +10,12 @@ module Admin
       end
 
       def identity_transferred_label(identity)
-        if identity.user_id == identity.external_identifier
+        if identity.original_identity?
           "Original"
-        else
+        elsif identity.transferred_identity?
           "Transferred"
+        elsif identity.additional_identity?
+          "Additional"
         end
       end
     end

--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -9,7 +9,7 @@ module CurrentUser
     original = super
     return if original.nil?
 
-    transferred_identity = ParticipantIdentity.transferred.find_by(external_identifier: original.id)
+    transferred_identity = ParticipantIdentity.secondary.find_by(external_identifier: original.id)
 
     @deduped_current_user = transferred_identity&.user || original
   end
@@ -20,7 +20,7 @@ module CurrentUser
     original = super
     return if original.nil?
 
-    transferred_identity = ParticipantIdentity.transferred.find_by(external_identifier: original.id)
+    transferred_identity = ParticipantIdentity.secondary.find_by(external_identifier: original.id)
 
     @deduped_true_user = transferred_identity&.user || original
   end

--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -16,11 +16,31 @@ class ParticipantIdentity < ApplicationRecord
   }, _suffix: true
 
   scope :original, -> { where("participant_identities.external_identifier = participant_identities.user_id") }
-  scope :transferred, -> { where("participant_identities.external_identifier != participant_identities.user_id") }
+  scope :secondary, -> { where("participant_identities.external_identifier != participant_identities.user_id") }
 
   def self.email_matches(search_term)
     return none if search_term.blank?
 
     where("participant_identities.email like ?", "%#{search_term}%")
+  end
+
+  # The original identity of the participant
+  def original_identity?
+    external_identifier == user_id
+  end
+
+  # Any other identity than the original
+  def secondary_identity?
+    !original_identity?
+  end
+
+  # Most likely identity of de-duped user
+  def transferred_identity?
+    secondary_identity? && participant_profiles.any?
+  end
+
+  # Just another identity for the same user
+  def additional_identity?
+    secondary_identity? && participant_profiles.blank?
   end
 end

--- a/spec/components/admin/participants/identities_spec.rb
+++ b/spec/components/admin/participants/identities_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Admin::Participants::Identities, :with_default_schedules, type: :
   context "with transferred identities" do
     let(:identities) { build_list(:participant_identity, 2, :npq_origin, :transferred) }
 
-    it "renders info for all the identities and labels them as 'Transferred'" do
+    it "renders info for all the identities and labels them as 'Additional'" do
       identities.each do |identity|
         expect(rendered).to have_contents(
-          "Transferred",
+          "Additional",
           identity.user_id,
           identity.external_identifier,
           identity.email,

--- a/spec/components/admin/participants/identities_spec.rb
+++ b/spec/components/admin/participants/identities_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Admin::Participants::Identities, :with_default_schedules, type: :
     end
   end
 
-  context "with transferred identities" do
-    let(:identities) { build_list(:participant_identity, 2, :npq_origin, :transferred) }
+  context "with secondary identities" do
+    let(:identities) { build_list(:participant_identity, 2, :npq_origin, :secondary) }
 
     it "renders info for all the identities and labels them as 'Additional'" do
       identities.each do |identity|

--- a/spec/factories/participant_identity.rb
+++ b/spec/factories/participant_identity.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       origin { "npq" }
     end
 
-    trait :transferred do
+    trait :secondary do
       external_identifier { SecureRandom.uuid }
     end
   end

--- a/spec/models/participant_identity_spec.rb
+++ b/spec/models/participant_identity_spec.rb
@@ -5,6 +5,13 @@ require "rails_helper"
 RSpec.describe ParticipantIdentity, type: :model do
   subject(:participant_identity) { create(:participant_identity) }
 
+  let(:user) { participant_identity.user }
+  let(:additional_identity) { create(:participant_identity, :secondary, user:, email: Faker::Internet.email) }
+  let(:identity_of_duplicate_user) { create(:ecf_participant_profile).participant_identity }
+  let(:transferred_identity) do
+    identity_of_duplicate_user.tap { |identity| identity.update!(user:) }
+  end
+
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:participant_profiles) }
   it { is_expected.to have_many(:npq_applications) }
@@ -33,6 +40,39 @@ RSpec.describe ParticipantIdentity, type: :model do
         # address column is citext
         expect(described_class.email_matches("xyz").to_sql).to include("participant_identities.email like '%xyz%'")
       end
+    end
+
+    describe "#secondary" do
+      it "returns all the transferred and additional identities" do
+        expect(described_class.secondary).to include(additional_identity, transferred_identity)
+      end
+    end
+  end
+
+  describe "#original_identity?" do
+    it "returns true for the first identity of the participant" do
+      expect(participant_identity.original_identity?).to be true
+    end
+  end
+
+  describe "#secondary_identity?" do
+    it "returns true for any of the second identities" do
+      expect(additional_identity.secondary_identity?).to be true
+      expect(transferred_identity.secondary_identity?).to be true
+    end
+  end
+
+  describe "#additional_identity?" do
+    it "returns true when the identity has no participant profiles" do
+      expect(additional_identity.participant_profiles).to be_empty
+      expect(additional_identity.additional_identity?).to be true
+    end
+  end
+
+  describe "#transferred_identity?" do
+    it "returns true when the identity has participant profiles and the external_identifier does not matches the user id" do
+      expect(transferred_identity.participant_profiles).not_to be_empty
+      expect(transferred_identity.transferred_identity?).to be true
     end
   end
 end


### PR DESCRIPTION


### Context
The ParticipantIdentity model has two scopes to retrieve the 
1. original identity which is the one created with the user 
2. transferred identities which can be either 
2.1. just more identities of the same user
2.2. transferred identities from other user records of the same participant, caused by the de-dupping process

The transferred identities returning two different things, confuses things and can lead to more issues. 

So, this is a follow up from my previous PR #2628 as an attempt to identify the non original identities correctly and display them in the participants admin profile for easier troubleshooting. 

ps. it is inspired by the [discussion](https://github.com/DFE-Digital/early-careers-framework/pull/2628#discussion_r1000412139) with Tony on how the origin of the identities can be potentially determined.


- Ticket: N/A

### Changes proposed in this pull request
- Rename the `transferred` scope to something more inclusive
- Add method to get identify the origin of the identity
- Update the identities component to display a better label for the origin of the identity 

### Guidance to review

