### PR TITLE
Update Statuscake version to 2.0.5

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -90,7 +90,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.sha }}
           cd terraform/app

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -90,7 +90,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.sha }}

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -35,7 +35,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_PROD_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_PROD_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
           cd terraform/app

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -35,7 +35,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_PROD_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_PROD_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -33,7 +33,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SANDBOX }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_STAG_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
           cd terraform/app

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -33,7 +33,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SANDBOX }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_STAG_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -60,7 +60,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_STAG_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
           cd terraform/app

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -60,7 +60,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_STAG_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -44,7 +44,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=review-pr-${{ github.event.number }}/terraform.tfstate"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -44,7 +44,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           cd terraform/app

--- a/.github/workflows/force_destroy.yml
+++ b/.github/workflows/force_destroy.yml
@@ -46,7 +46,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=review-pr-${{ github.event.inputs.number }}/terraform.tfstate"

--- a/.github/workflows/force_destroy.yml
+++ b/.github/workflows/force_destroy.yml
@@ -46,7 +46,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           cd terraform/app

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -98,7 +98,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-dev:${{ github.event.pull_request.head.sha }}
           cd terraform/app

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -98,7 +98,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_DEV_USERNAME }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
         run: |
           export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-dev:${{ github.event.pull_request.head.sha }}

--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -1,12 +1,22 @@
-resource "statuscake_test" "alert" {
-  for_each      = var.statuscake_alerts
-  website_name  = each.value.website_name
-  website_url   = each.value.website_url
-  test_type     = "HTTP"
-  check_rate    = 30
-  contact_group = each.value.contact_group
-  trigger_rate  = 0
-  find_string   = lookup(each.value, "find_string", null)
-  do_not_find   = lookup(each.value, "do_not_find", false)
-  confirmations = 1
+resource "statuscake_uptime_check" "alert" {
+  for_each       = var.statuscake_alerts
+
+  name           = each.value.website_name
+  contact_groups = each.value.contact_group
+  confirmation   = 1
+  trigger_rate   = 0
+  check_interval = 30
+  regions        = ["london", "dublin"]
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes     = ["204", "205", "206", "303", "400", "401", "403", "404", "405", "406", "408", "410", "413", "444", "429", "494", "495", "496", "499", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511", "521", "522", "523", "524", "520", "598", "599"]
+    validate_ssl     = false
+  }
+
+  monitored_resource {
+    address = each.value.website_url
+  }
 }

--- a/terraform/app/modules/statuscake/providers.tf
+++ b/terraform/app/modules/statuscake/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = ">= 1.0.1"
+      version = ">= 2.0.5"
     }
   }
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -16,7 +16,7 @@ provider cloudfoundry {
 }
 
 provider "statuscake" {
-  api_token = var.statuscake_apikey
+  api_token = var.statuscake_api_token
 }
 
 /*

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -16,8 +16,7 @@ provider cloudfoundry {
 }
 
 provider "statuscake" {
-  username = var.statuscake_username
-  apikey   = var.statuscake_apikey
+  api_token = var.statuscake_apikey
 }
 
 /*

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -111,9 +111,6 @@ variable "statuscake_alerts" {
   default     = {}
 }
 
-variable statuscake_username {
-}
-
 variable statuscake_apikey {
 }
 

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -111,7 +111,7 @@ variable "statuscake_alerts" {
   default     = {}
 }
 
-variable statuscake_apikey {
+variable statuscake_api_token {
 }
 
 locals {

--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = "~> 1.0.1"
+      version = "~> 2.0.5"
     }
   }
 }


### PR DESCRIPTION
### Context

Deploys have started failing as we are using a deprecated API version of statuscake

### Changes proposed in this pull request
- Update statuscake version in terraform
- Use API token instead of API key and username
- update statuscake required resource variables

### Guidance to review

