### PR TITLE
Stop autovalidation on manual validation details change

### DIFF
--- a/app/controllers/admin/participants/validation_data_controller.rb
+++ b/app/controllers/admin/participants/validation_data_controller.rb
@@ -5,7 +5,7 @@ module Admin::Participants
     before_action :load_participant_profile
     before_action :load_validation_data_form, except: :validate_details
     before_action :check_can_update_validation_data, if: -> { request.put? || request.post? }
-    before_action :validate_save_and_redirect, except: :validate_details
+    before_action :save_and_redirect, except: :validate_details
 
     def full_name; end
 
@@ -33,7 +33,7 @@ module Admin::Participants
       end
     end
 
-    def validate_save_and_redirect
+    def save_and_redirect
       if (request.put? || request.post?) && step_valid?
         save_validation_data!
         set_status_message_for_update
@@ -53,11 +53,7 @@ module Admin::Participants
     end
 
     def set_status_message_for_update
-      if validation_data.can_validate_participant?
-        generate_status_message(validate_participant!)
-      else
-        set_success_message(content: "Validation information updated")
-      end
+      set_success_message(content: "Validation information updated")
     end
 
     def generate_status_message(validation_result)

--- a/app/controllers/admin/participants/validation_data_controller.rb
+++ b/app/controllers/admin/participants/validation_data_controller.rb
@@ -36,7 +36,7 @@ module Admin::Participants
     def save_and_redirect
       if (request.put? || request.post?) && step_valid?
         save_validation_data!
-        set_status_message_for_update
+        set_success_message(content: "Validation information updated")
 
         redirect_to validation_page
       end
@@ -50,10 +50,6 @@ module Admin::Participants
         validation_data[current_action] = @validation_data_form.send(current_action)
       end
       validation_data.save!
-    end
-
-    def set_status_message_for_update
-      set_success_message(content: "Validation information updated")
     end
 
     def generate_status_message(validation_result)


### PR DESCRIPTION
### Context

Currently we auto-validate a participant when any of their manual validation data is changed. Once validated it's _fixed_ can no longer be amended by support staff.

> ...we've noticed when trying to manually validate participants on the service as soon as you update the TRN it automatically validates their record before you update their NIN. So we now have a few ECT/Mentors with the correct DOB/TRN but someone else's NINO

This is usually fine but we occasionally have a problem where two fields need to be amended. After the first one is changed the autovalidation runs and the second one can no longer be.

To prevent this from happening this change removes the auto-validation. Now agents will need to click the 'Validate details' button to trigger it. This way they can be sure all data is correct.
