### PR TITLE
Hide phase banner on admin pages

### DIFF
--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -78,7 +78,7 @@
 
     <%= yield(:nav_bar) %>
 
-    <%= render "layouts/phase_banner" %>
+    <%= render "layouts/phase_banner" unless params[:controller].starts_with?("admin") %>
 
     <% if current_user != true_user %>
       <div class="govuk-width-container">


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/c/sADGOBFA/11-phase-banner

### Changes proposed in this pull request

Remove phase banner from admin section.

