### PR TITLE
Improve error handling in NPQ Application Eligibility Importer and related jobs

### DIFF
--- a/app/jobs/admin/npq_applications/eligibility_import_job.rb
+++ b/app/jobs/admin/npq_applications/eligibility_import_job.rb
@@ -42,7 +42,10 @@ module Admin
           end
         end
       rescue StandardError => e
-        Sentry.capture_exception(e, hint: { eligibility_import_id: eligibility_import.id })
+        Sentry.with_scope do |scope|
+          scope.set_context("NPQ Eligibility Import Record", id: eligibility_import.id)
+          Sentry.capture_exception(e)
+        end
 
         eligibility_import.import_errors.append("Processing Failed, contact an administrator for details")
         eligibility_import.fail!

--- a/app/services/admin/npq_applications/eligibility_import/application_updater.rb
+++ b/app/services/admin/npq_applications/eligibility_import/application_updater.rb
@@ -75,13 +75,11 @@ module Admin
 
           update_errors.append(build_error_message(csv_row:, message: error_message)) if error_message.present?
         rescue StandardError => e
-          Sentry.capture_exception(
-            e,
-            hint: {
-              application_id: application_update.ecf_id,
-              eligibility_import_id: eligibility_import.id,
-            },
-          )
+          Sentry.with_scope do |scope|
+            scope.set_context("NPQ Eligibility Import Record", id: eligibility_import.id)
+            scope.set_context("NPQ Application Record", id: application_update.ecf_id)
+            Sentry.capture_exception(e)
+          end
 
           error_message = build_error_message(
             csv_row:,

--- a/app/services/admin/secure_drive_downloader.rb
+++ b/app/services/admin/secure_drive_downloader.rb
@@ -25,13 +25,10 @@ module Admin
 
       stringio.tap(&:rewind).read
     rescue StandardError => e
-      Sentry.capture_exception(
-        e,
-        hint: {
-          filename:,
-          folder:,
-        },
-      )
+      Sentry.with_scope do |scope|
+        scope.set_context("File Details", { filename:, folder: })
+        Sentry.capture_exception(e)
+      end
 
       errors.append("Error downloading file, contact an administrator for details")
       false


### PR DESCRIPTION
### Context

There have been a few reports lately of failing eligibility imports without clear errors. Also, when investigated on Sentry, the contextual information to make searching easier was not coming through.

### Changes proposed in this pull request

- Move to context capturing for gathering non-error data in sentry exception capturing.
- Adds step to validate presence of correct values in each column while parsing NPQ Application eligibility imports
- Prevent coercing of unclear eligible_for_funding values into false while parsing NPQ Application eligibility imports