### PR TITLE
[CPDNPQ-723] Expand NPQ Funding API call to include targeted funding

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -38,6 +38,8 @@ class NPQApplication < ApplicationRecord
     rejected: "rejected",
   }
 
+  scope :with_targeted_delivery_funding_eligibility, -> { where(targeted_delivery_funding_eligibility: true) }
+
   validates :eligible_for_funding_before_type_cast, inclusion: { in: [true, false, "true", "false"] }
 
   delegate :start_year, to: :cohort, prefix: true, allow_nil: true

--- a/app/services/npq/funding_eligibility.rb
+++ b/app/services/npq/funding_eligibility.rb
@@ -22,7 +22,7 @@ module NPQ
       @npq_course ||= NPQCourse.find_by!(identifier: npq_course_identifier)
     end
 
-    def all_npq_courses
+    def npq_course_and_rebranded_alternatives
       npq_course.rebranded_alternative_courses
     end
 
@@ -38,7 +38,7 @@ module NPQ
       @accepted_applications ||= begin
         application_ids = users.flat_map do |user|
           user.npq_applications
-              .where(npq_course: all_npq_courses)
+              .where(npq_course: npq_course_and_rebranded_alternatives)
               .where(eligible_for_funding: true)
               .accepted
               .pluck(:id)

--- a/spec/factories/services/npq/npq_application.rb
+++ b/spec/factories/services/npq/npq_application.rb
@@ -21,8 +21,8 @@ FactoryBot.define do
     eligible_for_funding                  { false }
     funding_eligiblity_status_code        { :ineligible_establishment_type }
     targeted_delivery_funding_eligibility { false }
-    teacher_catchment { "england" }
-    teacher_catchment_country { nil }
+    teacher_catchment                     { "england" }
+    teacher_catchment_country             { nil }
 
     initialize_with do
       NPQ::BuildApplication.call(

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
           eligible_for_funding: true,
           teacher_reference_number_verified: true,
           targeted_delivery_funding_eligibility: true,
-          )
+        )
       end
       let(:npq_course) { application.npq_course }
 
@@ -153,7 +153,7 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
         expect(subject.call[:previously_funded]).to be_falsey
         expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
       end
-end
+    end
 
     context "when trn does not yield any teachers" do
       let(:trn) { "0000000" }

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
 
       it "returns falsey" do
         expect(subject.call[:previously_funded]).to be_falsey
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
       end
     end
 
@@ -39,6 +40,29 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
 
       it "returns truthy" do
         expect(subject.call[:previously_funded]).to be_truthy
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+      end
+    end
+
+    context "when previously funded with targeted delivery funding" do
+      let(:trn) { application.teacher_reference_number }
+      let(:application) do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          teacher_reference_number_verified: true,
+          targeted_delivery_funding_eligibility: true,
+        )
+      end
+      let(:npq_course) { application.npq_course }
+
+      before do
+        NPQ::Application::Accept.new(npq_application: application).call
+      end
+
+      it "returns truthy" do
+        expect(subject.call[:previously_funded]).to be_truthy
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_truthy
       end
     end
 
@@ -64,6 +88,7 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
 
       it "returns truthy" do
         expect(subject.call[:previously_funded]).to be_truthy
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
       end
     end
 
@@ -85,8 +110,27 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
 
       it "returns truthy" do
         expect(subject.call[:previously_funded]).to be_truthy
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
       end
     end
+
+    context "when previously funded with targeted delivery funding but not accepted" do
+      let(:trn) { application.teacher_reference_number }
+      let(:application) do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          teacher_reference_number_verified: true,
+          targeted_delivery_funding_eligibility: true,
+          )
+      end
+      let(:npq_course) { application.npq_course }
+
+      it "returns truthy" do
+        expect(subject.call[:previously_funded]).to be_falsey
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+      end
+end
 
     context "when trn does not yield any teachers" do
       let(:trn) { "0000000" }
@@ -96,6 +140,7 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
 
       it "returns falsey" do
         expect(subject.call[:previously_funded]).to be_falsey
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
       end
     end
   end

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -44,6 +44,29 @@ RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
       end
     end
 
+    context "when previously funded for a different course" do
+      let(:trn) { application.teacher_reference_number }
+      let(:application) do
+        create(
+          :npq_application,
+          eligible_for_funding: true,
+          teacher_reference_number_verified: true,
+        )
+      end
+      let(:npq_application_course) { application.npq_course }
+      # Making sure they are completely separate courses
+      let(:npq_course) { create(:npq_course, identifier: npq_application_course.identifier.reverse) }
+
+      before do
+        NPQ::Application::Accept.new(npq_application: application).call
+      end
+
+      it "returns truthy" do
+        expect(subject.call[:previously_funded]).to be_falsey
+        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+      end
+    end
+
     context "when previously funded with targeted delivery funding" do
       let(:trn) { application.teacher_reference_number }
       let(:application) do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-723

### Changes proposed in this pull request

api/v1/npq-funding/:id wil now return previously_received_targeted_funding_support in its response. This will be true if the user has any accepted applications where targeted_delivery_funding_eligibility is true
