### PR TITLE
[CPDLP-2003] Allow ASO/EHCO completed declarations without `has_passed` param

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -209,9 +209,17 @@ private
 
   def validate_has_passed?
     return false unless FeatureFlag.active?(:participant_outcomes_feature)
+    return false unless valid_course_identifier_for_participant_outcome?
 
     participant_profile&.npq? &&
       declaration_type == "completed"
+  end
+
+  def valid_course_identifier_for_participant_outcome?
+    !(
+      ::Finance::Schedule::NPQEhco::IDENTIFIERS +
+      ::Finance::Schedule::NPQSupport::IDENTIFIERS
+    ).compact.include?(course_identifier)
   end
 
   def participant_outcome_state

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
       context "ehco course identifier" do
         let!(:npq_ehco_schedule) { create(:npq_ehco_schedule) }
         let(:npq_course) { create(:npq_ehco_course) }
-        let(:has_passed) { true }
+        let(:has_passed) { nil }
 
         it "does not create participant outcome" do
           travel_to declaration_date do
@@ -436,7 +436,7 @@ RSpec.describe RecordDeclaration, :with_default_schedules do
       context "aso course identifier" do
         let!(:npq_aso_schedule) { create(:npq_aso_schedule) }
         let(:npq_course) { create(:npq_aso_course) }
-        let(:has_passed) { true }
+        let(:has_passed) { nil }
 
         it "does not create participant outcome" do
           travel_to declaration_date do


### PR DESCRIPTION
### Context

We are not allowing ASO/EHCO completed declarations through if they've not defined the `has_passed` param

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2003

### Changes proposed in this pull request
Allow those declarations through as those courses don't require outcomes

### Guidance to review
Did I miss anything?
