### PR TITLE
Fix Course payment breakdown flakey test

### DIFF
--- a/spec/features/finance/npq/course_payment_breakdown_spec.rb
+++ b/spec/features/finance/npq/course_payment_breakdown_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature "NPQ Course payment breakdown", :with_default_schedules, type: :fe
   end
 
   def create_started_declarations(npq_application)
-    timestamp = npq_application.profile.schedule.milestones.first.start_date + 1.day
+    timestamp = npq_application.profile.schedule.milestones.order(start_date: :asc).first.start_date + 1.day
     travel_to(timestamp) do
       RecordDeclaration.new(
         participant_id: npq_application.participant_identity.external_identifier,


### PR DESCRIPTION
### Context
We are getting flakey tests on `spec/features/finance/npq/course_payment_breakdown_spec.rb:77` where the statement cannot be found when attempting to create a declaration

- Ticket: n/a

### Changes proposed in this pull request
When attempting to find the `next_output_fee_statement` for a provider, we are attempting to get the statement where the `deadline_date` is more than or equal to the current date. This current date is being set to the first milestone on the
schedule in the test. It seems picking the first one does not respect the start date order, explicitly set the order to the first date to avoid flakey failures where the statement cannot be found.

### Guidance to review
Failure example: https://github.com/DFE-Digital/early-careers-framework/actions/runs/3559650405/jobs/5979146937
