### PR TITLE
Ensure concurrent migration errors are logged

### DIFF
--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -5,9 +5,8 @@ namespace :db do
     desc "Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors"
     task ignore_concurrent_migration_exceptions: :environment do
       Rake::Task["db:migrate"].invoke
-    rescue ActiveRecord::ConcurrentMigrationError
-
-      # Do nothing
+    rescue ActiveRecord::ConcurrentMigrationError => e
+      Sentry.capture_exception(e)
     end
   end
 end


### PR DESCRIPTION
### Context

We've had a few instances where they've occurred and nobody's noticed.

