### PR TITLE
Fix Axe failure on having empty table headers

### DIFF
--- a/app/views/lead_providers/report_schools/confirm/show.html.erb
+++ b/app/views/lead_providers/report_schools/confirm/show.html.erb
@@ -16,7 +16,7 @@
       <th scope="col" class="govuk-table__header">Local Authority</th>
       <!-- <th scope="col" class="govuk-table__header">MAT/Network</th> -->
       <th scope="col" class="govuk-table__header">Delivery partner</th>
-      <th scope="col" class="govuk-table__header"></th>
+      <th scope="col" class="govuk-table__header">Actions</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">


### PR DESCRIPTION
### Context

> Table header elements should have visible text that describes the purpose of the row or column to both sighted users and screen reader users.

https://dequeuniversity.com/rules/axe/4.1/empty-table-header

This is currently blocking

### How it looked before this change

![Screenshot from 2022-10-26 10-07-44](https://user-images.githubusercontent.com/128088/197989877-2a8cdd8d-b7d4-4018-ab2e-08d3ac33189f.png)
 #2656



