### PR TITLE
[CPDLP-1703] Financial Statements - Replace word 'trainee' with 'participant'

### DIFF
--- a/app/components/finance/npq/payment_overviews/course.html.erb
+++ b/app/components/finance/npq/payment_overviews/course.html.erb
@@ -20,8 +20,8 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-body-s"><%= t("finance.payment_type") %></th>
-        <th scope="col" class="govuk-table__header govuk-body-s"><%= t("finance.trainees") %></th>
-        <th scope="col" class="govuk-table__header govuk-body-s"><%= t("finance.payment_per_trainee") %></th>
+        <th scope="col" class="govuk-table__header govuk-body-s"><%= t("finance.course.participants") %></th>
+        <th scope="col" class="govuk-table__header govuk-body-s"><%= t("finance.course.payment_per_participant") %></th>
         <th scope="col" class="govuk-table__header govuk-body-s"><%= t("finance.total") %></th>
       </tr>
     </thead>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -136,7 +136,7 @@
               <% end %>
 
               <% body.row do |row| %>
-                <% row.cell(text: "Fee per trainee") %>
+                <% row.cell(text: "Fee per participant") %>
 
                 <% @calculator.band_letters.each do |letter| %>
                   <% row.cell(text: number_to_pounds(@calculator.public_send("#{event_type}_band_#{letter}_fee_per_declaration")), numeric: true) %>
@@ -187,8 +187,8 @@
         <% table.head do |head| %>
           <% head.row do |row| %>
             <% row.cell(header: true, text: "Adjustment type") %>
-            <% row.cell(header: true, text: "Number of trainees") %>
-            <% row.cell(header: true, text: "Fee per trainee") %>
+            <% row.cell(header: true, text: "Number of participants") %>
+            <% row.cell(header: true, text: "Fee per participant") %>
             <% row.cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,6 +485,9 @@ en:
     current_milestone: Current milestone
     trainees: Trainees
     view: View
+    course:
+      participants: Participants
+      payment_per_participant: Payment per participant
     contract:
       version: Contract reference
       per_participant: Per participant


### PR DESCRIPTION
### Context

- Ticket:  https://dfedigital.atlassian.net/browse/CPDLP-1703

### Changes proposed in this pull request

* Quick fix for NPQ+ECF finance statement page
* "Trainee" replaced with "Participant"

### Guidance to review

* See NPQ finance statement
* See ECF finance statement

