### PR TITLE
CST-1184: remove :start_term field from ParticipantProfile

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -37,15 +37,6 @@ class Cohort < ApplicationRecord
     Cohort.find_by(start_year: start_year - 1)
   end
 
-  def start_term_options
-    # TODO: Set the terms dependant on dates provided by the team.
-    terms = []
-    terms << "autumn_#{start_year}" unless start_year == 2021
-    terms << "spring_#{start_year + 1}" unless start_year == 2022
-    terms << "summer_#{start_year + 1}" unless start_year == 2022
-    terms
-  end
-
   def display_name
     start_year.to_s
   end

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -36,7 +36,7 @@ class ParticipantProfile < ApplicationRecord
       other
     ].freeze
 
-    self.ignored_columns = %i[mentor_profile_id school_cohort_id start_term]
+    self.ignored_columns = %i[mentor_profile_id school_cohort_id]
     belongs_to :school, optional: true
     belongs_to :npq_course, optional: true
 

--- a/app/policies/participant_profile/ecf_policy.rb
+++ b/app/policies/participant_profile/ecf_policy.rb
@@ -26,18 +26,9 @@ class ParticipantProfile::ECFPolicy < ParticipantProfilePolicy
   alias_method :appropriate_body_confirmation?, :update?
   alias_method :update_appropriate_body?, :update?
 
-  def update_start_term?
-    return true if admin?
-    return false if record.participant_declarations.any?
-
-    user.induction_coordinator? && same_school?
-  end
-
   def update_validation_data?
     admin? && record.training_status_active? && (record.ecf_participant_eligibility.blank? || !record.ecf_participant_eligibility.eligible_status?)
   end
-
-  alias_method :edit_start_term?, :update_start_term?
 
   def withdraw_record?
     return false if record.participant_declarations.not_voided.any?

--- a/app/serializers/finance/ecf/duplicate_serializer.rb
+++ b/app/serializers/finance/ecf/duplicate_serializer.rb
@@ -17,7 +17,6 @@ module Finance
       attribute :request_for_details_sent_at, &:request_for_details_sent_at
       attribute :training_status, &:training_status
       attribute :profile_duplicity, &:profile_duplicity
-      attribute :start_term, &:start_term
       attribute :notes, &:notes
 
       attribute :npq_course_id, &:npq_course_id

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -50,12 +50,11 @@ module EarlyCareerTeachers
 
   private
 
-    attr_reader :full_name, :email, :start_term, :school_cohort, :mentor_profile_id, :year_2020, :start_date, :sit_validation, :appropriate_body_id
+    attr_reader :full_name, :email, :school_cohort, :mentor_profile_id, :year_2020, :start_date, :sit_validation, :appropriate_body_id
 
-    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_term: nil, start_date: nil, year_2020: false, sit_validation: false, appropriate_body_id: nil)
+    def initialize(full_name:, email:, school_cohort:, mentor_profile_id: nil, start_date: nil, year_2020: false, sit_validation: false, appropriate_body_id: nil)
       @full_name = full_name
       @email = email
-      @start_term = start_term || school_cohort.cohort.start_term_options.first
       @school_cohort = school_cohort
       @mentor_profile_id = mentor_profile_id
       @start_date = start_date
@@ -66,7 +65,6 @@ module EarlyCareerTeachers
 
     def ect_attributes
       {
-        start_term:,
         school_cohort_id: school_cohort.id,
         mentor_profile_id:,
         sparsity_uplift: sparsity_uplift?(start_year),

--- a/app/services/mentors/create.rb
+++ b/app/services/mentors/create.rb
@@ -42,12 +42,11 @@ module Mentors
 
   private
 
-    attr_reader :full_name, :email, :start_term, :school_cohort, :start_date, :sit_validation
+    attr_reader :full_name, :email, :school_cohort, :start_date, :sit_validation
 
-    def initialize(full_name:, email:, school_cohort:, start_term: nil, start_date: nil, sit_validation: false, **)
+    def initialize(full_name:, email:, school_cohort:, start_date: nil, sit_validation: false, **)
       @full_name = full_name
       @email = email
-      @start_term = start_term || school_cohort.cohort.start_term_options.first
       @start_date = start_date
       @school_cohort = school_cohort
       @sit_validation = sit_validation
@@ -55,7 +54,6 @@ module Mentors
 
     def mentor_attributes
       {
-        start_term:,
         school_cohort_id: school_cohort.id,
         sparsity_uplift: sparsity_uplift?(start_year),
         pupil_premium_uplift: pupil_premium_uplift?(start_year),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,8 +98,6 @@ en:
       blank: "Enter an email address"
     type:
       blank: "Select whether to add or transfer a teacher"
-    start_term:
-      blank: "Enter a start term"
     date_of_birth: &date_of_birth_error_messages
       blank: "Enter date of birth"
       invalid: "Invalid date of birth"
@@ -325,8 +323,6 @@ en:
           attributes:
             mentor_id:
               blank: "Choose a mentor"
-            start_term:
-              blank: "Choose a start term"
             do_you_know_teachers_trn:
               blank: "Select whether you know the teacher reference number (TRN) for the teacher you are adding"
             trn:

--- a/config/locales/schools/participants.yml
+++ b/config/locales/schools/participants.yml
@@ -1,15 +1,6 @@
 en:
   schools:
     participants:
-      add:
-        start_term:
-          ect: "When do you expect %{full_name} to start their induction programme?"
-          mentor: "When do you expect %{full_name} to begin mentoring ECTs?"
-      change:
-        start_term:
-          ect: "Change when you expect %{full_name} to start their induction programme"
-          mentor: "Change when you expect %{full_name} to start mentoring ECTs"
-
       type:
         ect: "Early career teacher"
         mentor: "Mentor"

--- a/db/migrate/20221212162506_remove_start_term_from_participant_profiles.rb
+++ b/db/migrate/20221212162506_remove_start_term_from_participant_profiles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveStartTermFromParticipantProfiles < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_column :participant_profiles, :start_term, :string, default: "Autumn 2021", null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_06_192349) do
+ActiveRecord::Schema.define(version: 2022_12_12_162506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -710,7 +710,6 @@ ActiveRecord::Schema.define(version: 2022_12_06_192349) do
     t.string "training_status", default: "active", null: false
     t.string "profile_duplicity", default: "single", null: false
     t.uuid "participant_identity_id"
-    t.string "start_term", default: "autumn_2021", null: false
     t.string "notes"
     t.date "induction_start_date"
     t.index ["cohort_id"], name: "index_participant_profiles_on_cohort_id"

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -168,7 +168,7 @@ module ManageTrainingSteps
   end
 
   def and_i_have_added_an_eligible_mentor
-    @eligible_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible mentor"), school_cohort: @school_cohort, start_term: "summer_2022")
+    @eligible_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible mentor"), school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @eligible_mentor, induction_programme: @induction_programme)
   end
 
@@ -362,7 +362,7 @@ module ManageTrainingSteps
   end
 
   def and_i_have_added_a_details_being_checked_ect_with_mentor
-    @details_being_checked_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort, start_term: "Spring 2022")
+    @details_being_checked_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
     @details_being_checked_ect_with_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
     Induction::Enrol.call(participant_profile: @details_being_checked_ect_with_mentor, induction_programme: @induction_programme)
   end
@@ -380,7 +380,7 @@ module ManageTrainingSteps
   end
 
   def and_i_have_added_a_no_qts_ect_with_mentor
-    @no_qts_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "No-qts With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort, start_term: "Spring 2022")
+    @no_qts_ect_with_mentor = create(:ect_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "No-qts With-Mentor"), mentor_profile_id: @contacted_for_info_mentor.id, school_cohort: @school_cohort)
     @no_qts_ect_with_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
     Induction::Enrol.call(participant_profile: @no_qts_ect_with_mentor, induction_programme: @induction_programme)
   end
@@ -536,10 +536,6 @@ module ManageTrainingSteps
     fill_in "Email", with: @participant_profile_ect.user.email
   end
 
-  def when_i_choose_start_term
-    choose(@participant_data[:start_term].humanize, allow_label_click: true)
-  end
-
   def when_i_choose_assign_mentor_later
     choose("Assign mentor later", allow_label_click: true)
   end
@@ -550,10 +546,6 @@ module ManageTrainingSteps
 
   def when_i_add_ect_or_mentor_updated_email
     fill_in "Email", with: @updated_participant_data[:email]
-  end
-
-  def when_i_add_ect_or_mentor_updated_term
-    choose(@updated_participant_data[:start_term].humanize, allow_label_click: true)
   end
 
   def when_i_choose_an_appropriate_body
@@ -832,11 +824,6 @@ module ManageTrainingSteps
     expect(page).to have_text((@updated_participant_data[:email]).to_s)
   end
 
-  def then_i_can_view_updated_term
-    expect(page).to have_selector("h1", text: "Check your answers")
-    expect(page).to have_text(@updated_participant_data[:start_term].humanize)
-  end
-
   def then_i_can_view_the_added_materials
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_text("Materials")
@@ -1063,7 +1050,6 @@ module ManageTrainingSteps
       date_of_birth: Date.new(1998, 3, 22),
       email: "sally@school.com",
       nino: "AB123456A",
-      start_term: "summer_2022",
       start_date: Date.new(2022, 9, 1),
     }
   end
@@ -1091,7 +1077,6 @@ module ManageTrainingSteps
     @updated_participant_data = {
       full_name: "Jane Teacher",
       email: "jane@school.com",
-      start_term: "spring_2022",
     }
   end
 

--- a/spec/policies/participant_profile/ecf_policy_spec.rb
+++ b/spec/policies/participant_profile/ecf_policy_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
       it { is_expected.to forbid_action(:update_validation_data) }
     end
 
@@ -40,8 +38,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
       it { is_expected.to permit_action(:update_validation_data) }
     end
 
@@ -62,8 +58,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
       it { is_expected.to forbid_action(:update_validation_data) }
     end
 
@@ -82,8 +76,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
         it { is_expected.to permit_action(:update_name) }
         it { is_expected.to permit_action(:edit_email) }
         it { is_expected.to permit_action(:update_email) }
-        it { is_expected.to permit_action(:edit_start_term) }
-        it { is_expected.to permit_action(:update_start_term) }
       end
 
       context "with only voided declarations" do
@@ -96,8 +88,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
         it { is_expected.to permit_action(:update_name) }
         it { is_expected.to permit_action(:edit_email) }
         it { is_expected.to permit_action(:update_email) }
-        it { is_expected.to permit_action(:edit_start_term) }
-        it { is_expected.to permit_action(:update_start_term) }
       end
     end
 
@@ -111,8 +101,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
     end
   end
 
@@ -135,8 +123,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
     end
 
     context "when the participant is found to be ineligible" do
@@ -147,8 +133,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
     end
 
     context "with a declaration" do
@@ -161,8 +145,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to permit_action(:update_name) }
       it { is_expected.to permit_action(:edit_email) }
       it { is_expected.to permit_action(:update_email) }
-      it { is_expected.to forbid_action(:edit_start_term) }
-      it { is_expected.to forbid_action(:update_start_term) }
     end
 
     context "with only voided declarations" do
@@ -175,8 +157,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to forbid_action(:update_name) }
       it { is_expected.to forbid_action(:edit_email) }
       it { is_expected.to forbid_action(:update_email) }
-      it { is_expected.to forbid_action(:edit_start_term) }
-      it { is_expected.to forbid_action(:update_start_term) }
     end
 
     context "with an NPQ application" do
@@ -189,8 +169,6 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
       it { is_expected.to forbid_action(:update_name) }
       it { is_expected.to forbid_action(:edit_email) }
       it { is_expected.to forbid_action(:update_email) }
-      it { is_expected.to permit_action(:edit_start_term) }
-      it { is_expected.to permit_action(:update_start_term) }
     end
   end
 
@@ -206,7 +184,5 @@ RSpec.describe ParticipantProfile::ECFPolicy, :with_default_schedules, type: :po
     it { is_expected.to forbid_action(:update_name) }
     it { is_expected.to forbid_action(:edit_email) }
     it { is_expected.to forbid_action(:update_email) }
-    it { is_expected.to forbid_action(:edit_start_term) }
-    it { is_expected.to forbid_action(:update_start_term) }
   end
 end


### PR DESCRIPTION
### Context
First PR of several as part of this big [ticket](https://dfedigital.atlassian.net/browse/CST-1184).

### Changes proposed in this pull request
- Remove legacy field `start_term` from ParticipantProfile.

### Guidance to review

