### PR TITLE
Add new Deleted Duplicate table to store serialised profiles

### DIFF
--- a/app/models/finance/ecf/deleted_duplicate.rb
+++ b/app/models/finance/ecf/deleted_duplicate.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    class DeletedDuplicate < ApplicationRecord
+      belongs_to :primary_participant_profile, class_name: "ParticipantProfile"
+    end
+  end
+end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -32,6 +32,7 @@ class ParticipantProfile < ApplicationRecord
   }, class_name: "ParticipantProfileState"
 
   has_many :participant_profile_schedules
+  has_many :deleted_duplicates, class_name: "Finance::ECF::DeletedDuplicate", foreign_key: :primary_participant_profile_id
 
   enum status: {
     active: "active",

--- a/app/serializers/finance/ecf/duplicate_serializer.rb
+++ b/app/serializers/finance/ecf/duplicate_serializer.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module Finance
+  module ECF
+    class DuplicateSerializer
+      include JSONAPI::Serializer
+
+      set_id :id
+      set_type :duplicate
+
+      attribute :type, &:type
+      attribute :sparsity_uplift, &:sparsity_uplift
+      attribute :pupil_premium_uplift, &:pupil_premium_uplift
+      attribute :status, &:status
+      attribute :school_urn, &:school_urn
+      attribute :school_ukprn, &:school_ukprn
+      attribute :request_for_details_sent_at, &:request_for_details_sent_at
+      attribute :training_status, &:training_status
+      attribute :profile_duplicity, &:profile_duplicity
+      attribute :start_term, &:start_term
+      attribute :notes, &:notes
+
+      attribute :npq_course_id, &:npq_course_id
+      attribute :schedule_id, &:schedule_id
+      attribute :school_id, &:school_id
+      attribute :core_induction_programme_id, &:core_induction_programme_id
+      attribute :mentor_profile_id, &:mentor_profile_id
+      attribute :school_cohort_id, &:school_cohort_id
+      attribute :teacher_profile_id, &:teacher_profile_id
+      attribute :participant_identity_id, &:participant_identity_id
+
+      attribute :schedule_name do |object|
+        object.schedule&.name
+      end
+
+      attribute :trn do |object|
+        object.teacher_profile&.trn
+      end
+
+      attribute :external_identifier do |object|
+        object.participant_identity&.external_identifier
+      end
+
+      attribute :email do |object|
+        object.participant_identity&.email
+      end
+
+      attribute :cohort do |object|
+        object&.school_cohort&.cohort&.display_name
+      end
+
+      attribute :created_at do |object|
+        object.created_at.rfc3339
+      end
+
+      attribute :updated_at do |object|
+        object.updated_at.rfc3339
+      end
+
+      attribute(:induction_records) do |object|
+        object.induction_records.oldest_first.map do |induction_record|
+          {
+            id: induction_record.id,
+            cohort: induction_record.induction_programme&.school_cohort&.cohort&.display_name,
+            schedule_name: induction_record.schedule&.name,
+            training_status: induction_record.training_status,
+            start_date: induction_record.start_date&.rfc3339,
+            end_date: induction_record.end_date&.rfc3339,
+            induction_status: induction_record.induction_status,
+            school_transfer: induction_record.school_transfer,
+            preferred_identity_email: induction_record.preferred_identity&.email,
+            preferred_identity_id: induction_record.preferred_identity_id,
+            induction_programme_id: induction_record.induction_programme_id,
+            mentor_profile_id: induction_record.mentor_profile_id,
+            appropriate_body_id: induction_record.appropriate_body_id,
+            created_at: induction_record.created_at.rfc3339,
+            updated_at: induction_record.updated_at.rfc3339,
+          }
+        end
+      end
+
+      attribute(:participant_declarations) do |object|
+        object.participant_declarations.map do |participant_declaration|
+          {
+            id: participant_declaration.id,
+            declaration_type: participant_declaration.declaration_type,
+            declaration_date: participant_declaration.declaration_date&.rfc3339,
+            course_identifier: participant_declaration.course_identifier,
+            evidence_held: participant_declaration.evidence_held,
+            type: participant_declaration.type,
+            cpd_lead_provider: participant_declaration.cpd_lead_provider&.name,
+            state: participant_declaration.state,
+            superseded_by_id: participant_declaration.superseded_by_id,
+            sparsity_uplift: participant_declaration.sparsity_uplift,
+            pupil_premium_uplift: participant_declaration.pupil_premium_uplift,
+            delivery_partner_name: participant_declaration.delivery_partner&.name,
+            created_at: participant_declaration.created_at.rfc3339,
+            updated_at: participant_declaration.updated_at.rfc3339,
+          }
+        end
+      end
+
+      attribute(:participant_profile_states) do |object|
+        object.participant_profile_states.map do |participant_profile_state|
+          {
+            id: participant_profile_state.id,
+            reason: participant_profile_state.reason,
+            state: participant_profile_state.state,
+            created_at: participant_profile_state.created_at.rfc3339,
+            updated_at: participant_profile_state.updated_at.rfc3339,
+          }
+        end
+      end
+
+      attribute(:participant_validation_data) do |object|
+        participant_validation_data = object.ecf_participant_validation_data
+
+        {
+          id: participant_validation_data&.id,
+          full_name: participant_validation_data&.full_name,
+          date_of_birth: participant_validation_data&.date_of_birth&.rfc3339,
+          trn: participant_validation_data&.trn,
+          nino: participant_validation_data&.nino,
+          api_failure: participant_validation_data&.api_failure,
+          created_at: participant_validation_data&.created_at&.rfc3339,
+          updated_at: participant_validation_data&.updated_at&.rfc3339,
+        }
+      end
+
+      attribute(:validation_decisions) do |object|
+        object.validation_decisions.map do |validation_decision|
+          {
+            id: validation_decision.id,
+            validation_step: validation_decision.validation_step,
+            approved: validation_decision.approved,
+            note: validation_decision.note,
+            created_at: validation_decision.created_at.rfc3339,
+            updated_at: validation_decision.updated_at.rfc3339,
+          }
+        end
+      end
+
+      attribute(:participant_eligibility) do |object|
+        ecf_participant_eligibility = object.ecf_participant_eligibility
+
+        {
+          id: ecf_participant_eligibility&.id,
+          qts: ecf_participant_eligibility&.qts,
+          active_flags: ecf_participant_eligibility&.active_flags,
+          previous_participation: ecf_participant_eligibility&.previous_participation,
+          previous_induction: ecf_participant_eligibility&.previous_induction,
+          manually_validated: ecf_participant_eligibility&.manually_validated,
+          status: ecf_participant_eligibility&.status,
+          reason: ecf_participant_eligibility&.reason,
+          different_trn: ecf_participant_eligibility&.different_trn,
+          no_induction: ecf_participant_eligibility&.no_induction,
+          exempt_from_induction: ecf_participant_eligibility&.exempt_from_induction,
+          created_at: ecf_participant_eligibility&.created_at&.rfc3339,
+          updated_at: ecf_participant_eligibility&.updated_at&.rfc3339,
+        }
+      end
+
+      attribute(:participant_profile_schedules) do |object|
+        object.participant_profile_schedules.map do |participant_profile_schedule|
+          {
+            id: participant_profile_schedule.id,
+            schedule_id: participant_profile_schedule.schedule_id,
+            created_at: participant_profile_schedule.created_at.rfc3339,
+            updated_at: participant_profile_schedule.updated_at.rfc3339,
+          }
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20221102132300_create_deleted_duplicates.rb
+++ b/db/migrate/20221102132300_create_deleted_duplicates.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDeletedDuplicates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :deleted_duplicates do |t|
+      t.jsonb :data
+      t.references :primary_participant_profile, null: false, foreign_key: { to_table: :participant_profiles }, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_27_113219) do
+ActiveRecord::Schema.define(version: 2022_11_02_132300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -217,6 +217,14 @@ ActiveRecord::Schema.define(version: 2022_10_27_113219) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "state_reason"
     t.index ["participant_declaration_id"], name: "index_declaration_states_on_participant_declaration_id"
+  end
+
+  create_table "deleted_duplicates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.jsonb "data"
+    t.uuid "primary_participant_profile_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["primary_participant_profile_id"], name: "index_deleted_duplicates_on_primary_participant_profile_id"
   end
 
   create_table "delivery_partner_profiles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1018,6 +1026,7 @@ ActiveRecord::Schema.define(version: 2022_10_27_113219) do
   add_foreign_key "cohorts_lead_providers", "lead_providers"
   add_foreign_key "data_stage_school_changes", "data_stage_schools"
   add_foreign_key "data_stage_school_links", "data_stage_schools"
+  add_foreign_key "deleted_duplicates", "participant_profiles", column: "primary_participant_profile_id"
   add_foreign_key "delivery_partner_profiles", "delivery_partners"
   add_foreign_key "delivery_partner_profiles", "users"
   add_foreign_key "district_sparsities", "local_authority_districts"

--- a/spec/serializers/finance/ecf/duplicate_serializer_spec.rb
+++ b/spec/serializers/finance/ecf/duplicate_serializer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Finance::ECF::DuplicateSerializer, :with_default_schedules do
+  describe "serialization" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+    let(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+    let!(:participant_declaration) { create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:) }
+    let!(:participant_validation_data) { create :ecf_participant_validation_data, participant_profile:, trn: "8421937", full_name: "Rolande Mueller" }
+    let!(:participant_eligibility) { create(:ecf_participant_eligibility, :eligible, participant_profile:) }
+
+    subject { described_class.new(participant_profile) }
+
+    it "returns the participant profile id" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:id]).to eq(participant_profile.id)
+    end
+
+    it "returns the correct type" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:type]).to eq(:duplicate)
+    end
+
+    it "returns the expected data attributes for the participant profile" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:attributes]).to include(
+        schedule_name: participant_profile.schedule.name,
+        trn: participant_profile.teacher_profile.trn,
+        external_identifier: participant_profile.participant_identity.external_identifier,
+        email: participant_profile.participant_identity.email,
+        cohort: "2021",
+      )
+    end
+
+    it "returns the expected data attributes for the participant profile induction records" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:attributes][:induction_records][0]).to include(
+        cohort: "2021",
+        training_status: "active",
+        induction_status: "active",
+        start_date: "2021-09-01T00:00:00Z",
+        end_date: nil,
+        school_transfer: false,
+      )
+    end
+
+    it "returns the expected data attributes for the participant profile declarations" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:attributes][:participant_declarations][0]).to include(
+        declaration_type: "started",
+        declaration_date: "2021-09-01T00:00:00Z",
+        course_identifier: "ecf-induction",
+      )
+    end
+
+    it "returns the expected data attributes for the participant profile states" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:attributes][:participant_profile_states][0]).to include(
+        reason: nil,
+        state: "active",
+      )
+    end
+
+    it "returns the expected data attributes for the participant profile validation data" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:attributes][:participant_validation_data]).to include(
+        trn: "8421937",
+        full_name: "Rolande Mueller",
+      )
+    end
+
+    it "returns the expected data attributes for the participant profile eligibility" do
+      result = subject.serializable_hash
+
+      expect(result[:data][:attributes][:participant_eligibility]).to include(
+        status: "eligible",
+        reason: "none",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

To make sure we have a record of deleted duplicate participant profiles, add a new table which stores a serialised record of the deleted profile and any related records. Also a link to the primary participant profile.

- Ticket: n/a

### Changes proposed in this pull request
- Add new table for deleted duplicates
- Add new serialiser for profiles to be deleted, including all relevant attributes of related models
- 
### Guidance to review
Did I miss anything?
