### PR TITLE
Require CSV for db seeding to complete successfully

### DIFF
--- a/app/services/importers/seed_schedule.rb
+++ b/app/services/importers/seed_schedule.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "csv"
+
 class Importers::SeedSchedule
   attr_reader :path_to_csv, :klass
 


### PR DESCRIPTION
### Context

Deployment to dev has failed because we need to require "csv" where needed. Add it to seed file

- Ticket: n/a

### Changes proposed in this pull request

### Guidance to review
Maybe we should move the requirement higher up so we don't need to worry about it anymore
