### PR TITLE
Remove unnecessary creation of NPQ default schedule

### DIFF
--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe NPQ::Application::Accept, :with_default_schedules do
-  before { create(:npq_leadership_schedule) }
-
   let(:cohort_2021) { Cohort.current }
   let(:cohort_2022) { create(:cohort, :next) }
 


### PR DESCRIPTION
### Context
With the `with_default_schedules` we create all necessary schedules. When creating the extra schedule the test is flakey as there are two similar default schedules and we can return either one, which fails on equality expectation

- Ticket: n/a

### Changes proposed in this pull request
Remove creation of default as its done here: https://github.com/DFE-Digital/early-careers-framework/blob/develop/spec/support/with_default_schedules.rb

### Guidance to review

example failure: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3419197516/jobs/5692417259