### PR TITLE
Fix bug on history tab

### DIFF
--- a/app/views/admin/participants/history/show.html.erb
+++ b/app/views/admin/participants/history/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render partial: "admin/participants/nav" %>
 
-<% if @latest_induction_records.present? %>
+<% if @latest_induction_record.present? %>
   <h2 class="govuk-heading-m">Key events</h2>
 
   <%= govuk_summary_list(


### PR DESCRIPTION
### Context

We're checking for the presence of plural `@latest_induction_records` but the instance variable is singular `@latest_induction_record`.
