### PR TITLE
Open links to a school's GIAS page in new tab

### DIFF
--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -21,6 +21,7 @@
         row.action(
           text: "Open in GIAS",
           href: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@school.urn}",
+          html_attributes: { rel: "noreferrer noopener", target: "_blank" },
         )
       end
     end


### PR DESCRIPTION
### Context

This was made after a direct request from the support team. Opening it in the same window often makes them lose their place.
