### PR TITLE
Correct school UI induction start date

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -29,7 +29,8 @@ class Schools::ParticipantsController < Schools::BaseController
 
   def show
     @induction_record = @profile.induction_records.for_school(@school).latest
-    @first_induction_record = @profile.induction_records.for_school(@school).order(created_at: :asc).first
+    @first_school_induction_record = @profile.induction_records.for_school(@school).order(created_at: :asc).first
+    @first_induction_record = @profile.induction_records.order(created_at: :asc).first
     @mentor_profile = @induction_record.mentor_profile
   end
 

--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -29,8 +29,7 @@ class Schools::ParticipantsController < Schools::BaseController
 
   def show
     @induction_record = @profile.induction_records.for_school(@school).latest
-    @first_school_induction_record = @profile.induction_records.for_school(@school).order(created_at: :asc).first
-    @first_induction_record = @profile.induction_records.order(created_at: :asc).first
+    @first_induction_record = @profile.induction_records.oldest
     @mentor_profile = @induction_record.mentor_profile
   end
 

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -77,6 +77,8 @@ class InductionRecord < ApplicationRecord
   scope :oldest_first, -> { order(created_at: :asc) }
   scope :newest_first, -> { order(created_at: :desc) }
 
+  scope :oldest, -> { oldest_first.first }
+
   def self.latest
     newest_first.first
   end

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -51,6 +51,16 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          School start
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @first_school_induction_record&.start_date.to_date.to_s(:govuk) %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           Role
         </dt>
         <dd class="govuk-summary-list__value">

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -51,16 +51,6 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          School start
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @first_school_induction_record&.start_date.to_date.to_s(:govuk) %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
           Role
         </dt>
         <dd class="govuk-summary-list__value">


### PR DESCRIPTION
### Context

Shows the oldest start_date for the participant representing the date that the induction training history began.

### Changes proposed in this pull request

Adds an `oldest` scope for induction records which is the opposite of `latest`

