### PR TITLE
[CPDLP-1989] Fix big data participants query to fetch the training status from latest induction record

### DIFF
--- a/analytics_queries/participants.sql
+++ b/analytics_queries/participants.sql
@@ -13,7 +13,7 @@
             WHERE pp2.id = pp.mentor_profile_id)                  as mentor_id,
           c.start_year                                            as cohort,
           pp.status                                               as status,
-          latest_induction_record.training_status                 as training_status,
+          latest_induction_records.training_status                as training_status,
           pps.reason                                              as training_status_reason,
           s.name                                                  as schedule,
           s.schedule_identifier                                   as schedule_identifier,
@@ -36,17 +36,23 @@
             JOIN participant_identities pi on pp.participant_identity_id = pi.id
             LEFT OUTER JOIN ecf_participant_validation_data epvd on pp.id = epvd.participant_profile_id
             LEFT OUTER JOIN ecf_participant_eligibilities epe on pp.id = epe.participant_profile_id
-            JOIN (
-                 SELECT
-                    DISTINCT ON (participant_profile_id) participant_profile_id,
-                    training_status
-                 FROM induction_records
-                 JOIN induction_programmes ON induction_programmes.id = induction_records.induction_programme_id
-                 JOIN partnerships ON partnerships.id = induction_programmes.partnership_id
-                 ORDER BY participant_profile_id, induction_records.created_at DESC
-            ) AS latest_induction_record ON latest_induction_record.participant_profile_id = pp.id
+            LEFT OUTER JOIN (
+              SELECT
+                induction_records.*,
+                partnerships.lead_provider_id,
+                schools.id AS school_id,
+                schools.name AS school_name,
+                lead_providers.name AS lead_provider_name,
+                induction_programmes.training_programme AS training_programme,
+                ROW_NUMBER() OVER (PARTITION BY participant_profile_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
+              FROM induction_records
+              JOIN induction_programmes ON induction_programmes.id = induction_records.induction_programme_id
+              LEFT OUTER JOIN partnerships         ON partnerships.id         = induction_programmes.partnership_id
+              LEFT OUTER JOIN lead_providers       ON lead_providers.id       = partnerships.lead_provider_id
+              LEFT OUTER JOIN schools              ON schools.id              = partnerships.school_id
+            ) AS latest_induction_records ON latest_induction_records.participant_profile_id = pp.id AND induction_record_sort_order = 1
             LEFT OUTER JOIN participant_profile_states pps on pp.id = pps.participant_profile_id AND pps.id = (
-              SELECT id from participant_profile_states _pps WHERE _pps.participant_profile_id = pp.id AND _pps.state = latest_induction_record.training_status ORDER BY created_at desc LIMIT 1
+              SELECT id from participant_profile_states _pps WHERE _pps.participant_profile_id = pp.id AND _pps.state = latest_induction_records.training_status ORDER BY created_at desc LIMIT 1
             )
     WHERE pp.type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
       AND c.start_year > 2020

--- a/app/components/appropriate_bodies/participants/table_row.rb
+++ b/app/components/appropriate_bodies/participants/table_row.rb
@@ -53,6 +53,7 @@ module AppropriateBodies
       def status_name
         @status_name ||= ParticipantProfileStatus.new(
           participant_profile:,
+          induction_record:,
         ).status_name
       end
     end

--- a/app/components/delivery_partners/participants/table_row.rb
+++ b/app/components/delivery_partners/participants/table_row.rb
@@ -49,21 +49,13 @@ module DeliveryPartners
       attr_reader :participant_profile, :delivery_partner
 
       def induction_record
-        @induction_record ||= participant_profile.induction_records.includes(induction_programme: [:partnership]).where(
-          induction_programme: {
-            partnerships: {
-              delivery_partner:,
-              challenged_at: nil,
-              challenge_reason: nil,
-              pending: false,
-            },
-          },
-        ).latest
+        @induction_record ||= participant_profile.relevant_induction_record_for(delivery_partner:)
       end
 
       def status_name
         @status_name ||= ParticipantProfileStatus.new(
           participant_profile:,
+          induction_record:,
         ).status_name
       end
     end

--- a/app/controllers/appropriate_bodies/participants_controller.rb
+++ b/app/controllers/appropriate_bodies/participants_controller.rb
@@ -5,7 +5,7 @@ module AppropriateBodies
     def index
       collection = InductionRecord.includes(:participant_profile).where(appropriate_body:)
 
-      @filter = ParticipantsFilter.new(collection:, params: params.permit(:query, :role, :academic_year, :status))
+      @filter = ParticipantsFilter.new(collection:, params: filter_params)
 
       respond_to do |format|
         format.html do
@@ -39,6 +39,10 @@ module AppropriateBodies
           csv << attributes.map { |attribute| item[:attributes][attribute].to_s }
         end
       end
+    end
+
+    def filter_params
+      params.permit(:query, :role, :academic_year, :status)
     end
   end
 end

--- a/app/controllers/delivery_partners/participants_controller.rb
+++ b/app/controllers/delivery_partners/participants_controller.rb
@@ -20,7 +20,7 @@ module DeliveryPartners
         },
       )
 
-      @filter = ParticipantsFilter.new(collection:, params: params.permit(:query, :role, :academic_year, :status))
+      @filter = ParticipantsFilter.new(collection:, params: filter_params)
 
       respond_to do |format|
         format.html do
@@ -61,6 +61,10 @@ module DeliveryPartners
           csv << attributes.map { |attribute| item[:attributes][attribute].to_s }
         end
       end
+    end
+
+    def filter_params
+      params.permit(:query, :role, :academic_year, :status).merge(delivery_partner:)
     end
   end
 end

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -118,6 +118,19 @@ class ParticipantProfile < ApplicationRecord
       !!latest_induction_record_for(cpd_lead_provider:)&.training_status_active?
     end
 
+    def relevant_induction_record_for(delivery_partner:)
+      induction_records.includes(induction_programme: [:partnership]).where(
+        induction_programme: {
+          partnerships: {
+            delivery_partner:,
+            challenged_at: nil,
+            challenge_reason: nil,
+            pending: false,
+          },
+        },
+      ).latest
+    end
+
   private
 
     def update_analytics

--- a/app/serializers/appropriate_bodies/induction_records_serializer.rb
+++ b/app/serializers/appropriate_bodies/induction_records_serializer.rb
@@ -45,7 +45,10 @@ module AppropriateBodies
     attribute :training_status, &:training_status
 
     attribute :status do |induction_record|
-      status_name = ParticipantProfileStatus.new(participant_profile: induction_record.participant_profile).status_name
+      status_name = ParticipantProfileStatus.new(
+        participant_profile: induction_record.participant_profile,
+        induction_record:,
+      ).status_name
       I18n.t("participant_profile_status.status.#{status_name}.title") if status_name
     end
   end

--- a/app/serializers/delivery_partners/participants_serializer.rb
+++ b/app/serializers/delivery_partners/participants_serializer.rb
@@ -9,21 +9,14 @@ module DeliveryPartners
 
     class << self
       def induction_record(participant_profile, delivery_partner)
-        participant_profile.induction_records.includes(induction_programme: [:partnership]).where(
-          induction_programme: {
-            partnerships: {
-              delivery_partner:,
-              challenged_at: nil,
-              challenge_reason: nil,
-              pending: false,
-            },
-          },
-        ).latest
+        @induction_record ||= {}
+        @induction_record["#{participant_profile.id},#{delivery_partner.id}"] ||= participant_profile.relevant_induction_record_for(delivery_partner:)
       end
 
-      def status_name(participant_profile)
+      def status_name(participant_profile, delivery_partner)
         ParticipantProfileStatus.new(
           participant_profile:,
+          induction_record: induction_record(participant_profile, delivery_partner),
         ).status_name
       end
     end
@@ -65,8 +58,8 @@ module DeliveryPartners
       induction_record(participant_profile, params[:delivery_partner])&.training_status
     end
 
-    attribute :status do |participant_profile|
-      I18n.t("participant_profile_status.status.#{status_name(participant_profile)}.title")
+    attribute :status do |participant_profile, params|
+      I18n.t("participant_profile_status.status.#{status_name(participant_profile, params[:delivery_partner])}.title")
     end
   end
 end

--- a/app/services/analytics/ecf_validation_service.rb
+++ b/app/services/analytics/ecf_validation_service.rb
@@ -23,7 +23,7 @@ module Analytics
         record.active = participant_profile.active_record?
         record.sparsity = participant_profile.sparsity_uplift
         record.pupil_premium = participant_profile.pupil_premium_uplift
-        record.training_status = participant_profile.training_status
+        record.training_status = training_status_for(participant_profile)
         record.schedule_identifier = participant_profile.schedule&.schedule_identifier
 
         record.save!
@@ -53,6 +53,10 @@ module Analytics
 
       def trn_verified?(participant_profile)
         participant_profile.ecf_participant_eligibility.present?
+      end
+
+      def training_status_for(participant_profile)
+        participant_profile&.latest_induction_record&.training_status
       end
     end
   end

--- a/app/services/analytics/ecf_validation_service.rb
+++ b/app/services/analytics/ecf_validation_service.rb
@@ -56,7 +56,7 @@ module Analytics
       end
 
       def training_status_for(participant_profile)
-        participant_profile&.latest_induction_record&.training_status
+        participant_profile&.latest_induction_record&.training_status.presence || participant_profile.training_status
       end
     end
   end

--- a/app/services/appropriate_bodies/participants_filter.rb
+++ b/app/services/appropriate_bodies/participants_filter.rb
@@ -72,7 +72,7 @@ module AppropriateBodies
         pp = ir.participant_profile
         next unless pp
 
-        pps = ParticipantProfileStatus.new(participant_profile: pp)
+        pps = ParticipantProfileStatus.new(participant_profile: pp, induction_record: ir)
         if pps.is_status?(status)
           ids << ir.id
         end

--- a/app/services/delivery_partners/participants_filter.rb
+++ b/app/services/delivery_partners/participants_filter.rb
@@ -71,7 +71,9 @@ module DeliveryPartners
     def filter_status(scoped, status)
       ids = []
       scoped.each do |pp|
-        pps = ParticipantProfileStatus.new(participant_profile: pp)
+        ir = pp.relevant_induction_record_for(delivery_partner: params[:delivery_partner])
+
+        pps = ParticipantProfileStatus.new(participant_profile: pp, induction_record: ir)
         if pps.is_status?(status)
           ids << pp.id
         end

--- a/app/services/participant_profile_status.rb
+++ b/app/services/participant_profile_status.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class ParticipantProfileStatus
-  def initialize(participant_profile:)
+  def initialize(participant_profile:, induction_record:)
     @participant_profile = participant_profile
+    @induction_record = induction_record
   end
 
   def status_name
     return unless participant_profile
 
-    if participant_profile.training_status_withdrawn?
+    if training_status_withdrawn?
       "no_longer_being_trained"
 
     elsif eligible? && participant_profile.single_profile?
@@ -68,7 +69,7 @@ class ParticipantProfileStatus
 
 private
 
-  attr_reader :participant_profile
+  attr_reader :participant_profile, :induction_record
 
   delegate :school_cohort,
            :ecf_participant_eligibility,
@@ -108,5 +109,9 @@ private
 
   def participant_has_no_qts?
     ecf_participant_eligibility&.no_qts_reason?
+  end
+
+  def training_status_withdrawn?
+    induction_record.present? ? induction_record.training_status_withdrawn? : participant_profile.training_status_withdrawn?
   end
 end

--- a/spec/components/appropriate_bodies/participants/table_row_spec.rb
+++ b/spec/components/appropriate_bodies/participants/table_row_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AppropriateBodies::Participants::TableRow, type: :component do
 
   let(:appropriate_body) { create(:appropriate_body_local_authority) }
   let(:participant_profile) { create :ect_participant_profile }
-  let(:induction_record) { create :induction_record, participant_profile: }
+  let!(:induction_record) { create :induction_record, participant_profile: }
 
   context "when the request for details has not been sent yet" do
     it { is_expected.to have_text("Contacted for information") }
@@ -114,6 +114,7 @@ RSpec.describe AppropriateBodies::Participants::TableRow, type: :component do
 
     context "has a withdrawn status" do
       let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort:) }
+      let!(:induction_record) { create(:induction_record, training_status: "withdrawn", participant_profile:) }
 
       it { is_expected.to have_text("No longer being trained") }
     end

--- a/spec/components/delivery_partners/participants/table_row_spec.rb
+++ b/spec/components/delivery_partners/participants/table_row_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe DeliveryPartners::Participants::TableRow, type: :component do
 
     context "has a withdrawn status" do
       let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort:) }
+      let!(:induction_record) { create(:induction_record, training_status: "withdrawn", participant_profile:) }
 
       it { is_expected.to have_text("No longer being trained") }
     end

--- a/spec/features/appropriate_bodies/participants_spec.rb
+++ b/spec/features/appropriate_bodies/participants_spec.rb
@@ -98,7 +98,8 @@ RSpec.feature "Appropriate body users participants", type: :feature do
   end
 
   context "Filter status" do
-    let(:participant_profile) { create(:ect_participant_profile, school_cohort:, training_status: "withdrawn") }
+    let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+    let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:, appropriate_body:, training_status: "withdrawn") }
 
     scenario "None existing status" do
       when_i_choose("status", with: "Checking QTS")

--- a/spec/features/delivery_partners/participants_spec.rb
+++ b/spec/features/delivery_partners/participants_spec.rb
@@ -97,7 +97,8 @@ RSpec.feature "Delivery partner users participants", type: :feature do
   end
 
   context "Filter status" do
-    let(:participant_profile) { create(:ect_participant_profile, school_cohort:, training_status: "withdrawn") }
+    let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+    let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:, training_status: "withdrawn") }
 
     scenario "None existing status" do
       when_i_choose("status", with: "Checking QTS")

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
   describe "#relevant_induction_record_for" do
     let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
     let(:lead_provider) { cpd_lead_provider.lead_provider }
-    let(:cohort) { Cohort.next || create(:cohort, :next) }
+    let(:cohort) { Cohort.current || create(:cohort, :current) }
     let(:delivery_partner) { create(:delivery_partner) }
     let(:partnership) do
       create(

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -334,4 +334,47 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
       expect(subject.record_to_serialize_for(lead_provider:)).to eq(subject.induction_records.latest.reload)
     end
   end
+
+  describe "#relevant_induction_record_for" do
+    let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+    let(:lead_provider) { cpd_lead_provider.lead_provider }
+    let(:cohort) { Cohort.next || create(:cohort, :next) }
+    let(:delivery_partner) { create(:delivery_partner) }
+    let(:partnership) do
+      create(
+        :partnership,
+        delivery_partner:,
+        cohort:,
+        lead_provider:,
+        challenged_at: nil,
+        challenge_reason: nil,
+        pending: false,
+      )
+    end
+    let(:another_partnership) do
+      create(
+        :partnership,
+        cohort:,
+        lead_provider:,
+        challenged_at: nil,
+        challenge_reason: nil,
+        pending: false,
+      )
+    end
+    let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort:) }
+    let(:induction_programme) { create(:induction_programme, school_cohort:, partnership:) }
+    let(:another_induction_programme) { create(:induction_programme, school_cohort:, partnership: another_partnership) }
+    let(:profile) { create(:ecf_participant_profile, school_cohort:) }
+    let!(:induction_record_oldest) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 3.days.ago) }
+    let!(:induction_record_latest_first_delivery_partner) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 2.days.ago) }
+    let!(:induction_record_latest_second_delivery_partner) { create(:induction_record, participant_profile: profile, induction_programme: another_induction_programme, start_date: 1.day.ago) }
+
+    it "finds the most recent induction record for the given delivery partner" do
+      expect(profile.relevant_induction_record_for(delivery_partner: partnership.delivery_partner)).to eq(induction_record_latest_first_delivery_partner)
+    end
+
+    it "finds the most recent induction record for the given delivery partner" do
+      expect(profile.relevant_induction_record_for(delivery_partner: another_partnership.delivery_partner)).to eq(induction_record_latest_second_delivery_partner)
+    end
+  end
 end

--- a/spec/services/participant_profile_status_spec.rb
+++ b/spec/services/participant_profile_status_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantProfileStatus, :with_default_schedules do
+  let(:participant_profile) { create(:ecf_participant_profile) }
+  let!(:induction_record) { create(:induction_record, participant_profile:) }
+
+  let(:params) { { participant_profile:, induction_record: } }
+
+  subject { described_class.new(**params) }
+
+  describe "#initialize" do
+    it "sets it to the injected params if provided" do
+      expect(subject.instance_variable_get(:@participant_profile)).to eq(participant_profile)
+    end
+
+    it "sets it to the injected params if provided" do
+      expect(subject.instance_variable_get(:@induction_record)).to eq(induction_record)
+    end
+  end
+
+  describe "#status_name" do
+    context "when the request for details has not been sent yet" do
+      it "returns the correct status" do
+        response = subject.status_name
+        expect(response).to eq("contacted_for_information")
+      end
+    end
+
+    context "with a request for details email record" do
+      let!(:email) { create(:email, tags: %i[request_for_details], associated_with: participant_profile, status: email_status) }
+
+      context "which has been successfully delivered" do
+        let(:email_status) { :delivered }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("contacted_for_information")
+        end
+      end
+
+      context "which has failed to be deliver" do
+        let(:email_status) { Email::FAILED_STATUSES.sample }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("contacted_for_information")
+        end
+      end
+
+      context "which is still pending" do
+        let(:email_status) { :submitted }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("contacted_for_information")
+        end
+      end
+    end
+
+    context "mentor with multiple profiles" do
+      let(:school_cohort) { create(:school_cohort) }
+
+      context "when the primary profile is eligible" do
+        let(:participant_profile) { create(:mentor_participant_profile, :primary_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("training_or_eligible_for_training")
+        end
+      end
+
+      context "when the secondary profile is ineligible because it is a duplicate" do
+        let(:participant_profile) { create(:mentor_participant_profile, :secondary_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :secondary_profile_state, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("training_or_eligible_for_training")
+        end
+      end
+    end
+
+    context "full induction programme participant" do
+      context "has submitted validation data" do
+        let(:school_cohort) { create(:school_cohort, :fip) }
+        let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("training_or_eligible_for_training")
+        end
+      end
+
+      context "was a participant in early roll out" do
+        let(:school_cohort) { create(:school_cohort, :fip) }
+        let(:participant_profile) { create(:mentor_participant_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :previous_participation_state, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("training_or_eligible_for_training")
+        end
+      end
+    end
+
+    context "core induction programme participant" do
+      context "has submitted validation data" do
+        let(:school_cohort) { create(:school_cohort, :cip) }
+        let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :manual_check, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("dfe_checking_eligibility")
+        end
+      end
+
+      context "has a previous induction reason" do
+        let(:school_cohort) { create(:school_cohort, :cip) }
+        let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :previous_induction_state, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("not_eligible_for_funded_training")
+        end
+      end
+
+      context "has no QTS reason" do
+        let(:school_cohort) { create(:school_cohort, :cip) }
+        let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :no_qts_state, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("checking_qts")
+        end
+      end
+
+      context "has an ineligible status" do
+        let(:school_cohort) { create(:school_cohort, :cip) }
+        let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, :ineligible, participant_profile:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("not_eligible_for_funded_training")
+        end
+      end
+
+      context "has a withdrawn status" do
+        let(:school_cohort) { create(:school_cohort, :fip) }
+        let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort:) }
+        let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, participant_profile:) }
+        let(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
+        let!(:induction_record) { Induction::Enrol.call(participant_profile:, induction_programme:) }
+
+        it "returns the correct status" do
+          response = subject.status_name
+          expect(response).to eq("training_or_eligible_for_training")
+        end
+
+        context "when induction record does not exist" do
+          let(:participant_profile) { create(:ecf_participant_profile, training_status: "withdrawn") }
+          let!(:induction_record) { nil }
+
+          it "returns the correct status" do
+            response = subject.status_name
+            expect(response).to eq("no_longer_being_trained")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

There's a participant that has transferred where the API shows the correct value for training_status but the check data service shows something wrong.

This is the participant in question: 55485a55-c6ec-49c5-b9b6-ccb68d05cea0 https://manage-training-for-early-career-teachers.education.gov.uk/admin/participants/b8fdaffa-da1c-418b-9ad8-ae31a32120fd/induction_recordsThe lead provider (Ambition) sees active while the DP (3 rivers) sees the equivalent of withdrawn. It appears to be a 'botched transfer' and the participant has changed cohort too

- Ticket: [CPDLP-1989](https://dfedigital.atlassian.net/browse/CPDLP-1989)

### Changes proposed in this pull request

The `training_status` on the `participants.sql` query is being fetched from `participant_profiles` (profile level) and not from the latest induction record as we’re doing in the API. So we're making a change in the sql query to fetch the `training_status` from the latest induction record instead of doing it from participant profile, with that the delivery partner view will become the same as what a provider sees in the API.



[CPDLP-1989]: https://dfedigital.atlassian.net/browse/CPDLP-1989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ