### PR TITLE
Add TRN and Cohort to admin participant page header

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -47,14 +47,18 @@ module AdminHelper
     safe_join(parts.compact_blank, tag.br)
   end
 
-  def admin_participant_header_and_title(full_name:, role:, trn:, cohort:, section:)
-    content_for(:title) { "#{full_name} - #{section}" }
+  def admin_participant_header_and_title(profile:, section:)
+    full_name = profile.full_name
+    role = admin_participant_role_name(profile.class.name)
+    trn = profile.teacher_profile.trn
+    cohort = profile.cohort.start_year
 
-    caption = tag.span(role, class: "govuk-caption-xl")
     visually_hidden = tag.span(" - #{section}", class: "govuk-visually-hidden")
 
+    content_for(:title) { "#{full_name} - #{section}" }
+
     safe_join([
-      caption,
+      tag.span(role, class: "govuk-caption-xl"),
       tag.h1(class: "govuk-heading-xl") { safe_join([full_name, visually_hidden]) },
       tag.p do
         safe_join(

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -47,7 +47,7 @@ module AdminHelper
     safe_join(parts.compact_blank, tag.br)
   end
 
-  def admin_participant_header_and_title(full_name:, role:, trn:, section:)
+  def admin_participant_header_and_title(full_name:, role:, trn:, cohort:, section:)
     content_for(:title) { "#{full_name} - #{section}" }
 
     caption = tag.span(role, class: "govuk-caption-xl")
@@ -61,6 +61,14 @@ module AdminHelper
           [
             tag.span("TRN: ", class: "govuk-body govuk-!-font-weight-bold"),
             trn,
+          ],
+        )
+      end,
+      tag.p do
+        safe_join(
+          [
+            tag.span("Cohort: ", class: "govuk-body govuk-!-font-weight-bold"),
+            cohort,
           ],
         )
       end,

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -47,7 +47,7 @@ module AdminHelper
     safe_join(parts.compact_blank, tag.br)
   end
 
-  def admin_participant_header_and_title(full_name:, role:, section:)
+  def admin_participant_header_and_title(full_name:, role:, trn:, section:)
     content_for(:title) { "#{full_name} - #{section}" }
 
     caption = tag.span(role, class: "govuk-caption-xl")
@@ -56,6 +56,14 @@ module AdminHelper
     safe_join([
       caption,
       tag.h1(class: "govuk-heading-xl") { safe_join([full_name, visually_hidden]) },
+      tag.p do
+        safe_join(
+          [
+            tag.span("TRN: ", class: "govuk-body govuk-!-font-weight-bold"),
+            trn,
+          ],
+        )
+      end,
     ])
   end
 

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -51,7 +51,7 @@ module AdminHelper
     full_name = profile.full_name
     role = admin_participant_role_name(profile.class.name)
     trn = profile.teacher_profile.trn
-    cohort = profile.cohort.start_year
+    cohort = profile.cohort&.start_year
 
     visually_hidden = tag.span(" - #{section}", class: "govuk-visually-hidden")
 

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -37,6 +37,7 @@ class ParticipantProfile < ApplicationRecord
     ].freeze
 
     self.ignored_columns = %i[mentor_profile_id school_cohort_id]
+    belongs_to :cohort, optional: true
     belongs_to :school, optional: true
     belongs_to :npq_course, optional: true
 

--- a/app/views/admin/participants/cohorts/show.html.erb
+++ b/app/views/admin/participants/cohorts/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "Cohorts"
   )
 %>

--- a/app/views/admin/participants/cohorts/show.html.erb
+++ b/app/views/admin/participants/cohorts/show.html.erb
@@ -2,6 +2,7 @@
   admin_participant_header_and_title(
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
     section: "Cohorts"
   )
 %>

--- a/app/views/admin/participants/cohorts/show.html.erb
+++ b/app/views/admin/participants/cohorts/show.html.erb
@@ -3,6 +3,7 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
+    cohort: @participant_profile.cohort.start_year,
     section: "Cohorts"
   )
 %>

--- a/app/views/admin/participants/declaration_history/show.html.erb
+++ b/app/views/admin/participants/declaration_history/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "Declaration history"
   )
 %>

--- a/app/views/admin/participants/declaration_history/show.html.erb
+++ b/app/views/admin/participants/declaration_history/show.html.erb
@@ -3,6 +3,7 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
+    cohort: @participant_profile.cohort.start_year,
     section: "Declaration history"
   )
 %>

--- a/app/views/admin/participants/declaration_history/show.html.erb
+++ b/app/views/admin/participants/declaration_history/show.html.erb
@@ -2,6 +2,7 @@
   admin_participant_header_and_title(
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
     section: "Declaration history"
   )
 %>

--- a/app/views/admin/participants/details/show.html.erb
+++ b/app/views/admin/participants/details/show.html.erb
@@ -3,6 +3,7 @@
     full_name: @user.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
+    cohort: @participant_profile.cohort.start_year,
     section: "Details"
   )
 %>

--- a/app/views/admin/participants/details/show.html.erb
+++ b/app/views/admin/participants/details/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @user.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "Details"
   )
 %>

--- a/app/views/admin/participants/details/show.html.erb
+++ b/app/views/admin/participants/details/show.html.erb
@@ -1,4 +1,11 @@
-<%= admin_participant_header_and_title(full_name: @user.full_name, role: admin_participant_role_name(@participant_profile.class.name), section: "Details") %>
+<%=
+  admin_participant_header_and_title(
+    full_name: @user.full_name,
+    role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
+    section: "Details"
+  )
+%>
 
 <% if @participant_profile.npq? %>
   <%= render partial: "show_npq" %>

--- a/app/views/admin/participants/history/show.html.erb
+++ b/app/views/admin/participants/history/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "History"
   )
 %>

--- a/app/views/admin/participants/history/show.html.erb
+++ b/app/views/admin/participants/history/show.html.erb
@@ -3,8 +3,10 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
-    section: "History")
-  %>
+    cohort: @participant_profile.cohort.start_year,
+    section: "History"
+  )
+%>
 
 <%= render partial: "admin/participants/nav" %>
 

--- a/app/views/admin/participants/history/show.html.erb
+++ b/app/views/admin/participants/history/show.html.erb
@@ -1,4 +1,10 @@
-<%= admin_participant_header_and_title(full_name: @participant_profile.full_name, role: admin_participant_role_name(@participant_profile.class.name), section: "History") %>
+<%=
+  admin_participant_header_and_title(
+    full_name: @participant_profile.full_name,
+    role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
+    section: "History")
+  %>
 
 <%= render partial: "admin/participants/nav" %>
 

--- a/app/views/admin/participants/identities/show.html.erb
+++ b/app/views/admin/participants/identities/show.html.erb
@@ -3,6 +3,7 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
+    cohort: @participant_profile.cohort.start_year,
     section: "Identities"
   )
 %>

--- a/app/views/admin/participants/identities/show.html.erb
+++ b/app/views/admin/participants/identities/show.html.erb
@@ -2,6 +2,7 @@
   admin_participant_header_and_title(
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
     section: "Identities"
   )
 %>

--- a/app/views/admin/participants/identities/show.html.erb
+++ b/app/views/admin/participants/identities/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "Identities"
   )
 %>

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -3,6 +3,7 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
+    cohort: @participant_profile.cohort.start_year,
     section: "Induction records"
   )
 %>

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "Induction records"
   )
 %>

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -2,6 +2,7 @@
   admin_participant_header_and_title(
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
     section: "Induction records"
   )
 %>

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -1,4 +1,10 @@
-<%= admin_participant_header_and_title(full_name: @participant_profile.full_name, role: admin_participant_role_name(@participant_profile.class.name), section: "School") %>
+<%=
+  admin_participant_header_and_title(
+    full_name: @participant_profile.full_name,
+    role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
+    section: "School")
+  %>
 
 <%= render partial: "admin/participants/nav" %>
 

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -1,12 +1,9 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "School"
   )
-  %>
+%>
 
 <%= render partial: "admin/participants/nav" %>
 

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -3,7 +3,9 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
-    section: "School")
+    cohort: @participant_profile.cohort.start_year,
+    section: "School"
+  )
   %>
 
 <%= render partial: "admin/participants/nav" %>

--- a/app/views/admin/participants/validation_data/show.html.erb
+++ b/app/views/admin/participants/validation_data/show.html.erb
@@ -2,6 +2,7 @@
   admin_participant_header_and_title(
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
+    trn: @participant_profile.teacher_profile.trn,
     section: "Validation data"
   )
 %>

--- a/app/views/admin/participants/validation_data/show.html.erb
+++ b/app/views/admin/participants/validation_data/show.html.erb
@@ -1,9 +1,6 @@
 <%=
   admin_participant_header_and_title(
-    full_name: @participant_profile.full_name,
-    role: admin_participant_role_name(@participant_profile.class.name),
-    trn: @participant_profile.teacher_profile.trn,
-    cohort: @participant_profile.cohort.start_year,
+    profile: @participant_profile,
     section: "Validation data"
   )
 %>

--- a/app/views/admin/participants/validation_data/show.html.erb
+++ b/app/views/admin/participants/validation_data/show.html.erb
@@ -3,6 +3,7 @@
     full_name: @participant_profile.full_name,
     role: admin_participant_role_name(@participant_profile.class.name),
     trn: @participant_profile.teacher_profile.trn,
+    cohort: @participant_profile.cohort.start_year,
     section: "Validation data"
   )
 %>

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -89,11 +89,34 @@ RSpec.describe AdminHelper, type: :helper do
   end
 
   describe "#admin_participant_header_and_title" do
-    subject { admin_participant_header_and_title(section: "ABC", full_name: "Joey", role: "Mentor") }
+    let(:profile) do
+      create(
+        :mentor_participant_profile,
+        user: create(:user, full_name: "Joey"),
+      )
+    end
+
+    subject do
+      admin_participant_header_and_title(
+        profile:,
+        section: "ABC",
+      )
+    end
 
     it "returns a h1 tag the section that has a caption containing the user name" do
       expect(subject).to have_css("h1", text: /Joey - ABC/)
+    end
+
+    it "returns a caption containing the user role" do
       expect(subject).to have_css(".govuk-caption-xl", text: "Mentor")
+    end
+
+    it "returns the TRN" do
+      expect(subject).to have_content(/TRN: \d+/)
+    end
+
+    it "returns the cohort" do
+      expect(subject).to have_content(/Cohort: \d+/)
     end
   end
 


### PR DESCRIPTION
### Context

TRN is Teacher Reference Number. It's a unique number given to all qualified teachers

Cohort is the year the person began their ECF.

We already show the data in the admin pages.

This PR surfaces them so they're visible from everywhere.

