### PR TITLE
Add induction record created_at to analytics data

### DIFF
--- a/app/services/analytics/ecf_induction_service.rb
+++ b/app/services/analytics/ecf_induction_service.rb
@@ -27,6 +27,7 @@ module Analytics
         record.cohort_id = induction_record&.cohort&.id
         record.user_id = participant_profile.user_id
         record.participant_type = participant_profile.type
+        record.induction_record_created_at = induction_record.created_at
 
         record.save!
       end

--- a/db/analytics_migrate/20230131103200_add_created_at_to_inductions.rb
+++ b/db/analytics_migrate/20230131103200_add_created_at_to_inductions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCreatedAtToInductions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ecf_inductions, :induction_record_created_at, :datetime
+  end
+end

--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_06_194713) do
+ActiveRecord::Schema.define(version: 2023_01_31_103200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2022_12_06_194713) do
     t.uuid "cohort_id"
     t.uuid "user_id"
     t.string "participant_type"
+    t.datetime "induction_record_created_at"
     t.index ["induction_record_id"], name: "index_ecf_inductions_on_induction_record_id", unique: true
   end
 

--- a/spec/services/analytics/ecf_induction_service_spec.rb
+++ b/spec/services/analytics/ecf_induction_service_spec.rb
@@ -26,5 +26,6 @@ describe Analytics::ECFInductionService do
     expect(record.induction_status).to eq "leaving"
     expect(record.end_date).to be_within(1.second).of end_date
     expect(record.cohort_id).to eq induction_programme.school_cohort.cohort.id
+    expect(record.induction_record_created_at).to eq induction_record.created_at
   end
 end


### PR DESCRIPTION
### Context

The creation timestamp for induction records is useful for the analytics team. The existing `created_at` timestamp on the analytics table is the creation date of the analytics record, not the induction record itself.
