### PR TITLE
Improve duplicate query

### DIFF
--- a/app/views/finance/ecf/duplicates/compare/_details.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_details.html.erb
@@ -20,13 +20,23 @@
       body.row { |row| comparative_table_row_for(row: row, header: "School", method: :school_name, primary_profile:, duplicate_profile:) }
       body.row do |row|
         row.cell(header: true, text: "Starts on")
-        row.cell(text: primary_profile.start_date.to_s(:short))
-        row.cell(text: duplicate_profile.start_date.to_s(:short))
+        row.cell(text: primary_profile.start_date&.to_s(:short))
+        row.cell(text: duplicate_profile.start_date&.to_s(:short))
       end
       body.row do |row|
         row.cell(header: true, text: "Ends on")
         row.cell(text: primary_profile.end_date&.to_s(:short))
         row.cell(text: duplicate_profile.end_date&.to_s(:short))
+      end
+      body.row do |row|
+        row.cell(header: true, text: "Created at")
+        row.cell(text: primary_profile.created_at&.to_s(:short))
+        row.cell(text: duplicate_profile.created_at&.to_s(:short))
+      end
+      body.row do |row|
+        row.cell(header: true, text: "Updated at")
+        row.cell(text: primary_profile.updated_at&.to_s(:short))
+        row.cell(text: duplicate_profile.updated_at&.to_s(:short))
       end
       body.row { |row| comparative_table_row_for(row: row, header: "Declaration count", method: :declaration_count, primary_profile:, duplicate_profile:) }
     end

--- a/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
@@ -5,7 +5,7 @@
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Lead provider" }
-    row.value  { induction_record.lead_provider.name }
+    row.value  { induction_record.lead_provider&.name }
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Cohort" }
@@ -34,5 +34,9 @@
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key    { "Training status" }
     row.value  { induction_record.training_status }
+  end
+  summary_list.row(classes: "govuk-body-s") do |row|
+    row.key    { "Induction Programme Type" }
+    row.value  { induction_record.induction_programme.training_programme }
   end
 end %>

--- a/app/views/finance/ecf/duplicates/show.html.erb
+++ b/app/views/finance/ecf/duplicates/show.html.erb
@@ -53,7 +53,7 @@
               row.cell(text: participant_profile.training_status)
               row.cell(text: participant_profile.provider_name)
               row.cell(text: participant_profile.school_name)
-              row.cell(text: participant_profile.start_date.to_date.to_s(:govuk_short))
+              row.cell(text: participant_profile.start_date&.to_date&.to_s(:govuk_short))
               row.cell(text: participant_profile.end_date&.to_date&.to_s(:govuk_short))
               row.cell(text: participant_profile.declaration_count)
               row.cell do

--- a/db/migrate/20221025074937_update_ecf_duplicates_to_version_2.rb
+++ b/db/migrate/20221025074937_update_ecf_duplicates_to_version_2.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateECFDuplicatesToVersion2 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :ecf_duplicates, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_29_104505) do
+ActiveRecord::Schema.define(version: 2022_10_25_074937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1098,6 +1098,15 @@ ActiveRecord::Schema.define(version: 2022_09_29_104505) do
       SELECT participant_identities.user_id,
       participant_identities.external_identifier,
       participant_profiles.id,
+      participant_profiles.created_at,
+      participant_profiles.updated_at,
+      first_value(participant_profiles.id) OVER (PARTITION BY participant_identities.user_id ORDER BY
+          CASE
+              WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1
+              WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text <> 'active'::text)) THEN 2
+              WHEN (((latest_induction_records.training_status)::text <> 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 3
+              ELSE 4
+          END) AS primary_participant_profile_id,
           CASE participant_profiles.type
               WHEN 'ParticipantProfile::Mentor'::text THEN 'mentor'::text
               ELSE 'ect'::text
@@ -1111,28 +1120,22 @@ ActiveRecord::Schema.define(version: 2022_09_29_104505) do
       latest_induction_records.school_transfer,
       latest_induction_records.school_id,
       latest_induction_records.school_name,
+      latest_induction_records.lead_provider_name AS provider_name,
+      latest_induction_records.training_programme,
       schedules.schedule_identifier,
       cohorts.start_year AS cohort,
-      lead_providers.name AS provider_name,
       teacher_profiles.trn AS teacher_profile_trn,
       teacher_profiles.id AS teacher_profile_id,
       COALESCE(declarations.count, (0)::bigint) AS declaration_count,
-      row_number() OVER (PARTITION BY participant_profiles.participant_identity_id ORDER BY
+      row_number() OVER (PARTITION BY participant_identities.user_id ORDER BY
           CASE
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text <> 'active'::text)) THEN 2
               WHEN (((latest_induction_records.training_status)::text <> 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 3
               ELSE 4
-          END) AS participant_profile_status,
-      first_value(participant_profiles.id) OVER (PARTITION BY participant_profiles.participant_identity_id ORDER BY
-          CASE
-              WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1
-              WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text <> 'active'::text)) THEN 2
-              WHEN (((latest_induction_records.training_status)::text <> 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 3
-              ELSE 4
-          END) AS primary_participant_profile_id
-     FROM ((((((((participant_profiles
-       JOIN ( SELECT induction_records.id,
+          END) AS participant_profile_status
+     FROM (((((((participant_profiles
+       LEFT JOIN ( SELECT induction_records.id,
               induction_records.induction_programme_id,
               induction_records.participant_profile_id,
               induction_records.schedule_id,
@@ -1149,34 +1152,36 @@ ActiveRecord::Schema.define(version: 2022_09_29_104505) do
               partnerships.lead_provider_id,
               schools.id AS school_id,
               schools.name AS school_name,
-              lead_providers_1.name AS lead_provider_name,
-              row_number() OVER (PARTITION BY induction_records.participant_profile_id, partnerships.lead_provider_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
+              lead_providers.name AS lead_provider_name,
+              induction_programmes.training_programme,
+              row_number() OVER (PARTITION BY induction_records.participant_profile_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
              FROM ((((induction_records
                JOIN induction_programmes ON ((induction_programmes.id = induction_records.induction_programme_id)))
-               JOIN partnerships ON ((partnerships.id = induction_programmes.partnership_id)))
-               JOIN lead_providers lead_providers_1 ON ((lead_providers_1.id = partnerships.lead_provider_id)))
-               JOIN schools ON ((schools.id = partnerships.school_id)))) latest_induction_records ON (((latest_induction_records.participant_profile_id = participant_profiles.id) AND (latest_induction_records.induction_record_sort_order = 1))))
-       JOIN lead_providers ON ((lead_providers.id = latest_induction_records.lead_provider_id)))
-       JOIN ( SELECT count(*) AS count,
-              participant_profiles_1.participant_identity_id
-             FROM participant_profiles participant_profiles_1
-            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
-            GROUP BY participant_profiles_1.participant_identity_id) duplicates ON ((duplicates.participant_identity_id = participant_profiles.participant_identity_id)))
+               LEFT JOIN partnerships ON ((partnerships.id = induction_programmes.partnership_id)))
+               LEFT JOIN lead_providers ON ((lead_providers.id = partnerships.lead_provider_id)))
+               LEFT JOIN schools ON ((schools.id = partnerships.school_id)))) latest_induction_records ON (((latest_induction_records.participant_profile_id = participant_profiles.id) AND (latest_induction_records.induction_record_sort_order = 1))))
        JOIN participant_identities ON ((participant_identities.id = participant_profiles.participant_identity_id)))
-       JOIN teacher_profiles ON ((teacher_profiles.id = participant_profiles.teacher_profile_id)))
-       JOIN schedules ON ((latest_induction_records.schedule_id = schedules.id)))
-       JOIN cohorts ON ((schedules.cohort_id = cohorts.id)))
+       JOIN ( SELECT participant_identities_1.user_id,
+              count(*) AS count
+             FROM (participant_profiles participant_profiles_1
+               JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
+            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
+            GROUP BY participant_profiles_1.type, participant_identities_1.user_id) duplicates ON ((duplicates.user_id = participant_identities.user_id)))
+       LEFT JOIN teacher_profiles ON ((teacher_profiles.id = participant_profiles.teacher_profile_id)))
+       LEFT JOIN schedules ON ((latest_induction_records.schedule_id = schedules.id)))
+       LEFT JOIN cohorts ON ((schedules.cohort_id = cohorts.id)))
        LEFT JOIN ( SELECT participant_declarations.participant_profile_id,
-              participant_declarations.cpd_lead_provider_id,
               count(*) AS count
              FROM participant_declarations
-            GROUP BY participant_declarations.participant_profile_id, participant_declarations.cpd_lead_provider_id) declarations ON (((participant_profiles.id = declarations.participant_profile_id) AND (lead_providers.cpd_lead_provider_id = declarations.cpd_lead_provider_id))))
-    WHERE (participant_profiles.participant_identity_id IN ( SELECT participant_profiles_1.participant_identity_id
-             FROM participant_profiles participant_profiles_1
+            GROUP BY participant_declarations.participant_profile_id) declarations ON ((participant_profiles.id = declarations.participant_profile_id)))
+    WHERE (participant_identities.user_id IN ( SELECT participant_identities_1.user_id
+             FROM ((participant_profiles participant_profiles_1
+               JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
+               JOIN users ON ((users.id = participant_identities_1.user_id)))
             WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
-            GROUP BY participant_profiles_1.type, participant_profiles_1.participant_identity_id
+            GROUP BY participant_profiles_1.type, participant_identities_1.user_id
            HAVING (count(*) > 1)))
-    ORDER BY participant_identities.external_identifier, (row_number() OVER (PARTITION BY participant_profiles.participant_identity_id ORDER BY
+    ORDER BY participant_identities.external_identifier, (row_number() OVER (PARTITION BY participant_identities.user_id ORDER BY
           CASE
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text <> 'active'::text)) THEN 2

--- a/db/views/ecf_duplicates_v02.sql
+++ b/db/views/ecf_duplicates_v02.sql
@@ -1,0 +1,80 @@
+SELECT
+  participant_identities.user_id AS user_id,
+  participant_identities.external_identifier AS external_identifier,
+  participant_profiles.id,
+  participant_profiles.created_at,
+  participant_profiles.updated_at,
+  FIRST_VALUE(participant_profiles.id) OVER (
+               PARTITION BY participant_identities.user_id
+               ORDER BY CASE
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status = 'active' THEN 1
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status != 'active' THEN 2
+               WHEN latest_induction_records.training_status != 'active' AND latest_induction_records.induction_status = 'active' THEN 3
+               ELSE 4 END
+  ) AS primary_participant_profile_id,
+  CASE participant_profiles.type WHEN 'ParticipantProfile::Mentor' THEN 'mentor' ELSE 'ect' END AS profile_type,
+  duplicates.count            AS duplicate_profile_count,
+  latest_induction_records.id AS latest_induction_record_id,
+  latest_induction_records.induction_status,
+  latest_induction_records.training_status,
+  latest_induction_records.start_date,
+  latest_induction_records.end_date,
+  latest_induction_records.school_transfer,
+  latest_induction_records.school_id,
+  latest_induction_records.school_name,
+  latest_induction_records.lead_provider_name  AS provider_name,
+  latest_induction_records.training_programme,
+  schedules.schedule_identifier,
+  cohorts.start_year   AS cohort,
+  teacher_profiles.trn AS teacher_profile_trn,
+  teacher_profiles.id  AS teacher_profile_id,
+  COALESCE(declarations.count, 0) AS declaration_count,
+  ROW_NUMBER() OVER (
+               PARTITION BY participant_identities.user_id
+               ORDER BY CASE
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status = 'active' THEN 1
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status != 'active' THEN 2
+               WHEN latest_induction_records.training_status != 'active' AND latest_induction_records.induction_status = 'active' THEN 3
+               ELSE 4 END
+  ) AS participant_profile_status
+FROM participant_profiles
+LEFT OUTER JOIN (
+     SELECT
+       induction_records.*,
+       partnerships.lead_provider_id,
+       schools.id AS school_id,
+       schools.name AS school_name,
+       lead_providers.name AS lead_provider_name,
+       induction_programmes.training_programme AS training_programme,
+       ROW_NUMBER() OVER (PARTITION BY participant_profile_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
+     FROM induction_records
+     JOIN induction_programmes ON induction_programmes.id = induction_records.induction_programme_id
+     LEFT OUTER JOIN partnerships         ON partnerships.id         = induction_programmes.partnership_id
+     LEFT OUTER JOIN lead_providers       ON lead_providers.id       = partnerships.lead_provider_id
+     LEFT OUTER JOIN schools              ON schools.id              = partnerships.school_id
+) AS latest_induction_records ON latest_induction_records.participant_profile_id = participant_profiles.id AND induction_record_sort_order = 1
+JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+JOIN (
+      SELECT
+        user_id,
+        COUNT(*) as count
+      FROM participant_profiles
+      JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+      WHERE type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      GROUP BY type, user_id
+) AS duplicates ON duplicates.user_id = participant_identities.user_id
+LEFT OUTER JOIN teacher_profiles ON teacher_profiles.id = participant_profiles.teacher_profile_id
+LEFT OUTER JOIN schedules ON latest_induction_records.schedule_id = schedules.id
+LEFT OUTER JOIN cohorts ON schedules.cohort_id = cohorts.id
+LEFT OUTER JOIN (
+     SELECT participant_profile_id, COUNT(*) AS count FROM participant_declarations GROUP BY participant_profile_id
+) AS declarations ON participant_profiles.id = declarations.participant_profile_id
+WHERE participant_identities.user_id IN (
+      SELECT user_id
+      FROM participant_profiles
+      JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+      JOIN users ON users.id = participant_identities.user_id
+      WHERE type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      GROUP BY type, user_id
+      HAVING COUNT(*) > 1)
+ORDER BY participant_identities.external_identifier ASC, participant_profile_status ASC, participant_profiles.created_at DESC;


### PR DESCRIPTION
co-authored with @StupidCodeFactory 

### Context
After manually inspecting records we found the following:
- Some induction records don't have lead providers
- Transferred participants can have induction records belonging to multiple lead providers
- Participants have multiple identities

- Ticket: n/a

### Changes proposed in this pull request
Amend duplicate query to:
- Account for induction records not linked to lead providers
- Group declarations by profile only to avoid not linking to them in the UI if we have multiple lead providers
- Join on user_id rather than external id on profiles to include ones with multiple identities
- Account for transferred participants 
- Surface timestamps and induction programme types in UI 
### Guidance to review
