### PR TITLE
Populate `cohort_id` column in analytics inductions table

### DIFF
--- a/app/services/analytics/ecf_induction_service.rb
+++ b/app/services/analytics/ecf_induction_service.rb
@@ -24,6 +24,7 @@ module Analytics
         record.induction_status = induction_record.induction_status
         record.training_status = induction_record.training_status
         record.school_transfer = induction_record.school_transfer
+        record.cohort_id = induction_record&.cohort&.id
 
         record.save!
       end

--- a/spec/services/analytics/ecf_induction_service_spec.rb
+++ b/spec/services/analytics/ecf_induction_service_spec.rb
@@ -25,5 +25,6 @@ describe Analytics::ECFInductionService do
     record = Analytics::ECFInduction.find_by(induction_record_id: induction_record.id)
     expect(record.induction_status).to eq "leaving"
     expect(record.end_date).to be_within(1.second).of end_date
+    expect(record.cohort_id).to eq induction_programme.school_cohort.cohort.id
   end
 end


### PR DESCRIPTION
### Context

This is part 2/2. In part one (#2704) we added a new field to the `Analytics::ECFInductions` table. This change updates the job which populates it.

The reason we're splitting this over two parts is that I can't see any automatic running of the `db:migrate:analytics` task. We don't want to start trying to populate the table before the migrations have run.
