### PR TITLE
scenarios tests for comparing support ECTs query and serialiser

### DIFF
--- a/app/serializers/api/v1/ecf_induction_record_serializer.rb
+++ b/app/serializers/api/v1/ecf_induction_record_serializer.rb
@@ -25,58 +25,78 @@ module Api
       }.freeze
 
       set_id :id do |induction_record|
-        induction_record.preferred_identity.user_id
+        find_participant_identity(induction_record)&.user_id
       end
 
-      attributes :email, &:participant_email
+      attributes :email do |induction_record|
+        find_participant_identity(induction_record)&.email
+      end
 
       attributes :full_name do |induction_record|
-        induction_record.preferred_identity.user.full_name
+        find_participant_identity(induction_record)&.user&.full_name
       end
 
       attributes :user_type do |induction_record|
-        case induction_record.participant_profile.type
-        when ParticipantProfile::ECT.name
-          USER_TYPES[:early_career_teacher]
-        when ParticipantProfile::Mentor.name
-          USER_TYPES[:mentor]
-        else
+        if is_consistently_withdrawn(induction_record)
           USER_TYPES[:other]
+        else
+          case induction_record.participant_profile.type
+          when ParticipantProfile::ECT.name
+            USER_TYPES[:early_career_teacher]
+          when ParticipantProfile::Mentor.name
+            USER_TYPES[:mentor]
+          else
+            USER_TYPES[:other]
+          end
         end
       end
 
       attributes :core_induction_programme do |induction_record|
-        core_induction_programme = find_core_induction_programme(induction_record)
-        case core_induction_programme&.name
-        when "Ambition Institute"
-          CIP_TYPES[:ambition]
-        when "Education Development Trust"
-          CIP_TYPES[:edt]
-        when "Teach First"
-          CIP_TYPES[:teach_first]
-        when "UCL Institute of Education"
-          CIP_TYPES[:ucl]
-        else
+        if is_consistently_withdrawn(induction_record)
           CIP_TYPES[:none]
+        else
+          core_induction_programme = find_core_induction_programme(induction_record)
+          case core_induction_programme&.name
+          when "Ambition Institute"
+            CIP_TYPES[:ambition]
+          when "Education Development Trust"
+            CIP_TYPES[:edt]
+          when "Teach First"
+            CIP_TYPES[:teach_first]
+          when "UCL Institute of Education"
+            CIP_TYPES[:ucl]
+          else
+            CIP_TYPES[:none]
+          end
         end
       end
 
       attributes :induction_programme_choice do |induction_record|
-        induction_record.induction_programme.training_programme
+        induction_record.induction_programme.training_programme unless is_consistently_withdrawn(induction_record)
       end
 
       attributes :registration_completed do |induction_record|
-        induction_record.participant_profile.completed_validation_wizard?
+        induction_record.participant_profile.completed_validation_wizard? unless is_consistently_withdrawn(induction_record)
       end
 
       attributes :cohort do |induction_record|
-        induction_record.school_cohort.cohort.start_year
+        induction_record.school_cohort.cohort.start_year unless is_consistently_withdrawn(induction_record)
       end
 
       def self.find_core_induction_programme(induction_record)
         induction_record.induction_programme.core_induction_programme ||
           induction_record.participant_profile&.core_induction_programme ||
           induction_record.participant_profile&.school_cohort&.core_induction_programme
+      end
+
+      def self.find_participant_identity(induction_record)
+        induction_record.preferred_identity ||
+          induction_record.participant_profile.participant_identity
+      end
+
+      # guard against some of the more complex scenarios where it is not possible to determine what is correct behaviour
+      def self.is_consistently_withdrawn(induction_record)
+        induction_record.induction_status == "withdrawn" && induction_record.participant_profile.status == "withdrawn"
       end
     end
   end

--- a/app/serializers/api/v1/ecf_induction_record_serializer.rb
+++ b/app/serializers/api/v1/ecf_induction_record_serializer.rb
@@ -96,7 +96,7 @@ module Api
 
       # guard against some of the more complex scenarios where it is not possible to determine what is correct behaviour
       def self.is_consistently_withdrawn(induction_record)
-        induction_record.induction_status == "withdrawn" && induction_record.participant_profile.status == "withdrawn"
+        induction_record.withdrawn_induction_status? && induction_record.participant_profile.withdrawn_record?
       end
     end
   end

--- a/app/serializers/api/v1/ecf_user_serializer.rb
+++ b/app/serializers/api/v1/ecf_user_serializer.rb
@@ -28,7 +28,7 @@ module Api
       attributes :email, :full_name
 
       attributes :user_type do |user|
-        case user.teacher_profile.ecf_profiles.last&.type
+        case find_oldest_profile(user)&.type
         when ParticipantProfile::ECT.name
           USER_TYPES[:early_career_teacher]
         when ParticipantProfile::Mentor.name
@@ -60,19 +60,23 @@ module Api
       end
 
       attributes :registration_completed do |user|
-        user.teacher_profile.ecf_profiles.last&.completed_validation_wizard?
+        find_oldest_profile(user)&.completed_validation_wizard?
       end
 
       attributes :cohort do |user|
         find_school_cohort(user)&.cohort&.start_year
       end
 
+      def self.find_oldest_profile(user)
+        user.teacher_profile.ecf_profiles.min_by(&:created_at)
+      end
+
       def self.find_school_cohort(user)
-        user.teacher_profile.ecf_profiles.last&.school_cohort
+        find_oldest_profile(user)&.school_cohort
       end
 
       def self.find_core_induction_programme(user)
-        user.teacher_profile.ecf_profiles.last&.core_induction_programme ||
+        find_oldest_profile(user)&.core_induction_programme ||
           find_school_cohort(user)&.core_induction_programme
       end
     end

--- a/app/services/api/v1/ecf/induction_records_query.rb
+++ b/app/services/api/v1/ecf/induction_records_query.rb
@@ -13,10 +13,14 @@ module Api::V1::ECF
       induction_records = relevant_induction_records
 
       if updated_since.present?
-        induction_records = induction_records.where("induction_records.updated_at > ?", updated_since)
+        # this has to check all updatable entities
+        induction_records = induction_records
+                              .joins(participant_profile: [:user])
+                              .where("induction_records.updated_at > ? OR participant_profiles.updated_at > ? OR users.updated_at > ?", updated_since, updated_since, updated_since)
       end
 
       if email.present?
+        # this has to return just one record
         induction_records = induction_records.joins(:preferred_identity).where(preferred_identity: { email: })
       end
 
@@ -24,29 +28,26 @@ module Api::V1::ECF
     end
 
     def relevant_induction_records
-      InductionRecord
-        .joins(
-          <<-SQL,
-            JOIN (#{induction_record_history.to_sql}) AS historical_induction_records
-              ON historical_induction_records.id = induction_records.id AND historical_induction_records.chronology = 1
-            JOIN participant_profiles ON induction_records.participant_profile_id = participant_profiles.id
-          SQL
-        )
-        .merge(ParticipantProfile.ecf)
+      InductionRecord.where(id: induction_record_history)
     end
 
     def induction_record_history
-      InductionRecord.start_date_in_past
-                     .select(
-                       <<-SQL,
-                         induction_records.id,
-                         ROW_NUMBER() OVER (
-                           PARTITION BY induction_records.participant_profile_id
-                           ORDER BY induction_records.end_date ASC NULLS FIRST, induction_records.start_date ASC
-                         ) AS chronology
-                       SQL
-                     )
-                     .joins(:participant_profile)
+      # we can't use `InductionRecord.current` here, because we need to include records that finished in the past if there is no current one
+      # we can't use `InductionRecord.latest` here because the latest record might not be what they are doing right now
+      #
+      # we need to find the oldest `participant_profile` for the user otherwise we risk unwanted changes to their access
+      # we need to prioritise `end_date` with `null` first because we need to find the record describing what they are doing right now over what they will eventually do after a transfer
+      # we need to order by `start_date` second in case two records have the same `end_date` such as after modifying a transfer to add a mentor
+      InductionRecord.select(
+        <<-SQL,
+          FIRST_VALUE(induction_records.id) OVER (
+            PARTITION BY "users"."id"
+            ORDER BY induction_records.end_date ASC NULLS FIRST, induction_records.start_date ASC
+          ) AS id
+        SQL
+      )
+      .joins(participant_profile: %i[teacher_profile user])
+      .merge(ParticipantProfile.ecf, :user)
     end
   end
 end

--- a/app/services/api/v1/ecf/induction_records_query.rb
+++ b/app/services/api/v1/ecf/induction_records_query.rb
@@ -42,7 +42,7 @@ module Api::V1::ECF
         <<-SQL,
           FIRST_VALUE(induction_records.id) OVER (
             PARTITION BY "users"."id"
-            ORDER BY induction_records.end_date ASC NULLS FIRST, induction_records.start_date ASC
+            ORDER BY induction_records.end_date ASC NULLS FIRST, induction_records.start_date ASC, induction_records.created_at ASC
           ) AS id
         SQL
       )

--- a/spec/serializers/api/v1/ecf_induction_record_serializer_spec.rb
+++ b/spec/serializers/api/v1/ecf_induction_record_serializer_spec.rb
@@ -2,56 +2,77 @@
 
 require "rails_helper"
 
-module Api
-  module V1
-    RSpec.describe ECFInductionRecordSerializer do
-      let(:core_induction_programme) { create(:core_induction_programme, name: "Teach First") }
-      let(:induction_programme) do
-        induction_programme = create(:induction_programme, :cip)
-        induction_programme.update!(core_induction_programme:)
-        induction_programme
-      end
-      let(:ect_profile) { create(:ect_participant_profile) }
+RSpec.describe Api::V1::ECFInductionRecordSerializer, :with_support_for_ect_examples do
+  it "includes the correct id" do
+    expect(record_id(cip_ect_only)).to eq cip_ect_only.user.id
+  end
 
-      before do
-        Induction::Enrol.call(participant_profile: ect_profile, induction_programme:, start_date: 2.months.ago)
-      end
+  it "includes the correct full_name" do
+    expect(record_attributes(cip_ect_only)[:full_name]).to eq cip_ect_only.user.full_name
+  end
 
-      describe "registration_completed" do
-        context "before validation started" do
-          it "returns false" do
-            expect(user_attributes(ect_profile)[:registration_completed]).to be false
-          end
-        end
+  it "includes the correct email" do
+    expect(record_attributes(cip_ect_only)[:email]).to eq cip_ect_only.participant_identity.email
+  end
 
-        context "when details were not matched" do
-          before do
-            create(:ecf_participant_validation_data, participant_profile: ect_profile)
-          end
-
-          it "returns true" do
-            expect(user_attributes(ect_profile)[:registration_completed]).to be true
-          end
-        end
-
-        context "when the details were matched" do
-          before do
-            create(:ecf_participant_validation_data, participant_profile: ect_profile)
-            eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
-            eligibility.matched_status!
-          end
-
-          it "returns true" do
-            expect(user_attributes(ect_profile)[:registration_completed]).to be true
-          end
-        end
-      end
-
-    private
-
-      def user_attributes(profile)
-        described_class.new(profile.current_induction_records.first).serializable_hash[:data][:attributes]
+  describe "registration_completed" do
+    context "before validation started" do
+      it "returns false" do
+        expect(record_attributes(cip_ect_only)[:registration_completed]).to be false
       end
     end
+
+    context "when details were not matched" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: cip_ect_only)
+      end
+
+      it "returns true" do
+        expect(record_attributes(cip_ect_only)[:registration_completed]).to be true
+      end
+    end
+
+    context "when the details were matched" do
+      it "returns true" do
+        expect(record_attributes(cip_ect_reg_complete)[:registration_completed]).to be true
+      end
+    end
+  end
+
+  describe "when an induction_record has a missing preferred_identity" do
+    let!(:participant_with_missing_identity) do
+      school_cohort = create(:school_cohort)
+      induction_programme = create(:induction_programme, :fip, school_cohort:)
+      user = create(:user, email: "ect@example.com")
+      preferred_identity_ect = create(:participant_identity, user:)
+      preferred_identity_mentor = create(:participant_identity, :secondary, user:, email: "mentor@example.com")
+      teacher_profile = create(:teacher_profile, user:)
+      ect_profile = create(:ect_participant_profile, teacher_profile:, participant_identity: preferred_identity_ect)
+      Induction::Enrol.call(participant_profile: ect_profile, induction_programme:, start_date: 1.year.ago)
+      mentor_profile = create(:mentor_participant_profile, teacher_profile:, participant_identity: preferred_identity_mentor)
+      Induction::Enrol.call(participant_profile: mentor_profile, induction_programme:, start_date: 6.months.ago)
+      mentor_profile.induction_records.first.update! preferred_identity_id: preferred_identity_mentor.id
+      preferred_identity_mentor.delete
+
+      mentor_profile
+    end
+
+    it "includes an email address" do
+      expect(record_attributes(participant_with_missing_identity)[:email]).to eq participant_with_missing_identity.participant_identity.email
+    end
+
+    it "includes a full name" do
+      expect(record_attributes(participant_with_missing_identity)[:full_name]).to eq participant_with_missing_identity.participant_identity.user.full_name
+    end
+  end
+
+private
+
+  def record_attributes(profile)
+    described_class.new(profile.current_induction_records.first).serializable_hash[:data][:attributes]
+  end
+
+  def record_id(profile)
+    described_class.new(profile.current_induction_records.first).serializable_hash[:data][:id]
   end
 end

--- a/spec/serializers/api/v1/ecf_user_serializer_spec.rb
+++ b/spec/serializers/api/v1/ecf_user_serializer_spec.rb
@@ -2,46 +2,50 @@
 
 require "rails_helper"
 
-module Api
-  module V1
-    RSpec.describe ECFUserSerializer do
-      let(:ect_profile) { create(:ect_participant_profile) }
+RSpec.describe Api::V1::ECFUserSerializer, :with_support_for_ect_examples do
+  it "includes the correct id" do
+    expect(record_id(cip_ect_only)).to eq cip_ect_only.user.id
+  end
 
-      describe "registration_completed" do
-        context "before validation started" do
-          it "returns false" do
-            expect(user_attributes(ect_profile.user)[:registration_completed]).to be false
-          end
-        end
+  it "includes the correct full_name" do
+    expect(record_attributes(cip_ect_only)[:full_name]).to eq cip_ect_only.user.full_name
+  end
 
-        context "when details were not matched" do
-          before do
-            create(:ecf_participant_validation_data, participant_profile: ect_profile)
-          end
+  it "includes the correct email" do
+    expect(record_attributes(cip_ect_only)[:email]).to eq cip_ect_only.user.email
+  end
 
-          it "returns true" do
-            expect(user_attributes(ect_profile.user)[:registration_completed]).to be true
-          end
-        end
-
-        context "when the details were matched" do
-          before do
-            create(:ecf_participant_validation_data, participant_profile: ect_profile)
-            eligibility = ECFParticipantEligibility.create!(participant_profile: ect_profile)
-            eligibility.matched_status!
-          end
-
-          it "returns true" do
-            expect(user_attributes(ect_profile.user)[:registration_completed]).to be true
-          end
-        end
-      end
-
-    private
-
-      def user_attributes(user)
-        described_class.new(user).serializable_hash[:data][:attributes]
+  describe "registration_completed" do
+    context "before validation started" do
+      it "returns false" do
+        expect(record_attributes(cip_ect_only)[:registration_completed]).to be false
       end
     end
+
+    context "when details were not matched" do
+      before do
+        create(:ecf_participant_validation_data, participant_profile: cip_ect_only)
+      end
+
+      it "returns true" do
+        expect(record_attributes(cip_ect_only)[:registration_completed]).to be true
+      end
+    end
+
+    context "when the details were matched" do
+      it "returns true" do
+        expect(record_attributes(cip_ect_reg_complete)[:registration_completed]).to be true
+      end
+    end
+  end
+
+private
+
+  def record_attributes(profile)
+    described_class.new(profile.user).serializable_hash[:data][:attributes]
+  end
+
+  def record_id(profile)
+    described_class.new(profile.user).serializable_hash[:data][:id]
   end
 end

--- a/spec/serializers/api/v1/ecf_user_vs_induction_record_serializer_spec.rb
+++ b/spec/serializers/api/v1/ecf_user_vs_induction_record_serializer_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api::V1
+  context "ECFInductionRecordSerializer versus ECFUserSerializer", :with_support_for_ect_examples do
+    it "serialises a CIP ECT the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_ect_only.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_ect_only.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a FIP ECT the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_ect_only.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_ect_only.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a FIP Mentor the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([fip_mentor_only.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([fip_mentor_only.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "mentor"
+    end
+
+    it "serializes a CIP Mentor the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_mentor_only.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_mentor_only.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "mentor"
+    end
+
+    it "serializes a CIP ECT with registration complete the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_ect_reg_complete.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_ect_reg_complete.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a CIP ECT updated a year ago the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_ect_updated_a_year_ago.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_ect_updated_a_year_ago.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a FIP ECT transferring in the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([fip_ect_transferring_in.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([fip_ect_transferring_in.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a FIP ECT transferring out the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([fip_ect_transferring_out.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([fip_ect_transferring_out.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a FIP ECT withdrawn the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([fip_ect_withdrawn.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([fip_ect_withdrawn.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "other"
+    end
+
+    it "serializes a CIP ECT registered for the future the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_ect_reg_for_future.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_ect_reg_for_future.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+    end
+
+    # the IR query filters out records without IRs so this would actually never occur
+    it "serializes an NPQ only the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([npq_only.user]).serializable_hash[:data][0]
+      serialised_induction_record = nil
+
+      expect { serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([npq_only.induction_records&.latest]).serializable_hash[:data][0] }.to raise_error(NoMethodError)
+
+      expect(serialised_induction_record).to eq nil
+      expect(serialised_user).not_to eq nil
+      expect(serialised_user[:attributes][:user_type]).to eq "other"
+    end
+
+    # real cases found in production
+
+    it "serializes a FIP ECT that becomes a mentor as an ECT the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([fip_ect_then_mentor[:ect_profile].user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([fip_ect_then_mentor[:ect_profile].induction_records&.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+      expect(serialised_induction_record).to eq serialised_user
+    end
+
+    # 37 production cases
+    it "serializes a FIP ECT with a different identity on some IRs using wrong_profile as an ECT the same" do
+      profile = fip_ect_with_different_identity[:wrong_profile]
+      serialised_user = Api::V1::ECFUserSerializer.new([profile.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([profile.induction_records.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+    end
+
+    it "serializes a FIP ECT with a different identity on some IRs using correct_profile as an ECT the same" do
+      profile = fip_ect_with_different_identity[:correct_profile]
+      serialised_user = Api::V1::ECFUserSerializer.new([profile.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([profile.induction_records.filter { |ir| ir.end_date.nil? }.first]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+    end
+
+    it "serializes a FIP ECT that has no participant_identity as an ECT the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([fip_ect_with_no_identity.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([fip_ect_with_no_identity.induction_records&.latest]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+
+    it "serializes a CIP ECT with a corrupt induction record history as an ECT the same" do
+      serialised_user = Api::V1::ECFUserSerializer.new([cip_ect_with_corrupt_history.user]).serializable_hash[:data][0]
+      serialised_induction_record = Api::V1::ECFInductionRecordSerializer.new([cip_ect_with_corrupt_history.induction_records.filter { |ir| ir.end_date.nil? }.first]).serializable_hash[:data][0]
+
+      expect(serialised_induction_record).not_to eq nil
+      expect(serialised_induction_record).to eq serialised_user
+      expect(serialised_induction_record[:attributes][:user_type]).to eq "early_career_teacher"
+    end
+  end
+end

--- a/spec/services/api/v1/ecf/induction_records_query_spec.rb
+++ b/spec/services/api/v1/ecf/induction_records_query_spec.rb
@@ -2,110 +2,251 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_default_schedules do
-  let(:cip_induction_programme) { create(:induction_programme, :cip) }
-
-  let!(:induction_records_ect_1) { create(:induction_record, :ect, :preferred_identity) }
-  let!(:induction_records_ect_2) { create(:induction_record, :ect, :preferred_identity) }
-  let!(:induction_records_cip_ect) { create(:induction_record, :ect, :preferred_identity, induction_programme: cip_induction_programme) }
-  let!(:induction_records_mentor) { create_list(:induction_record, 2, :mentor, :preferred_identity) }
-
-  let!(:transferring_in_induction_record) do
-    induction_record = create(:induction_record, :ect, :preferred_identity, start_date: 2.months.ago)
-    induction_record.leaving!(1.month.from_now, transferring_out: false)
-    induction_record
-  end
-  let!(:transferring_out_induction_record) do
-    induction_record = create(:induction_record, :ect, :preferred_identity, start_date: 3.months.ago)
-    induction_record.leaving!(2.months.ago, transferring_out: true)
-    induction_record
-  end
-  let!(:withdrawn_induction_record) do
-    induction_record = create(:induction_record, :ect, :preferred_identity, start_date: 2.weeks.ago)
-    induction_record.withdrawing!(1.week.ago)
-    induction_record
-  end
-  let!(:future_induction_record) { create(:induction_record, :ect, :preferred_identity, start_date: 1.year.from_now) }
-
-  let(:induction_records_ects) do
-    [
-      induction_records_ect_1,
-      induction_records_ect_2,
-      induction_records_cip_ect,
-      transferring_in_induction_record,
-      transferring_out_induction_record,
-      withdrawn_induction_record,
-    ]
-  end
-
-  # real case from seed data
-  let!(:non_ecf_induction_record) do
-    induction_record = create(:induction_record)
-    induction_record.participant_profile.update! type: "ParticipantProfile::NPQ"
-    induction_record
-  end
-
-  let(:all_ecf_induction_records) { induction_records_ects + induction_records_mentor }
-  let(:all_non_ecf_induction_records) { [non_ecf_induction_record] }
-
+RSpec.describe Api::V1::ECF::InductionRecordsQuery, :with_support_for_ect_examples do
   subject { described_class.new.all }
 
-  it "returns a list of induction records" do
+  it "finds that latest and current return different results" do
+    profile = cip_ect_only
+
+    expect(profile.induction_records.count).to eq 1
+    expect(profile.induction_records.current.first).to eq profile.induction_records.first
+    expect(profile.induction_records.latest).to eq profile.induction_records.first
+    expect(profile.induction_records.filter { |ir| ir.end_date.nil? }.count).to eq 1
+    expect(profile.induction_records.filter { |ir| ir.end_date.nil? }.first).to eq profile.induction_records.first
+  end
+
+  it "returns a list of users" do
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      fip_ect_only,
+      fip_mentor_only,
+      cip_mentor_only,
+      cip_ect_updated_a_year_ago,
+    )
+
     expect(subject).to all(be_a(InductionRecord))
+    expect(subject).to match_array included_records
   end
 
   it "includes ECF participants" do
-    expect(subject).to include(*all_ecf_induction_records)
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      fip_ect_only,
+      fip_mentor_only,
+      cip_mentor_only,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   it "includes Mentor participants" do
-    expect(subject).to include(*induction_records_mentor)
+    included_records = records_for(
+      fip_mentor_only,
+      cip_mentor_only,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   it "includes ECT participants" do
-    expect(subject).to include(*induction_records_ects)
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      fip_ect_only,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   it "includes CIP participants" do
-    expect(subject).to include(*induction_records_cip_ect)
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      cip_mentor_only,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   it "includes past 'transferring_in' participants" do
-    expect(subject).to include(transferring_in_induction_record)
+    included_records = records_for(
+      fip_ect_transferring_in,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   it "includes past 'transferring_out' participants" do
-    expect(subject).to include(transferring_out_induction_record)
+    included_records = records_for(
+      fip_ect_transferring_out,
+    )
+
+    # current does not work for these sorts of records
+    excluded_records = [
+      fip_ect_transferring_out.induction_records.current.first,
+    ]
+
+    expect(subject).to match_array included_records
+    expect(subject).not_to include(*excluded_records)
   end
 
   it "includes past 'Withdrawn' participants" do
-    expect(subject).to include(withdrawn_induction_record)
+    included_records = records_for(
+      fip_ect_withdrawn,
+    )
+
+    # InductionRecord.current does not work for these sorts of records
+    excluded_records = [
+      fip_ect_withdrawn.induction_records.current.first,
+    ]
+
+    expect(subject).to match_array included_records
+    expect(subject).not_to include(*excluded_records)
   end
 
   it "does not include Non-ECF participants" do
-    expect(subject).not_to include(*all_non_ecf_induction_records)
+    excluded_records = records_for(
+      npq_only,
+      npq_with_induction_record,
+    )
+
+    expect(subject).not_to include(*excluded_records)
   end
 
-  it "does not include Future participants" do
-    expect(subject).not_to include(future_induction_record)
+  it "does not include Non-participant users" do
+    excluded_records = records_for(
+      sit_only,
+    )
+
+    expect(subject).not_to include(*excluded_records)
+  end
+
+  it "includes Future participants" do
+    included_records = records_for(
+      cip_ect_reg_for_future,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   context "when filtering by updated_since" do
-    before { induction_records_ect_1.update(updated_at: 1.year.ago) }
+    let(:target) { cip_ect_updated_a_year_ago }
 
-    subject { described_class.new(updated_since: 4.months.ago).all }
+    subject { described_class.new(updated_since: target.updated_at + 1.month).all }
 
     it "returns a list of users with updated_at timestamps later than the supplied one" do
-      expect(subject).to match_array(all_ecf_induction_records.without(induction_records_ect_1))
+      included_records = records_for(
+        cip_ect_only,
+        cip_ect_reg_complete,
+        fip_ect_only,
+        fip_mentor_only,
+        cip_mentor_only,
+      )
+
+      excluded_records = records_for(
+        target,
+      )
+
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
     end
   end
 
   context "when filtering by email" do
-    subject { described_class.new(email: induction_records_ect_1.preferred_identity.email).all }
+    let(:target) { cip_ect_only }
+
+    subject { described_class.new(email: target.user.email).all }
 
     it "it only returns users with the matching email address" do
-      expect(subject).to include(induction_records_ect_1)
-      expect(subject).not_to include(all_ecf_induction_records.without(induction_records_ect_1))
+      included_records = records_for(
+        target,
+      )
+
+      excluded_records = records_for(
+        cip_ect_reg_complete,
+        fip_ect_only,
+        fip_mentor_only,
+        cip_mentor_only,
+      )
+
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
+    end
+  end
+
+  context "complex scenarios" do
+    it "excludes user withdrawn before we added induction_records once" do
+      excluded_records = records_for(
+        ect_with_no_induction_record,
+      )
+
+      # not found by query but is ignored by Support ECTs
+      expect(subject).not_to include(*excluded_records)
+    end
+
+    it "includes user who is a second year ECT and is now a Mentor only as an ECT" do
+      included_records = records_for(
+        fip_ect_then_mentor[:ect_profile],
+      )
+
+      excluded_records = records_for(
+        fip_ect_then_mentor[:mentor_profile],
+      )
+
+      # both have the same user so only the ECT record is returned
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
+    end
+
+    it "includes user with a corrupt induction record history" do
+      included_records = [
+        cip_ect_with_corrupt_history.induction_records.filter { |ir| ir.end_date.nil? }.first,
+      ]
+
+      # InductionRecord.current and InductionRecord.latest do not work for these sorts of records
+      excluded_records = [
+        cip_ect_with_corrupt_history.induction_records.latest,
+        cip_ect_with_corrupt_history.induction_records.current.first,
+      ]
+
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
+    end
+
+    it "includes a FIP ECT with no identity" do
+      included_records = records_for(
+        fip_ect_with_no_identity,
+      )
+
+      expect(subject).to match_array included_records
+    end
+
+    it "includes a FIP ECT with a different identity for some induction records once only" do
+      included_records = [
+        fip_ect_with_different_identity[:correct_profile].induction_records.filter { |ir| ir.end_date.nil? }.first,
+        # InductionRecord.latest works here as it is the only induction_record for this profile
+        fip_ect_with_different_identity[:wrong_profile].induction_records.latest,
+      ]
+
+      excluded_records = [
+        # InductionRecord.latest does not work here as created_at order is mixed up
+        fip_ect_with_different_identity[:correct_profile].induction_records.latest,
+        # InductionRecord.current does not work here as it is withdrawn
+        fip_ect_with_different_identity[:wrong_profile].induction_records.current.first,
+      ]
+
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
+    end
+  end
+
+private
+
+  def records_for(*profiles)
+    profiles.map do |profile|
+      profile.induction_records&.latest if profile.methods.include? :induction_records
     end
   end
 end

--- a/spec/services/api/v1/ecf/users_query_spec.rb
+++ b/spec/services/api/v1/ecf/users_query_spec.rb
@@ -2,42 +2,209 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::ECF::UsersQuery, :with_default_schedules do
-  let!(:ecf_users) { create_list(:ecf_participant_profile, 3).map(&:user) }
-  let!(:non_ecf_user) { create(:npq_participant_profile).user }
-
+RSpec.describe Api::V1::ECF::UsersQuery, :with_support_for_ect_examples do
   subject { described_class.new.all }
 
   it "returns a list of users" do
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      fip_ect_only,
+      fip_mentor_only,
+      cip_mentor_only,
+      cip_ect_updated_a_year_ago,
+    )
+
     expect(subject).to all(be_a(User))
+    expect(subject).to match_array included_records
   end
 
-  it "only includes ECF participants" do
-    expect(subject).to match_array(ecf_users)
-    expect(subject).not_to include(non_ecf_user)
+  it "includes ECF participants" do
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      fip_ect_only,
+      fip_mentor_only,
+      cip_mentor_only,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "includes Mentor participants" do
+    included_records = records_for(
+      fip_mentor_only,
+      cip_mentor_only,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "includes ECT participants" do
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      fip_ect_only,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "includes CIP participants" do
+    included_records = records_for(
+      cip_ect_only,
+      cip_ect_reg_complete,
+      cip_mentor_only,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "includes past 'transferring_in' participants" do
+    included_records = records_for(
+      fip_ect_transferring_in,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "includes past 'transferring_out' participants" do
+    included_records = records_for(
+      fip_ect_transferring_out,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "includes past 'Withdrawn' participants" do
+    included_records = records_for(
+      fip_ect_withdrawn,
+    )
+
+    expect(subject).to match_array included_records
+  end
+
+  it "does not include Non-ECF participants" do
+    excluded_records = records_for(
+      npq_only,
+      npq_with_induction_record,
+    )
+
+    expect(subject).not_to include(*excluded_records)
+  end
+
+  it "does not include Non-participant users" do
+    excluded_records = records_for(
+      sit_only,
+    )
+
+    expect(subject).not_to include(*excluded_records)
+  end
+
+  it "includes Future participants" do
+    included_records = records_for(
+      cip_ect_reg_for_future,
+    )
+
+    expect(subject).to match_array included_records
   end
 
   context "when filtering by updated_since" do
-    let!(:ecf_user_updated_a_long_time_ago) { create(:ecf_participant_profile).user }
+    let(:filter_date) { cip_ect_updated_a_year_ago.updated_at + 1.month }
 
-    before { ecf_user_updated_a_long_time_ago.update(updated_at: 1.year.ago) }
-
-    subject { described_class.new(updated_since: 1.month.ago).all }
+    subject { described_class.new(updated_since: filter_date).all }
 
     it "returns a list of users with updated_at timestamps later than the supplied one" do
-      expect(subject).to match_array(ecf_users)
-      expect(subject).not_to include(ecf_user_updated_a_long_time_ago)
+      included_records = records_for(
+        cip_ect_only,
+        cip_ect_reg_complete,
+        fip_ect_only,
+        fip_mentor_only,
+        cip_mentor_only,
+      )
+
+      excluded_records = records_for(
+        cip_ect_updated_a_year_ago,
+      )
+
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
     end
   end
 
   context "when filtering by email" do
-    let(:target) { ecf_users.first }
+    let(:filter_email) { cip_ect_only.user.email }
 
-    subject { described_class.new(email: target.email).all }
+    subject { described_class.new(email: filter_email).all }
 
     it "it only returns users with the matching email address" do
-      expect(subject).to include(target)
-      expect(subject).not_to include(ecf_users.without(target))
+      included_records = records_for(
+        cip_ect_only,
+      )
+
+      excluded_records = records_for(
+        cip_ect_reg_complete,
+        fip_ect_only,
+        fip_mentor_only,
+        cip_mentor_only,
+      )
+
+      expect(subject).to match_array included_records
+      expect(subject).not_to include(*excluded_records)
     end
+  end
+
+  context "complex scenarios" do
+    it "includes user withdrawn before we added induction_records once" do
+      included_records = records_for(
+        ect_with_no_induction_record,
+      )
+
+      # found by user query but turned into type: "other" by serializer so ignored by Support ECTs
+      expect(subject).to match_array included_records
+    end
+
+    it "includes user who is a second year ECT and is now a Mentor once" do
+      included_records = records_for(
+        fip_ect_then_mentor[:ect_profile],
+        fip_ect_then_mentor[:mentor_profile],
+      )
+
+      # both have the same user so both are included but only 1 record is returned
+      # It is the job of the serializer to pick the correct participant_profile to use
+      expect(subject).to match_array [included_records.first]
+      expect(subject).to match_array [included_records.second]
+    end
+
+    it "includes user with a corrupt induction record history" do
+      included_records = records_for(
+        cip_ect_with_corrupt_history,
+      )
+
+      expect(subject).to match_array included_records
+    end
+
+    it "includes a FIP ECT with no identity" do
+      included_records = records_for(
+        fip_ect_with_no_identity,
+      )
+
+      expect(subject).to match_array included_records
+    end
+
+    it "includes a FIP ECT with a different identity for some induction records once only" do
+      included_records = records_for(
+        fip_ect_with_different_identity[:correct_profile],
+        fip_ect_with_different_identity[:wrong_profile],
+      )
+
+      expect(subject).to match_array included_records
+    end
+  end
+
+private
+
+  def records_for(*profiles)
+    profiles.map(&:user)
   end
 end

--- a/spec/support/with_support_for_ect_examples.rb
+++ b/spec/support/with_support_for_ect_examples.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with Support for ECTs example profiles", shared_context: :metadata do
+  let(:core_induction_programme) { create(:core_induction_programme, name: "Teach First") }
+  let(:cip_school_cohort) { create :school_cohort, induction_programme_choice: "core_induction_programme" }
+  let(:cip_induction_programme) { create(:induction_programme, core_induction_programme:, training_programme: "core_induction_programme", school_cohort: cip_school_cohort) }
+
+  let(:fip_school_cohort) { create :school_cohort, induction_programme_choice: "full_induction_programme" }
+  let(:fip_induction_programme) { create(:induction_programme, :fip, school_cohort: fip_school_cohort) }
+
+  let(:sit_only) do
+    user = create(:user, :induction_coordinator, full_name: "SIT Only")
+    user.induction_coordinator_profile
+  end
+
+  let(:cip_ect_only) do
+    user = create(:user, full_name: "CIP ECT Only")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+    participant_profile
+  end
+
+  let(:fip_ect_only) do
+    user = create(:user, full_name: "FIP ECT Only")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: fip_school_cohort)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme)
+    participant_profile
+  end
+
+  let(:fip_mentor_only) do
+    user = create(:user, full_name: "FIP Mentor Only")
+    participant_profile = create(:mentor_participant_profile, user:, school_cohort: fip_school_cohort)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme)
+    participant_profile
+  end
+
+  let(:cip_mentor_only) do
+    user = create(:user, full_name: "CIP Mentor Only")
+    participant_profile = create(:mentor_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+    participant_profile
+  end
+
+  let(:cip_ect_reg_complete) do
+    user = create(:user, full_name: "CIP ECT registration complete")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+    create(:ecf_participant_validation_data, participant_profile:)
+    eligibility = ECFParticipantEligibility.create!(participant_profile:)
+    eligibility.matched_status!
+    participant_profile
+  end
+
+  let(:cip_ect_updated_a_year_ago) do
+    user = create(:user, full_name: "CIP ECT updated a year ago")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+
+    participant_profile.induction_records.first.update!(updated_at: 1.year.ago)
+    participant_profile.update!(updated_at: 1.year.ago)
+    # has to be done last because of "touch: true" on ParticipantProfile
+    user.update!(updated_at: 1.year.ago)
+
+    participant_profile
+  end
+
+  let(:fip_ect_transferring_in) do
+    user = create(:user, full_name: "FIP ECT transferring in")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: fip_school_cohort)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme, start_date: 2.months.ago)
+    participant_profile.induction_records.latest.leaving!(1.month.from_now, transferring_out: false)
+    participant_profile
+  end
+
+  let(:fip_ect_transferring_out) do
+    user = create(:user, full_name: "FIP ECT transferring out")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: fip_school_cohort)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme, start_date: 3.months.ago)
+    participant_profile.induction_records.latest.leaving!(2.months.ago, transferring_out: true)
+    participant_profile
+  end
+
+  let(:fip_ect_withdrawn) do
+    user = create(:user, full_name: "FIP ECT withdrawn")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: fip_school_cohort)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme, start_date: 2.weeks.ago)
+    participant_profile.induction_records.latest.withdrawing!(1.week.ago)
+    participant_profile.update! status: "withdrawn"
+    participant_profile
+  end
+
+  let(:cip_ect_reg_for_future) do
+    user = create(:user, full_name: "CIP ECT registered for future")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme, start_date: 1.year.from_now)
+    participant_profile
+  end
+
+  let(:npq_only) { create(:npq_participant_profile) }
+
+  # real cases found in production
+
+  let(:fip_ect_then_mentor) do
+    user = create(:user, full_name: "FIP ECT then Mentor")
+    teacher_profile = create(:teacher_profile, user:)
+
+    ect_identity = create(:participant_identity, user:)
+    ect_profile = create(:ect_participant_profile, teacher_profile:, school_cohort: fip_school_cohort, participant_identity: ect_identity)
+    Induction::Enrol.call(participant_profile: ect_profile, induction_programme: fip_induction_programme, start_date: 6.months.ago)
+
+    mentor_identity = create(:participant_identity, :secondary, user:, email: "mentor_1@example.com")
+    mentor_profile = create(:mentor_participant_profile, teacher_profile:, school_cohort: fip_school_cohort, participant_identity: mentor_identity)
+    Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: fip_induction_programme, start_date: 3.months.ago)
+
+    { ect_profile:, mentor_profile: }
+  end
+
+  # real cases found in seed data
+
+  let(:npq_with_induction_record) do
+    user = create(:user, full_name: "NPQ with induction record")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+    participant_profile.update! type: "ParticipantProfile::NPQ"
+    participant_profile
+  end
+
+  let(:ect_with_no_induction_record) do
+    user = create(:user, full_name: "ECT with no induction record")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    participant_profile.update! status: "withdrawn"
+    participant_profile
+  end
+
+  # search test needed
+  let(:cip_ect_with_corrupt_history) do
+    user = create(:user, full_name: "CIP ECT with corrupt history")
+    participant_profile = create(:ect_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
+    Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+
+    induction_record = participant_profile.induction_records.latest
+    Induction::ChangeInductionRecord.call(induction_record:, changes: { training_status: "withdrawn", induction_status: "withdrawn" })
+    Induction::ChangeInductionRecord.call(induction_record:, changes: { training_status: "active" })
+
+    participant_profile
+  end
+
+  # search test needed
+  let(:fip_ect_with_no_identity) do
+    user = create(:user, full_name: "FIP ECT with no identity")
+    teacher_profile = create(:teacher_profile, user:)
+
+    participant_identity = create(:participant_identity, user:)
+    participant_profile = create(:ect_participant_profile, teacher_profile:, school_cohort: fip_school_cohort, participant_identity:)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme, start_date: 6.months.ago)
+
+    participant_profile.induction_records.first.update! preferred_identity_id: SecureRandom.uuid
+    participant_profile
+  end
+
+  # search test needed
+  let(:fip_ect_with_different_identity) do
+    user = create(:user, full_name: "FIP ECT with different identity")
+    teacher_profile = create(:teacher_profile, user:)
+
+    participant_identity = create(:participant_identity, user:)
+    participant_profile = create(:ect_participant_profile, teacher_profile:, school_cohort: fip_school_cohort, participant_identity:)
+    Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme)
+
+    user_2 = create(:user, full_name: "FIP ECT with different identity (other)")
+    teacher_profile_2 = create(:teacher_profile, user: user_2)
+
+    participant_identity_2 = create(:participant_identity, user: user_2)
+    participant_profile_2 = create(:ect_participant_profile, teacher_profile: teacher_profile_2, school_cohort: fip_school_cohort, participant_identity: participant_identity_2)
+    Induction::Enrol.call(participant_profile: participant_profile_2, induction_programme: fip_induction_programme)
+    induction_record = participant_profile_2.induction_records.latest
+    induction_record.withdrawing!
+    Induction::ChangeInductionRecord.call(induction_record:, changes: { training_status: "active", induction_status: "active" })
+    induction_record_2 = participant_profile_2.induction_records.latest
+    Induction::ChangeInductionRecord.call(induction_record: induction_record_2, changes: { training_status: "active", induction_status: "active" })
+    induction_record_3 = participant_profile_2.induction_records.latest
+
+    induction_record_2.update! participant_profile_id: participant_profile.id
+    induction_record_3.update! participant_profile_id: participant_profile.id
+    induction_record.withdrawing!
+
+    { correct_profile: participant_profile, wrong_profile: participant_profile_2 }
+  end
+end
+
+RSpec.configure do |config|
+  config.include_context "with Support for ECTs example profiles", :with_support_for_ect_examples
+  config.include_context "with default schedules", :with_support_for_ect_examples
+end


### PR DESCRIPTION
Does
------

- add shared examples file to add user record scenarios that have caused issues in migration to IRs
- add tests that check both the queries and the serialisers for consistency for the provided scenarios
- amend the user serialiser to remove flip-flopping on user type in ECT/Mentor scenario - chooses oldest profile for consistency
- build in fallbacks within IR serialiser for badly formed records
- add comments and tests to prove that it is not possible to use `InductionRecord.current` or `InductionRecord.latest` to identify correct records
- use SQL window query to order and group InductionRecords by user id and select the single relevant record to work with for performance

Does not
----------

- add support for more than one email address per user in Support ECTs - requires work in Support ECTs
- add support for newer or multiple `participant_profiles` where for instance an ECT has become a Mentor - assumes access still needed as ECT but does not check if ECT training is finished
