### PR TITLE
Rejig the analytics queries for multiple cohorts

### DIFF
--- a/analytics_queries/Makefile
+++ b/analytics_queries/Makefile
@@ -1,7 +1,8 @@
-flatten_queries: 
+flatten_queries:
 	mkdir -p /tmp/exports
 	rm -f /tmp/exports/*.sql
-	cat declarations.sql | tr --delete '\n' > /tmp/exports/declarations.sql
-	cat participants.sql | tr --delete '\n' > /tmp/exports/participants.sql
-	cat partnerships.sql | tr --delete '\n' > /tmp/exports/partnerships.sql
-	cat schools.sql      | tr --delete '\n' > /tmp/exports/schools.sql
+	cat declarations.sql     | tr --delete '\n' > /tmp/exports/declarations.sql
+	cat participants.sql     | tr --delete '\n' > /tmp/exports/participants.sql
+	cat induction_tutors.sql | tr --delete '\n' > /tmp/exports/induction_tutors.sql
+	cat partnerships.sql     | tr --delete '\n' > /tmp/exports/partnerships.sql
+	cat schools.sql          | tr --delete '\n' > /tmp/exports/schools.sql

--- a/analytics_queries/induction_tutors.sql
+++ b/analytics_queries/induction_tutors.sql
@@ -6,7 +6,7 @@
           u.full_name                        AS tutor_name,
           u.email                            AS tutor_email,
           (pp.id IS NOT NULL)                AS sit_mentor,
-          u.id                               AS sit_mentor_id
+          pi.external_identifier             AS sit_mentor_id
 
     FROM schools s
 
@@ -18,4 +18,5 @@
       ON tp.id = pp.teacher_profile_id
       AND pp.status = 'active'
       AND pp.type = 'ParticipantProfile::Mentor'
+    LEFT OUTER JOIN participant_identities pi on pp.participant_identity_id = pi.id
 ) to '/tmp/exports/induction_tutors.csv' with csv header;

--- a/analytics_queries/induction_tutors.sql
+++ b/analytics_queries/induction_tutors.sql
@@ -1,0 +1,21 @@
+\copy (
+  SELECT s.urn,
+          (icp.id IS NOT NULL)               AS tutor_nominated,
+          icp.created_at                     AS tutor_nominated_at,
+          (u.current_sign_in_at IS NOT NULL) AS tutor_signed_in,
+          u.full_name                        AS tutor_name,
+          u.email                            AS tutor_email,
+          (pp.id IS NOT NULL)                AS sit_mentor,
+          u.id                               AS sit_mentor_id
+
+    FROM schools s
+
+    LEFT OUTER JOIN induction_coordinator_profiles_schools icps on s.id = icps.school_id
+    LEFT OUTER JOIN induction_coordinator_profiles icp on icps.induction_coordinator_profile_id = icp.id
+    LEFT OUTER JOIN users u on icp.user_id = u.id
+    LEFT OUTER JOIN teacher_profiles tp on u.id = tp.user_id
+    LEFT OUTER JOIN participant_profiles pp
+      ON tp.id = pp.teacher_profile_id
+      AND pp.status = 'active'
+      AND pp.type = 'ParticipantProfile::Mentor'
+) to '/tmp/exports/induction_tutors.csv' with csv header;

--- a/analytics_queries/partnerships.sql
+++ b/analytics_queries/partnerships.sql
@@ -1,12 +1,16 @@
 \copy (
-    SELECT s.urn        as school_urn,
-          lp.name      as lead_provider_name,
-          dp.name      as delivery_partner_name,
-          p.created_at AS partnership_reported_at,
-          p.challenge_reason,
-          p.challenged_at
-    FROM partnerships p
-            JOIN lead_providers lp on lp.id = p.lead_provider_id
-            JOIN delivery_partners dp on p.delivery_partner_id = dp.id
-            JOIN schools s on p.school_id = s.id
+  SELECT s.urn        as school_urn,
+        lp.name      as lead_provider_name,
+        dp.name      as delivery_partner_name,
+        p.created_at as partnership_reported_at,
+        p.challenge_reason,
+        p.challenged_at,
+        c.start_year as cohort,
+        p.relationship
+  FROM partnerships p
+  JOIN lead_providers lp on lp.id = p.lead_provider_id
+  JOIN delivery_partners dp on p.delivery_partner_id = dp.id
+  JOIN schools s on p.school_id = s.id
+  JOIN cohorts c on p.cohort_id = c.id
+  WHERE NOT p.relationship
 ) to '/tmp/exports/partnerships.csv' with csv header;

--- a/analytics_queries/schools.sql
+++ b/analytics_queries/schools.sql
@@ -8,7 +8,7 @@
       dp.name                         as delivery_partner_name,
       c.start_year                    as cohort
 
-    FROM schools s
+    from schools s
 
     left outer join school_cohorts sc on s.id = sc.school_id
     left outer join cohorts c on sc.cohort_id = c.id
@@ -17,6 +17,7 @@
     left outer join delivery_partners dp on p.delivery_partner_id = dp.id
 
     where (c.start_year > 2020 or c.id is null)
+    and p.challenged_at is null
   ),
   just_2021 as (
     select *


### PR DESCRIPTION
### Context

Written under Nathan's supervision! 😅

Main changes:

* we split up the complicated schools query by removing  the induction tutor specific bits
* added a cohort identifier to the partnerships table
* made the schools query combine data from the 2021/2022 cohorts and display them side-by-side

### Notes for review

These scripts aren't used by the app in any way, they power an ad hoc export that's used for reporting purposes.

