### PR TITLE
Use fetch when selecting a creator

### DIFF
--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -287,7 +287,7 @@ module Schools
     def save!
       profile = nil
       ActiveRecord::Base.transaction do
-        profile = creators[participant_type].call(
+        profile = creators.fetch(participant_type).call(
           full_name:,
           email:,
           school_cohort:,


### PR DESCRIPTION
### Context

We see the odd `undefined method 'call' for nil:NilClass error` in production where there's a participant_type of neither `:ect` or `mentor`.

Looking at the code it appears participant_type can also be `:self` but the error sent to sentry doesn't give us a clue what's going on or what's being looked for (:self, nil, something else?)

Instead, we can improve the error message reported to Sentry by using `#fetch` instead of `:[]`
