### PR TITLE
Ignore NPQ profiles in duplicate query

### DIFF
--- a/app/views/finance/ecf/duplicates/compare/_details.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_details.html.erb
@@ -20,23 +20,23 @@
       body.row { |row| comparative_table_row_for(row: row, header: "School", method: :school_name, primary_profile:, duplicate_profile:) }
       body.row do |row|
         row.cell(header: true, text: "Starts on")
-        row.cell(text: primary_profile.start_date&.to_s(:short))
-        row.cell(text: duplicate_profile.start_date&.to_s(:short))
+        row.cell(text: primary_profile.start_date&.to_s(:govuk))
+        row.cell(text: duplicate_profile.start_date&.to_s(:govuk))
       end
       body.row do |row|
         row.cell(header: true, text: "Ends on")
-        row.cell(text: primary_profile.end_date&.to_s(:short))
-        row.cell(text: duplicate_profile.end_date&.to_s(:short))
+        row.cell(text: primary_profile.end_date&.to_s(:govuk))
+        row.cell(text: duplicate_profile.end_date&.to_s(:govuk))
       end
       body.row do |row|
         row.cell(header: true, text: "Created at")
-        row.cell(text: primary_profile.created_at&.to_s(:short))
-        row.cell(text: duplicate_profile.created_at&.to_s(:short))
+        row.cell(text: primary_profile.created_at&.to_s(:govuk))
+        row.cell(text: duplicate_profile.created_at&.to_s(:govuk))
       end
       body.row do |row|
         row.cell(header: true, text: "Updated at")
-        row.cell(text: primary_profile.updated_at&.to_s(:short))
-        row.cell(text: duplicate_profile.updated_at&.to_s(:short))
+        row.cell(text: primary_profile.updated_at&.to_s(:govuk))
+        row.cell(text: duplicate_profile.updated_at&.to_s(:govuk))
       end
       body.row { |row| comparative_table_row_for(row: row, header: "Declaration count", method: :declaration_count, primary_profile:, duplicate_profile:) }
     end

--- a/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
@@ -17,15 +17,15 @@
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Starts on" }
-    row.value { induction_record.start_date.to_s(:short) }
+    row.value { induction_record.start_date.to_s(:govuk) }
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key    { "Ends on" }
-    row.value  { induction_record.end_date&.to_s(:short) }
+    row.value  { induction_record.end_date&.to_s(:govuk) }
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key    { "Preferred email" }
-    row.value  { induction_record.preferred_identity.email }
+    row.value  { induction_record.preferred_identity&.email }
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key    { "Induction status" }

--- a/app/views/finance/ecf/duplicates/compare/_induction_records.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_induction_records.html.erb
@@ -3,7 +3,7 @@
     <h2 class="govuk-headding-s">Primary profile induction records</h2>
     <% if primary_profile.induction_records.any? %>
       <% primary_profile.induction_records.includes(:cpd_lead_provider).order(created_at: :desc).each do |induction_record| %>
-        <%= govuk_details(summary_text: "View induction record created at #{induction_record.created_at.to_s(:govuk_short)}") do
+        <%= govuk_details(summary_text: "View induction record created at #{induction_record.created_at.to_s(:govuk)}") do
           render "induction_record_summary_list", induction_record: induction_record
         end %>
       <% end %>
@@ -15,7 +15,7 @@
     <h2 class="govuk-headding-s">Duplicate profile induction records</h2>
     <% if duplicate_profile.induction_records.any? %>
       <% duplicate_profile.induction_records.includes(:cpd_lead_provider).order(created_at: :desc).each do |induction_record| %>
-        <%= govuk_details(summary_text: "View induction record created at #{induction_record.created_at.to_s(:govuk_short)}") do
+        <%= govuk_details(summary_text: "View induction record created at #{induction_record.created_at.to_s(:govuk)}") do
           render "induction_record_summary_list", induction_record: induction_record
         end %>
       <% end %>

--- a/app/views/finance/ecf/duplicates/compare/_participant_declaration_summary_list.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_participant_declaration_summary_list.html.erb
@@ -17,7 +17,7 @@
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Declaration date" }
-    row.value { participant_declaration.declaration_date.to_s(:short) }
+    row.value { participant_declaration.declaration_date.to_s(:govuk) }
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Course" }
@@ -37,10 +37,10 @@
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Updated at" }
-    row.value { participant_declaration.updated_at.to_s(:short) }
+    row.value { participant_declaration.updated_at.to_s(:govuk) }
   end
   summary_list.row(classes: "govuk-body-s") do |row|
     row.key { "Created at" }
-    row.value { participant_declaration.created_at.to_s(:short) }
+    row.value { participant_declaration.created_at.to_s(:govuk) }
   end
 end %>

--- a/app/views/finance/ecf/duplicates/show.html.erb
+++ b/app/views/finance/ecf/duplicates/show.html.erb
@@ -36,8 +36,8 @@
             row.cell(text: @participant_profile.training_status)
             row.cell(text: @participant_profile.provider_name)
             row.cell(text: @participant_profile.school_name)
-            row.cell(text: @participant_profile.start_date.to_date.to_s(:govuk_short))
-            row.cell(text: @participant_profile.end_date&.to_date&.to_s(:govuk_short))
+            row.cell(text: @participant_profile.start_date.to_date.to_s(:govuk))
+            row.cell(text: @participant_profile.end_date&.to_date&.to_s(:govuk))
             row.cell(text: @participant_profile.declaration_count)
             row.cell {}
           end
@@ -53,8 +53,8 @@
               row.cell(text: participant_profile.training_status)
               row.cell(text: participant_profile.provider_name)
               row.cell(text: participant_profile.school_name)
-              row.cell(text: participant_profile.start_date&.to_date&.to_s(:govuk_short))
-              row.cell(text: participant_profile.end_date&.to_date&.to_s(:govuk_short))
+              row.cell(text: participant_profile.start_date&.to_date&.to_s(:govuk))
+              row.cell(text: participant_profile.end_date&.to_date&.to_s(:govuk))
               row.cell(text: participant_profile.declaration_count)
               row.cell do
                 govuk_link_to "View details", finance_ecf_duplicate_compare_path(participant_profile, @participant_profile)

--- a/db/migrate/20221026073938_update_ecf_duplicates_to_version_3.rb
+++ b/db/migrate/20221026073938_update_ecf_duplicates_to_version_3.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateECFDuplicatesToVersion3 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :ecf_duplicates, version: 3, revert_to_version: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_25_074937) do
+ActiveRecord::Schema.define(version: 2022_10_26_073938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1174,13 +1174,12 @@ ActiveRecord::Schema.define(version: 2022_10_25_074937) do
               count(*) AS count
              FROM participant_declarations
             GROUP BY participant_declarations.participant_profile_id) declarations ON ((participant_profiles.id = declarations.participant_profile_id)))
-    WHERE (participant_identities.user_id IN ( SELECT participant_identities_1.user_id
-             FROM ((participant_profiles participant_profiles_1
+    WHERE ((participant_identities.user_id IN ( SELECT participant_identities_1.user_id
+             FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-               JOIN users ON ((users.id = participant_identities_1.user_id)))
             WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id
-           HAVING (count(*) > 1)))
+           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[])))
     ORDER BY participant_identities.external_identifier, (row_number() OVER (PARTITION BY participant_identities.user_id ORDER BY
           CASE
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1

--- a/db/views/ecf_duplicates_v03.sql
+++ b/db/views/ecf_duplicates_v03.sql
@@ -1,0 +1,80 @@
+SELECT
+  participant_identities.user_id AS user_id,
+  participant_identities.external_identifier AS external_identifier,
+  participant_profiles.id,
+  participant_profiles.created_at,
+  participant_profiles.updated_at,
+  FIRST_VALUE(participant_profiles.id) OVER (
+               PARTITION BY participant_identities.user_id
+               ORDER BY CASE
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status = 'active' THEN 1
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status != 'active' THEN 2
+               WHEN latest_induction_records.training_status != 'active' AND latest_induction_records.induction_status = 'active' THEN 3
+               ELSE 4 END
+  ) AS primary_participant_profile_id,
+  CASE participant_profiles.type WHEN 'ParticipantProfile::Mentor' THEN 'mentor' ELSE 'ect' END AS profile_type,
+  duplicates.count            AS duplicate_profile_count,
+  latest_induction_records.id AS latest_induction_record_id,
+  latest_induction_records.induction_status,
+  latest_induction_records.training_status,
+  latest_induction_records.start_date,
+  latest_induction_records.end_date,
+  latest_induction_records.school_transfer,
+  latest_induction_records.school_id,
+  latest_induction_records.school_name,
+  latest_induction_records.lead_provider_name  AS provider_name,
+  latest_induction_records.training_programme,
+  schedules.schedule_identifier,
+  cohorts.start_year   AS cohort,
+  teacher_profiles.trn AS teacher_profile_trn,
+  teacher_profiles.id  AS teacher_profile_id,
+  COALESCE(declarations.count, 0) AS declaration_count,
+  ROW_NUMBER() OVER (
+               PARTITION BY participant_identities.user_id
+               ORDER BY CASE
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status = 'active' THEN 1
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status != 'active' THEN 2
+               WHEN latest_induction_records.training_status != 'active' AND latest_induction_records.induction_status = 'active' THEN 3
+               ELSE 4 END
+  ) AS participant_profile_status
+FROM participant_profiles
+LEFT OUTER JOIN (
+     SELECT
+       induction_records.*,
+       partnerships.lead_provider_id,
+       schools.id AS school_id,
+       schools.name AS school_name,
+       lead_providers.name AS lead_provider_name,
+       induction_programmes.training_programme AS training_programme,
+       ROW_NUMBER() OVER (PARTITION BY participant_profile_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
+     FROM induction_records
+     JOIN induction_programmes ON induction_programmes.id = induction_records.induction_programme_id
+     LEFT OUTER JOIN partnerships         ON partnerships.id         = induction_programmes.partnership_id
+     LEFT OUTER JOIN lead_providers       ON lead_providers.id       = partnerships.lead_provider_id
+     LEFT OUTER JOIN schools              ON schools.id              = partnerships.school_id
+) AS latest_induction_records ON latest_induction_records.participant_profile_id = participant_profiles.id AND induction_record_sort_order = 1
+JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+JOIN (
+      SELECT
+        user_id,
+        COUNT(*) as count
+      FROM participant_profiles
+      JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+      WHERE type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      GROUP BY type, user_id
+) AS duplicates ON duplicates.user_id = participant_identities.user_id
+LEFT OUTER JOIN teacher_profiles ON teacher_profiles.id = participant_profiles.teacher_profile_id
+LEFT OUTER JOIN schedules ON latest_induction_records.schedule_id = schedules.id
+LEFT OUTER JOIN cohorts ON schedules.cohort_id = cohorts.id
+LEFT OUTER JOIN (
+     SELECT participant_profile_id, COUNT(*) AS count FROM participant_declarations GROUP BY participant_profile_id
+) AS declarations ON participant_profiles.id = declarations.participant_profile_id
+WHERE participant_identities.user_id IN (
+      SELECT user_id
+      FROM participant_profiles
+      JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+      WHERE type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      GROUP BY type, user_id
+      HAVING COUNT(*) > 1)
+     AND participant_profiles.type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+ORDER BY participant_identities.external_identifier ASC, participant_profile_status ASC, participant_profiles.created_at DESC;


### PR DESCRIPTION
### Context
We were surfacing NPQ profiles in duplicates.

- Ticket: n/a

### Changes proposed in this pull request
- Ignore none ECF profiles when calculating duplicates
- Show normal `govuk` date format instead of short as we want to see the year
- Account for missing identities when showing preferred email

### Guidance to review

