### PR TITLE
[CPLD-1913] Improve participant query performance

### DIFF
--- a/app/controllers/api/v1/ecf_participants_controller.rb
+++ b/app/controllers/api/v1/ecf_participants_controller.rb
@@ -40,7 +40,7 @@ module Api
     private
 
       def serializer_class
-        ParticipantFromInductionRecordSerializer
+        ParticipantFromQuerySerializer
       end
 
       def induction_records

--- a/app/controllers/concerns/api/v1/participant_actions.rb
+++ b/app/controllers/concerns/api/v1/participant_actions.rb
@@ -29,12 +29,8 @@ module Api
 
     private
 
-      def serializer_class
-        ParticipantFromInductionRecordSerializer
-      end
-
       def serialized_response_for(service)
-        render_from_service(service, serializer_class, params: { lead_provider: })
+        render_from_service(service, ParticipantFromInductionRecordSerializer, params: { lead_provider: })
       end
 
       def permitted_params

--- a/app/serializers/api/v1/participant_from_query_serializer.rb
+++ b/app/serializers/api/v1/participant_from_query_serializer.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "jsonapi/serializer/instrumentation"
+
+module Api
+  module V1
+    class ParticipantFromQuerySerializer
+      include JSONAPI::Serializer
+      include JSONAPI::Serializer::Instrumentation
+
+      class << self
+        def trn(record)
+          record.teacher_profile_trn || record.ecf_participant_validation_data_trn
+        end
+
+        def validated_trn(record)
+          eligibility = record.ecf_participant_eligibility_reason
+          eligibility.present? && eligibility != "different_trn"
+        end
+
+        def eligible_for_funding?(record)
+          ecf_participant_eligibility_status = record.ecf_participant_eligibility_status
+          return if ecf_participant_eligibility_status.nil?
+          return true if ecf_participant_eligibility_status == "eligible"
+          return false if ecf_participant_eligibility_status == "ineligible"
+        end
+      end
+
+      set_type :participant
+
+      set_id :id, &:external_identifier
+
+      attribute :email do |induction_record|
+        induction_record.preferred_identity_email ||
+          induction_record.user_email
+      end
+
+      attribute :full_name, &:full_name
+
+      attribute :mentor_id do |induction_record|
+        if induction_record.participant_profile_type == "ParticipantProfile::ECT"
+          induction_record.mentor_external_identifier
+        end
+      end
+
+      attribute :school_urn, &:schools_urn
+
+      attribute :participant_type do |induction_record|
+        if induction_record.participant_profile_type == "ParticipantProfile::ECT"
+          :ect
+        else
+          :mentor
+        end
+      end
+
+      attribute :cohort do |induction_record|
+        induction_record.start_year&.to_s
+      end
+
+      attribute :status do |induction_record|
+        case induction_record.induction_status
+        when "active", "completed", "leaving"
+          "active"
+        when "withdrawn", "changed"
+          "withdrawn"
+        end
+      end
+
+      attribute :teacher_reference_number do |induction_record|
+        trn(induction_record)
+      end
+
+      attribute :teacher_reference_number_validated do |induction_record|
+        if trn(induction_record).nil?
+          nil
+        else
+          validated_trn(induction_record).present?
+        end
+      end
+
+      attribute :eligible_for_funding do |induction_record|
+        eligible_for_funding?(induction_record)
+      end
+
+      attribute :pupil_premium_uplift, &:pupil_premium_uplift
+
+      attribute :sparsity_uplift, &:sparsity_uplift
+
+      attribute :training_status, &:training_status
+
+      attribute :schedule_identifier, &:schedule_identifier
+
+      attribute :updated_at do |induction_record|
+        [
+          induction_record.participant_profile_updated_at,
+          induction_record.user_updated_at,
+          induction_record.participant_identity_updated_at,
+          induction_record.updated_at,
+        ].compact.max.rfc3339
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v1/participant_from_query_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_query_serializer_spec.rb
@@ -1,0 +1,403 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  module V1
+    RSpec.describe ParticipantFromQuerySerializer, :with_default_schedules do
+      let(:query_result) { OpenStruct.new(results) }
+      let(:results) do
+        {
+          participant_profile_updated_at: Time.zone.now,
+          user_updated_at: Time.zone.now,
+          participant_identity_updated_at: Time.zone.now,
+          updated_at: Time.zone.now,
+        }.merge(fields)
+      end
+
+      subject { described_class.new(query_result) }
+
+      describe "#id" do
+        let(:external_identifier) { Faker::Internet.uuid }
+        let(:fields) { { external_identifier: } }
+
+        it "returns the external identifier" do
+          expect(subject.serializable_hash[:data][:id]).to eql(external_identifier)
+        end
+      end
+
+      describe "#email" do
+        context "when user email present" do
+          let(:fields) do
+            {
+              preferred_identity_email: nil,
+              user_email: "firsts_email@example.com",
+            }
+          end
+
+          it "returns user email" do
+            expect(subject.serializable_hash[:data][:attributes][:email]).to eql("firsts_email@example.com")
+          end
+        end
+
+        context "when preferred identity email present" do
+          let(:fields) do
+            {
+              preferred_identity_email: "preferred_email@example.com",
+              user_email: "firsts_email@example.com",
+            }
+          end
+
+          it "returns preferred identity email" do
+            expect(subject.serializable_hash[:data][:attributes][:email]).to eql("preferred_email@example.com")
+          end
+        end
+      end
+
+      describe "#full_name" do
+        let(:full_name) { "John Doe" }
+        let(:fields) { { full_name: } }
+
+        it "returns the full name" do
+          expect(subject.serializable_hash[:data][:attributes][:full_name]).to eql(full_name)
+        end
+      end
+
+      describe "#mentor_id" do
+        let(:external_identifier) { Faker::Internet.uuid }
+
+        context "when participant is an ECT" do
+          let(:fields) do
+            {
+              mentor_external_identifier: external_identifier,
+              participant_profile_type: "ParticipantProfile::ECT",
+            }
+          end
+
+          it "returns the mentor external identifier" do
+            expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to eql(external_identifier)
+          end
+        end
+
+        context "when participant is a Mentor" do
+          let(:fields) do
+            {
+              mentor_external_identifier: external_identifier,
+              participant_profile_type: "ParticipantProfile::Mentor",
+            }
+          end
+
+          it "returns preferred identity email" do
+            expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to be_nil
+          end
+        end
+      end
+
+      describe "#school_urn" do
+        let(:school_urn) { 123_456 }
+        let(:fields) { { schools_urn: school_urn } }
+
+        it "returns the school urn" do
+          expect(subject.serializable_hash[:data][:attributes][:school_urn]).to eql(school_urn)
+        end
+      end
+
+      describe "#participant_type" do
+        context "when participant is an ECT" do
+          let(:fields) do
+            {
+              participant_profile_type: "ParticipantProfile::ECT",
+            }
+          end
+
+          it "returns the participant type as an ect" do
+            expect(subject.serializable_hash[:data][:attributes][:participant_type]).to eql(:ect)
+          end
+        end
+
+        context "when participant is a Mentor" do
+          let(:fields) do
+            {
+              participant_profile_type: "ParticipantProfile::Mentor",
+            }
+          end
+
+          it "returns the participant type as a mentor" do
+            expect(subject.serializable_hash[:data][:attributes][:participant_type]).to eql(:mentor)
+          end
+        end
+      end
+
+      describe "#cohort" do
+        let(:start_year) { 2021 }
+        let(:fields) { { start_year: } }
+
+        it "returns the cohort" do
+          expect(subject.serializable_hash[:data][:attributes][:cohort]).to eql("2021")
+        end
+      end
+
+      describe "#status" do
+        context "when active" do
+          let(:fields) do
+            {
+              induction_status: "active",
+            }
+          end
+
+          it "returns active" do
+            expect(subject.serializable_hash[:data][:attributes][:status]).to eq("active")
+          end
+        end
+
+        context "when the status has changed" do
+          context "when completed" do
+            let(:fields) do
+              {
+                induction_status: "completed",
+              }
+            end
+
+            it "returns active" do
+              expect(subject.serializable_hash[:data][:attributes][:status]).to eq("active")
+            end
+          end
+
+          context "when leaving" do
+            let(:induction_record) { ect.reload.current_induction_record }
+            let(:fields) do
+              {
+                induction_status: "leaving",
+              }
+            end
+
+            it "returns active" do
+              expect(subject.serializable_hash[:data][:attributes][:status]).to eq("active")
+            end
+          end
+
+          context "when withdrawn" do
+            let(:fields) do
+              {
+                induction_status: "withdrawn",
+              }
+            end
+
+            it "returns withdrawn" do
+              expect(subject.serializable_hash[:data][:attributes][:status]).to eq("withdrawn")
+            end
+          end
+
+          context "when changed" do
+            let(:fields) do
+              {
+                induction_status: "changed",
+              }
+            end
+
+            it "returns withdrawn" do
+              expect(subject.serializable_hash[:data][:attributes][:status]).to eq("withdrawn")
+            end
+          end
+        end
+      end
+
+      describe "#teacher_reference_number" do
+        let(:fields) do
+          {
+            teacher_profile_trn:,
+            ecf_participant_validation_data_trn: 654_321,
+          }
+        end
+        context "when no teacher profile trn present" do
+          let(:teacher_profile_trn) { nil }
+
+          it "returns the validation data trn" do
+            expect(subject.serializable_hash[:data][:attributes][:teacher_reference_number]).to eql(654_321)
+          end
+        end
+
+        context "when teacher profile trn present" do
+          let(:teacher_profile_trn) { 123_456 }
+
+          it "returns the teacher profile trn" do
+            expect(subject.serializable_hash[:data][:attributes][:teacher_reference_number]).to eql(teacher_profile_trn)
+          end
+        end
+      end
+
+      describe "#teacher_reference_number_validated" do
+        let(:fields) do
+          {
+            teacher_profile_trn:,
+            ecf_participant_validation_data_trn:,
+            ecf_participant_eligibility_reason:,
+          }
+        end
+
+        context "when no trn present" do
+          let(:teacher_profile_trn) { nil }
+          let(:ecf_participant_validation_data_trn) { nil }
+          let(:ecf_participant_eligibility_reason) { nil }
+
+          it "returns nil" do
+            expect(subject.serializable_hash[:data][:attributes][:teacher_reference_number_validated]).to be_nil
+          end
+        end
+
+        context "when a trn is present but there is no participant eligibility reason" do
+          let(:teacher_profile_trn) { 123_456 }
+          let(:ecf_participant_validation_data_trn) { 654_321 }
+          let(:ecf_participant_eligibility_reason) { nil }
+
+          it "returns false" do
+            expect(subject.serializable_hash[:data][:attributes][:teacher_reference_number_validated]).to be false
+          end
+        end
+
+        context "when a trn is present and the participant eligibility reason is not 'different_trn'" do
+          let(:teacher_profile_trn) { 123_456 }
+          let(:ecf_participant_validation_data_trn) { 654_321 }
+          let(:ecf_participant_eligibility_reason) { "active_flags" }
+
+          it "returns true" do
+            expect(subject.serializable_hash[:data][:attributes][:teacher_reference_number_validated]).to be true
+          end
+        end
+
+        context "when a trn is present and the participant eligibility reason is 'different_trn'" do
+          let(:teacher_profile_trn) { 123_456 }
+          let(:ecf_participant_validation_data_trn) { 654_321 }
+          let(:ecf_participant_eligibility_reason) { "different_trn" }
+
+          it "returns false" do
+            expect(subject.serializable_hash[:data][:attributes][:teacher_reference_number_validated]).to be false
+          end
+        end
+      end
+
+      describe "#eligible_for_funding" do
+        let(:fields) { { ecf_participant_eligibility_status: } }
+
+        context "when status is empty" do
+          let(:ecf_participant_eligibility_status) { nil }
+
+          it "returns nil" do
+            expect(subject.serializable_hash[:data][:attributes][:eligible_for_funding]).to be_nil
+          end
+        end
+
+        context "when status is eligible" do
+          let(:ecf_participant_eligibility_status) { "eligible" }
+
+          it "returns true" do
+            expect(subject.serializable_hash[:data][:attributes][:eligible_for_funding]).to be true
+          end
+        end
+
+        context "when status is ineligible" do
+          let(:ecf_participant_eligibility_status) { "ineligible" }
+
+          it "returns false" do
+            expect(subject.serializable_hash[:data][:attributes][:eligible_for_funding]).to be false
+          end
+        end
+      end
+
+      describe "#pupil_premium_uplift" do
+        let(:fields) { { pupil_premium_uplift: true } }
+
+        it "returns the pupil_premium_uplift" do
+          expect(subject.serializable_hash[:data][:attributes][:pupil_premium_uplift]).to be true
+        end
+      end
+
+      describe "#pupil_premium_uplift" do
+        let(:fields) { { pupil_premium_uplift: true } }
+
+        it "returns the pupil_premium_uplift" do
+          expect(subject.serializable_hash[:data][:attributes][:pupil_premium_uplift]).to be true
+        end
+      end
+
+      describe "#sparsity_uplift" do
+        let(:fields) { { sparsity_uplift: false } }
+
+        it "returns the sparsity_uplift" do
+          expect(subject.serializable_hash[:data][:attributes][:sparsity_uplift]).to be false
+        end
+      end
+
+      describe "#training_status" do
+        let(:fields) { { training_status: "active" } }
+
+        it "returns the training_status" do
+          expect(subject.serializable_hash[:data][:attributes][:training_status]).to eql("active")
+        end
+      end
+
+      describe "#schedule_identifier" do
+        let(:fields) { { schedule_identifier: "ecf-standard-september" } }
+
+        it "returns the schedule_identifier" do
+          expect(subject.serializable_hash[:data][:attributes][:schedule_identifier]).to eql("ecf-standard-september")
+        end
+      end
+
+      describe "#updated_at" do
+        let(:fields) do
+          {
+            participant_profile_updated_at:,
+            user_updated_at:,
+            participant_identity_updated_at:,
+            updated_at:,
+          }
+        end
+
+        context "when induction record touched" do
+          let(:participant_profile_updated_at) { Time.zone.now - 3.days }
+          let(:user_updated_at) { Time.zone.now - 2.days }
+          let(:participant_identity_updated_at) { Time.zone.now - 1.day }
+          let(:updated_at) { Time.zone.now }
+
+          it "considers updated_at of induction record" do
+            expect(Time.zone.parse(subject.serializable_hash[:data][:attributes][:updated_at])).to eq(updated_at.rfc3339)
+          end
+        end
+
+        context "when user touched" do
+          let(:participant_profile_updated_at) { Time.zone.now - 3.days }
+          let(:user_updated_at) { Time.zone.now }
+          let(:participant_identity_updated_at) { Time.zone.now - 1.day }
+          let(:updated_at) { Time.zone.now - 2.days }
+
+          it "considers updated_at of user" do
+            expect(Time.zone.parse(subject.serializable_hash[:data][:attributes][:updated_at])).to eq(user_updated_at.rfc3339)
+          end
+        end
+
+        context "when profile touched" do
+          let(:participant_profile_updated_at) { Time.zone.now }
+          let(:user_updated_at) { Time.zone.now - 3.days }
+          let(:participant_identity_updated_at) { Time.zone.now - 1.day }
+          let(:updated_at) { Time.zone.now - 2.days }
+
+          it "considers updated_at of profile" do
+            expect(Time.zone.parse(subject.serializable_hash[:data][:attributes][:updated_at])).to eq(participant_profile_updated_at.rfc3339)
+          end
+        end
+
+        context "when identity touched" do
+          let(:participant_profile_updated_at) { Time.zone.now - 1.day }
+          let(:user_updated_at) { Time.zone.now - 3.days }
+          let(:participant_identity_updated_at) { Time.zone.now }
+          let(:updated_at) { Time.zone.now - 2.days }
+
+          it "considers updated_at of identity" do
+            expect(Time.zone.parse(subject.serializable_hash[:data][:attributes][:updated_at])).to eq(participant_identity_updated_at.rfc3339)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/api/v1/ecf/participants_query_spec.rb
+++ b/spec/services/api/v1/ecf/participants_query_spec.rb
@@ -20,6 +20,37 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
       expect(subject.induction_records).to match_array([induction_record])
     end
 
+    context "with preferred identity" do
+      let(:preferred_email) { Faker::Internet.email }
+      let(:preferred_identity) { create(:participant_identity, :secondary, user: participant_profile.user, email: preferred_email) }
+      let!(:another_induction_record) { create(:induction_record, induction_programme:, participant_profile:, preferred_identity:) }
+      let(:external_identifier) { participant_profile.participant_identity.external_identifier }
+
+      it "returns the original external identifier of the participant identity" do
+        expect(subject.induction_records.first.external_identifier).to eq(external_identifier)
+      end
+
+      it "returns the preferred email" do
+        expect(subject.induction_records.first.preferred_identity_email).to eq(preferred_email)
+      end
+    end
+
+    context "with mentor profile" do
+      let(:mentor_participant_profile) { create(:mentor_participant_profile) }
+      let(:participant_profile) { create(:ect_participant_profile, mentor_profile_id: mentor_participant_profile.id) }
+      let(:mentor_external_identifier) { mentor_participant_profile.participant_identity.external_identifier }
+      let(:external_identifier) { participant_profile.participant_identity.external_identifier }
+      let!(:induction_record) { create(:induction_record, induction_programme:, participant_profile:, mentor_profile_id: mentor_participant_profile.id) }
+
+      it "returns the mentor external identifier" do
+        expect(subject.induction_records.first.mentor_external_identifier).to eq(mentor_external_identifier)
+      end
+
+      it "returns the external identifier" do
+        expect(subject.induction_records.first.external_identifier).to eq(external_identifier)
+      end
+    end
+
     describe "cohort filter" do
       context "with correct value" do
         let(:params) { { filter: { cohort: cohort.display_name } } }


### PR DESCRIPTION
### Context

The participant query is the worst performing query in the API. We've seen frequent timeouts even when providers use filters and pagination: https://sentry.io/organizations/dfe-teacher-services/issues/3739447110/?project=5748989&query=is%3Aunresolved&referrer=issue-stream

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1913

### Changes proposed in this pull request
- Use left joins instead of `includes` to allow the selection of specific fields from models, which `includes` does not allow
- Specify some left joins to avoid obscurity around some fields we need for the serialiser 
- Eager load schedules as some fields are delegated in the model
- specify a different `schools_urn` field name to avoid n+1 queries due to delegation in the model
- Add a new serialiser which reads from the selected fields
- Swap out old serialiser with new serialiser in specific API endpoints only, as some endpoints user the old serialiser but not the query

### Guidance to review
* Query analysis

Old query
```
-------------------------------------------
 Sort  (cost=305969.18..305969.58 rows=158 width=2205)
   Sort Key: users.created_at
   ->  Hash Join  (cost=169598.91..305963.41 rows=158 width=2205)
         Hash Cond: (induction_records.id = latest_induction_records.id)
         ->  Hash Left Join  (cost=147972.82..283728.77 rows=161859 width=2205)
               Hash Cond: (induction_records.participant_profile_id = participant_profiles_induction_records.id)
               ->  Gather  (cost=43964.31..109564.26 rows=161859 width=1391)
                     Workers Planned: 2
                     ->  Parallel Hash Left Join  (cost=42964.31..92378.36 rows=67441 width=1391)
                           Hash Cond: (mentor_profiles_induction_records.participant_identity_id = participant_identities_participant_profiles.id)
                           ->  Hash Left Join  (cost=34229.84..60499.86 rows=67441 width=1293)
                                 Hash Cond: (school_cohorts.cohort_id = cohorts.id)
                                 ->  Hash Left Join  (cost=34228.82..60071.72 rows=67441 width=1243)
                                       Hash Cond: (induction_records.schedule_id = schedules.id)
                                       ->  Hash Left Join  (cost=34221.05..59864.85 rows=67441 width=1104)
                                             Hash Cond: (induction_records.induction_programme_id = induction_programmes.id)
                                             ->  Parallel Hash Left Join  (cost=16291.61..29520.08 rows=67441 width=535)
                                                   Hash Cond: (induction_records.mentor_profile_id = mentor_profiles_induction_records.id)
                                                   ->  Parallel Hash Left Join  (cost=8734.47..16793.92 rows=67441 width=216)
                                                         Hash Cond: (induction_records.preferred_identity_id = participant_identities.id)
                                                         ->  Parallel Seq Scan on induction_records  (cost=0.00..4277.41 rows=67441 width=118)
                                                         ->  Parallel Hash  (cost=6515.10..6515.10 rows=78910 width=98)
                                                               ->  Parallel Seq Scan on participant_identities  (cost=0.00..6515.10 rows=78910 width=98)
                                                   ->  Parallel Hash  (cost=6207.67..6207.67 rows=24757 width=319)
                                                         ->  Parallel Seq Scan on participant_profiles mentor_profiles_induction_records  (cost=0.00..6207.67 rows=24757 width=319)
                                                               Filter: ((type)::text = 'ParticipantProfile::Mentor'::text)
                                             ->  Hash  (cost=15276.72..15276.72 rows=30938 width=569)
                                                   ->  Hash Left Join  (cost=8042.90..15276.72 rows=30938 width=569)
                                                         Hash Cond: (school_cohorts.school_id = schools.id)
                                                         ->  Hash Left Join  (cost=2295.53..5110.14 rows=30938 width=250)
                                                               Hash Cond: (induction_programmes.school_cohort_id = school_cohorts.id)
                                                               ->  Seq Scan on induction_programmes  (cost=0.00..934.38 rows=30938 width=105)
                                                               ->  Hash  (cost=1076.46..1076.46 rows=35846 width=145)
                                                                     ->  Seq Scan on school_cohorts  (cost=0.00..1076.46 rows=35846 width=145)
                                                         ->  Hash  (cost=2864.05..2864.05 rows=52905 width=319)
                                                               ->  Seq Scan on schools  (cost=0.00..2864.05 rows=52905 width=319)
                                       ->  Hash  (cost=7.34..7.34 rows=34 width=139)
                                             ->  Seq Scan on schedules  (cost=0.00..7.34 rows=34 width=139)
                                 ->  Hash  (cost=1.01..1.01 rows=1 width=50)
                                       ->  Seq Scan on cohorts  (cost=0.00..1.01 rows=1 width=50)
                           ->  Parallel Hash  (cost=6515.10..6515.10 rows=78910 width=98)
                                 ->  Parallel Seq Scan on participant_identities participant_identities_participant_profiles  (cost=0.00..6515.10 rows=78910 width=98)
               ->  Hash  (cost=90006.13..90006.13 rows=121710 width=814)
                     ->  Gather  (cost=40951.36..90006.13 rows=121710 width=814)
                           Workers Planned: 2
                           ->  Parallel Hash Left Join  (cost=39951.36..76835.13 rows=50712 width=814)
                                 Hash Cond: (participant_profiles_induction_records.teacher_profile_id = teacher_profiles.id)
                                 ->  Parallel Hash Left Join  (cost=20019.77..45642.07 rows=50712 width=587)
                                       Hash Cond: (participant_profiles_induction_records.participant_identity_id = participant_identities_participant_profiles_2.id)
                                       ->  Parallel Hash Left Join  (cost=11285.30..29101.48 rows=50712 width=489)
                                             Hash Cond: (participant_profiles_induction_records.id = ecf_participant_validation_data.participant_profile_id)
                                             ->  Parallel Hash Left Join  (cost=5158.50..16841.56 rows=50712 width=405)
                                                   Hash Cond: (participant_profiles_induction_records.id = ecf_participant_eligibilities.participant_profile_id)
                                                   ->  Parallel Seq Scan on participant_profiles participant_profiles_induction_records  (cost=0.00..6299.94 rows=50712 width=335)
                                                         Filter: ((type)::text = ANY ('{ParticipantProfile::ECF,ParticipantProfile::ECT,ParticipantProfile::Mentor}'::text[]))
                                                   ->  Parallel Hash  (cost=3521.78..3521.78 rows=67578 width=70)
                                                         ->  Parallel Seq Scan on ecf_participant_eligibilities  (cost=0.00..3521.78 rows=67578 width=70)
                                             ->  Parallel Hash  (cost=4883.02..4883.02 rows=47502 width=84)
                                                   ->  Parallel Seq Scan on ecf_participant_validation_data  (cost=0.00..4883.02 rows=47502 width=84)
                                       ->  Parallel Hash  (cost=6515.10..6515.10 rows=78910 width=98)
                                             ->  Parallel Seq Scan on participant_identities participant_identities_participant_profiles_2  (cost=0.00..6515.10 rows=78910 width=98)
                                 ->  Parallel Hash  (cost=15528.98..15528.98 rows=100609 width=227)
                                       ->  Parallel Hash Left Join  (cost=7489.77..15528.98 rows=100609 width=227)
                                             Hash Cond: (teacher_profiles.user_id = users.id)
                                             ->  Parallel Seq Scan on teacher_profiles  (cost=0.00..3611.09 rows=100609 width=71)
                                             ->  Parallel Hash  (cost=4682.01..4682.01 rows=80301 width=156)
                                                   ->  Parallel Seq Scan on users  (cost=0.00..4682.01 rows=80301 width=156)
         ->  Hash  (cost=21624.12..21624.12 rows=158 width=16)
               ->  Subquery Scan on latest_induction_records  (cost=20594.13..21624.12 rows=158 width=16)
                     Filter: (latest_induction_records.created_at_precedence = 1)
                     ->  WindowAgg  (cost=20594.13..21227.97 rows=31692 width=48)
                           ->  Sort  (cost=20594.13..20673.36 rows=31692 width=40)
                                 Sort Key: induction_records_1.participant_profile_id, induction_records_1.created_at DESC
                                 ->  Gather  (cost=10256.43..18224.86 rows=31692 width=40)
                                       Workers Planned: 2
                                       ->  Hash Join  (cost=9256.43..14055.66 rows=13205 width=40)
                                             Hash Cond: (induction_records_1.schedule_id = schedule.id)
                                             ->  Hash Join  (cost=9248.58..14008.83 rows=13205 width=56)
                                                   Hash Cond: (induction_records_1.induction_programme_id = induction_programme.id)
                                                   ->  Parallel Hash Join  (cost=6933.84..11388.28 rows=46335 width=72)
                                                         Hash Cond: (induction_records_1.participant_profile_id = participant_profiles.id)
                                                         ->  Parallel Seq Scan on induction_records induction_records_1  (cost=0.00..4277.41 rows=67441 width=72)
                                                         ->  Parallel Hash  (cost=6299.94..6299.94 rows=50712 width=16)
                                                               ->  Parallel Seq Scan on participant_profiles  (cost=0.00..6299.94 rows=50712 width=16)
                                                                     Filter: ((type)::text = ANY ('{ParticipantProfile::ECF,ParticipantProfile::ECT,ParticipantProfile::Mentor}'::text[]))
                                                   ->  Hash  (cost=2204.53..2204.53 rows=8817 width=16)
                                                         ->  Hash Join  (cost=1188.92..2204.53 rows=8817 width=16)
                                                               Hash Cond: (induction_programme.partnership_id = partnerships.id)
                                                               ->  Seq Scan on induction_programmes induction_programme  (cost=0.00..934.38 rows=30938 width=32)
                                                               ->  Hash  (cost=1089.14..1089.14 rows=7983 width=16)
                                                                     ->  Seq Scan on partnerships  (cost=0.00..1089.14 rows=7983 width=16)
                                                                           Filter: ((challenged_at IS NULL) AND (challenge_reason IS NULL) AND (lead_provider_id = 'xxxx'::uuid))
                                             ->  Hash  (cost=7.42..7.42 rows=34 width=16)
                                                   ->  Seq Scan on schedules schedule  (cost=0.00..7.42 rows=34 width=16)
                                                         Filter: (cohort_id = ANY ('{xxxx}'::uuid[]))
(95 rows)
```
New query
```
-------------------------------------------------
 Sort  (cost=138763.30..138763.69 rows=158 width=475)
  Sort Key: users.created_at
   ->  Nested Loop Left Join  (cost=95293.22..138757.53 rows=158 width=475)
         ->  Hash Join  (cost=95292.80..138664.48 rows=158 width=475)
               Hash Cond: (induction_records.id = latest_induction_records.id)
               ->  Hash Left Join  (cost=73666.71..116429.83 rows=161859 width=475)
                     Hash Cond: (induction_records.schedule_id = schedules.id)
                     ->  Gather  (cost=73658.94..115944.22 rows=161859 width=336)
                           Workers Planned: 2
                           ->  Parallel Hash Left Join  (cost=72658.94..98758.32 rows=67441 width=336)
                                 Hash Cond: (induction_records.participant_profile_id = participant_profiles.id)
                                 ->  Parallel Hash Left Join  (cost=54113.90..73999.36 rows=67441 width=261)
                                       Hash Cond: (participant_profiles_induction_records.teacher_profile_id = teacher_profiles.id)
                                       ->  Parallel Hash Left Join  (cost=38305.30..52213.16 rows=67441 width=209)
                                             Hash Cond: (induction_records.preferred_identity_id = preferred_identities.id)
                                             ->  Parallel Hash Left Join  (cost=30109.83..39720.65 rows=67441 width=179)
                                                   Hash Cond: (induction_records.mentor_profile_id = mentor_profiles.id)
                                                   ->  Parallel Hash Left Join  (cost=22659.02..28425.81 rows=67441 width=163)
                                                         Hash Cond: (participant_profiles_induction_records.id = ecf_participant_validation_data.participant_profile_id)
                                                         ->  Parallel Hash Left Join  (cost=17182.22..22771.98 rows=67441 width=172)
                                                               Hash Cond: (participant_profiles_induction_records.id = ecf_participant_eligibilities.participant_profile_id)
                                                               ->  Parallel Hash Left Join  (cost=12815.72..18228.44 rows=67441 width=158)
                                                                     Hash Cond: (induction_records.participant_profile_id = participant_profiles_induction_records.id)
                                                                     ->  Hash Left Join  (cost=5881.88..11117.57 rows=67441 width=126)
                                                                           Hash Cond: (school_cohorts.cohort_id = cohorts.id)
                                                                           ->  Parallel Hash Left Join  (cost=5880.86..10689.42 rows=67441 width=140)
                                                                                 Hash Cond: (school_cohorts.school_id = schools.id)
                                                                                 ->  Hash Left Join  (cost=2845.64..7477.16 rows=67441 width=150)
                                                                                       Hash Cond: (induction_programmes.school_cohort_id = school_cohorts.id)
                                                                                       ->  Hash Left Join  (cost=1321.11..5775.57 rows=67441 width=134)
                                                                                             Hash Cond: (induction_records.induction_programme_id = induction_programmes.id)
                                                                                             ->  Parallel Seq Scan on induction_records  (cost=0.00..4277.41 rows=67441 width=118)
                                                                                             ->  Hash  (cost=934.38..934.38 rows=30938 width=32)
                                                                                                   ->  Seq Scan on induction_programmes  (cost=0.00..934.38 rows=30938 width=32)
                                                                                       ->  Hash  (cost=1076.46..1076.46 rows=35846 width=48)
                                                                                             ->  Seq Scan on school_cohorts  (cost=0.00..1076.46 rows=35846 width=48)
                                                                                 ->  Parallel Hash  (cost=2646.21..2646.21 rows=31121 width=22)
                                                                                       ->  Parallel Seq Scan on schools  (cost=0.00..2646.21 rows=31121 width=22)
                                                                           ->  Hash  (cost=1.01..1.01 rows=1 width=18)
                                                                                 ->  Seq Scan on cohorts  (cost=0.00..1.01 rows=1 width=18)
                                                                     ->  Parallel Hash  (cost=6299.94..6299.94 rows=50712 width=32)
                                                                           ->  Parallel Seq Scan on participant_profiles participant_profiles_induction_records  (cost=0.00..6299.94 rows=50712 width=32)
                                                                                 Filter: ((type)::text = ANY ('{ParticipantProfile::ECF,ParticipantProfile::ECT,ParticipantProfile::Mentor}'::text[]))
                                                               ->  Parallel Hash  (cost=3521.78..3521.78 rows=67578 width=30)
                                                                     ->  Parallel Seq Scan on ecf_participant_eligibilities  (cost=0.00..3521.78 rows=67578 width=30)
                                                         ->  Parallel Hash  (cost=4883.02..4883.02 rows=47502 width=23)
                                                               ->  Parallel Seq Scan on ecf_participant_validation_data  (cost=0.00..4883.02 rows=47502 width=23)
                                                   ->  Parallel Hash  (cost=6023.14..6023.14 rows=73814 width=32)
                                                         ->  Parallel Seq Scan on participant_profiles mentor_profiles  (cost=0.00..6023.14 rows=73814 width=32)
                                             ->  Parallel Hash  (cost=6515.10..6515.10 rows=78910 width=46)
                                                   ->  Parallel Seq Scan on participant_identities preferred_identities  (cost=0.00..6515.10 rows=78910 width=46)
                                       ->  Parallel Hash  (cost=13174.98..13174.98 rows=100609 width=84)
                                             ->  Parallel Hash Left Join  (cost=6705.77..13174.98 rows=100609 width=84)
                                                   Hash Cond: (teacher_profiles.user_id = users.id)
                                                   ->  Parallel Seq Scan on teacher_profiles  (cost=0.00..3611.09 rows=100609 width=39)
                                                   ->  Parallel Hash  (cost=4682.01..4682.01 rows=80301 width=77)
                                                         ->  Parallel Seq Scan on users  (cost=0.00..4682.01 rows=80301 width=77)
                                 ->  Parallel Hash  (cost=16684.37..16684.37 rows=73814 width=75)
                                       ->  Parallel Hash Left Join  (cost=8118.47..16684.37 rows=73814 width=75)
                                             Hash Cond: (participant_profiles.participant_identity_id = participant_identities.id)
                                             ->  Parallel Seq Scan on participant_profiles  (cost=0.00..6023.14 rows=73814 width=67)
                                             ->  Parallel Hash  (cost=6515.10..6515.10 rows=78910 width=40)
                                                   ->  Parallel Seq Scan on participant_identities  (cost=0.00..6515.10 rows=78910 width=40)
                     ->  Hash  (cost=7.34..7.34 rows=34 width=139)
                           ->  Seq Scan on schedules  (cost=0.00..7.34 rows=34 width=139)
               ->  Hash  (cost=21624.12..21624.12 rows=158 width=16)
                     ->  Subquery Scan on latest_induction_records  (cost=20594.13..21624.12 rows=158 width=16)
                           Filter: (latest_induction_records.created_at_precedence = 1)
                           ->  WindowAgg  (cost=20594.13..21227.97 rows=31692 width=48)
                                 ->  Sort  (cost=20594.13..20673.36 rows=31692 width=40)
                                       Sort Key: induction_records_1.participant_profile_id, induction_records_1.created_at DESC
                                       ->  Gather  (cost=10256.43..18224.86 rows=31692 width=40)
                                             Workers Planned: 2
                                             ->  Hash Join  (cost=9256.43..14055.66 rows=13205 width=40)
                                                   Hash Cond: (induction_records_1.schedule_id = schedule.id)
                                                   ->  Hash Join  (cost=9248.58..14008.83 rows=13205 width=56)
                                                         Hash Cond: (induction_records_1.induction_programme_id = induction_programme.id)
                                                         ->  Parallel Hash Join  (cost=6933.84..11388.28 rows=46335 width=72)
                                                               Hash Cond: (induction_records_1.participant_profile_id = participant_profiles_1.id)
                                                               ->  Parallel Seq Scan on induction_records induction_records_1  (cost=0.00..4277.41 rows=67441 width=72)
                                                               ->  Parallel Hash  (cost=6299.94..6299.94 rows=50712 width=16)
                                                                     ->  Parallel Seq Scan on participant_profiles participant_profiles_1  (cost=0.00..6299.94 rows=50712 width=16)
                                                                           Filter: ((type)::text = ANY ('{ParticipantProfile::ECF,ParticipantProfile::ECT,ParticipantProfile::Mentor}'::text[]))
                                                         ->  Hash  (cost=2204.53..2204.53 rows=8817 width=16)
                                                               ->  Hash Join  (cost=1188.92..2204.53 rows=8817 width=16)
                                                                     Hash Cond: (induction_programme.partnership_id = partnerships.id)
                                                                     ->  Seq Scan on induction_programmes induction_programme  (cost=0.00..934.38 rows=30938 width=32)
                                                                     ->  Hash  (cost=1089.14..1089.14 rows=7983 width=16)
                                                                           ->  Seq Scan on partnerships  (cost=0.00..1089.14 rows=7983 width=16)
                                                                                 Filter: ((challenged_at IS NULL) AND (challenge_reason IS NULL) AND (lead_provider_id = 'xxxx'::uuid))
                                                   ->  Hash  (cost=7.42..7.42 rows=34 width=16)
                                                         ->  Seq Scan on schedules schedule  (cost=0.00..7.42 rows=34 width=16)
                                                               Filter: (cohort_id = ANY ('{xxxx}'::uuid[]))
         ->  Index Scan using participant_identities_pkey on participant_identities participant_identities_mentor_profiles  (cost=0.42..0.59 rows=1 width=32)
               Index Cond: (id = mentor_profiles.participant_identity_id)
(95 rows)


```
* Benchmarking

Running the following benchmarking on getting all records (without pagination) from a production DB for the biggest provider:
```
Benchmark.bm do |x|
  x.report("Old:") do
    ActiveRecord::Base.connection.clear_query_cache
    Api::V1::ParticipantFromInductionRecordSerializer.new(
  Api::V1::ECF::ParticipantsQuery.new(
    lead_provider: CpdLeadProvider.find_by(name: "Name").lead_provider, 
    params: {}).induction_records).serializable_hash; 0
  end
  x.report("New:") do
    ActiveRecord::Base.connection.clear_query_cache
    Api::V1::ParticipantFromQuerySerializer.new(
  Api::V1::ECF::ParticipantsQuery2.new(
    lead_provider: CpdLeadProvider.find_by(name: "Name").lead_provider, params: {}).induction_records).serializable_hash; 0
  end
end
```
yielded the following results:

```
Old:
 24.762972   1.201354  25.964326 ( 35.074589)
 24.470624   1.082605  25.553229 ( 34.487978)
New:  
  8.803960   0.542724   9.346684 ( 12.353814)
  8.609070   0.580131   9.189201 ( 11.815815)
```

* Comparing datasets with current query

Datasets for both queries have been tested to be exact matches, that includes filtering by cohort, updated since and pagination

