### PR TITLE
Add `travel_to` to specs where we are selecting the same date as today

### DIFF
--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "old and new SIT transferring the same participant", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+RSpec.describe "old and new SIT transferring the same participant", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 10, 21) do
   context "Transfer out an ECT that has already been transferred in" do
     before do
       set_participant_data

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "transfer out participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false do
+RSpec.describe "transfer out participants", with_feature_flags: { change_of_circumstances: "active", multiple_cohorts: "active" }, type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 10, 21) do
   context "Transfer out an ECT" do
     before do
       set_participant_data


### PR DESCRIPTION
### Context
Failing specs due to us selecting a date that passed (beginning of day today)

- Ticket: n/a

### Changes proposed in this pull request
Time travel to a date before to avoid failures

### Guidance to review

