### PR TITLE
Change DatabaseCleaner to :transaction mode

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 RSpec.configure do |rspec|
-  rspec.before(:suite) { DatabaseCleaner.clean_with :truncation }
+  rspec.before(:suite) { DatabaseCleaner.clean_with :transaction }
 end


### PR DESCRIPTION
### Context

We currently seed our test database and then truncate it immediately. We have plenty of data that _needs_ to be present like cohorts and schedules, that never 'won't be there' in prod.

This is a small first step towards removing legacy feature flags. The [`Cohort#next` method](https://github.com/DFE-Digital/early-careers-framework/blob/develop/app/models/cohort.rb#L20) causes loads of failures when `2021` or `2022` aren't present (either, depending on the test).
