### PR TITLE
Upgrade to `govuk-frontend` 4.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,8 @@ gem "mail-notify", "~> 1.1"
 # do not rely on host's timezone data, which can be inconsistent
 gem "tzinfo-data"
 
-gem "govuk-components", "~> 3.2"
-gem "govuk_design_system_formbuilder", "~> 3.2"
+gem "govuk-components", "~> 3.3"
+gem "govuk_design_system_formbuilder", "~> 3.3"
 gem "view_component", require: "view_component/engine"
 
 # Fetching from APIs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,14 +212,11 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (3.2.2)
-      actionpack (>= 6.1)
-      activemodel (>= 6.1)
+    govuk-components (3.3.0)
       html-attributes-utils (~> 0.9, >= 0.9.2)
       pagy (~> 5.10.1)
-      railties (>= 6.1)
       view_component (~> 2.74.1)
-    govuk_design_system_formbuilder (3.2.0)
+    govuk_design_system_formbuilder (3.3.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -624,8 +621,8 @@ DEPENDENCIES
   google-apis-drive_v3
   google-cloud-bigquery
   googleauth
-  govuk-components (~> 3.2)
-  govuk_design_system_formbuilder (~> 3.2)
+  govuk-components (~> 3.3)
+  govuk_design_system_formbuilder (~> 3.3)
   httpclient (~> 2.8, >= 2.8.3)
   json-diff (~> 0.4.1)
   json-schema (>= 2.8.1)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "css-loader": "^6.7.2",
     "css-minimizer-webpack-plugin": "^3.4.1",
     "es6-promise": "^4.2.8",
-    "govuk-frontend": "^4.3.1",
+    "govuk-frontend": "^4.4.0",
     "mini-css-extract-plugin": "^2.7.0",
     "sass": "^1.56.1",
     "sass-loader": "^12.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4289,10 +4289,10 @@ globals@^13.15.0:
   dependencies:
     type-fest "^0.20.2"
 
-govuk-frontend@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
-  integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
+govuk-frontend@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.4.0.tgz#36531ae3b12798267e5a72409c7e4b3b10565102"
+  integrity sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"


### PR DESCRIPTION
### Context

This upgrades `govuk-frontend` to [version 4.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0).

We need to update the components and form builder libraries in sync because there are some markup changes to the [error summary component](https://design-system.service.gov.uk/components/error-summary/).

Fixes #2750, #2742, #2751


### Notes

We still have a few hardcoded error summaries sprinkled throughout the templates. I haven't amended them as we're not using the pattern correctly anyway (it's essentially used like a red [notification banner](https://design-system.service.gov.uk/components/notification-banner/) instead of a error summary). I'll add a separate ticket for them to be removed.