### PR TITLE
[CPDLP-2019] Change job queue to use participant_outcomes

### DIFF
--- a/app/jobs/participant_outcomes/stream_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_big_query_job.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-module NPQ
-  class StreamBigQueryParticipantOutcomeJob < ApplicationJob
+module ParticipantOutcomes
+  class StreamBigQueryJob < ApplicationJob
+    queue_as :participant_outcomes
+
     def perform(participant_outcome_id:)
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_participant_outcomes", skip_lookup: true

--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -30,6 +30,6 @@ class ParticipantOutcome::NPQ < ApplicationRecord
 private
 
   def push_outcome_to_big_query
-    NPQ::StreamBigQueryParticipantOutcomeJob.perform_later(participant_outcome_id: id)
+    ParticipantOutcomes::StreamBigQueryJob.perform_later(participant_outcome_id: id)
   end
 end

--- a/spec/jobs/participant_outcomes/send_to_qualified_teachers_api_job_spec.rb
+++ b/spec/jobs/participant_outcomes/send_to_qualified_teachers_api_job_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ParticipantOutcomes::SendToQualifiedTeachersApiJob, :with_default_schedules do
   describe "#perform" do
     let(:participant_declaration) { create :npq_participant_declaration }
-    let(:participant_outcome) { create :participant_outcome, participant_declaration: }
+    let!(:participant_outcome) { create :participant_outcome, participant_declaration: }
 
     it "executes successfully" do
       expect(described_class.new.perform(participant_outcome)).to eql("actioned")

--- a/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
+++ b/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NPQ::StreamBigQueryParticipantOutcomeJob, :with_default_schedules do
+RSpec.describe ParticipantOutcomes::StreamBigQueryJob, :with_default_schedules do
   let(:participant_declaration) { create(:npq_participant_declaration) }
   let(:outcome) { create(:participant_outcome, participant_declaration:) }
 
@@ -28,6 +28,12 @@ RSpec.describe NPQ::StreamBigQueryParticipantOutcomeJob, :with_default_schedules
         created_at: outcome.created_at,
         updated_at: outcome.updated_at,
       }.stringify_keys], ignore_unknown: true)
+    end
+
+    it "queues job" do
+      expect {
+        described_class.perform_now(participant_outcome_id: outcome.id)
+      }.to have_enqueued_job.on_queue("participant_outcomes")
     end
   end
 end

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -100,18 +100,18 @@ RSpec.describe ParticipantOutcome::NPQ, :with_default_schedules, type: :model do
   describe "#push_outcome_to_big_query" do
     context "on create" do
       it "pushes outcome to BigQuery" do
-        allow(NPQ::StreamBigQueryParticipantOutcomeJob).to receive(:perform_later).and_call_original
+        allow(ParticipantOutcomes::StreamBigQueryJob).to receive(:perform_later).and_call_original
         outcome
-        expect(NPQ::StreamBigQueryParticipantOutcomeJob).to have_received(:perform_later).with(participant_outcome_id: outcome.id)
+        expect(ParticipantOutcomes::StreamBigQueryJob).to have_received(:perform_later).with(participant_outcome_id: outcome.id)
       end
     end
 
     context "on update" do
       it "pushes outcome to BigQuery" do
-        allow(NPQ::StreamBigQueryParticipantOutcomeJob).to receive(:perform_later).and_call_original
+        allow(ParticipantOutcomes::StreamBigQueryJob).to receive(:perform_later).and_call_original
         outcome
         outcome.update!(state: "voided")
-        expect(NPQ::StreamBigQueryParticipantOutcomeJob).to have_received(:perform_later).with(participant_outcome_id: outcome.id).twice
+        expect(ParticipantOutcomes::StreamBigQueryJob).to have_received(:perform_later).with(participant_outcome_id: outcome.id).twice
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2019

### Changes proposed in this pull request

* Renamed `StreamBigQueryParticipantOutcomeJob` to `ParticipantOutcomes::StreamBigQueryJob`
* Job using `participant_outcomes` queue
* Moved job to the `apps/jobs/participant_outcomes` folder, to keep all outcome jobs in one place

### Guidance to review

