### PR TITLE
Create job to handle notify callbacks offline

### DIFF
--- a/app/controllers/api/notify_callbacks_controller.rb
+++ b/app/controllers/api/notify_callbacks_controller.rb
@@ -10,14 +10,7 @@ class Api::NotifyCallbacksController < Api::ApiController
 
     log_email if failed_email?
 
-    # TODO: Replace PartnershipNotificationEmail and NominationEmail with more generic Email
-    mail = PartnershipNotificationEmail.find_by(notify_id: params[:id]) || NominationEmail.find_by(notify_id: params[:id])
-    mail.update!(notify_status: params[:status], delivered_at: params[:sent_at]&.to_datetime) if mail
-
-    Email.where(id: params[:id]).update_all(
-      status: params[:status],
-      delivered_at: params[:sent_at],
-    )
+    HandleNotifyCallbackJob.perform_later(email_id: params[:id], delivery_status: params[:status], sent_at: params[:sent_at])
 
     head :no_content
   end

--- a/app/jobs/handle_notify_callback_job.rb
+++ b/app/jobs/handle_notify_callback_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HandleNotifyCallbackJob < ApplicationJob
+  def perform(email_id:, delivery_status:, sent_at:)
+    mail = PartnershipNotificationEmail.find_by(notify_id: email_id) || NominationEmail.find_by(notify_id: email_id)
+    mail.update!(notify_status: delivery_status, delivered_at: sent_at) if mail
+
+    Email.find(email_id).update!(status: delivery_status, delivered_at: sent_at)
+  end
+end

--- a/spec/jobs/handle_notify_callback_job_spec.rb
+++ b/spec/jobs/handle_notify_callback_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe(HandleNotifyCallbackJob, :with_default_schedules) do
+  let(:one_hour_ago) { 1.hour.ago }
+  let!(:email) { Email.create(id: notify_email.notify_id) }
+
+  context "when the email is a partnership notification email" do
+    let!(:notify_email) { FactoryBot.create(:partnership_notification_email) }
+
+    it "updates the partnership notification email record" do
+      expect(notify_email.notify_status).to be_blank
+      expect(email.status).to eq("submitted")
+      expect(email.delivered_at).to be_blank
+
+      HandleNotifyCallbackJob.new.perform(
+        email_id: notify_email.notify_id,
+        delivery_status: "delivered",
+        sent_at: one_hour_ago.to_s,
+      )
+
+      notify_email.reload
+      email.reload
+
+      expect(notify_email.notify_status).to eq("delivered")
+      expect(email.status).to eq("delivered")
+      expect(email.delivered_at).to eq(one_hour_ago.to_s)
+    end
+  end
+
+  context "when the email is a nomination email" do
+    let!(:notify_email) { FactoryBot.create(:nomination_email) }
+
+    it "updates the nomination email record" do
+      expect(notify_email.notify_status).to be_blank
+      expect(email.status).to eq("submitted")
+      expect(email.delivered_at).to be_blank
+
+      HandleNotifyCallbackJob.new.perform(
+        email_id: notify_email.notify_id,
+        delivery_status: "delivered",
+        sent_at: one_hour_ago.to_s,
+      )
+
+      notify_email.reload
+      email.reload
+
+      expect(notify_email.notify_status).to eq("delivered")
+      expect(email.status).to eq("delivered")
+      expect(email.delivered_at).to eq(one_hour_ago.to_s)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We don't need to deal with the notify callbacks immediately, instead create jobs and let them be picked up in due course.
