### PR TITLE
CST-1122: set school default appropriate body to new participants wit…

### DIFF
--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -33,7 +33,11 @@ private
     @preferred_email = preferred_email
     @mentor_profile = mentor_profile
     @school_transfer = school_transfer
-    @appropriate_body_id = appropriate_body_id
+    @appropriate_body_id = appropriate_body_id || school_appropriate_body_id
+  end
+
+  def school_appropriate_body_id
+    induction_programme.school_cohort.appropriate_body_id
   end
 
   def preferred_identity
@@ -45,13 +49,13 @@ private
     end
   end
 
-  def schedule_start_date
-    participant_profile.schedule.milestones.first.start_date
-  end
-
   def record_active_profile_participant_state!
     ParticipantProfileState.create!(participant_profile:,
                                     state: ParticipantProfileState.states[:active],
                                     cpd_lead_provider: induction_programme&.lead_provider&.cpd_lead_provider)
+  end
+
+  def schedule_start_date
+    participant_profile.schedule.milestones.first.start_date
   end
 end

--- a/spec/services/induction/enrol_spec.rb
+++ b/spec/services/induction/enrol_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Induction::Enrol do
   describe "#call" do
-    let(:school_cohort) { create :school_cohort }
+    let(:school_cohort) { create :school_cohort, appropriate_body: create(:appropriate_body_local_authority) }
     let!(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
     let(:teacher_profile) { create(:teacher_profile) }
     let(:participant_profile) { create(:ect_participant_profile, teacher_profile:, school_cohort:) }
@@ -28,6 +28,10 @@ RSpec.describe Induction::Enrol do
 
       it "sets the preferred identity to be the participant_profile.participant_identity" do
         expect(induction_record.preferred_identity_id).to eq(participant_profile.participant_identity_id)
+      end
+
+      it "sets the appropriate body the default one from the school cohort of the induction programme" do
+        expect(induction_record.appropriate_body_id).to eq(school_cohort.appropriate_body_id)
       end
     end
 


### PR DESCRIPTION
…h no customized AB

### Context
After the changes to school and participant AB setup, an induction_record always has its appropriate_body_id field set to either the participant customized AB or the school default AB.

I think there is a part still missing: when we create new induction records (add a participant, change a participant's programme, etc) we need to setup their AB to that of the school if nothing given.
 
- [Ticket](https://dfedigital.atlassian.net/browse/CST-1122)

### Changes proposed in this pull request
- Setup the induction record AB to be the one of the school if no customized AB provided when a participant is enrolled in a programme (Induction::Enroll service object)

### Guidance to review

