### PR TITLE
Cpdlp 1685/fetch outcomes for single participant

### DIFF
--- a/app/controllers/api/v1/participant_outcomes_controller.rb
+++ b/app/controllers/api/v1/participant_outcomes_controller.rb
@@ -11,6 +11,11 @@ module Api
         render json: participant_declarations_hash.to_json
       end
 
+      def show
+        participant_declarations_hash = serializer_class.new(query_scope).serializable_hash
+        render json: participant_declarations_hash.to_json
+      end
+
     private
 
       def serializer_class
@@ -20,11 +25,16 @@ module Api
       def query_scope
         ParticipantOutcomesQuery.new(
           cpd_lead_provider:,
+          participant_external_id:,
         ).scope
       end
 
       def cpd_lead_provider
         current_user
+      end
+
+      def participant_external_id
+        params[:id]
       end
     end
   end

--- a/app/controllers/api/v1/provider_outcomes_controller.rb
+++ b/app/controllers/api/v1/provider_outcomes_controller.rb
@@ -2,11 +2,12 @@
 
 module Api
   module V1
-    class ParticipantOutcomesController < Api::ApiController
+    class ProviderOutcomesController < Api::ApiController
       include ApiTokenAuthenticatable
+      include ApiPagination
 
       def index
-        participant_declarations_hash = serializer_class.new(query_scope).serializable_hash
+        participant_declarations_hash = serializer_class.new(paginate(query_scope)).serializable_hash
         render json: participant_declarations_hash.to_json
       end
 
@@ -19,16 +20,11 @@ module Api
       def query_scope
         ParticipantOutcomesQuery.new(
           cpd_lead_provider:,
-          participant_external_id:,
         ).scope
       end
 
       def cpd_lead_provider
         current_user
-      end
-
-      def participant_external_id
-        params[:id]
       end
     end
   end

--- a/app/controllers/api/v2/provider_outcomes_controller.rb
+++ b/app/controllers/api/v2/provider_outcomes_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    class ProviderOutcomesController < V1::ProviderOutcomesController
+    end
+  end
+end

--- a/app/services/api/v1/participant_outcomes_query.rb
+++ b/app/services/api/v1/participant_outcomes_query.rb
@@ -3,23 +3,36 @@
 module Api
   module V1
     class ParticipantOutcomesQuery
-      attr_reader :cpd_lead_provider
+      attr_reader :cpd_lead_provider, :participant_external_id
 
-      def initialize(cpd_lead_provider:)
+      def initialize(cpd_lead_provider:, participant_external_id: nil)
         @cpd_lead_provider = cpd_lead_provider
+        @participant_external_id = participant_external_id
       end
 
       def scope
+        if participant_external_id.nil?
+          return ParticipantOutcome::NPQ
+            .joins(:participant_declaration)
+            .order(:created_at)
+            .merge(declarations_scope)
+        end
+
         ParticipantOutcome::NPQ
-          .joins(:participant_declaration)
+          .joins(participant_declaration: { participant_profile: :participant_identity })
           .order(:created_at)
           .merge(declarations_scope)
+          .merge(participant_scope)
       end
 
     private
 
       def declarations_scope
         ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
+      end
+
+      def participant_scope
+        ParticipantIdentity.where(external_identifier: participant_external_id)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,9 @@ Rails.application.routes.draw do
         collection do
           resources :outcomes, only: %i[index], controller: "participant_outcomes"
         end
+        member do
+          resources :outcomes, only: %i[index], controller: "participant_outcomes", action: :show
+        end
       end
       resources :users, only: %i[index create]
       resources :ecf_users, only: %i[index create], path: "ecf-users"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,9 @@ Rails.application.routes.draw do
         collection do
           resources :outcomes, only: %i[index], controller: "participant_outcomes"
         end
+        member do
+          resources :outcomes, only: %i[index], controller: "participant_outcomes", action: :show
+        end
       end
       resources :npq_enrolments, only: %i[index], path: "npq-enrolments"
       resources :users, only: %i[index create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,10 +85,10 @@ Rails.application.routes.draw do
       resources :npq_participants, only: %i[index show], path: "participants/npq" do
         concerns :participant_actions
         collection do
-          resources :outcomes, only: %i[index], controller: "participant_outcomes"
+          resources :outcomes, only: %i[index], controller: "provider_outcomes"
         end
         member do
-          resources :outcomes, only: %i[index], controller: "participant_outcomes", action: :show
+          resources :outcomes, only: %i[index], controller: "participant_outcomes"
         end
       end
       resources :users, only: %i[index create]
@@ -123,10 +123,10 @@ Rails.application.routes.draw do
       resources :npq_participants, only: %i[index show], path: "participants/npq" do
         concerns :participant_actions
         collection do
-          resources :outcomes, only: %i[index], controller: "participant_outcomes"
+          resources :outcomes, only: %i[index], controller: "provider_outcomes"
         end
         member do
-          resources :outcomes, only: %i[index], controller: "participant_outcomes", action: :show
+          resources :outcomes, only: %i[index], controller: "participant_outcomes"
         end
       end
       resources :npq_enrolments, only: %i[index], path: "npq-enrolments"

--- a/spec/docs/v1/participant_outcomes_spec.rb
+++ b/spec/docs/v1/participant_outcomes_spec.rb
@@ -44,4 +44,46 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/
       end
     end
   end
+
+  path "/api/v1/participants/npq/{id}/outcomes" do
+    let(:id) { npq_application.participant_identity.external_identifier }
+    get "List NPQ outcomes for single participant" do
+      operationId :participant_outcomes
+      tags "participants outcomes"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The external ID of the participant"
+
+      parameter name: :page,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/Pagination",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
+                description: "Pagination options to navigate through the list of participant NPQ outcomes."
+
+      response "200", "A list of participant outcomes" do
+        schema({ "$ref": "#/components/schemas/NPQOutcomesResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/docs/v2/participant_outcomes_spec.rb
+++ b/spec/docs/v2/participant_outcomes_spec.rb
@@ -44,4 +44,46 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/
       end
     end
   end
+
+  path "/api/v2/participants/npq/{id}/outcomes" do
+    let(:id) { npq_application.participant_identity.external_identifier }
+    get "List NPQ outcomes for single participant" do
+      operationId :participant_outcomes
+      tags "participants outcomes"
+      security [bearerAuth: []]
+
+      parameter name: :id,
+                in: :path,
+                type: :string,
+                required: true,
+                example: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+                description: "The external ID of the participant"
+
+      parameter name: :page,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/Pagination",
+                },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
+                description: "Pagination options to navigate through the list of participant NPQ outcomes."
+
+      response "200", "A list of participant outcomes" do
+        schema({ "$ref": "#/components/schemas/NPQOutcomesResponse" })
+
+        run_test!
+      end
+
+      response "401", "Unauthorized" do
+        let(:Authorization) { "Bearer invalid" }
+
+        schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
+
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/lib/lead_provider_api_specification_spec.rb
+++ b/spec/lib/lead_provider_api_specification_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe LeadProviderApiSpecification do
         /api/v1/participants/ecf/{id}/change-schedule
         /api/v1/participants/npq/{id}/change-schedule
         /api/v1/participants/npq/outcomes
+        /api/v1/participants/npq/{id}/outcomes
         /api/v1/participants/{id}/withdraw
       ]
 

--- a/spec/requests/api/v1/participant_outcome_spec.rb
+++ b/spec/requests/api/v1/participant_outcome_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
 
           expect(parsed_response).to eq(expected_response)
         end
+
+        it "returns matching outcomes by participant_external_id" do
+          get "/api/v1/participants/npq/#{npq_application.participant_identity.external_identifier}/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq(expected_response)
+        end
+
+        it "doesn't return outcomes unless matching participant_external_id" do
+          get "/api/v1/participants/npq/#{SecureRandom.uuid}/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq("data" => [])
+        end
       end
 
       it "can return paginated data" do

--- a/spec/requests/api/v1/provider_outcomes_spec.rb
+++ b/spec/requests/api/v1/provider_outcomes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
 
       context "when no outcome exists" do
         it "returns empty array" do
-          get "/api/v1/participants/npq/#{npq_application.participant_identity.external_identifier}/outcomes"
+          get "/api/v1/participants/npq/outcomes"
           expect(response.status).to eq 200
 
           expect(parsed_response).to eq("data" => [])
@@ -31,19 +31,23 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
         end
         let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
 
-        it "returns matching outcomes by participant_external_id" do
-          get "/api/v1/participants/npq/#{npq_application.participant_identity.external_identifier}/outcomes"
+        it "returns serialised data" do
+          get "/api/v1/participants/npq/outcomes"
           expect(response.status).to eq 200
 
           expect(parsed_response).to eq(expected_response)
         end
+      end
 
-        it "doesn't return outcomes unless matching participant_external_id" do
-          get "/api/v1/participants/npq/#{SecureRandom.uuid}/outcomes"
-          expect(response.status).to eq 200
+      it "can return paginated data" do
+        create :participant_outcome, :failed, participant_declaration: declaration
+        create :participant_outcome, :passed, participant_declaration: declaration
+        create :participant_outcome, :voided, participant_declaration: declaration
+        get "/api/v1/participants/npq/outcomes", params: { page: { per_page: 2, page: 1 } }
+        expect(parsed_response["data"].size).to eql(2)
 
-          expect(parsed_response).to eq("data" => [])
-        end
+        get "/api/v1/participants/npq/outcomes", params: { page: { per_page: 2, page: 2 } }
+        expect(parsed_response["data"].size).to eql(1)
       end
     end
 

--- a/spec/requests/api/v2/participant_outcome_spec.rb
+++ b/spec/requests/api/v2/participant_outcome_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
 
           expect(parsed_response).to eq(expected_response)
         end
+
+        it "returns matching outcomes by participant_external_id" do
+          get "/api/v2/participants/npq/#{npq_application.participant_identity.external_identifier}/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq(expected_response)
+        end
+
+        it "doesn't return outcomes unless matching participant_external_id" do
+          get "/api/v2/participants/npq/#{SecureRandom.uuid}/outcomes"
+          expect(response.status).to eq 200
+
+          expect(parsed_response).to eq("data" => [])
+        end
       end
 
       it "can return paginated data" do

--- a/spec/requests/api/v2/participant_outcome_spec.rb
+++ b/spec/requests/api/v2/participant_outcome_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
 
       context "when no outcome exists" do
         it "returns empty array" do
-          get "/api/v2/participants/npq/outcomes"
+          get "/api/v2/participants/npq/#{npq_application.participant_identity.external_identifier}/outcomes"
           expect(response.status).to eq 200
 
           expect(parsed_response).to eq("data" => [])
@@ -30,13 +30,6 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
           expected_json_response(outcome:, profile: npq_application.profile)
         end
         let!(:outcome) { create :participant_outcome, participant_declaration: declaration }
-
-        it "returns serialised data" do
-          get "/api/v2/participants/npq/outcomes"
-          expect(response.status).to eq 200
-
-          expect(parsed_response).to eq(expected_response)
-        end
 
         it "returns matching outcomes by participant_external_id" do
           get "/api/v2/participants/npq/#{npq_application.participant_identity.external_identifier}/outcomes"
@@ -51,17 +44,6 @@ RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, ty
 
           expect(parsed_response).to eq("data" => [])
         end
-      end
-
-      it "can return paginated data" do
-        create :participant_outcome, :failed, participant_declaration: declaration
-        create :participant_outcome, :passed, participant_declaration: declaration
-        create :participant_outcome, :voided, participant_declaration: declaration
-        get "/api/v2/participants/npq/outcomes", params: { page: { per_page: 2, page: 1 } }
-        expect(parsed_response["data"].size).to eql(2)
-
-        get "/api/v2/participants/npq/outcomes", params: { page: { per_page: 2, page: 2 } }
-        expect(parsed_response["data"].size).to eql(1)
       end
     end
 

--- a/spec/services/api/v1/participant_outcomes_query_spec.rb
+++ b/spec/services/api/v1/participant_outcomes_query_spec.rb
@@ -3,38 +3,59 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::ParticipantOutcomesQuery, :with_default_schedules do
+  let(:provider_declaration) { create_declaration }
+  let!(:provider_outcomes) { create_outcomes(provider_declaration) }
+  let(:other_provider_declaration) { create_declaration }
+  let!(:other_provider_outcomes) { create_outcomes(other_provider_declaration) }
+
   describe "#scope" do
-    let(:provider_declaration) { create_declaration }
-    let!(:provider_outcomes) { create_outcomes(provider_declaration) }
-    let(:other_provider_declaration) { create_declaration }
-    let!(:other_provider_outcomes) { create_outcomes(other_provider_declaration) }
-    subject(:index) { described_class.new(cpd_lead_provider: provider_declaration.cpd_lead_provider) }
+    context "for lead provider only" do
+      subject(:index) { described_class.new(cpd_lead_provider: provider_declaration.cpd_lead_provider) }
 
-    it "returns all declarations outcomes for the provider" do
-      expect(index.scope.to_a).to eq(provider_outcomes)
+      it "returns all declarations outcomes for the provider" do
+        expect(index.scope.to_a).to eq(provider_outcomes)
+      end
+
+      it "returns outcomes across multiple declarations" do
+        other_provider_declaration.update!(cpd_lead_provider: provider_declaration.cpd_lead_provider)
+        expect(index.scope.to_a).to eq(provider_outcomes.append(other_provider_outcomes).flatten)
+      end
     end
 
-    it "returns outcomes across multiple declarations" do
-      other_provider_declaration.update!(cpd_lead_provider: provider_declaration.cpd_lead_provider)
-      expect(index.scope.to_a).to eq(provider_outcomes.append(other_provider_outcomes).flatten)
-    end
+    context "when participant_id is supplied" do
+      subject!(:index) do
+        described_class.new(
+          cpd_lead_provider: provider_declaration.cpd_lead_provider,
+          participant_external_id: provider_declaration.participant_profile.participant_identity.external_identifier,
+        )
+      end
 
-  private
+      it "returns outcomes for the participant" do
+        expect(index.scope.to_a).to eq(provider_outcomes)
+      end
 
-    def create_declaration
-      provider = create(:cpd_lead_provider, :with_npq_lead_provider)
-      npq_application = create(:npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider)
-      create(:npq_participant_declaration,
-             participant_profile: npq_application.profile,
-             cpd_lead_provider: provider)
+      it "does not return outcomes for other participants" do
+        provider_declaration.update!(participant_profile: other_provider_declaration.participant_profile)
+        expect(index.scope.to_a).to eq([])
+      end
     end
+  end
 
-    def create_outcomes(declaration)
-      [
-        create(:participant_outcome, :failed, participant_declaration: declaration),
-        create(:participant_outcome, :passed, participant_declaration: declaration),
-        create(:participant_outcome, :voided, participant_declaration: declaration),
-      ]
-    end
+private
+
+  def create_declaration
+    provider = create(:cpd_lead_provider, :with_npq_lead_provider)
+    npq_application = create(:npq_application, :accepted, npq_lead_provider: provider.npq_lead_provider)
+    create(:npq_participant_declaration,
+           participant_profile: npq_application.profile,
+           cpd_lead_provider: provider)
+  end
+
+  def create_outcomes(declaration)
+    [
+      create(:participant_outcome, :failed, participant_declaration: declaration),
+      create(:participant_outcome, :passed, participant_declaration: declaration),
+      create(:participant_outcome, :voided, participant_declaration: declaration),
+    ]
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -932,6 +932,68 @@
         }
       }
     },
+    "/api/v1/participants/npq/{id}/outcomes": {
+      "get": {
+        "summary": "List NPQ outcomes for single participant",
+        "operationId": "participant_outcomes",
+        "tags": [
+          "participants outcomes"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The external ID of the participant",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of participant NPQ outcomes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of participant outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQOutcomesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/participants/ecf": {
       "get": {
         "summary": "Retrieve multiple participants, replaces <code>/api/v1/participants</code>",

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -984,6 +984,68 @@
         }
       }
     },
+    "/api/v2/participants/npq/{id}/outcomes": {
+      "get": {
+        "summary": "List NPQ outcomes for single participant",
+        "operationId": "participant_outcomes",
+        "tags": [
+          "participants outcomes"
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "example": "28c461ee-ffc0-4e56-96bd-788579a0ed75",
+            "description": "The external ID of the participant",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Pagination"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "example": "page[page]=1&page[per_page]=5",
+            "description": "Pagination options to navigate through the list of participant NPQ outcomes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of participant outcomes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NPQOutcomesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorisedResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/participants/ecf": {
       "get": {
         "summary": "Retrieve multiple participants, replaces <code>/api/v2/participants</code>",


### PR DESCRIPTION
Re-opening as a new PR because the review app would not deploy against the old one.

### Context
A provider can view all a single  participant’s NPQ outcomes if they GET  /api/v3/participants/npq/{participant_id}/outcomes

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1685

### Changes proposed in this pull request
- Allow `participant_external_id` to be filtered in `Api::V1::ParticipantOutcomesQuery`
- Add endpoint at `/api/v1/participants/npq/[participant_external_identifier]/outcomes`

