### PR TITLE
Change target branch across all workflows

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -5,10 +5,10 @@ name: Brakeman Scan
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [ main ]
   schedule:
     - cron: '0 12 * * *'
 

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -3,7 +3,7 @@ name: Deploy to Dev
 on:
   push:
     branches:
-      - develop
+      - main
     paths-ignore:
       - 'documentation/**'
 

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -9,7 +9,7 @@ on:
       ref:
         description: Git ref to deploy
         required: true
-        default: develop
+        default: main
 jobs:
   deploy-to-staging:
     runs-on: ubuntu-20.04

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,7 +1,7 @@
 name: Destroy
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
     types: [ closed ]
 
 jobs:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,7 +1,7 @@
 name: Create Review App
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'documentation/**'


### PR DESCRIPTION
### Context

Conventionally we use `main` for the default branch. When working on multiple projects having to remember ECF uses `develop` is a bit of a hassle.

### Changes

- switch `develop` for `main` in the workflows that are triggered by activity on a branch or clone the repo
