### PR TITLE
[CPDLP-1936] Check that user exists before creating declaration attempt

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -85,15 +85,19 @@ private
   end
 
   def declaration_attempt
-    if participant_id && cpd_lead_provider
+    if user && cpd_lead_provider
       @declaration_attempt ||= ParticipantDeclarationAttempt.create!(
         course_identifier:,
         declaration_date:,
         declaration_type:,
         cpd_lead_provider:,
-        user_id: participant_id,
+        user:,
       )
     end
+  end
+
+  def user
+    @user ||= participant_identity&.user
   end
 
   def set_eligibility


### PR DESCRIPTION
### Context
If the participant external ID does not match a user with the same ID we are failing to create record declarations as it fails the validation for creating a declaration attempt which requires a user to exist.

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1936

### Changes proposed in this pull request

Do not depend on the user having the same ID as the external ID, look up the user and check they exist before attempting to create the declaration attempt to avoid unnecessary failures.

### Guidance to review

