### PR TITLE
Remove TRN prior to validation unless NPQ present

### DIFF
--- a/app/controllers/admin/participants/validation_data_controller.rb
+++ b/app/controllers/admin/participants/validation_data_controller.rb
@@ -26,6 +26,7 @@ module Admin::Participants
       return unless validation_data.present? && validation_data.can_validate_participant?
 
       ActiveRecord::Base.transaction do
+        @participant_profile.teacher_profile.update!(trn: nil) unless has_npq_profile?
         @participant_profile.ecf_participant_eligibility&.destroy!
         # this returns either nil, false on failure or an ECFParticipantEligibility record on success
         Participants::ParticipantValidationForm.call(@participant_profile)
@@ -75,6 +76,10 @@ module Admin::Participants
       @participant_profile = policy_scope(ParticipantProfile).find(params[:participant_id]).tap do |participant_profile|
         authorize participant_profile, :update?, policy_class: participant_profile.policy_class
       end
+    end
+
+    def has_npq_profile?
+      @participant_profile.teacher_profile.npq_profiles.any?
     end
 
     def validation_data

--- a/spec/requests/admin/participants/change_validation_data_spec.rb
+++ b/spec/requests/admin/participants/change_validation_data_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Participants::ValidationDataController", :with_default_schedules, type: :request do
+  let(:admin_user) { create(:user, :admin) }
+
+  let(:user) { create(:user, full_name: "John Doe") }
+  let(:ect_profile) { create(:ect, user:) }
+  let!(:validation_data) { create(:ecf_participant_validation_data, participant_profile: ect_profile) }
+  let(:validation_result) { { a: "value" } }
+
+  before { sign_in(admin_user) }
+
+  describe "POST /admin/participants/:participant_id/validation-data/validate-details" do
+    before do
+      ect_profile.teacher_profile.update!(trn: "1234567")
+      allow(validation_data).to receive(:can_validate_participant?).and_return(true)
+      allow(Participants::ParticipantValidationForm).to receive(:call).and_return(validation_result).once
+      post("/admin/participants/#{ect_profile.id}/validation-data/validate-details")
+    end
+
+    it "validates the validation data" do
+      expect(response).to redirect_to("/admin/participants/#{ect_profile.id}#validation-data")
+    end
+
+    it "clears the TRN prior to validation" do
+      expect(ect_profile.reload.teacher_profile.reload.trn).to be_nil
+    end
+
+    context "when an NPQ profile is present" do
+      before do
+        create(:npq_participant_profile, trn: "1234567", user:)
+      end
+
+      it "does not remove the TRN prior to validation" do
+        expect(ect_profile.teacher_profile.trn).to eq "1234567"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We allow admins to revalidate participants but if an errant TRN is present on the teacher profile we end up with a "manual check"/"different TRN" status.  This removes any existing TRN from the `TeacherProfile` __unless__ there are any NPQ profiles present (as they would've set the TRN).

### Changes proposed in this pull request
Remove TRN from `TeacherProfile` prior to admin (re)validation

### Guidance to review

