### PR TITLE
Export path in Dockerfile to avoid having to type full path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,10 @@ COPY --from=assets-precompile /app /app
 COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
 COPY --from=middleman /public/ /app/public/
 
-RUN echo "cd /app && /usr/local/bin/bundle exec rails c" > /root/.ash_history
+RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
+ENV ENV="/root/.ashrc"
+
+RUN echo "cd /app && bundle exec rails c" > /root/.ash_history
 RUN echo "IRB.conf[:USE_AUTOCOMPLETE] = false" > /root/.irbrc
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -94,6 +94,9 @@ RUN apk -U upgrade && \
 COPY --from=assets-precompile /app /app
 COPY --from=assets-precompile /usr/local/bundle/ /usr/local/bundle/
 
+RUN echo export PATH=/usr/local/bin:\$PATH > /root/.ashrc
+ENV ENV="/root/.ashrc"
+
 WORKDIR /app
 
 # Use this for development testing


### PR DESCRIPTION
### Context
We currently have to include the full path to run /usr/local/bin/bundle exec when sshing into the container

- Ticket: n/a

### Changes proposed in this pull request

### Guidance to review

