### PR TITLE
Fix assets not found in API docs

### DIFF
--- a/docs/source/api-reference/stylesheets/print.css.scss
+++ b/docs/source/api-reference/stylesheets/print.css.scss
@@ -1,3 +1,4 @@
 $is-print: true;
+$govuk-assets-path: "/api-reference/assets/govuk/assets/";
 
 @import "govuk_tech_docs";

--- a/docs/source/api-reference/stylesheets/screen-old-ie.css.scss
+++ b/docs/source/api-reference/stylesheets/screen-old-ie.css.scss
@@ -1,4 +1,5 @@
 $is-ie: true;
 $ie-version: 8;
+$govuk-assets-path: "/api-reference/assets/govuk/assets/";
 
 @import "govuk_tech_docs";

--- a/docs/source/api-reference/stylesheets/screen.css.scss
+++ b/docs/source/api-reference/stylesheets/screen.css.scss
@@ -1,3 +1,5 @@
+$govuk-assets-path: "/api-reference/assets/govuk/assets/";
+
 @import "govuk_tech_docs";
 
 .technical-documentation pre {


### PR DESCRIPTION
Fixes an issue where image/font assets were not working in the API docs at `/api-reference`.