### PR TITLE
[CPDLP-1866] Fix inconsistent email usage detection in users API

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -50,8 +50,8 @@ module Api
       def users
         users = User.all
         users = users.changed_since(updated_since) if updated_since.present?
-        users = users.where(email:) if email.present?
-        users
+        users = users.joins(:participant_identities).where(participant_identities: { email: }).or(users.where(email:)) if email.present?
+        users.distinct
       end
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -48,10 +48,7 @@ module Api
       end
 
       def users
-        users = User.all
-        users = users.changed_since(updated_since) if updated_since.present?
-        users = users.joins(:participant_identities).where(participant_identities: { email: }).or(users.where(email:)) if email.present?
-        users.distinct
+        Api::V1::UsersQuery.new(updated_since:, email:).all
       end
     end
   end

--- a/app/services/api/v1/users_query.rb
+++ b/app/services/api/v1/users_query.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class UsersQuery
+      attr_reader :updated_since, :email
+
+      def initialize(updated_since: nil, email: nil)
+        @updated_since = updated_since
+        @email         = email
+      end
+
+      def all
+        users = User.all
+        users = users.changed_since(updated_since) if updated_since.present?
+        users = users.left_joins(:participant_identities).where(participant_identities: { email: }).or(users.where(email:)) if email.present?
+        users.distinct
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -81,6 +81,37 @@ RSpec.describe "API Users", :with_default_schedules, type: :request do
           expect(parsed_response["data"].size).to eql(0)
         end
       end
+
+      context "when filtering by identity record email" do
+        let(:user) { create(:user, email: "fred@example.com") }
+        let!(:identity) { create(:participant_identity, user:, email: "charlie@example.com") }
+
+        context "when a matching identity record exists" do
+          it "returns the associated user record" do
+            get "/api/v1/users", params: { filter: { email: "charlie@example.com" } }
+
+            expect(parsed_response["data"].size).to eql(1)
+            expect(parsed_response.dig("data", 0, "attributes", "email")).to eql("fred@example.com")
+          end
+        end
+
+        context "when a matching user record exists" do
+          it "returns the user record" do
+            get "/api/v1/users", params: { filter: { email: "fred@example.com" } }
+
+            expect(parsed_response["data"].size).to eql(1)
+            expect(parsed_response.dig("data", 0, "attributes", "email")).to eql("fred@example.com")
+          end
+        end
+
+        context "when a matching identity or user record is not found" do
+          it "returns no users" do
+            get "/api/v1/users", params: { filter: { email: "arthur@example.com" } }
+
+            expect(parsed_response["data"].size).to eql(0)
+          end
+        end
+      end
     end
 
     context "when unauthorized" do

--- a/spec/services/api/v1/users_query_spec.rb
+++ b/spec/services/api/v1/users_query_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::UsersQuery, :with_default_schedules do
+  let!(:users) { create_list(:user, 3) }
+  let(:updated_since) { nil }
+  let(:email) { nil }
+
+  subject { described_class.new(updated_since:, email:) }
+
+  describe "#all" do
+    it "returns a list of users" do
+      expect(subject.all).to all(be_a(User))
+      expect(subject.all).to match_array(users)
+    end
+
+    context "when filtering by updated_since" do
+      let!(:user_updated_a_long_time_ago) { create(:user, updated_at: 1.year.ago) }
+      let(:updated_since) { 1.month.ago }
+
+      it "returns a list of users with updated_at timestamps later than the supplied one" do
+        expect(subject.all).to match_array(users)
+        expect(subject.all).not_to include(user_updated_a_long_time_ago)
+      end
+    end
+
+    context "when filtering by email" do
+      context "with a matching email address" do
+        let(:email) { users.last.email }
+
+        it "only returns the user record" do
+          expect(subject.all).to include(users.last)
+          expect(subject.all).not_to include(users.without(users.last))
+        end
+      end
+
+      context "with no matching email address" do
+        let(:email) { "dontexist@example.com" }
+
+        it "returns no users" do
+          expect(subject.all).to be_empty
+        end
+      end
+    end
+
+    context "when filtering by identity record email" do
+      let(:user) { create(:user, email: "fred@example.com") }
+      let!(:identity) { create(:participant_identity, user:, email: "charlie@example.com") }
+
+      context "when a matching identity record exists" do
+        let(:email) { "charlie@example.com" }
+
+        it "returns the associated user record" do
+          expect(subject.all.size).to eql(1)
+          expect(subject.all.first.email).to eql("fred@example.com")
+        end
+      end
+
+      context "when a matching user record exists" do
+        let(:email) { "fred@example.com" }
+
+        it "returns the user record" do
+          expect(subject.all.size).to eql(1)
+          expect(subject.all.first.email).to eql("fred@example.com")
+        end
+      end
+
+      context "when a matching identity or user record is not found" do
+        let(:email) { "arthur@example.com" }
+
+        it "returns no users" do
+          expect(subject.all).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/services/defer_participant_spec.rb
+++ b/spec/services/defer_participant_spec.rb
@@ -82,7 +82,7 @@ RSpec.shared_examples "validating a participant is not already deferred" do
   end
 end
 
-RSpec.shared_examples "validating a participant is not withdrawn" do
+RSpec.shared_examples "validating a participant is not withdrawn for a defer" do
   it "is invalid returning a meaningful error message" do
     is_expected.to be_invalid
 
@@ -153,7 +153,7 @@ RSpec.describe DeferParticipant, :with_default_schedules do
         let(:participant_profile) { create(:ect, :deferred) }
       end
 
-      it_behaves_like "validating a participant is not withdrawn" do
+      it_behaves_like "validating a participant is not withdrawn for a defer" do
         let(:participant_profile) { create(:ect, :withdrawn) }
       end
     end
@@ -176,7 +176,7 @@ RSpec.describe DeferParticipant, :with_default_schedules do
         let(:participant_profile) { create(:mentor, :deferred) }
       end
 
-      it_behaves_like "validating a participant is not withdrawn" do
+      it_behaves_like "validating a participant is not withdrawn for a defer" do
         let(:participant_profile) { create(:mentor, :withdrawn) }
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe DeferParticipant, :with_default_schedules do
         let(:participant_profile) { create(:npq_participant_profile, :deferred) }
       end
 
-      it_behaves_like "validating a participant is not withdrawn" do
+      it_behaves_like "validating a participant is not withdrawn for a defer" do
         let(:participant_profile) { create(:npq_participant_profile, :withdrawn) }
       end
     end

--- a/spec/services/resume_participants_spec.rb
+++ b/spec/services/resume_participants_spec.rb
@@ -62,7 +62,7 @@ RSpec.shared_examples "validating a participant is not already active" do
   end
 end
 
-RSpec.shared_examples "validating a participant is not withdrawn" do
+RSpec.shared_examples "validating a participant is not withdrawn for a resume" do
   it "is invalid returning a meaningful error message" do
     is_expected.to be_invalid
 
@@ -130,7 +130,7 @@ RSpec.describe ResumeParticipant, :with_default_schedules do
         let(:participant_profile) { create(:ect) }
       end
 
-      it_behaves_like "validating a participant is not withdrawn" do
+      it_behaves_like "validating a participant is not withdrawn for a resume" do
         let(:participant_profile) { create(:ect, :withdrawn) }
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe ResumeParticipant, :with_default_schedules do
         let(:participant_profile) { create(:mentor) }
       end
 
-      it_behaves_like "validating a participant is not withdrawn" do
+      it_behaves_like "validating a participant is not withdrawn for a resume" do
         let(:participant_profile) { create(:mentor, :withdrawn) }
       end
     end
@@ -176,7 +176,7 @@ RSpec.describe ResumeParticipant, :with_default_schedules do
         let(:participant_profile) { create(:npq_participant_profile) }
       end
 
-      it_behaves_like "validating a participant is not withdrawn" do
+      it_behaves_like "validating a participant is not withdrawn for a resume" do
         let(:participant_profile) { create(:npq_participant_profile, :withdrawn) }
       end
     end


### PR DESCRIPTION
### Context

Fix inconsistent email usage detection in users API

- Ticket: [CPDLP-1866](https://dfedigital.atlassian.net/browse/CPDLP-1866)

### Changes proposed in this pull request
There is a disconnect between the user lookup and user creation API endpoints. When attempting to sync a user from NPQ to the CPD database an “Email already in use” error occurred during user creation after a user lookup via that email returned no user. 

This is happening because GET /api/v1/users (Api::V1::UsersController#index) is using .where(email:) to find the relevant users instead of looking up via Identity. This is causing issues when a user is looked up via an email that isn’t in the direct email field on the User record but is attached to it elsewhere.

