### PR TITLE
Minor changes to Support ECTs User Query by Induction Record

### DIFF
--- a/app/serializers/api/v1/ecf_induction_record_serializer.rb
+++ b/app/serializers/api/v1/ecf_induction_record_serializer.rb
@@ -46,7 +46,8 @@ module Api
       end
 
       attributes :core_induction_programme do |induction_record|
-        case induction_record.induction_programme.core_induction_programme&.name
+        core_induction_programme = find_core_induction_programme(induction_record)
+        case core_induction_programme&.name
         when "Ambition Institute"
           CIP_TYPES[:ambition]
         when "Education Development Trust"
@@ -70,6 +71,12 @@ module Api
 
       attributes :cohort do |induction_record|
         induction_record.school_cohort.cohort.start_year
+      end
+
+      def self.find_core_induction_programme(induction_record)
+        induction_record.induction_programme.core_induction_programme ||
+          induction_record.participant_profile&.core_induction_programme ||
+          induction_record.participant_profile&.school_cohort&.core_induction_programme
       end
     end
   end

--- a/app/services/api/v1/ecf/induction_records_query.rb
+++ b/app/services/api/v1/ecf/induction_records_query.rb
@@ -11,7 +11,7 @@ module Api::V1::ECF
 
     def all
       induction_records = InductionRecord
-        .current
+        .merge(InductionRecord.end_date_null.or(InductionRecord.end_date_in_future)).and(InductionRecord.start_date_in_past.or(InductionRecord.not_school_transfer))
         .joins(:induction_programme, :preferred_identity, :participant_profile)
         .merge(ParticipantProfile.ecf)
 
@@ -24,7 +24,7 @@ module Api::V1::ECF
       end
 
       induction_records
-        .group_by(&:preferred_identity_id)
+        .group_by(&:participant_profile_id)
         .transform_values(&:first)
         .values
     end

--- a/lib/tasks/compare/ecf_users_and_induction_records.rake
+++ b/lib/tasks/compare/ecf_users_and_induction_records.rake
@@ -23,6 +23,7 @@ namespace :compare do
 
         ids_from_serialized_users = serialized_users[:data].map { |u| u[:id] }
         ids_from_serialized_induction_records = serialized_induction_records[:data].map { |u| u[:id] }
+        duplicate_records = ids_from_serialized_induction_records.tally.filter { |_, v| v > 1 }
 
         users_with_no_ir_report = []
         ir_with_no_user_report = []
@@ -52,6 +53,7 @@ namespace :compare do
 
         puts "Records returned by the users query:            #{serialized_users[:data].count}"
         puts "Records returned by the induction record query: #{serialized_induction_records[:data].count}"
+        puts "Duplicates found in induction record query:     #{duplicate_records.count}"
         puts "Records found in users query but not in IR:     #{users_with_no_ir_report.count}"
         puts "Records found in IR query but not in users:     #{ir_with_no_user_report.count}"
         puts "Records with differences:                       #{diff_report.count}"

--- a/spec/services/api/v1/ecf/induction_records_query_spec.rb
+++ b/spec/services/api/v1/ecf/induction_records_query_spec.rb
@@ -6,8 +6,16 @@ RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_default_schedules do
   let!(:induction_records_ect_1) { create(:induction_record, :ect, :preferred_identity) }
   let!(:induction_records_ect_2) { create(:induction_record, :ect, :preferred_identity) }
   let!(:induction_records_mentor) { create_list(:induction_record, 2, :mentor, :preferred_identity) }
+
+  # real case from seed data
+  let!(:non_ecf_induction_record) do
+    induction_record = create(:induction_record)
+    induction_record.participant_profile.update! type: "ParticipantProfile::NPQ"
+    induction_record
+  end
+
   let(:all_ecf_induction_records) { [induction_records_ect_1, induction_records_ect_2] + induction_records_mentor }
-  let!(:non_ecf_induction_record) { create(:induction_record) }
+  let(:all_non_ecf_induction_records) { [non_ecf_induction_record] }
 
   subject { described_class.new.all }
 
@@ -17,7 +25,7 @@ RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_default_schedules do
 
   it "only includes ECF participants" do
     expect(subject).to match_array(all_ecf_induction_records)
-    expect(subject).not_to include(non_ecf_induction_record)
+    expect(subject).not_to include(all_non_ecf_induction_records)
   end
 
   context "when filtering by updated_since" do

--- a/spec/services/api/v1/ecf/induction_records_query_spec.rb
+++ b/spec/services/api/v1/ecf/induction_records_query_spec.rb
@@ -3,9 +3,40 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_default_schedules do
+  let(:cip_induction_programme) { create(:induction_programme, :cip) }
+
   let!(:induction_records_ect_1) { create(:induction_record, :ect, :preferred_identity) }
   let!(:induction_records_ect_2) { create(:induction_record, :ect, :preferred_identity) }
+  let!(:induction_records_cip_ect) { create(:induction_record, :ect, :preferred_identity, induction_programme: cip_induction_programme) }
   let!(:induction_records_mentor) { create_list(:induction_record, 2, :mentor, :preferred_identity) }
+
+  let!(:transferring_in_induction_record) do
+    induction_record = create(:induction_record, :ect, :preferred_identity, start_date: 2.months.ago)
+    induction_record.leaving!(1.month.from_now, transferring_out: false)
+    induction_record
+  end
+  let!(:transferring_out_induction_record) do
+    induction_record = create(:induction_record, :ect, :preferred_identity, start_date: 3.months.ago)
+    induction_record.leaving!(2.months.ago, transferring_out: true)
+    induction_record
+  end
+  let!(:withdrawn_induction_record) do
+    induction_record = create(:induction_record, :ect, :preferred_identity, start_date: 2.weeks.ago)
+    induction_record.withdrawing!(1.week.ago)
+    induction_record
+  end
+  let!(:future_induction_record) { create(:induction_record, :ect, :preferred_identity, start_date: 1.year.from_now) }
+
+  let(:induction_records_ects) do
+    [
+      induction_records_ect_1,
+      induction_records_ect_2,
+      induction_records_cip_ect,
+      transferring_in_induction_record,
+      transferring_out_induction_record,
+      withdrawn_induction_record,
+    ]
+  end
 
   # real case from seed data
   let!(:non_ecf_induction_record) do
@@ -14,7 +45,7 @@ RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_default_schedules do
     induction_record
   end
 
-  let(:all_ecf_induction_records) { [induction_records_ect_1, induction_records_ect_2] + induction_records_mentor }
+  let(:all_ecf_induction_records) { induction_records_ects + induction_records_mentor }
   let(:all_non_ecf_induction_records) { [non_ecf_induction_record] }
 
   subject { described_class.new.all }
@@ -23,15 +54,46 @@ RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_default_schedules do
     expect(subject).to all(be_a(InductionRecord))
   end
 
-  it "only includes ECF participants" do
-    expect(subject).to match_array(all_ecf_induction_records)
-    expect(subject).not_to include(all_non_ecf_induction_records)
+  it "includes ECF participants" do
+    expect(subject).to include(*all_ecf_induction_records)
+  end
+
+  it "includes Mentor participants" do
+    expect(subject).to include(*induction_records_mentor)
+  end
+
+  it "includes ECT participants" do
+    expect(subject).to include(*induction_records_ects)
+  end
+
+  it "includes CIP participants" do
+    expect(subject).to include(*induction_records_cip_ect)
+  end
+
+  it "includes past 'transferring_in' participants" do
+    expect(subject).to include(transferring_in_induction_record)
+  end
+
+  it "includes past 'transferring_out' participants" do
+    expect(subject).to include(transferring_out_induction_record)
+  end
+
+  it "includes past 'Withdrawn' participants" do
+    expect(subject).to include(withdrawn_induction_record)
+  end
+
+  it "does not include Non-ECF participants" do
+    expect(subject).not_to include(*all_non_ecf_induction_records)
+  end
+
+  it "does not include Future participants" do
+    expect(subject).not_to include(future_induction_record)
   end
 
   context "when filtering by updated_since" do
     before { induction_records_ect_1.update(updated_at: 1.year.ago) }
 
-    subject { described_class.new(updated_since: 1.month.ago).all }
+    subject { described_class.new(updated_since: 4.months.ago).all }
 
     it "returns a list of users with updated_at timestamps later than the supplied one" do
       expect(subject).to match_array(all_ecf_induction_records.without(induction_records_ect_1))


### PR DESCRIPTION
Changes a few selection rules:

  - group by clause - so it is participant_profiles not preferred_identities
  - ordering - as current API does not filter out leaving and withdrawn
  - fallback to participant_profile to try and get core_induction_programme name if it is not copied to the induction_record