### PR TITLE
Update Shakapacker to version 6.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "ar-uuid", "~> 0.2.3"
 gem "puma", "~> 5.6"
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem "shakapacker", "~> 6.5.2"
+gem "shakapacker", "~> 6.5.3"
 
 # Soft delete
 gem "discard", "~> 1.2", ">= 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,7 +486,7 @@ GEM
     sentry-sidekiq (5.5.0)
       sentry-ruby (~> 5.5.0)
       sidekiq (>= 3.0)
-    shakapacker (6.5.2)
+    shakapacker (6.5.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -670,7 +670,7 @@ DEPENDENCIES
   sentry-rails (~> 5.5)
   sentry-ruby (~> 5.4)
   sentry-sidekiq
-  shakapacker (~> 6.5.2)
+  shakapacker (~> 6.5.3)
   shoulda-matchers (~> 5.2)
   sidekiq
   sidekiq-cron

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mini-css-extract-plugin": "^2.6.1",
     "sass": "^1.55.0",
     "sass-loader": "^12.6.0",
-    "shakapacker": "6.5.2",
+    "shakapacker": "6.5.3",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.6",
     "webpack": "^5.74",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,10 +6359,10 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shakapacker@6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.5.2.tgz#dda95543107a71c7ada3f6ee102a1a31563c6738"
-  integrity sha512-32hpr/AuyQJEk/4J8quL/xLPl+NPR0mBvJ3D9AtwHIkbSTUA0++LZrvVO+aQ4S1Uy3Iz2KSI/JVRGGD/C4SFFg==
+shakapacker@6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.5.3.tgz#4ac2902dae1c6531b4f5f63ce0fa9319cf5cc232"
+  integrity sha512-PtEuP2drIl8RjkWtC6S2iTMJ8IDadIG0HijyVArCD6jUDzpGWA0gtnWGr/pvmGbvg3MPS6kF5RFVOz1YDUvxJw==
   dependencies:
     glob "^7.2.0"
     js-yaml "^4.1.0"


### PR DESCRIPTION
### Context

Update Shakapacker to `6.5.3`.

We need to do this manually because the JavaScript and Ruby libs need to be updated at once so the two individual Dependabot PR's fail.

Fixes #2698, #2699
