### PR TITLE
[CPDLP-1965] Add validation to has_passed field for npq completed declarations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
   invalid_schedule: "The property '#/schedule_identifier' must be present and correspond to a valid schedule"
   invalid_reason: "The property '#/reason' must be a valid reason"
   invalid_state: "The property '#/state' must be a valid state"
+  invalid_has_passed: "The property '#/has_passed' must be true or false"
   no_started_declaration_found: An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance
   schedule_already_on_the_profile: Selected schedule is already on the profile
   schedule_invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -345,6 +345,15 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
         end
       end
 
+      context "has_passed is invalid text" do
+        let(:has_passed) { "no_supported" }
+
+        it "returns error" do
+          expect(service).to be_invalid
+          expect(service.errors.messages_for(:has_passed)).to eq(["The property '#/has_passed' must be true or false"])
+        end
+      end
+
       context "has_passed is true" do
         let(:has_passed) { true }
 
@@ -361,8 +370,40 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
         end
       end
 
+      context "has_passed is 'true'" do
+        let(:has_passed) { "true" }
+
+        it "creates participant outcome" do
+          travel_to declaration_date do
+            expect(service).to be_valid
+            participant_declaration = service.call
+            expect(participant_declaration.outcomes.count).to be(1)
+
+            outcome = participant_declaration.outcomes.first
+            expect(outcome.completion_date).to eql(participant_declaration.declaration_date.to_date)
+            expect(outcome).to be_passed
+          end
+        end
+      end
+
       context "has_passed is false" do
         let(:has_passed) { false }
+
+        it "does not create participant outcome" do
+          travel_to declaration_date do
+            expect(service).to be_valid
+            participant_declaration = service.call
+            expect(participant_declaration.outcomes.count).to be(1)
+
+            outcome = participant_declaration.outcomes.first
+            expect(outcome.completion_date).to eql(participant_declaration.declaration_date.to_date)
+            expect(outcome).to be_failed
+          end
+        end
+      end
+
+      context "has_passed is 'false'" do
+        let(:has_passed) { "false" }
 
         it "does not create participant outcome" do
           travel_to declaration_date do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1965

### Changes proposed in this pull request

* Added validation for declarations endpoint to validate `has_passed` when unsupported values are provided.

### Guidance to review

