### PR TITLE
[CPDLP-1994] Validate declaration date format when creating a participant declaration via the api

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -15,7 +15,8 @@ class RecordDeclaration
 
   before_validation :declaration_attempt
 
-  validates :declaration_date, :declaration_type, presence: true
+  validates :declaration_date, presence: { message: I18n.t(:missing_declaration_date) }
+  validates :declaration_type, presence: { message: I18n.t(:missing_declaration_type) }
   validates :declaration_date, future_date: true, declaration_date: true, allow_blank: true
   validates :participant_id, participant_not_withdrawn: true
   validates :cpd_lead_provider, induction_record: true

--- a/app/validators/declaration_date_validator.rb
+++ b/app/validators/declaration_date_validator.rb
@@ -11,8 +11,12 @@ class DeclarationDateValidator < ActiveModel::Validator
 private
 
   def date_has_the_right_format(record)
-    return if record.declaration_date.blank?
-    return if record.raw_declaration_date.match?(RFC3339_DATE_REGEX)
+    return if record.raw_declaration_date.blank?
+    return if record.raw_declaration_date.match?(RFC3339_DATE_REGEX) && begin
+      record.raw_declaration_date&.to_datetime
+    rescue Date::Error
+      false
+    end
 
     record.errors.add(:declaration_date, I18n.t(:invalid_declaration_date))
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
   missing_cpd_lead_provider: "The property '#/cpd_lead_provider' must be present"
   missing_reason: "The property '#/reason' must be present"
   missing_state: "The property '#/state' must be present"
+  missing_declaration_date: "The property '#/declaration_date' must be present"
   missing_completion_date: "The property '#/completion_date' must be present"
   declaration_already_exists: A declaration has already been submitted that will be, or has been, paid for this event
   already_active: The participant is already active

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -421,8 +421,8 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
           expect(parsed_response["errors"])
             .to eq(
               [
-                { "title" => "declaration_date",  "detail" => "can't be blank" },
-                { "title" => "declaration_type",  "detail" => "can't be blank" },
+                { "title" => "declaration_date",  "detail" => "The property '#/declaration_date' must be present" },
+                { "title" => "declaration_type",  "detail" => "The property '#/declaration_type' must be present" },
                 { "title" => "participant_id",    "detail" => "The property '#/participant_id' must be a valid Participant ID" },
                 { "title" => "course_identifier", "detail" => "The property '#/course_identifier' must be an available course to '#/participant_id'" },
               ],

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
         expect(parsed_response["errors"])
           .to eq(
             [
-              { "title" => "declaration_date", "detail" => "can't be blank" },
-              { "title" => "declaration_type", "detail" => "can't be blank" },
+              { "title" => "declaration_date", "detail" => "The property '#/declaration_date' must be present" },
+              { "title" => "declaration_type", "detail" => "The property '#/declaration_type' must be present" },
               { "title" => "participant_id", "detail" => "The property '#/participant_id' must be a valid Participant ID" },
               { "title" => "course_identifier", "detail" => "The property '#/course_identifier' must be an available course to '#/participant_id'" },
             ],

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -78,6 +78,44 @@ RSpec.shared_examples "validates the course_identifier, cpd_lead_provider, parti
       expect(service.errors.messages_for(:course_identifier)).to eq(["The property '#/course_identifier' must be an available course to '#/participant_id'"])
     end
   end
+
+  context "when the declaration date is invalid" do
+    context "When the declaration date is empty" do
+      before { params[:declaration_date] = "" }
+
+      it "has a meaningful error", :aggregate_failures do
+        expect(service).to be_invalid
+        expect(service.errors.messages_for(:declaration_date)).to include("The property '#/declaration_date' must be present")
+      end
+    end
+
+    context "when declaration date format is invalid" do
+      before { params[:declaration_date] = "2021-06-21 08:46:29" }
+
+      it "has a meaningful error", :aggregate_failures do
+        expect(service).to be_invalid
+        expect(service.errors.messages_for(:declaration_date)).to include("The property '#\/declaration_date' must be a valid RCF3339 date")
+      end
+    end
+
+    context "when declaration date is invalid" do
+      before { params[:declaration_date] = "2023-19-01T11:21:55Z" }
+
+      it "has a meaningful error", :aggregate_failures do
+        expect(service).to be_invalid
+        expect(service.errors.messages_for(:declaration_date)).to include("The property '#\/declaration_date' must be a valid RCF3339 date")
+      end
+    end
+
+    context "when declaration time is invalid" do
+      before { params[:declaration_date] = "2023-19-01T29:21:55Z" }
+
+      it "has a meaningful error", :aggregate_failures do
+        expect(service).to be_invalid
+        expect(service.errors.messages_for(:declaration_date)).to include("The property '#\/declaration_date' must be a valid RCF3339 date")
+      end
+    end
+  end
 end
 
 RSpec.shared_examples "validates existing declarations" do

--- a/spec/validators/declaration_date_validator_spec.rb
+++ b/spec/validators/declaration_date_validator_spec.rb
@@ -44,15 +44,34 @@ RSpec.describe DeclarationDateValidator do
     before { allow(subject).to receive(:milestone).and_return(milestone) }
 
     describe "the declaration date has the right format" do
-      context "When the declaration date is empty" do
+      context "when the declaration date is empty" do
         subject { model_class.new(declaration_date: "") }
 
         it "does not errors when the declaration date is blank" do
           expect(subject).to be_valid
         end
       end
-      context "when declaration date is invalid" do
+
+      context "when declaration date format is invalid" do
         subject { model_class.new(declaration_date: "2021-06-21 08:46:29") }
+
+        it "has a meaningful error", :aggregate_failures do
+          expect(subject).to be_invalid
+          expect(subject.errors.messages_for(:declaration_date)).to include("The property '#\/declaration_date' must be a valid RCF3339 date")
+        end
+      end
+
+      context "when declaration date is invalid" do
+        subject { model_class.new(declaration_date: "2023-19-01T11:21:55Z") }
+
+        it "has a meaningful error", :aggregate_failures do
+          expect(subject).to be_invalid
+          expect(subject.errors.messages_for(:declaration_date)).to include("The property '#\/declaration_date' must be a valid RCF3339 date")
+        end
+      end
+
+      context "when declaration time is invalid" do
+        subject { model_class.new(declaration_date: "2023-19-01T29:21:55Z") }
 
         it "has a meaningful error", :aggregate_failures do
           expect(subject).to be_invalid


### PR DESCRIPTION
### Context

The API expects year-month-day, whereas TDT have swapped month and day.. so the API sent a response back to the lead provider: `Declaration date can't be blank` when lead provider posted for example `declaration_date`: `"2023-19-01T10:00:00Z"`.. which is a invalid year-month-day date.

- Ticket: [CPDLP-1994](https://dfedigital.atlassian.net/browse/CPDLP-1994)

### Changes proposed in this pull request

Improve declaration date format validation and error message when an invalid date is posted to the service.

[CPDLP-1994]: https://dfedigital.atlassian.net/browse/CPDLP-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ