### PR TITLE
Remove references to ParticipantProfile::ECF

### DIFF
--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -6,7 +6,7 @@ module Admin
     skip_after_action :verify_policy_scoped
 
     def index
-      @participant_profiles = policy_scope(ParticipantProfile, policy_scope_class: ParticipantProfile::ECFPolicy)
+      @participant_profiles = policy_scope(ParticipantProfile, policy_scope_class: ParticipantProfilePolicy::Scope)
         .ecf
         .where(id: InductionRecord.for_school(school).current_or_transferring_in.select(:participant_profile_id))
         .includes(participant_identity: :user)

--- a/app/controllers/admin/schools/participants_controller.rb
+++ b/app/controllers/admin/schools/participants_controller.rb
@@ -6,7 +6,8 @@ module Admin
     skip_after_action :verify_policy_scoped
 
     def index
-      @participant_profiles = policy_scope(ParticipantProfile::ECF, policy_scope_class: ParticipantProfilePolicy::Scope)
+      @participant_profiles = policy_scope(ParticipantProfile, policy_scope_class: ParticipantProfile::ECFPolicy)
+        .ecf
         .where(id: InductionRecord.for_school(school).current_or_transferring_in.select(:participant_profile_id))
         .includes(participant_identity: :user)
         .order("users.full_name")

--- a/app/forms/admin/validation_data_form.rb
+++ b/app/forms/admin/validation_data_form.rb
@@ -23,7 +23,7 @@ class Admin::ValidationDataForm
 private
 
   def participant_profile
-    @participant_profile ||= ParticipantProfile::ECF.find(participant_profile_id)
+    @participant_profile ||= ParticipantProfile.ecf.find(participant_profile_id)
   end
 
   def date_of_birth_is_valid

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -213,7 +213,8 @@ module Schools
     end
 
     def check_for_existing_profile
-      self.existing_participant_profile = ParticipantProfile::ECF
+      self.existing_participant_profile = ParticipantProfile
+                                            .ecf
                                             .joins(:ecf_participant_validation_data)
                                             .where(ecf_participant_validation_data: { trn: formatted_trn })
                                             .first

--- a/app/models/ecf_participant_validation_data.rb
+++ b/app/models/ecf_participant_validation_data.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 class ECFParticipantValidationData < ApplicationRecord
-  belongs_to :participant_profile, class_name: "ParticipantProfile::ECF", touch: true
+  belongs_to :participant_profile, class_name: "ParticipantProfile", touch: true
+  validate :belongs_to_ecf_participant
 
   def can_validate_participant?
     date_of_birth.present? && (trn.present? || nino.present?)
+  end
+
+private
+
+  def belongs_to_ecf_participant
+    return if participant_profile.blank?
+    return if participant_profile.type.in?(["ParticipantProfile::ECT", "ParticipantProfile::Mentor"])
+
+    errors.add(:participant_profile_id, "participant is not an ECT or Mentor")
   end
 end

--- a/spec/components/admin/participants/table_spec.rb
+++ b/spec/components/admin/participants/table_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::Participants::Table, :with_default_schedules, type: :component do
-  let!(:participant_profiles) { create_list :ecf_participant_profile, rand(11..15) }
+  let!(:participant_profiles) { create_list :ect_participant_profile, rand(11..15) }
   let(:page) { rand 1..2 }
 
   let(:component) { described_class.new profiles: ParticipantProfile.all.order(:id), page: }

--- a/spec/components/participant_status_tag_component_spec.rb
+++ b/spec/components/participant_status_tag_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ParticipantStatusTagComponent, type: :component do
-  let!(:participant_profile) { create :ecf_participant_profile }
+  let!(:participant_profile) { create :ect_participant_profile }
   let(:component) { described_class.new profile: participant_profile }
   subject { page }
 

--- a/spec/components/schools/participants/coc_status_table_spec.rb
+++ b/spec/components/schools/participants/coc_status_table_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Schools::Participants::CocStatusTable, type: :component do
-  let(:participant_profile) { create(:ecf_participant_profile, :ecf_participant_eligibility, school_cohort:) }
+  let(:participant_profile) { create(:ect_participant_profile, :ecf_participant_eligibility, school_cohort:) }
   let(:induction_record) { Induction::Enrol.call(participant_profile:, induction_programme: programme) }
 
   let(:component) { described_class.new induction_records: [induction_record] }

--- a/spec/cypress/app_commands/scenarios/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/school_participants.rb
@@ -35,7 +35,7 @@ FactoryBot.create(
 )
 
 FactoryBot.create(
-  :ecf_participant_profile,
+  :ect_participant_profile,
   school_cohort:,
   mentor_profile:,
   user: FactoryBot.create(:user, full_name: "Joe Bloggs", email: "joe-bloggs@example.com"),

--- a/spec/factories/ecf_participant_eligibility.rb
+++ b/spec/factories/ecf_participant_eligibility.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ecf_participant_eligibility, class: ECFParticipantEligibility do
-    association :participant_profile, factory: :ecf_participant_profile
+    association :participant_profile, factory: :ect_participant_profile
 
     qts { true }
     active_flags { false }

--- a/spec/factories/ecf_participant_validation_data.rb
+++ b/spec/factories/ecf_participant_validation_data.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ecf_participant_validation_data, class: ECFParticipantValidationData do
-    association :participant_profile, factory: :ecf_participant_profile
+    association :participant_profile, factory: :ect_participant_profile
 
     full_name { Faker::Name.name }
     trn { sprintf("%07i", Random.random_number(9_999_999)) }

--- a/spec/factories/induction_record.rb
+++ b/spec/factories/induction_record.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
       end_date { 2.months.ago }
     end
 
-    trait(:ecf) { participant_profile { create(:ecf_participant_profile) } }
+    trait(:ecf) { participant_profile { create(:ect_participant_profile) } } # FIXME: remove
     trait(:ect) { participant_profile { create(:ect_participant_profile) } }
     trait(:mentor) { participant_profile { create(:mentor_participant_profile) } }
 

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -7,18 +7,16 @@ FactoryBot.define do
       profile_traits { [] }
     end
 
-    factory :ecf_participant_profile, class: "ParticipantProfile::ECF" do
-      profile_duplicity { :single }
-      school_cohort { association :school_cohort, cohort: }
-      teacher_profile { association :teacher_profile, school: school_cohort.school }
-      schedule { Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort) || create(:ecf_schedule, cohort: school_cohort.cohort) }
-      after :build do |participant_profile|
-        participant_profile.participant_identity = Identity::Create.call(user: participant_profile.user)
-      end
-
-      factory :ect_participant_profile, class: "ParticipantProfile::ECT"
-      factory :mentor_participant_profile, class: "ParticipantProfile::Mentor"
+    after :build do |participant_profile|
+      participant_profile.participant_identity = Identity::Create.call(user: participant_profile.user)
     end
+
+    profile_duplicity { :single }
+    school_cohort { association :school_cohort, cohort: }
+    teacher_profile { association :teacher_profile, school: school_cohort.school }
+    schedule { Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort) || create(:ecf_schedule, cohort: school_cohort.cohort) }
+    factory :ect_participant_profile, class: "ParticipantProfile::ECT"
+    factory :mentor_participant_profile, class: "ParticipantProfile::Mentor"
 
     trait :ecf_participant_validation_data do
       ecf_participant_validation_data { association :ecf_participant_validation_data }

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -7,16 +7,19 @@ FactoryBot.define do
       profile_traits { [] }
     end
 
-    after :build do |participant_profile|
-      participant_profile.participant_identity = Identity::Create.call(user: participant_profile.user)
+    trait(:ecf) do
+      profile_duplicity { :single }
+      school_cohort { association :school_cohort, cohort: }
+      teacher_profile { association :teacher_profile, school: school_cohort.school }
+      schedule { Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort) || create(:ecf_schedule, cohort: school_cohort.cohort) }
+
+      after :build do |participant_profile|
+        participant_profile.participant_identity = Identity::Create.call(user: participant_profile.user)
+      end
     end
 
-    profile_duplicity { :single }
-    school_cohort { association :school_cohort, cohort: }
-    teacher_profile { association :teacher_profile, school: school_cohort.school }
-    schedule { Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort) || create(:ecf_schedule, cohort: school_cohort.cohort) }
-    factory :ect_participant_profile, class: "ParticipantProfile::ECT"
-    factory :mentor_participant_profile, class: "ParticipantProfile::Mentor"
+    factory(:ect_participant_profile, class: "ParticipantProfile::ECT") { ecf }
+    factory(:mentor_participant_profile, class: "ParticipantProfile::Mentor") { ecf }
 
     trait :ecf_participant_validation_data do
       ecf_participant_validation_data { association :ecf_participant_validation_data }

--- a/spec/factories/seeds/finance_milestone_factory.rb
+++ b/spec/factories/seeds/finance_milestone_factory.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_finance_milestone, class: "Finance::Milestone") do
+    name { Faker::Lorem.sentence }
+
+    milestone_date { 6.months.ago.to_date }
+    payment_date { 5.months.ago.to_date }
+
+    trait(:with_schedule) do
+      association(:schedule, factory: %i[seed_finance_schedule valid])
+    end
+
+    trait(:valid) { with_schedule }
+
+    after(:build) do |m|
+      Rails.logger.debug("created milestone #{m.name}")
+    end
+  end
+end

--- a/spec/lib/mail/delivery_recorder_spec.rb
+++ b/spec/lib/mail/delivery_recorder_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Mail::DeliveryRecorder, :with_default_schedules do
   end
 
   context "with some other associated objects" do
-    let(:object) { create %i[ecf_participant_profile school school_cohort].sample }
+    let(:object) { create %i[ect_participant_profile school school_cohort].sample }
     let(:name) { Faker::Lorem.words.join("_").to_sym }
 
     it "records the association between email and an object" do

--- a/spec/models/ecf_participant_validation_data_spec.rb
+++ b/spec/models/ecf_participant_validation_data_spec.rb
@@ -14,4 +14,37 @@ RSpec.describe ECFParticipantValidationData, type: :model do
     validation_data.touch
     expect(user.reload.updated_at).to be_within(1.second).of Time.zone.now
   end
+
+  describe "validating the associated participant profile type" do
+    subject { FactoryBot.build(:seed_ecf_participant_validation_data, participant_profile:) }
+    before { subject.valid? }
+
+    context "when linked to a Mentor participant profile" do
+      let(:participant_profile) { FactoryBot.create(:seed_mentor_participant_profile, :valid) }
+
+      it "passes validation" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when linked to a ECT participant profile" do
+      let(:participant_profile) { FactoryBot.create(:seed_ect_participant_profile, :valid) }
+
+      it "passes validation" do
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when linked to a non-ECF participant profile" do
+      let(:participant_profile) { FactoryBot.create(:seed_npq_participant_profile, :valid) }
+
+      it "fails validation" do
+        expect(subject).not_to be_valid
+      end
+
+      it "has an informative error message" do
+        expect(subject.errors.messages[:participant_profile_id]).to include(/not an ECT or Mentor/)
+      end
+    end
+  end
 end

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -198,12 +198,12 @@ RSpec.describe InductionRecord, :with_default_schedules, type: :model do
 
     describe "current scopes" do
       let(:induction_programme) { create(:induction_programme, :fip) }
-      let(:charlie_current_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
-      let(:theresa_transfer_in_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.from_now, school_transfer: true) }
-      let(:linda_leaving_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
-      let(:tina_transferred_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
-      let(:wendy_withdrawn_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
-      let(:terry_transferring_out_ir) { Induction::Enrol.call(participant_profile: create(:ecf_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:charlie_current_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:theresa_transfer_in_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.from_now, school_transfer: true) }
+      let(:linda_leaving_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:tina_transferred_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:wendy_withdrawn_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
+      let(:terry_transferring_out_ir) { Induction::Enrol.call(participant_profile: create(:ect_participant_profile), induction_programme:, start_date: 2.months.ago) }
 
       before do
         linda_leaving_ir.leaving!(1.month.from_now)
@@ -373,7 +373,7 @@ RSpec.describe InductionRecord, :with_default_schedules, type: :model do
   describe "callbacks" do
     it "updates analytics when an induction record is created", :with_default_schedules do
       induction_programme = create(:induction_programme)
-      participant_profile = create(:ecf_participant_profile)
+      participant_profile = create(:ect_participant_profile)
 
       expect {
         Induction::Enrol.call(participant_profile:, induction_programme:)

--- a/spec/models/participant_identity_spec.rb
+++ b/spec/models/participant_identity_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ParticipantIdentity, type: :model do
 
   let(:user) { participant_identity.user }
   let(:additional_identity) { create(:participant_identity, :secondary, user:, email: Faker::Internet.email) }
-  let(:identity_of_duplicate_user) { create(:ecf_participant_profile).participant_identity }
+  let(:identity_of_duplicate_user) { create(:ect_participant_profile).participant_identity }
   let(:transferred_identity) do
     identity_of_duplicate_user.tap { |identity| identity.update!(user:) }
   end

--- a/spec/models/participant_profile/ecf_spec.rb
+++ b/spec/models/participant_profile/ecf_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 RSpec.describe ParticipantProfile::ECF, type: :model do
-  let(:profile) { create(:ecf_participant_profile) }
+  let(:profile) { create(:ect_participant_profile) }
 
   describe ":current_cohort" do
     let!(:cohort_2020) { Cohort.find_by(start_year: 2020) || create(:cohort, start_year: 2020) }
     let!(:current_cohort) { Cohort.current || create(:cohort, :current) }
-    let!(:participant_2020) { create(:ecf_participant_profile, school_cohort: create(:school_cohort, cohort: cohort_2020)) }
-    let!(:current_participant) { create(:ecf_participant_profile, school_cohort: create(:school_cohort, cohort: current_cohort)) }
+    let!(:participant_2020) { create(:ect_participant_profile, school_cohort: create(:school_cohort, cohort: cohort_2020)) }
+    let!(:current_participant) { create(:ect_participant_profile, school_cohort: create(:school_cohort, cohort: current_cohort)) }
 
     it "does not include 2020 participants" do
       expect(ParticipantProfile::ECF.current_cohort).not_to include(participant_2020)
@@ -236,7 +236,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     let(:partnership) { create(:partnership, lead_provider:, cohort:) }
     let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort:) }
     let(:induction_programme) { create(:induction_programme, school_cohort:, partnership:) }
-    let(:profile) { create(:ecf_participant_profile, school_cohort:) }
+    let(:profile) { create(:ect_participant_profile, school_cohort:) }
     let!(:induction_record_older) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 2.days.ago) }
     let!(:induction_record_latest) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 1.day.ago) }
 
@@ -269,7 +269,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     end
 
     context "when participant has no induction records" do
-      subject { create(:ecf_participant_profile) }
+      subject { create(:ect_participant_profile) }
 
       it { is_expected.not_to be_withdrawn_for(cpd_lead_provider:) }
     end
@@ -291,7 +291,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     end
 
     context "when participant has no induction records" do
-      subject { create(:ecf_participant_profile) }
+      subject { create(:ect_participant_profile) }
 
       it { is_expected.not_to be_active_for(cpd_lead_provider:) }
     end
@@ -313,7 +313,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     end
 
     context "when participant has no induction records" do
-      subject { create(:ecf_participant_profile) }
+      subject { create(:ect_participant_profile) }
 
       it { is_expected.not_to be_deferred_for(cpd_lead_provider:) }
     end
@@ -364,7 +364,7 @@ RSpec.describe ParticipantProfile::ECF, type: :model do
     let(:school_cohort) { create(:school_cohort, school: partnership.school, cohort:) }
     let(:induction_programme) { create(:induction_programme, school_cohort:, partnership:) }
     let(:another_induction_programme) { create(:induction_programme, school_cohort:, partnership: another_partnership) }
-    let(:profile) { create(:ecf_participant_profile, school_cohort:) }
+    let(:profile) { create(:ect_participant_profile, school_cohort:) }
     let!(:induction_record_oldest) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 3.days.ago) }
     let!(:induction_record_latest_first_delivery_partner) { create(:induction_record, participant_profile: profile, induction_programme:, start_date: 2.days.ago) }
     let!(:induction_record_latest_second_delivery_partner) { create(:induction_record, participant_profile: profile, induction_programme: another_induction_programme, start_date: 1.day.ago) }

--- a/spec/requests/schools/add_participants_spec.rb
+++ b/spec/requests/schools/add_participants_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Schools::AddParticipant", type: :request do
       context "when participant is a transfer" do
         let(:induction_programme) { create(:induction_programme, :fip, school_cohort: create(:school_cohort, cohort: participant_cohort)) }
         let(:ecf_participant_validation_data) { create(:ecf_participant_validation_data, trn: "3333333") }
-        let(:participant_profile) { create(:ecf_participant_profile, ecf_participant_validation_data:) }
+        let(:participant_profile) { create(:ect_participant_profile, ecf_participant_validation_data:) }
 
         before do
           Induction::Enrol.call(participant_profile:, induction_programme:)

--- a/spec/seeds/seed_factories/finance_milestone_factory_spec.rb
+++ b/spec/seeds/seed_factories/finance_milestone_factory_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "./shared_factory_examples"
+
+RSpec.describe("seed_finance_milestone") do
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_finance_milestone }
+    let(:factory_class) { Finance::Milestone }
+  end
+end

--- a/spec/services/admin/participants/search_spec.rb
+++ b/spec/services/admin/participants/search_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Admin::Participants::Search, :with_default_schedules do
     let!(:user_2) { create(:user, full_name: "Bonnie Benson", email: "bbbb@example.com") }
     let!(:user_3) { create(:user, full_name: "Charles Cross", email: "cccc@example.com") }
 
-    let!(:pp_1) { create(:ecf_participant_profile, user: user_1) }
-    let!(:pp_2) { create(:ecf_participant_profile, user: user_2) }
+    let!(:pp_1) { create(:ect_participant_profile, user: user_1) }
+    let!(:pp_2) { create(:ect_participant_profile, user: user_2) }
     let!(:pp_3) { create(:npq_participant_profile, user: user_3) }
 
     context "when searching with a string" do

--- a/spec/services/analytics/ecf_induction_service_spec.rb
+++ b/spec/services/analytics/ecf_induction_service_spec.rb
@@ -2,7 +2,7 @@
 
 describe Analytics::ECFInductionService do
   let(:induction_programme) { create(:induction_programme, :fip) }
-  let(:participant_profile) { create(:ecf_participant_profile, school_cohort: induction_programme.school_cohort) }
+  let(:participant_profile) { create(:ect_participant_profile, school_cohort: induction_programme.school_cohort) }
   let(:participant_identity) { participant_profile.participant_identity }
   let!(:induction_record) { create(:induction_record, induction_programme:, participant_profile:, preferred_identity: participant_identity, start_date: Time.zone.now) }
 

--- a/spec/services/api/v1/ecf/participants_query_spec.rb
+++ b/spec/services/api/v1/ecf/participants_query_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let(:cohort) { Cohort.current || create(:cohort, :current) }
   let(:partnership) { create(:partnership, lead_provider:, cohort:) }
-  let(:participant_profile) { create(:ecf_participant_profile) }
+  let(:participant_profile) { create(:ect_participant_profile) }
   let(:induction_programme) { create(:induction_programme, :fip, partnership:) }
   let!(:induction_record) { create(:induction_record, induction_programme:, participant_profile:) }
 
@@ -63,7 +63,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
       context "with multiple values" do
         let(:another_cohort) { create(:cohort, start_year: "2050") }
         let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
-        let(:another_participant_profile) { create(:ecf_participant_profile) }
+        let(:another_participant_profile) { create(:ect_participant_profile) }
         let(:another_induction_programme) { create(:induction_programme, :fip, partnership: another_partnership) }
         let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
 
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
     describe "updated_since filter" do
       context "with correct value" do
-        let(:another_participant_profile) { create(:ecf_participant_profile) }
+        let(:another_participant_profile) { create(:ect_participant_profile) }
         let(:another_induction_programme) { create(:induction_programme, :fip, partnership:) }
         let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
 
@@ -103,7 +103,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
   describe "#induction_record" do
     describe "id filter" do
       context "with correct value" do
-        let(:another_participant_profile) { create(:ecf_participant_profile) }
+        let(:another_participant_profile) { create(:ect_participant_profile) }
         let(:another_induction_programme) { create(:induction_programme, :fip, partnership:) }
         let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
 

--- a/spec/services/data_stage/process_school_changes_spec.rb
+++ b/spec/services/data_stage/process_school_changes_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe DataStage::ProcessSchoolChanges do
           let!(:staged_successor_school) { create(:staged_school, urn: 10_001, name: "Starship Juniors School", la_code: local_authority.code, administrative_district_code: local_authority_district.code, ukprn: "22334455") }
           let(:school_cohort) { create(:school_cohort, :fip, school: live_school) }
           let!(:induction_tutor) { create(:induction_coordinator_profile, schools: [live_school]) }
-          let!(:participants) { create_list(:ecf_participant_profile, 2, school_cohort:) }
+          let!(:participants) { create_list(:ect_participant_profile, 2, school_cohort:) }
           let!(:partnership) { create(:partnership, school: live_school, cohort: school_cohort.cohort) }
           let!(:school_link) { create(:staged_school_link, :successor, school: staged_school, link_urn: successor_school.urn) }
 

--- a/spec/services/identity/transfer_spec.rb
+++ b/spec/services/identity/transfer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Identity::Transfer do
     context "when participant profiles are attached to the user" do
       let(:school_cohort) { create(:school_cohort) }
       let(:teacher_profile1) { create(:teacher_profile, user: user1) }
-      let!(:participant_profile) { create(:ecf_participant_profile, teacher_profile: teacher_profile1, school_cohort:) }
+      let!(:participant_profile) { create(:ect_participant_profile, teacher_profile: teacher_profile1, school_cohort:) }
 
       context "when the receiver does not have a teacher_profile" do
         it "creates a teacher_profile for the user" do

--- a/spec/services/participant_profile_status_spec.rb
+++ b/spec/services/participant_profile_status_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ParticipantProfileStatus, :with_default_schedules do
-  let(:participant_profile) { create(:ecf_participant_profile) }
+  let(:participant_profile) { create(:ect_participant_profile) }
   let!(:induction_record) { create(:induction_record, participant_profile:) }
 
   let(:params) { { participant_profile:, induction_record: } }
@@ -165,7 +165,7 @@ RSpec.describe ParticipantProfileStatus, :with_default_schedules do
         end
 
         context "when induction record does not exist" do
-          let(:participant_profile) { create(:ecf_participant_profile, training_status: "withdrawn") }
+          let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn") }
           let!(:induction_record) { nil }
 
           it "returns the correct status" do


### PR DESCRIPTION
### Context

`ParticipantProfile` is inherited by a (almost) abstract model, `ParticipantProfile::ECF`. No `ParticipantProfile::ECF` records can exist in prod but we did use them in a few places for testing.

When trying to upgrade to Rails 7 #3004 this caused problems as Rails complains about the [STI structure](https://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html). Removing the references to `ParticipantProfile::ECF` should allow us to restructure the STI and make it work with newer versions of Active Record

The longer term goal is to flatten the STI structure but to do that we first need to remove references to `ParticipantProfile::ECF`.

| What we have now | What we're aiming for (not in this PR!) |
| --------------------- | ---------------------|
| ![Screenshot from 2023-02-15 18-51-08](https://user-images.githubusercontent.com/128088/220903246-2aa9b948-e216-4239-ae34-cc106f6e030b.png) | ![Screenshot from 2023-02-15 18-58-21](https://user-images.githubusercontent.com/128088/220904177-d5ab1a00-2f5b-4204-a09c-930c5587b965.png) |



