### PR TITLE
Show informative messages on empty admin pages

### DIFF
--- a/app/views/admin/participants/history/show.html.erb
+++ b/app/views/admin/participants/history/show.html.erb
@@ -2,26 +2,30 @@
 
 <%= render partial: "admin/participants/nav" %>
 
-<h2 class="govuk-heading-m">Key events</h2>
+<% if @latest_induction_records.present? %>
+  <h2 class="govuk-heading-m">Key events</h2>
 
-<%= govuk_summary_list(
-  rows: [
-    {
-      key: { text: "Added to the service" },
-      value: { text: @latest_induction_record.user.created_at.to_date.to_s(:govuk) }
-    }
-  ]
-) %>
-
-<%= govuk_table(
-  caption: "School transfers",
-  head: ["School name", "Induction programme", "Start date", "End date"],
-  rows: @historical_induction_records.map do |r|
-    [
-      r.school_cohort.school.name,
-      r.induction_programme.training_programme.humanize,
-      r.start_date.to_date.to_s(:govuk),
-      r.end_date&.to_date&.to_s(:govuk),
+  <%= govuk_summary_list(
+    rows: [
+      {
+        key: { text: "Added to the service" },
+        value: { text: @latest_induction_record.user.created_at.to_date.to_s(:govuk) }
+      }
     ]
-  end,
-) %>
+  ) %>
+
+  <%= govuk_table(
+    caption: "School transfers",
+    head: ["School name", "Induction programme", "Start date", "End date"],
+    rows: @historical_induction_records.map do |r|
+      [
+        r.school_cohort.school.name,
+        r.induction_programme.training_programme.humanize,
+        r.start_date.to_date.to_s(:govuk),
+        r.end_date&.to_date&.to_s(:govuk),
+      ]
+    end,
+  ) %>
+<% else %>
+  <p>No key events for <%= @participant_profile.full_name %>.</p>
+<% end %>

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -8,98 +8,101 @@
 
 <%= render partial: "admin/participants/nav" %>
 
-<h2 class="govuk-heading-m">Induction records</h2>
+<% if @all_induction_records.present? %>
+  <h2 class="govuk-heading-m">Induction records</h2>
 
-<% @all_induction_records.each do |induction_record| %>
-  <%= tag.h3(induction_record.id, class: "govuk-heading-s") %>
+  <% @all_induction_records.each do |induction_record| %>
+    <%= tag.h3(induction_record.id, class: "govuk-heading-s") %>
 
-  <%=
-    govuk_summary_list do |sl|
-      sl.row do |row|
-        row.key(text: "Cohort")
-        row.value(text: induction_record.cohort.start_year)
-      end
+    <%=
+      govuk_summary_list do |sl|
+        sl.row do |row|
+          row.key(text: "Cohort")
+          row.value(text: induction_record.cohort.start_year)
+        end
 
-      sl.row do |row|
-        row.key(text: "School name")
-        row.value do
-          govuk_link_to(
-            induction_record.school_name,
-            admin_school_path(induction_record.school.friendly_id)
-          )
+        sl.row do |row|
+          row.key(text: "School name")
+          row.value do
+            govuk_link_to(
+              induction_record.school_name,
+              admin_school_path(induction_record.school.friendly_id)
+            )
+          end
+        end
+
+        sl.row do |row|
+          row.key(text: "School URN")
+          row.value(text: induction_record.school_urn)
+        end
+
+        sl.row do |row|
+          row.key(text: "Preferred email")
+          row.value(text: induction_record.participant_email)
+        end
+
+        sl.row do |row|
+          row.key(text: "Training programme")
+          row.value(text: induction_programme_friendly_name(induction_record.training_programme))
+        end
+
+        sl.row do |row|
+          row.key(text: "Lead provider")
+          row.value(text: induction_record.lead_provider_name || "No lead provider")
+        end
+
+        sl.row do |row|
+          row.key(text: "Delivery partner")
+          row.value(text: induction_record.delivery_partner_name || "No delivery partner")
+        end
+
+        sl.row do |row|
+          row.key(text: "School transfer")
+          row.value(text: induction_record.school_transfer)
+        end
+
+        sl.row do |row|
+          row.key(text: "Induction status")
+          row.value(text: induction_record.induction_status)
+        end
+
+        sl.row do |row|
+          row.key(text: "Training status")
+          row.value(text: induction_record.training_status)
+        end
+
+        sl.row do |row|
+          row.key(text: "Mentor")
+          row.value(text: induction_record.mentor_full_name)
+        end
+
+        sl.row do |row|
+          row.key(text: "Schedule")
+          row.value(text: induction_record.schedule_identifier)
+        end
+
+        sl.row do |row|
+          row.key(text: "Appropriate body")
+          row.value(text: induction_record.appropriate_body_name)
+        end
+
+        sl.row do |row|
+          row.key(text: "Creation date")
+          row.value(text: induction_record.created_at&.to_s(:govuk))
+        end
+
+        sl.row do |row|
+          row.key(text: "Start date")
+          row.value(text: induction_record.start_date.to_formatted_s(:govuk))
+        end
+
+        sl.row do |row|
+          row.key(text: "End date")
+          row.value(text: induction_record.end_date&.to_s(:govuk))
         end
       end
-
-      sl.row do |row|
-        row.key(text: "School URN")
-        row.value(text: induction_record.school_urn)
-      end
-
-      sl.row do |row|
-        row.key(text: "Preferred email")
-        row.value(text: induction_record.participant_email)
-      end
-
-      sl.row do |row|
-        row.key(text: "Training programme")
-        row.value(text: induction_programme_friendly_name(induction_record.training_programme))
-      end
-
-      sl.row do |row|
-        row.key(text: "Lead provider")
-        row.value(text: induction_record.lead_provider_name || "No lead provider")
-      end
-
-      sl.row do |row|
-        row.key(text: "Delivery partner")
-        row.value(text: induction_record.delivery_partner_name || "No delivery partner")
-      end
-
-      sl.row do |row|
-        row.key(text: "School transfer")
-        row.value(text: induction_record.school_transfer)
-      end
-
-      sl.row do |row|
-        row.key(text: "Induction status")
-        row.value(text: induction_record.induction_status)
-      end
-
-      sl.row do |row|
-        row.key(text: "Training status")
-        row.value(text: induction_record.training_status)
-      end
-
-      sl.row do |row|
-        row.key(text: "Mentor")
-        row.value(text: induction_record.mentor_full_name)
-      end
-
-      sl.row do |row|
-        row.key(text: "Schedule")
-        row.value(text: induction_record.schedule_identifier)
-      end
-
-      sl.row do |row|
-        row.key(text: "Appropriate body")
-        row.value(text: induction_record.appropriate_body_name)
-      end
-
-      sl.row do |row|
-        row.key(text: "Creation date")
-        row.value(text: induction_record.created_at&.to_s(:govuk))
-      end
-
-      sl.row do |row|
-        row.key(text: "Start date")
-        row.value(text: induction_record.start_date.to_formatted_s(:govuk))
-      end
-
-      sl.row do |row|
-        row.key(text: "End date")
-        row.value(text: induction_record.end_date&.to_s(:govuk))
-      end
-    end
-  %>
-
+    %>
+  <% end %>
+<% else %>
+  <p>No induction records for <%= @participant_profile.full_name %>.</p>
 <% end %>

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -3,6 +3,10 @@
 module ParticipantSteps
   include Capybara::DSL
 
+  def active_tab_selector
+    ".app-subnav__list-item--selected"
+  end
+
   # Given
 
   def given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
@@ -181,11 +185,11 @@ module ParticipantSteps
   end
 
   def and_i_should_see_the_participant_history
-    expect(page).to have_css("h2", text: "Key events")
+    expect(page).to have_css(active_tab_selector, text: "History")
   end
 
   def and_i_should_see_the_participant_induction_records
-    expect(page).to have_css("h2", text: "Induction records")
+    expect(page).to have_css(active_tab_selector, text: "Induction records")
   end
 
   def and_i_should_see_the_participant_cohorts
@@ -205,7 +209,7 @@ module ParticipantSteps
   end
 
   def and_i_should_see_the_participant_identities
-    expect(page).to have_css("h2", text: "Identities")
+    expect(page).to have_css(active_tab_selector, text: "Identities")
     expect(page).to have_text(@participant_profile_ect.user.email)
   end
 


### PR DESCRIPTION
### Changes proposed in this pull request

Instead of showing an empty page or an error display a message that tells the user there is no data.

Would recommend disabling whitespace when reviewing this PR, only a handful of lines have actually changed.
