### PR TITLE
Check prev partnership exists before traversing

### DIFF
--- a/app/controllers/schools/setup_school_cohort_controller.rb
+++ b/app/controllers/schools/setup_school_cohort_controller.rb
@@ -148,6 +148,15 @@ module Schools
     def send_fip_programme_changed_email!
       previous_partnership = previous_school_cohort.default_induction_programme.partnership
 
+      if previous_partnership.blank?
+        msg = "no previous partnership found for cohort #{previous_school_cohort.id}"
+
+        Sentry.capture_message(msg, level: :warning)
+        Rails.logger.warning(msg)
+
+        return
+      end
+
       previous_partnership.lead_provider.users.each do |lead_provider_user|
         LeadProviderMailer.programme_changed_email(
           partnership: previous_partnership,


### PR DESCRIPTION
### Context

The following errror [is reported by Sentry](https://sentry.io/organizations/dfe-teacher-services/issues/3698544696/?project=5748989) when trying to notify about fip programme changes:

```
undefined method `lead_provider' for nil:NilClass
```

It happens when no partnership is found on the default_induciton_programme. I think in these cases we should emit a warning that the partnership isn't present and not try to send the email
