### PR TITLE
[CPDLP-1900] Fix csv extract query to account for two bugs (line items and duplicates)

### DIFF
--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -42,7 +42,7 @@ module Finance
               sc.urn                                                           AS school_urn,
               sc.name                                                          AS school_name,
               pd.id                                                            AS declaration_id,
-              pd.state                                                         AS declaration_status,
+              sli.state                                                        AS declaration_status,
               pd.declaration_type                                              AS declaration_type,
               pd.declaration_date                                              AS declaration_date,
               pd.created_at                                                    AS declaration_created_at,
@@ -54,7 +54,11 @@ module Finance
             JOIN cpd_lead_providers clp    ON clp.id = pd.cpd_lead_provider_id
             JOIN lead_providers lp         ON lp.cpd_lead_provider_id = clp.id
             JOIN participant_profiles pp   ON pd.participant_profile_id = pp.id
-            LEFT OUTER JOIN participant_profile_states pps ON pps.participant_profile_id = pp.id AND pps.cpd_lead_provider_id = clp.id AND pps.state = 'withdrawn'
+            LEFT OUTER JOIN (
+              SELECT DISTINCT ON (cpd_lead_provider_id) cpd_lead_provider_id, participant_profile_id, state, reason
+              FROM participant_profile_states
+              ORDER BY cpd_lead_provider_id, created_at DESC
+            ) AS pps ON pps.participant_profile_id = pp.id AND pd.cpd_lead_provider_id = pps.cpd_lead_provider_id AND pps.state = 'withdrawn'
             JOIN participant_identities pi ON pp.participant_identity_id = pi.id
             JOIN users u                   ON u.id = pi.user_id
             JOIN teacher_profiles tp       ON tp.id = pp.teacher_profile_id

--- a/app/services/finance/npq/assurance_report/query.rb
+++ b/app/services/finance/npq/assurance_report/query.rb
@@ -33,7 +33,7 @@ module Finance
               pp.status                               AS training_status,
               pps.reason                              AS training_status_reason,
               pd.id                                   AS declaration_id,
-              pd.state                                AS declaration_status,
+              sli.state                               AS declaration_status,
               pd.declaration_type                     AS declaration_type,
               pd.declaration_date                     AS declaration_date,
               pd.created_at                           AS declaration_created_at,

--- a/spec/requests/finance/npq/assurance_reports_spec.rb
+++ b/spec/requests/finance/npq/assurance_reports_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe Finance::NPQ::AssuranceReportsController, :with_default_schedules
   let(:school)                  { create(:school, name: "A school") }
   let(:other_cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:other_statement)         { create(:npq_statement, cpd_lead_provider: other_cpd_lead_provider) }
+
+  let(:parsed_response) { CSV.parse(response.body.force_encoding("utf-8"), headers: true, encoding: "utf-8", col_sep: ",") }
+
   before do
     travel_to statement.deadline_date do
-      create_list(:npq_participant_declaration, 2, :eligible, cpd_lead_provider:, school_urn: school.urn)
+      @declarations = create_list(:npq_participant_declaration, 2, :eligible, cpd_lead_provider:, school_urn: school.urn)
     end
     travel_to other_statement.deadline_date do
       create_list(:npq_participant_declaration, 2, :eligible, cpd_lead_provider: other_cpd_lead_provider)
@@ -20,14 +23,18 @@ RSpec.describe Finance::NPQ::AssuranceReportsController, :with_default_schedules
     sign_in user
   end
 
-  it "allows to download a CSV of the assurance report", :aggregate_failures do
+  it "allows to download a CSV of the assurance report" do
     get finance_npq_statement_assurance_report_path(statement, format: "csv")
 
     content_disposition_cookie_header = Rack::Utils.parse_cookies_header(response.headers["Content-Disposition"])
     expect(content_disposition_cookie_header)
       .to include({ "filename" => "\"NPQ-Declarations-#{npq_lead_provider.name.gsub(/\W/, '')}-Cohort#{statement.cohort.start_year}-#{statement.name.gsub(/\W/, '')}.csv\"" })
+  end
 
-    CSV.parse(response.body.force_encoding("utf-8"), headers: true, encoding: "utf-8", col_sep: ",") do |row|
+  it "returns the correct values in the CSV", :aggregate_failures do
+    get finance_npq_statement_assurance_report_path(statement, format: "csv")
+
+    parsed_response.each do |row|
       expect(row["Statement Name"]).to eq(statement.name)
       expect(row["Statement ID"]).to eq(statement.id)
 
@@ -50,6 +57,40 @@ RSpec.describe Finance::NPQ::AssuranceReportsController, :with_default_schedules
       expect(row["School Name"]).to               eq(school.name)
       expect(row["Targeted Delivery Funding"]).to eq(npq_application.targeted_delivery_funding_eligibility.to_s)
       expect(row["Eligible For Funding"]).to      eq("true")
+    end
+  end
+
+  context "with multiple withdrawn participant profile states" do
+    let(:participant_profile) { @declarations.first.participant_profile }
+    let(:other_participant_profile) { @declarations.last.participant_profile }
+
+    before do
+      participant_profile.participant_profile_states.create!({ state: "withdrawn", cpd_lead_provider: })
+      participant_profile.participant_profile_states.create!({ state: "withdrawn", cpd_lead_provider: })
+      other_participant_profile.participant_profile_states.create!({ state: "withdrawn", cpd_lead_provider: })
+      other_participant_profile.participant_profile_states.create!({ state: "withdrawn", cpd_lead_provider: })
+    end
+
+    it "does not duplicate the CSV response rows count" do
+      get finance_npq_statement_assurance_report_path(statement, format: "csv")
+
+      expect(parsed_response.length).to eql(2)
+    end
+  end
+
+  context "with latest declaration status different from the one originally set for the statement" do
+    before do
+      @declarations.map { |declaration| declaration.statement_line_items.update_all(state: "awaiting_clawback") }
+    end
+
+    it "gets the declaration status from statement line items" do
+      get finance_npq_statement_assurance_report_path(statement, format: "csv")
+
+      parsed_response.each do |row|
+        participant_declaration = ParticipantDeclaration.find(row["Declaration ID"])
+        expect(row["Declaration Status"]).not_to eq(participant_declaration.state)
+        expect(row["Declaration Status"]).to eql("awaiting_clawback")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

The counts of declarations in particular states in the statement csv extracts may not match the statement on the service due to a couple of bugs. First, the csv extract may duplicate a declaration where the participant’s training_status has changed since the declaration was submitted (see Capita November 2022, cohort 2, ECF statement). Second, the query extract may not count a declaration as paid where it has been clawed_back, as the query pulls the latest state for a declaration, rather than state via statement_line_items (See Ambition October 2022, Cohort 2021, ECF statement).

- Ticket: [CPDLP-1900](https://dfedigital.atlassian.net/browse/CPDLP-1900)

### Changes proposed in this pull request
Fix csv extract query to account for the two bugs reported above (line items and duplicates)


