### PR TITLE
[CPDLP-1955] Create participant outcome api request model

### DIFF
--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -8,6 +8,8 @@ class ParticipantOutcome::NPQ < ApplicationRecord
   private_constant :VALID_STATES
 
   belongs_to :participant_declaration, class_name: "ParticipantDeclaration::NPQ"
+  has_many :participant_outcome_api_requests, foreign_key: :participant_outcome_id
+
   enum state: VALID_STATES.index_with(&:to_s)
 
   validates :state, presence: true

--- a/app/models/participant_outcome_api_request.rb
+++ b/app/models/participant_outcome_api_request.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ParticipantOutcomeApiRequest < ApplicationRecord
+  belongs_to :participant_outcome, class_name: "ParticipantOutcome::NPQ"
+end

--- a/db/migrate/20230210115830_add_qualified_teachers_api_status_and_sent_to_qualified_teachers_api_at_to_participant_outcomes.rb
+++ b/db/migrate/20230210115830_add_qualified_teachers_api_status_and_sent_to_qualified_teachers_api_at_to_participant_outcomes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddQualifiedTeachersApiStatusAndSentToQualifiedTeachersApiAtToParticipantOutcomes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :participant_outcomes, :qualified_teachers_api_request_successful, :boolean
+    add_column :participant_outcomes, :sent_to_qualified_teachers_api_at, :datetime
+  end
+end

--- a/db/migrate/20230210120533_create_participant_outcome_api_requests.rb
+++ b/db/migrate/20230210120533_create_participant_outcome_api_requests.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateParticipantOutcomeApiRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :participant_outcome_api_requests do |t|
+      t.string :request_path
+      t.integer :status_code
+      t.jsonb :request_headers
+      t.jsonb :request_body
+      t.jsonb :response_body
+      t.jsonb :response_headers
+      t.references :participant_outcome, null: false, foreign_key: true, type: :uuid, index: { name: "index_participant_outcome_api_requests_on_participant_outcome" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_25_182955) do
+ActiveRecord::Schema.define(version: 2023_02_10_120533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -662,12 +662,27 @@ ActiveRecord::Schema.define(version: 2023_01_25_182955) do
     t.index ["user_id"], name: "index_participant_identities_on_user_id"
   end
 
+  create_table "participant_outcome_api_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "request_path"
+    t.integer "status_code"
+    t.jsonb "request_headers"
+    t.jsonb "request_body"
+    t.jsonb "response_body"
+    t.jsonb "response_headers"
+    t.uuid "participant_outcome_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["participant_outcome_id"], name: "index_participant_outcome_api_requests_on_participant_outcome"
+  end
+
   create_table "participant_outcomes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "state", null: false
     t.date "completion_date", null: false
     t.uuid "participant_declaration_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "qualified_teachers_api_request_successful"
+    t.datetime "sent_to_qualified_teachers_api_at"
     t.index ["participant_declaration_id"], name: "index_declaration"
   end
 
@@ -1075,6 +1090,7 @@ ActiveRecord::Schema.define(version: 2023_01_25_182955) do
   add_foreign_key "participant_declarations", "participant_profiles"
   add_foreign_key "participant_declarations", "users"
   add_foreign_key "participant_identities", "users"
+  add_foreign_key "participant_outcome_api_requests", "participant_outcomes"
   add_foreign_key "participant_outcomes", "participant_declarations"
   add_foreign_key "participant_profile_schedules", "participant_profiles"
   add_foreign_key "participant_profile_schedules", "schedules"

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe ParticipantOutcome::NPQ, :with_default_schedules, type: :model do
       )
       expect(declaration.reload.outcomes).to include(new_outcome)
     end
+
+    it { is_expected.to have_many(:participant_outcome_api_requests) }
   end
 
   describe "state" do

--- a/spec/models/participant_outcome_api_request_spec.rb
+++ b/spec/models/participant_outcome_api_request_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomeApiRequest, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:participant_outcome).class_name("ParticipantOutcome::NPQ") }
+  end
+end


### PR DESCRIPTION
### Context

Some new required models/fields are required for TRA outcome integration.

- Ticket: [CPDLP-1955](https://dfedigital.atlassian.net/browse/CPDLP-1955)

### Changes proposed in this pull request

- Add the new fields qualifications_api_status and sent_to_qualifications_api_at  to the outcomes table; (think of better names that indicate which API). This will help us re-queue jobs and capture the timestamp of a successful request to TRA. 

- Add the following new model: ParticipantOutcomeAPIRequest;

[CPDLP-1955]: https://dfedigital.atlassian.net/browse/CPDLP-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ