### PR TITLE
Support participant profile id in admin search

### DIFF
--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -33,6 +33,7 @@ private
         .or(ParticipantProfile.where(id: search_term))
         .or(TeacherProfile.where(id: search_term))
         .or(User.where(id: search_term))
+        .or(ParticipantIdentity.where(external_identifier: search_term))
     else
       User.all
     end

--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -31,6 +31,8 @@ private
         .or(ParticipantIdentity.email_matches(search_term))
         .or(TeacherProfile.trn_matches(search_term))
         .or(ParticipantProfile.where(id: search_term))
+        .or(TeacherProfile.where(id: search_term))
+        .or(User.where(id: search_term))
     else
       User.all
     end

--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -30,6 +30,7 @@ private
         .or(User.email_matches(search_term))
         .or(ParticipantIdentity.email_matches(search_term))
         .or(TeacherProfile.trn_matches(search_term))
+        .or(ParticipantProfile.where(id: search_term))
     else
       User.all
     end

--- a/app/views/admin/participants/index.html.erb
+++ b/app/views/admin/participants/index.html.erb
@@ -3,7 +3,7 @@
 <%= render SearchBox.new(
   query: params[:query],
   title: "Search participants",
-  hint: "Enter the participant’s name, email address or TRN",
+  hint: "Enter the participant’s ID, name, email address or TRN",
   filters: [
     {
       field: :type,

--- a/spec/cypress/integration/admin/ParticipantManagment.feature
+++ b/spec/cypress/integration/admin/ParticipantManagment.feature
@@ -8,7 +8,7 @@ Feature: Admin user managing participants
 
   Scenario: Viewing a list of participants
     Then the table should have 7 rows
-    And "page body" should contain "Enter the participant’s name, email address or TRN"
+    And "page body" should contain "Enter the participant’s ID, name, email address or TRN"
     And the page should be accessible
 
     When I type "example" into "search box"

--- a/spec/services/admin/participants/search_spec.rb
+++ b/spec/services/admin/participants/search_spec.rb
@@ -82,6 +82,34 @@ RSpec.describe Admin::Participants::Search, :with_default_schedules do
           expect(results).not_to include(pp_2, pp_3)
         end
       end
+
+      describe "matching by teacher profile id" do
+        let(:search_term) { user_2.teacher_profile.id }
+
+        let(:results) { search.call(ParticipantProfile, search_term:) }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_2)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_1, pp_3)
+        end
+      end
+
+      describe "matching by user id" do
+        let(:search_term) { user_3.id }
+
+        let(:results) { search.call(ParticipantProfile, search_term:) }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_3)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_1, pp_2)
+        end
+      end
     end
   end
 end

--- a/spec/services/admin/participants/search_spec.rb
+++ b/spec/services/admin/participants/search_spec.rb
@@ -68,6 +68,20 @@ RSpec.describe Admin::Participants::Search, :with_default_schedules do
           expect(results).not_to include(pp_1, pp_2)
         end
       end
+
+      describe "matching by participant profile id" do
+        let(:search_term) { pp_1.id }
+
+        let(:results) { search.call(ParticipantProfile, search_term:) }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_1)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_2, pp_3)
+        end
+      end
     end
   end
 end

--- a/spec/services/admin/participants/search_spec.rb
+++ b/spec/services/admin/participants/search_spec.rb
@@ -110,6 +110,20 @@ RSpec.describe Admin::Participants::Search, :with_default_schedules do
           expect(results).not_to include(pp_1, pp_2)
         end
       end
+
+      describe "matching by user id" do
+        let(:search_term) { pp_1.participant_identity.external_identifier }
+
+        let(:results) { search.call(ParticipantProfile, search_term:) }
+
+        it "returns matching participants" do
+          expect(results).to include(pp_1)
+        end
+
+        it "doesn't return non-matching participants" do
+          expect(results).not_to include(pp_2, pp_3)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Sometimes we have a participant's profile ID and need to find their record. The search didn't support doing this so admins had to make a round trip to the participant drill down (finance) to get the other details and then back to the admin console.
