### PR TITLE
Reduce unfound country Sentry messages from `:error` to `:warning`

### DIFF
--- a/app/services/npq/build_application.rb
+++ b/app/services/npq/build_application.rb
@@ -69,7 +69,7 @@ module NPQ
       if (country = ISO3166::Country.find_country_by_any_name(teacher_catchment_country))
         country.alpha3
       else
-        Sentry.capture_message("Could not find the ISO3166 alpha3 code for #{teacher_catchment_country}.")
+        Sentry.capture_message("Could not find the ISO3166 alpha3 code for #{teacher_catchment_country}.", level: :warning)
         nil
       end
     end

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -18,7 +18,7 @@ namespace :one_offs do
       if (country = ISO3166::Country.find_country_by_any_name(npq_application.teacher_catchment_country))
         npq_application.update!(teacher_catchment_iso_country_code: country.alpha3)
       else
-        Sentry.capture_message("Could not find the ISO3166 alpha3 code for #{npq_application.teacher_catchment_country}.")
+        Sentry.capture_message("Could not find the ISO3166 alpha3 code for #{npq_application.teacher_catchment_country}.", level: :warning)
       end
     end
   end

--- a/spec/services/npq/build_application_spec.rb
+++ b/spec/services/npq/build_application_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe NPQ::BuildApplication do
         it "does not store the iso alpha3 country code", :aggregate_failures do
           expect(npq_application.save).to be true
           expect(npq_application.teacher_catchment_iso_country_code).to be nil
-          expect(Sentry).to have_received(:capture_message).with("Could not find the ISO3166 alpha3 code for wonderland.")
+          expect(Sentry).to have_received(:capture_message).with("Could not find the ISO3166 alpha3 code for wonderland.", level: :warning)
         end
       end
     end


### PR DESCRIPTION
### Context

The default [error level is :error](https://docs.sentry.io/platforms/ruby/usage/set-level/), which triggers an alert. In this case we do want to know about the missing/wrong countries because it'll show a mismatch between our countries lists in the NPQ and ECF apps, but it's not important enough to be considered an error.

The originally selected value will still be saved in `teacher_catchment_country` making the problem rows easy to identify and fix later if needed.
