### PR TITLE
Make the withdrawal email more robust when there's no partnership

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -446,8 +446,8 @@ class SchoolMailer < ApplicationMailer
         name: induction_coordinator.user.full_name,
         withdrawn_participant_name: withdrawn_participant.user.full_name,
         school: withdrawn_participant.school.name,
-        delivery_partner: partnership.delivery_partner_name || "No delivery partner",
-        lead_provider: partnership.lead_provider.name,
+        delivery_partner: partnership&.delivery_partner_name || "No delivery partner",
+        lead_provider: partnership&.lead_provider_name || "No lead provider",
       },
     )
     email

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -197,9 +197,13 @@ RSpec.describe SchoolMailer, type: :mailer do
         withdrawn_participant: participant_profile,
         induction_coordinator: sit_profile,
       )
+    end
 
-      expect(email.from).to eq(["mail@example.com"])
-      expect(email.to).to eq([induction_coordinator_profile.user.email])
+    it "sets the right sender and recipient addresses" do
+      aggregate_failures do
+        expect(email.from).to eq(["mail@example.com"])
+        expect(email.to).to eq([sit_profile.user.email])
+      end
     end
   end
 end


### PR DESCRIPTION
### Context and changes

This follows on from f57fdc6e422d9 which didn't entirely solve the problem. Sometimes there is no partnership which means the second step, setting the `partnership.lead_provider.name` also fails.

I also fixed the spec, the expectations were wrapped in the `let` block meaning they were never run.
