### PR TITLE
Refactor NPQ details component, fix `#last_updated`

### DIFF
--- a/app/components/admin/npq/participants/details.html.erb
+++ b/app/components/admin/npq/participants/details.html.erb
@@ -5,31 +5,31 @@
 <%= govuk_summary_list do |sl|
   sl.row do |row|
     row.key(text: "Participant name")
-    row.value(text: full_name)
+    row.value(text: user_full_name)
     row.action(text: "Change", href: edit_admin_participant_npq_change_full_name_path(profile), visually_hidden_text: "participant name")
   end
 
   sl.row do |row|
     row.key(text: "Participant email")
-    row.value(text: email)
+    row.value(text: user_email)
     row.action(text: "Change", href: edit_admin_participant_npq_change_email_path(profile), visually_hidden_text: "participant email address")
   end
 
-  if pending?
+  if npq_application_pending?
     sl.row do |row|
       row.key(text: "National Insurance number")
-      row.value(text: ni_number)
+      row.value(text: npq_application_nino)
     end
 
     sl.row do |row|
       row.key(text: "Date of birth")
-      row.value(text: date_of_birth)
+      row.value(text: npq_application_date_of_birth.to_formatted_s(:govuk))
     end
   end
 
   sl.row do |row|
     row.key(text: "Teacher reference number")
-    row.value(text: trn)
+    row.value(text: npq_application_teacher_reference_number)
   end
 
   sl.row do |row|
@@ -49,12 +49,12 @@
 
   sl.row do |row|
     row.key(text: "Provider")
-    row.value(text: lead_provider_name)
+    row.value(text: npq_application.npq_lead_provider_name)
   end
 
   sl.row do |row|
     row.key(text: "NPQ course")
-    row.value(text: npq_course_name)
+    row.value(text: npq_application.npq_course_name)
   end
 
   sl.row do |row|

--- a/app/components/admin/npq/participants/details.html.erb
+++ b/app/components/admin/npq/participants/details.html.erb
@@ -15,7 +15,7 @@
     row.action(text: "Change", href: edit_admin_participant_npq_change_email_path(profile), visually_hidden_text: "participant email address")
   end
 
-  if npq_application_pending?
+  if profile_pending?
     sl.row do |row|
       row.key(text: "National Insurance number")
       row.value(text: npq_application_nino)

--- a/app/components/admin/npq/participants/details.rb
+++ b/app/components/admin/npq/participants/details.rb
@@ -4,43 +4,34 @@ module Admin
   module NPQ
     module Participants
       class Details < BaseComponent
-        attr_reader :profile
+        attr_reader :profile, :user, :npq_application, :school
 
-        def initialize(profile:)
-          @profile = profile
+        def initialize(profile:, user:, npq_application:, school:)
+          @profile         = profile
+          @user            = user
+          @npq_application = npq_application
+          @school          = school
         end
 
-        delegate :user, :pending?, :school, :school_urn, :npq_application, :updated_at, to: :profile
-        delegate :full_name, :email, to: :user
+        delegate :full_name, :email, to: :user, prefix: true
 
-        def school_name
-          return if school.blank?
+        delegate :urn, :name, to: :school, prefix: true, allow_nil: true
 
-          school.name
-        end
-
-        def trn
-          npq_application&.teacher_reference_number
-        end
-
-        def date_of_birth
-          npq_application&.date_of_birth&.to_formatted_s(:govuk)
-        end
-
-        def lead_provider_name
-          npq_application&.npq_lead_provider&.name
-        end
-
-        def npq_course_name
-          npq_application&.npq_course&.name
-        end
-
-        def ni_number
-          npq_application&.nino
-        end
+        delegate :teacher_reference_number,
+                 :nino,
+                 :date_of_birth,
+                 :course_name,
+                 :pending?,
+                 to: :npq_application,
+                 prefix: true,
+                 allow_nil: true
 
         def last_updated
-          updated_at.to_formatted_s(:govuk)
+          latest_updated_timestamp = [profile.updated_at, user.updated_at].compact.max
+
+          return if latest_updated_timestamp.blank?
+
+          latest_updated_timestamp.to_formatted_s(:govuk)
         end
       end
     end

--- a/app/components/admin/npq/participants/details.rb
+++ b/app/components/admin/npq/participants/details.rb
@@ -13,6 +13,8 @@ module Admin
           @school          = school
         end
 
+        delegate :pending?, to: :profile, prefix: true
+
         delegate :full_name, :email, to: :user, prefix: true
 
         delegate :urn, :name, to: :school, prefix: true, allow_nil: true
@@ -21,7 +23,6 @@ module Admin
                  :nino,
                  :date_of_birth,
                  :course_name,
-                 :pending?,
                  to: :npq_application,
                  prefix: true,
                  allow_nil: true

--- a/app/components/admin/npq/participants/details.rb
+++ b/app/components/admin/npq/participants/details.rb
@@ -28,11 +28,10 @@ module Admin
                  allow_nil: true
 
         def last_updated
-          latest_updated_timestamp = [profile.updated_at, user.updated_at].compact.max
-
-          return if latest_updated_timestamp.blank?
-
-          latest_updated_timestamp.to_formatted_s(:govuk)
+          [profile.updated_at, user.updated_at]
+            &.compact
+            &.max
+            &.to_formatted_s(:govuk)
         end
       end
     end

--- a/app/components/admin/npq/participants/details.rb
+++ b/app/components/admin/npq/participants/details.rb
@@ -28,7 +28,7 @@ module Admin
                  allow_nil: true
 
         def last_updated
-          [profile.updated_at, user.updated_at]
+          [profile.updated_at, user.updated_at, npq_application.updated_at]
             &.compact
             &.max
             &.to_formatted_s(:govuk)

--- a/app/views/admin/participants/show.html.erb
+++ b/app/views/admin/participants/show.html.erb
@@ -11,7 +11,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if @participant_profile.npq? %>
-      <%= render Admin::NPQ::Participants::Details.new(profile: @participant_profile) %>
+      <%=
+        render Admin::NPQ::Participants::Details.new(
+          profile: @participant_profile,
+          npq_application: @participant_profile.npq_application,
+          school: @participant_profile.school,
+          user: @participant_profile.user,
+        )
+      %>
       <%= render Admin::NPQ::Participants::ValidationTasks.new(profile: @participant_profile) %>
       <%= render Admin::Participants::Identities.new(identities: @participant_identities) %>
     <% else %>

--- a/spec/components/admin/npq/participants/details_spec.rb
+++ b/spec/components/admin/npq/participants/details_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type:
   describe "delegations" do
     subject { component }
 
+    it { is_expected.to delegate_method(:pending?).to(:profile).with_prefix(true) }
+
     it { is_expected.to delegate_method(:full_name).to(:user).with_prefix(true) }
     it { is_expected.to delegate_method(:email).to(:user).with_prefix(true) }
 
@@ -21,7 +23,6 @@ RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type:
     it { is_expected.to delegate_method(:nino).to(:npq_application).with_prefix(true).allow_nil }
     it { is_expected.to delegate_method(:date_of_birth).to(:npq_application).with_prefix(true).allow_nil }
     it { is_expected.to delegate_method(:course_name).to(:npq_application).with_prefix(true).allow_nil }
-    it { is_expected.to delegate_method(:pending?).to(:npq_application).with_prefix(true).allow_nil }
   end
 
   describe "heading" do

--- a/spec/components/admin/npq/participants/details_spec.rb
+++ b/spec/components/admin/npq/participants/details_spec.rb
@@ -1,25 +1,70 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type: :component do
-  let(:component) { described_class.new profile: }
-  context "for unvalidated npq profile" do
-    let(:npq_application) { create(:npq_application, :accepted, npq_course: create(:npq_course, identifier: "npq-senior-leadership")) }
-    let(:profile) { npq_application.profile }
+  let(:component) { described_class.new(profile:, school:, user:, npq_application:) }
 
+  let(:npq_application) { build(:npq_application) }
+  let(:school) { build(:school) }
+  let(:user) { build(:user, updated_at: 1.week.ago) }
+  let(:profile) { build(:npq_participant_profile, updated_at: 1.week.ago) }
+
+  describe "delegations" do
+    subject { component }
+
+    it { is_expected.to delegate_method(:full_name).to(:user).with_prefix(true) }
+    it { is_expected.to delegate_method(:email).to(:user).with_prefix(true) }
+
+    it { is_expected.to delegate_method(:urn).to(:school).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:name).to(:school).with_prefix(true).allow_nil }
+
+    it { is_expected.to delegate_method(:teacher_reference_number).to(:npq_application).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:nino).to(:npq_application).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:date_of_birth).to(:npq_application).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:course_name).to(:npq_application).with_prefix(true).allow_nil }
+    it { is_expected.to delegate_method(:pending?).to(:npq_application).with_prefix(true).allow_nil }
+  end
+
+  describe "heading" do
+    subject! { render_inline(component) }
+
+    it "renders a level 2 'Details' heading" do
+      expect(rendered_content).to have_css("h2", text: "Details")
+    end
+  end
+
+  describe "#last_updated" do
+    context "when the profile was updated more recently than the user record" do
+      let(:user) { build(:user, updated_at: 3.weeks.ago) }
+
+      it "uses the profile's updated_at value" do
+        expect(component.last_updated).to eql(profile.updated_at.to_formatted_s(:govuk))
+      end
+    end
+
+    context "when the user record was updated more recently than the profile" do
+      let(:profile) { build(:npq_participant_profile, updated_at: 3.weeks.ago) }
+
+      it "uses the user record's updated_at value" do
+        expect(component.last_updated).to eql(user.updated_at.to_formatted_s(:govuk))
+      end
+    end
+  end
+
+  context "for unvalidated npq profile" do
     subject! { render_inline(component) }
 
     it "renders all the required information" do
-      expect(rendered_content).to include(
-        profile.user.full_name,
-        profile.user.email,
-        profile.npq_application.nino,
-        profile.npq_application.date_of_birth.to_formatted_s(:govuk),
-        profile.npq_application.teacher_reference_number,
-        profile.npq_application.school_urn,
-        I18n.t(:npq, scope: "schools.participants.type"),
-        profile.npq_application.npq_lead_provider.name,
-        profile.npq_application.npq_course.name,
-      )
+      aggregate_failures do
+        expect(rendered_content).to include(user.full_name)
+        expect(rendered_content).to include(user.email)
+        expect(rendered_content).to include(npq_application.nino)
+        expect(rendered_content).to include(npq_application.date_of_birth.to_formatted_s(:govuk))
+        expect(rendered_content).to include(npq_application.teacher_reference_number)
+        expect(rendered_content).to include(school.urn)
+        expect(rendered_content).to include(I18n.t(:npq, scope: "schools.participants.type"))
+        expect(rendered_content).to include(npq_application.npq_lead_provider.name)
+        expect(rendered_content).to include(npq_application.npq_course.name)
+      end
     end
   end
 
@@ -35,17 +80,17 @@ RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type:
     subject! { render_inline(component) }
 
     it "renders all the required information" do
-      expect(rendered_content).to include(
-        profile.user.full_name,
-        profile.user.email,
-        profile.npq_application.teacher_reference_number,
-        profile.npq_application.school_urn,
-        I18n.t(:npq, scope: "schools.participants.type"),
-        profile.npq_application.npq_lead_provider.name,
-        profile.npq_application.npq_course.name,
-      )
+      aggregate_failures do
+        expect(rendered_content).to include(user.full_name)
+        expect(rendered_content).to include(user.email)
+        expect(rendered_content).to include(npq_application.teacher_reference_number)
+        expect(rendered_content).to include(school.urn)
+        expect(rendered_content).to include(I18n.t(:npq, scope: "schools.participants.type"))
+        expect(rendered_content).to include(npq_application.npq_lead_provider.name)
+        expect(rendered_content).to include(npq_application.npq_course.name)
 
-      expect(rendered_content).not_to have_content(profile.npq_application.date_of_birth.to_s(:govuk))
+        expect(rendered_content).not_to have_content(npq_application.date_of_birth.to_s(:govuk))
+      end
     end
   end
 end

--- a/spec/components/admin/npq/participants/details_spec.rb
+++ b/spec/components/admin/npq/participants/details_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type: :component do
   let(:component) { described_class.new(profile:, school:, user:, npq_application:) }
 
-  let(:npq_application) { build(:npq_application) }
   let(:school) { build(:school) }
-  let(:user) { build(:user, updated_at: 1.week.ago) }
-  let(:profile) { build(:npq_participant_profile, updated_at: 1.week.ago) }
+  let(:npq_application) { build(:npq_application, updated_at: 3.weeks.ago) }
+  let(:user) { build(:user, updated_at: 3.weeks.ago) }
+  let(:profile) { build(:npq_participant_profile, updated_at: 3.weeks.ago) }
 
   describe "delegations" do
     subject { component }
@@ -34,63 +34,77 @@ RSpec.describe Admin::NPQ::Participants::Details, :with_default_schedules, type:
   end
 
   describe "#last_updated" do
-    context "when the profile was updated more recently than the user record" do
-      let(:user) { build(:user, updated_at: 3.weeks.ago) }
+    context "when the profile was updated most recently" do
+      let(:profile) { build(:npq_participant_profile, updated_at: 3.days.ago) }
 
       it "uses the profile's updated_at value" do
         expect(component.last_updated).to eql(profile.updated_at.to_formatted_s(:govuk))
       end
     end
 
-    context "when the user record was updated more recently than the profile" do
-      let(:profile) { build(:npq_participant_profile, updated_at: 3.weeks.ago) }
+    context "when the user record was updated most recently" do
+      let(:user) { build(:user, updated_at: 3.days.ago) }
 
       it "uses the user record's updated_at value" do
         expect(component.last_updated).to eql(user.updated_at.to_formatted_s(:govuk))
       end
     end
-  end
 
-  context "for unvalidated npq profile" do
-    subject! { render_inline(component) }
+    context "when the NPQ application was updated most recently" do
+      let(:npq_application) { build(:npq_application, updated_at: 3.days.ago) }
 
-    it "renders all the required information" do
-      aggregate_failures do
-        expect(rendered_content).to include(user.full_name)
-        expect(rendered_content).to include(user.email)
-        expect(rendered_content).to include(npq_application.nino)
-        expect(rendered_content).to include(npq_application.date_of_birth.to_formatted_s(:govuk))
-        expect(rendered_content).to include(npq_application.teacher_reference_number)
-        expect(rendered_content).to include(school.urn)
-        expect(rendered_content).to include(I18n.t(:npq, scope: "schools.participants.type"))
-        expect(rendered_content).to include(npq_application.npq_lead_provider.name)
-        expect(rendered_content).to include(npq_application.npq_course.name)
+      it "uses the user record's updated_at value" do
+        expect(component.last_updated).to eql(npq_application.updated_at.to_formatted_s(:govuk))
       end
     end
   end
 
-  context "for validated npq profile" do
-    let(:npq_application) { create(:npq_application, :accepted, npq_course: create(:npq_course, identifier: "npq-senior-leadership")) }
-    let(:profile) { npq_application.profile }
-
-    before do
-      allow(profile).to receive(%i[approved? rejected?].sample).and_return true
-      allow(profile).to receive(:pending?).and_return false
+  describe "displaying information" do
+    shared_examples "basic NPQ details" do
+      it "renders all the required information" do
+        aggregate_failures do
+          expect(rendered_content).to include(user.full_name)
+          expect(rendered_content).to include(user.email)
+          expect(rendered_content).to include(npq_application.teacher_reference_number)
+          expect(rendered_content).to include(school.urn)
+          expect(rendered_content).to include(I18n.t(:npq, scope: "schools.participants.type"))
+          expect(rendered_content).to include(npq_application.npq_lead_provider.name)
+          expect(rendered_content).to include(npq_application.npq_course.name)
+        end
+      end
     end
 
-    subject! { render_inline(component) }
+    context "when the profile is pending" do
+      subject! { render_inline(component) }
 
-    it "renders all the required information" do
-      aggregate_failures do
-        expect(rendered_content).to include(user.full_name)
-        expect(rendered_content).to include(user.email)
-        expect(rendered_content).to include(npq_application.teacher_reference_number)
-        expect(rendered_content).to include(school.urn)
-        expect(rendered_content).to include(I18n.t(:npq, scope: "schools.participants.type"))
-        expect(rendered_content).to include(npq_application.npq_lead_provider.name)
-        expect(rendered_content).to include(npq_application.npq_course.name)
+      include_examples "basic NPQ details"
 
-        expect(rendered_content).not_to have_content(npq_application.date_of_birth.to_s(:govuk))
+      it "renders the extra NPQ details" do
+        aggregate_failures do
+          expect(rendered_content).to include(npq_application.nino)
+          expect(rendered_content).to include(npq_application.date_of_birth.to_formatted_s(:govuk))
+        end
+      end
+    end
+
+    context "when the profile isn't pending" do
+      let(:npq_application) { create(:npq_application, :accepted, npq_course: create(:npq_course, identifier: "npq-senior-leadership")) }
+      let(:profile) { npq_application.profile }
+
+      before do
+        allow(profile).to receive(%i[approved? rejected?].sample).and_return true
+        allow(profile).to receive(:pending?).and_return false
+      end
+
+      subject! { render_inline(component) }
+
+      include_examples "basic NPQ details"
+
+      it "doesn't render the extra NPQ details" do
+        aggregate_failures do
+          expect(rendered_content).not_to include("National Insurance number")
+          expect(rendered_content).not_to include("Date of birth")
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-717

### Changes proposed in this pull request

The first iteration of the NPQ details component accepted the profile object and traversed along its relationships to get the school, npq_application and user.

This made testing:

* tricky as more complex setup is needed
* slower as objects need to be persisted by the factory

This refactor changes the component's behaviour so we need to pass in the school, npq_application and user separately, allowing us to simplify the component and access values via a single level of delegation.

The `#last_updated` method wsa also tweaked to show the most recent `#updated_at` from either the participant profile or the user record.
