### PR TITLE
[CPDLP-1904] Fix induction records issue when start & end dates are off

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -31,6 +31,7 @@ class InductionRecord < ApplicationRecord
   belongs_to :preferred_identity, class_name: "ParticipantIdentity", optional: true
 
   validates :start_date, presence: true
+  validate :validate_sensible_dates
 
   enum induction_status: {
     active: "active",
@@ -137,5 +138,11 @@ private
 
   def update_analytics
     Analytics::UpsertECFInductionJob.perform_later(induction_record: self) if saved_changes?
+  end
+
+  def validate_sensible_dates
+    return if start_date.blank? || end_date.blank?
+
+    errors.add(:end_date, :before_start_date) if start_date > end_date
   end
 end

--- a/app/services/induction/change_induction_record.rb
+++ b/app/services/induction/change_induction_record.rb
@@ -21,6 +21,7 @@ class Induction::ChangeInductionRecord < BaseService
 
         induction_record.changing!(time_now)
         new_record.assign_attributes(default_attrs.merge(changes))
+        new_record.start_date = new_record.end_date if new_record.start_date && new_record.end_date && new_record.start_date > new_record.end_date
         new_record.save!
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,10 @@ en:
               cannot_change_from_accepted: Once accepted an application cannot change state
               cannot_change_from_rejected: Once rejected an application cannot change state
               declarations_exist: There are already declarations for this participant on this course, please ask provider to void and/or clawback any declarations they have made before attempting to reset the application.
+        induction_record:
+          attributes:
+            end_date:
+              before_start_date: "End date must be after start date"
 
   activemodel:
     errors:


### PR DESCRIPTION
### Context

Some induction records have start_date > end_date.

- Ticket: [CPDLP-1904](https://dfedigital.atlassian.net/browse/CPDLP-1904)

### Changes proposed in this pull request

The idea is to add a validation on InductionRecord model to prevent the dates being off and also 

Found out that `Induction::ChangeInductionRecord` is copying over the end_date to the newly created induction record.

example

before:

old induction record has start_date = 01/09/2022 & end_date = 11/09/2022
new induction record will have start_date = 01/10/2022 & end_date = 11/09/2022

proposed changes:

do not copy end date over to the new induction record

after:
old induction record has start_date = 01/09/2022 & end_date = 11/09/2022
new induction record will have start_date = 01/10/2022 & end_date = nil


[CPDLP-1904]: https://dfedigital.atlassian.net/browse/CPDLP-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ