### PR TITLE
Enable API V3 added specs

### DIFF
--- a/app/serializers/api/v3/delivery_partner_serializer.rb
+++ b/app/serializers/api/v3/delivery_partner_serializer.rb
@@ -17,7 +17,7 @@ module Api
       end
 
       attribute :cohort do |delivery_partner, params|
-        delivery_partner.cohorts_with_provider(params[:lead_provider]).map(&:start_year)
+        delivery_partner.cohorts_with_provider(params[:lead_provider]).map(&:display_name)
       end
     end
   end

--- a/spec/serializers/api/v3/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/v3/delivery_partner_serializer_spec.rb
@@ -22,7 +22,7 @@ module Api
             attributes: {
               name: delivery_partner.name,
               updated_at: delivery_partner.updated_at.rfc3339,
-              cohort: [cohort.start_year],
+              cohort: [cohort.display_name],
             },
           ])
         end

--- a/swagger/v3/component_schemas/DeliveryPartnerAttributes.yml
+++ b/swagger/v3/component_schemas/DeliveryPartnerAttributes.yml
@@ -1,7 +1,5 @@
 description: "The data attributes associated with a delivery partner"
 type: object
-required:
-  - name
 properties:
   name:
     description: The name of the delivery partner you are working with

--- a/swagger/v3/component_schemas/StatementAttributes.yml
+++ b/swagger/v3/component_schemas/StatementAttributes.yml
@@ -1,7 +1,5 @@
 description: "The data attributes associated with a financial statement"
 type: object
-required:
-  - name
 properties:
   month:
     description: "The month which appears on the statement in the DfE portal"


### PR DESCRIPTION
### Context
We added endpoints for V3, enable schema tests for those

- Ticket: n/a

### Changes proposed in this pull request
- Enable and fix statements and delivery partner tests
- Remove erroneous required name in schema
- Fix delivery partner serializer to return string for cohort start year

### Guidance to review

