### PR TITLE
Remove database and Redis reset on Dev environment

### DIFF
--- a/terraform/workspace-variables/dev.tfvars
+++ b/terraform/workspace-variables/dev.tfvars
@@ -12,5 +12,5 @@ paas_app_stopped = false
 paas_web_app_deployment_strategy = "blue-green-v2"
 paas_web_app_instances = 1
 paas_web_app_memory = 1024
-paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate db:safe_reset redis:flushall && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
+paas_web_app_start_command = "bundle exec rake cf:on_first_instance db:migrate && (bundle exec sidekiq -C config/sidekiq.yml &) && rails s"
 paas_redis_service_plan = "tiny-6_x"


### PR DESCRIPTION
### Context
Resetting the data on dev causes issues with our NPQ registration app, as we lose synced user ids which prevents users from creating NPQ applications to existing users. It also removes important test data that might have been accumulated from previous testing done by the team. 

- Ticket: n/a

### Changes proposed in this pull request
- Stop resetting and reseeding DB on dev on each deploy
- Stop flushing Redis on dev on each deploy

### Guidance to review
Does this break anything else?
