### PR TITLE
Move json-diff gem out of development/test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,11 +105,11 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 
+gem "json-diff", "~> 0.4.1", require: false
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
-
-  gem "json-diff", "~> 0.4.1"
 
   # GOV.UK interpretation of rubocop for linting Ruby
   gem "rubocop-govuk", ">= 4.8"

--- a/lib/tasks/compare/ecf_users_and_induction_records.rake
+++ b/lib/tasks/compare/ecf_users_and_induction_records.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json-diff"
+
 namespace :compare do
   namespace :ecf_users_and_induction_records do
     desc "compare"


### PR DESCRIPTION
### Context and changes

Also make it `require: false` and explicitly require it in the comparison script as that's the only place it'll be used for the time being.
