### PR TITLE
[CPDLP-1909] Set paper_trail whodunnit on the finance base controller

### DIFF
--- a/app/controllers/finance/base_controller.rb
+++ b/app/controllers/finance/base_controller.rb
@@ -7,6 +7,7 @@ module Finance
 
     before_action :authenticate_user!
     before_action :ensure_finance
+    before_action :set_paper_trail_whodunnit
 
     layout "finance"
 


### PR DESCRIPTION
### Context

When taking actions from the finance user admin dashboard (ie: changing participant training status).. we currently don't set the whodunnit ID on the papertrail versions table. Ideally we need to track who's done the changes for debug purposes.

- Ticket: [CPDLP-1909](https://dfedigital.atlassian.net/browse/CPDLP-1909)

### Changes proposed in this pull request

Set paper_trail whodunnit from the finance base controller