### PR TITLE
Run rubocop with progress formatter too

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         run: bundle install
 
       - name: Lint Ruby
-        run: bundle exec rubocop --format json --out=${{ github.workspace }}/rubocop-result.json
+        run: bundle exec rubocop --format progress --format json --out=${{ github.workspace }}/rubocop-result.json
 
       - name: Lint ERB Templates
         if: false


### PR DESCRIPTION
It's handy to be able to see the results of rubocop runs in the GitHub actions log as well as the JSON artefact. Rubocop [allows multiple `--format` params to be passed in](https://docs.rubocop.org/rubocop/formatters.html) so we can do both.


![image](https://user-images.githubusercontent.com/128088/221578535-9cc49ccc-6462-4fb7-84b1-cdb8fa78b609.png)
