### PR TITLE
[CPDNPQ-883] Add api/v1/npq/previous_funding#show

### DIFF
--- a/app/controllers/api/v1/npq/previous_fundings_controller.rb
+++ b/app/controllers/api/v1/npq/previous_fundings_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     module NPQ
       class PreviousFundingsController < ApiController
-        before_action :ensure_identifier_present, only: :show
+        before_action :ensure_user_identifier_present, only: :show
         before_action :ensure_npq_course_present, only: :show
 
         def show
@@ -25,10 +25,10 @@ module Api
           params[:npq_course_identifier]
         end
 
-        def ensure_identifier_present
+        def ensure_user_identifier_present
           return if trn.present? || get_an_identity_id.present?
 
-          error_body = { error: "No identifier provided. Valid identifier params: trn or get_an_identity_id" }
+          error_body = { error: "No user identifier provided. Valid identifier params: trn or get_an_identity_id" }
           render json: error_body, status: :bad_request
         end
 

--- a/app/controllers/api/v1/npq/previous_fundings_controller.rb
+++ b/app/controllers/api/v1/npq/previous_fundings_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module NPQ
+      class PreviousFundingsController < ApiController
+        before_action :ensure_identifier_present, only: :show
+        before_action :ensure_npq_course_present, only: :show
+
+        def show
+          render json: service.call
+        end
+
+      private
+
+        def trn
+          params[:trn]
+        end
+
+        def get_an_identity_id
+          params[:get_an_identity_id]
+        end
+
+        def npq_course
+          params[:npq_course_identifier]
+        end
+
+        def ensure_identifier_present
+          return if trn.present? || get_an_identity_id.present?
+
+          error_body = { error: "No identifier provided. Valid identifier params: trn or get_an_identity_id" }
+          render json: error_body, status: :bad_request
+        end
+
+        def ensure_npq_course_present
+          return if npq_course.present?
+
+          error_body = { error: "No npq_course_identifier provided" }
+          render json: error_body, status: :bad_request
+        end
+
+        def service
+          @service ||= ::NPQ::FundingEligibility.new(
+            trn:,
+            get_an_identity_id:,
+            npq_course_identifier: npq_course,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/npq/funding_eligibility.rb
+++ b/app/services/npq/funding_eligibility.rb
@@ -2,10 +2,13 @@
 
 module NPQ
   class FundingEligibility
-    attr_reader :trn, :npq_course_identifier
+    attr_reader :npq_course_identifier,
+                :trn,
+                :get_an_identity_id
 
-    def initialize(trn:, npq_course_identifier:)
+    def initialize(npq_course_identifier:, trn: nil, get_an_identity_id: nil)
       @trn = trn
+      @get_an_identity_id = get_an_identity_id
       @npq_course_identifier = npq_course_identifier
     end
 
@@ -27,11 +30,23 @@ module NPQ
     end
 
     def users
-      User.where(teacher_profile: teacher_profiles)
+      get_an_identity_id_users.or(trn_users).distinct
     end
 
-    def teacher_profiles
-      @teacher_profiles ||= TeacherProfile.where(trn:)
+    def get_an_identity_id_users
+      return User.none if get_an_identity_id.blank?
+
+      User.where(get_an_identity_id:)
+    end
+
+    def trn_users
+      return User.none if trn.blank?
+
+      User.where(teacher_profile: teacher_profiles_with_trn)
+    end
+
+    def teacher_profiles_with_trn
+      @teacher_profiles_with_trn ||= TeacherProfile.where(trn:)
     end
 
     def accepted_applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
 
       namespace :npq do
         resources :users, only: %i[show create update]
+        resource :previous_funding, only: [:show]
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -67,5 +67,9 @@ FactoryBot.define do
     trait :random_name do
       full_name { Faker::Name.name }
     end
+
+    trait :with_get_an_identity_id do
+      get_an_identity_id { SecureRandom.uuid }
+    end
   end
 end

--- a/spec/requests/api/v1/npq/previous_funding/show_spec.rb
+++ b/spec/requests/api/v1/npq/previous_funding/show_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe "NPQ Funding API", type: :request do
           expect(parsed_response).to eq(stubbed_response)
         end
 
+        context "with get_an_identity_id" do
+          it "returns correct response" do
+            stubbed_response = stub_funding_eligibility_response(
+              trn:,
+              get_an_identity_id:,
+              npq_course_identifier: "npq-leading-literacy",
+            )
+
+            get "#{base_url}?trn=#{trn}&get_an_identity_id=#{get_an_identity_id}&npq_course_identifier=#{npq_course_identifier}"
+
+            expect(parsed_response).to eq(stubbed_response)
+          end
+        end
+
         context "with no npq_course_identifier" do
           it "returns an error" do
             get "#{base_url}?trn=#{trn}"

--- a/spec/requests/api/v1/npq/previous_funding/show_spec.rb
+++ b/spec/requests/api/v1/npq/previous_funding/show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "NPQ Funding API", type: :request do
           get "#{base_url}?npq_course_identifier=#{npq_course_identifier}"
 
           expect(parsed_response).to eq({
-            "error" => "No identifier provided. Valid identifier params: trn or get_an_identity_id",
+            "error" => "No user identifier provided. Valid identifier params: trn or get_an_identity_id",
           })
           expect(response.status).to eq 400
         end

--- a/spec/requests/api/v1/npq/previous_funding/show_spec.rb
+++ b/spec/requests/api/v1/npq/previous_funding/show_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NPQ Funding API", type: :request do
+  let(:token) { NPQRegistrationApiToken.create_with_random_token!(private_api_access: true) }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:parsed_response) { JSON.parse(response.body) }
+
+  let(:base_url) { "/api/v1/npq/previous_funding" }
+
+  let(:npq_course_identifier) { "npq-leading-literacy" }
+  let(:trn) { "1234567" }
+  let(:get_an_identity_id) { "87654321" }
+
+  def stub_funding_eligibility_response(trn: nil, get_an_identity_id: nil, npq_course_identifier: nil)
+    stubbed_response = {
+      "previously_funded" => SecureRandom.uuid,
+      "previously_received_targeted_funding_support" => SecureRandom.uuid,
+    }
+
+    stubbed_checker = double(:npq_funding_eligibility)
+    allow(stubbed_checker).to receive(:call).and_return(stubbed_response)
+    expect(NPQ::FundingEligibility).to receive(:new)
+                                         .with(
+                                           get_an_identity_id:,
+                                           trn:,
+                                           npq_course_identifier:,
+                                         )
+                                         .and_return(stubbed_checker)
+
+    stubbed_response
+  end
+
+  describe "GET /api/v1/npq/previous_funding" do
+    context "when authorized" do
+      before do
+        default_headers[:Authorization] = bearer_token
+      end
+
+      context "with no identifiers" do
+        it "returns an error" do
+          get "#{base_url}?npq_course_identifier=#{npq_course_identifier}"
+
+          expect(parsed_response).to eq({
+            "error" => "No identifier provided. Valid identifier params: trn or get_an_identity_id",
+          })
+          expect(response.status).to eq 400
+        end
+      end
+
+      context "with trn" do
+        it "returns response from NPQ::FundingEligibility" do
+          stubbed_response = stub_funding_eligibility_response(
+            trn:,
+            npq_course_identifier: "npq-leading-literacy",
+          )
+
+          get "#{base_url}?trn=#{trn}&npq_course_identifier=#{npq_course_identifier}"
+
+          expect(parsed_response).to eq(stubbed_response)
+        end
+
+        context "with no npq_course_identifier" do
+          it "returns an error" do
+            get "#{base_url}?trn=#{trn}"
+
+            expect(parsed_response).to eq({
+              "error" => "No npq_course_identifier provided",
+            })
+            expect(response.status).to eq 400
+          end
+        end
+      end
+
+      context "with get_an_identity_id" do
+        before do
+          default_headers[:Authorization] = bearer_token
+        end
+
+        it "returns correct response" do
+          stubbed_response = stub_funding_eligibility_response(
+            get_an_identity_id:,
+            npq_course_identifier: "npq-leading-literacy",
+          )
+
+          get "#{base_url}?get_an_identity_id=#{get_an_identity_id}&npq_course_identifier=#{npq_course_identifier}"
+
+          expect(parsed_response).to eq(stubbed_response)
+        end
+
+        context "with no npq_course_identifier" do
+          it "returns an error" do
+            get "#{base_url}?get_an_identity_id=#{get_an_identity_id}"
+
+            expect(parsed_response).to eq({
+              "error" => "No npq_course_identifier provided",
+            })
+            expect(response.status).to eq 400
+          end
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get base_url
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end

--- a/spec/services/npq/funding_eligibility_spec.rb
+++ b/spec/services/npq/funding_eligibility_spec.rb
@@ -3,167 +3,417 @@
 require "rails_helper"
 
 RSpec.describe NPQ::FundingEligibility, :with_default_schedules do
-  subject { described_class.new(trn:, npq_course_identifier: npq_course.identifier) }
+  subject { described_class.new(trn:, get_an_identity_id:, npq_course_identifier: course_for_lookup.identifier) }
+
+  let(:course_for_lookup) { npq_course }
+
+  # Having this application in the DB makes sure that other user's applications
+  # don't have an impact on the results. If we were failing to scope our search by
+  # user then this accepted and funded application for the same course would produce
+  # incorrect results
+  let!(:unrelated_application) do
+    create(
+      :npq_application,
+      lead_provider_approval_status: "accepted",
+      eligible_for_funding: true,
+      npq_course: course_for_lookup,
+    )
+  end
+
+  let(:trn) { nil }
+  let(:get_an_identity_id) { nil }
 
   describe "#call" do
-    context "when not previously funded" do
-      let(:trn) { application.teacher_reference_number }
-      let(:application) do
-        create(
-          :npq_application,
-          lead_provider_approval_status: "accepted",
-          eligible_for_funding: false,
-        )
-      end
-      let(:npq_course) { application.npq_course }
+    context "with a trn" do
+      context "when not previously funded" do
+        let(:trn) { application.teacher_reference_number }
+        let(:application) do
+          create(
+            :npq_application,
+            lead_provider_approval_status: "accepted",
+            eligible_for_funding: false,
+          )
+        end
+        let(:npq_course) { application.npq_course }
 
-      it "returns falsey" do
-        expect(subject.call[:previously_funded]).to be_falsey
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
+
+        context "with a get_an_identity_id" do
+          let(:get_an_identity_id) { SecureRandom.uuid }
+          let(:user) { create(:user, get_an_identity_id:) }
+
+          context "that is not previously funded" do
+            before do
+              create(
+                :npq_application,
+                lead_provider_approval_status: "accepted",
+                eligible_for_funding: false,
+              )
+            end
+
+            it "returns falsey for previously_funded" do
+              expect(subject.call[:previously_funded]).to be_falsey
+            end
+
+            it "returns falsey for previously_received_targeted_funding_support" do
+              expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+            end
+          end
+
+          context "that is previously funded" do
+            before do
+              get_an_identity_application = create(
+                :npq_application,
+                user:,
+                eligible_for_funding: true,
+                teacher_reference_number_verified: true,
+                targeted_delivery_funding_eligibility: true,
+                npq_course:,
+              )
+              NPQ::Application::Accept.new(npq_application: get_an_identity_application).call
+            end
+
+            it "returns truthy for previously_funded" do
+              expect(subject.call[:previously_funded]).to be_truthy
+            end
+
+            it "returns truthy for previously_received_targeted_funding_support" do
+              expect(subject.call[:previously_received_targeted_funding_support]).to be_truthy
+            end
+          end
+        end
+      end
+
+      context "when previously funded" do
+        let(:trn) { application.teacher_reference_number }
+        let(:application) do
+          create(
+            :npq_application,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
+
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
+      end
+
+      context "when previously funded for a different course" do
+        let(:trn) { application.teacher_reference_number }
+        let(:application) do
+          create(
+            :npq_application,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+          )
+        end
+        let(:npq_application_course) { application.npq_course }
+        # Making sure they are completely separate courses
+        let(:npq_course) { create(:npq_course, identifier: npq_application_course.identifier.reverse) }
+
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
+      end
+
+      context "when previously funded with targeted delivery funding" do
+        let(:trn) { application.teacher_reference_number }
+        let(:application) do
+          create(
+            :npq_application,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+            targeted_delivery_funding_eligibility: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
+
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
+
+        it "returns truthy for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_truthy
+        end
+      end
+
+      context "when previously funded ASO and applying for EHCO" do
+        let(:trn) { application.teacher_reference_number }
+        let(:npq_course) { create(:npq_course, identifier: "npq-additional-support-offer") }
+        let(:application) do
+          create(
+            :npq_application,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+            npq_course:,
+          )
+        end
+
+        let!(:ehco_npq_course) { create(:npq_course, identifier: "npq-early-headship-coaching-offer") }
+
+        let(:course_identifier_for_subject) { ehco_npq_course }
+
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
+      end
+
+      context "when previously funded with multiple teacher profiles" do
+        let(:trn) { application.teacher_reference_number }
+        let(:application) do
+          create(
+            :npq_application,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
+
+        before do
+          create(:teacher_profile, trn:)
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
+      end
+
+      context "when previously funded with targeted delivery funding but not accepted" do
+        let(:trn) { application.teacher_reference_number }
+        let(:application) do
+          create(
+            :npq_application,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+            targeted_delivery_funding_eligibility: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
+
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
+      end
+
+      context "when trn does not yield any teachers" do
+        let(:trn) { "0000000" }
+        let(:npq_course) { create(:npq_course) }
+
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
     end
 
-    context "when previously funded" do
-      let(:trn) { application.teacher_reference_number }
-      let(:application) do
-        create(
-          :npq_application,
-          eligible_for_funding: true,
-          teacher_reference_number_verified: true,
-        )
-      end
-      let(:npq_course) { application.npq_course }
+    context "with a get_an_identity_id" do
+      let(:get_an_identity_id) { SecureRandom.uuid }
+      let(:user) { create(:user, get_an_identity_id:) }
 
-      before do
-        NPQ::Application::Accept.new(npq_application: application).call
-      end
+      context "when not previously funded" do
+        let(:application) do
+          create(
+            :npq_application,
+            user:,
+            lead_provider_approval_status: "accepted",
+            eligible_for_funding: false,
+          )
+        end
+        let(:npq_course) { application.npq_course }
 
-      it "returns truthy" do
-        expect(subject.call[:previously_funded]).to be_truthy
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
-      end
-    end
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
 
-    context "when previously funded for a different course" do
-      let(:trn) { application.teacher_reference_number }
-      let(:application) do
-        create(
-          :npq_application,
-          eligible_for_funding: true,
-          teacher_reference_number_verified: true,
-        )
-      end
-      let(:npq_application_course) { application.npq_course }
-      # Making sure they are completely separate courses
-      let(:npq_course) { create(:npq_course, identifier: npq_application_course.identifier.reverse) }
-
-      before do
-        NPQ::Application::Accept.new(npq_application: application).call
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
 
-      it "returns truthy" do
-        expect(subject.call[:previously_funded]).to be_falsey
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
-      end
-    end
+      context "when previously funded" do
+        let(:application) do
+          create(
+            :npq_application,
+            user:,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
 
-    context "when previously funded with targeted delivery funding" do
-      let(:trn) { application.teacher_reference_number }
-      let(:application) do
-        create(
-          :npq_application,
-          eligible_for_funding: true,
-          teacher_reference_number_verified: true,
-          targeted_delivery_funding_eligibility: true,
-        )
-      end
-      let(:npq_course) { application.npq_course }
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
 
-      before do
-        NPQ::Application::Accept.new(npq_application: application).call
-      end
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
 
-      it "returns truthy" do
-        expect(subject.call[:previously_funded]).to be_truthy
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_truthy
-      end
-    end
-
-    context "when previously funded ASO and applying for EHCO" do
-      let(:trn) { application.teacher_reference_number }
-      let(:npq_course) { create(:npq_course, identifier: "npq-additional-support-offer") }
-      let(:application) do
-        create(
-          :npq_application,
-          eligible_for_funding: true,
-          teacher_reference_number_verified: true,
-          npq_course:,
-        )
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
 
-      let!(:ehco_npq_course) { create(:npq_course, identifier: "npq-early-headship-coaching-offer") }
+      context "when previously funded for a different course" do
+        let(:application) do
+          create(
+            :npq_application,
+            user:,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+          )
+        end
+        let(:npq_application_course) { application.npq_course }
+        # Making sure they are completely separate courses
+        let(:npq_course) { create(:npq_course, identifier: npq_application_course.identifier.reverse) }
 
-      before do
-        NPQ::Application::Accept.new(npq_application: application).call
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
 
-      subject { described_class.new(trn:, npq_course_identifier: "npq-early-headship-coaching-offer") }
+      context "when previously funded with targeted delivery funding" do
+        let(:application) do
+          create(
+            :npq_application,
+            user:,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+            targeted_delivery_funding_eligibility: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
 
-      it "returns truthy" do
-        expect(subject.call[:previously_funded]).to be_truthy
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
+
+        it "returns truthy for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_truthy
+        end
       end
-    end
 
-    context "when previously funded with multiple teacher profiles" do
-      let(:trn) { application.teacher_reference_number }
-      let(:application) do
-        create(
-          :npq_application,
-          eligible_for_funding: true,
-          teacher_reference_number_verified: true,
-        )
+      context "when previously funded ASO and applying for EHCO" do
+        let(:npq_course) { create(:npq_course, identifier: "npq-additional-support-offer") }
+        let(:application) do
+          create(
+            :npq_application,
+            user:,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+            npq_course:,
+          )
+        end
+
+        let!(:ehco_npq_course) { create(:npq_course, identifier: "npq-early-headship-coaching-offer") }
+
+        let(:course_identifier_for_subject) { ehco_npq_course }
+
+        before do
+          NPQ::Application::Accept.new(npq_application: application).call
+        end
+
+        it "returns truthy for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_truthy
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
-      let(:npq_course) { application.npq_course }
 
-      before do
-        create(:teacher_profile, trn:)
-        NPQ::Application::Accept.new(npq_application: application).call
+      context "when previously funded with targeted delivery funding but not accepted" do
+        let(:application) do
+          create(
+            :npq_application,
+            user:,
+            eligible_for_funding: true,
+            teacher_reference_number_verified: true,
+            targeted_delivery_funding_eligibility: true,
+          )
+        end
+        let(:npq_course) { application.npq_course }
+
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
+
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
 
-      it "returns truthy" do
-        expect(subject.call[:previously_funded]).to be_truthy
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
-      end
-    end
+      context "when GAI ID does not yield any teachers" do
+        let(:get_an_identity_id) { SecureRandom.uuid }
+        let(:npq_course) { create(:npq_course) }
 
-    context "when previously funded with targeted delivery funding but not accepted" do
-      let(:trn) { application.teacher_reference_number }
-      let(:application) do
-        create(
-          :npq_application,
-          eligible_for_funding: true,
-          teacher_reference_number_verified: true,
-          targeted_delivery_funding_eligibility: true,
-        )
-      end
-      let(:npq_course) { application.npq_course }
+        it "returns falsey for previously_funded" do
+          expect(subject.call[:previously_funded]).to be_falsey
+        end
 
-      it "returns truthy" do
-        expect(subject.call[:previously_funded]).to be_falsey
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
-      end
-    end
-
-    context "when trn does not yield any teachers" do
-      let(:trn) { "0000000" }
-      let(:npq_course) { create(:npq_course) }
-
-      subject { described_class.new(trn:, npq_course_identifier: npq_course.identifier) }
-
-      it "returns falsey" do
-        expect(subject.call[:previously_funded]).to be_falsey
-        expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        it "returns falsey for previously_received_targeted_funding_support" do
+          expect(subject.call[:previously_received_targeted_funding_support]).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-883

### Changes proposed in this pull request

This API is built as a replacement for api/v1/npq-funding/:trn.

The primary goal of building this replacement is to introduce an API that doesn’t depend on the existence of a TRN for it to function.

The existing API embedded the TRN being queried against into the URL itself. The new API doesn’t include any identifiers in the URL, instead receiving the user identifier data in the same way as course identifier information via query parameters.

This allows us to break out from a model where you have to have a TRN to where you can use multiple different kind of identifiers.

Old API formatting example:
`/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership`

New API formatting example:
`/api/v1/npq/previous-funding?npq_course_identifier=npq-senior-leadership&trn=1234567`

The response body for the API remains identical so that this should function as a drop in replacement. Though people swapping should be aware that errors are now more descriptive:

#### Success response

Status: **200**
Body: 
```
{
  "previously_funded" => false,
  "previously_received_targeted_funding_support" => false,
}
```

#### No npq_course_identifier error

Status: **400**
Body: 
```
{
  "error" => "No npq_course_identifier provided",
}
```

#### No identifier error

Status: **400**
Body: 
```
{
  "error" => "No identifier provided. Valid identifier params: trn or get_an_identity_id",
}
```