### PR TITLE
[CPDLP-1898] amend existing api post declarations endpoint to support outcomes

### DIFF
--- a/app/controllers/api/v1/participant_declarations_controller.rb
+++ b/app/controllers/api/v1/participant_declarations_controller.rb
@@ -72,7 +72,7 @@ module Api
       def permitted_params
         params
           .require(:data)
-          .permit(:type, attributes: %i[course_identifier declaration_date declaration_type participant_id evidence_held])
+          .permit(:type, attributes: %i[course_identifier declaration_date declaration_type participant_id evidence_held has_passed])
       rescue ActionController::ParameterMissing => e
         if e.param == :data
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -159,6 +159,14 @@ class ParticipantDeclaration < ApplicationRecord
       )
   end
 
+  def npq?
+    false
+  end
+
+  def ecf?
+    false
+  end
+
 private
 
   def build_initial_declaration_state

--- a/app/models/participant_declaration/ecf.rb
+++ b/app/models/participant_declaration/ecf.rb
@@ -2,4 +2,8 @@
 
 class ParticipantDeclaration::ECF < ParticipantDeclaration
   has_many :statements, class_name: "Finance::Statement::ECF", through: :statement_line_items
+
+  def ecf?
+    true
+  end
 end

--- a/app/models/participant_declaration/npq.rb
+++ b/app/models/participant_declaration/npq.rb
@@ -43,4 +43,8 @@ class ParticipantDeclaration::NPQ < ParticipantDeclaration
     .where.not(state: states.values_at("voided", "awaiting_clawback", "clawed_back"))
     .order(created_at: :desc)
   }
+
+  def npq?
+    true
+  end
 end

--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -16,4 +16,10 @@ class ParticipantOutcome::NPQ < ApplicationRecord
   def self.latest
     order(created_at: :desc).first
   end
+
+  def has_passed?
+    return nil if voided?
+
+    passed?
+  end
 end

--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -13,5 +13,7 @@ class ParticipantOutcome::NPQ < ApplicationRecord
   validates :state, presence: true
   validates :completion_date, presence: true, future_date: true
 
-  scope :latest, -> { order(created_at: :desc).first }
+  def self.latest
+    order(created_at: :desc).first
+  end
 end

--- a/app/serializers/api/v1/participant_declaration_serializer.rb
+++ b/app/serializers/api/v1/participant_declaration_serializer.rb
@@ -35,7 +35,7 @@ module Api
         declaration.current_state.dasherize
       end
 
-      attribute :has_passed do |declaration|
+      attribute :has_passed, if: FeatureFlag.active?(:participant_outcomes_feature) do |declaration|
         if declaration.npq?
           declaration.outcomes.latest&.passed?
         end

--- a/app/serializers/api/v1/participant_declaration_serializer.rb
+++ b/app/serializers/api/v1/participant_declaration_serializer.rb
@@ -37,7 +37,7 @@ module Api
 
       attribute :has_passed, if: -> { FeatureFlag.active?(:participant_outcomes_feature) } do |declaration|
         if declaration.npq?
-          declaration.outcomes.latest&.passed?
+          declaration.outcomes.latest&.has_passed?
         end
       end
     end

--- a/app/serializers/api/v1/participant_declaration_serializer.rb
+++ b/app/serializers/api/v1/participant_declaration_serializer.rb
@@ -35,7 +35,7 @@ module Api
         declaration.current_state.dasherize
       end
 
-      attribute :has_passed, if: FeatureFlag.active?(:participant_outcomes_feature) do |declaration|
+      attribute :has_passed, if: -> { FeatureFlag.active?(:participant_outcomes_feature) } do |declaration|
         if declaration.npq?
           declaration.outcomes.latest&.passed?
         end

--- a/app/serializers/api/v1/participant_declaration_serializer.rb
+++ b/app/serializers/api/v1/participant_declaration_serializer.rb
@@ -34,6 +34,12 @@ module Api
       attribute :state do |declaration|
         declaration.current_state.dasherize
       end
+
+      attribute :has_passed do |declaration|
+        if declaration.npq?
+          declaration.outcomes.latest&.passed?
+        end
+      end
     end
   end
 end

--- a/app/serializers/api/v2/participant_declaration_serializer.rb
+++ b/app/serializers/api/v2/participant_declaration_serializer.rb
@@ -26,7 +26,7 @@ module Api
         declaration.current_state.dasherize
       end
 
-      attribute :has_passed, if: FeatureFlag.active?(:participant_outcomes_feature) do |declaration|
+      attribute :has_passed, if: -> { FeatureFlag.active?(:participant_outcomes_feature) } do |declaration|
         if declaration.npq?
           declaration.outcomes.latest&.passed?
         end

--- a/app/serializers/api/v2/participant_declaration_serializer.rb
+++ b/app/serializers/api/v2/participant_declaration_serializer.rb
@@ -25,6 +25,12 @@ module Api
       attribute :state do |declaration|
         declaration.current_state.dasherize
       end
+
+      attribute :has_passed do |declaration|
+        if declaration.npq?
+          declaration.outcomes.latest&.passed?
+        end
+      end
     end
   end
 end

--- a/app/serializers/api/v2/participant_declaration_serializer.rb
+++ b/app/serializers/api/v2/participant_declaration_serializer.rb
@@ -28,7 +28,7 @@ module Api
 
       attribute :has_passed, if: -> { FeatureFlag.active?(:participant_outcomes_feature) } do |declaration|
         if declaration.npq?
-          declaration.outcomes.latest&.passed?
+          declaration.outcomes.latest&.has_passed?
         end
       end
     end

--- a/app/serializers/api/v2/participant_declaration_serializer.rb
+++ b/app/serializers/api/v2/participant_declaration_serializer.rb
@@ -26,7 +26,7 @@ module Api
         declaration.current_state.dasherize
       end
 
-      attribute :has_passed do |declaration|
+      attribute :has_passed, if: FeatureFlag.active?(:participant_outcomes_feature) do |declaration|
         if declaration.npq?
           declaration.outcomes.latest&.passed?
         end

--- a/app/serializers/finance/ecf/assurance_report/csv_serializer.rb
+++ b/app/serializers/finance/ecf/assurance_report/csv_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "csv"
+
 module Finance
   module ECF
     module AssuranceReport

--- a/app/serializers/finance/npq/assurance_report/csv_serializer.rb
+++ b/app/serializers/finance/npq/assurance_report/csv_serializer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "csv"
+
 module Finance
   module NPQ
     module AssuranceReport

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     multiple_cohorts
     api_v3
     appropriate_bodies
+    participant_outcomes_feature
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/services/importers/seed_statements.rb
+++ b/app/services/importers/seed_statements.rb
@@ -4,6 +4,8 @@
 # It is not designed to keep statements in sync
 # For that should be done by hand
 
+require "csv"
+
 class Importers::SeedStatements
   def call
     (2021..2022).each do |start_year|

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -201,7 +201,16 @@ private
   def validate_has_passed?
     return false unless FeatureFlag.active?(:participant_outcomes_feature)
 
-    participant_profile&.npq? && declaration_type == "completed"
+    participant_profile&.npq? &&
+      declaration_type == "completed" &&
+      valid_course_identifier_for_participant_outcome?
+  end
+
+  def valid_course_identifier_for_participant_outcome?
+    !(
+      ::Finance::Schedule::NPQEhco::IDENTIFIERS +
+      ::Finance::Schedule::NPQSupport::IDENTIFIERS
+    ).compact.include?(course_identifier)
   end
 
   def participant_outcome_state

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -199,6 +199,8 @@ private
   end
 
   def validate_has_passed?
+    return false unless FeatureFlag.active?(:participant_outcomes_feature)
+
     participant_profile&.npq? && declaration_type == "completed"
   end
 
@@ -207,7 +209,7 @@ private
   end
 
   def create_participant_outcome
-    return unless FeatureFlag.active?(:participant_outcomes_feature)
+    return unless validate_has_passed?
 
     NPQ::CreateParticipantOutcome.new(
       cpd_lead_provider:,

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,10 +44,6 @@ module EarlyCareerFramework
       require file
     end
 
-    Dir.glob(Rails.root.join("app/serializers/**/*_serializer*.rb")).each do |c|
-      require_dependency(c)
-    end
-
     config.exceptions_app = routes
     config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
   mismatch_declaration_type_for_schedule: "The property '#/declaration_type does not exist for this schedule"
   missing_declaration_type: "The property '#/declaration_type' must be present"
   missing_evidence_held: "The property '#/evidence_held' must be present"
+  missing_has_passed: "The property '#/has_passed' must be present for completed declaration types"
   missing_lead_provider: "The lead provider must be present"
   missing_course_identifier: "The property '#/course_identifier' must be present"
   missing_participant_id: "The property '#/participant_id' must be present"

--- a/spec/factories/participant_declaration.rb
+++ b/spec/factories/participant_declaration.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     transient do
       profile_traits { [] }
       uplifts        { [] }
+      has_passed     { false }
     end
 
     factory :ecf_participant_declaration, class: "ParticipantDeclaration::ECF" do
@@ -45,6 +46,7 @@ FactoryBot.define do
         declaration_date: declaration_date.rfc3339,
         declaration_type:,
         cpd_lead_provider:,
+        has_passed:,
       }
 
       params[:evidence_held] = "other" if declaration_type != "started"

--- a/spec/features/finance/banding_tracker_spec.rb
+++ b/spec/features/finance/banding_tracker_spec.rb
@@ -52,6 +52,7 @@ RSpec.feature "Banding tracker", :with_default_schedules, type: :feature, js: tr
   end
 
   before do
+    allow(FeatureFlag).to receive(:active?).with(:participant_outcomes_feature).and_return(false)
     allow(FeatureFlag).to receive(:active?).with(:multiple_cohorts).and_return(true)
 
     generate_declarations(state: :payable)

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -77,4 +77,21 @@ RSpec.describe ParticipantOutcome::NPQ, :with_default_schedules, type: :model do
       end
     end
   end
+
+  describe ".has_passed?" do
+    it "returns true if passed" do
+      outcome = described_class.new(state: "passed")
+      expect(outcome.has_passed?).to eql(true)
+    end
+
+    it "returns false if failed" do
+      outcome = described_class.new(state: "failed")
+      expect(outcome.has_passed?).to eql(false)
+    end
+
+    it "returns nil if voided" do
+      outcome = described_class.new(state: "voided")
+      expect(outcome.has_passed?).to eql(nil)
+    end
+  end
 end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -573,7 +573,61 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
           end
         end
       end
+
+      context "when NPQ participant has completed declaration", with_feature_flags: { participant_outcomes_feature: "active" } do
+        let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+        let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
+        let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+        let(:npq_course) { create(:npq_leadership_course) }
+        let(:participant_profile) do
+          create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)
+        end
+        let(:course_identifier) { npq_course.identifier }
+        let(:declaration_type)  { "completed" }
+        let(:has_passed) { nil }
+        let(:params) do
+          {
+            data: {
+              type: "participant-declaration",
+              attributes: {
+                participant_id:,
+                declaration_type:,
+                declaration_date: declaration_date.rfc3339,
+                course_identifier:,
+                has_passed:,
+              },
+            },
+          }
+        end
+
+        before do
+          travel_to declaration_date
+        end
+
+        context "has_passed is true" do
+          let(:has_passed)  { true }
+
+          it "creates passed participant outcome" do
+            expect(ParticipantOutcome::NPQ.count).to eql(0)
+            post "/api/v1/participant-declarations", params: params.to_json
+            expect(parsed_response["data"]["attributes"]["has_passed"]).to eq(true)
+            expect(ParticipantOutcome::NPQ.count).to eql(1)
+          end
+        end
+
+        context "has_passed is false" do
+          let(:has_passed)  { false }
+
+          it "creates failed participant outcome" do
+            expect(ParticipantOutcome::NPQ.count).to eql(0)
+            post "/api/v1/participant-declarations", params: params.to_json
+            expect(parsed_response["data"]["attributes"]["has_passed"]).to eq(false)
+            expect(ParticipantOutcome::NPQ.count).to eql(1)
+          end
+        end
+      end
     end
+
     context "when unauthorized" do
       it "returns 401 for invalid bearer token" do
         default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
@@ -734,7 +788,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
 
     it "returns the correct headers" do
       expect(parsed_response.headers).to match_array(
-        %w[id course_identifier declaration_date declaration_type participant_id state eligible_for_payment voided updated_at],
+        %w[id course_identifier declaration_date declaration_type participant_id state eligible_for_payment voided updated_at has_passed],
       )
     end
 
@@ -800,23 +854,23 @@ private
     JSON.parse(response.body)
   end
 
-  def expected_json_response(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted")
+  def expected_json_response(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted", has_passed: nil)
     {
       "data" =>
       [
-        single_json_declaration(declaration:, profile:, course_identifier:, state:),
+        single_json_declaration(declaration:, profile:, course_identifier:, state:, has_passed:),
       ],
     }
   end
 
-  def expected_single_json_response(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted")
+  def expected_single_json_response(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted", has_passed: nil)
     {
       "data" =>
-      single_json_declaration(declaration:, profile:, course_identifier:, state:),
+      single_json_declaration(declaration:, profile:, course_identifier:, state:, has_passed:),
     }
   end
 
-  def single_json_declaration(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted")
+  def single_json_declaration(declaration:, profile:, course_identifier: "ecf-induction", state: "submitted", has_passed: nil)
     {
       "id" => declaration.id,
       "type" => "participant-declaration",
@@ -829,6 +883,7 @@ private
         "eligible_for_payment" => state == "eligible",
         "voided" => state == "voided",
         "updated_at" => declaration.updated_at.rfc3339,
+        "has_passed" => has_passed,
       },
     }
   end

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "participant-declarations endpoint spec", :with_default_schedules, type: :request do
+RSpec.describe "participant-declarations endpoint spec", :with_default_schedules, type: :request, with_feature_flags: { participant_outcomes_feature: "active" } do
   let(:cpd_lead_provider)    { create(:cpd_lead_provider, :with_lead_provider) }
   let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token)         { "Bearer #{token}" }
@@ -574,7 +574,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
         end
       end
 
-      context "when NPQ participant has completed declaration", with_feature_flags: { participant_outcomes_feature: "active" } do
+      context "when NPQ participant has completed declaration" do
         let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
         let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
         let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date + 1.day }

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "participant-declarations endpoint spec", :with_default_schedules, type: :request do
+RSpec.describe "participant-declarations endpoint spec", :with_default_schedules, type: :request, with_feature_flags: { participant_outcomes_feature: "active" } do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:started_milestone) { ect_profile.schedule.milestones.find_by(declaration_type: "started") }
   let(:declaration_date)  { started_milestone.start_date }
@@ -237,7 +237,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
         end
       end
 
-      context "when NPQ participant has completed declaration", with_feature_flags: { participant_outcomes_feature: "active" } do
+      context "when NPQ participant has completed declaration" do
         let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
         let(:schedule)              { NPQCourse.schedule_for(npq_course:) }
         let(:declaration_date)      { schedule.milestones.find_by(declaration_type:).start_date + 1.day }

--- a/spec/serializers/api/v1/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_declaration_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::ParticipantDeclarationSerializer, :with_default_schedules do
+RSpec.describe Api::V1::ParticipantDeclarationSerializer, :with_default_schedules, with_feature_flags: { participant_outcomes_feature: "active" } do
   describe "#state" do
     let(:participant_declaration) do
       create(:ect_participant_declaration, :awaiting_clawback)
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::ParticipantDeclarationSerializer, :with_default_schedule
     end
   end
 
-  describe "#has_passed", with_feature_flags: { participant_outcomes_feature: "active" } do
+  describe "#has_passed" do
     let(:declaration_type) { "completed" }
     let(:npq_course) { create(:npq_leadership_course) }
     let(:schedule) { NPQCourse.schedule_for(npq_course:) }
@@ -46,15 +46,7 @@ RSpec.describe Api::V1::ParticipantDeclarationSerializer, :with_default_schedule
     end
 
     describe "when participant outcome is false" do
-      let(:has_passed) { true }
-
-      let(:participant_declaration) do
-        travel_to declaration_date do
-          dec = create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:)
-          dec.outcomes.first.update!(state: "failed")
-          dec
-        end
-      end
+      let(:has_passed) { false }
 
       it "returns false" do
         result = described_class.new(participant_declaration).serializable_hash

--- a/spec/serializers/api/v2/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v2/participant_declaration_serializer_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V2::ParticipantDeclarationSerializer, :with_default_schedules do
-  describe "#has_passed", with_feature_flags: { participant_outcomes_feature: "active" } do
+RSpec.describe Api::V2::ParticipantDeclarationSerializer, :with_default_schedules, with_feature_flags: { participant_outcomes_feature: "active" } do
+  describe "#has_passed" do
     let(:declaration_type) { "completed" }
     let(:npq_course) { create(:npq_leadership_course) }
     let(:schedule) { NPQCourse.schedule_for(npq_course:) }
@@ -35,15 +35,7 @@ RSpec.describe Api::V2::ParticipantDeclarationSerializer, :with_default_schedule
     end
 
     describe "when participant outcome is false" do
-      let(:has_passed) { true }
-
-      let(:participant_declaration) do
-        travel_to declaration_date do
-          dec = create(:npq_participant_declaration, :eligible, declaration_type:, declaration_date:, has_passed:)
-          dec.outcomes.first.update!(state: "failed")
-          dec
-        end
-      end
+      let(:has_passed) { false }
 
       it "returns false" do
         result = described_class.new(participant_declaration).serializable_hash

--- a/spec/serializers/api/v2/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v2/participant_declaration_serializer_spec.rb
@@ -2,18 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::ParticipantDeclarationSerializer, :with_default_schedules do
-  describe "#state" do
-    let(:participant_declaration) do
-      create(:ect_participant_declaration, :awaiting_clawback)
-    end
-
-    it "dasherizes the value" do
-      result = described_class.new(participant_declaration).serializable_hash
-      expect(result[:data][:attributes][:state]).to eql("awaiting-clawback")
-    end
-  end
-
+RSpec.describe Api::V2::ParticipantDeclarationSerializer, :with_default_schedules do
   describe "#has_passed", with_feature_flags: { participant_outcomes_feature: "active" } do
     let(:declaration_type) { "completed" }
     let(:npq_course) { create(:npq_leadership_course) }

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
   let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider, name: "Unknown") }
   let(:declaration_type)      { "started" }
   let(:participant_id) { participant_profile.participant_identity.external_identifier }
-  let(:has_passed)            { false }
+  let(:has_passed) { false }
   let(:params) do
     {
       participant_id:,

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -389,6 +389,36 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
           end
         end
       end
+
+      context "ehco course identifier" do
+        let!(:npq_ehco_schedule) { create(:npq_ehco_schedule) }
+        let(:npq_course) { create(:npq_ehco_course) }
+        let(:has_passed) { true }
+
+        it "does not create participant outcome" do
+          travel_to declaration_date do
+            expect(ParticipantOutcome::NPQ.count).to be(0)
+            expect(service).to be_valid
+            service.call
+            expect(ParticipantOutcome::NPQ.count).to be(0)
+          end
+        end
+      end
+
+      context "aso course identifier" do
+        let!(:npq_aso_schedule) { create(:npq_aso_schedule) }
+        let(:npq_course) { create(:npq_aso_course) }
+        let(:has_passed) { true }
+
+        it "does not create participant outcome" do
+          travel_to declaration_date do
+            expect(ParticipantOutcome::NPQ.count).to be(0)
+            expect(service).to be_valid
+            service.call
+            expect(ParticipantOutcome::NPQ.count).to be(0)
+          end
+        end
+      end
     end
   end
 

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
   let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider, name: "Unknown") }
   let(:declaration_type)      { "started" }
   let(:participant_id) { participant_profile.participant_identity.external_identifier }
+  let(:has_passed)            { false }
   let(:params) do
     {
       participant_id:,
@@ -206,6 +207,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
       declaration_type:,
       course_identifier:,
       cpd_lead_provider:,
+      has_passed:,
     }
   end
 
@@ -340,6 +342,52 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
 
         expect(declaration).to be_eligible
         expect(declaration.statements).to include(statement)
+      end
+    end
+
+    context "when submitting completed", with_feature_flags: { participant_outcomes_feature: "active" } do
+      let(:declaration_type) { "completed" }
+      let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date + 1.day }
+
+      context "has_passed is nil" do
+        let(:has_passed) { nil }
+
+        it "returns error" do
+          expect(service).to be_invalid
+          expect(service.errors.messages_for(:has_passed)).to eq(["The property '#/has_passed' must be present for completed declaration types"])
+        end
+      end
+
+      context "has_passed is true" do
+        let(:has_passed) { true }
+
+        it "creates participant outcome" do
+          travel_to declaration_date do
+            expect(service).to be_valid
+            participant_declaration = service.call
+            expect(participant_declaration.outcomes.count).to be(1)
+
+            outcome = participant_declaration.outcomes.first
+            expect(outcome.completion_date).to eql(participant_declaration.declaration_date.to_date)
+            expect(outcome).to be_passed
+          end
+        end
+      end
+
+      context "has_passed is false" do
+        let(:has_passed) { false }
+
+        it "does not create participant outcome" do
+          travel_to declaration_date do
+            expect(service).to be_valid
+            participant_declaration = service.call
+            expect(participant_declaration.outcomes.count).to be(1)
+
+            outcome = participant_declaration.outcomes.first
+            expect(outcome.completion_date).to eql(participant_declaration.declaration_date.to_date)
+            expect(outcome).to be_failed
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 #
 require "with_model"
+require "csv"
 
 RSpec.configure do |config|
   # Configure rutabaga/turnip to find features outside of /features/ folders in

--- a/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
@@ -76,3 +76,8 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  has_passed:
+    description: Whether the participant has failed or passed
+    type: boolean
+    example: true
+    nullable: true

--- a/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
@@ -62,3 +62,8 @@ properties:
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  has_passed:
+    description: Whether the participant has failed or passed
+    type: boolean
+    example: true
+    nullable: true

--- a/swagger/v3/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
+++ b/swagger/v3/component_schemas/NPQParticipantDeclarationCompletedAttributesRequest.yml
@@ -43,6 +43,7 @@ properties:
     description: Whether the participant has failed or passed
     type: boolean
     example: true
+    nullable: true
 example:
   participant_id: db3a7848-7308-4879-942a-c4a70ced400a
   declaration_type: completed


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1898
- Depends on PR: https://github.com/DFE-Digital/early-careers-framework/pull/2809

### Changes proposed in this pull request

* Added feature flag `participant_outcomes_feature`
* Updated POST `/api/v1/participant-declarations` to include `has_passed`
* Updated POST `/api/v2/participant-declarations` to include `has_passed`
* `ParticipantOutcome::NPQ` is created when `has_passed` is true
* Updated API doc

### Guidance to review

* Enable feature
* Add `completed` declaration with `has_passed` set to `true`



[CPDLP-1898]: https://dfedigital.atlassian.net/browse/CPDLP-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ