### PR TITLE
CST-1055: add Manage link to participants SIT view

### DIFF
--- a/app/components/schools/participants/coc_status_table.html.erb
+++ b/app/components/schools/participants/coc_status_table.html.erb
@@ -1,23 +1,24 @@
 <thead class="govuk-table__head">
   <tr class="govuk-table__row">
-  <% if ineligible_participants? %>
-    <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Name</th>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action required</th>
-  <% elsif transferred_participants? %>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Transferred</th>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action required</th>
-  <% else %>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-
-    <% if school_chose_cip? %>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Materials supplier</th>
+    <% if ineligible_participants? %>
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action required</th>
+    <% elsif transferred_participants? %>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Transferred</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action required</th>
     <% else %>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Lead provider</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Delivery partner</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+
+      <% if school_chose_cip? %>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Materials supplier</th>
+      <% else %>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Lead provider</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Delivery partner</th>
+      <% end %>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"><%= date_column_heading %></th>
     <% end %>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"><%= date_column_heading %></th>
-  <% end %>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"></th>
   </tr>
 </thead>
 

--- a/app/components/schools/participants/coc_status_table_row.html.erb
+++ b/app/components/schools/participants/coc_status_table_row.html.erb
@@ -1,17 +1,17 @@
 <tr class="govuk-table__row">
   <% if ineligible_participant? && !mentor_in_early_rollout? %>
-    <td class="govuk-table__cell govuk-!-width-three-quarters"><%= govuk_link_to induction_record.user.full_name, schools_participant_path(id: induction_record.participant_profile_id, **path_ids) %></td>
+    <td class="govuk-table__cell govuk-!-width-three-quarters"><%= govuk_link_to induction_record.user.full_name, schools_participant_path(id: induction_record.participant_profile_id, **path_ids), class: "govuk-link--no-visited-state" %></td>
     <td class="govuk-table__cell govuk-!-width-one-quarter">Remove</td>
 
   <% elsif transferred? %>
 
-    <td class="govuk-table__cell govuk-!-width-one-half"><%= govuk_link_to induction_record.user.full_name, schools_participant_path(id: induction_record.participant_profile_id, **path_ids) %></td>
+    <td class="govuk-table__cell govuk-!-width-one-half"><%= govuk_link_to induction_record.user.full_name, schools_participant_path(id: induction_record.participant_profile_id, **path_ids), class: "govuk-link--no-visited-state" %></td>
     <td class="govuk-table__cell govuk-!-width-one-quarter"><%= induction_record.end_date.to_date.to_s(:govuk) %></td>
     <td class="govuk-table__cell govuk-!-width-one-quarter">Remove</td>
 
   <% else %>
 
-    <td class="govuk-table__cell govuk-!-width-one-quarter"><%= govuk_link_to induction_record.user.full_name, schools_participant_path(id: induction_record.participant_profile_id, **path_ids) %></td>
+    <td class="govuk-table__cell govuk-!-width-one-quarter"><%= govuk_link_to induction_record.user.full_name, schools_participant_path(id: induction_record.participant_profile_id, **path_ids), class: "govuk-link--no-visited-state" %></td>
 
     <% if induction_record.enrolled_in_cip? %>
       <td class="govuk-table__cell govuk-!-width-one-half"><%= induction_record.induction_programme.core_induction_programme&.name %></td>
@@ -22,4 +22,10 @@
 
     <td class="govuk-table__cell govuk-!-width-one-quarter"><%= date_column_value %></td>
   <% end %>
+  <td class="govuk-table__cell govuk-!-width-one-quarter">
+    <%= govuk_link_to schools_participant_path(id: induction_record.participant_profile_id, **path_ids),
+                      class: "govuk-link--no-visited-state" do %>
+      Manage <span class="govuk-visually-hidden"><%= induction_record.user.full_name %></span>
+    <% end %>
+  </td>
 </tr>

--- a/app/components/schools/participants/status_table.html.erb
+++ b/app/components/schools/participants/status_table.html.erb
@@ -1,18 +1,19 @@
 <thead class="govuk-table__head">
   <tr class="govuk-table__row">
-  <% if ineligible_participants? %>
-    <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Name</th>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action required</th>
-  <% else %>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-
-    <% if school_cohort.school_chose_cip? %>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Materials supplier</th>
+    <% if ineligible_participants? %>
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarters">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action required</th>
     <% else %>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Lead provider</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Delivery partner</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+
+      <% if school_cohort.school_chose_cip? %>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Materials supplier</th>
+      <% else %>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Lead provider</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Delivery partner</th>
+      <% end %>
     <% end %>
-  <% end %>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"></th>
   </tr>
 </thead>
 

--- a/app/components/schools/participants/status_table_row.html.erb
+++ b/app/components/schools/participants/status_table_row.html.erb
@@ -1,11 +1,11 @@
 <tr class="govuk-table__row">
   <% if ineligible_participant? && !mentor_in_early_rollout? %>
-    <td class="govuk-table__cell govuk-!-width-three-quarters"><%= govuk_link_to profile.user.full_name, schools_participant_path(id: profile, **path_ids) %></td>
+    <td class="govuk-table__cell govuk-!-width-three-quarters"><%= govuk_link_to profile.user.full_name, schools_participant_path(id: profile, **path_ids), class: "govuk-link--no-visited-state" %></td>
     <td class="govuk-table__cell govuk-!-width-one-quarter">Remove</td>
 
   <% else %>
 
-    <td class="govuk-table__cell govuk-!-width-one-quarter"><%= govuk_link_to profile.user.full_name, schools_participant_path(id: profile, **path_ids) %></td>
+    <td class="govuk-table__cell govuk-!-width-one-quarter"><%= govuk_link_to profile.user.full_name, schools_participant_path(id: profile, **path_ids), class: "govuk-link--no-visited-state" %></td>
 
     <% if participant_is_on_a_cip? %>
       <td class="govuk-table__cell govuk-!-width-one-half"><%= profile.school_cohort&.core_induction_programme&.name %></td>
@@ -14,4 +14,9 @@
       <td class="govuk-table__cell govuk-!-width-one-quarter"><%= profile.school_cohort&.delivery_partner&.name %></td>
     <% end %>
   <% end %>
+  <td class="govuk-table__cell govuk-!-width-one-quarter">
+    <%= govuk_link_to schools_participant_path(id: profile, **path_ids), class: "govuk-link--no-visited-state" do %>
+      Manage <span class="govuk-visually-hidden"><%= profile.user.full_name %></span>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/schools/participants/_ects.html.erb
+++ b/app/views/schools/participants/_ects.html.erb
@@ -41,13 +41,13 @@
     </div>
   </div>
 
-<table class="govuk-table govuk-!-margin-bottom-9" data-test="no_qts">
-  <% if FeatureFlag.active?(:change_of_circumstances) %>
-    <%= render Schools::Participants::CocStatusTable.new(induction_records: ect_profiles.no_qts_participants) %>
-  <% else %>
-    <%= render Schools::Participants::StatusTable.new(participant_profiles: ect_profiles.no_qts_participants, school_cohort: @school_cohort) %>
-  <% end %>
-</table>
+  <table class="govuk-table govuk-!-margin-bottom-9" data-test="no_qts">
+    <% if FeatureFlag.active?(:change_of_circumstances) %>
+      <%= render Schools::Participants::CocStatusTable.new(induction_records: ect_profiles.no_qts_participants) %>
+    <% else %>
+      <%= render Schools::Participants::StatusTable.new(participant_profiles: ect_profiles.no_qts_participants, school_cohort: @school_cohort) %>
+    <% end %>
+  </table>
 <% end %>
 
 <% if ect_profiles.eligible.any? %>

--- a/app/views/schools/participants/_mentors.html.erb
+++ b/app/views/schools/participants/_mentors.html.erb
@@ -36,15 +36,15 @@
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Eligible to start</h2>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-  <% if @school_cohort.core_induction_programme? %>
-    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. They have access to their materials.</p>
-  <% elsif @school_cohort.delivery_partner.present? %>
-    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.</p>
-  <% else %>
-    <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
-  <% end %>
+      <% if @school_cohort.core_induction_programme? %>
+        <p class="govuk-body">We’ve confirmed these people are eligible for this programme. They have access to their materials.</p>
+      <% elsif @school_cohort.delivery_partner.present? %>
+        <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Your training provider will contact them directly.</p>
+      <% else %>
+        <p class="govuk-body">We’ve confirmed these people are eligible for this programme. Once you choose a training provider, they’ll contact your ECTs and mentors directly.</p>
+      <% end %>
+    </div>
   </div>
-</div>
 
   <table class="govuk-table govuk-!-margin-bottom-9" data-test="eligible">
     <% if FeatureFlag.active?(:change_of_circumstances) %>
@@ -54,4 +54,3 @@
     <% end %>
   </table>
 <% end %>
-

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
         when_i_navigate_to_participants_dashboard
         then_i_can_view_transferring_in_participants
 
-        when_i_click_on_the_participants_name "Transferring in participant"
+        when_i_go_to_manage_the_participant_named "Transferring in participant"
         then_i_am_taken_to_view_details_page
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe "Manage FIP partnered participants with change of circumstances",
       click_on "Not training"
       then_i_can_view_transferred_from_your_school_participants
 
-      when_i_click_on_the_participants_name "Eligible ect"
+      when_i_go_to_manage_the_participant_named "Eligible ect"
       then_i_am_taken_to_view_details_page
     end
   end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -633,6 +633,10 @@ module ManageTrainingSteps
     click_on name
   end
 
+  def when_i_go_to_manage_the_participant_named(name)
+    click_on "Manage #{name}"
+  end
+
   def when_i_navigate_to_participants_dashboard(action: "Manage")
     when_i_click_on_summary_row_action("ECTs and mentors", action)
     then_i_am_taken_to_your_ect_and_mentors_page


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1055)

### Changes proposed in this pull request
- Add Manage link to each participant row in the participant lists of the SIT dashboard as an alternative way for the user to get and manage a user details 

Before
<img width="864" alt="Screenshot 2023-01-13 at 18 42 59" src="https://user-images.githubusercontent.com/264612/212385641-2c60e5d0-447b-47f1-a660-8d7567548904.png">


After
![Screenshot 2023-01-13 at 18 45 03](https://user-images.githubusercontent.com/264612/212386263-5f981a76-3b72-49a0-8b46-d123e1ade9e2.png)


### Guidance to review

