### PR TITLE
Fix banding tracker flaky test

### DIFF
--- a/spec/features/finance/banding_tracker_spec.rb
+++ b/spec/features/finance/banding_tracker_spec.rb
@@ -55,11 +55,6 @@ RSpec.feature "Banding tracker", :with_default_schedules, type: :feature, js: tr
     generate_declarations(state: :payable)
     generate_declarations(state: :paid)
 
-    create(:milestone,
-           declaration_type: "started",
-           milestone_date: Date.new(cohort.start_year, 12, 22),
-           schedule: create(:schedule, schedule_identifier: "ecf-standard-september", name: "ECF September Standard", type: "Finance::Schedule::ECF", cohort:))
-
     travel_to ect.schedule.milestones.find_by(declaration_type: "started").milestone_date do
       create(
         :ect_participant_declaration,


### PR DESCRIPTION
### Context

`rspec ./spec/features/finance/banding_tracker_spec.rb:72` is failing.

``` 
1) Banding tracker displays the distribution of declaration by band, retention type and declaration state
     Failure/Error: raise ArgumentError, service.errors.full_messages unless service.valid?

     ArgumentError:
       ["Declaration date The property '#/declaration_date' can not declare a future date", "Declaration date The property '#/declaration_date' can not be after milestone end"]
     # ./spec/factories/participant_declaration.rb:56:in `block (3 levels) in <top (required)>'
     # ./spec/features/finance/banding_tracker_spec.rb:64:in `block (3 levels) in <top (required)>'
     # ./spec/features/finance/banding_tracker_spec.rb:63:in `block (2 levels) in <top (required)>'
```

### Changes proposed in this pull request

Fix flaky test setting up test data correctly.