### PR TITLE
Fix manual validation exporter

### DIFF
--- a/app/services/exporters/manual_validation.rb
+++ b/app/services/exporters/manual_validation.rb
@@ -46,10 +46,10 @@ private
       puts [profile.participant_identity.user.id,
             profile.participant_identity.user.email,
             profile.type,
-            profile.ecf_participant_validation_data.full_name,
-            profile.ecf_participant_validation_data.date_of_birth,
-            profile.ecf_participant_validation_data.trn,
-            profile.ecf_participant_validation_data.nino].join(",")
+            profile.ecf_participant_validation_data&.full_name,
+            profile.ecf_participant_validation_data&.date_of_birth,
+            profile.ecf_participant_validation_data&.trn,
+            profile.ecf_participant_validation_data&.nino].join(",")
     end
   end
 end


### PR DESCRIPTION
### Context

Manual validation exporter can fail if the validation data is `nil`.  This prevents it from generating an error.



