### PR TITLE
Switch around the header and hide the section

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -50,9 +50,13 @@ module AdminHelper
   def admin_participant_header_and_title(full_name:, role:, section:)
     content_for(:title) { "#{full_name} - #{section}" }
 
-    tag.h1 do
-      safe_join([tag.span("#{full_name} - #{role}", class: "govuk-caption-m"), section])
-    end
+    caption = tag.span(role, class: "govuk-caption-xl")
+    visually_hidden = tag.span(" - #{section}", class: "govuk-visually-hidden")
+
+    safe_join([
+      caption,
+      tag.h1(class: "govuk-heading-xl") { safe_join([full_name, visually_hidden]) },
+    ])
   end
 
   def admin_participant_role_name(class_name)

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe AdminHelper, type: :helper do
     subject { admin_participant_header_and_title(section: "ABC", full_name: "Joey", role: "Mentor") }
 
     it "returns a h1 tag the section that has a caption containing the user name" do
-      expect(subject).to have_css("h1", text: /ABC/)
-      expect(subject).to have_css(".govuk-caption-m", text: "Joey - Mentor")
+      expect(subject).to have_css("h1", text: /Joey - ABC/)
+      expect(subject).to have_css(".govuk-caption-xl", text: "Mentor")
     end
   end
 


### PR DESCRIPTION
### Context

This is closer to the original design while keeping the distinct section name available for screen reader users.

| Header | HTML |
|------|-------|
|  ![image](https://user-images.githubusercontent.com/128088/212878168-9ea3aade-9ec2-467f-9c19-d0165e5edc83.png) |  ![image](https://user-images.githubusercontent.com/128088/212878351-0e3ca2ff-c914-40db-a383-cd334704f8f9.png) |
