### PR TITLE
Throw RecordInvalid if any data in the Accept transaction is invalid

### DIFF
--- a/app/services/npq/application/accept.rb
+++ b/app/services/npq/application/accept.rb
@@ -19,7 +19,8 @@ module NPQ
         ApplicationRecord.transaction do
           teacher_profile.update!(trn: npq_application.teacher_reference_number) if npq_application.teacher_reference_number_verified?
           create_participant_profile!
-          npq_application.update(lead_provider_approval_status: "accepted") && other_applications_in_same_cohort.update(lead_provider_approval_status: "rejected")
+          npq_application.update!(lead_provider_approval_status: "accepted")
+          other_applications_in_same_cohort.update(lead_provider_approval_status: "rejected") # rubocop:disable Rails/SaveBang
           deduplicate_by_trn!
         end
 

--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe NPQ::Application::Accept, :with_default_schedules do
           expect(service.errors.messages_for(:npq_application)).to include("Once rejected an application cannot change state")
         end
       end
+
+      context "when the existing data is invalid" do
+        let(:npq_application) { create(:npq_application) }
+
+        it "throws ActiveRecord::RecordInvalid" do
+          npq_application.eligible_for_funding = nil
+          expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
     end
 
     context "when user applies for EHCO but has accepted ASO" do


### PR DESCRIPTION
### Context

Updates to NPQApplication in `NPQ::Application::Accept` could fail silently
- Ticket: [Tweak accept NPQ application endpoint code to ensure it fails if an update does not work on a NPQ profile ensuring it doesn't fail silently](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?assignee=636be0f2c87c50433008e608&selectedIssue=CPDLP-1915)

### Changes proposed in this pull request
Call `update!` not `update` so `ActiveRecord::RecordInvalid` is raised and the transaction is rolled back.

### Possible alternative approach

rescue the `ActiveRecord::RecordInvalid` and add any errors to the service object errors. 

I didn't take this approach because the error would likely not be caused by data they sent - but by our underlying data, making it something that should show up in Sentry - it would make no sense to the Providers.
