### PR TITLE
Improve accessibility by refactoring hidden form legend and label elements

### DIFF
--- a/app/views/admin/participants/school_transfer/email.html.erb
+++ b/app/views/admin/participants/school_transfer/email.html.erb
@@ -5,19 +5,19 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: { action: @school_transfer_form.previous_step }) %>
 
 <div class="govuk-grid-row">
-	<div class="govuk-grid-column-two-thirds">
-    	
-    <span class="govuk-caption-xl">Transferring school - <%= @school_transfer_form.participant_name %></span>
-    	<h1 class="govuk-heading-xl"><%= title %></h1>
-
-		<p class="govuk-body">You can enter their personal or school email address.</p>
-    	
-		<%= form_for @school_transfer_form, url: { action: :email }, method: :put do |f| %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @school_transfer_form, url: { action: :email }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :email, label: { hidden: true }, width: "two-thirds" %>
+      <%= f.govuk_text_field :email,
+          width: "two-thirds",
+          label: { text: title, tag: :h1, size: 'xl' },
+          caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", tag: :h1, size: 'xl' } do %>
+
+          <p class="govuk-body">You can enter their personal or school email address.</p>
+      <% end %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>
 
-  	</div>
+    </div>
 </div>

--- a/app/views/admin/participants/school_transfer/email.html.erb
+++ b/app/views/admin/participants/school_transfer/email.html.erb
@@ -11,7 +11,7 @@
       <%= f.govuk_text_field :email,
           width: "two-thirds",
           label: { text: title, tag: :h1, size: 'xl' },
-          caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", tag: :h1, size: 'xl' } do %>
+          caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", size: 'xl' } do %>
 
           <p class="govuk-body">You can enter their personal or school email address.</p>
       <% end %>

--- a/app/views/admin/participants/school_transfer/start_date.html.erb
+++ b/app/views/admin/participants/school_transfer/start_date.html.erb
@@ -10,7 +10,7 @@
               start_date: true,
               width: "two-thirds",
               legend: { text: title, tag: :h1, size: 'xl' },
-              caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", tag: :h1, size: 'xl' },
+              caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", size: 'xl' },
               hint: { text: "For example, 14 7 2023"}
           %>
           <%= f.govuk_submit "Continue" %>

--- a/app/views/admin/participants/school_transfer/start_date.html.erb
+++ b/app/views/admin/participants/school_transfer/start_date.html.erb
@@ -4,15 +4,13 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl">Transferring school - <%= @school_transfer_form.participant_name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
-
         <%= form_for @school_transfer_form, url: { action: :start_date }, method: :put do |f| %>
           <%= f.govuk_error_summary %>
           <%= f.govuk_date_field :start_date,
               start_date: true,
               width: "two-thirds",
-              legend: { text: "#{@school_transfer_form.participant_name} start date", class: "govuk-visually-hidden" },
+              legend: { text: title, tag: :h1, size: 'xl' },
+              caption: { text: "Transferring school - #{@school_transfer_form.participant_name}", tag: :h1, size: 'xl' },
               hint: { text: "For example, 14 7 2023"}
           %>
           <%= f.govuk_submit "Continue" %>

--- a/app/views/appropriate_body_selection/_autocomplete_body_selection.html.erb
+++ b/app/views/appropriate_body_selection/_autocomplete_body_selection.html.erb
@@ -3,7 +3,7 @@
   :id,
   :name,
   label: { text: title, tag: :h1, size: 'xl' },
-  caption: { text: appropriate_body_school_name, tag: :h1, size: 'xl' },
+  caption: { text: appropriate_body_school_name, size: 'xl' },
   options: { include_blank: true },
   class: "autocomplete") do %>
 

--- a/app/views/appropriate_body_selection/_autocomplete_body_selection.html.erb
+++ b/app/views/appropriate_body_selection/_autocomplete_body_selection.html.erb
@@ -1,0 +1,13 @@
+<%= f.govuk_collection_select(:body_id,
+  appropriate_bodies,
+  :id,
+  :name,
+  label: { text: title, tag: :h1, size: 'xl' },
+  caption: { text: appropriate_body_school_name, tag: :h1, size: 'xl' },
+  options: { include_blank: true },
+  class: "autocomplete") do %>
+
+  <div class="govuk-inset-text">
+    Remember to contact the appropriate body directly to appoint them for your ECTs, if you have not done so already.
+  </div>
+<% end %>

--- a/app/views/appropriate_body_selection/_radio_button_body_selection.html.erb
+++ b/app/views/appropriate_body_selection/_radio_button_body_selection.html.erb
@@ -1,0 +1,11 @@
+<%= f.govuk_collection_radio_buttons(:body_id,
+  appropriate_bodies,
+  :id,
+  :name,
+  legend: { text: title, tag: :h1, size: 'xl' },
+  caption: { text: appropriate_body_school_name, tag: :h1, size: 'xl' }) do %>
+
+  <div class="govuk-inset-text">
+    Remember to contact the appropriate body directly to appoint them for your ECTs, if you have not done so already.
+  </div>
+<% end %>

--- a/app/views/appropriate_body_selection/_radio_button_body_selection.html.erb
+++ b/app/views/appropriate_body_selection/_radio_button_body_selection.html.erb
@@ -3,7 +3,7 @@
   :id,
   :name,
   legend: { text: title, tag: :h1, size: 'xl' },
-  caption: { text: appropriate_body_school_name, tag: :h1, size: 'xl' }) do %>
+  caption: { text: appropriate_body_school_name, size: 'xl' }) do %>
 
   <div class="govuk-inset-text">
     Remember to contact the appropriate body directly to appoint them for your ECTs, if you have not done so already.

--- a/app/views/appropriate_body_selection/body_appointed.html.erb
+++ b/app/views/appropriate_body_selection/body_appointed.html.erb
@@ -4,9 +4,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= appropriate_body_school_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
-
     <%= form_for @appropriate_body_form, url: { action: :update_appropriate_body_appointed }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
@@ -14,7 +11,8 @@
         @appropriate_body_form.body_appointed_choices,
         :id, :name,
         inline: true,
-        legend: { hidden: true }) do %>
+        legend: { text: title, tag: :h1, size: 'xl' },
+        caption: { text: appropriate_body_school_name, size: 'xl' }) do %>
       <% end %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/appropriate_body_selection/body_selection.html.erb
+++ b/app/views/appropriate_body_selection/body_selection.html.erb
@@ -7,31 +7,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= appropriate_body_school_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
-
-    <div class="govuk-inset-text">
-      Remember to contact the appropriate body directly to appoint them for your ECTs, if you have not done so already.
-    </div>
-
     <%= form_for @appropriate_body_form, url: { action: :update_appropriate_body }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if @appropriate_body_form.body_type == "national" %>
-        <%= f.govuk_collection_radio_buttons(:body_id,
-                                             appropriate_bodies,
-                                             :id,
-                                             :name,
-                                             legend: { hidden: true },
-                                             ) %>
+        <%= render partial: "appropriate_body_selection/radio_button_body_selection", locals: { f:, appropriate_bodies:, title:} %>
       <% else %>
-        <%= f.govuk_collection_select(:body_id,
-                                      appropriate_bodies,
-                                      :id,
-                                      :name,
-                                      label: { hidden: true },
-                                      options: { include_blank: true },
-                                      class: "autocomplete") %>
+        <%= render partial: "appropriate_body_selection/autocomplete_body_selection", locals: { f:, appropriate_bodies:, title:} %>
       <% end %>
 
       <%= f.govuk_submit "Continue" %>

--- a/app/views/appropriate_body_selection/body_type.html.erb
+++ b/app/views/appropriate_body_selection/body_type.html.erb
@@ -12,7 +12,7 @@
         @appropriate_body_form.body_type_choices,
         :id, :name,
         legend: { text: title, tag: :h1, size: 'xl' },
-        caption: { text: appropriate_body_school_name, tag: :h1, size: 'xl' }) do %>
+        caption: { text: appropriate_body_school_name, size: 'xl' }) do %>
 
           <%= yield :pre_form %>
         <% end %>

--- a/app/views/appropriate_body_selection/body_type.html.erb
+++ b/app/views/appropriate_body_selection/body_type.html.erb
@@ -5,18 +5,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= appropriate_body_school_name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
-
-    <%= yield :pre_form %>
-
     <%= form_for @appropriate_body_form, url: { action: :update_appropriate_body_type }, method: :put do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_collection_radio_buttons(
         :body_type,
         @appropriate_body_form.body_type_choices,
         :id, :name,
-        legend: { hidden: true }) %>
+        legend: { text: title, tag: :h1, size: 'xl' },
+        caption: { text: appropriate_body_school_name, tag: :h1, size: 'xl' }) do %>
+
+          <%= yield :pre_form %>
+        <% end %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/participants/validations/trn.html.erb
+++ b/app/views/participants/validations/trn.html.erb
@@ -9,10 +9,9 @@
       <%= f.hidden_field :no_trn, value: false %>
       <%= f.govuk_text_field :trn,
         width: "three-quarters",
-        label: { text: "Teacher reference number (TRN)", class: "govuk-visually-hidden" },
+        label: { text: title, tag: :h1, size: 'xl' },
         hint: -> do
       %>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
         <p class="govuk-body">This unique ID is:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>usually 7 digits long, for example ‘4567814’</li>

--- a/app/views/schools/add_participants/email.html.erb
+++ b/app/views/schools/add_participants/email.html.erb
@@ -4,15 +4,15 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">What’s <%= add_participant_form.full_name %>’s email address?</h1>
-
-        <p class="govuk-body">You can enter their personal or school email address.</p>
-
         <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
-        <%= f.govuk_error_summary %>
-            <%= f.govuk_text_field :email, label: { hidden: true }, width: "two-thirds" %>
+            <%= f.govuk_error_summary %>
+                <%= f.govuk_text_field :email,
+                  width: "two-thirds",
+                  label: { text: "What’s #{add_participant_form.full_name}’s email address?", tag: :h1, size: 'xl' },
+                  caption: { text: @school.name, size: 'xl' } do %>
+
+                  <p class="govuk-body">You can enter their personal or school email address.</p>
+                <% end %>
             <%= f.govuk_submit "Continue" %>
         <% end %>
 

--- a/app/views/schools/add_participants/name.html.erb
+++ b/app/views/schools/add_participants/name.html.erb
@@ -5,16 +5,20 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <% if add_participant_form.type == :ect %>
-        <h1 class="govuk-heading-xl">What’s this person’s full name?</h1>
-        <% else %>
-        <h1 class="govuk-heading-xl">What’s the full name of this mentor?</h1>
-        <% end %>
+
+        <%
+          full_name_label = if add_participant_form.type == :ect
+            'What’s this person’s full name?'
+          else
+            'What’s the full name of this mentor?'
+          end
+        %>
 
         <%= form_for add_participant_form, url: { action: :update }, method: :patch do |f| %>
             <%= f.govuk_error_summary %>
-            <%= f.govuk_text_field :full_name, width: "three-quarters", label: { hidden: true } %>
+            <%= f.govuk_text_field :full_name, width: "three-quarters",
+                label: { text: full_name_label, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, size: 'xl' } %>
             <%= f.govuk_submit "Continue" %>
         <% end %>
 

--- a/app/views/schools/transfer_out/teacher_end_date.html.erb
+++ b/app/views/schools/transfer_out/teacher_end_date.html.erb
@@ -13,7 +13,7 @@
             <%= f.govuk_date_field :end_date,
                 width: "two-thirds",
                 legend: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, size: 'xl' },
                 hint: { text: "For example, 14 7 2023"}
             %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transfer_out/teacher_end_date.html.erb
+++ b/app/views/schools/transfer_out/teacher_end_date.html.erb
@@ -6,17 +6,14 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
-
         <%= form_for @transfer_out_form, url: { action: :teacher_end_date }, method: :put do |f| %>
 
             <%= f.govuk_error_summary %>
 
             <%= f.govuk_date_field :end_date,
                 width: "two-thirds",
-                legend: { text: title, class: "govuk-visually-hidden" },
+                legend: { text: title, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, tag: :h1, size: 'xl' },
                 hint: { text: "For example, 14 7 2023"}
             %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transferring_participants/dob.html.erb
+++ b/app/views/schools/transferring_participants/dob.html.erb
@@ -11,7 +11,7 @@
                 date_of_birth: true,
                 width: "two-thirds",
                 legend: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, size: 'xl' },
                 hint: { text: "For example, 14 7 1990"} %>
 
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transferring_participants/dob.html.erb
+++ b/app/views/schools/transferring_participants/dob.html.erb
@@ -6,15 +6,12 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
-
         <%= form_for @transferring_participant_form, url: { action: :dob }, method: :put do |f| %>
             <%= f.govuk_date_field :date_of_birth,
                 date_of_birth: true,
                 width: "two-thirds",
-                legend: { text: title, class: "govuk-visually-hidden" },
+                legend: { text: title, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, tag: :h1, size: 'xl' },
                 hint: { text: "For example, 14 7 1990"} %>
 
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transferring_participants/email.html.erb
+++ b/app/views/schools/transferring_participants/email.html.erb
@@ -7,13 +7,13 @@
 <div class="govuk-grid-row">
 	<div class="govuk-grid-column-two-thirds">
 
-		<span class="govuk-caption-xl"><%= @school.name %></span>
-    	<h1 class="govuk-heading-xl"><%= title %></h1>
-
-		<p class="govuk-body">You can enter their personal or school email address.</p>
-
 		<%= form_for @transferring_participant_form, url: { action: :email }, method: :put do |f| %>
-      		<%= f.govuk_text_field :email, label: { hidden: true }, width: "two-thirds" %>
+          <%= f.govuk_text_field :email, width: "two-thirds",
+              label: { text: title, tag: :h1, size: 'xl' },
+              caption: { text: @school.name, size: 'xl' } do %>
+
+              <p class="govuk-body">You can enter their personal or school email address.</p>
+          <% end %>
 
       		<%= f.govuk_submit "Continue" %>
     	<% end %>

--- a/app/views/schools/transferring_participants/full_name.html.erb
+++ b/app/views/schools/transferring_participants/full_name.html.erb
@@ -4,12 +4,11 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl">What’s this person’s full name?</h1>
-
         <%= form_for @transferring_participant_form, url: { action: :full_name }, method: :put do |f| %>
-            <%= f.govuk_text_field :full_name, width: "two-thirds", label: { hidden: true } %>
+            <%= f.govuk_text_field :full_name,
+              width: "two-thirds",
+              label: { text: "What’s this person’s full name?", tag: :h1, size: 'xl' },
+              caption: { text: @school.name, size: 'xl' } %>
             <%= f.govuk_submit "Continue" %>
         <% end %>
 

--- a/app/views/schools/transferring_participants/teacher_start_date.html.erb
+++ b/app/views/schools/transferring_participants/teacher_start_date.html.erb
@@ -9,7 +9,7 @@
                 start_date: true,
                 width: "two-thirds",
                 legend: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, size: 'xl' },
                 hint: { text: "For example, 14 7 2023"}
             %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transferring_participants/teacher_start_date.html.erb
+++ b/app/views/schools/transferring_participants/teacher_start_date.html.erb
@@ -4,15 +4,12 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
-
         <%= form_for @transferring_participant_form, url: { action: :teacher_start_date }, method: :put do |f| %>
             <%= f.govuk_date_field :start_date,
                 start_date: true,
                 width: "two-thirds",
-                legend: { text: "#{possessive_name(@transferring_participant_form.full_name)} start date", class: "govuk-visually-hidden" },
+                legend: { text: title, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, tag: :h1, size: 'xl' },
                 hint: { text: "For example, 14 7 2023"}
             %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/transferring_participants/trn.html.erb
+++ b/app/views/schools/transferring_participants/trn.html.erb
@@ -10,7 +10,7 @@
             <%= f.govuk_text_field :trn,
                 width: "two-thirds",
                 label: { text: title, tag: :h1, size: 'xl' },
-                caption: { text: @school.name, tag: :h1, size: 'xl' } do %>
+                caption: { text: @school.name, size: 'xl' } do %>
 
                 <p class="govuk-body">This unique ID:</p>
                 <ul class="govuk-list govuk-list--bullet">

--- a/app/views/schools/transferring_participants/trn.html.erb
+++ b/app/views/schools/transferring_participants/trn.html.erb
@@ -6,23 +6,19 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-        <span class="govuk-caption-xl"><%= @school.name %></span>
-        <h1 class="govuk-heading-xl"><%= title %></h1>
-
-        <p class="govuk-body">This unique ID:</p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>is usually 7 digits long, for example ‘4567814’</li>
-            <li>may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’</li>
-            <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
-        </ul>
-
         <%= form_for @transferring_participant_form, url: { action: :trn }, method: :put do |f| %>
-
             <%= f.govuk_text_field :trn,
-            width: "two-thirds",
-            label: { text: "Teacher reference number (TRN)", class: "govuk-visually-hidden" }
-            %>
+                width: "two-thirds",
+                label: { text: title, tag: :h1, size: 'xl' },
+                caption: { text: @school.name, tag: :h1, size: 'xl' } do %>
+
+                <p class="govuk-body">This unique ID:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>is usually 7 digits long, for example ‘4567814’</li>
+                    <li>may include the letters ‘RP’ or a slash ‘/’ symbol, for example ‘RP99/12345’</li>
+                    <li>may also be called a QTS, GTC, DfE, DfES or DCSF number</li>
+                </ul>
+            <% end %>
             <%= f.govuk_submit "Continue" %>
 
         <% end %>

--- a/spec/features/participants/participant_validation_spec.rb
+++ b/spec/features/participants/participant_validation_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Participant validation journey",
     click_on "Continue"
     then_i_see_an_error_message "Enter your teacher reference number (TRN)"
 
-    when_i_add_teacher_reference_number_to_the_participant_registration_wizard "1234567"
+    when_i_add_teacher_reference_number_to_the_participant_registration_wizard ect_full_name, "1234567"
     click_on "Continue"
     then_i_see_an_error_message "Enter your date of birth"
 
@@ -79,7 +79,7 @@ RSpec.feature "Participant validation journey",
     and_i_am_on_the_participant_registration_wizard
     then_the_page_is_accessible
 
-    when_i_add_teacher_reference_number_to_the_participant_registration_wizard "1234567"
+    when_i_add_teacher_reference_number_to_the_participant_registration_wizard ect_full_name, "1234567"
     then_the_page_is_accessible
 
     when_i_add_date_of_birth_to_the_participant_registration_wizard Date.new(1983, 2, 28)
@@ -122,7 +122,7 @@ RSpec.feature "Participant validation journey",
     and_i_am_on_the_mentor_registration_wizard
 
     when_i_confirm_have_trn_on_the_mentor_registration_wizard
-    and_i_add_teacher_reference_number_to_the_mentor_registration_wizard "7654321"
+    and_i_add_teacher_reference_number_to_the_mentor_registration_wizard ect_full_name, "7654321"
     and_i_add_date_of_birth_to_the_mentor_registration_wizard Date.new(1991, 11, 4)
     and_i_choose_add_your_national_insurance_number_to_the_mentor_registration_wizard
     and_i_add_national_insurance_number_to_the_mentor_registration_wizard "AB123456C"

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Reporting participants with a known TRN",
     click_on "Continue"
     then_i_see_an_error_message "Enter an email address"
 
-    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email]
+    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email], "Sally Teacher"
     click_on "Continue"
     then_i_see_an_error_message "Enter the teacher’s induction start date"
 
@@ -130,7 +130,7 @@ RSpec.describe "Reporting participants with a known TRN",
     when_i_add_date_of_birth_to_the_school_add_participant_wizard participant_data[:date_of_birth]
     then_the_page_is_accessible
 
-    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email]
+    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email], "Sally Teacher"
     then_the_page_is_accessible
 
     when_i_add_start_date_to_the_school_add_participant_wizard participant_data[:start_date]
@@ -155,11 +155,11 @@ RSpec.describe "Reporting participants with a known TRN",
     and_i_choose_to_add_a_new_mentor_on_the_school_add_participant_wizard
     then_the_page_is_accessible
 
-    when_i_add_full_name_to_the_school_add_participant_wizard participant_data[:full_name]
+    when_i_add_mentor_full_name_to_the_school_add_participant_wizard participant_data[:full_name]
     when_i_add_teacher_reference_number_to_the_school_add_participant_wizard participant_data[:full_name], participant_data[:trn]
     when_i_add_date_of_birth_to_the_school_add_participant_wizard participant_data[:date_of_birth]
 
-    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email]
+    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email], "Sally Teacher"
     then_the_page_is_accessible
 
     when_i_confirm_and_add_on_the_school_add_participant_wizard

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Reporting participants with a known TRN",
     click_on "Continue"
     then_i_see_an_error_message "Enter an email address"
 
-    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email], "Sally Teacher"
+    when_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", participant_data[:email]
     click_on "Continue"
     then_i_see_an_error_message "Enter the teacher’s induction start date"
 
@@ -130,7 +130,7 @@ RSpec.describe "Reporting participants with a known TRN",
     when_i_add_date_of_birth_to_the_school_add_participant_wizard participant_data[:date_of_birth]
     then_the_page_is_accessible
 
-    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email], "Sally Teacher"
+    when_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", participant_data[:email]
     then_the_page_is_accessible
 
     when_i_add_start_date_to_the_school_add_participant_wizard participant_data[:start_date]
@@ -159,7 +159,7 @@ RSpec.describe "Reporting participants with a known TRN",
     when_i_add_teacher_reference_number_to_the_school_add_participant_wizard participant_data[:full_name], participant_data[:trn]
     when_i_add_date_of_birth_to_the_school_add_participant_wizard participant_data[:date_of_birth]
 
-    when_i_add_email_address_to_the_school_add_participant_wizard participant_data[:email], "Sally Teacher"
+    when_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", participant_data[:email]
     then_the_page_is_accessible
 
     when_i_confirm_and_add_on_the_school_add_participant_wizard

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
     and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
+    and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     and_i_choose_a_mentor_on_the_school_add_participant_wizard @participant_profile_mentor.full_name
     and_i_confirm_and_add_on_the_school_add_participant_wizard
@@ -46,7 +46,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
     and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
+    and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
     and_i_confirm_and_add_on_the_school_add_participant_wizard
 
     then_i_am_on_the_school_add_participant_completed_page

--- a/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_can_validate_with_nino_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
     and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email]
+    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     and_i_choose_a_mentor_on_the_school_add_participant_wizard @participant_profile_mentor.full_name
     and_i_confirm_and_add_on_the_school_add_participant_wizard
@@ -41,12 +41,12 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     and_i_choose_to_add_an_ect_or_mentor_on_the_school_participants_dashboard_page
     and_i_choose_to_add_a_new_mentor_on_the_school_add_participant_wizard
 
-    when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
+    when_i_add_mentor_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
     and_i_confirm_details_and_continue_on_the_school_add_participant_wizard
     and_i_add_nino_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:nino]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email]
+    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
     and_i_confirm_and_add_on_the_school_add_participant_wizard
 
     then_i_am_on_the_school_add_participant_completed_page

--- a/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
+++ b/spec/features/schools/participants/add_participants/unhappy_path_cannot_validate_with_nino_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Add participants", with_feature_flags: { change_of_circumstances
     when_i_navigate_to_participants_dashboard
     and_i_choose_to_add_an_ect_or_mentor_on_the_school_participants_dashboard_page
     and_i_choose_to_add_a_new_mentor_on_the_school_add_participant_wizard
-    and_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
+    and_i_add_mentor_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
     and_i_confirm_details_and_continue_on_the_school_add_participant_wizard

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe "Transferring participants", with_feature_flags: { change_of_circ
   end
 
   def when_i_update_the_name_with(name)
-    fill_in "Full_name", with: name
+    fill_in "What’s this person’s full name?", with: name
   end
 
   def when_i_add_a_valid_trn
-    fill_in "Teacher reference number (TRN)", with: "1001000"
+    fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "1001000"
   end
 
   def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -100,15 +100,15 @@ RSpec.describe "transferring participants", :with_default_schedules, with_featur
       end
 
       def when_i_update_the_name_with(name)
-        fill_in "Full_name", with: name
+        fill_in "What’s this person’s full name?", with: name
       end
 
       def when_i_update_the_email_with(email)
-        fill_in "Email", with: email
+        fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: email
       end
 
       def when_i_add_a_valid_trn
-        fill_in "Teacher reference number (TRN)", with: "1001000"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "1001000"
       end
 
       def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -175,15 +175,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_update_the_name_with(name)
-        fill_in "Full_name", with: name
+        fill_in "What’s this person’s full name?", with: name
       end
 
       def when_i_update_the_email_with(email)
-        fill_in "Email", with: email
+        fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: email
       end
 
       def when_i_add_a_valid_trn
-        fill_in "Teacher reference number (TRN)", with: "1001000"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "1001000"
       end
 
       def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -152,19 +152,19 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_update_the_name_with(name)
-        fill_in "Full_name", with: name
+        fill_in "What’s this person’s full name?", with: name
       end
 
       def when_i_update_the_email_with(email)
-        fill_in "Email", with: email
+        fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: email
       end
 
       def when_i_add_an_invalid_trn
-        fill_in "Teacher reference number (TRN)", with: "1234"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "1234"
       end
 
       def when_i_add_a_valid_trn
-        fill_in "Teacher reference number (TRN)", with: "1001000"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "1001000"
       end
 
       def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -158,15 +158,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_update_the_name_with(name)
-        fill_in "Full_name", with: name
+        fill_in "What’s this person’s full name?", with: name
       end
 
       def when_i_update_the_email_with(email)
-        fill_in "Email", with: email
+        fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: email
       end
 
       def when_i_add_a_valid_trn
-        fill_in "Teacher reference number (TRN)", with: "1001000"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "1001000"
       end
 
       def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -99,15 +99,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_update_the_name_with(name)
-        fill_in "Full_name", with: name
+        fill_in "What’s this person’s full name?", with: name
       end
 
       def when_i_update_the_email_with(email)
-        fill_in "Email", with: email
+        fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: email
       end
 
       def when_i_add_a_valid_trn
-        fill_in "Teacher reference number (TRN)", with: "1001000"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)?", with: "1001000"
       end
 
       def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -84,15 +84,15 @@ RSpec.describe "transferring participants", with_feature_flags: { change_of_circ
       end
 
       def when_i_update_the_name_with(name)
-        fill_in "Full_name", with: name
+        fill_in "What’s this person’s full name?", with: name
       end
 
       def when_i_update_the_email_with(email)
-        fill_in "Email", with: email
+        fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: email
       end
 
       def when_i_add_a_valid_trn
-        fill_in "Teacher reference number (TRN)", with: "2002000"
+        fill_in "What’s #{@participant_data[:full_name]}’s teacher reference number (TRN)", with: "2002000"
       end
 
       def when_i_add_a_valid_date_of_birth

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Update participants details", js: true do
     when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email]
+    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     and_i_choose_mentor_later_on_the_school_add_participant_wizard
     then_i_am_taken_to_check_details_page
@@ -50,7 +50,7 @@ RSpec.describe "Update participants details", js: true do
     when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email]
+    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     then_i_am_taken_to_add_mentor_page
     then_the_page_should_be_accessible

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Update participants details", js: true do
     when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
+    and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     and_i_choose_mentor_later_on_the_school_add_participant_wizard
     then_i_am_taken_to_check_details_page
@@ -50,7 +50,7 @@ RSpec.describe "Update participants details", js: true do
     when_i_add_full_name_to_the_school_add_participant_wizard @participant_data[:full_name]
     and_i_add_teacher_reference_number_to_the_school_add_participant_wizard @participant_data[:full_name], @participant_data[:trn]
     and_i_add_date_of_birth_to_the_school_add_participant_wizard @participant_data[:date_of_birth]
-    and_i_add_email_address_to_the_school_add_participant_wizard @participant_data[:email], "Sally Teacher"
+    and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
     and_i_add_start_date_to_the_school_add_participant_wizard @participant_data[:start_date]
     then_i_am_taken_to_add_mentor_page
     then_the_page_should_be_accessible

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -552,11 +552,11 @@ module ManageTrainingSteps
   end
 
   def when_i_add_ect_or_mentor_name
-    fill_in "Full_name", with: @participant_data[:full_name]
+    fill_in "What’s this person’s full name?", with: @participant_data[:full_name]
   end
 
   def when_i_add_ect_or_mentor_email
-    fill_in "Email", with: @participant_data[:email]
+    fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: @participant_data[:email]
   end
 
   def when_i_add_ect_or_mentor_nino_for(name)
@@ -564,7 +564,7 @@ module ManageTrainingSteps
   end
 
   def when_i_add_ect_or_mentor_email_that_already_exists
-    fill_in "Email", with: @participant_profile_ect.user.email
+    fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: @participant_profile_ect.user.email
   end
 
   def when_i_choose_assign_mentor_later
@@ -572,11 +572,11 @@ module ManageTrainingSteps
   end
 
   def when_i_add_ect_or_mentor_updated_name
-    fill_in "Full_name", with: @updated_participant_data[:full_name]
+    fill_in "What’s this person’s full name?", with: @updated_participant_data[:full_name]
   end
 
   def when_i_add_ect_or_mentor_updated_email
-    fill_in "Email", with: @updated_participant_data[:email]
+    fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: @updated_participant_data[:email]
   end
 
   def when_i_choose_an_appropriate_body

--- a/spec/support/features/pages/participant/participant_registration_wizard.rb
+++ b/spec/support/features/pages/participant/participant_registration_wizard.rb
@@ -39,7 +39,7 @@ module Pages
     end
 
     def add_teacher_reference_number(trn)
-      fill_in "Teacher reference number (TRN)", with: trn
+      fill_in "What’s your teacher reference number (TRN)?", with: trn
       click_on "Continue"
 
       self

--- a/spec/support/features/pages/participant/participant_registration_wizard.rb
+++ b/spec/support/features/pages/participant/participant_registration_wizard.rb
@@ -38,8 +38,8 @@ module Pages
       self
     end
 
-    def add_teacher_reference_number(full_name, trn)
-      fill_in "What’s #{full_name}’s teacher reference number (TRN)", with: trn
+    def add_teacher_reference_number(_full_name, trn)
+      fill_in "What’s your teacher reference number (TRN)", with: trn
       click_on "Continue"
 
       self

--- a/spec/support/features/pages/participant/participant_registration_wizard.rb
+++ b/spec/support/features/pages/participant/participant_registration_wizard.rb
@@ -12,7 +12,7 @@ module Pages
     def complete_for_ect(full_name, date_of_birth, trn)
       setup_response_from_dqt full_name, date_of_birth, trn
 
-      add_teacher_reference_number trn
+      add_teacher_reference_number full_name, trn
       add_date_of_birth date_of_birth
     end
 
@@ -20,7 +20,7 @@ module Pages
       setup_response_from_dqt full_name, date_of_birth, trn
 
       confirm_have_trn
-      add_teacher_reference_number trn
+      add_teacher_reference_number full_name, trn
       add_date_of_birth date_of_birth
     end
 
@@ -38,8 +38,8 @@ module Pages
       self
     end
 
-    def add_teacher_reference_number(trn)
-      fill_in "What’s your teacher reference number (TRN)?", with: trn
+    def add_teacher_reference_number(full_name, trn)
+      fill_in "What’s #{full_name}’s teacher reference number (TRN)", with: trn
       click_on "Continue"
 
       self

--- a/spec/support/features/pages/schools/school_add_participant_wizard.rb
+++ b/spec/support/features/pages/schools/school_add_participant_wizard.rb
@@ -74,7 +74,15 @@ module Pages
 
     def add_full_name(participant_name)
       # TODO: is this label correct? it is visually hidden, but pretty sure it should be proper english
-      fill_in "Full_name", with: participant_name
+      fill_in "What’s this person’s full name?", with: participant_name
+      click_on "Continue"
+
+      self
+    end
+
+    def add_mentor_full_name(participant_name)
+      # TODO: is this label correct? it is visually hidden, but pretty sure it should be proper english
+      fill_in "What’s the full name of this mentor?", with: participant_name
       click_on "Continue"
 
       self
@@ -96,8 +104,8 @@ module Pages
       self
     end
 
-    def add_email_address(participant_email)
-      fill_in "Email", with: participant_email
+    def add_email_address(participant_email, full_name)
+      fill_in "What’s #{full_name}’s email address?", with: participant_email
       click_on "Continue"
 
       self

--- a/spec/support/features/pages/schools/school_add_participant_wizard.rb
+++ b/spec/support/features/pages/schools/school_add_participant_wizard.rb
@@ -32,7 +32,7 @@ module Pages
       add_full_name full_name
       add_teacher_reference_number full_name, trn
       add_date_of_birth date_of_birth
-      add_email_address email_address
+      add_email_address full_name, email_address
       add_start_date start_date
       choose_a_mentor mentor_full_name if mentor_full_name.present?
 
@@ -41,10 +41,10 @@ module Pages
 
     def add_mentor(full_name, trn, date_of_birth, email_address)
       choose_to_add_a_new_mentor
-      add_full_name full_name
+      add_mentor_full_name full_name
       add_teacher_reference_number full_name, trn
       add_date_of_birth date_of_birth
-      add_email_address email_address
+      add_email_address full_name, email_address
 
       confirm_and_add
     end
@@ -81,7 +81,6 @@ module Pages
     end
 
     def add_mentor_full_name(participant_name)
-      # TODO: is this label correct? it is visually hidden, but pretty sure it should be proper english
       fill_in "What’s the full name of this mentor?", with: participant_name
       click_on "Continue"
 
@@ -104,7 +103,7 @@ module Pages
       self
     end
 
-    def add_email_address(participant_email, full_name)
+    def add_email_address(full_name, participant_email)
       fill_in "What’s #{full_name}’s email address?", with: participant_email
       click_on "Continue"
 

--- a/spec/support/features/pages/schools/school_transfer_participant_wizard.rb
+++ b/spec/support/features/pages/schools/school_transfer_participant_wizard.rb
@@ -21,10 +21,10 @@ module Pages
       confirm_transferring_an_ect_or_mentor
 
       add_full_name full_name
-      add_teacher_reference_number participant_trn
+      add_teacher_reference_number full_name, participant_trn
       add_date_of_birth date_of_birth
       add_start_date start_date
-      add_email_address email_address
+      add_email_address full_name, email_address
 
       if same_provider
         # UI does not ask about provider
@@ -42,10 +42,10 @@ module Pages
       confirm_transferring_an_ect_or_mentor
 
       add_full_name full_name
-      add_teacher_reference_number participant_trn
+      add_teacher_reference_number full_name, participant_trn
       add_date_of_birth date_of_birth
       add_start_date start_date
-      add_email_address email_address
+      add_email_address full_name, email_address
 
       if same_provider
         # UI does not ask about provider
@@ -73,14 +73,21 @@ module Pages
 
     def add_full_name(participant_name)
       # TODO: is this label correct? it is visually hidden, but pretty sure it should be proper english
-      fill_in "Full_name", with: participant_name
+      fill_in "What’s this person’s full name?", with: participant_name
       click_on "Continue"
 
       self
     end
 
-    def add_teacher_reference_number(trn)
-      fill_in "Teacher reference number (TRN)", with: trn
+    def add_mentor_full_name(participant_name)
+      fill_in "What’s the full name of this mentor?", with: participant_name
+      click_on "Continue"
+
+      self
+    end
+
+    def add_teacher_reference_number(full_name, trn)
+      fill_in "What’s #{full_name}’s teacher reference number (TRN)", with: trn
       click_on "Continue"
 
       self
@@ -104,8 +111,8 @@ module Pages
       self
     end
 
-    def add_email_address(participant_email)
-      fill_in "Email", with: participant_email
+    def add_email_address(full_name, participant_email)
+      fill_in "What’s #{full_name}’s email address?", with: participant_email
       click_on "Continue"
 
       self


### PR DESCRIPTION
### Context

- Ticket: [CST-31](https://dfedigital.atlassian.net/browse/CST-31)

The generated html in question pages with hidden form label and legend elements can be improved and be more accessible and easier for screen readers by replacing them with the question itself.

### Changes proposed in this pull request
- Remove the hidden css classes
- Move the question header and caption inside the form builder

### Guidance to review

|before|after|
|-|-|
|![screenshot_20221207-150538](https://user-images.githubusercontent.com/951947/206215186-343153ce-6218-43ab-b11b-49c85dcb8d3c.png)|![screenshot_20221207-150620](https://user-images.githubusercontent.com/951947/206215160-d5024672-2eda-4351-a946-b9429bc2c60a.png)|
|![screenshot_20221207-150536](https://user-images.githubusercontent.com/951947/206215187-727d792a-d797-44a1-b6bc-1b62dcc2c0c1.png)|![screenshot_20221207-150619](https://user-images.githubusercontent.com/951947/206215180-680debf1-e12a-4500-8a08-cf494fba7f3a.png)|



[CST-31]: https://dfedigital.atlassian.net/browse/CST-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ