### PR TITLE
Build induction coordinators when seeding data

### DIFF
--- a/db/new_seeds/base/add_schools_and_local_authorities.rb
+++ b/db/new_seeds/base/add_schools_and_local_authorities.rb
@@ -51,6 +51,7 @@ end
   add_school_to_local_authority(
     school: FactoryBot.create(
       :seed_school,
+      :with_induction_coordinator,
       urn: i.to_s.rjust(6, "0"),
       name: "ZZ Test School #{i}",
       primary_contact_email: "cpd-test+school-#{i}@digital.education.gov.uk",

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -38,7 +38,7 @@ module NewSeeds
             # set up school with cohort, lead provider, delivery partner and induction programme
 
             # we'll probably be doing a lot of this, might make sense to move it somewhere communal
-            @school ||= FactoryBot.create(:seed_school)
+            @school ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
             @lead_provider ||= FactoryBot.create(:seed_lead_provider)
 
             @school_cohort = @school.school_cohorts.find_by(cohort: cohort(2022)) || FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school:)
@@ -110,7 +110,7 @@ module NewSeeds
             participant_validation_data = if validation_data
                                             FactoryBot.create(
                                               :seed_ecf_participant_validation_data,
-                                              :valid,
+                                              participant_profile:,
                                               user:,
                                             )
                                           end

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
@@ -42,8 +42,8 @@ module NewSeeds
 
           def setup
             # schools with cohorts
-            @school_from ||= FactoryBot.create(:seed_school)
-            @school_to ||= FactoryBot.create(:seed_school)
+            @school_from ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
+            @school_to ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
             @school_cohort_from = FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school: school_from)
             @school_cohort_to = FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school: school_to)
 

--- a/spec/factories/seeds/school_cohort_factory.rb
+++ b/spec/factories/seeds/school_cohort_factory.rb
@@ -10,13 +10,13 @@ FactoryBot.define do
     trait(:fip) { induction_programme_choice { "full_induction_programme" } }
     trait(:cip) { induction_programme_choice { "core_induction_programme" } }
 
+    trait(:starting_in_2021) { cohort { Cohort.find_or_create_by!(start_year: 2021) } }
+    trait(:starting_in_2022) { cohort { Cohort.find_or_create_by!(start_year: 2022) } }
+
     trait(:valid) do
       with_school
-      with_cohort
+      starting_in_2022
     end
-
-    trait(:starting_in_2021) { cohort { Cohort.find_by!(start_year: 2021) } }
-    trait(:starting_in_2022) { cohort { Cohort.find_by!(start_year: 2022) } }
 
     after(:build) do |sc|
       if sc.cohort.present? && sc.school.present?

--- a/spec/factories/seeds/school_factory.rb
+++ b/spec/factories/seeds/school_factory.rb
@@ -19,6 +19,11 @@ FactoryBot.define do
     administrative_district_code { "E123" }
 
     trait(:closed) { school_status_code { 2 } }
+
+    trait(:with_induction_coordinator) do
+      induction_coordinator_profiles { FactoryBot.build_list(:seed_induction_coordinator_profile, 2, :with_user) }
+    end
+
     trait(:valid) {}
 
     after(:build) { |s| Rails.logger.debug("seeded school #{s.name}") }

--- a/spec/factories/seeds/user_factory.rb
+++ b/spec/factories/seeds/user_factory.rb
@@ -5,7 +5,11 @@ FactoryBot.define do
     transient { identity { Faker::Name.name } }
 
     full_name { identity }
-    email { "#{identity.parameterize}@#{Faker::Alphanumeric.alpha(number: 5)}.#{Faker::Internet.domain_name}" }
+    email { "#{identity.parameterize}.#{Faker::Alphanumeric.alpha(number: 5)}@example.com" }
+
+    trait :random do
+      email { "#{identity.parameterize}@#{Faker::Alphanumeric.alpha(number: 5)}.#{Faker::Internet.domain_name}" }
+    end
 
     trait :with_login_token do
       login_token { Faker::Alphanumeric.alpha(number: 10) }


### PR DESCRIPTION
### Context

Previously schools were built without an induction coordinator. So we can test various journies more easily the following changes have been made:

* make user emails end in @example.com by default (allowing us to log in with any account in dev)
* ensure we generate induction coordinator profiles for schools when seeding

The process for testing out a school journey as an IC would be to log in with admin@example.com, choose a school, copy the email address and either log out and back in with it or to log in in a private browser window.
