### PR TITLE
[Bug-fix] Fix issue when email already exists in an identity record when creating a Mentor profile

### DIFF
--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -17,7 +17,7 @@ module Mentors
         mentor_profile = ParticipantProfile::Mentor.create!({
           teacher_profile:,
           schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort),
-          participant_identity: Identity::Create.call(user:),
+          participant_identity: Identity::Create.call(user:, email:),
         }.merge(mentor_attributes))
 
         ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
@@ -67,9 +67,11 @@ module Mentors
       # the scenario I am working on is enabling a NPQ user to be added as a mentor
       # Not matching on full_name means this works more smoothly for the end user
       # and they don't get "email already in use" errors if they spell the name differently
-      @user ||= User.find_or_create_by!(email:) do |mentor|
-        mentor.full_name = full_name
-      end
+      @user ||= find_or_create_user!
+    end
+
+    def find_or_create_user!
+      Identity.find_user_by(email:) || User.create!(email:, full_name:)
     end
 
     def teacher_profile

--- a/spec/services/mentors/create_spec.rb
+++ b/spec/services/mentors/create_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe Mentors::Create, :with_default_schedules do
     }.to change { user.reload.full_name }
   end
 
+  context "when the email exists on an identity but not a user record" do
+    let!(:identity) { Identity::Create.call(user:, email: "another.identity@example.com") }
+
+    it "creates the mentor profile under the users identity" do
+      expect {
+        described_class.call(
+          email: identity.email,
+          full_name: user.full_name,
+          school_cohort:,
+        )
+      }.to change { identity.participant_profiles.mentors.count }.by(1)
+    end
+  end
+
   context "when default induction programme is set on the school cohort" do
     it "creates an induction record" do
       induction_programme = create(:induction_programme, :fip, school_cohort:)


### PR DESCRIPTION
### Context

Fix an issue I spotted where if you try to create a mentor profile for a user and they already have a `ParticipantIdentity` with the email address, and this isn't the email address on `User.email` it raises an error.

