### PR TITLE
Stop writing Sentry object to country code field

### DIFF
--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -70,6 +70,7 @@ module NPQ
         country.alpha3
       else
         Sentry.capture_message("Could not find the ISO3166 alpha3 code for #{teacher_catchment_country}.")
+        nil
       end
     end
 


### PR DESCRIPTION
### Context and changes

When we can't find a teacher_catchment_iso_country_code we log a message to Sentry with the country we can't find's name in it. Here the call to Sentry is the final thing in the method so when we can't find one, the return value of `Sentry#capture_message` (a `Sentry::ErrorEvent`) is set.

This causes an error when writing to the database as the string is longer than 3 characters.
