### PR TITLE
Update to the latest version of actions/checkout

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Customize the ruby version depending on your needs
     - name: Setup Ruby

--- a/.github/workflows/deploy_monitoring_dev.yml
+++ b/.github/workflows/deploy_monitoring_dev.yml
@@ -20,7 +20,7 @@ jobs:
     needs: turnstyle
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Pin Terraform version

--- a/.github/workflows/deploy_monitoring_production.yml
+++ b/.github/workflows/deploy_monitoring_production.yml
@@ -20,7 +20,7 @@ jobs:
     needs: turnstyle
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Pin Terraform version

--- a/.github/workflows/deploy_monitoring_staging.yml
+++ b/.github/workflows/deploy_monitoring_staging.yml
@@ -20,7 +20,7 @@ jobs:
     needs: turnstyle
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Pin Terraform version

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Pin Terraform version

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -20,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
 

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -20,7 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v1.4.0

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           terraform_version: 0.14.0
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
         with:
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Terraform pin version

--- a/.github/workflows/force_destroy.yml
+++ b/.github/workflows/force_destroy.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Terraform pin version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       GOVUK_NOTIFY_API_KEY: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2.5.1
         with:
           node-version: '16.17.x'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Code
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.127.0
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.127.0
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.127.0


### PR DESCRIPTION
### Context

v2 is rather old now and comes with node-12. v3 brings us more up to date with the node-16 runtime by default.
