### PR TITLE
Add some validation data to the seeds

### DIFF
--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -5,7 +5,14 @@ module NewSeeds
     module Participants
       module Mentors
         class MentoringMultipleEctsWithSameProvider
-          Person = Struct.new(:user, :teacher_profile, :participant_profile, :participant_identity, keyword_init: true)
+          Person = Struct.new(
+            :user,
+            :teacher_profile,
+            :participant_profile,
+            :participant_identity,
+            :participant_validation_data,
+            keyword_init: true,
+          )
 
           attr_accessor :mentor,
                         :mentees,
@@ -72,7 +79,7 @@ module NewSeeds
           end
 
           def build_mentee
-            build_person(mentor: false)
+            build_person(mentor: false, validation_data: true)
           end
 
         private
@@ -81,7 +88,7 @@ module NewSeeds
             Cohort.find_by!(start_year: year)
           end
 
-          def build_person(mentor: false)
+          def build_person(mentor: false, validation_data: false)
             user = FactoryBot.create(:seed_user)
 
             teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school:)
@@ -100,7 +107,21 @@ module NewSeeds
                                                       school_cohort:)
                                   end
 
-            Person.new(user:, teacher_profile:, participant_identity:, participant_profile:)
+            participant_validation_data = if validation_data
+                                            FactoryBot.create(
+                                              :seed_ecf_participant_validation_data,
+                                              :valid,
+                                              user:,
+                                            )
+                                          end
+
+            Person.new(
+              user:,
+              teacher_profile:,
+              participant_identity:,
+              participant_profile:,
+              participant_validation_data:,
+            )
           end
         end
       end

--- a/spec/factories/seeds/ecf_participant_validation_data_factory.rb
+++ b/spec/factories/seeds/ecf_participant_validation_data_factory.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_ecf_participant_validation_data, class: "ECFParticipantValidationData") do
+    transient do
+      user { FactoryBot.build(:user) }
+      extra_initial { Faker::Alphanumeric::ULetters.sample }
+    end
+
+    full_name { user.full_name.split.insert(1, "#{extra_initial}.").join(" ") }
+    trn { Faker::Number.unique.rand_in_range(10_000, 100_000).to_s }
+    date_of_birth { Faker::Date.between(from: 70.years.ago, to: 21.years.ago) }
+    nino { SecureRandom.hex }
+
+    trait(:with_participant_profile) do
+      association(:participant_profile, factory: %i[seed_ect_participant_profile valid])
+    end
+
+    trait(:valid) { with_participant_profile }
+
+    after(:build) do
+      Rails.logger.debug("added participant validation data")
+    end
+  end
+end

--- a/spec/seeds/seed_factories/ecf_participant_validation_data_factory_spec.rb
+++ b/spec/seeds/seed_factories/ecf_participant_validation_data_factory_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "./shared_factory_examples"
+
+RSpec.describe("seed_ecf_participant_validation_data") do
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_ecf_participant_validation_data }
+    let(:factory_class) { ECFParticipantValidationData }
+  end
+end


### PR DESCRIPTION
We're taking an extra step here and making the seeded validation data closely resemble the user by adding an initial to their name via the transient user attribute.
