### PR TITLE
Tidy up the statement date scopes

### DIFF
--- a/app/helpers/finance/ecf_payments_helper.rb
+++ b/app/helpers/finance/ecf_payments_helper.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Finance
-  module ECFPaymentsHelper
-  end
-end

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Finance::Statement < ApplicationRecord
-  include Finance::ECFPaymentsHelper
-
   self.table_name = "statements"
 
   belongs_to :cpd_lead_provider

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -27,12 +27,12 @@ class Finance::Statement < ApplicationRecord
            through: :refundable_statement_line_items,
            source: :participant_declaration
 
-  scope :payable,                   -> { where("deadline_date < DATE(NOW()) AND payment_date >= DATE(NOW())") }
-  scope :closed,                    -> { where("payment_date < ?", Date.current) }
-  scope :with_future_deadline_date, -> { where("deadline_date >= DATE(NOW())") }
+  scope :payable,                   -> { where(deadline_date: ...Date.current, payment_date: Date.current...) }
+  scope :closed,                    -> { where(payment_date: ...Date.current) }
+  scope :with_future_deadline_date, -> { where(deadline_date: Date.current...) }
   scope :upto_current,              -> { payable.or(closed) }
   scope :latest,                    -> { order(deadline_date: :asc).last }
-  scope :upto,                      ->(statement) { where("deadline_date < ?", statement.deadline_date) }
+  scope :upto,                      ->(statement) { where(deadline_date: ...statement.deadline_date) }
   scope :output,                    -> { where(output_fee: true) }
   scope :next_output_fee_statements, lambda {
     output

--- a/spec/models/finance/statement_spec.rb
+++ b/spec/models/finance/statement_spec.rb
@@ -10,4 +10,36 @@ RSpec.describe Finance::Statement do
 
     it { is_expected.not_to be_paid }
   end
+
+  describe "scopes" do
+    let(:today) { Date.current }
+
+    describe ".payable" do
+      subject { described_class.payable.to_sql }
+
+      it { is_expected.to match(%("deadline_date" < '#{today}')) }
+      it { is_expected.to match(%("payment_date" >= '#{today}')) }
+    end
+
+    describe ".closed" do
+      subject { described_class.closed.to_sql }
+
+      it { is_expected.to match(%("payment_date" < '#{today}')) }
+    end
+
+    describe ".with_future_deadline_date" do
+      subject { described_class.with_future_deadline_date.to_sql }
+
+      it { is_expected.to match(%("deadline_date" >= '#{today}')) }
+    end
+
+    describe ".upto" do
+      let(:a_week_ago) { 1.week.ago.to_date }
+      let(:fake_statement) { instance_double(Finance::Statement, deadline_date: a_week_ago) }
+
+      subject { described_class.upto(fake_statement).to_sql }
+
+      it { is_expected.to match(%("deadline_date" < '#{a_week_ago}')) }
+    end
+  end
 end


### PR DESCRIPTION
### Context and changes

We ran into a few date-related problems where time travel in the tests was expected but the scopes which used PostgreSQL's `date()` function were unaware. This is a quick attempt at tidying and standardising them, plus covering with specs.

- Remove empty Finance::ECFPaymentsHelper
- Use ActiveRecord range syntax for date queries
