### PR TITLE
Allow sync of email when only 1 identity

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
   has_many :npq_application_exports
 
   before_validation :strip_whitespace
+  after_update :sync_email_with_identity
 
   validates :full_name, presence: true
   validates :email, presence: true, uniqueness: true, notify_email: true
@@ -183,6 +184,12 @@ class User < ApplicationRecord
   end
 
 private
+
+  def sync_email_with_identity
+    if saved_change_to_email? && participant_identities.count == 1
+      participant_identities.original.first&.update!(email:)
+    end
+  end
 
   def strip_whitespace
     full_name&.squish!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -112,6 +112,23 @@ RSpec.describe User, type: :model do
           before do
             user.update!(email: "mary.jones@example.com")
           end
+
+          it "updates the original identity email" do
+            expect(user.participant_identities.original.first.email).to eq user.email
+          end
+
+          context "when more than 1 identity exists" do
+            let!(:identity2) { create(:participant_identity, email: "mjones@somemail.com") }
+
+            before do
+              identity2.update!(user:)
+              user.participant_identities.original.first.update!(email: "m.jones@example.com")
+            end
+
+            it "does not update the original identity email" do
+              expect(user.participant_identities.original.first.email).not_to eq user.email
+            end
+          end
         end
 
         context "when there are transferred identity records" do


### PR DESCRIPTION
### Context

Recently the sync between `User.email` and the original `ParticipantIdentity.email` was removed to facilitate easier changes to emails typically for CIP users when multiple identities are in play.  However this is causing issues when the `User` only has a single `ParticipantIdentity` and there is an expectation that they will be in sync.

### Changes proposed in this pull request
Reintroduce the sync when there is only a single identity

### Guidance to review

