### PR TITLE
Create mentors/ects for delivery partner user

### DIFF
--- a/db/new_seeds/base/add_users.rb
+++ b/db/new_seeds/base/add_users.rb
@@ -19,6 +19,7 @@ Rails.logger.info("Building a delivery partner user with two delivery partners")
 NewSeeds::Scenarios::Users::DeliveryPartnerUser
   .new(number: 2, email: "delivery-partner@example.com", full_name: "Delivery partner user")
   .build
+  .add_mentors_and_ects
 
 Rails.logger.info("Building a lead provider user")
 NewSeeds::Scenarios::Users::LeadProviderUser

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -26,12 +26,13 @@ module NewSeeds
                         :lead_provider,
                         :induction_programme
 
-          def initialize(school: nil, mentor: nil, lead_provider: nil, number: 2)
+          def initialize(school: nil, mentor: nil, lead_provider: nil, delivery_partner: nil, number: 2)
             Rails.logger.info("################# seeding scenario MentoringMultipleEctsWithSameProvider")
-            @school        = school
-            @mentor        = mentor
-            @number        = number
-            @lead_provider = lead_provider
+            @school           = school
+            @mentor           = mentor
+            @number           = number
+            @lead_provider    = lead_provider
+            @delivery_partner = delivery_partner
           end
 
           def build
@@ -40,10 +41,10 @@ module NewSeeds
             # we'll probably be doing a lot of this, might make sense to move it somewhere communal
             @school ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
             @lead_provider ||= FactoryBot.create(:seed_lead_provider)
+            @delivery_partner ||= FactoryBot.create(:seed_delivery_partner)
 
             @school_cohort = @school.school_cohorts.find_by(cohort: cohort(2022)) || FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school:)
 
-            @delivery_partner = FactoryBot.create(:seed_delivery_partner)
             @partnership = FactoryBot.create(:seed_partnership,
                                              cohort: cohort(2022),
                                              school:,

--- a/db/new_seeds/scenarios/users/delivery_partner_user.rb
+++ b/db/new_seeds/scenarios/users/delivery_partner_user.rb
@@ -4,7 +4,7 @@ module NewSeeds
   module Scenarios
     module Users
       class DeliveryPartnerUser
-        attr_reader :user, :supplied_delivery_partners, :number, :new_user_attributes
+        attr_reader :user, :supplied_delivery_partners, :number, :new_user_attributes, :all_delivery_partners
 
         def initialize(user: nil, delivery_partner: nil, delivery_partners: [], number: 0, full_name: nil, email: nil)
           @user = user
@@ -18,8 +18,20 @@ module NewSeeds
 
           generated_delivery_partners = FactoryBot.create_list(:seed_delivery_partner, number)
 
-          [*supplied_delivery_partners, *generated_delivery_partners].map do |delivery_partner|
+          @all_delivery_partners = [*supplied_delivery_partners, *generated_delivery_partners]
+
+          all_delivery_partners.map do |delivery_partner|
             FactoryBot.create(:seed_delivery_partner_profile, delivery_partner:, user:)
+          end
+
+          self
+        end
+
+        def add_mentors_and_ects
+          all_delivery_partners.each do |delivery_partner|
+            NewSeeds::Scenarios::Participants::Mentors::MentoringMultipleEctsWithSameProvider
+              .new(delivery_partner:)
+              .build
           end
         end
       end


### PR DESCRIPTION
### Context

When we log into a fresh app as `delivery-partner@example.com` there were no participants listed. We can use the existing 'mentor with ects' scenario to generate them by allowing it to take `delivery_partner` as an argument.
