### PR TITLE
Critical stats task

### DIFF
--- a/app/controllers/admin/participants/event_history_controller.rb
+++ b/app/controllers/admin/participants/event_history_controller.rb
@@ -7,7 +7,7 @@ module Admin::Participants
     def show
       @user = @participant_profile.user
 
-      events = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events.sort(&:date).reverse
+      events = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events.sort_by(&:date).reverse
       @event_list = events
     end
   end

--- a/app/controllers/admin/participants/event_history_controller.rb
+++ b/app/controllers/admin/participants/event_history_controller.rb
@@ -6,9 +6,7 @@ module Admin::Participants
 
     def show
       @user = @participant_profile.user
-
-      events = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events.sort_by(&:date).reverse
-      @event_list = events
+      @event_list = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events
     end
   end
 end

--- a/app/controllers/admin/participants/event_history_controller.rb
+++ b/app/controllers/admin/participants/event_history_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class EventHistoryController < Admin::BaseController
+    include RetrieveProfile
+
+    def show
+      @user = @participant_profile.user
+
+      events = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events.sort(&:date).reverse
+      @event_list = events
+    end
+  end
+end

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+# noinspection RubyInstanceMethodNamingConvention
+class Participants::HistoryBuilder
+  class ParticipantEvent
+    attr_reader :object, :date, :predicate, :reporter, :value
+
+    def initialize(id, date, predicate, reporter, value)
+      @object = id
+      @predicate = predicate
+      @value = value
+      @date = date
+      @reporter = reporter
+    end
+
+    def to_h
+      {
+        object:,
+        predicate:,
+        value:,
+        date:,
+        reporter:,
+      }
+    end
+  end
+
+  attr_reader :events
+
+  def initialize(user)
+    @user = user
+    @events = []
+
+    # TODO: paper trail entities to investigate for other relevant events
+    # - InductionCoordinatorProfile ( showing when a new SIT took over )
+    # - SchoolMentors ( what schools the participant is a mentor for )
+
+    return if @user.nil?
+
+    record_user_events @user
+    record_teacher_record_events @user.teacher_profile unless @user.teacher_profile.nil?
+
+    @user.participant_identities.each { |identity| record_identity_events(identity) } unless @user.participant_identities.empty?
+
+    unless @user.participant_profiles.empty?
+      @user.participant_profiles.each do |profile|
+        record_profile_events(profile)
+        record_participant_declaration_events(profile.participant_declarations.sort_by(&:created_at))
+
+        # the following are only relevant to ECF profiles
+        next unless profile.ecf?
+
+        record_school_cohort_events(profile.school_cohort) unless profile.school_cohort.nil?
+        record_validation_events(profile.ecf_participant_validation_data) unless profile.ecf_participant_validation_data.nil?
+        record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.nil?
+        record_eligibility_events(profile.ecf_participant_eligibility) unless profile.ecf_participant_eligibility.nil?
+
+        # not all ECF Participants have induction records !!
+        record_induction_record_events(profile.induction_records.oldest_first) unless profile.induction_records.empty?
+      end
+    end
+
+    @events.sort_by!(&:date)
+  end
+
+  def self.from_participant_profile(profile)
+    new(profile.user)
+  end
+
+  def self.from_user(user)
+    new(user)
+  end
+
+private
+
+  def record_user_events(user)
+    record_paper_trail_events(user)
+  end
+
+  def record_teacher_record_events(teacher_record)
+    record_paper_trail_events(teacher_record)
+  end
+
+  def record_profile_events(participant_profile)
+    record_paper_trail_events(participant_profile)
+  end
+
+  def record_identity_events(identity)
+    @events.push ParticipantEvent.new(@user.id, identity.created_at, "#{identity.class}.email", "Unknown", "email-hidden")
+  end
+
+  def record_induction_record_events(induction_records)
+    # TODO: induction_record versions might create duplicate events in the log
+    induction_records.each { |record| record_paper_trail_events(record) }
+  end
+
+  def record_participant_declaration_events(declarations)
+    declarations.each do |declaration|
+      description = "#{declaration.declaration_type.capitalize}Declaration.made"
+      actor = declaration.cpd_lead_provider.name
+      @events.push ParticipantEvent.new(@user.id, declaration.declaration_date, description, actor, nil)
+
+      declaration.declaration_states.each do |declaration_state|
+        description = "#{declaration.declaration_type.capitalize}Declaration.state"
+        actor = declaration.cpd_lead_provider.name
+        value = declaration_state.state
+
+        @events.push ParticipantEvent.new(@user.id, declaration_state.created_at, description, actor, value)
+      end
+    end
+  end
+
+  def record_school_cohort_events(school_cohort)
+    record_paper_trail_events(school_cohort)
+  end
+
+  def record_partnership_events(partnership)
+    record_paper_trail_events(partnership)
+  end
+
+  def record_validation_events(validation_data)
+    validation_data.attributes.each do |key, value|
+      next unless key != "created_at" || key != "updated_at"
+
+      description = "#{validation_data.class}.#{key}"
+      actor = "Unknown"
+
+      value = "#{key}-hidden" if %w[full_name date_of_birth nino].include?(key)
+
+      # as we don't keep a history the data in this object can only be reliably true from the last updated field
+      @events.push ParticipantEvent.new(@user.id, validation_data.updated_at, description, actor, value)
+    end
+
+    # validation_data is not auditable
+  end
+
+  def record_eligibility_events(eligibility)
+    record_paper_trail_events(eligibility)
+  end
+
+  def record_validation_decision_events(decisions)
+    decisions.each { |decision| record_paper_trail_events(decision) }
+  end
+
+  def record_paper_trail_events(entity)
+    entity.versions&.each do |version|
+      # TODO: if the version is of type "created" then we need to record the default values that were not overridden
+
+      version.object_changes&.each do |key, value|
+        if key == "school_cohort_id"
+          record_school_cohort_events(value)
+        end
+
+        next unless key != "created_at" && key != "updated_at" && key != "notes" && key != "school_ukprn" && key != "start_date" && key != "end_date" && !(key == "induction_status" && value == "changed")
+
+        description = "#{entity.class}.#{key}"
+        actor = get_user_label(version.whodunnit)
+        value = value[1]
+
+        # hide PII
+        value = "#{key}-hidden" if %w[full_name email date_of_birth nino].include?(key)
+        value = get_cohort_label(value) if key == "cohort_id"
+        value = get_schedule_label(value) if key == "schedule_id"
+        value = get_lead_provider_label(value) if key == "lead_provider_id"
+        value = get_delivery_partner_label(value) if key == "delivery_partner_id"
+        value = get_appropriate_body_label(value) if key == "appropriate_body_id"
+
+        if %w[induction_programme_id core_induction_programme_id default_induction_programme_id].include?(key)
+          value = get_induction_programme_label(value)
+        end
+
+        @events.push ParticipantEvent.new(@user.id, version.created_at, description, actor, value)
+      end
+    end
+  end
+
+  def get_user_label(whodunnit)
+    user = User.find whodunnit
+    return whodunnit || "Unknown" if user.nil?
+
+    parts = user.email.split("@")
+    parts[1] || parts[0]
+  end
+
+  def get_lead_provider_label(lead_provider_id)
+    lead_provider = LeadProvider.find lead_provider_id
+    return lead_provider_id if lead_provider.nil?
+
+    lead_provider.name
+  end
+
+  def get_delivery_partner_label(delivery_partner_id)
+    delivery_partner = DeliveryPartner.find delivery_partner_id
+    return delivery_partner_id if delivery_partner.nil?
+
+    delivery_partner.name
+  end
+
+  def get_schedule_label(schedule_id)
+    schedule = Schedule.find schedule_id
+    return schedule_id if schedule.nil?
+
+    schedule.schedule_identifier
+  end
+
+  def get_appropriate_body_label(appropriate_body_id)
+    appropriate_body = AppropriateBody.find appropriate_body_id
+    return appropriate_body_id if appropriate_body.nil?
+
+    appropriate_body.name
+  end
+
+  def get_cohort_label(cohort_id)
+    cohort = Cohort.find cohort_id
+    return cohort_id if cohort.nil?
+
+    cohort.academic_year
+  end
+
+  def get_induction_programme_label(induction_programme_id)
+    induction_programme = InductionProgramme.find induction_programme_id
+    return induction_programme_id if induction_programme.nil?
+
+    "#{induction_programme.training_programme}|#{induction_programme.lead_provider.name}|#{induction_programme.delivery_partner.name}|#{induction_programme.cohort.academic_year}"
+  end
+end

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -51,7 +51,7 @@ class Participants::HistoryBuilder
 
         record_school_cohort_events(profile.school_cohort) unless profile.school_cohort.nil?
         record_validation_events(profile.ecf_participant_validation_data) unless profile.ecf_participant_validation_data.nil?
-        record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.nil?
+        record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.empty?
         record_eligibility_events(profile.ecf_participant_eligibility) unless profile.ecf_participant_eligibility.nil?
 
         # not all ECF Participants have induction records !!
@@ -147,7 +147,8 @@ private
 
       version.object_changes&.each do |key, value|
         if key == "school_cohort_id"
-          record_school_cohort_events(value)
+          school_cohort = SchoolCohort.find value
+          record_school_cohort_events(school_cohort) unless school_cohort.nil?
         end
 
         next unless key != "created_at" && key != "updated_at" && key != "notes" && key != "school_ukprn" && key != "start_date" && key != "end_date" && !(key == "induction_status" && value == "changed")

--- a/app/views/admin/participants/event_history/show.html.erb
+++ b/app/views/admin/participants/event_history/show.html.erb
@@ -1,0 +1,20 @@
+<%= admin_participant_header_and_title(full_name: @participant_profile.full_name, role: admin_participant_role_name(@participant_profile.class.name), section: "Event history") %>
+
+<%= render partial: "admin/participants/nav" %>
+
+<% if @event_list.present? %>
+  <%= govuk_table(
+    caption: "Event history",
+    head: %w[Description Value Reporter Date],
+    rows: @event_list.map do |r|
+      [
+        r.predicate,
+        r.value,
+        r.reporter,
+        r.date&.to_s(:govuk),
+      ]
+    end,
+  ) %>
+<% else %>
+  <p>No event history for <%= @participant_profile.full_name %>.</p>
+<% end %>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -29,7 +29,7 @@
           Email address
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @induction_record.preferred_identity.email %>
+          <%= @induction_record.preferred_identity&.email || @profile.participant_identity&.email %>
         </dd>
           <dd class="govuk-summary-list__actions">
           <% if @profile.policy_class.new(current_user, @profile).edit_email? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,6 +277,7 @@ Rails.application.routes.draw do
       resource :cohorts, only: :show, controller: "participants/cohorts"
       resource :declaration_history, only: :show, controller: "participants/declaration_history"
       resource :identities, only: :show, controller: "participants/identities"
+      resource :event_history, only: :show, controller: "participants/event_history"
 
       resource :validation_data, path: "validation-data", only: :show, controller: "participants/validation_data" do
         member do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -642,7 +642,7 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
     t.boolean "sparsity_uplift"
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying, 'clawed_back'::character varying])::text[]))"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text, ('clawed_back'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"
     t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
@@ -1203,7 +1203,7 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
               count(*) AS count
              FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
+            WHERE ((participant_profiles_1.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id) duplicates ON ((duplicates.user_id = participant_identities.user_id)))
        LEFT JOIN teacher_profiles ON ((teacher_profiles.id = participant_profiles.teacher_profile_id)))
        LEFT JOIN schedules ON ((latest_induction_records.schedule_id = schedules.id)))
@@ -1215,9 +1215,9 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
     WHERE ((participant_identities.user_id IN ( SELECT participant_identities_1.user_id
              FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
+            WHERE ((participant_profiles_1.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id
-           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[])))
+           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text])))
     ORDER BY participant_identities.external_identifier, (row_number() OVER (PARTITION BY participant_identities.user_id ORDER BY
           CASE
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -642,7 +642,7 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
     t.boolean "sparsity_uplift"
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text, ('clawed_back'::character varying)::text]))"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying, 'clawed_back'::character varying])::text[]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"
     t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
@@ -1203,7 +1203,7 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
               count(*) AS count
              FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-            WHERE ((participant_profiles_1.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text]))
+            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id) duplicates ON ((duplicates.user_id = participant_identities.user_id)))
        LEFT JOIN teacher_profiles ON ((teacher_profiles.id = participant_profiles.teacher_profile_id)))
        LEFT JOIN schedules ON ((latest_induction_records.schedule_id = schedules.id)))
@@ -1215,9 +1215,9 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
     WHERE ((participant_identities.user_id IN ( SELECT participant_identities_1.user_id
              FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-            WHERE ((participant_profiles_1.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text]))
+            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id
-           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text])))
+           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[])))
     ORDER BY participant_identities.external_identifier, (row_number() OVER (PARTITION BY participant_identities.user_id ORDER BY
           CASE
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1

--- a/lib/tasks/compare/critical_data_changed_checker.rake
+++ b/lib/tasks/compare/critical_data_changed_checker.rake
@@ -113,7 +113,7 @@ Row = Struct.new(
       changed_schedule:,
       registration_year:,
       change_month:,
-      change_year:
+      change_year:,
     }
   end
 

--- a/lib/tasks/compare/critical_data_changed_checker.rake
+++ b/lib/tasks/compare/critical_data_changed_checker.rake
@@ -16,11 +16,14 @@ CSV_REPORT_COLUMNS = %i[
   changed_email
   changed_schedule
   registration_year
+  change_month
+  change_year
 ].freeze
 
 Row = Struct.new(
   :induction_record,
   :participant_profile_id,
+  :participant_type,
   :past_lead_provider_ids,
   :past_delivery_partner_ids,
   :past_school_urns,
@@ -31,6 +34,8 @@ Row = Struct.new(
   :past_schedules,
   :records_started_on,
   :last_updated_on,
+  :change_month,
+  :change_year,
   keyword_init: true,
 ) do
   def records_started
@@ -94,6 +99,7 @@ Row = Struct.new(
   def to_h
     {
       participant_profile_id:,
+      participant_type:,
       records_started:,
       last_updated:,
       changed:,
@@ -106,6 +112,8 @@ Row = Struct.new(
       changed_email:,
       changed_schedule:,
       registration_year:,
+      change_month:,
+      change_year:
     }
   end
 
@@ -124,105 +132,118 @@ def create_csv_report(file_path, rows)
   end
 end
 
-def analyse_period(period_start_date, period_end_date)
+def analyse_period(report_start_date, report_end_date)
   rows = []
-  ParticipantProfile::ECF.find_in_batches.each do |batch|
+  ParticipantProfile::ECF.joins(:induction_records).find_in_batches.each do |batch|
     batch.each do |participant_profile|
       induction_record = participant_profile.induction_records.latest
 
-      previous_versions = InductionRecord
-                            .where(participant_profile_id: induction_record.participant_profile_id)
-                            .where(InductionRecord.arel_table[:updated_at].gteq(period_start_date))
-                            .where(InductionRecord.arel_table[:updated_at].lteq(period_end_date))
-                            .where.not(id: induction_record.id)
+      period_end_date = Date.new(report_start_date.year, report_start_date.month, -1)
 
-      row = Row.new(induction_record:, participant_profile_id: induction_record.participant_profile_id)
+      while period_end_date <= report_end_date
+        period_start_date = period_end_date + 1.day
+        period_end_date = Date.new(period_start_date.year, period_start_date.month, -1)
 
-      participant_created_on = induction_record.participant_profile&.created_at
-      first_induction_record_start_date = induction_record.participant_profile&.induction_records&.oldest&.start_date
-      row.records_started_on = (participant_created_on < first_induction_record_start_date ? participant_created_on : first_induction_record_start_date) unless participant_created_on.nil?
+        previous_versions = InductionRecord
+                              .where(participant_profile_id: participant_profile.id)
+                              .where(InductionRecord.arel_table[:created_at].gteq(period_start_date))
+                              .where(InductionRecord.arel_table[:created_at].lteq(period_end_date))
+                              .where.not(id: induction_record.id)
 
-      row.last_updated_on = induction_record.updated_at
+        row = Row.new(
+          induction_record:,
+          participant_profile_id: participant_profile.id,
+          participant_type: participant_profile.type,
+          change_month: period_start_date.month,
+          change_year: period_start_date.year,
+        )
 
-      # participant identifier
-      # this finds all the previous participant identities and retrieves the external identifiers
-      row.past_identity_ids = previous_versions.map { |pv| pv&.preferred_identity&.external_identifier }
+        participant_created_on = participant_profile.created_at
+        first_induction_record_start_date = participant_profile.induction_records.oldest.start_date
+        row.records_started_on = participant_created_on < first_induction_record_start_date ? participant_created_on : first_induction_record_start_date
 
-      # lead provider
-      # this finds all the previous lead providers which indicates if the participant would have been available in the API
-      row.past_lead_provider_ids = previous_versions.map { |pv| pv&.lead_provider&.id }
+        row.last_updated_on = induction_record.created_at
 
-      # delivery partner
-      # this should have no effect on the availability of the participant through the UI
-      row.past_delivery_partner_ids = previous_versions.map { |pv| pv&.delivery_partner&.id }
+        # participant identifier
+        # this finds all the previous participant identities and retrieves the external identifiers
+        row.past_identity_ids = previous_versions.map { |pv| pv&.preferred_identity&.external_identifier }
 
-      # email
-      # this provides the ability for the Lead Provider to continue with registration
-      row.past_emails = previous_versions.map { |pv| pv&.preferred_identity&.email }
+        # lead provider
+        # this finds all the previous lead providers which indicates if the participant would have been available in the API
+        row.past_lead_provider_ids = previous_versions.map { |pv| pv&.lead_provider&.id }
 
-      # full name
-      # This has to be done through support and should trigger a re-validation of the TRN
-      # a confirmation of DoB is required
-      # in a case where a new TRN is identified a new User and TeacherProfile should be created
+        # delivery partner
+        # this should have no effect on the availability of the participant through the UI
+        row.past_delivery_partner_ids = previous_versions.map { |pv| pv&.delivery_partner&.id }
 
-      # mentor
-      # changes to mentors is a thing that happens due to leavers or reorganisation
-      # mentors are also assigned later in some cases
-      row.past_mentor_ids = previous_versions.map { |pv| pv&.mentor&.id }
+        # email
+        # this provides the ability for the Lead Provider to continue with registration
+        row.past_emails = previous_versions.map { |pv| pv&.preferred_identity&.email }
 
-      # school
-      # a change to this would indicate a transfer of management responsibility
-      row.past_school_urns = previous_versions.map { |pv| pv&.school&.urn }
+        # full name
+        # This has to be done through support and should trigger a re-validation of the TRN
+        # a confirmation of DoB is required
+        # in a case where a new TRN is identified a new User and TeacherProfile should be created
 
-      # participant type
-      # a new ParticipantProfile would be the result of this so it can't be measured
+        # mentor
+        # changes to mentors is a thing that happens due to leavers or reorganisation
+        # mentors are also assigned later in some cases
+        row.past_mentor_ids = previous_versions.map { |pv| pv&.mentor&.id }
 
-      # cohort
-      # lead providers use this to identify which materials are required for a participant
-      # they should actually contact the school for this sort of information
-      row.past_cohort_years = previous_versions.map { |pv| pv&.cohort&.start_year }
+        # school
+        # a change to this would indicate a transfer of management responsibility
+        row.past_school_urns = previous_versions.map { |pv| pv&.school&.urn }
 
-      # school status
-      # indicates whether the current school has stopped managing the records for this participant
+        # participant type
+        # a new ParticipantProfile would be the result of this so it can't be measured
 
-      # TRN
-      # allows multiple participations to be reconciled against each other
-      # fallback for outcome reporting to TRA if it does not come through the CPD APIs
+        # cohort
+        # lead providers use this to identify which materials are required for a participant
+        # they should actually contact the school for this sort of information
+        row.past_cohort_years = previous_versions.map { |pv| pv&.cohort&.start_year }
 
-      # TRN validated
-      # indicates whether there is a possibility that this participant is a duplicate or incorrectly reported
+        # school status
+        # indicates whether the current school has stopped managing the records for this participant
 
-      # funding eligibility
-      # indicates if the school will need to fund the Induction Training themselves
+        # TRN
+        # allows multiple participations to be reconciled against each other
+        # fallback for outcome reporting to TRA if it does not come through the CPD APIs
 
-      # lead provider training status
-      # confirmation of the status set by the lead provider themselves
+        # TRN validated
+        # indicates whether there is a possibility that this participant is a duplicate or incorrectly reported
 
-      # schedule
-      # determines when milestones will be hit
-      row.past_schedules = previous_versions.map { |pv| pv&.schedule&.id }
+        # funding eligibility
+        # indicates if the school will need to fund the Induction Training themselves
 
-      # updated date
-      # changes on sub entities are bubbled up to the ParticipantProfile
-      # User <- ParticipantIdentity
-      # User <- TeacherProfile
-      # User <- TeacherProfile <- ParticipantProfile
-      # User <- TeacherProfile <- ParticipantProfile <- InductionRecord
-      # User <- TeacherProfile <- ParticipantProfile <- ECFParticipantEligibility
-      # User <- TeacherProfile <- ParticipantProfile <- ECFParticipantValidationData
-      # User <- TeacherProfile <- ParticipantProfile <- NPQApplication
+        # lead provider training status
+        # confirmation of the status set by the lead provider themselves
 
-      # paper trail entities
-      # - User
-      # - TeacherProfile
-      # - ParticipantProfile
-      # - InductionRecord
-      # - InductionProgramme
-      # - ECFParticipantEligibility
-      # - Partnership
-      # - SchoolCohort
+        # schedule
+        # determines when milestones will be hit
+        row.past_schedules = previous_versions.map { |pv| pv&.schedule&.id }
 
-      rows << row
+        # updated date
+        # changes on sub entities are bubbled up to the ParticipantProfile
+        # User <- ParticipantIdentity
+        # User <- TeacherProfile
+        # User <- TeacherProfile <- ParticipantProfile
+        # User <- TeacherProfile <- ParticipantProfile <- InductionRecord
+        # User <- TeacherProfile <- ParticipantProfile <- ECFParticipantEligibility
+        # User <- TeacherProfile <- ParticipantProfile <- ECFParticipantValidationData
+        # User <- TeacherProfile <- ParticipantProfile <- NPQApplication
+
+        # paper trail entities
+        # - User
+        # - TeacherProfile
+        # - ParticipantProfile
+        # - InductionRecord
+        # - InductionProgramme
+        # - ECFParticipantEligibility
+        # - Partnership
+        # - SchoolCohort
+
+        rows << row
+      end
     end
   end
 
@@ -254,7 +275,7 @@ namespace :compare do
   #
   # The results are stored in an array of Row structs which is intended to be
   # parsed into a CSV and written to disk
-  namespace :critical_data_changed_checker do
+  namespace :critical_data_changed_checker_task do
     desc "Analyse critical data changes over a period"
 
     task :run, %i[start_date end_date] => :environment do |_task, args|
@@ -268,24 +289,12 @@ namespace :compare do
       puts "Creating folder #{folder_path}/"
       Dir.mkdir folder_path
 
-      period_end_date = Date.new(report_start_date.year, report_start_date.month - 1, 1)
+      file_path = "#{folder_path}/critical-data-changes-report.csv"
+      rows = analyse_period(report_start_date, report_end_date)
+      puts "Writing report to #{file_path}"
 
-      while period_end_date < report_end_date
-        period_start_date = period_end_date + 1.day
-        period_end_date = Date.new(period_start_date.year, period_start_date.month, -1)
-
-        file_path = "#{folder_path}/critical-data-changes-report-#{period_start_date.strftime('%Y-%m-%d')}-#{period_end_date.strftime('%Y-%m-%d')}.csv"
-        rows = analyse_period(period_start_date, period_end_date)
-        puts "Writing report to #{file_path}"
-        create_csv_report(file_path, rows)
-
-        unchanged = rows.reject(&:changed).count
-        changed = rows.filter(&:changed).count
-
-        puts "for period #{period_start_date.strftime('%Y-%m-%d')} to #{period_end_date.strftime('%Y-%m-%d')}"
-        puts sprintf("total participants without changes: %i", unchanged)
-        puts sprintf("total participants with changes: %i", changed)
-      end
+      create_csv_report(file_path, rows)
+      puts "for period #{report_start_date.strftime('%Y-%m-%d')} to #{report_end_date.strftime('%Y-%m-%d')}"
     end
   end
 end

--- a/lib/tasks/compare/event_history_analyser.rake
+++ b/lib/tasks/compare/event_history_analyser.rake
@@ -1,198 +1,20 @@
 # frozen_string_literal: true
 
-require "json-diff"
-
-#noinspection RubyInstanceMethodNamingConvention
-class HistoryBuilder
-  class ParticipantEvent
-    attr_reader :object, :date, :predicate, :reporter, :value
-
-    def initialize(id, date, predicate, reporter, value)
-      @object = id
-      @predicate = predicate
-      @value = value
-      @date = date
-      @reporter = reporter
-    end
-
-    def to_h
-      {
-        object:,
-        predicate:,
-        value:,
-        date:,
-        reporter:,
-      }
-    end
-  end
-
-  attr_reader :events
-
-  def initialize(user)
-    @user = user
-    @events = []
-
-    # TODO: paper trail entities to investigate for other relevant events
-    # - SchoolCohort ( changing may affect participant )
-    # - InductionProgramme ( default changing for school_cohort may affect participant )
-    # - Partnership ( default changing for school_cohort may affect participant )
-    # - InductionCoordinatorProfile ( showing when a new SIT took over )
-    # - SchoolMentors ( what schools the participant is a mentor for )
-
-    record_user_events @user unless @user.nil?
-    record_teacher_record_events @user.teacher_profile unless @user.teacher_profile.nil?
-
-    @user.participant_identities.each { |identity| record_identity_events(identity) } unless @user.participant_identities.empty?
-
-    unless @user.participant_profiles.empty?
-      @user.participant_profiles.each do |profile|
-        record_profile_events(profile)
-        record_participant_declaration_events(profile.participant_declarations.sort_by(&:created_at))
-
-        # the following are only relevant to ECF profiles
-        next unless profile.ecf?
-
-        # not all ECF Participants have induction records !!
-        record_induction_record_events(profile.induction_records.oldest_first) unless profile.induction_records.empty?
-        record_validation_events(profile.ecf_participant_validation_data) unless profile.ecf_participant_validation_data.nil?
-        record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.nil?
-        record_eligibility_events(profile.ecf_participant_eligibility) unless profile.ecf_participant_eligibility.nil?
-
-        # if profile.mentor?
-        #   profile.school_mentors
-        # end
-      end
-    end
-
-    @events.sort_by!(&:date)
-  end
-
-  def self.from_participant_profile(profile)
-    new(profile.user)
-  end
-
-  def self.from_user(user)
-    new(user)
-  end
-
-  private
-
-  def record_user_events(user)
-    record_created_event(user, user.school&.name)
-    record_paper_trail_events(user)
-  end
-
-  def record_teacher_record_events(teacher_record)
-    record_created_event(teacher_record, teacher_record.school&.name)
-    record_paper_trail_events(teacher_record)
-  end
-
-  def record_profile_events(participant_profile)
-    record_created_event(participant_profile, participant_profile.school&.name)
-    record_paper_trail_events(participant_profile)
-  end
-
-  def record_identity_events(identity)
-    record_created_event(identity, nil)
-  end
-
-  def record_induction_record_events(induction_records)
-    record_created_event(induction_records.first, nil)
-
-    previous_record = nil
-    induction_records.each do |record|
-      record.attributes.each do |key, value|
-        if previous_record.nil? || previous_record[key] != value
-          if key != "created_at" && key != "updated_at" && key != "start_date" && key != "end_date" && !(key == "induction_status" && value == "changed")
-            description = "#{record.class}.#{key}"
-            actor = "Unknown" # TODO: papertrail created version will tell us the user
-
-            @events.push ParticipantEvent.new(@user.id, record.start_date, description, actor, value)
-          end
-        end
-      end
-
-      # TODO: we need to compare the created version to the previous_record
-      # record_paper_trail_events(record)
-
-      previous_record = record
-    end
-  end
-
-  def record_participant_declaration_events(declarations)
-    declarations.each do |declaration|
-      description = "#{declaration.declaration_type.capitalize}Declaration.made"
-      actor = declaration.cpd_lead_provider.name
-      @events.push ParticipantEvent.new(@user.id, declaration.declaration_date, description, actor, nil)
-
-      declaration.declaration_states.each do |declaration_state|
-        description = "#{declaration.declaration_type.capitalize}Declaration.state"
-        actor = declaration.cpd_lead_provider.name
-        value = declaration_state.state
-
-        @events.push ParticipantEvent.new(@user.id, declaration_state.created_at, description, actor, value)
-      end
-    end
-  end
-
-  def record_validation_events(validation_data)
-    validation_data.attributes.each do |key, value|
-      if key != "created_at" || key != "updated_at"
-        description = "#{validation_data.class}.#{key}"
-        actor = "Unknown"
-        value = "#{key}-hidden" # obfuscate the value
-
-        @events.push ParticipantEvent.new(@user.id, validation_data.created_at, description, actor, value)
-      end
-    end
-
-    # validation_data is not auditable
-  end
-
-  def record_eligibility_events(eligibility)
-    record_paper_trail_events(eligibility)
-  end
-
-  def record_validation_decision_events(decisions)
-    decisions.each { |decision| record_paper_trail_events(decision) }
-  end
-
-  def record_created_event(entity, actor, value = nil)
-    description = "#{entity.class}.created"
-    actor = actor || "Unknown"
-    @events.push ParticipantEvent.new(@user.id, entity.created_at, description, actor, value)
-  end
-
-  def record_paper_trail_events(entity)
-    entity.versions&.each do |version|
-      version.object_changes&.each do |key, value|
-        if key != "created_at" || key != "updated_at" || key != "notes" || key != "school_ukprn"
-          description = "#{entity.class}.#{key}"
-          actor = version.whodunnit || "Unknown"
-          value = value[1]
-          value = "#{key}-hidden" if key == "full_name" || key == "email"
-          @events.push ParticipantEvent.new(@user.id, version.created_at, description, actor, value)
-        end
-      end
-    end
-  end
-end
-
 namespace :compare do
   namespace :event_history_analyser do
     desc "Extracts a history of events from each user in the database"
 
     task :run, %i[batch_size page] => :environment do |_task, args|
-      args.with_defaults batch_size: '1000', page: '1'
+      args.with_defaults batch_size: "1000", page: "1"
 
       report_batch_size = args[:batch_size].to_i
       report_page = args[:page].to_i - 1
-      report_page = 0 if report_page < 0
+      report_page = 0 if report_page.negative?
 
       folder_timestamp = Time.zone.now.strftime "%Y-%m-%d"
       folder_path = "/tmp/#{folder_timestamp}"
       unless Dir.exist? folder_path
-        puts "[#{DateTime.current.strftime("%H:%M:%S")}] Creating folder #{folder_path}/"
+        puts "[#{Time.current.strftime('%H:%M:%S')}] Creating folder #{folder_path}/"
         Dir.mkdir folder_path
       end
 
@@ -202,11 +24,11 @@ namespace :compare do
 
       events = []
       ecf_participant_profiles.each do |participant_profile|
-        HistoryBuilder.from_participant_profile(participant_profile).events.each { |event| events << event.to_h }
+        Participants::HistoryBuilder.from_participant_profile(participant_profile).events.each { |event| events << event.to_h }
       end
 
       file_path = "#{folder_path}/event-history-#{args[:page]}.json"
-      puts "[#{DateTime.current.strftime("%H:%M:%S")}] Writing #{events.count} events to #{file_path}"
+      puts "[#{Time.current.strftime('%H:%M:%S')}] Writing #{events.count} events to #{file_path}"
       File.open(file_path, "w") { |r| r.puts JSON.generate(events) }
     end
   end

--- a/lib/tasks/compare/event_history_analyser.rake
+++ b/lib/tasks/compare/event_history_analyser.rake
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require "json-diff"
+
+#noinspection RubyInstanceMethodNamingConvention
+class HistoryBuilder
+  class ParticipantEvent
+    attr_reader :object, :date, :predicate, :reporter, :value
+
+    def initialize(id, date, predicate, reporter, value)
+      @object = id
+      @predicate = predicate
+      @value = value
+      @date = date
+      @reporter = reporter
+    end
+
+    def to_h
+      {
+        object:,
+        predicate:,
+        value:,
+        date:,
+        reporter:,
+      }
+    end
+  end
+
+  attr_reader :events
+
+  def initialize(user)
+    @user = user
+    @events = []
+
+    # TODO: paper trail entities to investigate for other relevant events
+    # - SchoolCohort ( changing may affect participant )
+    # - InductionProgramme ( default changing for school_cohort may affect participant )
+    # - Partnership ( default changing for school_cohort may affect participant )
+    # - InductionCoordinatorProfile ( showing when a new SIT took over )
+    # - SchoolMentors ( what schools the participant is a mentor for )
+
+    record_user_events @user unless @user.nil?
+    record_teacher_record_events @user.teacher_profile unless @user.teacher_profile.nil?
+
+    @user.participant_identities.each { |identity| record_identity_events(identity) } unless @user.participant_identities.empty?
+
+    unless @user.participant_profiles.empty?
+      @user.participant_profiles.each do |profile|
+        record_profile_events(profile)
+        record_participant_declaration_events(profile.participant_declarations.sort_by(&:created_at))
+
+        # the following are only relevant to ECF profiles
+        next unless profile.ecf?
+
+        # not all ECF Participants have induction records !!
+        record_induction_record_events(profile.induction_records.oldest_first) unless profile.induction_records.empty?
+        record_validation_events(profile.ecf_participant_validation_data) unless profile.ecf_participant_validation_data.nil?
+        record_validation_decision_events(profile.validation_decisions) unless profile.validation_decisions.nil?
+        record_eligibility_events(profile.ecf_participant_eligibility) unless profile.ecf_participant_eligibility.nil?
+
+        # if profile.mentor?
+        #   profile.school_mentors
+        # end
+      end
+    end
+
+    @events.sort_by!(&:date)
+  end
+
+  def self.from_participant_profile(profile)
+    new(profile.user)
+  end
+
+  def self.from_user(user)
+    new(user)
+  end
+
+  private
+
+  def record_user_events(user)
+    record_created_event(user, user.school&.name)
+    record_paper_trail_events(user)
+  end
+
+  def record_teacher_record_events(teacher_record)
+    record_created_event(teacher_record, teacher_record.school&.name)
+    record_paper_trail_events(teacher_record)
+  end
+
+  def record_profile_events(participant_profile)
+    record_created_event(participant_profile, participant_profile.school&.name)
+    record_paper_trail_events(participant_profile)
+  end
+
+  def record_identity_events(identity)
+    record_created_event(identity, nil)
+  end
+
+  def record_induction_record_events(induction_records)
+    record_created_event(induction_records.first, nil)
+
+    previous_record = nil
+    induction_records.each do |record|
+      record.attributes.each do |key, value|
+        if previous_record.nil? || previous_record[key] != value
+          if key != "created_at" && key != "updated_at" && key != "start_date" && key != "end_date" && !(key == "induction_status" && value == "changed")
+            description = "#{record.class}.#{key}"
+            actor = "Unknown" # TODO: papertrail created version will tell us the user
+
+            @events.push ParticipantEvent.new(@user.id, record.start_date, description, actor, value)
+          end
+        end
+      end
+
+      # TODO: we need to compare the created version to the previous_record
+      # record_paper_trail_events(record)
+
+      previous_record = record
+    end
+  end
+
+  def record_participant_declaration_events(declarations)
+    declarations.each do |declaration|
+      description = "#{declaration.declaration_type.capitalize}Declaration.made"
+      actor = declaration.cpd_lead_provider.name
+      @events.push ParticipantEvent.new(@user.id, declaration.declaration_date, description, actor, nil)
+
+      declaration.declaration_states.each do |declaration_state|
+        description = "#{declaration.declaration_type.capitalize}Declaration.state"
+        actor = declaration.cpd_lead_provider.name
+        value = declaration_state.state
+
+        @events.push ParticipantEvent.new(@user.id, declaration_state.created_at, description, actor, value)
+      end
+    end
+  end
+
+  def record_validation_events(validation_data)
+    validation_data.attributes.each do |key, value|
+      if key != "created_at" || key != "updated_at"
+        description = "#{validation_data.class}.#{key}"
+        actor = "Unknown"
+        value = "#{key}-hidden" # obfuscate the value
+
+        @events.push ParticipantEvent.new(@user.id, validation_data.created_at, description, actor, value)
+      end
+    end
+
+    # validation_data is not auditable
+  end
+
+  def record_eligibility_events(eligibility)
+    record_paper_trail_events(eligibility)
+  end
+
+  def record_validation_decision_events(decisions)
+    decisions.each { |decision| record_paper_trail_events(decision) }
+  end
+
+  def record_created_event(entity, actor, value = nil)
+    description = "#{entity.class}.created"
+    actor = actor || "Unknown"
+    @events.push ParticipantEvent.new(@user.id, entity.created_at, description, actor, value)
+  end
+
+  def record_paper_trail_events(entity)
+    entity.versions&.each do |version|
+      version.object_changes&.each do |key, value|
+        if key != "created_at" || key != "updated_at" || key != "notes" || key != "school_ukprn"
+          description = "#{entity.class}.#{key}"
+          actor = version.whodunnit || "Unknown"
+          value = value[1]
+          value = "#{key}-hidden" if key == "full_name" || key == "email"
+          @events.push ParticipantEvent.new(@user.id, version.created_at, description, actor, value)
+        end
+      end
+    end
+  end
+end
+
+namespace :compare do
+  namespace :event_history_analyser do
+    desc "Extracts a history of events from each user in the database"
+
+    task :run, %i[batch_size page] => :environment do |_task, args|
+      args.with_defaults batch_size: '1000', page: '1'
+
+      report_batch_size = args[:batch_size].to_i
+      report_page = args[:page].to_i - 1
+      report_page = 0 if report_page < 0
+
+      folder_timestamp = Time.zone.now.strftime "%Y-%m-%d"
+      folder_path = "/tmp/#{folder_timestamp}"
+      unless Dir.exist? folder_path
+        puts "[#{DateTime.current.strftime("%H:%M:%S")}] Creating folder #{folder_path}/"
+        Dir.mkdir folder_path
+      end
+
+      ecf_participant_profiles = ParticipantProfile::ECF.order(:created_at)
+                                        .limit(report_batch_size)
+                                        .offset(report_page * report_batch_size)
+
+      events = []
+      ecf_participant_profiles.each do |participant_profile|
+        HistoryBuilder.from_participant_profile(participant_profile).events.each { |event| events << event.to_h }
+      end
+
+      file_path = "#{folder_path}/event-history-#{args[:page]}.json"
+      puts "[#{DateTime.current.strftime("%H:%M:%S")}] Writing #{events.count} events to #{file_path}"
+      File.open(file_path, "w") { |r| r.puts JSON.generate(events) }
+    end
+  end
+end

--- a/spec/services/participants/history_builder_spec.rb
+++ b/spec/services/participants/history_builder_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
+  subject { Participants::HistoryBuilder }
+
+  after do
+    # just to make sure that if we turned it on we don't affect other spec tests
+    PaperTrail.enabled = false
+  end
+
+  describe "without paper_trail enabled" do
+    it "should have the correct attributes listed when a FIP ECT is created" do
+      travel_to(Time.current - 1.minute) do
+        fip_ect_only
+      end
+
+      event_list = described_class.from_participant_profile(fip_ect_only).events
+
+      attributes_changed = event_list.map(&:predicate)
+      expect(attributes_changed).to eq %w[
+        ParticipantIdentity.email
+        ParticipantProfile::ECT.id
+        ParticipantProfile::ECT.participant_identity_id
+        ParticipantProfile::ECT.profile_duplicity
+        ParticipantProfile::ECT.pupil_premium_uplift
+        ParticipantProfile::ECT.schedule_id
+        ParticipantProfile::ECT.school_cohort_id
+        ParticipantProfile::ECT.sparsity_uplift
+        ParticipantProfile::ECT.status
+        ParticipantProfile::ECT.teacher_profile_id
+        ParticipantProfile::ECT.training_status
+        ParticipantProfile::ECT.type
+        SchoolCohort.cohort_id
+        SchoolCohort.id
+        SchoolCohort.induction_programme_choice
+        SchoolCohort.opt_out_of_updates
+        SchoolCohort.school_id
+        TeacherProfile.id
+        TeacherProfile.school_id
+        TeacherProfile.trn
+        TeacherProfile.user_id
+        User.email
+        User.full_name
+        User.id
+        User.sign_in_count
+      ]
+    end
+  end
+
+  describe "with paper_trail enabled" do
+    before do
+      PaperTrail.enabled = true
+    end
+
+    it "should have the correct attributes listed when a FIP ECT is created" do
+      travel_to(Time.current - 1.minute) do
+        fip_ect_only
+      end
+
+      event_list = described_class.from_participant_profile(fip_ect_only).events
+      attributes_changed = event_list.map(&:predicate)
+      expect(attributes_changed).to eq %w[
+        InductionRecord.id
+        InductionRecord.induction_programme_id
+        InductionRecord.participant_profile_id
+        InductionRecord.preferred_identity_id
+        InductionRecord.schedule_id
+        ParticipantIdentity.email
+        ParticipantProfile::ECT.id
+        ParticipantProfile::ECT.participant_identity_id
+        ParticipantProfile::ECT.schedule_id
+        ParticipantProfile::ECT.school_cohort_id
+        ParticipantProfile::ECT.teacher_profile_id
+        ParticipantProfile::ECT.type
+        SchoolCohort.cohort_id
+        SchoolCohort.id
+        SchoolCohort.induction_programme_choice
+        SchoolCohort.school_id
+        TeacherProfile.id
+        TeacherProfile.school_id
+        TeacherProfile.trn
+        TeacherProfile.user_id
+        TeacherProfile.user_id
+        User.email
+        User.full_name
+        User.id
+      ]
+    end
+
+    it "should have the correct lead provider induction programme when a FIP ECT is created" do
+      travel_to(Time.current - 1.minute) do
+        fip_ect_only
+      end
+
+      event_list = described_class.from_participant_profile(fip_ect_only).events
+
+      induction_programme_entries = event_list.filter { |ev| ev.predicate == "InductionRecord.induction_programme_id" }
+      expect(induction_programme_entries.first.value).to include "full_induction_programme|Teach First"
+    end
+
+    it "should record a name change at the end" do
+      travel_to(Time.current - 1.minute) do
+        fip_ect_only
+      end
+
+      fip_ect_only.user.update! full_name: "Martin Luthor"
+
+      event_list = described_class.from_participant_profile(fip_ect_only).events
+
+      expect(event_list.last.predicate).to eq "User.full_name"
+    end
+
+    it "should record a trn change at the end" do
+      travel_to(Time.current - 1.minute) do
+        fip_ect_only
+      end
+
+      fip_ect_only.user.teacher_profile.update! trn: "0123456"
+
+      event_list = described_class.from_participant_profile(fip_ect_only).events
+
+      expect(event_list.last.predicate).to eq "TeacherProfile.trn"
+    end
+
+    it "should record Mentor change at the end" do
+      travel_to(Time.current - 1.minute) do
+        fip_ect_only
+      end
+
+      Induction::ChangeMentor.call induction_record: fip_ect_only.induction_records.latest,
+                                   mentor_profile: fip_mentor_only
+
+      event_list = described_class.from_participant_profile(fip_ect_only).events
+
+      attributes_changed = event_list.map(&:predicate)
+      expect(attributes_changed.last(8)).to eq %w[
+        InductionRecord.id
+        InductionRecord.induction_programme_id
+        InductionRecord.induction_status
+        InductionRecord.mentor_profile_id
+        InductionRecord.participant_profile_id
+        InductionRecord.preferred_identity_id
+        InductionRecord.schedule_id
+        ParticipantProfile::ECT.mentor_profile_id
+      ]
+    end
+  end
+end

--- a/spec/support/with_support_for_ect_examples.rb
+++ b/spec/support/with_support_for_ect_examples.rb
@@ -3,7 +3,7 @@
 RSpec.shared_context "with Support for ECTs example profiles", shared_context: :metadata do
   let!(:cohort) { Cohort.current || create(:cohort, :current) }
 
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Teach First") }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
 
   let(:core_induction_programme) { create(:core_induction_programme, name: lead_provider.name) }

--- a/spec/support/with_support_for_ect_examples.rb
+++ b/spec/support/with_support_for_ect_examples.rb
@@ -3,12 +3,16 @@
 RSpec.shared_context "with Support for ECTs example profiles", shared_context: :metadata do
   let!(:cohort) { Cohort.current || create(:cohort, :current) }
 
-  let(:core_induction_programme) { create(:core_induction_programme, name: "Teach First") }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:lead_provider) { cpd_lead_provider.lead_provider }
+
+  let(:core_induction_programme) { create(:core_induction_programme, name: lead_provider.name) }
   let(:cip_school_cohort) { create :school_cohort, induction_programme_choice: "core_induction_programme" }
   let(:cip_induction_programme) { create(:induction_programme, core_induction_programme:, training_programme: "core_induction_programme", school_cohort: cip_school_cohort) }
 
-  let(:fip_school_cohort) { create :school_cohort, induction_programme_choice: "full_induction_programme" }
-  let(:fip_induction_programme) { create(:induction_programme, :fip, school_cohort: fip_school_cohort) }
+  let(:fip_partnership) { create :partnership, lead_provider: }
+  let(:fip_school_cohort) { create :school_cohort, lead_provider:, induction_programme_choice: "full_induction_programme" }
+  let(:fip_induction_programme) { create(:induction_programme, partnership: fip_partnership, training_programme: "full_induction_programme", school_cohort: fip_school_cohort) }
 
   let(:sit_only) do
     user = create(:user, :induction_coordinator, full_name: "SIT Only")


### PR DESCRIPTION
### Context

It should be possible to see the historical events or changes to a CPD record over time in order to help determine why a record is in the state is is and where we might go to correct or undo any actions that misreported information.

Rake task creates a lists of CPD record change events that can be used to build up metrics of frequency and type of changes made over time

### Changes proposed in this pull request

Add an events tab to the Admin Participants UI to allow Admin Users to view the event history of the record.

Provide a model within the application that understands how to traverse the relevant parts of the data model and papertrails in order to identify significant events in the record making process and transform them into an event list.

a rake task that can be run in small batches to process user profiles into event history lists

### Guidance to review

login as an admin user and proceed to the participants dashboard, from here you can bring up any participants screen and replace the last item in the path with `/event_history`.

bring up the rails console in your chosen environment and run a query to find a `User` or `ParticipantProfile` object. Call `ParticipantEventHistory.from_user` or `ParticipantEventHistory.from_participant_profile` and access the `events` attribute to see a full list of events created for a record.


