### PR TITLE
Explicity define cohort years in school cohorts

### DIFF
--- a/spec/requests/admin/schools/cohort_2020_spec.rb
+++ b/spec/requests/admin/schools/cohort_2020_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Admin::Schools::Cohort2020", type: :request do
   let(:cohort_2020) { create(:cohort, start_year: 2020) }
   let(:school_cohort) { create(:school_cohort, :cip, cohort: cohort_2020, school:, core_induction_programme: cip) }
   let!(:participants) { create_list(:ect_participant_profile, 5, school_cohort:) }
-  let(:other_cohort) { create(:cohort) }
-  let(:other_school_cohort) { create(:school_cohort, :cip, cohort: other_cohort, school: school_cohort.school, core_induction_programme: cip) }
+  let(:cohort_2021) { Cohort.find_by(start_year: 2021) }
+  let(:other_school_cohort) { create(:school_cohort, :cip, cohort: cohort_2021, school: school_cohort.school, core_induction_programme: cip) }
   let!(:other_participants) { create_list(:ect_participant_profile, 5, school_cohort: other_school_cohort) }
 
   before do
@@ -62,7 +62,7 @@ RSpec.describe "Admin::Schools::Cohort2020", type: :request do
     end
 
     context "when there is an active ECT with that email" do
-      let!(:participant_profile) { create(:ect_participant_profile) }
+      let!(:participant_profile) { create(:ect_participant_profile, school_cohort: build(:school_cohort, cohort: cohort_2021)) }
       let(:name) { participant_profile.user.full_name }
       let(:email) { participant_profile.user.email }
 


### PR DESCRIPTION
### Context
The Factory when creating a cohort can create cohorts in years 2055, which might override the `active_registration_cohort` scope.

In the flakey spec we are creating a school cohort for a participant using the current year, so when the validation check kicks in this record isn't returned as the `active_registration_cohort` is different.

Explicitly set cohort years so we don't get failures.

- Ticket: 

### Changes proposed in this pull request

### Guidance to review

example of failure: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3328033619/jobs/5503552423
