### PR TITLE
[CPDLP-1934] Void an outcome when a provider voids a completion declaration which has an outcome

### DIFF
--- a/app/services/npq/create_participant_outcome.rb
+++ b/app/services/npq/create_participant_outcome.rb
@@ -16,6 +16,7 @@ module NPQ
               presence: { message: I18n.t(:missing_completion_date) },
               format: { with: /\d{4}-\d{2}-\d{2}/, message: I18n.t(:invalid_completion_date) }
     validates :course_identifier, course: true, presence: { message: I18n.t(:missing_course_identifier) }
+    validate :check_for_valid_course_identifiers
     validates :state,
               presence: { message: I18n.t(:missing_state) },
               inclusion: {
@@ -79,6 +80,12 @@ module NPQ
 
     def participant_declaration
       @participant_declaration ||= participant_declarations&.first
+    end
+
+    def check_for_valid_course_identifiers
+      if (::Finance::Schedule::NPQEhco::IDENTIFIERS + ::Finance::Schedule::NPQSupport::IDENTIFIERS).compact.include?(course_identifier)
+        errors.add(:course_identifier, I18n.t("errors.participant_outcomes.invalid_course_identifier"))
+      end
     end
   end
 end

--- a/app/services/npq/void_participant_outcome.rb
+++ b/app/services/npq/void_participant_outcome.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module NPQ
+  class VoidParticipantOutcome
+    def initialize(participant_declaration)
+      @participant_declaration = participant_declaration
+    end
+
+    def call
+      return unless create_participant_outcome?
+      return if latest_participant_outcome&.voided?
+
+      ParticipantOutcome::NPQ.create!(
+        participant_declaration:,
+        completion_date: declaration_date,
+        state: "voided",
+      )
+    end
+
+  private
+
+    attr_reader :participant_declaration
+
+    delegate :course_identifier, :participant_profile,
+             :declaration_date, :declaration_type,
+             to: :participant_declaration
+
+    def create_participant_outcome?
+      return false unless FeatureFlag.active?(:participant_outcomes_feature)
+
+      participant_profile&.npq? &&
+        declaration_type == "completed" &&
+        valid_course_identifier_for_participant_outcome?
+    end
+
+    def valid_course_identifier_for_participant_outcome?
+      !(
+        ::Finance::Schedule::NPQEhco::IDENTIFIERS +
+        ::Finance::Schedule::NPQSupport::IDENTIFIERS
+      ).compact.include?(course_identifier)
+    end
+
+    def latest_participant_outcome
+      participant_declaration&.outcomes&.latest
+    end
+  end
+end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -202,15 +202,7 @@ private
     return false unless FeatureFlag.active?(:participant_outcomes_feature)
 
     participant_profile&.npq? &&
-      declaration_type == "completed" &&
-      valid_course_identifier_for_participant_outcome?
-  end
-
-  def valid_course_identifier_for_participant_outcome?
-    !(
-      ::Finance::Schedule::NPQEhco::IDENTIFIERS +
-      ::Finance::Schedule::NPQSupport::IDENTIFIERS
-    ).compact.include?(course_identifier)
+      declaration_type == "completed"
   end
 
   def participant_outcome_state

--- a/app/services/void_participant_declaration.rb
+++ b/app/services/void_participant_declaration.rb
@@ -12,6 +12,8 @@ class VoidParticipantDeclaration
       make_voided
     end
 
+    NPQ::VoidParticipantOutcome.new(participant_declaration).call
+
     participant_declaration
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,8 @@ en:
       exist: "The participant must have no declarations"
       billable_or_submitted: "The participant has billable or submitted declarations in the current cohort"
       completed: "The participant has no completed declarations"
+    participant_outcomes:
+      invalid_course_identifier: "Invalid course identifier for participant outcome"
     participant_profile:
       blank: "Not registered"
       not_active: "Not active"

--- a/spec/services/npq/void_participant_outcome_spec.rb
+++ b/spec/services/npq/void_participant_outcome_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::VoidParticipantOutcome, :with_default_schedules, with_feature_flags: { participant_outcomes_feature: "active" } do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
+  let(:schedule) { NPQCourse.schedule_for(npq_course:) }
+  let(:declaration_date) { schedule.milestones.find_by(declaration_type:).start_date }
+  let(:npq_course) { create(:npq_leadership_course) }
+  let(:declaration_type) { "completed" }
+  let(:participant_profile) do
+    create(:npq_participant_profile, npq_lead_provider: cpd_lead_provider.npq_lead_provider, npq_course:)
+  end
+  let(:participant_declaration) do
+    travel_to declaration_date do
+      create(:npq_participant_declaration, participant_profile:, cpd_lead_provider:, declaration_type:, declaration_date:, state: "paid", has_passed: true)
+    end
+  end
+
+  before do
+    create(:npq_statement, :output_fee, deadline_date: 6.weeks.from_now, cpd_lead_provider:)
+  end
+
+  subject(:service) { described_class.new(participant_declaration) }
+
+  describe "#call" do
+    context "completed declaration" do
+      it "creates new participant outcome record" do
+        expect(participant_declaration.outcomes.count).to eql(1)
+
+        travel_to declaration_date + 1.day do
+          service.call
+        end
+
+        expect(participant_declaration.outcomes.count).to eql(2)
+        expect(participant_declaration.outcomes.latest).to be_voided
+      end
+    end
+
+    context "submitted declaration" do
+      let(:declaration_type) { "started" }
+
+      it "does not create participant outcome record" do
+        expect(participant_declaration.outcomes.count).to eql(0)
+
+        travel_to declaration_date + 1.day do
+          service.call
+        end
+
+        expect(participant_declaration.outcomes.count).to eql(0)
+      end
+    end
+
+    context "ehco course" do
+      let!(:npq_ehco_schedule) { create(:npq_ehco_schedule) }
+      let(:npq_course) { create(:npq_ehco_course) }
+
+      it "does not create participant outcome record" do
+        expect(participant_declaration.outcomes.count).to eql(0)
+
+        travel_to declaration_date + 1.day do
+          service.call
+        end
+
+        expect(participant_declaration.outcomes.count).to eql(0)
+      end
+    end
+
+    context "aso course identifier" do
+      let!(:npq_aso_schedule) { create(:npq_aso_schedule) }
+      let(:npq_course) { create(:npq_aso_course) }
+
+      it "does not create participant outcome record" do
+        expect(participant_declaration.outcomes.count).to eql(0)
+
+        travel_to declaration_date + 1.day do
+          service.call
+        end
+
+        expect(participant_declaration.outcomes.count).to eql(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1934

### Changes proposed in this pull request

* Updated void participant declaration endpoint service to create void participant outcome
* Created `NPQ::VoidParticipantOutcome` service to action void outcome creation.

### Guidance to review

