### PR TITLE
Ignore the .mailmap file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 /public/assets
 .byebug_history
+.mailmap
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key


### PR DESCRIPTION
### Context

[gitmailmap](https://git-scm.com/docs/gitmailmap) lets you locally override the names of people who committed to a project. I find it easier to work with names than a combination of name and GitHub handles, so adding this to the `.gitignore`.
