### PR TITLE
CST-1297: add validation data to participant profiles seeded

### DIFF
--- a/db/new_seeds/base/add_mentor_scenarios.rb
+++ b/db/new_seeds/base/add_mentor_scenarios.rb
@@ -84,7 +84,7 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
     .build(
       schedule: mentor_params.schedule,
     )
-    .chain_add_validation_data
-    .chain_add_eligibility
+    .with_validation_data
+    .with_eligibility
     .add_induction_record(induction_programme: mentor_params.induction_programme)
 end

--- a/db/new_seeds/base/add_mentor_scenarios.rb
+++ b/db/new_seeds/base/add_mentor_scenarios.rb
@@ -80,10 +80,11 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   ),
 ].each do |mentor_params|
   NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts
-    .new(full_name: mentor_params.full_name)
+    .new(school_cohort: mentor_params.school_cohort, full_name: mentor_params.full_name)
     .build(
-      school_cohort: mentor_params.school_cohort,
       schedule: mentor_params.schedule,
     )
+    .chain_add_validation_data
+    .chain_add_eligibility
     .add_induction_record(induction_programme: mentor_params.induction_programme)
 end

--- a/db/new_seeds/base/add_schools_and_local_authorities.rb
+++ b/db/new_seeds/base/add_schools_and_local_authorities.rb
@@ -16,18 +16,14 @@ def add_school_to_local_authority(school:, local_authority:, lead_providers:, co
 
       scenarios = Random.rand(1..4).times.map do
         NewSeeds::Scenarios::Participants::Mentors::MentoringMultipleEctsWithSameProvider
-          .new(
-            school:,
-            lead_provider:,
-            number: Random.rand(1..4), # number of mentees
-          )
+          .new(school:, lead_provider:)
           .build
+          .add_mentees(Random.rand(1..4), with_eligibility: false, with_validation_data: true)
       end
 
       scenarios.flat_map(&:mentees).map(&:participant_profile).each do |participant_profile|
         Rails.logger.debug("seeding eligibility for #{participant_profile.user.full_name}")
 
-        participant_profile.ecf_participant_eligibility&.destroy!
         FactoryBot.create(:seed_ecf_participant_eligibility, random_weighted_eligibility_trait, participant_profile:)
       end
     end

--- a/db/new_seeds/base/add_schools_and_local_authorities.rb
+++ b/db/new_seeds/base/add_schools_and_local_authorities.rb
@@ -27,7 +27,8 @@ def add_school_to_local_authority(school:, local_authority:, lead_providers:, co
       scenarios.flat_map(&:mentees).map(&:participant_profile).each do |participant_profile|
         Rails.logger.debug("seeding eligibility for #{participant_profile.user.full_name}")
 
-        FactoryBot.create(:seed_ecf_participant_eligibilty, random_weighted_eligibility_trait, participant_profile:)
+        participant_profile.ecf_participant_eligibility&.destroy!
+        FactoryBot.create(:seed_ecf_participant_eligibility, random_weighted_eligibility_trait, participant_profile:)
       end
     end
 

--- a/db/new_seeds/base/add_schools_and_local_authorities.rb
+++ b/db/new_seeds/base/add_schools_and_local_authorities.rb
@@ -12,16 +12,13 @@ def add_school_to_local_authority(school:, local_authority:, lead_providers:, co
     end
 
     lead_providers.sample.tap do |lead_provider|
-      FactoryBot.create(:seed_partnership, :with_delivery_partner, school:, lead_provider:, cohort: cohorts.sample)
-
       scenarios = Random.rand(1..4).times.map do
         NewSeeds::Scenarios::Participants::Mentors::MentoringMultipleEctsWithSameProvider
           .new(school:, lead_provider:)
-          .build
-          .add_mentees(Random.rand(1..4), with_eligibility: false, with_validation_data: true)
+          .build(with_eligibility: false)
       end
 
-      scenarios.flat_map(&:mentees).map(&:participant_profile).each do |participant_profile|
+      scenarios.flat_map(&:mentees).each do |participant_profile|
         Rails.logger.debug("seeding eligibility for #{participant_profile.user.full_name}")
 
         FactoryBot.create(:seed_ecf_participant_eligibility, random_weighted_eligibility_trait, participant_profile:)

--- a/db/new_seeds/scenarios/participants/ects/ect.rb
+++ b/db/new_seeds/scenarios/participants/ects/ect.rb
@@ -5,7 +5,14 @@ module NewSeeds
     module Participants
       module Ects
         class Ect
-          attr_reader :user, :new_user_attributes, :participant_profile, :participant_identity, :teacher_profile, :school_cohort
+          attr_reader :new_user_attributes,
+                      :participant_identity,
+                      :participant_profile,
+                      :school_cohort,
+                      :teacher_profile,
+                      :user
+
+          delegate :ecf_participant_eligibility, :ecf_participant_validation_data, to: :participant_profile
 
           def initialize(school_cohort:, full_name: nil, email: nil)
             @school_cohort = school_cohort
@@ -14,11 +21,8 @@ module NewSeeds
 
           def build(**_profile_args)
             @user = FactoryBot.create(:seed_user, **new_user_attributes)
-
             @participant_identity = FactoryBot.create(:seed_participant_identity, user:)
-
             @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school: school_cohort.school)
-
             @participant_profile = FactoryBot.create(:seed_ect_participant_profile, participant_identity:, teacher_profile:, school_cohort:)
 
             self
@@ -29,7 +33,7 @@ module NewSeeds
             self
           end
 
-          def add_induction_record(induction_programme:, start_date:, end_date:, induction_status: "active", training_status: "active")
+          def add_induction_record(induction_programme:, start_date: 6.months.ago, end_date: nil, induction_status: "active", training_status: "active")
             FactoryBot.create(
               :seed_induction_record,
               induction_programme:,
@@ -40,6 +44,41 @@ module NewSeeds
               induction_status:,
               training_status:,
             )
+          end
+
+          def chain_add_validation_data(**args)
+            add_validation_data(**args)
+
+            self
+          end
+
+          def add_validation_data(**args)
+            validation_data = { full_name: args[:full_name] || user.full_name,
+                                trn: args[:trn] || teacher_profile.trn,
+                                date_of_birth: args[:date_of_birth],
+                                nino: args[:nino],
+                                participant_profile: }
+
+            FactoryBot.create(:seed_ecf_participant_validation_data, **validation_data.compact)
+          end
+
+          def chain_add_eligibility(**args)
+            add_eligibility(**args)
+
+            self
+          end
+
+          def add_eligibility(**args)
+            eligibility_data = { qts: args[:qts],
+                                 active_flags: args[:active_flags],
+                                 previous_participation: args[:previous_participation],
+                                 previous_induction: args[:previous_induction],
+                                 no_induction: args[:no_induction],
+                                 status: args[:status],
+                                 reason: args[:reason],
+                                 participant_profile: }
+
+            FactoryBot.create(:seed_ecf_participant_eligibility, **eligibility_data.compact)
           end
         end
       end

--- a/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
@@ -5,14 +5,7 @@ module NewSeeds
     module Participants
       module Mentors
         class MentorWithNoEcts
-          attr_reader :new_user_attributes,
-                      :participant_identity,
-                      :participant_profile,
-                      :school_cohort,
-                      :teacher_profile,
-                      :user
-
-          delegate :ecf_participant_eligibility, :ecf_participant_validation_data, to: :participant_profile
+          attr_reader :participant_profile
 
           def initialize(school_cohort: nil, full_name: nil, email: nil)
             @school_cohort = school_cohort
@@ -21,14 +14,17 @@ module NewSeeds
 
           def build(**profile_args)
             @user = FactoryBot.create(:seed_user, **new_user_attributes)
-            @participant_identity = FactoryBot.create(:seed_participant_identity, user:)
             @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school: school_cohort.school)
-            @participant_profile = FactoryBot.create(:seed_mentor_participant_profile, :valid, participant_identity:, **profile_args)
+            @participant_profile = FactoryBot.create(:seed_mentor_participant_profile,
+                                                     participant_identity: FactoryBot.create(:seed_participant_identity, user:),
+                                                     school_cohort:,
+                                                     teacher_profile:,
+                                                     **profile_args)
 
             self
           end
 
-          def chain_add_induction_record(**induction_args)
+          def with_induction_record(**induction_args)
             add_induction_record(**induction_args)
             self
           end
@@ -46,7 +42,7 @@ module NewSeeds
             )
           end
 
-          def chain_add_validation_data(**args)
+          def with_validation_data(**args)
             add_validation_data(**args)
             self
           end
@@ -57,10 +53,11 @@ module NewSeeds
                                 date_of_birth: args[:date_of_birth],
                                 nino: args[:nino],
                                 participant_profile: }
+
             FactoryBot.create(:seed_ecf_participant_validation_data, **validation_data.compact)
           end
 
-          def chain_add_eligibility(**args)
+          def with_eligibility(**args)
             add_eligibility(**args)
             self
           end
@@ -77,6 +74,13 @@ module NewSeeds
 
             FactoryBot.create(:seed_ecf_participant_eligibility, **eligibility_data.compact)
           end
+
+        private
+
+          attr_reader :new_user_attributes,
+                      :school_cohort,
+                      :teacher_profile,
+                      :user
         end
       end
     end

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
@@ -20,9 +20,6 @@ module NewSeeds
                       :school_to,
                       :school_cohort_from,
                       :school_cohort_to,
-                      :user,
-                      :teacher_profile,
-                      :participant_identity,
                       :participant_profile,
                       :lead_provider_from,
                       :lead_provider_to,
@@ -38,6 +35,13 @@ module NewSeeds
             @school_to = to_school
           end
 
+          delegate :ecf_participant_eligibility,
+                   :ecf_participant_validation_data,
+                   :participant_identity,
+                   :teacher_profile,
+                   :user,
+                   to: :participant_profile
+
         private
 
           def setup
@@ -48,13 +52,11 @@ module NewSeeds
             @school_cohort_to = FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school: school_to)
 
             # a teacher to transfer
-            @user = FactoryBot.create(:seed_user)
-            @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school: school_from)
-            @participant_identity = FactoryBot.create(:seed_participant_identity, user:)
-            @participant_profile = FactoryBot.create(:seed_ect_participant_profile,
-                                                     participant_identity:,
-                                                     teacher_profile:,
-                                                     school_cohort: school_cohort_from)
+            @participant_profile = NewSeeds::Scenarios::Participants::Ects::Ect.new(school_cohort: school_cohort_from)
+                                                                               .build
+                                                                               .chain_add_validation_data
+                                                                               .chain_add_eligibility
+                                                                               .participant_profile
 
             # create two lead providers
             @lead_provider_from = FactoryBot.create(:seed_lead_provider)

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
@@ -35,13 +35,6 @@ module NewSeeds
             @school_to = to_school
           end
 
-          delegate :ecf_participant_eligibility,
-                   :ecf_participant_validation_data,
-                   :participant_identity,
-                   :teacher_profile,
-                   :user,
-                   to: :participant_profile
-
         private
 
           def setup
@@ -50,13 +43,6 @@ module NewSeeds
             @school_to ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
             @school_cohort_from = FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school: school_from)
             @school_cohort_to = FactoryBot.create(:seed_school_cohort, cohort: cohort(2022), school: school_to)
-
-            # a teacher to transfer
-            @participant_profile = NewSeeds::Scenarios::Participants::Ects::Ect.new(school_cohort: school_cohort_from)
-                                                                               .build
-                                                                               .chain_add_validation_data
-                                                                               .chain_add_eligibility
-                                                                               .participant_profile
 
             # create two lead providers
             @lead_provider_from = FactoryBot.create(:seed_lead_provider)
@@ -89,6 +75,15 @@ module NewSeeds
                                                         :fip,
                                                         school_cohort: school_cohort_to,
                                                         partnership: partnership_to)
+
+            # a teacher to transfer
+            @participant_profile = NewSeeds::Scenarios::Participants::Ects::Ect
+                                     .new(school_cohort: school_cohort_from)
+                                     .build
+                                     .with_validation_data
+                                     .with_eligibility
+                                     .with_induction_record(induction_programme: induction_programme_from)
+                                     .participant_profile
           end
 
           def cohort(year)

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
@@ -15,7 +15,7 @@ module NewSeeds
           def build
             setup
 
-            Rails.logger.info("seeded transfer of #{user.full_name} from #{school_from.name} to #{school_to.name} using the new school's training provider")
+            Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} using the new school's training provider")
 
             FactoryBot.create(:seed_induction_record,
                               participant_profile:,

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
@@ -34,7 +34,7 @@ module NewSeeds
                                                                   school_cohort: school_cohort_to,
                                                                   partnership: relationship)
 
-            Rails.logger.info("seeded transfer of #{user.full_name} from #{school_from.name} to #{school_to.name} while keeping their original training provider")
+            Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} while keeping their original training provider")
 
             # enrol the participant to the new programme (aka create an induction record)
             @relationship_induction_record = FactoryBot.create(:seed_induction_record,

--- a/db/new_seeds/util/seed_utils.rb
+++ b/db/new_seeds/util/seed_utils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# this is intended for use with the seed_ecf_participant_eligibilty factory
+# this is intended for use with the seed_ecf_participant_eligibility factory
 def random_weighted_eligibility_trait
   {
     eligible: 20,

--- a/spec/factories/seeds/ecf_participant_eligibility_factory.rb
+++ b/spec/factories/seeds/ecf_participant_eligibility_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory(:seed_ecf_participant_eligibilty, class: "ECFParticipantEligibility") do
+  factory(:seed_ecf_participant_eligibility, class: "ECFParticipantEligibility") do
     trait(:with_participant_profile) do
       association(:participant_profile, factory: %i[seed_ect_participant_profile valid])
     end

--- a/spec/queries/with_ects_with_no_mentor_query_spec.rb
+++ b/spec/queries/with_ects_with_no_mentor_query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
     context "when there are participants with mentor assigned" do
       let!(:mentor_profile) { create(:seed_mentor_participant_profile, :valid) }
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, mentor_profile:) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, participant_profile:) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 
@@ -20,7 +20,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
 
     context "when there are participants with withdrawn induction status" do
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, status: :withdrawn) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, participant_profile:) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 
@@ -31,7 +31,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
 
     context "when there are participants with withdrawn training induction status" do
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, training_status: :withdrawn) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, participant_profile:) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 
@@ -42,7 +42,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
 
     context "when there are participants with deferred training induction status" do
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid, training_status: :deferred) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, participant_profile:) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 
@@ -53,7 +53,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
 
     context "when there are active participants :ineligible and with no mentor associated" do
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, :ineligible, participant_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, :ineligible, participant_profile:) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 
@@ -64,7 +64,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
 
     context "when there are active participants on :matched eligibility and no mentor associated" do
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, participant_profile:, status: :matched) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, participant_profile:, status: :matched) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 
@@ -75,7 +75,7 @@ RSpec.describe Schools::WithEctsWithNoMentorQuery do
 
     context "when there are active participants on :manual-check eligibility and no mentor associated" do
       let!(:participant_profile) { create(:seed_ect_participant_profile, :valid) }
-      let!(:eligibility) { create(:seed_ecf_participant_eligibilty, :manual_check, participant_profile:) }
+      let!(:eligibility) { create(:seed_ecf_participant_eligibility, :manual_check, participant_profile:) }
       let!(:induction_record) { create(:seed_induction_record, :valid, participant_profile:) }
       let!(:seed_induction_coordinator_profiles_school) { create(:seed_induction_coordinator_profiles_school, :valid, school: induction_record.school) }
 

--- a/spec/seeds/seed_factories/ecf_participant_eligibility_factory_spec.rb
+++ b/spec/seeds/seed_factories/ecf_participant_eligibility_factory_spec.rb
@@ -2,9 +2,9 @@
 
 require_relative "./shared_factory_examples"
 
-RSpec.describe("seed_ecf_participant_eligibilty") do
+RSpec.describe("seed_ecf_participant_eligibility") do
   it_behaves_like("a seed factory") do
-    let(:factory_name) { :seed_ecf_participant_eligibilty }
+    let(:factory_name) { :seed_ecf_participant_eligibility }
     let(:factory_class) { ECFParticipantEligibility }
   end
 end


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1297):  add validation data to ECTs/Mentors seeded so they can be displayed properly in the participants dashboard.

### Changes proposed in this pull request

### Guidance to review

