### PR TITLE
Amend participant query to prioritise absence of end date

### DIFF
--- a/db/migrate/20230222142649_add_timestamp_indices_to_induction_records.rb
+++ b/db/migrate/20230222142649_add_timestamp_indices_to_induction_records.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddTimestampIndicesToInductionRecords < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :induction_records, :start_date, algorithm: :concurrently
+    add_index :induction_records, :end_date, algorithm: :concurrently
+    add_index :induction_records, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_10_120533) do
+ActiveRecord::Schema.define(version: 2023_02_22_142649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -409,11 +409,14 @@ ActiveRecord::Schema.define(version: 2023_02_10_120533) do
     t.boolean "school_transfer", default: false, null: false
     t.uuid "appropriate_body_id"
     t.index ["appropriate_body_id"], name: "index_induction_records_on_appropriate_body_id"
+    t.index ["created_at"], name: "index_induction_records_on_created_at"
+    t.index ["end_date"], name: "index_induction_records_on_end_date"
     t.index ["induction_programme_id"], name: "index_induction_records_on_induction_programme_id"
     t.index ["mentor_profile_id"], name: "index_induction_records_on_mentor_profile_id"
     t.index ["participant_profile_id"], name: "index_induction_records_on_participant_profile_id"
     t.index ["preferred_identity_id"], name: "index_induction_records_on_preferred_identity_id"
     t.index ["schedule_id"], name: "index_induction_records_on_schedule_id"
+    t.index ["start_date"], name: "index_induction_records_on_start_date"
   end
 
   create_table "lead_provider_cips", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
### Context

Induction records might not be in the correct `created_at` order, due to possible transfers and further amendments done in admin interface or console. This is causing the wrong induction record to be surfaced in the API, where providers might see a status as `withdrawn`


- Ticket: N/A

### Changes proposed in this pull request

To ensure sure we prioritise the latest induction record correctly order by:
- End date being `nil`
- latest start date
- latest created at timestamp
This aligns with our `latest` scope fixed recently by @tonyheadford 


### Guidance to review
Did I miss anything?

