### PR TITLE
Show 'No delivery partner' in email when missing

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -446,7 +446,7 @@ class SchoolMailer < ApplicationMailer
         name: induction_coordinator.user.full_name,
         withdrawn_participant_name: withdrawn_participant.user.full_name,
         school: withdrawn_participant.school.name,
-        delivery_partner: partnership.delivery_partner.name,
+        delivery_partner: partnership&.delivery_partner&.name || "No delivery partner",
         lead_provider: partnership.lead_provider.name,
       },
     )

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -446,7 +446,7 @@ class SchoolMailer < ApplicationMailer
         name: induction_coordinator.user.full_name,
         withdrawn_participant_name: withdrawn_participant.user.full_name,
         school: withdrawn_participant.school.name,
-        delivery_partner: partnership&.delivery_partner&.name || "No delivery partner",
+        delivery_partner: partnership.delivery_partner_name || "No delivery partner",
         lead_provider: partnership.lead_provider.name,
       },
     )

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -37,6 +37,7 @@ class Partnership < ApplicationRecord
   scope :relationships, -> { where(relationship: true) }
 
   delegate :name, to: :lead_provider, allow_nil: true, prefix: true
+  delegate :name, to: :delivery_partner, allow_nil: true, prefix: true
 
   # NOTE: challenge! has been moved to a service Partnerships::Challenge as there
   # are now many side affects that need to be considered.

--- a/spec/models/partnership_spec.rb
+++ b/spec/models/partnership_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe Partnership, type: :model do
     it { is_expected.to have_many(:partnership_notification_emails) }
   end
 
+  describe "delegations" do
+    it { is_expected.to delegate_method(:name).to(:lead_provider).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:name).to(:delivery_partner).with_prefix(true).allow_nil }
+  end
+
   it "updates the updated_at on participant profiles and users", :with_default_schedules do
     freeze_time
     school_cohort = create(:school_cohort)


### PR DESCRIPTION
### Changes and context

Currently when sending a fip_provider_has_withdrawn_a_participant email we try to access the partnership's delivery partner. This is an optional value so not all partnerships are guaranteed to have one.

Currently it fails when one is missing, here I'm proposing that we instead display a string of text that says 'No delivery partner' instead.
