### PR TITLE
Add direct route for new form url and update link in views

### DIFF
--- a/app/views/layouts/_phase_banner.erb
+++ b/app/views/layouts/_phase_banner.erb
@@ -14,7 +14,7 @@
       </strong>
       <span class="govuk-phase-banner__text">
         This is a new service – your
-        <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
+        <%= govuk_link_to "feedback", feedback_form_url, target: "_blank", rel: "noopener noreferrer" %>
         will help us to improve it.
       </span>
     </p>

--- a/app/views/layouts/_phase_banner_wide.html.erb
+++ b/app/views/layouts/_phase_banner_wide.html.erb
@@ -14,7 +14,7 @@
       </strong>
       <span class="govuk-phase-banner__text">
         This is a new service – your
-        <%= govuk_link_to "feedback", "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u", target: "_blank", rel: "noopener noreferrer" %>
+        <%= govuk_link_to "feedback", feedback_form_url, target: "_blank", rel: "noopener noreferrer" %>
         will help us to improve it.
       </span>
     </p>

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -178,4 +178,4 @@ end %>
 <h3 class="govuk-heading-m">Take part in user research and give feedback</h3>
 <p class="govuk-body-m">We welcome feedback on all aspects of Manage continuing professional development. When you participate in user research, you help shape current and future service features.</p>
 
-<p class="govuk-body-m">Please <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-VlIdprT6TlEmsOS8-ufjHVUQzgyQVVOSERHWkZYV045RVYxSTBQWlNUSi4u" class="govuk-link">complete this 30-second form</a> and we’ll be in touch. Or, simply give us your feedback over email at <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-link">continuing-professional-development@digital.education.gov.uk</a>.</p>
+<p class="govuk-body-m">Please <%= govuk_link_to "complete this 30-second form", feedback_form_url, target: "_blank", rel: "noopener noreferrer" %> and we’ll be in touch. Or, simply give us your feedback over email at <a href="mailto:continuing-professional-development@digital.education.gov.uk" class="govuk-link">continuing-professional-development@digital.education.gov.uk</a>.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
     get "/users/link-invalid", to: "users/sessions#link_invalid"
   end
 
+  direct :feedback_form do
+    "https://docs.google.com/forms/d/e/1FAIpQLSdjpB1VMwZlcQxOoTzfW_bw7mnnKbGHek24_uZRhIRDid9f-Q/viewform?usp=sf_link"
+  end
+
   scope :pages, controller: "pages" do
     get "/ect-additional-information", to: redirect("https://www.gov.uk/guidance/guidance-for-early-career-teachers-ects-ecf-based-training")
     get "/mentor-additional-information", to: redirect("https://www.gov.uk/guidance/guidance-for-mentors-how-to-support-ecf-based-training")


### PR DESCRIPTION
### Context

The old feedback URL was stored in Microsoft land somewhere and the user who owned the account had left. As a temporary measure a simpler Google form has been put together by our UR team and this PR updates the URL to link to the new form.

### Changes proposed in this pull request

Move URL into the routes
Replace hard-coded URL in views with Rails URL helper `feedback_form_url`

### Guidance to review

Feedback link in header banner and lead provider content page now points to new form URL