### PR TITLE
Stop the n+1 query on admin participants index

### DIFF
--- a/app/services/admin/participants/search.rb
+++ b/app/services/admin/participants/search.rb
@@ -49,12 +49,12 @@ private
 
   def left_outer_joins
     [
-      :participant_identity,
+      :teacher_profile,
       :ecf_participant_eligibility,
       :ecf_participant_validation_data,
       :validation_decisions,
       { current_induction_records: :school },
-      { participant_identity: { user: :teacher_profile } },
+      { participant_identity: :user },
     ]
   end
 


### PR DESCRIPTION
### Context

We appear to be running many queries to pull details from the teacher profile table that are used in the participants table on the index view. We can fetch these using the main query by joining using `participant_profile.teacher_profile_id`.

| Before | After |
| ------ | ------- |
| ![Screenshot from 2023-02-07 15-25-02](https://user-images.githubusercontent.com/128088/217287602-a1766292-3d57-48dd-9b6c-5df60f6d9f1b.png) | ![Screenshot from 2023-02-07 15-24-47](https://user-images.githubusercontent.com/128088/217287634-7b4a8011-c47d-4e77-9d43-8acf07d4d3f0.png) |

These benchmarks are local so won't be representative of what we'll see in prod where network traversal per query is factored in. This should make a decent impact.
