### PR TITLE
Ignore pull requests with label "dependencies" when destroying a review app

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   destroy:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies')) }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Context
Review apps are not created for dependabot prs.

When a pr is merged or closed we attempt to destroy that review app. The actor performing the closing or merging of a PR is never going to be dependabot. This means the check fails, and we are attempting to destroy review apps when they don't exist.

Look for the label and skip if it is a dependency instead.

- Ticket: n/a

### Changes proposed in this pull request

Check PR labels before destroying review app, and skip if it includes "dependencies"

### Guidance to review

Example of failures where check passed: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3297527233/jobs/5438449015 