### PR TITLE
Add a .keep file to logs directory

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Create mail log file
-        run: mkdir log && touch log/mail.log
+        run: touch log/mail.log
       - name: Lint ruby
         run: rubocop
       - name: Lint SCSS


### PR DESCRIPTION
### Context

When setting up the app from fresh we get this error because we try and write to the mail.log file without the log directory existing.

```
No such file or directory @ rb_sysopen - log/mail.log
```

The log directory being present will stop it from tripping people up in the future.
