### PR TITLE
[CPDLP-2009] Push participant outcome data to big query

### DIFF
--- a/app/jobs/npq/stream_big_query_participant_outcome_job.rb
+++ b/app/jobs/npq/stream_big_query_participant_outcome_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module NPQ
+  class StreamBigQueryParticipantOutcomeJob < ApplicationJob
+    def perform(participant_outcome_id:)
+      bigquery = Google::Cloud::Bigquery.new
+      dataset = bigquery.dataset "npq_participant_outcomes", skip_lookup: true
+      table = dataset.table "npq_participant_outcomes_#{Rails.env.downcase}", skip_lookup: true
+      outcome = ParticipantOutcome::NPQ.find(participant_outcome_id)
+
+      rows = [
+        {
+          participant_outcome_id: outcome.id,
+          state: outcome.state,
+          completion_date: outcome.completion_date,
+          participant_declaration_id: outcome.participant_declaration_id,
+          created_at: outcome.created_at,
+          updated_at: outcome.updated_at,
+        }.stringify_keys,
+      ]
+
+      table.insert(rows, ignore_unknown: true)
+    end
+  end
+end

--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -15,6 +15,8 @@ class ParticipantOutcome::NPQ < ApplicationRecord
   validates :state, presence: true
   validates :completion_date, presence: true, future_date: true
 
+  after_commit :push_outcome_to_big_query
+
   def self.latest
     order(created_at: :desc).first
   end
@@ -23,5 +25,11 @@ class ParticipantOutcome::NPQ < ApplicationRecord
     return nil if voided?
 
     passed?
+  end
+
+private
+
+  def push_outcome_to_big_query
+    NPQ::StreamBigQueryParticipantOutcomeJob.perform_later(participant_outcome_id: id)
   end
 end

--- a/spec/jobs/npq/stream_big_query_participant_outcome_job_spec.rb
+++ b/spec/jobs/npq/stream_big_query_participant_outcome_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NPQ::StreamBigQueryParticipantOutcomeJob, :with_default_schedules do
+  let(:participant_declaration) { create(:npq_participant_declaration) }
+  let(:outcome) { create(:participant_outcome, participant_declaration:) }
+
+  describe "#perform" do
+    let(:bigquery) { double("bigquery") }
+    let(:dataset)  { double("dataset") }
+    let(:table)    { double("table", insert: nil) }
+
+    before do
+      allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery)
+      allow(bigquery).to receive(:dataset).and_return(dataset)
+      allow(dataset).to receive(:table).and_return(table)
+    end
+
+    it "sends correct data to BigQuery" do
+      described_class.perform_now(participant_outcome_id: outcome.id)
+
+      expect(table).to have_received(:insert).with([{
+        participant_outcome_id: outcome.id,
+        state: outcome.state,
+        completion_date: outcome.completion_date,
+        participant_declaration_id: outcome.participant_declaration_id,
+        created_at: outcome.created_at,
+        updated_at: outcome.updated_at,
+      }.stringify_keys], ignore_unknown: true)
+    end
+  end
+end

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -96,4 +96,23 @@ RSpec.describe ParticipantOutcome::NPQ, :with_default_schedules, type: :model do
       expect(outcome.has_passed?).to eql(nil)
     end
   end
+
+  describe "#push_outcome_to_big_query" do
+    context "on create" do
+      it "pushes outcome to BigQuery" do
+        allow(NPQ::StreamBigQueryParticipantOutcomeJob).to receive(:perform_later).and_call_original
+        outcome
+        expect(NPQ::StreamBigQueryParticipantOutcomeJob).to have_received(:perform_later).with(participant_outcome_id: outcome.id)
+      end
+    end
+
+    context "on update" do
+      it "pushes outcome to BigQuery" do
+        allow(NPQ::StreamBigQueryParticipantOutcomeJob).to receive(:perform_later).and_call_original
+        outcome
+        outcome.update!(state: "voided")
+        expect(NPQ::StreamBigQueryParticipantOutcomeJob).to have_received(:perform_later).with(participant_outcome_id: outcome.id).twice
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- We need to be able to report the participant outcomes

- Ticket: [CPDLP-2009](https://dfedigital.atlassian.net/browse/CPDLP-2009)

### Changes proposed in this pull request

- Add the ability to push/stream data into BigQuery
- On npq outcomes creation and updating of state, stream this data to BigQuery asynchronously.



[CPDLP-2009]: https://dfedigital.atlassian.net/browse/CPDLP-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ