### PR TITLE
[CPDLP-1957] Add Sidekiq job for sending a participant outcome to TRA

### DIFF
--- a/app/jobs/participant_outcomes/send_to_qualified_teachers_api_job.rb
+++ b/app/jobs/participant_outcomes/send_to_qualified_teachers_api_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ParticipantOutcomes
+  class SendToQualifiedTeachersApiJob < ApplicationJob
+    queue_as :participant_outcomes
+    retry_on StandardError, attempts: 3
+
+    def perform(_participant_outcome)
+      # TODO: needs to be implemented
+      "actioned"
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,4 @@
   - priority_mailers
   - mailers
   - default
+  - participant_outcomes

--- a/spec/jobs/participant_outcomes/send_to_qualified_teachers_api_job_spec.rb
+++ b/spec/jobs/participant_outcomes/send_to_qualified_teachers_api_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomes::SendToQualifiedTeachersApiJob, :with_default_schedules do
+  describe "#perform" do
+    let(:participant_declaration) { create :npq_participant_declaration }
+    let(:participant_outcome) { create :participant_outcome, participant_declaration: }
+
+    it "executes successfully" do
+      expect(described_class.new.perform(participant_outcome)).to eql("actioned")
+    end
+
+    it "queues job" do
+      expect {
+        described_class.perform_later(participant_outcome)
+      }.to have_enqueued_job.on_queue("participant_outcomes")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1957

### Changes proposed in this pull request

* Sidekiq config setup and empty job `ParticipantOutcomes::SendToQualifiedTeachersApiJob` created

### Guidance to review

