### PR TITLE
Extend NPQ seed scenarios

### DIFF
--- a/db/new_seeds/base/add_npq_registrations.rb
+++ b/db/new_seeds/base/add_npq_registrations.rb
@@ -2,10 +2,11 @@
 
 npq_lead_providers = NPQLeadProvider.all
 
-20.times do
+# Create accepted NPQ applications
+10.times do
   NewSeeds::Scenarios::NPQ
     .new(lead_provider: npq_lead_providers.sample)
     .build
-    .add_application
+    .accept_application
     .add_declaration
 end

--- a/db/new_seeds/base/add_npq_registrations.rb
+++ b/db/new_seeds/base/add_npq_registrations.rb
@@ -10,3 +10,11 @@ npq_lead_providers = NPQLeadProvider.all
     .accept_application
     .add_declaration
 end
+
+# Create rejected NPQ applications
+5.times do
+  NewSeeds::Scenarios::NPQ
+    .new(lead_provider: npq_lead_providers.sample)
+    .build
+    .reject_application
+end

--- a/db/new_seeds/base/add_npq_registrations.rb
+++ b/db/new_seeds/base/add_npq_registrations.rb
@@ -2,7 +2,15 @@
 
 npq_lead_providers = NPQLeadProvider.all
 
-# Create accepted NPQ applications
+# Create pending NPQ applications
+5.times do
+  NewSeeds::Scenarios::NPQ
+    .new(lead_provider: npq_lead_providers.sample)
+    .build
+end
+
+# Create accepted NPQ applications with participant profiles
+# and a declaration
 10.times do
   NewSeeds::Scenarios::NPQ
     .new(lead_provider: npq_lead_providers.sample)
@@ -17,4 +25,24 @@ end
     .new(lead_provider: npq_lead_providers.sample)
     .build
     .reject_application
+end
+
+# Create pending NPQ applications to ASO NPQ course
+3.times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: "npq-additional-support-offer"),
+    )
+    .build
+end
+
+# Create pending NPQ applications to EHCO NPQ course
+3.times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer"),
+    )
+    .build
 end

--- a/db/new_seeds/scenarios/npq.rb
+++ b/db/new_seeds/scenarios/npq.rb
@@ -24,7 +24,7 @@ module NewSeeds
           :valid,
           participant_identity:,
           npq_lead_provider:,
-          npq_course:
+          npq_course:,
         )
 
         self
@@ -48,6 +48,10 @@ module NewSeeds
         application.update!(lead_provider_approval_status: "accepted")
 
         self
+      end
+
+      def reject_application
+        application.update!(lead_provider_approval_status: "rejected")
       end
 
       def add_declaration

--- a/spec/factories/seeds/npq_application_factory.rb
+++ b/spec/factories/seeds/npq_application_factory.rb
@@ -42,10 +42,14 @@ FactoryBot.define do
       private_childcare_provider_urn { "EY#{SecureRandom.rand(100_000..999_999)}" }
     end
 
+    trait(:starting_in_2021) { cohort { Cohort.find_or_create_by!(start_year: 2021) } }
+    trait(:starting_in_2022) { cohort { Cohort.find_or_create_by!(start_year: 2022) } }
+
     trait(:valid) do
       with_participant_identity
       with_npq_lead_provider
       with_npq_course
+      starting_in_2022
     end
 
     after(:build) do |npqa|


### PR DESCRIPTION
### Context

When testing NPQ applications we found some gaps in our seed data.
It's been requested we add the following scenarios to help with testing:

- Accepted applications with profiles
- Pending applications with no profiles
- Rejected applications
- ASO/EHCO applications to test certain journeys

- Ticket: n/a

### Changes proposed in this pull request
- Change NPQ scenarios to create a pending NPQ application, and if only accepted an NPQ participant profile
- Extend NPQ scenarios with rejected applications
- Add cohort to NPQ application seed
- Add multiple scenarios in our seed file to accommodate different states and courses

### Guidance to review
Did I miss anything?
