### PR TITLE
Amend qualified API teacher logic to send empty completion date on failure/voided

### DIFF
--- a/app/services/qualified_teachers_api_sender.rb
+++ b/app/services/qualified_teachers_api_sender.rb
@@ -67,9 +67,13 @@ private
 
   def request_body
     @request_body ||= {
-      completionDate: participant_outcome.completion_date.to_s,
+      completionDate: completion_date,
       qualificationType: participant_outcome.participant_declaration.qualification_type,
     }
+  end
+
+  def completion_date
+    participant_outcome.completion_date.to_s if participant_outcome.passed?
   end
 
   def trn


### PR DESCRIPTION
### Context
When an outcome is voided or failed to unset the certificate we need to send a request to the API with no completion date

- Ticket: n/a

### Changes proposed in this pull request
Amend logic to not send completion date if an outcome is not passed

### Guidance to review

Did I miss anything?