### PR TITLE
Support ECT user endpoint reports

### DIFF
--- a/app/serializers/api/v1/ecf_induction_record_serializer.rb
+++ b/app/serializers/api/v1/ecf_induction_record_serializer.rb
@@ -25,14 +25,14 @@ module Api
       }.freeze
 
       set_id :id do |induction_record|
-        induction_record.preferred_identity.external_identifier
+        induction_record.preferred_identity.user_id
       end
+
+      attributes :email, &:participant_email
 
       attributes :full_name do |induction_record|
         induction_record.preferred_identity.user.full_name
       end
-
-      attributes :email, &:participant_email
 
       attributes :user_type do |induction_record|
         case induction_record.participant_profile.type

--- a/lib/tasks/compare/ecf_users_and_induction_records.rake
+++ b/lib/tasks/compare/ecf_users_and_induction_records.rake
@@ -14,32 +14,28 @@ namespace :compare do
       induction_records = Api::V1::ECF::InductionRecordsQuery.new.all
       serialized_induction_records = Api::V1::ECFInductionRecordSerializer.new(induction_records).serializable_hash
 
-      puts "getting mapping data..."
-      ui_to_ei_map = ParticipantIdentity.select("participant_identities.user_id AS id, participant_identities.external_identifier AS external_identifier").to_a.map(&:serializable_hash)
-
       puts "analysing..."
-
       if serialized_users.count.zero? && serialized_induction_records.count.zero?
         puts "The API responses are both empty!"
       else
         indexed_serialized_users = serialized_users[:data].index_by { |x| x[:id] }
         indexed_serialized_induction_records = serialized_induction_records[:data].index_by { |x| x[:id] }
 
+        ids_from_serialized_users = serialized_users[:data].map { |u| u[:id] }
+        ids_from_serialized_induction_records = serialized_induction_records[:data].map { |u| u[:id] }
+
         users_with_no_ir_report = []
         ir_with_no_user_report = []
         diff_report = []
 
-        ui_to_ei_map.each do |records|
-          record_from_users_query = indexed_serialized_users[records["id"]]
-          record_from_ir_query = indexed_serialized_induction_records[records["external_identifier"]]
+        [*ids_from_serialized_users, *ids_from_serialized_induction_records].uniq.sort.each do |id|
+          record_from_users_query = indexed_serialized_users[id]
+          record_from_ir_query = indexed_serialized_induction_records[id]
 
-          if record_from_users_query.blank? && record_from_ir_query.blank?
-            # skip if both are not found - do we care about these ?
-            next
-          elsif record_from_users_query.blank?
-            ir_with_no_user_report.push user_id: records["id"], induction_record: record_from_ir_query
+          if record_from_users_query.blank?
+            ir_with_no_user_report.push record_from_ir_query
           elsif record_from_ir_query.blank?
-            users_with_no_ir_report.push external_identifier: records["external_identifier"], user_record: record_from_users_query
+            users_with_no_ir_report.push record_from_users_query
           elsif record_from_users_query[:attributes] == record_from_ir_query[:attributes]
             # skip if the attributes are the same
             next
@@ -49,9 +45,7 @@ namespace :compare do
               original_attributes[el["path"].sub("/", "")] = el["was"]
             end
 
-            diff_report.push user_id: records["id"],
-                             external_identifier: records["external_identifier"],
-                             old_record: { attributes: original_attributes },
+            diff_report.push old_record: { attributes: original_attributes },
                              new_record: record_from_ir_query
           end
         end
@@ -64,15 +58,51 @@ namespace :compare do
         puts ""
         puts "building detailed reports..."
 
+        anon_serialized_users = serialized_users[:data].map do |record|
+          record[:attributes][:full_name] = "anon"
+          record[:attributes][:email] = "example@example.com"
+          record
+        end
+        anon_serialized_users = anon_serialized_users.sort_by { |record| record[:id] }
+
+        anon_serialized_induction_records = serialized_induction_records[:data].map do |record|
+          record[:attributes][:full_name] = "anon"
+          record[:attributes][:email] = "example@example.com"
+          record
+        end
+        anon_serialized_induction_records = anon_serialized_induction_records.sort_by { |record| record[:id] }
+
+        anon_users_with_no_ir_report = users_with_no_ir_report.map do |record|
+          record[:attributes][:full_name] = "anon"
+          record[:attributes][:email] = "example@example.com"
+          record
+        end
+
+        anon_ir_with_no_user_report = ir_with_no_user_report.map do |record|
+          record[:attributes][:full_name] = "anon"
+          record[:attributes][:email] = "example@example.com"
+          record
+        end
+
+        anon_diff_report = diff_report.map do |record|
+          record[:old_record][:attributes][:full_name] = "anon" unless record[:old_record][:attributes][:full_name] == nil
+          record[:old_record][:attributes][:email] = "example@example.com" unless record[:old_record][:attributes][:email] == nil
+          record[:new_record][:attributes][:full_name] = "anon"
+          record[:new_record][:attributes][:email] = "example@example.com"
+          record
+        end
+
         folder_timestamp = Time.zone.now.strftime "%Y-%m-%dT%H-%M-%S"
         folder_path = "/tmp/#{folder_timestamp}"
 
         puts "writing detailed reports to folder #{folder_path}/"
 
         Dir.mkdir folder_path
-        File.open("#{folder_path}/api_users_with_no_ir_report.json", "w") { |r| r.puts JSON.pretty_generate(users_with_no_ir_report) }
-        File.open("#{folder_path}/api_ir_with_no_user_report.json", "w") { |r| r.puts JSON.pretty_generate(ir_with_no_user_report) }
-        File.open("#{folder_path}/api_diff_report.json", "w") { |r| r.puts JSON.pretty_generate(diff_report) }
+        File.open("#{folder_path}/api_anon_users_response.json", "w") { |r| r.puts JSON.pretty_generate(anon_serialized_users) }
+        File.open("#{folder_path}/api_anon_ir_response.json", "w") { |r| r.puts JSON.pretty_generate(anon_serialized_induction_records) }
+        File.open("#{folder_path}/api_users_with_no_ir_report.json", "w") { |r| r.puts JSON.pretty_generate(anon_users_with_no_ir_report) }
+        File.open("#{folder_path}/api_ir_with_no_user_report.json", "w") { |r| r.puts JSON.pretty_generate(anon_ir_with_no_user_report) }
+        File.open("#{folder_path}/api_diff_report.json", "w") { |r| r.puts JSON.pretty_generate(anon_diff_report) }
       end
     end
   end

--- a/lib/tasks/compare/ecf_users_and_induction_records.rake
+++ b/lib/tasks/compare/ecf_users_and_induction_records.rake
@@ -85,8 +85,8 @@ namespace :compare do
         end
 
         anon_diff_report = diff_report.map do |record|
-          record[:old_record][:attributes][:full_name] = "anon" unless record[:old_record][:attributes][:full_name] == nil
-          record[:old_record][:attributes][:email] = "example@example.com" unless record[:old_record][:attributes][:email] == nil
+          record[:old_record][:attributes][:full_name] = "anon" unless record[:old_record][:attributes][:full_name].nil?
+          record[:old_record][:attributes][:email] = "example@example.com" unless record[:old_record][:attributes][:email].nil?
           record[:new_record][:attributes][:full_name] = "anon"
           record[:new_record][:attributes][:email] = "example@example.com"
           record


### PR DESCRIPTION
Small change to ensure we return the same id in the API as Support for ECTs uses that to find the record for a user and if we did not then some people would get emailed another invite but some would not get one at all.