### PR TITLE
Bump the expires in security.txt

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,3 +1,3 @@
 Contact: mailto:cpd-developers@digital.education.gov.uk
-Expires: 2022-10-18T23:00:00.000Z
+Expires: 2023-12-07T23:00:00.000Z
 Policy: https://github.com/ukncsc/Vulnerability-Disclosure/blob/master/UK-Government-Vulnerability-Disclosure-Policy.md


### PR DESCRIPTION
### Context

I was looking at creating a security.txt for another Rails app that we're working on, and found that yours had an out of date expires field.

### Changes proposed in this pull request

Assuming the contact details are still relevant, we should be able to bump this forward by one year.

### Guidance to review

Check that the email address / Google group is still set up correctly and that people can still access it. If that's the case, bumping this should be fine.