### PR TITLE
Fix manual validation importer

### DIFF
--- a/app/services/importers/ecf_manual_validation.rb
+++ b/app/services/importers/ecf_manual_validation.rb
@@ -2,53 +2,82 @@
 
 class Importers::ECFManualValidation < BaseService
   def call
-    check_headers
+    check_headers!
 
     rows.each do |row|
-      user = Identity.find_user_by(id: row["id"])
+      participant_profile = get_profile(row["id"]) || next
 
-      if user.nil?
-        puts "No profile found for #{row['id']}. Skipping"
-        next
-      end
-
-      participant_profile = user.teacher_profile.current_ecf_profile
-      if participant_profile.nil?
-        puts "No profile found for #{row['id']}. Skipping"
-        next
-      end
+      prepare_profile(participant_profile)
 
       Participants::ParticipantValidationForm.call(
         participant_profile,
-        save_validation_data_without_match: false,
+        save_validation_data_without_match: true,
         data: {
           trn: row["trn"],
           nino: row["nino"],
-          dob: Date.parse(row["dob"]),
+          date_of_birth: safe_parse(row["dob"]),
           full_name: row["name"],
         },
       )
 
-      if participant_profile.ecf_participant_eligibility.nil?
-        puts "No match found #{row['id']}"
-        next
-      end
-
-      unless participant_profile.ecf_participant_eligibility.eligible_status?
-        puts "#{participant_profile.ecf_participant_eligibility.reason} #{row['id']}"
+      if participant_profile.reload.ecf_participant_eligibility.nil?
+        logger.warn "No match found #{row['id']}"
+      elsif !participant_profile.ecf_participant_eligibility.eligible_status?
+        logger.warn "#{participant_profile.ecf_participant_eligibility.reason} #{row['id']}"
       end
     end
   end
 
 private
 
-  attr_reader :path_to_csv
+  attr_reader :path_to_csv, :logger
 
-  def initialize(path_to_csv:)
+  def initialize(path_to_csv:, logger: Rails.logger)
     @path_to_csv = path_to_csv
+    @logger = logger
   end
 
-  def check_headers
+  def get_profile(id)
+    user = Identity.find_user_by(id:)
+    if user.nil?
+      logger.warn "No profile found for #{id}. Skipping"
+      return
+    end
+
+    ecf_profiles = user.teacher_profile.ecf_profiles
+
+    if ecf_profiles.empty?
+      logger.warn "No profile found for #{id}. Skipping"
+      return
+    elsif ecf_profiles.count > 1
+      logger.warn "Multiple profiles found for #{id}. Skipping"
+      return
+    end
+
+    ecf_profiles.first
+  end
+
+  def prepare_profile(participant_profile)
+    # reset TRN if present on teacher profile to avoid "different trn" errors
+    # unless already set via NPQ
+    teacher_profile = participant_profile.teacher_profile
+    if teacher_profile.trn.present?
+      teacher_profile.update!(trn: nil) unless teacher_profile.participant_profiles.npqs.any?
+    end
+
+    # remove any existing eligibilty
+    participant_profile.ecf_participant_eligibility&.destroy
+  end
+
+  def safe_parse(date)
+    return if date.blank?
+    Date.parse(date)
+  rescue Date::Error
+    logger.warn "Error parsing date"
+    nil
+  end
+
+  def check_headers!
     unless %w[id name trn dob nino].all? { |header| rows.headers.include?(header) }
       raise NameError, "Invalid headers"
     end

--- a/app/services/importers/ecf_manual_validation.rb
+++ b/app/services/importers/ecf_manual_validation.rb
@@ -61,16 +61,17 @@ private
     # reset TRN if present on teacher profile to avoid "different trn" errors
     # unless already set via NPQ
     teacher_profile = participant_profile.teacher_profile
-    if teacher_profile.trn.present?
-      teacher_profile.update!(trn: nil) unless teacher_profile.participant_profiles.npqs.any?
+    if teacher_profile.trn.present? && teacher_profile.participant_profiles.npqs.none?
+      teacher_profile.update!(trn: nil)
     end
 
     # remove any existing eligibilty
-    participant_profile.ecf_participant_eligibility&.destroy
+    participant_profile.ecf_participant_eligibility&.destroy!
   end
 
   def safe_parse(date)
     return if date.blank?
+
     Date.parse(date)
   rescue Date::Error
     logger.warn "Error parsing date"

--- a/spec/fixtures/files/example_ecf_manual_validation.csv
+++ b/spec/fixtures/files/example_ecf_manual_validation.csv
@@ -1,0 +1,7 @@
+id,name,trn,dob,nino
+e9052338-6f4c-4ee6-8e12-dc1cfdc23263,Ellie Eligible,1234567,12/3/1986,QQ123456A
+0f4b8062-1e1c-45f0-8a4b-32ad860ecd7c,Nina Not-Found,9210,18/05/1978,
+2628a013-c966-4d73-8f94-740ab6c3ebb4,Martin Manual-Check,901921,21/02/1987,QQ121212B
+9bd5df46-4197-45eb-9c3c-87b27462563f,Ingrid Ineligible,9039201,19/12/1989,QQ321321A
+70f9da7f-7bd7-4db0-97b6-fcdbd2838773,Norman Nodate,1000865,,
+981a19c2-d212-4149-8f67-50dc86882d3d,Betty Bad-date,1000475,banana,

--- a/spec/services/importers/ecf_manual_validation_spec.rb
+++ b/spec/services/importers/ecf_manual_validation_spec.rb
@@ -17,16 +17,15 @@ RSpec.describe Importers::ECFManualValidation do
           tp = create(:teacher_profile, user:)
           create(:ect_participant_profile, teacher_profile: tp)
         end
+
+        allow(Participants::ParticipantValidationForm).to receive(:call).exactly(6).times
       end
 
       it "calls the validation service for each participant" do
-        expect(Participants::ParticipantValidationForm).to receive(:call).exactly(6).times
         importer.call(path_to_csv: example_csv_file)
       end
 
-      it "does handles bad or empty dates" do
-        expect(Participants::ParticipantValidationForm).to receive(:call).exactly(6).times
-
+      it "handles bad or empty dates" do
         expect {
           importer.call(path_to_csv: example_csv_file)
         }.not_to raise_error

--- a/spec/services/importers/ecf_manual_validation_spec.rb
+++ b/spec/services/importers/ecf_manual_validation_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Importers::ECFManualValidation do
       before do
         users = []
         CSV.read(example_csv_file, headers: true).each { |row| users << create(:user, id: row["id"], full_name: row["name"]) }
-        users.each { |user| tp = create(:teacher_profile, user:); create(:ect_participant_profile, teacher_profile: tp) }
+        users.each do |user|
+          tp = create(:teacher_profile, user:)
+          create(:ect_participant_profile, teacher_profile: tp)
+        end
       end
 
       it "calls the validation service for each participant" do
@@ -23,7 +26,8 @@ RSpec.describe Importers::ECFManualValidation do
 
       it "does handles bad or empty dates" do
         expect(Participants::ParticipantValidationForm).to receive(:call).exactly(6).times
-        expect { 
+
+        expect {
           importer.call(path_to_csv: example_csv_file)
         }.not_to raise_error
       end

--- a/spec/services/importers/ecf_manual_validation_spec.rb
+++ b/spec/services/importers/ecf_manual_validation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "csv"
+
+RSpec.describe Importers::ECFManualValidation do
+  let(:example_csv_file) { file_fixture "example_ecf_manual_validation.csv" }
+
+  subject(:importer) { described_class }
+
+  describe ".call" do
+    context "when participants exist" do
+      before do
+        users = []
+        CSV.read(example_csv_file, headers: true).each { |row| users << create(:user, id: row["id"], full_name: row["name"]) }
+        users.each { |user| tp = create(:teacher_profile, user:); create(:ect_participant_profile, teacher_profile: tp) }
+      end
+
+      it "calls the validation service for each participant" do
+        expect(Participants::ParticipantValidationForm).to receive(:call).exactly(6).times
+        importer.call(path_to_csv: example_csv_file)
+      end
+
+      it "does handles bad or empty dates" do
+        expect(Participants::ParticipantValidationForm).to receive(:call).exactly(6).times
+        expect { 
+          importer.call(path_to_csv: example_csv_file)
+        }.not_to raise_error
+      end
+    end
+
+    context "when matching participants do not exist" do
+      it "does not call the validation service" do
+        expect(Participants::ParticipantValidationForm).not_to receive(:call)
+        importer.call(path_to_csv: example_csv_file)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

ECF manual validation importer had issues with using `current_ecf_profile`, passing a wrong param name and not handling `nil` dates, so refactored to correct these.


