### PR TITLE
Seed provider relationships

### DIFF
--- a/db/new_seeds/base/add_users.rb
+++ b/db/new_seeds/base/add_users.rb
@@ -24,6 +24,7 @@ Rails.logger.info("Building a lead provider user")
 NewSeeds::Scenarios::Users::LeadProviderUser
   .new(email: "lead-provider@example.com", full_name: "Lead provider user")
   .build
+  .add_delivery_partners
 
 Rails.logger.info("Building a CIP induction coordinator")
 NewSeeds::Scenarios::InductionCoordinator

--- a/db/new_seeds/scenarios/users/lead_provider_user.rb
+++ b/db/new_seeds/scenarios/users/lead_provider_user.rb
@@ -16,6 +16,21 @@ module NewSeeds
           lead_provider_user = user || FactoryBot.create(:seed_user, **new_user_attributes)
 
           FactoryBot.create(:seed_lead_provider_profile, user: lead_provider_user, lead_provider:)
+
+          self
+        end
+
+        def add_delivery_partners
+          delivery_partner = DeliveryPartner.order(Arel.sql("RANDOM()")).first
+
+          Cohort.all.each do |cohort|
+            FactoryBot.create(
+              :seed_provider_relationship,
+              lead_provider:,
+              delivery_partner:,
+              cohort:,
+            )
+          end
         end
       end
     end

--- a/spec/factories/seeds/provider_relationship_factory.rb
+++ b/spec/factories/seeds/provider_relationship_factory.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_provider_relationship, class: "ProviderRelationship") do
+    trait(:with_cohort) do
+      association(:cohort, factory: :seed_cohort)
+    end
+
+    trait(:with_cohort_2022) do
+      cohort { Cohort.find_or_create_by!(start_year: 2022) }
+    end
+
+    trait(:with_lead_provider) do
+      association(:lead_provider, factory: :seed_lead_provider)
+    end
+
+    trait(:with_delivery_partner) do
+      association(:delivery_partner, factory: :seed_delivery_partner)
+    end
+
+    trait(:valid) do
+      with_delivery_partner
+      with_lead_provider
+      with_cohort_2022
+    end
+
+    after(:build) do |pr|
+      if pr.cohort.present? && pr.lead_provider.present? && pr.delivery_partner.present?
+        Rails.logger.debug("seeded provider relationships between #{pr.lead_provider.name} and #{pr.delivery_partner.name} for #{pr.cohort.start_year}")
+      else
+        Rails.logger.debug("seeded incomplete provider relationship")
+      end
+    end
+  end
+end

--- a/spec/seeds/seed_factories/provider_relationship_factory_spec.rb
+++ b/spec/seeds/seed_factories/provider_relationship_factory_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "./shared_factory_examples"
+
+RSpec.describe("seed_provider_relationship") do
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_provider_relationship }
+    let(:factory_class) { ProviderRelationship }
+  end
+end


### PR DESCRIPTION
### Context

This change adds provider relationships to the seeding process for the `lead-provider@example.com` user. Now when they log in there will be a list under 'Your schools' - before there was blank space.

### Changes proposed in this pull request

- Add factory for provider relationships
- Add provider relationship building to seed
