### PR TITLE
[CPDLP-1913] Restrict participants endpoint fields

### DIFF
--- a/app/services/api/v1/ecf/participants_query.rb
+++ b/app/services/api/v1/ecf/participants_query.rb
@@ -24,7 +24,19 @@ module Api
                      },
                    )
 
+          necessary_fields = %i[
+            induction_programme_id
+            induction_status
+            mentor_profile_id
+            participant_profile_id
+            preferred_identity_id
+            schedule_id
+            training_status
+            updated_at
+          ]
+
           scope = InductionRecord
+                    .select(*necessary_fields)
                     .references(participant_profile: %i[participant_identity])
                     .includes(
                       :preferred_identity,


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1913

This endpoint is currently timing out in production for certain providers. One possible way to speed it up is by reducing the amount of columns returned to only the necessary ones.

### Changes proposed in this pull request

Restrict the fields being returned by the query underlying the `/api/v1/participants/ecf` endpoint.

### Guidance to review

Before we merge this, it would be best to test it if possible to see if it has the expected effect of speeding up the endpoint when dealing with a prod-like data load.

This can be done locally, if we can get a prod-like database running with a similar amount of data, or it can be done on a prod-like env.

It's lacking a test, partly because I want to try it out first to see if it improves performance before I invest further, but also because testing for the removal of fields always feels weird to me. Checking if a field isn't found in a payload can easily be a false positive test. If someone has a better idea for a good way to test this, please shout and we can update this.