### PR TITLE
Stop returning a Sentry object when calculating missing qualification type

### DIFF
--- a/app/models/participant_declaration/npq.rb
+++ b/app/models/participant_declaration/npq.rb
@@ -60,5 +60,7 @@ class ParticipantDeclaration::NPQ < ParticipantDeclaration
   rescue KeyError => e
     Rails.logger.warn("A NPQ Qualification types mapping is missing: #{e.message}")
     Sentry.capture_exception(e)
+
+    nil
   end
 end


### PR DESCRIPTION
### Context

When we can't find an NPQ Outcome qualification type, we are logging this to Sentry. Since this is the final step in the method, the return value from the capture method is set to the qualification type and is attempted to be sent to the qualification API.

- Ticket: n/a

### Changes proposed in this pull request

Send an empty qualification type to log the correct error from the API instead.

### Guidance to review
Did I miss anything?
