### PR TITLE
Ensure preferred identities are created in the initial seed

### DIFF
--- a/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
@@ -26,6 +26,7 @@ module NewSeeds
             FactoryBot.create(
               :seed_induction_record,
               induction_programme:,
+              preferred_identity: participant_identity,
               participant_profile: mentor_profile,
               schedule: Finance::Schedule::ECF.default,
             )

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -66,6 +66,7 @@ module NewSeeds
             @mentee_induction_records = mentees.each do |mentee|
               FactoryBot.create(:seed_induction_record,
                                 participant_profile: mentee.participant_profile,
+                                preferred_identity: mentee.participant_identity,
                                 mentor_profile: mentor.participant_profile,
                                 induction_programme:)
 

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
@@ -19,6 +19,7 @@ module NewSeeds
 
             FactoryBot.create(:seed_induction_record,
                               participant_profile:,
+                              preferred_identity: @participant_identity,
                               induction_programme: induction_programme_to)
           end
         end

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
@@ -39,6 +39,7 @@ module NewSeeds
             # enrol the participant to the new programme (aka create an induction record)
             @relationship_induction_record = FactoryBot.create(:seed_induction_record,
                                                                participant_profile:,
+                                                               preferred_identity: @participant_identity,
                                                                induction_programme: relationship_induction_programme)
           end
         end

--- a/spec/factories/seeds/induction_record_factory.rb
+++ b/spec/factories/seeds/induction_record_factory.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     trait(:with_participant_profile) { association(:participant_profile, factory: %i[seed_ect_participant_profile valid]) }
     trait(:with_induction_programme) { association(:induction_programme, factory: %i[seed_induction_programme valid]) }
     trait(:with_schedule) { association(:schedule, factory: %i[seed_finance_schedule valid]) }
+    trait(:with_preferred_identity) { association(:preferred_identity, factory: %i[seed_participant_identity valid]) }
 
     trait(:valid) do
       with_schedule


### PR DESCRIPTION
### Context

Local dev environments and review apps sometimes crash when viewing a participant from a SIT's point of view because the `preferred_identity` hasn't been set on an induction record.

This PR

* ensures seeded records have a preferred identity
* displays no summary list row (instead of crashing) when there's no email address present

### Changes proposed in this pull request

- Don't blow up when preferred_identity is missing
- Ensure we're setting preferred_identity in seeds
- Add induction record 'preferred_identity' trait

