### PR TITLE
Add `cohort_id` column to analytics inductions table

### DIFF
--- a/db/analytics_migrate/20221103153412_add_cohort_id_to_analytics_ecf_induction.rb
+++ b/db/analytics_migrate/20221103153412_add_cohort_id_to_analytics_ecf_induction.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCohortIdToAnalyticsECFInduction < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ecf_inductions, :cohort_id, :uuid
+  end
+end

--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_19_102312) do
+ActiveRecord::Schema.define(version: 2022_11_03_153412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2022_08_19_102312) do
     t.boolean "school_transfer"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "cohort_id"
     t.index ["induction_record_id"], name: "index_ecf_inductions_on_induction_record_id", unique: true
   end
 


### PR DESCRIPTION
### Context

The `cohort_id` is useful to analysts and currently tricky to get at/deduce on the analytics side. Adding it will remove several steps from their workings.

This is part 1/2. In part two (#2705) we are populating the field we're adding here. It is important that **this PR is released before that oen is merged**, because it looks like the analytics migration needs to be manually run and we don't want to start trying to populate the field before it exists.
