### PR TITLE
CPDLP-1924 Change default cohort and schedule selection on NPQ EHCO applications

### DIFF
--- a/app/models/finance/schedule/npq_ehco.rb
+++ b/app/models/finance/schedule/npq_ehco.rb
@@ -9,8 +9,8 @@ module Finance
 
       PERMITTED_COURSE_IDENTIFIERS = IDENTIFIERS
 
-      def self.default
-        find_by(cohort: Cohort.find_by!(start_year: 2022), schedule_identifier: "npq-ehco-december")
+      def self.default_for(cohort: Cohort.current)
+        find_by(cohort:, schedule_identifier: "npq-ehco-november")
       end
 
       def self.schedule_for(cohort: Cohort.current)

--- a/app/models/finance/schedule/npq_ehco.rb
+++ b/app/models/finance/schedule/npq_ehco.rb
@@ -12,6 +12,27 @@ module Finance
       def self.default
         find_by(cohort: Cohort.find_by!(start_year: 2022), schedule_identifier: "npq-ehco-december")
       end
+
+      def self.schedule_for(cohort: Cohort.current)
+        return Finance::Schedule::NPQEhco.find_by!(cohort:) unless cohort_with_multiple_schedules?(cohort)
+
+        case Date.current
+        when Date.new(cohort.start_year, 9, 1)..Date.new(cohort.start_year, 11, -1)
+          Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-november")
+        when Date.new(cohort.start_year, 12, 1)..Date.new(cohort.start_year + 1, 2, -1)
+          Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-december")
+        when Date.new(cohort.start_year + 1, 3, 1)..Date.new(cohort.start_year + 1, 5, -1)
+          Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-march")
+        when Date.new(cohort.start_year + 1, 6, 1)..Date.new(cohort.start_year + 1, 9, -1)
+          Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-june")
+        else
+          raise ArgumentError, "Invalid cohort for NPQEhco schedule"
+        end
+      end
+
+      def self.cohort_with_multiple_schedules?(cohort)
+        Cohort.where(start_year: 2022..).include?(cohort)
+      end
     end
   end
 end

--- a/app/models/finance/schedule/npq_ehco.rb
+++ b/app/models/finance/schedule/npq_ehco.rb
@@ -17,13 +17,13 @@ module Finance
         return Finance::Schedule::NPQEhco.find_by!(cohort:) unless cohort_with_multiple_schedules?(cohort)
 
         case Date.current
-        when Date.new(cohort.start_year, 9, 1)..Date.new(cohort.start_year, 11, -1)
+        when first_day_of_september_current_year(cohort.start_year)..last_day_of_november_current_year(cohort.start_year)
           Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-november")
-        when Date.new(cohort.start_year, 12, 1)..Date.new(cohort.start_year + 1, 2, -1)
+        when first_day_of_december_current_year(cohort.start_year)..last_day_of_february_next_year(cohort.start_year)
           Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-december")
-        when Date.new(cohort.start_year + 1, 3, 1)..Date.new(cohort.start_year + 1, 5, -1)
+        when first_day_of_march_next_year(cohort.start_year)..last_day_of_may_next_year(cohort.start_year)
           Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-march")
-        when Date.new(cohort.start_year + 1, 6, 1)..Date.new(cohort.start_year + 1, 9, -1)
+        when first_day_of_june_next_year(cohort.start_year)..last_day_of_september_next_year(cohort.start_year)
           Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-june")
         else
           default_for(cohort:)
@@ -32,6 +32,38 @@ module Finance
 
       def self.cohort_with_multiple_schedules?(cohort)
         Cohort.where(start_year: 2022..).include?(cohort)
+      end
+
+      def self.first_day_of_september_current_year(cohort_start_year)
+        Date.new(cohort_start_year, 9, 1)
+      end
+
+      def self.last_day_of_november_current_year(cohort_start_year)
+        Date.new(cohort_start_year, 11, -1)
+      end
+
+      def self.first_day_of_december_current_year(cohort_start_year)
+        Date.new(cohort_start_year, 12, 1)
+      end
+
+      def self.last_day_of_february_next_year(cohort_start_year)
+        Date.new(cohort_start_year + 1, 2, -1)
+      end
+
+      def self.first_day_of_march_next_year(cohort_start_year)
+        Date.new(cohort_start_year + 1, 3, 1)
+      end
+
+      def self.last_day_of_may_next_year(cohort_start_year)
+        Date.new(cohort_start_year + 1, 5, -1)
+      end
+
+      def self.first_day_of_june_next_year(cohort_start_year)
+        Date.new(cohort_start_year + 1, 6, 1)
+      end
+
+      def self.last_day_of_september_next_year(cohort_start_year)
+        Date.new(cohort_start_year + 1, 9, -1)
       end
     end
   end

--- a/app/models/finance/schedule/npq_ehco.rb
+++ b/app/models/finance/schedule/npq_ehco.rb
@@ -10,7 +10,7 @@ module Finance
       PERMITTED_COURSE_IDENTIFIERS = IDENTIFIERS
 
       def self.default_for(cohort: Cohort.current)
-        find_by(cohort:, schedule_identifier: "npq-ehco-november")
+        find_by!(cohort:, schedule_identifier: "npq-ehco-june")
       end
 
       def self.schedule_for(cohort: Cohort.current)
@@ -26,7 +26,7 @@ module Finance
         when Date.new(cohort.start_year + 1, 6, 1)..Date.new(cohort.start_year + 1, 9, -1)
           Finance::Schedule::NPQEhco.find_by!(cohort:, schedule_identifier: "npq-ehco-june")
         else
-          raise ArgumentError, "Invalid cohort for NPQEhco schedule"
+          default_for(cohort:)
         end
       end
 

--- a/app/models/npq_course.rb
+++ b/app/models/npq_course.rb
@@ -7,7 +7,7 @@ class NPQCourse < ApplicationRecord
     pluck(:identifier)
   end
 
-  def self.schedule_for(npq_course:, cohort: Cohort.find_by!(start_year: 2021))
+  def self.schedule_for(npq_course:, cohort: Cohort.current)
     case npq_course.identifier
     when *Finance::Schedule::NPQLeadership::IDENTIFIERS
       Finance::Schedule::NPQLeadership.find_by!(cohort:)
@@ -16,7 +16,7 @@ class NPQCourse < ApplicationRecord
     when *Finance::Schedule::NPQSupport::IDENTIFIERS
       Finance::Schedule::NPQSupport.find_by!(cohort:)
     when *Finance::Schedule::NPQEhco::IDENTIFIERS
-      Finance::Schedule::NPQEhco.find_by!(cohort:)
+      Finance::Schedule::NPQEhco.schedule_for(cohort:)
     else
       raise ArgumentError, "Invalid course identifier"
     end

--- a/app/services/finance/npq/course_statement_calculator.rb
+++ b/app/services/finance/npq/course_statement_calculator.rb
@@ -84,7 +84,7 @@ module Finance
       end
 
       def milestones
-        NPQCourse.schedule_for(npq_course: course).milestones
+        NPQCourse.schedule_for(npq_course: course, cohort: contract.cohort).milestones
       end
 
       def declaration_count_for_milestone(milestone)

--- a/app/services/importers/npq_contracts.rb
+++ b/app/services/importers/npq_contracts.rb
@@ -30,7 +30,7 @@ module Importers
           recruitment_target: row["recruitment_target"].to_i,
           per_participant: row["per_participant"],
           service_fee_installments: row["service_fee_installments"].to_i,
-          number_of_payment_periods: number_of_payment_periods_for(course:),
+          number_of_payment_periods: number_of_payment_periods_for(course:, cohort:),
           service_fee_percentage: service_fee_percentage_for(course:),
           output_payment_percentage: output_payment_percentage_for(course:),
         )
@@ -39,7 +39,7 @@ module Importers
 
   private
 
-    def number_of_payment_periods_for(course:)
+    def number_of_payment_periods_for(course:, cohort:)
       case course.identifier
       when *Finance::Schedule::NPQLeadership::IDENTIFIERS
         Finance::Schedule::NPQLeadership.default.milestones.count
@@ -48,7 +48,7 @@ module Importers
       when *Finance::Schedule::NPQSupport::IDENTIFIERS
         Finance::Schedule::NPQSupport.default.milestones.count
       when *Finance::Schedule::NPQEhco::IDENTIFIERS
-        Finance::Schedule::NPQEhco.default.milestones.count
+        Finance::Schedule::NPQEhco.default_for(cohort:).milestones.count
       else
         raise ArgumentError, "Invalid course identifier"
       end

--- a/spec/models/finance/schedule/npq_ehco_spec.rb
+++ b/spec/models/finance/schedule/npq_ehco_spec.rb
@@ -19,4 +19,75 @@ RSpec.describe Finance::Schedule::NPQEhco, type: :model do
       expect(described_class.default).to eql(expected_schedule)
     end
   end
+
+  describe ".schedule_for" do
+    let(:cohort)            { Cohort.find_by!(start_year: 2022) }
+    let(:cohort_start_year) { cohort.start_year }
+
+    context "when date is between September and November of cohort start year" do
+      it "returns NPQ EHCO November schedule" do
+        expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-november")
+
+        travel_to Date.new(cohort_start_year, 9, 1) do
+          expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
+        end
+      end
+    end
+
+    context "when date is between December of cohort start year and February of the next year" do
+      it "returns NPQ EHCO December schedule" do
+        expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-december")
+
+        travel_to Date.new(cohort_start_year, 12, 1) do
+          expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
+        end
+      end
+    end
+
+    context "when date is between March and May of the next year" do
+      it "returns NPQ EHCO March schedule" do
+        expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-march")
+
+        travel_to Date.new(cohort_start_year + 1, 3, 1) do
+          expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
+        end
+      end
+    end
+
+    context "when date is between June and September of the next year" do
+      it "returns NPQ EHCO June schedule" do
+        expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-june")
+
+        travel_to Date.new(cohort_start_year + 1, 6, 1) do
+          expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
+        end
+      end
+    end
+
+    context "when date range exceeds the current cohort" do
+      it "raises an error" do
+        travel_to Date.new(cohort_start_year + 1, 10, 1) do
+          expect { described_class.schedule_for(cohort:) }.to raise_error(ArgumentError, "Invalid cohort for NPQEhco schedule")
+        end
+      end
+    end
+
+    context "when no schedule exists for the cohort" do
+      let(:cohort) { create(:cohort, start_year: 2020) }
+
+      it "raises an error" do
+        expect { described_class.schedule_for(cohort:) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when selected cohort is before multiple schedules existed for EHCO" do
+      let(:cohort) { Cohort.find_by!(start_year: 2021) }
+
+      it "returns NPQ EHCO June schedule" do
+        expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-june")
+
+        expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
+      end
+    end
+  end
 end

--- a/spec/models/finance/schedule/npq_ehco_spec.rb
+++ b/spec/models/finance/schedule/npq_ehco_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Finance::Schedule::NPQEhco, type: :model do
 
   describe ".default_for" do
     let(:cohort) { Cohort.find_by!(start_year: 2022) }
-    it "returns NPQ EHCO November schedule for the cohort" do
-      expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-november")
+    it "returns NPQ EHCO June schedule for the cohort" do
+      expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-june")
 
       expect(described_class.default_for(cohort:)).to eql(expected_schedule)
     end
@@ -67,9 +67,11 @@ RSpec.describe Finance::Schedule::NPQEhco, type: :model do
     end
 
     context "when date range exceeds the current cohort" do
-      it "raises an error" do
+      it "returns default schedule for cohort" do
+        expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-june")
+
         travel_to Date.new(cohort_start_year + 1, 10, 1) do
-          expect { described_class.schedule_for(cohort:) }.to raise_error(ArgumentError, "Invalid cohort for NPQEhco schedule")
+          expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
         end
       end
     end

--- a/spec/models/finance/schedule/npq_ehco_spec.rb
+++ b/spec/models/finance/schedule/npq_ehco_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Finance::Schedule::NPQEhco, type: :model do
     expect(schedule.milestones.count).to eql(4)
   end
 
-  describe "default" do
-    it "returns NPQ EHCO December schedule" do
-      expected_schedule = described_class.find_by(cohort: Cohort.find_by!(start_year: 2022), schedule_identifier: "npq-ehco-december")
-      expect(described_class.default).to eql(expected_schedule)
+  describe ".default_for" do
+    let(:cohort) { Cohort.find_by!(start_year: 2022) }
+    it "returns NPQ EHCO November schedule for the cohort" do
+      expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-ehco-november")
+
+      expect(described_class.default_for(cohort:)).to eql(expected_schedule)
     end
   end
 

--- a/spec/models/npq_course_spec.rb
+++ b/spec/models/npq_course_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe NPQCourse do
       end
     end
 
+    context "when a course is Early Headship Coaching Offer" do
+      let(:identifier) { "npq-early-headship-coaching-offer" }
+
+      it "returns the default NPQ EHCO schedule" do
+        expected_schedule = Finance::Schedule::NPQEhco.find_by(schedule_identifier: "npq-ehco-december")
+
+        travel_to Date.new(Cohort.current.start_year, 12, 1) do
+          expect(described_class.schedule_for(npq_course:)).to eq(expected_schedule)
+        end
+      end
+    end
+
     context "with and unknown course identifier" do
       let(:identifier) { "unknown-course-identifier" }
 

--- a/spec/services/importers/npq_contracts_spec.rb
+++ b/spec/services/importers/npq_contracts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Importers::NPQContracts do
     allow(Finance::Schedule::NPQLeadership).to receive_message_chain(:default, :milestones, :count) { 4 }
     allow(Finance::Schedule::NPQSpecialist).to receive_message_chain(:default, :milestones, :count) { 3 }
     allow(Finance::Schedule::NPQSupport).to receive_message_chain(:default, :milestones, :count) { 4 }
-    allow(Finance::Schedule::NPQEhco).to receive_message_chain(:default, :milestones, :count) { 4 }
+    allow(Finance::Schedule::NPQEhco).to receive_message_chain(:default_for, :milestones, :count) { 4 }
   end
 
   describe "#call" do

--- a/spec/support/with_default_schedules.rb
+++ b/spec/support/with_default_schedules.rb
@@ -6,6 +6,7 @@ RSpec.shared_context "with default schedules", shared_context: :metadata do
     create(:npq_specialist_schedule)
     create(:npq_leadership_schedule)
     create(:npq_aso_schedule)
+    create(:npq_ehco_schedule)
   end
 end
 


### PR DESCRIPTION
### Context

NPQ EHCO schedules currently differ in cohorts:
- Cohort 2021: we had only one schedule: `npq-ehco-june` which all NPQ applications with the EHCO course were set to.
- Cohort 2022: we can have multiple schedules: [`npq-ehco-november`, `npq-ehco-december`, `npq-ehco-march`, `npq-ehco-june`]. 
NPQ applications are set the schedule relevant to the date range when an application is to be created. 

Since we need to support both 2021 and 2022 cohorts, we need to maintain the previous logic and support setting the new schedules. Also since we are still receiving applications for 2021 NPQ EHCO course, and have not started receiving EHCO applications for 2022.

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1924

### Changes proposed in this pull request

- Maintain previous logic schedule for 2021 cohort
- Add new date range logic to set schedule for 2022 cohort
- Set a default per cohort for NPQ finance calculations, as well as import scripts

### Guidance to review
Did I miss anything?
