### PR TITLE
Update GitHub actions to remove warnings about node 12

### DIFF
--- a/.github/common_environment.yml
+++ b/.github/common_environment.yml
@@ -1,0 +1,4 @@
+DOCKER_REPOSITORY:     dfedigital/early-careers-framework
+APPLICATION:           Manage Teacher CPD Service
+DOMAIN:                london.cloudapps.digital
+REVIEW_APPLICATION:    ecf-review-pr

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -41,6 +41,6 @@ jobs:
 
     # Upload the SARIF file generated in the previous step
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: output.sarif.json

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   brakeman-scan:
     name: Brakeman Scan
     runs-on: ubuntu-latest
+
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
@@ -29,7 +30,7 @@ jobs:
 
     - name: Setup Brakeman
       env:
-        BRAKEMAN_VERSION: '5.1.1' # SARIF support is provided in Brakeman version 4.10+
+        BRAKEMAN_VERSION: '5.4.0' # SARIF support is provided in Brakeman version 4.10+
       run: |
         gem install brakeman --version $BRAKEMAN_VERSION
 

--- a/.github/workflows/deploy_monitoring.yml
+++ b/.github/workflows/deploy_monitoring.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.4.0
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 

--- a/.github/workflows/deploy_monitoring.yml
+++ b/.github/workflows/deploy_monitoring.yml
@@ -1,0 +1,76 @@
+name: Deploy monitoring stack
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Environment to deploy monitoring to
+        options:
+          - dev
+          - staging
+          - production
+        required: true
+
+jobs:
+  deploy-monitoring-dev:
+    name: deploy monitoring stack
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: deploy-monitoring-${{ github.event.inputs.environment }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Environment Variables
+        id: variables
+        shell: bash
+        run: |
+          if [ "${{ github.event.inputs.environment }}" == "dev" ]
+          then
+              echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}" >> !GITHUB_ENV
+              echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> !GITHUB_ENV
+              echo "TF_VAR_paas_user=${{ secrets.GOVPAAS_DEV_USERNAME }}" >> !GITHUB_ENV
+              echo "TF_VAR_paas_password=${{ secrets.GOVPAAS_DEV_PASSWORD }}" >> !GITHUB_ENV
+              echo "TF_VAR_grafana_admin_password=${{ secrets.GRAFANA_ADMIN_PASSWORD_DEV }}" >> !GITHUB_ENV
+
+              echo "bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" >> GITHUB_OUTPUT
+          fi
+
+          if [ "${{ github.event.inputs.environment }}" == "staging" ]
+          then
+              echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}" >> !GITHUB_ENV
+              echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}" >> !GITHUB_ENV
+              echo "TF_VAR_paas_user=${{ secrets.GOVPAAS_STAG_USERNAME }}" >> !GITHUB_ENV
+              echo "TF_VAR_paas_password=${{ secrets.GOVPAAS_STAG_PASSWORD }}" >> !GITHUB_ENV
+              echo "TF_VAR_grafana_admin_password=${{ secrets.GRAFANA_ADMIN_PASSWORD_STAGING }}" >> !GITHUB_ENV
+
+              echo "bucket=paas-s3-broker-prod-lon-e2123d0b-d394-4594-8056-315300e7d8a8" >> GITHUB_OUTPUT
+          fi
+
+          if [ "${{ github.event.inputs.environment }}" == "production" ]
+          then
+              echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID_PRODUCTION }}" >> !GITHUB_ENV
+              echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY_PRODUCTION }}" >> !GITHUB_ENV
+              echo "TF_VAR_paas_user=${{ secrets.GOVPAAS_PROD_USERNAME }}" >> !GITHUB_ENV
+              echo "TF_VAR_paas_password=${{ secrets.GOVPAAS_PROD_PASSWORD }}" >> !GITHUB_ENV
+              echo "TF_VAR_grafana_admin_password=${{ secrets.GRAFANA_ADMIN_PASSWORD_PRODUCTION }}" >> !GITHUB_ENV
+
+              echo "bucket=paas-s3-broker-prod-lon-037149fa-bf9a-4577-a066-f627d277d6c4" >> GITHUB_OUTPUT
+          fi
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v1.4.0
+        with:
+          terraform_version: 0.14.0
+
+      - name: Deploy monitoring ( ${{ github.event.inputs.environment }} )
+        run: |
+          cd terraform/monitoring
+          terraform init -reconfigure -input=false -backend-config="bucket=${{ steps.variables.outputs.bucket }}"
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/monitoring/${{ github.event.inputs.environment }}.tfvars
+        env:
+          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          TF_VAR_alertmanager_slack_url: ${{ secrets.ALERTMANAGER_SLACK_URL }}

--- a/.github/workflows/deploy_monitoring_dev.yml
+++ b/.github/workflows/deploy_monitoring_dev.yml
@@ -4,21 +4,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  turnstyle:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  deploy:
+  deploy-monitoring-dev:
     name: deploy monitoring stack
-    needs: turnstyle
     runs-on: ubuntu-20.04
+    concurrency:
+      group: deploy-monitoring-dev
     steps:
       - uses: actions/checkout@v3
         name: Checkout Code

--- a/.github/workflows/deploy_monitoring_production.yml
+++ b/.github/workflows/deploy_monitoring_production.yml
@@ -4,21 +4,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  turnstyle:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  deploy:
+  deploy-monitoring-production:
     name: deploy monitoring stack
-    needs: turnstyle
     runs-on: ubuntu-20.04
+    concurrency:
+      group: deploy-monitoring-production
     steps:
       - uses: actions/checkout@v3
         name: Checkout Code

--- a/.github/workflows/deploy_monitoring_staging.yml
+++ b/.github/workflows/deploy_monitoring_staging.yml
@@ -4,21 +4,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  turnstyle:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  deploy:
+  deploy-monitoring-staging:
     name: deploy monitoring stack
-    needs: turnstyle
     runs-on: ubuntu-20.04
+    concurrency:
+      group: deploy-monitoring-staging
     steps:
       - uses: actions/checkout@v3
         name: Checkout Code

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -81,7 +81,7 @@ jobs:
         uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2
         with:
           version: v0.9.1 # More recent buildx versions generate an OCI manifest
 

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -8,19 +8,15 @@ on:
       - 'documentation/**'
 
 jobs:
-  deploy-to-dev:
+  build-base:
     runs-on: ubuntu-20.04
-    concurrency:
-      group: deploy-to-dev
 
     steps:
       - uses: actions/checkout@v3
         name: Checkout Code
 
-      - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 0.14.0
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@master
@@ -39,9 +35,9 @@ jobs:
           target: builder
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:builder
+            ${{ env.DOCKER_REPOSITORY }}-dev:builder
           tags: |
-            dfedigital/early-careers-framework-dev:builder
+            ${{ env.DOCKER_REPOSITORY }}-dev:builder
           push: true
           provenance: false
           build-args: |
@@ -53,9 +49,9 @@ jobs:
           target: early-careers-framework-gems-node-modules
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:gems-node-modules
+            ${{ env.DOCKER_REPOSITORY }}-dev:gems-node-modules
           tags: |
-            dfedigital/early-careers-framework-dev:gems-node-modules
+            ${{ env.DOCKER_REPOSITORY }}-dev:gems-node-modules
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
@@ -66,12 +62,34 @@ jobs:
           target: assets-precompile
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:assets-precompile
+            ${{ env.DOCKER_REPOSITORY }}-dev:assets-precompile
           tags: |
-            dfedigital/early-careers-framework-dev:assets-precompile
+            ${{ env.DOCKER_REPOSITORY }}-dev:assets-precompile
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+
+  build-release:
+    runs-on: ubuntu-20.04
+    needs: [build-base]
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          version: v0.9.1 # More recent buildx versions generate an OCI manifest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
 
       - name: Build and push docker image from production target
         uses: docker/build-push-action@v4
@@ -79,14 +97,32 @@ jobs:
           target: production
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-prod:latest
+            ${{ env.DOCKER_REPOSITORY }}-prod:latest
           tags: |
-            dfedigital/early-careers-framework-prod:${{ github.sha }}
-            dfedigital/early-careers-framework-prod:latest
+            ${{ env.DOCKER_REPOSITORY }}-prod:${{ github.sha }}
+            ${{ env.DOCKER_REPOSITORY }}-prod:latest
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             SHA=${{ github.sha }}
+
+  deploy-to-dev:
+    runs-on: ubuntu-20.04
+    needs: [build-release]
+    concurrency:
+      group: deploy-to-dev
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 0.14.0
 
       - name: Deploy to dev
         env:
@@ -96,7 +132,7 @@ jobs:
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
           TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
-          export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.sha }}
+          export TF_VAR_paas_app_docker_image=${{ env.DOCKER_REPOSITORY }}-prod:${{ github.sha }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/dev.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -19,7 +19,7 @@ jobs:
         uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2
         with:
           version: v0.9.1 # More recent buildx versions generate an OCI manifest
 

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -8,84 +8,85 @@ on:
       - 'documentation/**'
 
 jobs:
-  deploy:
+  deploy-to-dev:
     runs-on: ubuntu-20.04
-    steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    concurrency:
+      group: deploy-to-dev
 
+    steps:
       - uses: actions/checkout@v3
         name: Checkout Code
 
       - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.4.0
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@master
         with:
           version: v0.9.1 # More recent buildx versions generate an OCI manifest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_DEV_PASSWORD }}
 
       - name: Build and push docker image from builder target
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          target: builder
           context: .
-          build-args: BUILDKIT_INLINE_CACHE=1
           cache-from: |
             dfedigital/early-careers-framework-dev:builder
+          tags: |
+            dfedigital/early-careers-framework-dev:builder
           push: true
-          tags: dfedigital/early-careers-framework-dev:builder
-          target: builder
           provenance: false
-
-      - name: Build and push docker image from early-careers-framework-gems-node-modules target
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: BUILDKIT_INLINE_CACHE=1
-          cache-from: |
-            dfedigital/early-careers-framework-dev:gems-node-modules
-          push: true
-          tags: dfedigital/early-careers-framework-dev:gems-node-modules
-          target: early-careers-framework-gems-node-modules
-
-      - name: Build and push docker image from assets-precompile target
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: BUILDKIT_INLINE_CACHE=1
-          cache-from: |
-            dfedigital/early-careers-framework-dev:assets-precompile
-          push: true
-          tags: dfedigital/early-careers-framework-dev:assets-precompile
-          target: assets-precompile
-
-      - name: Build and push docker image from production target
-        uses: docker/build-push-action@v2
-        with:
-          context: .
           build-args: |
             BUILDKIT_INLINE_CACHE=1
-            SHA=${{ github.sha }}
+
+      - name: Build and push docker image from early-careers-framework-gems-node-modules target
+        uses: docker/build-push-action@v4
+        with:
+          target: early-careers-framework-gems-node-modules
+          context: .
+          cache-from: |
+            dfedigital/early-careers-framework-dev:gems-node-modules
+          tags: |
+            dfedigital/early-careers-framework-dev:gems-node-modules
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Build and push docker image from assets-precompile target
+        uses: docker/build-push-action@v4
+        with:
+          target: assets-precompile
+          context: .
+          cache-from: |
+            dfedigital/early-careers-framework-dev:assets-precompile
+          tags: |
+            dfedigital/early-careers-framework-dev:assets-precompile
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Build and push docker image from production target
+        uses: docker/build-push-action@v4
+        with:
+          target: production
+          context: .
           cache-from: |
             dfedigital/early-careers-framework-prod:latest
-          push: true
           tags: |
             dfedigital/early-careers-framework-prod:${{ github.sha }}
             dfedigital/early-careers-framework-prod:latest
-          target: production
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            SHA=${{ github.sha }}
 
       - name: Deploy to dev
         env:

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -8,20 +8,28 @@ on:
         required: true
 
 jobs:
-  deploy-to-production:
+  validate-inputs:
     runs-on: ubuntu-20.04
-    concurrency:
-      group: deploy-to-production
 
     steps:
       - name: Check tag format
         run: |
           echo ${{ github.event.inputs.version }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
+  deploy-to-production:
+    runs-on: ubuntu-20.04
+    needs: [validate-inputs]
+    concurrency:
+      group: deploy-to-production
+
+    steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v2
@@ -36,7 +44,7 @@ jobs:
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_PROD_PASSWORD }}
           TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
-          export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
+          export TF_VAR_paas_app_docker_image=${{ env.DOCKER_REPOSITORY }}-prod:${{ github.event.inputs.version }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-037149fa-bf9a-4577-a066-f627d277d6c4"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/production.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_PRODUCTION}}", "RELEASE_VERSION":"${{github.event.inputs.version}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -4,20 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to deploy
+        description: Version to deploy ("vx.x.x")
         required: true
 
 jobs:
-  deploy:
+  deploy-to-production:
     runs-on: ubuntu-20.04
+    concurrency:
+      group: deploy-to-production
+
     steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check tag format
+        run: |
+          echo ${{ github.event.inputs.version }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -25,7 +24,7 @@ jobs:
           ref: ${{ github.event.inputs.version }}
 
       - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.4.0
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -8,20 +8,28 @@ on:
         required: true
 
 jobs:
-  deploy-to-sandbox:
+  validate-inputs:
     runs-on: ubuntu-20.04
-    concurrency:
-      group: deploy-to-sandbox
 
     steps:
       - name: Check tag format
         run: |
           echo ${{ github.event.inputs.version }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
+  deploy-to-sandbox:
+    runs-on: ubuntu-20.04
+    needs: [validate-inputs]
+    concurrency:
+      group: deploy-to-sandbox
+
+    steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.version }}
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Pin Terraform version
         uses: hashicorp/setup-terraform@v2
@@ -36,7 +44,7 @@ jobs:
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
           TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
-          export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
+          export TF_VAR_paas_app_docker_image=${{ env.DOCKER_REPOSITORY }}-prod:${{ github.event.inputs.version }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-d25ff054-929d-4206-8c6f-d5c4a93ed5c3"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/sandbox.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_SANDBOX}}", "RELEASE_VERSION":"${{github.event.inputs.version}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -4,26 +4,27 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to deploy
+        description: Version to deploy ("vx.x.x")
         required: true
 
 jobs:
-  deploy:
+  deploy-to-sandbox:
     runs-on: ubuntu-20.04
+    concurrency:
+      group: deploy-to-sandbox
+
     steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check tag format
+        run: |
+          echo ${{ github.event.inputs.version }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.version }}
 
       - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.4.0
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -10,31 +10,27 @@ on:
         description: Git ref to deploy
         required: true
         default: main
+
 jobs:
   deploy-to-staging:
     runs-on: ubuntu-20.04
-    steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    concurrency:
+      group: deploy-to-staging
 
+    steps:
       - name: Check tag format
         run: |
           echo ${{ github.event.inputs.version }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
-
-      - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.4.0
-        with:
-          terraform_version: 0.14.0
 
       - uses: actions/checkout@v3
         name: Checkout Code
         with:
           ref: ${{ github.event.inputs.ref }}
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 0.14.0
 
       - name: Tag deployment
         run: |

--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -12,25 +12,26 @@ on:
         default: main
 
 jobs:
-  deploy-to-staging:
+  validate-inputs:
     runs-on: ubuntu-20.04
-    concurrency:
-      group: deploy-to-staging
 
     steps:
       - name: Check tag format
         run: |
           echo ${{ github.event.inputs.version }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
 
+  tag-image:
+    runs-on: ubuntu-20.04
+    needs: [validate-inputs]
+
+    steps:
       - uses: actions/checkout@v3
         name: Checkout Code
         with:
           ref: ${{ github.event.inputs.ref }}
 
-      - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 0.14.0
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Tag deployment
         run: |
@@ -46,9 +47,29 @@ jobs:
 
       - name: retag docker image
         run: |
-          docker pull dfedigital/early-careers-framework-prod:${{ env.HEAD }}
-          docker tag dfedigital/early-careers-framework-prod:${{ env.HEAD }} dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
-          docker push dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
+          docker pull ${{ env.DOCKER_REPOSITORY }}-prod:${{ env.HEAD }}
+          docker tag ${{ env.DOCKER_REPOSITORY }}-prod:${{ env.HEAD }} ${{ env.DOCKER_REPOSITORY }}-prod:${{ github.event.inputs.version }}
+          docker push ${{ env.DOCKER_REPOSITORY }}-prod:${{ github.event.inputs.version }}
+
+  deploy-to-staging:
+    runs-on: ubuntu-20.04
+    needs: [tag-image]
+    concurrency:
+      group: deploy-to-staging
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 0.14.0
 
       - name: Deploy to staging
         env:
@@ -58,17 +79,31 @@ jobs:
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
           TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
-          export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-prod:${{ github.event.inputs.version }}
+          export TF_VAR_paas_app_docker_image=${{ env.DOCKER_REPOSITORY }}-prod:${{ github.event.inputs.version }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-e2123d0b-d394-4594-8056-315300e7d8a8"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/staging.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_STAGING}}", "RELEASE_VERSION":"${{github.event.inputs.version}}"}' -var 'logstash_url=${{secrets.SYSLOG_DRAIN_URL}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
 
+  post-release-notes:
+    runs-on: ubuntu-20.04
+    needs: [deploy-to-staging]
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
       - name: Set release notes
+        id: notes
         run: |
           git fetch --tags
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$(git log --first-parent --pretty='format: %b (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          echo "release_notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$(git log --first-parent --pretty='format: %b (%an)' $(git tag -l | sort -V | tail -2 | head -1)..${{ github.event.inputs.version }})" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Post release notes on cpd-dev-alerts
         uses: rtCamp/action-slack-notify@v2.2.0
@@ -76,6 +111,6 @@ jobs:
           SLACK_CHANNEL: cpd-dev-alerts
           SLACK_USERNAME: Release notes bot
           SLACK_TITLE: Version ${{ github.event.inputs.version }} release notes
-          SLACK_MESSAGE: ${{ env.RELEASE_NOTES }}
+          SLACK_MESSAGE: ${{ steps.notes.outputs.release_notes }}
           MSG_MINIMAL: true
           SLACK_WEBHOOK: ${{ secrets.ALERTMANAGER_SLACK_URL }}

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Code
 
-      - name: Terraform pin version
-        uses: hashicorp/setup-terraform@v1.4.0
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 

--- a/.github/workflows/force_destroy.yml
+++ b/.github/workflows/force_destroy.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Code
 
-      - name: Terraform pin version
-        uses: hashicorp/setup-terraform@v1.4.0
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  lint:
+  ruby_linting:
     env:
       GOVUK_NOTIFY_API_KEY: Test
     runs-on: ubuntu-latest
@@ -31,11 +31,25 @@ jobs:
       - name: Install dependencies
         run: bundle install
 
-      - name: Lint ruby
-        run: rubocop
+      - name: Lint Ruby
+        run: rubocop --format json --out=/app/out/rubocop-result.json
+
+      - name: Keep Rubocop output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: rubocop_results
+          path: ${{ github.workspace }}/out/rubocop-result.json
 
       - name: Lint SCSS
-        run: bundle exec rake lint:scss
+        run: |-
+          bundle exec rake lint:scss
 
       - name: Lint JS
-        run: yarn lint
+        run: |-
+          yarn lint
+
+      - name: Lint ERB Templates
+        if: false
+        run: |-
+          bundle exec erblint --lint-all

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,28 +18,11 @@ jobs:
         with:
           ruby-version: '3.1.3'
 
-      - name: Set up Node
-        uses: actions/setup-node@v3.6.0
-        with:
-          node-version: '18.14.x'
-          cache: 'yarn'
-
-      - name: Yarn install
-        run: npm i -g yarn && yarn
-
       - name: Install dependencies
         run: bundle install
 
       - name: Lint Ruby
         run: bundle exec rubocop --format json --out=${{ github.workspace }}/rubocop-result.json
-
-      - name: Lint SCSS
-        run: |-
-          bundle exec rake lint:scss
-
-      - name: Lint JS
-        run: |-
-          yarn lint
 
       - name: Lint ERB Templates
         if: false
@@ -52,3 +35,69 @@ jobs:
         with:
           name: rubocop_results
           path: ${{ github.workspace }}/rubocop-result.json
+
+  js_linting:
+    env:
+      GOVUK_NOTIFY_API_KEY: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: Set up Node
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: '18.14.x'
+          cache: 'yarn'
+
+      - name: Yarn install
+        run: npm i -g yarn && yarn
+
+      - name: Lint JS
+        run: |-
+          yarn lint
+
+
+  scss_linting:
+    env:
+      GOVUK_NOTIFY_API_KEY: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.138.0
+        with:
+          ruby-version: '3.1.3'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Lint SCSS
+        run: |-
+          bundle exec rake lint:scss
+
+  erb_linting:
+    env:
+      GOVUK_NOTIFY_API_KEY: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1.138.0
+        with:
+          ruby-version: '3.1.3'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Lint ERB Templates
+        if: false
+        run: |-
+          bundle exec erblint --lint-all

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,14 +32,14 @@ jobs:
         run: bundle install
 
       - name: Lint Ruby
-        run: rubocop --format json --out=/app/out/rubocop-result.json
+        run: rubocop --format json --out=${{ github.workspace }}/rubocop-result.json
 
       - name: Keep Rubocop output
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: rubocop_results
-          path: ${{ github.workspace }}/out/rubocop-result.json
+          path: ${{ github.workspace }}/rubocop-result.json
 
       - name: Lint SCSS
         run: |-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.138.0
         with:
-          bundler-cache: true
           ruby-version: '3.1.3'
 
       - name: Set up Node

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,23 +8,34 @@ jobs:
     env:
       GOVUK_NOTIFY_API_KEY: Test
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2.5.1
-        with:
-          node-version: '18.14.x'
-          cache: 'yarn'
-      - name: Yarn install
-        run: npm i -g yarn && yarn
+        name: Checkout Code
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.138.0
         with:
-          ruby-version: 3.1.3
+          bundler-cache: true
+          ruby-version: '3.1.3'
+
+      - name: Set up Node
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: '18.14.x'
+          cache: 'yarn'
+
+      - name: Yarn install
+        run: npm i -g yarn && yarn
+
       - name: Install dependencies
         run: bundle install
+
       - name: Lint ruby
         run: rubocop
+
       - name: Lint SCSS
         run: bundle exec rake lint:scss
+
       - name: Lint JS
         run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,14 +32,7 @@ jobs:
         run: bundle install
 
       - name: Lint Ruby
-        run: rubocop --format json --out=${{ github.workspace }}/rubocop-result.json
-
-      - name: Keep Rubocop output
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: rubocop_results
-          path: ${{ github.workspace }}/rubocop-result.json
+        run: bundle exec rubocop --format json --out=${{ github.workspace }}/rubocop-result.json
 
       - name: Lint SCSS
         run: |-
@@ -53,3 +46,10 @@ jobs:
         if: false
         run: |-
           bundle exec erblint --lint-all
+
+      - name: Keep Rubocop output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: rubocop_results
+          path: ${{ github.workspace }}/rubocop-result.json

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -23,7 +23,7 @@ jobs:
         uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2
         with:
           version: v0.9.1 # More recent buildx versions generate an OCI manifest
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,24 +1,21 @@
 name: Create Review App
+
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'documentation/**'
 
 jobs:
-  deploy:
+  deploy-to-review-pr:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
-    steps:
-      - uses: softprops/turnstyle@v1
-        name: Check workflow concurrency
-        with:
-          poll-interval-seconds: 20
-          same-branch-only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    concurrency:
+      group: deploy-to-review-pr-${{ github.event.number }}
 
+    steps:
       - name: setup-inputs
         run: |
           echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
@@ -29,71 +26,77 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v1.4.0
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 0.14.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@master
         with:
           version: v0.9.1 # More recent buildx versions generate an OCI manifest
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_DEV_PASSWORD }}
 
       - name: Build and push docker image from builder target
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          target: builder
           context: .
-          build-args: BUILDKIT_INLINE_CACHE=1
           cache-from: |
             dfedigital/early-careers-framework-dev:builder
+          tags: |
+            dfedigital/early-careers-framework-dev:builder
           push: true
-          tags: dfedigital/early-careers-framework-dev:builder
-          target: builder
           provenance: false
-
-      - name: Build and push docker image from early-careers-framework-gems-node-modules target
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: BUILDKIT_INLINE_CACHE=1
-          cache-from: |
-            dfedigital/early-careers-framework-dev:gems-node-modules
-          push: true
-          tags: dfedigital/early-careers-framework-dev:gems-node-modules
-          target: early-careers-framework-gems-node-modules
-
-      - name: Build and push docker image from assets-precompile target
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          build-args: BUILDKIT_INLINE_CACHE=1
-          cache-from: |
-            dfedigital/early-careers-framework-dev:assets-precompile
-          push: true
-          tags: dfedigital/early-careers-framework-dev:assets-precompile
-          target: assets-precompile
-
-      - name: Build and push docker image from production target
-        uses: docker/build-push-action@v2
-        with:
-          context: .
           build-args: |
             BUILDKIT_INLINE_CACHE=1
-            SHA=${{ github.event.pull_request.head.sha }}
+
+      - name: Build and push docker image from early-careers-framework-gems-node-modules target
+        uses: docker/build-push-action@v4
+        with:
+          target: early-careers-framework-gems-node-modules
+          context: .
+          cache-from: |
+            dfedigital/early-careers-framework-dev:gems-node-modules
+          tags: |
+            dfedigital/early-careers-framework-dev:gems-node-modules
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Build and push docker image from assets-precompile target
+        uses: docker/build-push-action@v4
+        with:
+          target: assets-precompile
+          context: .
+          cache-from: |
+            dfedigital/early-careers-framework-dev:assets-precompile
+          tags: |
+            dfedigital/early-careers-framework-dev:assets-precompile
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Build and push docker image from production target
+        uses: docker/build-push-action@v4
+        with:
+          target: production
+          context: .
           cache-from: |
             dfedigital/early-careers-framework-dev:${{ env.ENVIRONMENT }}
             dfedigital/early-careers-framework-dev:latest
-          push: true
           tags: |
             dfedigital/early-careers-framework-dev:${{ github.event.pull_request.head.sha }}
             dfedigital/early-careers-framework-dev:${{ env.ENVIRONMENT }}
             dfedigital/early-careers-framework-dev:latest
-          target: production
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            SHA=${{ github.event.pull_request.head.sha }}
 
       - name: Deploy review app to dev
         env:
@@ -109,7 +112,7 @@ jobs:
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{env.ENVIRONMENT}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@v1.3.0
+        uses: unsplash/comment-on-pr@v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -120,7 +123,7 @@ jobs:
   smoke-test:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
-    needs: [deploy]
+    needs: [deploy-to-review-pr]
     # Our rspec is deeply coupled with a database. I had a go at decoupling it for smoke tests, and gave up.
     # This database is provided as a hacky way to get rspec to run, and should not be populated in smoke tests.
     env:
@@ -145,14 +148,14 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      - name: setup-inputs
+        run: |
+          echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: setup-inputs
-        run: |
-          echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.138.0
@@ -161,7 +164,7 @@ jobs:
           ruby-version: '3.1.3'
 
       - name: Set up Node
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: '18.14.x'
           cache: 'yarn'
@@ -173,7 +176,7 @@ jobs:
         run: bundle exec rspec spec/smoke_tests/*_spec.rb --tag smoke_test
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@v1.3.0
+        uses: unsplash/comment-on-pr@v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -156,7 +156,7 @@ jobs:
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{env.ENVIRONMENT}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@v1.3.1
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -216,7 +216,7 @@ jobs:
         run: bundle exec rspec spec/smoke_tests/*_spec.rb --tag smoke_test
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@v1.3.1
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -92,7 +92,7 @@ jobs:
         uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2
         with:
           version: v0.9.1 # More recent buildx versions generate an OCI manifest
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,26 +9,18 @@ on:
       - 'documentation/**'
 
 jobs:
-  deploy-to-review-pr:
+  build-base:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
-    concurrency:
-      group: deploy-to-review-pr-${{ github.event.number }}
 
     steps:
-      - name: setup-inputs
-        run: |
-          echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
-
       - uses: actions/checkout@v3
         name: Checkout Code
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Pin Terraform version
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 0.14.0
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@master
@@ -47,9 +39,9 @@ jobs:
           target: builder
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:builder
+            ${{ env.DOCKER_REPOSITORY }}-dev:builder
           tags: |
-            dfedigital/early-careers-framework-dev:builder
+            ${{ env.DOCKER_REPOSITORY }}-dev:builder
           push: true
           provenance: false
           build-args: |
@@ -61,9 +53,9 @@ jobs:
           target: early-careers-framework-gems-node-modules
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:gems-node-modules
+            ${{ env.DOCKER_REPOSITORY }}-dev:gems-node-modules
           tags: |
-            dfedigital/early-careers-framework-dev:gems-node-modules
+            ${{ env.DOCKER_REPOSITORY }}-dev:gems-node-modules
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
@@ -74,12 +66,41 @@ jobs:
           target: assets-precompile
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:assets-precompile
+            ${{ env.DOCKER_REPOSITORY }}-dev:assets-precompile
           tags: |
-            dfedigital/early-careers-framework-dev:assets-precompile
+            ${{ env.DOCKER_REPOSITORY }}-dev:assets-precompile
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+
+  build-review-pr:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    needs: [build-base]
+
+    steps:
+      - name: setup-inputs
+        run: |
+          echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+        name: Checkout Code
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          version: v0.9.1 # More recent buildx versions generate an OCI manifest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
 
       - name: Build and push docker image from production target
         uses: docker/build-push-action@v4
@@ -87,16 +108,39 @@ jobs:
           target: production
           context: .
           cache-from: |
-            dfedigital/early-careers-framework-dev:${{ env.ENVIRONMENT }}
-            dfedigital/early-careers-framework-dev:latest
+            ${{ env.DOCKER_REPOSITORY }}-dev:${{ env.ENVIRONMENT }}
           tags: |
-            dfedigital/early-careers-framework-dev:${{ github.event.pull_request.head.sha }}
-            dfedigital/early-careers-framework-dev:${{ env.ENVIRONMENT }}
-            dfedigital/early-careers-framework-dev:latest
+            ${{ env.DOCKER_REPOSITORY }}-dev:${{ github.event.pull_request.head.sha }}
+            ${{ env.DOCKER_REPOSITORY }}-dev:${{ env.ENVIRONMENT }}
           push: true
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             SHA=${{ github.event.pull_request.head.sha }}
+
+  deploy-to-review-pr:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    needs: [build-review-pr]
+    concurrency:
+      group: deploy-to-review-pr-${{ github.event.number }}
+
+    steps:
+      - name: setup-inputs
+        run: |
+          echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+        name: Checkout Code
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Pin Terraform version
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 0.14.0
 
       - name: Deploy review app to dev
         env:
@@ -106,7 +150,7 @@ jobs:
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
           TF_VAR_statuscake_api_token: ${{ secrets.STATUSCAKE_API_TOKEN }}
         run: |
-          export TF_VAR_paas_app_docker_image=dfedigital/early-careers-framework-dev:${{ github.event.pull_request.head.sha }}
+          export TF_VAR_paas_app_docker_image=${{ env.DOCKER_REPOSITORY }}-dev:${{ github.event.pull_request.head.sha }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=paas-s3-broker-prod-lon-7f2ca242-9929-4662-a79c-c454ea56ea7b" -backend-config="key=${{ env.ENVIRONMENT }}/terraform.tfstate"
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}"}' -var='environment=${{env.ENVIRONMENT}}' -var 'docker_username=${{ secrets.DOCKER_USERNAME }}' -var 'docker_password=${{ secrets.DOCKER_DEV_PASSWORD }}'
@@ -116,7 +160,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: "Created review app at https://ecf-review-pr-${{ github.event.number }}.london.cloudapps.digital"
+          msg: "Created review app at https://${{env.REVIEW_APPLICATION}}-${{ github.event.number }}.${{env.DOMAIN}}"
           check_for_duplicate_msg: true
           duplicate_msg_pattern: Created review app at*
 
@@ -148,10 +192,6 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - name: setup-inputs
-        run: |
-          echo "ENVIRONMENT=review-pr-${{ github.event.number }}" >> $GITHUB_ENV
-
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/run_task_dev.yml
+++ b/.github/workflows/run_task_dev.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   run-task:
     runs-on: ubuntu-20.04
+
     steps:
       - name: CF CLI Action
         uses: citizen-of-planet-earth/cf-cli-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           ruby-version: '3.1.3'
 
       - name: Set up Node
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: '18.14.x'
           cache: 'yarn'
@@ -117,7 +117,7 @@ jobs:
           ruby-version: '3.1.3'
 
       - name: Set up Node
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: '18.14.x'
           cache: 'yarn'
@@ -178,7 +178,7 @@ jobs:
           ruby-version: '3.1.3'
 
       - name: Set up Node
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: '18.14.x'
           cache:  'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
         run: bin/webpacker
 
       - name: Run Cypress
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           start: bundle exec rails server -e test -p 5017
           wait-on: 'http://localhost:5017/'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,19 +6,9 @@ on:
       - '**'
 
 jobs:
-  create-nonce:
-    name: Create nonce
-    runs-on: ubuntu-20.04
-    outputs:
-      nonce: ${{ steps.generate-nonce.outputs.nonce }}
-    steps:
-      - id: generate-nonce
-        run: echo "::set-output name=nonce::$(tr -dc 0-9 </dev/urandom | head -c 18 ; echo '')"
-
   backend-tests:
     name: Run rspec
     runs-on: ubuntu-20.04
-    needs: create-nonce
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +66,6 @@ jobs:
   e2e-scenarios:
     name: Run end to end scenarios
     runs-on: ubuntu-20.04
-    needs: create-nonce
     strategy:
       fail-fast: false
       matrix:
@@ -137,7 +126,6 @@ jobs:
   e2e-tests:
     name: Run Cypress
     runs-on: ubuntu-20.04
-    needs: create-nonce
     strategy:
       fail-fast: false
       matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,9 @@ group :development, :test do
   gem "rswag-specs", "~> 2.8"
 
   gem "parallel_tests"
+
+  # Linting
+  gem "erb_lint", ">= 0.1.1", require: false
 end
 
 group :development, :deployed_development, :test, :sandbox do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,7 +666,7 @@ DEPENDENCIES
   lograge (~> 0.12.0)
   logstash-event
   mail-notify (~> 1.1)
-  mdl
+  mdl (~> 0.12.0)
   memory_profiler
   multi_json
   net-imap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,13 @@ GEM
     backport (1.2.0)
     bcrypt (3.1.17)
     benchmark (0.2.1)
+    better_html (2.0.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -120,6 +127,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chef-utils (18.1.0)
+      concurrent-ruby
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -157,6 +166,13 @@ GEM
       railties (>= 3.2)
     dumb_delegator (1.0.0)
     e2mmap (0.1.0)
+    erb_lint (0.3.1)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -277,12 +293,23 @@ GEM
       rack (>= 2.1.4.1)
     marcel (1.0.2)
     matrix (0.4.2)
+    mdl (0.12.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
     memoist (0.16.2)
     memory_profiler (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-shellout (3.2.7)
+      chef-utils
     msgpack (1.6.0)
     multi_json (1.15.0)
     net-imap (0.3.4)
@@ -517,6 +544,7 @@ GEM
       capybara (~> 3.15)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
+    smart_properties (1.17.0)
     solargraph (0.48.0)
       backport (~> 1.2)
       benchmark
@@ -551,6 +579,7 @@ GEM
     tilt (2.0.11)
     timecop (0.9.6)
     timeout (0.3.1)
+    tomlrb (2.0.3)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -617,6 +646,7 @@ DEPENDENCIES
   devise (>= 4.8.0)
   discard (~> 1.2, >= 1.2.0)
   dotenv-rails (~> 2.8.1)
+  erb_lint (>= 0.1.1)
   factory_bot_rails (~> 6.2.0)
   faker
   foreman
@@ -636,6 +666,7 @@ DEPENDENCIES
   lograge (~> 0.12.0)
   logstash-event
   mail-notify (~> 1.1)
+  mdl
   memory_profiler
   multi_json
   net-imap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,8 +127,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chef-utils (18.1.0)
-      concurrent-ruby
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -293,23 +291,12 @@ GEM
       rack (>= 2.1.4.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    mdl (0.12.0)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      mixlib-cli (~> 2.1, >= 2.1.1)
-      mixlib-config (>= 2.2.1, < 4)
-      mixlib-shellout
     memoist (0.16.2)
     memory_profiler (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
-    mixlib-cli (2.1.8)
-    mixlib-config (3.0.27)
-      tomlrb
-    mixlib-shellout (3.2.7)
-      chef-utils
     msgpack (1.6.0)
     multi_json (1.15.0)
     net-imap (0.3.4)
@@ -579,7 +566,6 @@ GEM
     tilt (2.0.11)
     timecop (0.9.6)
     timeout (0.3.1)
-    tomlrb (2.0.3)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -666,7 +652,6 @@ DEPENDENCIES
   lograge (~> 0.12.0)
   logstash-event
   mail-notify (~> 1.1)
-  mdl (~> 0.12.0)
   memory_profiler
   multi_json
   net-imap


### PR DESCRIPTION
### Changes proposed in this pull request

- update Github Action versions
- rename jobs
- break out steps in to separate jobs for readability

### Guidance to review

- branch builds and deploys

#### Notes

- once the branch is merged into the main branch the events `lint` and `deploy` will need to be removed as those jobs no longer exist,
- either two new status events can be added for `ruby-linting` and `deploy-to-review-pr` or "Run Linter" can be "required" and "Create Review App" can be required on PR branches
