### PR TITLE
Ensure all node-versions are set to 16.17.x

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.5.1
         with:
-          node-version: '12.x'
+          node-version: '16.17.x'
           cache: 'yarn'
 
       - name: Set up test database

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2.5.1
         with:
-          node-version: '16.x'
+          node-version: '16.17.x'
           cache: 'yarn'
 
       - name: Install node.js dependencies


### PR DESCRIPTION
### Context

We've had a couple of failures here and there where the node version hasn't matched up with the one that's on the alpine image. Hopefully this will fix it.
