### PR TITLE
Double health check timeout

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -18,7 +18,7 @@ resource cloudfoundry_app web_app {
   docker_credentials = var.docker_credentials
   health_check_type = "http"
   health_check_http_endpoint = "/check"
-  health_check_timeout = 60
+  health_check_timeout = var.health_check_timeout
   instances = var.web_app_instances
   memory = var.web_app_memory
 

--- a/terraform/app/modules/paas/variables.tf
+++ b/terraform/app/modules/paas/variables.tf
@@ -14,6 +14,10 @@ variable app_start_timeout {
   default = 300
 }
 
+variable health_check_timeout {
+  default = 60
+}
+
 variable app_stopped {
   default = false
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -44,6 +44,7 @@ module paas {
   }
   app_env_values                            = local.paas_app_env_values
   app_start_timeout                         = var.paas_app_start_timeout
+  health_check_timeout                      = var.paas_health_check_timeout
   app_stopped                               = var.paas_app_stopped
   service_name                              = local.service_name
   postgres_service_plan                     = var.paas_postgres_service_plan

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -24,6 +24,10 @@ variable paas_app_start_timeout {
   default = 300
 }
 
+variable paas_health_check_timeout {
+  default = 60
+}
+
 variable paas_app_stopped {
   default = false
 }

--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -7,6 +7,7 @@ paas_api_url = "https://api.london.cloud.service.gov.uk"
 paas_space_name = "earlycareers-framework-dev"
 paas_postgres_service_plan = "tiny-unencrypted-11"
 paas_app_start_timeout = "300"
+paas_health_check_timeout = "120"
 paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1

--- a/terraform/workspace-variables/review.tfvars
+++ b/terraform/workspace-variables/review.tfvars
@@ -6,6 +6,7 @@ paas_api_url = "https://api.london.cloud.service.gov.uk"
 paas_space_name = "earlycareers-framework-dev"
 paas_postgres_service_plan = "tiny-unencrypted-11"
 paas_app_start_timeout = "240"
+paas_health_check_timeout = "120"
 paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1


### PR DESCRIPTION
### Context
When deploying to Dev and Review envs, the deployment fails with health timeouts, which I assume is due to the long setup. We will be fixing our reseeding scripts however until that happens, increase our health timeout to 2 minutes to give the setup enough time to complete, and avoid having to rerun deploys.

- Ticket: n/a

### Changes proposed in this pull request
- Add a new variables `health_check_timeout` and `paas_health_check_timeout`
- Set those variables to the default value of 60s (as it was hardcoded before for all web apps)
- Override this in dev and review setup to 120s
- 
### Guidance to review

Failure examples on dev and review:
https://github.com/DFE-Digital/early-careers-framework/actions/runs/3296708732/jobs/5436680363
https://github.com/DFE-Digital/early-careers-framework/actions/runs/3296239479/jobs/5435672041
