### PR TITLE
CST-1246: add rake task to remind SITs to add mentors to their ECTs

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -28,6 +28,23 @@ class SchoolMailer < ApplicationMailer
   SIT_FIP_PARTICIPANT_VALIDATION_DEADLINE_REMINDER_TEMPLATE = "48f63205-a8d9-49a2-a76c-93d48ec9b23b"
   SCHOOL_PRETERM_REMINDER = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
   PARTICIPANT_WITHDRAWN_BY_PROVIDER = "29f94916-8c3a-4c5a-9e33-bdf3f5d7249a"
+  REMIND_TO_SETUP_MENTOR_TO_ECTS = "604ca80f-b152-4682-9295-9cf1d30f74c1"
+
+  def remind_sit_to_set_mentor_to_ects(sit:, ect_names:, campaign: nil)
+    campaign_tracking = campaign ? UTMService.email(campaign, campaign) : {}
+
+    template_mail(
+      REMIND_TO_SETUP_MENTOR_TO_ECTS,
+      to: sit.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sit_name: sit.full_name,
+        ect_names:,
+        sign_in: new_user_session_url(**campaign_tracking),
+      },
+    ).tag(:sit_to_set_mentor_to_ects).associate_with(sit.induction_coordinator_profile)
+  end
 
   # This email is currently (30/09/2021) only used for manually sent chaser emails
   def remind_induction_coordinator_to_setup_cohort_email(induction_coordinator_profile:, school_name:, campaign: nil)

--- a/app/queries/schools/with_ects_with_no_mentor_query.rb
+++ b/app/queries/schools/with_ects_with_no_mentor_query.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Schools
+  class WithEctsWithNoMentorQuery < BaseService
+    def call
+      ParticipantProfile::ECT.joins(:user,
+                                    :ecf_participant_eligibility,
+                                    current_induction_records: {
+                                      school: :induction_coordinators,
+                                    })
+                             .where(mentor_profile_id: nil, status: :active, training_status: :active)
+                             .where.not(ecf_participant_eligibilities: { status: :ineligible })
+                             .group_by do |ect|
+        ect.latest_current_induction_record.school
+      end
+    end
+  end
+end

--- a/lib/tasks/no_mentor_reminders.rake
+++ b/lib/tasks/no_mentor_reminders.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :no_mentor_reminders do
+  desc "Send reminder to all SITs whose school has at least one ECT with no mentor associated"
+  task send: :environment do
+    Schools::WithEctsWithNoMentorQuery.call.each do |school, ects|
+      SchoolMailer.remind_sit_to_set_mentor_to_ects(
+        sit: school.induction_coordinators.first,
+        ect_names: ects.map(&:full_name),
+      ).deliver_later
+    end
+  end
+end

--- a/spec/queries/with_ects_with_no_mentor_query_spec.rb
+++ b/spec/queries/with_ects_with_no_mentor_query_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Schools::WithEctsWithNoMentorQuery do
+  describe "#call" do
+    subject { described_class.new.call }
+
+    context "when there are participants with mentor assigned" do
+      let!(:mentor_profile) { create(:seed_mentor_participant_profile, :valid) }
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, mentor_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "do not include them" do
+        expect(subject).not_to include(induction_record.school)
+      end
+    end
+
+    context "when there are participants with withdrawn induction status" do
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, status: :withdrawn) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "do not include them" do
+        expect(subject).not_to include(induction_record.school)
+      end
+    end
+
+    context "when there are participants with withdrawn training induction status" do
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, training_status: :withdrawn) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "do not include them" do
+        expect(subject).not_to include(induction_record.school)
+      end
+    end
+
+    context "when there are participants with deferred training induction status" do
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, training_status: :deferred) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "do not include them" do
+        expect(subject).not_to include(induction_record.school)
+      end
+    end
+
+    context "when there are active participants :ineligible and with no mentor associated" do
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, :ineligible, participant_profile:) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "do not include them" do
+        expect(subject).not_to include(induction_record.school)
+      end
+    end
+
+    context "when there are active participants on :matched eligibility and no mentor associated" do
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:, status: :matched) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "include them" do
+        expect(subject).to include(induction_record.school => [participant_profile])
+      end
+    end
+
+    context "when there are active participants on :manual-check eligibility and no mentor associated" do
+      let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, :manual_check, participant_profile:) }
+      let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
+      let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
+
+      it "include them" do
+        expect(subject).to include(induction_record.school => [participant_profile])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1246)

### Changes proposed in this pull request

 - New rake task to print a list of schools with at least one ECT with no mentor associated.
 - New rake task to send a reminder to any school with at least one ECT with no mentor associated.

### Guidance to review

