### PR TITLE
Attempt at finding correct record in both responses

### DIFF
--- a/lib/tasks/compare/ecf_users_and_induction_records.rake
+++ b/lib/tasks/compare/ecf_users_and_induction_records.rake
@@ -44,10 +44,9 @@ namespace :compare do
             # skip if the attributes are the same
             next
           else
-            original_attributes = JsonDiff.diff(record_from_users_query[:attributes], record_from_ir_query[:attributes], include_was: true).map do |el|
-              attributes = {}
-              attributes[el["path"].sub("/", "")] = el["was"]
-              attributes
+            original_attributes = {}
+            JsonDiff.diff(record_from_users_query[:attributes], record_from_ir_query[:attributes], include_was: true).each do |el|
+              original_attributes[el["path"].sub("/", "")] = el["was"]
             end
 
             diff_report.push user_id: records["id"],


### PR DESCRIPTION
The ECF User query and the IR Query use different UUIDs for the id of the records. It is chance that ids match

This now uses a map of user_id to external_identifier to find matched records which should mean we see actual differences.