### PR TITLE
Add helper to fill in date fields in one go

### DIFF
--- a/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
@@ -119,15 +119,11 @@ private
     click_on "Continue"
     fill_in "schools_add_participant_form[trn]", with: "AB123445A"
     click_on "Continue"
-    fill_in "Day", with: "22"
-    fill_in "Month", with: "11"
-    fill_in "Year", with: "1998"
+    fill_in_date("What’s George ECT’s date of birth?", with: "1998-11-22")
     click_on "Continue"
     fill_in "schools_add_participant_form[email]", with: "ect@email.gov.uk"
     click_on "Continue"
-    fill_in "schools_add_participant_form[start_date(3i)]", with: "1"
-    fill_in "schools_add_participant_form[start_date(2i)]", with: "1"
-    fill_in "schools_add_participant_form[start_date(1i)]", with: Time.zone.today.year + 1
+    fill_in_date("What’s George ECT’s induction start date?", with: 1.year.from_now.at_beginning_of_year.to_date)
     click_on "Continue"
   end
 

--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -88,9 +88,9 @@ RSpec.describe "old and new SIT transferring the same participant", with_feature
     end
 
     def when_i_add_a_valid_end_date
-      fill_in "Day", with: "24"
-      fill_in "Month", with: "10"
-      fill_in "Year", with: "2022"
+      legend = "When is #{@participant_data[:full_name]} leaving your school?"
+
+      fill_in_date(legend, with: "2022-10-24")
     end
 
     def when_i_select(option)

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -72,15 +72,15 @@ RSpec.describe "transfer out participants", with_feature_flags: { change_of_circ
     end
 
     def when_i_add_an_invalid_date
-      fill_in "Day", with: "24"
-      fill_in "Month", with: "10"
-      fill_in "Year", with: "23"
+      legend = "When is #{@participant_data[:full_name]} leaving your school?"
+
+      fill_in_date(legend, with: "23-10-24")
     end
 
     def when_i_add_a_valid_end_date
-      fill_in "Day", with: "24"
-      fill_in "Month", with: "10"
-      fill_in "Year", with: "2022"
+      legend = "When is #{@participant_data[:full_name]} leaving your school?"
+
+      fill_in_date(legend, with: "2022-10-24")
     end
 
     def when_i_select(option)

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -122,9 +122,9 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
   end
 
   def when_i_add_a_valid_date_of_birth
-    fill_in "Day", with: "24"
-    fill_in "Month", with: "10"
-    fill_in "Year", with: "1990"
+    legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+    fill_in_date(legend, with: "1990-10-24")
   end
 
   def when_i_select(option)

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/active_cohort_speedbump_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/active_cohort_speedbump_spec.rb
@@ -119,30 +119,20 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         fill_in "Email", with: email
       end
 
-      def when_i_add_an_invalid_trn
-        fill_in "Teacher reference number (TRN)", with: "1234"
-      end
-
       def when_i_add_a_valid_trn
         fill_in "Teacher reference number (TRN)", with: "1001000"
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
-      end
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
 
-      def when_i_add_an_invalid_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "23"
+        fill_in_date(legend, with: "1990-10-24")
       end
 
       def when_i_add_a_valid_start_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "2023"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "2023-10-24")
       end
 
       def when_i_assign_a_mentor

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -118,15 +118,15 @@ RSpec.describe "transferring participants", :with_default_schedules, with_featur
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "1990-10-24")
       end
 
       def when_i_add_a_valid_start_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "2023"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "2023-10-24")
       end
 
       def when_i_assign_a_mentor

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -187,15 +187,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "1990-10-24")
       end
 
       def when_i_add_a_valid_start_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "2023"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "2023-10-24")
       end
 
       def when_i_assign_a_mentor

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
         click_on "Continue"
         then_i_should_see_enter_date_of_birth_error_message
 
-        when_i_add_an_invalid_date
+        when_i_add_an_invalid_date_of_birth
         click_on "Continue"
         then_i_should_see_invalid_date_of_birth_error_message
 
@@ -66,7 +66,7 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
 
         click_on "Continue"
         then_i_should_see_enter_start_date_error_message
-        when_i_add_an_invalid_date
+        when_i_add_an_invalid_start_date
         click_on "Continue"
         then_i_should_see_invalid_start_date_error_message
 
@@ -168,27 +168,33 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "1990-10-24")
       end
 
-      def when_i_add_an_invalid_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "23"
+      def when_i_add_an_invalid_date_of_birth
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "23-10-24")
       end
 
       def when_i_add_a_date_prior_to_the_participants_induction_start
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1998"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "1998-10-24")
+      end
+
+      def when_i_add_an_invalid_start_date
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "23-10-24")
       end
 
       def when_i_add_a_valid_start_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "2023"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "2023-10-24")
       end
 
       def when_i_assign_a_mentor

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -170,15 +170,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "1990-10-24")
       end
 
       def when_i_add_a_valid_start_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "2023"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "2023-10-24")
       end
 
       def when_i_select(option)

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -110,15 +110,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "1990-10-24")
       end
 
       def when_i_add_a_valid_start_date
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "2023"
+        legend = "#{@participant_data[:full_name]}’s start date"
+
+        fill_in_date(legend, with: "2023-10-24")
       end
 
       def when_i_select(option)

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_add_a_valid_date_of_birth
-        fill_in "Day", with: "24"
-        fill_in "Month", with: "10"
-        fill_in "Year", with: "1990"
+        legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
+
+        fill_in_date(legend, with: "1990-10-24")
       end
 
       def when_i_assign_a_mentor

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -572,24 +572,28 @@ module ManageTrainingSteps
   end
 
   def when_i_add_a_date_of_birth
+    legend = "What’s #{@participant_data[:full_name]}’s date of birth?"
     date = @participant_data[:date_of_birth]
-    fill_in "Day", with: date.day
-    fill_in "Month", with: date.month
-    fill_in "Year", with: date.year
+
+    fill_in_date(legend, with: date)
   end
 
   def when_i_add_my_date_of_birth
     date = @sit_data[:date_of_birth]
-    fill_in "Day", with: date.day
-    fill_in "Month", with: date.month
-    fill_in "Year", with: date.year
+    legend = "What’s your date of birth?"
+
+    fill_in_date(legend, with: date)
   end
 
   def when_i_add_a_start_date
     date = @participant_data[:start_date]
-    fill_in "Day", with: date.day
-    fill_in "Month", with: date.month
-    fill_in "Year", with: date.year
+
+    # this method is used in several contexts (start at school, induction
+    # start) so checking for the exact text is problematic. Just make sure
+    # it contains 'start'
+    legend = /start/
+
+    fill_in_date(legend, with: date)
   end
 
   def when_i_choose_materials

--- a/spec/support/features/interaction_helper.rb
+++ b/spec/support/features/interaction_helper.rb
@@ -71,4 +71,22 @@ module InteractionHelper
   end
 
   alias_method :and_i_click_on_summary_row_action, :when_i_click_on_summary_row_action
+
+  # with can be either a Date object or date in yyyy-mm-dd format
+  def fill_in_date(legend, with: date)
+    parts = case with
+            when Date
+              [with.year, with.month, with.day]
+            when String
+              with.split("-")
+            end
+
+    fieldset = page.find("legend", text: legend).ancestor("fieldset.govuk-fieldset")
+
+    within(fieldset) do
+      Hash[%w[Year Month Day].zip(parts)].each do |label, value|
+        fill_in label, with: value
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context


The `#fill_in_date` helper allows us to provide a bit more context in specs than individually calling `fill_in "{Date,Month,Year}:"` because:

* we need to reference the legend text, so it's more obvious by reading the spec _what_ we're filling in

* dates are easier to find by grepping if they're in a ISO 8601 style (eg. 2022-10-24) than they would be as separate numbers across three lines

### Changes proposed in this pull request

- Add a fill_in_date helper for use in features
- Update date steps to use fill_in_date method
