### PR TITLE
Fix Selenium deprecation warning

### DIFF
--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -8,13 +8,14 @@ require "site_prism"
 require "site_prism/all_there" # Optional but needed to perform more complex matching
 
 Capybara.register_driver :chrome_headless do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless") unless ENV["NOT_HEADLESS"]
-  options.add_argument("--no-sandbox")
-  options.add_argument("--disable-dev-shm-usage")
-  options.add_argument("--window-size=1400,1400")
+  args = %w[disable-dev-shm-usage no-sandbox window-size=1400,1400]
+  args << "headless" unless ENV["NOT_HEADLESS"]
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: options)
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: Selenium::WebDriver::Options.chrome(args:),
+  )
 end
 
 Capybara.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i


### PR DESCRIPTION
Fixes the following warning when running feature specs:

`WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead.`