### PR TITLE
Add NPQ Course seeds

### DIFF
--- a/db/new_seeds/base/add_npq_courses.rb
+++ b/db/new_seeds/base/add_npq_courses.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+[
+  {
+    id: "15c52ed8-06b5-426e-81a2-c2664978a0dc",
+    name: "NPQ Leading Teaching (NPQLT)",
+    identifier: "npq-leading-teaching",
+  },
+  {
+    id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5",
+    name: "NPQ Leading Behaviour and Culture (NPQLBC)",
+    identifier: "npq-leading-behaviour-culture",
+  },
+  {
+    id: "29fee78b-30ce-4b93-ba21-80be2fde286f",
+    name: "NPQ Leading Teacher Development (NPQLTD)",
+    identifier: "npq-leading-teaching-development",
+  },
+  {
+    id: "a42736ad-3d0b-401d-aebe-354ef4c193ec",
+    name: "NPQ for Senior Leadership (NPQSL)",
+    identifier: "npq-senior-leadership",
+  },
+  {
+    id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768",
+    name: "NPQ for Headship (NPQH)",
+    identifier: "npq-headship",
+  },
+  {
+    id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a",
+    name: "NPQ for Executive Leadership (NPQEL)",
+    identifier: "npq-executive-leadership",
+  },
+  {
+    id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7",
+    name: "Additional Support Offer for new headteachers",
+    identifier: "npq-additional-support-offer",
+  },
+
+  {
+    id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a",
+    name: "The Early Headship Coaching Offer",
+    identifier: "npq-early-headship-coaching-offer",
+  },
+  {
+    id: "66dff4af-a518-498f-9042-36a41f9e8aa7",
+    name: "NPQ Early Years Leadership (NPQEYL)",
+    identifier: "npq-early-years-leadership",
+  },
+  {
+    id: "829fcd45-e39d-49a9-b309-26d26debfa90",
+    name: "NPQ Leading Literacy (NPQLL)",
+    identifier: "npq-leading-literacy",
+  },
+].each do |hash|
+  FactoryBot.create(:seed_npq_course, id: hash[:id], name: hash[:name], identifier: hash[:identifier])
+end

--- a/db/new_seeds/run.rb
+++ b/db/new_seeds/run.rb
@@ -19,6 +19,7 @@ Rails.logger.info("Seeding database")
   "add_schedules.rb",
   "add_privacy_policy.rb",
   "add_lead_providers_and_cips.rb",
+  "add_npq_courses.rb",
   "add_seed_statements.rb",
   "add_users.rb",
   "add_appropriate_bodies.rb",

--- a/db/new_seeds/scenarios/npq.rb
+++ b/db/new_seeds/scenarios/npq.rb
@@ -3,16 +3,18 @@
 module NewSeeds
   module Scenarios
     class NPQ
-      attr_reader :user, :application, :participant_identity, :participant_profile, :npq_lead_provider
+      attr_reader :user, :application, :participant_identity, :participant_profile, :npq_lead_provider, :npq_course
 
-      def initialize(user: nil, lead_provider: nil)
+      def initialize(user: nil, lead_provider: nil, npq_course: nil)
         @supplied_user = user
         @supplied_lead_provider = lead_provider
+        @supplied_npq_course = npq_course
       end
 
       def build
         @user = @supplied_user || FactoryBot.create(:seed_user, :valid)
         @npq_lead_provider = @supplied_lead_provider || FactoryBot.create(:seed_npq_lead_provider, :valid)
+        @npq_course = @supplied_npq_course || FactoryBot.create(:seed_npq_course, :valid)
 
         @participant_identity = user&.participant_identities&.sample ||
           FactoryBot.create(:seed_participant_identity, user:)
@@ -30,6 +32,7 @@ module NewSeeds
           :valid,
           participant_identity:,
           npq_lead_provider:,
+          npq_course:,
 
           # it turns out that we don't find the NPQ application via the participant identity but
           # instead by the `has_one` on participant profile. The id of the NPQ application needs
@@ -47,6 +50,7 @@ module NewSeeds
           :seed_npq_participant_declaration,
           user:,
           participant_profile:,
+          course_identifier: npq_course.identifier,
           cpd_lead_provider: npq_lead_provider.cpd_lead_provider,
         )
 

--- a/spec/factories/seeds/npq_course_factory.rb
+++ b/spec/factories/seeds/npq_course_factory.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory(:seed_npq_course, class: "NPQCourse") do
     name { "NPQ Leading Teaching (#{SecureRandom.hex(6)})" }
+    identifier { Finance::Schedule::NPQLeadership::IDENTIFIERS.sample }
 
     trait(:valid) {}
 


### PR DESCRIPTION
### Context

We need NPQ courses when integrating with the NPQ registration application to create new applications and sync users successfully. We also need to add NPQ courses to NPQ applications when setting up scenarios and declarations as well.

- Ticket: n/a

### Changes proposed in this pull request
- Add new seeds to set up the previous ids and NPQ courses that sync up with the NPQ registration application in dec
- Add an identifier to the NPQ course factory as that's required for declarations and validity across the app
- Add an option to pass in an NPQ course when creating NPQ applications and declarations

### Guidance to review
Does this follow the new seed format?
