### PR TITLE
Use method stubs to avoid relying on Postgres `Date(now())`

### DIFF
--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -457,6 +457,8 @@ module Steps
     end
 
     def then_the_finance_portal_shows_the_lead_provider_payment_breakdown(lead_provider_name, statement_name, total_ects, total_mentors, started, retained, completed, voided, uplift: true)
+      allow(Finance::Statement::ECF).to receive(:current).and_return(Finance::Statement::ECF.find_by(cohort: Cohort.current, cpd_lead_provider: CpdLeadProvider.find_by(name: lead_provider_name), name: statement_name))
+
       when_i_am_on_the_finance_portal
       and_i_view_payment_breakdown_from_the_finance_portal
       and_i_complete_from_the_finance_payment_breakdown_report_wizard lead_provider_name


### PR DESCRIPTION
### Context
When rendering the finance statements page we rely on this scope:
https://github.com/DFE-Digital/early-careers-framework/blob/develop/app/models/finance/statement.rb#L34
Which uses a Postgres `DATE(NOW())` timestamp. This supersedes time traveling in the specs and returns the latest statement according the time now.

We extract the cohort param from the latest statement, which meant we were defaulting to 2022. This means we didn't find our `November 2021` with that cohort which is why the scenarios fail

- Ticket: n/a

### Changes proposed in this pull request
Use method stubs for the scope?

### Guidance to review
Rethink tomorrow
