### PR TITLE
[CPDLP-1945] Fix npq outcomes endpoint actions in the release notes

### DIFF
--- a/docs/source/_npq_usage_participant_actions.html.erb
+++ b/docs/source/_npq_usage_participant_actions.html.erb
@@ -231,8 +231,8 @@
   <li><p class="govuk-body-m">a participant has retaken their NPQ assessment and their outcome has changed. </p></li>
 </ul>
 <h3 class="govuk-heading-m">1. Updating NPQ outcomes</h3>
-<p class="govuk-body-m">Submit an updated NPQ outcome. </p>
-<p class="govuk-body-m"><pre><code>GET /api/v1/participant/npq/{participant_id}/outcomes</code></pre></p>
+<p class="govuk-body-m">Submit an updated NPQ outcome.</p>
+<p class="govuk-body-m"><pre><code>POST /api/v1/participant/npq/{participant_id}/outcomes</code></pre></p>
 <p class="govuk-body-m">The request body must contain all attributes described in the <a href="/api-reference/reference-v3.html#schema-npqoutcomerequest-example" class="govuk-link">NPQ participant outcome schema</a>, including updated values for the <code>completion_date</code> and <code>state</code> attributes.</p>
 <p class="govuk-body-m">This returns an <a href="/api-reference/reference-v3.html#schema-npqoutcomeresponse" class="govuk-link">NPQ outcomes response</a> including updates to the record.</p>
 <p class="govuk-body-m">See specifications for the <a href="/api-reference/reference-v1.html#api-v1-participants-npq-participant_id-outcomes-post" class="govuk-link">NPQ outcomes endpoint.</a></p>

--- a/docs/source/release-notes.html.erb
+++ b/docs/source/release-notes.html.erb
@@ -57,9 +57,9 @@ weight: 8
     <li><code>"state": voided</code> - This signifies a <code>completed</code> declaration has since been voided and therefore the associated outcome retracted.</li>
   </ul>
   Providers can view outcomes for all NPQ participants by using the new endpoint:
-  <pre><code>POST /api/v1/participants/npq/outcomes</pre></code>
+  <pre><code>GET /api/v1/participants/npq/outcomes</pre></code>
   Providers can view outcomes for a specific NPQ participant by using the new endpoint:
-  <pre><code>POST /api/v1/participants/npq/{participant_id}/outcomes</pre></code>
+  <pre><code>GET /api/v1/participants/npq/{participant_id}/outcomes</pre></code>
 </p>
 
 <h2 class="govuk-heading-l" id="9-21-2022">21st September 2022</h2>


### PR DESCRIPTION
### Context

View npq outcomes endpoint actions in the release notes is wrong. It should be "GET" instead of "POST".

- Ticket: [CPDLP-1945](https://dfedigital.atlassian.net/browse/CPDLP-1945)

### Changes proposed in this pull request

Small fix on npq outcomes endpoint actions in the release notes.

https://ecf-sandbox.london.cloudapps.digital/api-reference/release-notes.html#16-1-2023

[CPDLP-1945]: https://dfedigital.atlassian.net/browse/CPDLP-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ