### PR TITLE
Add seeding step for SIT nominations

### DIFF
--- a/db/new_seeds/base/add_sit_nominations.rb
+++ b/db/new_seeds/base/add_sit_nominations.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+FactoryBot
+  .create_list(:seed_school, 15)
+  .map { |school| NewSeeds::Scenarios::School::InviteSchool.new(school:).invite! }

--- a/db/new_seeds/run.rb
+++ b/db/new_seeds/run.rb
@@ -29,6 +29,7 @@ Rails.logger.info("Seeding database")
   "add_mentor_scenarios.rb",
   "add_api_tokens.rb",
   "add_feature_flags.rb",
+  "add_sit_nominations.rb",
 ].each do |file|
   Rails.logger.info("seeding #{file}")
   load_base_file(file)

--- a/db/new_seeds/scenarios/schools/invite_school.rb
+++ b/db/new_seeds/scenarios/schools/invite_school.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module NewSeeds
+  module Scenarios
+    module School
+      class InviteSchool
+        attr_reader :school, :token, :path
+
+        def initialize(school:)
+          @school = school
+        end
+
+        def invite!
+          InviteSchools.new.perform(Array.wrap(school.urn))
+
+          @token = NominationEmail.find_by(school_id: school.id).token
+
+          @path = Rails.application.routes.url_helpers.choose_how_to_continue_path(token:).tap do |p|
+            Rails.logger.info("seeding nomination path for #{school.name}: #{p}")
+          end
+
+          self
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This change should make it possible for people to test out the SIT journey from the beginning. We do it by seeding some blank schools and generating a notification email. This is usually where it gets complex because we need to pick that email up from Notify.

~~We need an easier way for non-devs to see paths/tokens they can use to start the SIT journey from the beginning, writing them to `public/seed_log.txt` seems like a good solution, but in the longer term being able to sign into the admin panel and click a button would probably be better.~~

The logging functionality was removed as @tonyheadford has a better solution on the way!