### PR TITLE
CST-1207: rectify mentor pools when a participant is rectified

### DIFF
--- a/app/services/data_stage/process_school_changes.rb
+++ b/app/services/data_stage/process_school_changes.rb
@@ -98,7 +98,8 @@ module DataStage
         school_cohort.update!(school: successor)
         school_cohort.ecf_participant_profiles.each do |profile|
           RectifyParticipantSchool.call(participant_profile: profile,
-                                        school: successor,
+                                        from_school: school,
+                                        to_school: successor,
                                         transfer_pupil_premium_and_sparsity: false)
         end
       end

--- a/app/services/rectify_participant_school.rb
+++ b/app/services/rectify_participant_school.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class RectifyParticipantSchool < BaseService
-  attr_reader :participant_profile, :school, :transfer_pupil_premium_and_sparsity
+  attr_reader :participant_profile, :from_school, :to_school, :transfer_pupil_premium_and_sparsity, :cohort, :school_cohort
 
-  def initialize(participant_profile:, school:, transfer_pupil_premium_and_sparsity: true)
+  def initialize(participant_profile:, from_school:, to_school:, transfer_pupil_premium_and_sparsity: true)
     @participant_profile = participant_profile
-    @school = school
+    @from_school = from_school
+    @to_school = to_school
     @transfer_pupil_premium_and_sparsity = transfer_pupil_premium_and_sparsity
   end
 
@@ -14,22 +15,35 @@ class RectifyParticipantSchool < BaseService
   # that have been added to the wrong school by mistake or in a GIAS school closure/reopen
   # scenario.
   def call
-    cohort = participant_profile.school_cohort.cohort
-    school_cohort = school.school_cohorts.find_by(cohort:)
+    @cohort = participant_profile.school_cohort.cohort
+    @school_cohort = to_school.school_cohorts.find_by(cohort:)
     return if school_cohort.blank?
 
     ActiveRecord::Base.transaction do
-      participant_profile.teacher_profile.update!(school:)
-      attrs = {
-        school_cohort:,
-      }
-
-      if transfer_pupil_premium_and_sparsity
-        attrs[:sparsity_uplift] = school.sparsity_uplift?(cohort.start_year)
-        attrs[:pupil_premium_uplift] = school.pupil_premium_uplift?(cohort.start_year)
-      end
-
-      participant_profile.update!(attrs)
+      rectify_teacher_profile
+      rectify_mentor_pools if participant_profile.mentor?
+      rectify_participant_profile
     end
+  end
+
+private
+
+  def rectify_mentor_pools
+    from_school.school_mentors.find_by(participant_profile:)&.update!(school: to_school)
+  end
+
+  def rectify_participant_profile
+    attrs = { school_cohort: }
+
+    if transfer_pupil_premium_and_sparsity
+      attrs[:sparsity_uplift] = to_school.sparsity_uplift?(cohort.start_year)
+      attrs[:pupil_premium_uplift] = to_school.pupil_premium_uplift?(cohort.start_year)
+    end
+
+    participant_profile.update!(attrs)
+  end
+
+  def rectify_teacher_profile
+    participant_profile.teacher_profile.update!(school: to_school)
   end
 end


### PR DESCRIPTION
### Context

   When a school gets closed their participants are moved to its successor but the mentor pools are left unchanged.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1207)

### Changes proposed in this pull request
   Rectify the mentor pools of the school and its successor so the entries are moved from one to the other.

### Guidance to review

