### PR TITLE
Add partnership_id to analytics ecf_inductions table

### DIFF
--- a/app/services/analytics/ecf_induction_service.rb
+++ b/app/services/analytics/ecf_induction_service.rb
@@ -28,6 +28,7 @@ module Analytics
         record.user_id = participant_profile.user_id
         record.participant_type = participant_profile.type
         record.induction_record_created_at = induction_record.created_at
+        record.partnership_id = induction_record.induction_programme.partnership_id
 
         record.save!
       end

--- a/db/analytics_migrate/20230227161000_add_partnership_id_to_inductions.rb
+++ b/db/analytics_migrate/20230227161000_add_partnership_id_to_inductions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPartnershipIdToInductions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :ecf_inductions, :partnership_id, :uuid
+  end
+end

--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_31_103200) do
+ActiveRecord::Schema.define(version: 2023_03_27_161000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2023_01_31_103200) do
     t.uuid "user_id"
     t.string "participant_type"
     t.datetime "induction_record_created_at"
+    t.uuid "partnership_id"
     t.index ["induction_record_id"], name: "index_ecf_inductions_on_induction_record_id", unique: true
   end
 

--- a/spec/services/analytics/ecf_induction_service_spec.rb
+++ b/spec/services/analytics/ecf_induction_service_spec.rb
@@ -22,10 +22,13 @@ describe Analytics::ECFInductionService do
 
     described_class.upsert_record(induction_record)
 
-    record = Analytics::ECFInduction.find_by(induction_record_id: induction_record.id)
-    expect(record.induction_status).to eq "leaving"
-    expect(record.end_date).to be_within(1.second).of end_date
-    expect(record.cohort_id).to eq induction_programme.school_cohort.cohort.id
-    expect(record.induction_record_created_at).to eq induction_record.created_at
+    aggregate_failures do
+      record = Analytics::ECFInduction.find_by(induction_record_id: induction_record.id)
+      expect(record.induction_status).to eq "leaving"
+      expect(record.end_date).to be_within(1.second).of end_date
+      expect(record.cohort_id).to eq induction_programme.school_cohort.cohort.id
+      expect(record.induction_record_created_at).to eq induction_record.created_at
+      expect(record.partnership_id).to eq induction_record.partnership_id
+    end
   end
 end


### PR DESCRIPTION
### Context

Nathan requested that the `partnership_id` field be added to `ecf_inductions` in the anaytics database as it would make downstream querying much easier.

### Changes proposed in this pull request

- Add `partnership_id` column to analytics ecf_inductions
- Set `partnership_id` for induction records analysis
