### PR TITLE
Add API endpoint to View all NPQ participant outcomes per provider

### DIFF
--- a/app/controllers/api/v1/participant_outcomes_controller.rb
+++ b/app/controllers/api/v1/participant_outcomes_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ParticipantOutcomesController < Api::ApiController
+      include ApiTokenAuthenticatable
+
+      def index
+        participant_declarations_hash = serializer_class.new(query_scope).serializable_hash
+        render json: participant_declarations_hash.to_json
+      end
+
+    private
+
+      def serializer_class
+        ParticipantOutcomeSerializer
+      end
+
+      def query_scope
+        ParticipantOutcomes::Index.new(
+          cpd_lead_provider:,
+        ).scope
+      end
+
+      def filter
+        params[:filter] ||= {}
+      end
+
+      def participant_id_filter
+        filter[:participant_id]
+      end
+
+      def cpd_lead_provider
+        current_user
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/participant_outcomes_controller.rb
+++ b/app/controllers/api/v1/participant_outcomes_controller.rb
@@ -4,9 +4,10 @@ module Api
   module V1
     class ParticipantOutcomesController < Api::ApiController
       include ApiTokenAuthenticatable
+      include ApiPagination
 
       def index
-        participant_declarations_hash = serializer_class.new(query_scope).serializable_hash
+        participant_declarations_hash = serializer_class.new(paginate(query_scope)).serializable_hash
         render json: participant_declarations_hash.to_json
       end
 

--- a/app/controllers/api/v1/participant_outcomes_controller.rb
+++ b/app/controllers/api/v1/participant_outcomes_controller.rb
@@ -23,14 +23,6 @@ module Api
         ).scope
       end
 
-      def filter
-        params[:filter] ||= {}
-      end
-
-      def participant_id_filter
-        filter[:participant_id]
-      end
-
       def cpd_lead_provider
         current_user
       end

--- a/app/controllers/api/v1/participant_outcomes_controller.rb
+++ b/app/controllers/api/v1/participant_outcomes_controller.rb
@@ -18,7 +18,7 @@ module Api
       end
 
       def query_scope
-        ParticipantOutcomes::Index.new(
+        ParticipantOutcomesQuery.new(
           cpd_lead_provider:,
         ).scope
       end

--- a/app/controllers/api/v2/participant_outcomes_controller.rb
+++ b/app/controllers/api/v2/participant_outcomes_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class ParticipantOutcomesController < V1::ParticipantOutcomesController
+    end
+  end
+end

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -14,8 +14,13 @@ module Api
       attribute :completion_date do |outcome|
         outcome.completion_date.rfc3339
       end
+
       attribute :course_identifier do |outcome|
         outcome.participant_declaration.course_identifier
+      end
+
+      attribute :has_passed do |outcome|
+        outcome.state == "passed"
       end
 
       attribute :participant_id do |outcome|

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "jsonapi/serializer/instrumentation"
+
+module Api
+  module V1
+    class ParticipantOutcomeSerializer
+      include JSONAPI::Serializer
+      include JSONAPI::Serializer::Instrumentation
+
+      set_id :id
+      set_type :'participant-outcome'
+
+      attribute :completion_date do |outcome|
+        outcome.completion_date.rfc3339
+      end
+      attribute :course_identifier do |outcome|
+        outcome.participant_declaration.course_identifier
+      end
+
+      attribute :participant_id do |outcome|
+        outcome.participant_declaration.participant_profile.npq_application.participant_identity.user_id
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -21,7 +21,7 @@ module Api
       end
 
       attribute :participant_id do |outcome|
-        outcome.participant_declaration.participant_profile.npq_application.participant_identity.external_identifier
+        outcome.participant_declaration.participant_profile.participant_identity.external_identifier
       end
 
       attribute :created_at do |outcome|

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -11,16 +11,13 @@ module Api
       set_id :id
       set_type :'participant-outcome'
 
+      attribute :state
       attribute :completion_date do |outcome|
         outcome.completion_date.rfc3339
       end
 
       attribute :course_identifier do |outcome|
         outcome.participant_declaration.course_identifier
-      end
-
-      attribute :has_passed do |outcome|
-        outcome.state == "passed"
       end
 
       attribute :participant_id do |outcome|

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -19,7 +19,7 @@ module Api
       end
 
       attribute :participant_id do |outcome|
-        outcome.participant_declaration.participant_profile.npq_application.participant_identity.user_id
+        outcome.participant_declaration.participant_profile.npq_application.participant_identity.external_identifier
       end
     end
   end

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -21,6 +21,10 @@ module Api
       attribute :participant_id do |outcome|
         outcome.participant_declaration.participant_profile.npq_application.participant_identity.external_identifier
       end
+
+      attribute :created_at do |outcome|
+        outcome.created_at.rfc3339
+      end
     end
   end
 end

--- a/app/services/api/participant_outcomes/index.rb
+++ b/app/services/api/participant_outcomes/index.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module ParticipantOutcomes
+    class Index
+      attr_reader :cpd_lead_provider
+
+      def initialize(cpd_lead_provider:)
+        @cpd_lead_provider = cpd_lead_provider
+      end
+
+      def scope
+        ParticipantOutcome::NPQ
+          .joins(:participant_declaration)
+          .order(:created_at)
+          .merge(declarations_scope)
+      end
+
+    private
+
+      def declarations_scope
+        ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
+      end
+    end
+  end
+end

--- a/app/services/api/v1/participant_outcomes_query.rb
+++ b/app/services/api/v1/participant_outcomes_query.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Api
-  module ParticipantOutcomes
-    class Index
+  module V1
+    class ParticipantOutcomesQuery
       attr_reader :cpd_lead_provider
 
       def initialize(cpd_lead_provider:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,9 @@ Rails.application.routes.draw do
       end
       resources :npq_participants, only: %i[index show], path: "participants/npq" do
         concerns :participant_actions
+        collection do
+          resources :outcomes, only: %i[index], controller: "participant_outcomes"
+        end
       end
       resources :npq_enrolments, only: %i[index], path: "npq-enrolments"
       resources :users, only: %i[index create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,9 @@ Rails.application.routes.draw do
       end
       resources :npq_participants, only: %i[index show], path: "participants/npq" do
         concerns :participant_actions
+        collection do
+          resources :outcomes, only: %i[index], controller: "participant_outcomes"
+        end
       end
       resources :users, only: %i[index create]
       resources :ecf_users, only: %i[index create], path: "ecf-users"

--- a/spec/docs/v1/participant_outcomes_spec.rb
+++ b/spec/docs/v1/participant_outcomes_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/
   let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
 
   path "/api/v1/participants/npq/outcomes" do
-    get "List all participant declarations" do
+    get "List all participant NPQ outcomes" do
       operationId :participant_outcomes
       tags "participants outcomes"
       security [bearerAuth: []]
@@ -27,7 +27,7 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/
                 explode: true,
                 required: false,
                 example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
-                description: "Pagination options to navigate through the list of participant declarations."
+                description: "Pagination options to navigate through the list of participant NPQ outcomes."
 
       response "200", "A list of participant outcomes" do
         schema({ "$ref": "#/components/schemas/NPQOutcomesResponse" })

--- a/spec/docs/v1/participant_outcomes_spec.rb
+++ b/spec/docs/v1/participant_outcomes_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_spec.json" do
+  let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
+  let(:bearer_token)         { "Bearer #{token}" }
+  let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
+  let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
+  let(:Authorization)     { bearer_token }
+  let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }
+  let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
+
+  path "/api/v1/participants/npq/outcomes" do
+    get "List all participant declarations" do
+      operationId :participant_outcomes
+      tags "participants outcomes"
+      security [bearerAuth: []]
+
+      parameter name: :page,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/Pagination",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
+                description: "Pagination options to navigate through the list of participant declarations."
+
+      response "200", "A list of participant outcomes" do
+        schema({ "$ref": "#/components/schemas/NPQOutcomesResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/docs/v2/participant_outcomes_spec.rb
+++ b/spec/docs/v2/participant_outcomes_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/
   let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
 
   path "/api/v2/participants/npq/outcomes" do
-    get "List all participant declarations" do
+    get "List all participant NPQ outcomes" do
       operationId :participant_outcomes
       tags "participants outcomes"
       security [bearerAuth: []]
@@ -27,7 +27,7 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/
                 explode: true,
                 required: false,
                 example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
-                description: "Pagination options to navigate through the list of participant declarations."
+                description: "Pagination options to navigate through the list of participant NPQ outcomes."
 
       response "200", "A list of participant outcomes" do
         schema({ "$ref": "#/components/schemas/NPQOutcomesResponse" })

--- a/spec/docs/v2/participant_outcomes_spec.rb
+++ b/spec/docs/v2/participant_outcomes_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_spec.json" do
+  let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
+  let(:bearer_token)         { "Bearer #{token}" }
+  let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
+  let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
+  let(:Authorization)     { bearer_token }
+  let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }
+  let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
+
+  path "/api/v2/participants/npq/outcomes" do
+    get "List all participant declarations" do
+      operationId :participant_outcomes
+      tags "participants outcomes"
+      security [bearerAuth: []]
+
+      parameter name: :page,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/Pagination",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
+                description: "Pagination options to navigate through the list of participant declarations."
+
+      response "200", "A list of participant outcomes" do
+        schema({ "$ref": "#/components/schemas/NPQOutcomesResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/factories/participant_outcome_npq.rb
+++ b/spec/factories/participant_outcome_npq.rb
@@ -7,8 +7,16 @@ FactoryBot.define do
     completion_date { Date.yesterday }
     state { :passed }
 
+    trait :passed do
+      state { :passed }
+    end
+
     trait :failed do
       state { :failed }
+    end
+
+    trait :voided do
+      state { :voided }
     end
   end
 end

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/participants/{id}/change-schedule
         /api/v1/participants/ecf/{id}/change-schedule
         /api/v1/participants/npq/{id}/change-schedule
+        /api/v1/participants/npq/outcomes
         /api/v1/participants/{id}/withdraw
       ]
 

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request do
   let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
   let(:bearer_token)         { "Bearer #{token}" }
-  let(:fake_logger)          { double("logger", info: nil) }
   let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
   let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
   let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -83,7 +83,7 @@ private
         "completion_date" => outcome.completion_date.rfc3339,
         "created_at" => outcome.created_at.rfc3339,
         "course_identifier" => course_identifier,
-        "has_passed" => outcome.state == "passed",
+        "state" => outcome.state,
         "participant_id" => profile.npq_application.participant_identity.user_id,
       },
       "id" => outcome.id,

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
           expect(parsed_response).to eq(expected_response)
         end
       end
+
+      it "can return paginated data" do
+        create :participant_outcome, :failed, participant_declaration: declaration
+        create :participant_outcome, :passed, participant_declaration: declaration
+        create :participant_outcome, :voided, participant_declaration: declaration
+        get "/api/v1/participants/npq/outcomes", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
+
+        get "/api/v1/participants/npq/outcomes", params: { page: { per_page: 2, page: 2 } }
+        expect(parsed_response["data"].size).to eql(1)
+      end
     end
 
     context "when unauthorized" do

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -83,6 +83,7 @@ private
         "completion_date" => outcome.completion_date.rfc3339,
         "created_at" => outcome.created_at.rfc3339,
         "course_identifier" => course_identifier,
+        "has_passed" => outcome.state == "passed",
         "participant_id" => profile.npq_application.participant_identity.user_id,
       },
       "id" => outcome.id,

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request do
+  let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
+  let(:bearer_token)         { "Bearer #{token}" }
+  let(:fake_logger)          { double("logger", info: nil) }
+  let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
+  let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
+  let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }
+
+  describe "JSON Index Api" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+        default_headers[:CONTENT_TYPE] = "application/json"
+      end
+
+      context "when no outcome exists" do
+        it "returns empty array" do
+          get "/api/v1/participants/npq/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq("data" => [])
+        end
+      end
+
+      context "when outcome exists" do
+        let(:expected_response) do
+          expected_json_response(outcome:, profile: npq_application.profile)
+        end
+        let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
+
+        it "returns serialised data" do
+          get "/api/v1/participants/npq/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq(expected_response)
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      let(:bearer_token) { "Bearer a43098a098a" }
+
+      it "returns 401 for invalid bearer token" do
+        get "/api/v1/participants/npq/outcomes"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+private
+
+  def parsed_response
+    JSON.parse(response.body)
+  end
+
+  def expected_json_response(outcome:, profile:, course_identifier: declaration.course_identifier)
+    {
+      "data" =>
+      [
+        single_json_outcome(outcome:, profile:, course_identifier:),
+      ],
+    }
+  end
+
+  def single_json_outcome(outcome:, profile:, course_identifier:)
+    {
+      "attributes" => {
+        "completion_date" => outcome.completion_date.rfc3339,
+        "course_identifier" => course_identifier,
+        "participant_id" => profile.npq_application.participant_identity.user_id,
+      },
+      "id" => outcome.id,
+      "type" => "participant-outcome",
+    }
+  end
+end

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -81,6 +81,7 @@ private
     {
       "attributes" => {
         "completion_date" => outcome.completion_date.rfc3339,
+        "created_at" => outcome.created_at.rfc3339,
         "course_identifier" => course_identifier,
         "participant_id" => profile.npq_application.participant_identity.user_id,
       },

--- a/spec/requests/api/v2/participant_outcome_spec.rb
+++ b/spec/requests/api/v2/participant_outcome_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request do
+  let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
+  let(:bearer_token)         { "Bearer #{token}" }
+  let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
+  let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
+  let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }
+
+  describe "JSON Index Api" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+        default_headers[:CONTENT_TYPE] = "application/json"
+      end
+
+      context "when no outcome exists" do
+        it "returns empty array" do
+          get "/api/v2/participants/npq/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq("data" => [])
+        end
+      end
+
+      context "when outcome exists" do
+        let(:expected_response) do
+          expected_json_response(outcome:, profile: npq_application.profile)
+        end
+        let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
+
+        it "returns serialised data" do
+          get "/api/v2/participants/npq/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq(expected_response)
+        end
+      end
+
+      it "can return paginated data" do
+        create :participant_outcome, :failed, participant_declaration: declaration
+        create :participant_outcome, :passed, participant_declaration: declaration
+        create :participant_outcome, :voided, participant_declaration: declaration
+        get "/api/v2/participants/npq/outcomes", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
+
+        get "/api/v2/participants/npq/outcomes", params: { page: { per_page: 2, page: 2 } }
+        expect(parsed_response["data"].size).to eql(1)
+      end
+    end
+
+    context "when unauthorized" do
+      let(:bearer_token) { "Bearer a43098a098a" }
+
+      it "returns 401 for invalid bearer token" do
+        get "/api/v2/participants/npq/outcomes"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+private
+
+  def parsed_response
+    JSON.parse(response.body)
+  end
+
+  def expected_json_response(outcome:, profile:, course_identifier: declaration.course_identifier)
+    {
+      "data" =>
+      [
+        single_json_outcome(outcome:, profile:, course_identifier:),
+      ],
+    }
+  end
+
+  def single_json_outcome(outcome:, profile:, course_identifier:)
+    {
+      "attributes" => {
+        "completion_date" => outcome.completion_date.rfc3339,
+        "created_at" => outcome.created_at.rfc3339,
+        "course_identifier" => course_identifier,
+        "state" => outcome.state,
+        "participant_id" => profile.npq_application.participant_identity.user_id,
+      },
+      "id" => outcome.id,
+      "type" => "participant-outcome",
+    }
+  end
+end

--- a/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::ParticipantOutcomeSerializer, :with_default_schedules do
+  describe "#serializable_hash" do
+    let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
+    let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
+    let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }
+    subject(:outcome) { create :participant_outcome, participant_declaration: declaration }
+
+    it "serialises to the correct structure" do
+      result = described_class.new(outcome).serializable_hash
+      expected = {
+        data: {
+          id: outcome.id,
+          type: :"participant-outcome",
+          attributes: {
+            completion_date: outcome.completion_date.rfc3339,
+            participant_id: npq_application.participant_identity.user_id,
+            course_identifier: declaration.course_identifier,
+          },
+        },
+      }
+      expect(result).to eql(expected)
+    end
+  end
+end

--- a/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::ParticipantOutcomeSerializer, :with_default_schedules do
     let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }
     let(:npq_application) { create :npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider }
     let(:declaration) { create :npq_participant_declaration, participant_profile: npq_application.profile, cpd_lead_provider: provider }
-    subject(:outcome) { create :participant_outcome, participant_declaration: declaration }
+    subject(:outcome) { create :participant_outcome, :passed, participant_declaration: declaration }
 
     it "serialises to the correct structure" do
       result = described_class.new(outcome).serializable_hash
@@ -18,6 +18,7 @@ RSpec.describe Api::V1::ParticipantOutcomeSerializer, :with_default_schedules do
           attributes: {
             completion_date: outcome.completion_date.rfc3339,
             created_at: outcome.created_at.rfc3339,
+            has_passed: true,
             participant_id: npq_application.participant_identity.external_identifier,
             course_identifier: declaration.course_identifier,
           },

--- a/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Api::V1::ParticipantOutcomeSerializer, :with_default_schedules do
           type: :"participant-outcome",
           attributes: {
             completion_date: outcome.completion_date.rfc3339,
+            created_at: outcome.created_at.rfc3339,
             participant_id: npq_application.participant_identity.external_identifier,
             course_identifier: declaration.course_identifier,
           },

--- a/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::ParticipantOutcomeSerializer, :with_default_schedules do
           attributes: {
             completion_date: outcome.completion_date.rfc3339,
             created_at: outcome.created_at.rfc3339,
-            has_passed: true,
+            state: "passed",
             participant_id: npq_application.participant_identity.external_identifier,
             course_identifier: declaration.course_identifier,
           },

--- a/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_outcome_serializer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V1::ParticipantOutcomeSerializer, :with_default_schedules do
           type: :"participant-outcome",
           attributes: {
             completion_date: outcome.completion_date.rfc3339,
-            participant_id: npq_application.participant_identity.user_id,
+            participant_id: npq_application.participant_identity.external_identifier,
             course_identifier: declaration.course_identifier,
           },
         },

--- a/spec/services/api/participant_outcomes/index_spec.rb
+++ b/spec/services/api/participant_outcomes/index_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::ParticipantOutcomes::Index, :with_default_schedules do
+  describe "#scope" do
+    let(:provider_declaration) { create_declaration }
+    let!(:provider_outcomes) { create_outcomes(provider_declaration) }
+    let(:other_provider_declaration) { create_declaration }
+    let!(:other_provider_outcomes) { create_outcomes(other_provider_declaration) }
+    subject(:index) { described_class.new(cpd_lead_provider: provider_declaration.cpd_lead_provider) }
+
+    it "returns all declarations outcomes for the provider" do
+      expect(index.scope.to_a).to eq(provider_outcomes)
+    end
+
+    it "returns outcomes across multiple declarations" do
+      other_provider_declaration.update!(cpd_lead_provider: provider_declaration.cpd_lead_provider)
+      expect(index.scope.to_a).to eq(provider_outcomes.append(other_provider_outcomes).flatten)
+    end
+
+  private
+
+    def create_declaration
+      provider = create(:cpd_lead_provider, :with_npq_lead_provider)
+      npq_application = create(:npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider)
+      create(:npq_participant_declaration,
+             participant_profile: npq_application.profile,
+             cpd_lead_provider: provider)
+    end
+
+    def create_outcomes(declaration)
+      [
+        create(:participant_outcome, :failed, participant_declaration: declaration),
+        create(:participant_outcome, :passed, participant_declaration: declaration),
+        create(:participant_outcome, :voided, participant_declaration: declaration),
+      ]
+    end
+  end
+end

--- a/spec/services/api/v1/participant_outcomes_query_spec.rb
+++ b/spec/services/api/v1/participant_outcomes_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::ParticipantOutcomes::Index, :with_default_schedules do
+RSpec.describe Api::V1::ParticipantOutcomesQuery, :with_default_schedules do
   describe "#scope" do
     let(:provider_declaration) { create_declaration }
     let!(:provider_outcomes) { create_outcomes(provider_declaration) }

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -882,7 +882,7 @@
     },
     "/api/v1/participants/npq/outcomes": {
       "get": {
-        "summary": "List all participant declarations",
+        "summary": "List all participant NPQ outcomes",
         "operationId": "participant_outcomes",
         "tags": [
           "participants outcomes"
@@ -905,7 +905,7 @@
             "explode": true,
             "required": false,
             "example": "page[page]=1&page[per_page]=5",
-            "description": "Pagination options to navigate through the list of participant declarations."
+            "description": "Pagination options to navigate through the list of participant NPQ outcomes."
           }
         ],
         "responses": {

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -880,6 +880,58 @@
         }
       }
     },
+    "/api/v1/participants/npq/outcomes": {
+      "get": {
+        "summary": "List all participant declarations",
+        "operationId": "participant_outcomes",
+        "tags": [
+          "participants outcomes"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of participant declarations."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of participant outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQOutcomesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participants/ecf": {
       "get": {
         "summary": "Retrieve multiple participants, replaces <code>/api/v1/participants</code>",
@@ -3346,6 +3398,103 @@
         "properties": {
           "data": {
             "$ref": "#/components/schemas/NPQApplication"
+          }
+        }
+      },
+      "NPQOutcome": {
+        "description": "An NPQ outcome",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the NPQ outcome",
+            "type": "string",
+            "format": "uuid",
+            "example": "cd3a12347-7308-4879-942a-c4a70ced400a"
+          },
+          "type": {
+            "description": "The data type",
+            "type": "string",
+            "example": "participant-outcome"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/NPQOutcomeAttributes"
+          }
+        }
+      },
+      "NPQOutcomeAttributes": {
+        "description": "The data attributes associated with an NPQ outcome",
+        "type": "object",
+        "required": [
+          "participant_id",
+          "course_identifier",
+          "state",
+          "completion_date",
+          "created_at"
+        ],
+        "properties": {
+          "participant_id": {
+            "description": "The unique ID of the participant",
+            "type": "string",
+            "nullable": false,
+            "format": "uuid",
+            "example": "66218835-9430-4d0c-98ef-7caf0bb4a59b"
+          },
+          "course_identifier": {
+            "description": "The course the participant is enrolled in",
+            "type": "string",
+            "nullable": false,
+            "enum": [
+              "npq-leading-teaching",
+              "npq-leading-behaviour-culture",
+              "npq-leading-teaching-development",
+              "npq-leading-literacy",
+              "npq-senior-leadership",
+              "npq-headship",
+              "npq-executive-leadership",
+              "npq-early-years-leadership"
+            ],
+            "example": "npq-leading-teaching"
+          },
+          "state": {
+            "description": "The state of the outcome (passed, failed, voided)",
+            "type": "string",
+            "nullable": false,
+            "enum": [
+              "passed",
+              "failed",
+              "voided"
+            ],
+            "example": "passed"
+          },
+          "completion_date": {
+            "description": "The date the participant received the assessment outcome for this course",
+            "type": "string",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "created_at": {
+            "description": "The date you created the participant-outcome record",
+            "type": "string",
+            "example": "2021-05-31T02:21:32.000Z"
+          }
+        }
+      },
+      "NPQOutcomesResponse": {
+        "description": "A list of NPQ outcomes",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NPQOutcome"
+            }
           }
         }
       },

--- a/swagger/v1/component_schemas/NPQOutcome.yml
+++ b/swagger/v1/component_schemas/NPQOutcome.yml
@@ -1,0 +1,18 @@
+description: "An NPQ outcome"
+type: object
+required:
+  - id
+  - type
+  - attributes
+properties:
+  id:
+    description: "The unique identifier of the NPQ outcome"
+    type: string
+    format: uuid
+    example: cd3a12347-7308-4879-942a-c4a70ced400a
+  type:
+    description: "The data type"
+    type: string
+    example: participant-outcome
+  attributes:
+    $ref: "#/components/schemas/NPQOutcomeAttributes"

--- a/swagger/v1/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v1/component_schemas/NPQOutcomeAttributes.yml
@@ -1,0 +1,46 @@
+description: "The data attributes associated with an NPQ outcome"
+type: object
+required:
+  - participant_id
+  - course_identifier
+  - state
+  - completion_date
+  - created_at
+properties:
+  participant_id:
+    description: The unique ID of the participant
+    type: string
+    nullable: false
+    format: uuid
+    example: 66218835-9430-4d0c-98ef-7caf0bb4a59b
+  course_identifier:
+    description: The course the participant is enrolled in
+    type: string
+    nullable: false
+    enum:
+      - npq-leading-teaching
+      - npq-leading-behaviour-culture
+      - npq-leading-teaching-development
+      - npq-leading-literacy
+      - npq-senior-leadership
+      - npq-headship
+      - npq-executive-leadership
+      - npq-early-years-leadership
+    example: npq-leading-teaching
+  state:
+    description: The state of the outcome (passed, failed, voided)
+    type: string
+    nullable: false
+    enum:
+      - passed
+      - failed
+      - voided
+    example: passed
+  completion_date:
+    description: The date the participant received the assessment outcome for this course
+    type: string
+    example: "2021-05-31T02:21:32.000Z"
+  created_at:
+    description: The date you created the participant-outcome record
+    type: string
+    example: "2021-05-31T02:21:32.000Z"

--- a/swagger/v1/component_schemas/NPQOutcomesResponse.yml
+++ b/swagger/v1/component_schemas/NPQOutcomesResponse.yml
@@ -1,0 +1,9 @@
+description: "A list of NPQ outcomes"
+type: object
+required:
+  - data
+properties:
+  data:
+    type: array
+    items:
+      $ref: "#/components/schemas/NPQOutcome"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -932,6 +932,58 @@
         }
       }
     },
+    "/api/v2/participants/npq/outcomes": {
+      "get": {
+        "summary": "List all participant declarations",
+        "operationId": "participant_outcomes",
+        "tags": [
+          "participants outcomes"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of participant declarations."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of participant outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQOutcomesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/participants/ecf": {
       "get": {
         "summary": "Retrieve multiple participants, replaces <code>/api/v2/participants</code>",
@@ -3373,6 +3425,103 @@
             "description": "The Unique Reference Number (URN) of the school where this NPQ participant is teaching",
             "type": "string",
             "example": "106286"
+          }
+        }
+      },
+      "NPQOutcome": {
+        "description": "An NPQ outcome",
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the NPQ outcome",
+            "type": "string",
+            "format": "uuid",
+            "example": "cd3a12347-7308-4879-942a-c4a70ced400a"
+          },
+          "type": {
+            "description": "The data type",
+            "type": "string",
+            "example": "participant-outcome"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/NPQOutcomeAttributes"
+          }
+        }
+      },
+      "NPQOutcomeAttributes": {
+        "description": "The data attributes associated with an NPQ outcome",
+        "type": "object",
+        "required": [
+          "participant_id",
+          "course_identifier",
+          "state",
+          "completion_date",
+          "created_at"
+        ],
+        "properties": {
+          "participant_id": {
+            "description": "The unique ID of the participant",
+            "type": "string",
+            "nullable": false,
+            "format": "uuid",
+            "example": "66218835-9430-4d0c-98ef-7caf0bb4a59b"
+          },
+          "course_identifier": {
+            "description": "The course the participant is enrolled in",
+            "type": "string",
+            "nullable": false,
+            "enum": [
+              "npq-leading-teaching",
+              "npq-leading-behaviour-culture",
+              "npq-leading-teaching-development",
+              "npq-leading-literacy",
+              "npq-senior-leadership",
+              "npq-headship",
+              "npq-executive-leadership",
+              "npq-early-years-leadership"
+            ],
+            "example": "npq-leading-teaching"
+          },
+          "state": {
+            "description": "The state of the outcome (passed, failed, voided)",
+            "type": "string",
+            "nullable": false,
+            "enum": [
+              "passed",
+              "failed",
+              "voided"
+            ],
+            "example": "passed"
+          },
+          "completion_date": {
+            "description": "The date the participant received the assessment outcome for this course",
+            "type": "string",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "created_at": {
+            "description": "The date you created the participant-outcome record",
+            "type": "string",
+            "example": "2021-05-31T02:21:32.000Z"
+          }
+        }
+      },
+      "NPQOutcomesResponse": {
+        "description": "A list of NPQ outcomes",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NPQOutcome"
+            }
           }
         }
       },

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -934,7 +934,7 @@
     },
     "/api/v2/participants/npq/outcomes": {
       "get": {
-        "summary": "List all participant declarations",
+        "summary": "List all participant NPQ outcomes",
         "operationId": "participant_outcomes",
         "tags": [
           "participants outcomes"
@@ -957,7 +957,7 @@
             "explode": true,
             "required": false,
             "example": "page[page]=1&page[per_page]=5",
-            "description": "Pagination options to navigate through the list of participant declarations."
+            "description": "Pagination options to navigate through the list of participant NPQ outcomes."
           }
         ],
         "responses": {

--- a/swagger/v2/component_schemas/NPQOutcome.yml
+++ b/swagger/v2/component_schemas/NPQOutcome.yml
@@ -1,0 +1,18 @@
+description: "An NPQ outcome"
+type: object
+required:
+  - id
+  - type
+  - attributes
+properties:
+  id:
+    description: "The unique identifier of the NPQ outcome"
+    type: string
+    format: uuid
+    example: cd3a12347-7308-4879-942a-c4a70ced400a
+  type:
+    description: "The data type"
+    type: string
+    example: participant-outcome
+  attributes:
+    $ref: "#/components/schemas/NPQOutcomeAttributes"

--- a/swagger/v2/component_schemas/NPQOutcomeAttributes.yml
+++ b/swagger/v2/component_schemas/NPQOutcomeAttributes.yml
@@ -1,0 +1,46 @@
+description: "The data attributes associated with an NPQ outcome"
+type: object
+required:
+  - participant_id
+  - course_identifier
+  - state
+  - completion_date
+  - created_at
+properties:
+  participant_id:
+    description: The unique ID of the participant
+    type: string
+    nullable: false
+    format: uuid
+    example: 66218835-9430-4d0c-98ef-7caf0bb4a59b
+  course_identifier:
+    description: The course the participant is enrolled in
+    type: string
+    nullable: false
+    enum:
+      - npq-leading-teaching
+      - npq-leading-behaviour-culture
+      - npq-leading-teaching-development
+      - npq-leading-literacy
+      - npq-senior-leadership
+      - npq-headship
+      - npq-executive-leadership
+      - npq-early-years-leadership
+    example: npq-leading-teaching
+  state:
+    description: The state of the outcome (passed, failed, voided)
+    type: string
+    nullable: false
+    enum:
+      - passed
+      - failed
+      - voided
+    example: passed
+  completion_date:
+    description: The date the participant received the assessment outcome for this course
+    type: string
+    example: "2021-05-31T02:21:32.000Z"
+  created_at:
+    description: The date you created the participant-outcome record
+    type: string
+    example: "2021-05-31T02:21:32.000Z"

--- a/swagger/v2/component_schemas/NPQOutcomesResponse.yml
+++ b/swagger/v2/component_schemas/NPQOutcomesResponse.yml
@@ -1,0 +1,9 @@
+description: "A list of NPQ outcomes"
+type: object
+required:
+  - data
+properties:
+  data:
+    type: array
+    items:
+      $ref: "#/components/schemas/NPQOutcome"


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-1899](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1899)

### Changes proposed in this pull request
- Introduce endpoint at `api/v1/participants/npq/outcomes` to return all outcomes - across all `ParticipantDeclaration`
for the authenticated provider.
- includes pagination
- Add the same endpoints to `/api/v2`


