### PR TITLE
[CPDLP-1937] Amend Participant not withdrawn validator

### DIFF
--- a/app/validators/participant_not_withdrawn_validator.rb
+++ b/app/validators/participant_not_withdrawn_validator.rb
@@ -8,19 +8,19 @@ class ParticipantNotWithdrawnValidator < ActiveModel::Validator
 private
 
   def validate_withdrawals(record)
-    return unless record.participant_profile.present? && (withdrawn_state = find_withdrawn_participant_state(record))
+    return unless record.participant_profile.present? && (latest_state = latest_participant_state(record))
+    return unless latest_state.withdrawn? && latest_state.created_at <= record.declaration_date
 
     record
       .errors
-      .add(:participant_id, I18n.t(:declaration_must_be_before_withdrawal_date, withdrawal_date: withdrawn_state.created_at.rfc3339))
+      .add(:participant_id, I18n.t(:declaration_must_be_before_withdrawal_date, withdrawal_date: latest_state.created_at.rfc3339))
   end
 
-  def find_withdrawn_participant_state(record)
+  def latest_participant_state(record)
     record.participant_profile
       .participant_profile_states
-      .withdrawn
       .where(cpd_lead_provider: record.cpd_lead_provider)
-      .where("created_at <= ?", record.declaration_date)
+      .most_recent
       .first
   end
 end

--- a/spec/validators/participant_not_withdrawn_validator_spec.rb
+++ b/spec/validators/participant_not_withdrawn_validator_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantNotWithdrawnValidator, :with_default_schedules do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      validates :participant_id, participant_not_withdrawn: true
+
+      attr_reader :participant_profile, :cpd_lead_provider, :declaration_date
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "temp")
+      end
+
+      def initialize(participant_profile:, cpd_lead_provider:, declaration_date:)
+        @participant_profile = participant_profile
+        @cpd_lead_provider = cpd_lead_provider
+        @declaration_date = declaration_date
+      end
+    end
+  end
+
+  describe "#validate" do
+    subject { klass.new(participant_profile:, cpd_lead_provider:, declaration_date:) }
+
+    context "NPQ participant" do
+      let(:participant_profile) { create(:npq_participant_profile) }
+      let(:npq_application) { participant_profile.npq_application }
+      let(:cpd_lead_provider) { npq_application.npq_lead_provider.cpd_lead_provider }
+      let(:declaration_date) { Time.zone.now + 1.day }
+
+      context "participant profile active" do
+        it { is_expected.to be_valid }
+      end
+
+      context "participant profile withdrawn before declaration_date" do
+        let(:participant_profile) { create(:npq_participant_profile, :withdrawn) }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "participant profile withdrawn after declaration_date" do
+        let(:declaration_date) { Time.zone.now - 1.day }
+        let(:participant_profile) { create(:npq_participant_profile, :withdrawn) }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "participant profile reinstated after being withdrawn" do
+        let(:participant_profile) { create(:npq_participant_profile, :withdrawn) }
+        let(:course_identifier) { participant_profile.npq_application.npq_course.identifier }
+
+        before do
+          ResumeParticipant.new(
+            cpd_lead_provider:,
+            participant_id: participant_profile.participant_identity.external_identifier,
+            course_identifier:,
+          ).call
+        end
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context "ECF participant" do
+      let(:participant_profile) { create :mentor }
+      let(:cpd_lead_provider) { participant_profile.lead_provider.cpd_lead_provider }
+      let(:declaration_date) { Time.zone.now + 1.day }
+
+      context "participant profile active" do
+        it { is_expected.to be_valid }
+      end
+
+      context "participant profile withdrawn before declaration_date" do
+        let(:participant_profile) { create :mentor, :withdrawn }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "participant profile withdrawn after declaration_date" do
+        let(:participant_profile) { create :mentor, :withdrawn }
+        let(:declaration_date) { Time.zone.now - 1.day }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "participant profile reinstated after being withdrawn" do
+        let(:participant_profile) { create :mentor, :withdrawn }
+
+        before do
+          ResumeParticipant.new(
+            cpd_lead_provider:,
+            participant_id: participant_profile.participant_identity.external_identifier,
+            course_identifier: "ecf-mentor",
+          ).call
+        end
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

A participant can be reinstated after being withdrawn. However the validation does not take that into account and finds any withdrawn participant state for a profile and raises a validation error.

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1937

### Changes proposed in this pull request

Change the validation to look for the most recent participant state scoped to provider, and then check if it has been withdrawn and the declaration is after the profile has been withdrawn.

Also add tests, we like tests.

### Guidance to review
Open to suggestions for a nicer implementation as always
