### PR TITLE
CST-1301: add default induction programme to school cohorts in seeds

### DIFF
--- a/db/analytics_schema.rb
+++ b/db/analytics_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_27_161000) do
+ActiveRecord::Schema.define(version: 2023_02_27_161000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/new_seeds/base/add_mentor_scenarios.rb
+++ b/db/new_seeds/base/add_mentor_scenarios.rb
@@ -2,29 +2,47 @@
 
 # generate some bits of data we'll need below first, roughly sticking to the
 # structure from the legacy seeds but this time spanning two cohorts (2021,
-# 2022) and three lead provoders
-
-school_cohort_one = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2021)
-induction_programme_one = FactoryBot.create(:seed_induction_programme, :cip, school_cohort: school_cohort_one)
-
-school_cohort_two = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2021)
-induction_programme_two = FactoryBot.create(:seed_induction_programme, :fip, school_cohort: school_cohort_two)
-
-school_cohort_three = FactoryBot.create(:seed_school_cohort, :fip, :valid, :starting_in_2021)
-induction_programme_three = FactoryBot.create(:seed_induction_programme, :cip, school_cohort: school_cohort_three)
-
-school_cohort_four = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2022)
-induction_programme_four = FactoryBot.create(:seed_induction_programme, :cip, school_cohort: school_cohort_four)
-
-school_cohort_five = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2022)
-induction_programme_five = FactoryBot.create(:seed_induction_programme, :cip, school_cohort: school_cohort_five)
-
-school_cohort_six = FactoryBot.create(:seed_school_cohort, :fip, :valid, :starting_in_2022)
-induction_programme_six = FactoryBot.create(:seed_induction_programme, :fip, school_cohort: school_cohort_six)
+# 2022) and three lead providers
 
 ambition = CoreInductionProgramme.find_by!(name: "Ambition Institute")
 edt = CoreInductionProgramme.find_by!(name: "Education Development Trust")
 ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
+
+school_cohort_one = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2021)
+induction_programme_one = NewSeeds::Scenarios::InductionProgrammes::Cip
+                            .new(school_cohort: school_cohort_one, core_induction_programme: ambition)
+                            .build
+                            .induction_programme
+
+school_cohort_two = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2021)
+induction_programme_two = NewSeeds::Scenarios::InductionProgrammes::Cip
+                            .new(school_cohort: school_cohort_two, core_induction_programme: edt)
+                            .build
+                            .induction_programme
+
+school_cohort_three = FactoryBot.create(:seed_school_cohort, :fip, :valid, :starting_in_2021)
+induction_programme_three = NewSeeds::Scenarios::InductionProgrammes::Fip
+                              .new(school_cohort: school_cohort_three)
+                              .build
+                              .induction_programme
+
+school_cohort_four = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2022)
+induction_programme_four = NewSeeds::Scenarios::InductionProgrammes::Cip
+                             .new(school_cohort: school_cohort_four, core_induction_programme: ambition)
+                             .build
+                             .induction_programme
+
+school_cohort_five = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2022)
+induction_programme_five = NewSeeds::Scenarios::InductionProgrammes::Cip
+                             .new(school_cohort: school_cohort_five, core_induction_programme: ucl)
+                             .build
+                             .induction_programme
+
+school_cohort_six = FactoryBot.create(:seed_school_cohort, :fip, :valid, :starting_in_2022)
+induction_programme_six = NewSeeds::Scenarios::InductionProgrammes::Fip
+                            .new(school_cohort: school_cohort_six)
+                            .build
+                            .induction_programme
 
 # first some generic mentors
 
@@ -32,7 +50,6 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   OpenStruct.new(
     full_name: "Sally Mentor",
     email: "rp-mentor.ambition.2021@example.com",
-    core_induction_programme: ambition,
     school_cohort: school_cohort_one,
     schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort_one.cohort),
     induction_programme: induction_programme_one,
@@ -40,7 +57,6 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   OpenStruct.new(
     full_name: "Bjorn Mentor",
     email: "rp-mentor.edt.2021@example.com",
-    core_induction_programme: edt,
     school_cohort: school_cohort_two,
     schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort_two.cohort),
     induction_programme: induction_programme_two,
@@ -48,7 +64,6 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   OpenStruct.new(
     full_name: "Abdul Mentor",
     email: "rp-mentor.ucl.2021@example.com",
-    core_induction_programme: ucl,
     school_cohort: school_cohort_three,
     schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort_three.cohort),
     induction_programme: induction_programme_three,
@@ -57,7 +72,6 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   OpenStruct.new(
     full_name: "Claire Mentor",
     email: "rp-mentor.ambition.2022@example.com",
-    core_induction_programme: ambition,
     school_cohort: school_cohort_four,
     schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort_four.cohort),
     induction_programme: induction_programme_four,
@@ -65,7 +79,6 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   OpenStruct.new(
     full_name: "Rita Mentor",
     email: "rp-mentor.edt.2022@example.com",
-    core_induction_programme: edt,
     school_cohort: school_cohort_five,
     schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort_five.cohort),
     induction_programme: induction_programme_five,
@@ -73,18 +86,15 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
   OpenStruct.new(
     full_name: "Luigi Mentor",
     email: "rp-mentor.ucl.2022@example.com",
-    core_induction_programme: ucl,
     school_cohort: school_cohort_six,
     schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort_six.cohort),
     induction_programme: induction_programme_six,
   ),
 ].each do |mentor_params|
   NewSeeds::Scenarios::Participants::Mentors::MentorWithNoEcts
-    .new(school_cohort: mentor_params.school_cohort, full_name: mentor_params.full_name)
-    .build(
-      schedule: mentor_params.schedule,
-    )
+    .new(school_cohort: mentor_params.school_cohort, full_name: mentor_params.full_name, email: mentor_params.email)
+    .build(schedule: mentor_params.schedule)
     .with_validation_data
     .with_eligibility
-    .add_induction_record(induction_programme: mentor_params.induction_programme)
+    .with_induction_record(induction_programme: mentor_params.induction_programme)
 end

--- a/db/new_seeds/base/add_mentor_scenarios.rb
+++ b/db/new_seeds/base/add_mentor_scenarios.rb
@@ -10,38 +10,44 @@ ucl = CoreInductionProgramme.find_by!(name: "UCL Institute of Education")
 
 school_cohort_one = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2021)
 induction_programme_one = NewSeeds::Scenarios::InductionProgrammes::Cip
-                            .new(school_cohort: school_cohort_one, core_induction_programme: ambition)
+                            .new(school_cohort: school_cohort_one)
                             .build
+                            .with_core_induction_programme(core_induction_programme: ambition)
                             .induction_programme
 
 school_cohort_two = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2021)
 induction_programme_two = NewSeeds::Scenarios::InductionProgrammes::Cip
-                            .new(school_cohort: school_cohort_two, core_induction_programme: edt)
+                            .new(school_cohort: school_cohort_two)
                             .build
+                            .with_core_induction_programme(core_induction_programme: edt)
                             .induction_programme
 
 school_cohort_three = FactoryBot.create(:seed_school_cohort, :fip, :valid, :starting_in_2021)
 induction_programme_three = NewSeeds::Scenarios::InductionProgrammes::Fip
                               .new(school_cohort: school_cohort_three)
                               .build
+                              .with_partnership
                               .induction_programme
 
 school_cohort_four = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2022)
 induction_programme_four = NewSeeds::Scenarios::InductionProgrammes::Cip
-                             .new(school_cohort: school_cohort_four, core_induction_programme: ambition)
+                             .new(school_cohort: school_cohort_four)
                              .build
+                             .with_core_induction_programme(core_induction_programme: ambition)
                              .induction_programme
 
 school_cohort_five = FactoryBot.create(:seed_school_cohort, :cip, :valid, :starting_in_2022)
 induction_programme_five = NewSeeds::Scenarios::InductionProgrammes::Cip
-                             .new(school_cohort: school_cohort_five, core_induction_programme: ucl)
+                             .new(school_cohort: school_cohort_five)
                              .build
+                             .with_core_induction_programme(core_induction_programme: ucl)
                              .induction_programme
 
 school_cohort_six = FactoryBot.create(:seed_school_cohort, :fip, :valid, :starting_in_2022)
 induction_programme_six = NewSeeds::Scenarios::InductionProgrammes::Fip
                             .new(school_cohort: school_cohort_six)
                             .build
+                            .with_partnership
                             .induction_programme
 
 # first some generic mentors

--- a/db/new_seeds/scenarios/induction_programmes/cip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/cip.rb
@@ -15,18 +15,18 @@ module NewSeeds
         end
 
         def build(default_induction_programme: true)
-          tap do
-            @induction_programme = FactoryBot.create(:seed_induction_programme, :cip, school_cohort:)
-            set_default_induction_programme! if default_induction_programme
-          end
+          @induction_programme = FactoryBot.create(:seed_induction_programme, :cip, school_cohort:)
+          set_default_induction_programme! if default_induction_programme
+
+          self
         end
 
         def with_core_induction_programme(core_induction_programme: nil, default_core_induction_programme: true)
-          tap do
-            core_induction_programme ||= FactoryBot.create(:seed_core_induction_programme)
-            induction_programme.update!(core_induction_programme:)
-            set_default_core_induction_programme! if default_core_induction_programme
-          end
+          core_induction_programme ||= FactoryBot.create(:seed_core_induction_programme)
+          induction_programme.update!(core_induction_programme:)
+          set_default_core_induction_programme! if default_core_induction_programme
+
+          self
         end
 
       private

--- a/db/new_seeds/scenarios/induction_programmes/cip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/cip.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module NewSeeds
+  module Scenarios
+    module InductionProgrammes
+      # Creates a CIP induction programme to the given school cohort.
+      # Also links it to the provided core induction programme or a fresh new one.
+      # Optionally sets it as the default induction programme of the school cohort. Default: true.
+      # Optionally sets the core induction programme as the default for the school cohort. Default: true.
+      class Cip
+        attr_accessor :induction_programme
+
+        def initialize(school_cohort:, core_induction_programme: nil)
+          @school_cohort = school_cohort
+          @core_induction_programme = core_induction_programme
+        end
+
+        def build(default_induction_programme: true, default_core_induction_programme: true)
+          tap do
+            @induction_programme = FactoryBot.create(:seed_induction_programme,
+                                                     :cip,
+                                                     school_cohort:,
+                                                     core_induction_programme:)
+            set_defaults!(default_induction_programme:, default_core_induction_programme:)
+          end
+        end
+
+      private
+
+        attr_reader :school_cohort
+
+        def core_induction_programme
+          return if with_no_core_induction_programme?
+
+          @core_induction_programme ||= FactoryBot.create(:seed_core_induction_programme)
+        end
+
+        def set_defaults!(default_induction_programme:, default_core_induction_programme:)
+          defaults = default_core_induction_programme ? { core_induction_programme: } : {}
+          defaults.merge!(default_induction_programme: induction_programme) if default_induction_programme
+          school_cohort.update!(**defaults) if defaults.present?
+        end
+
+        def with_no_core_induction_programme?
+          @with_no_core_induction_programme ||= @core_induction_programme == :none
+        end
+      end
+    end
+  end
+end

--- a/db/new_seeds/scenarios/induction_programmes/fip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/fip.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module NewSeeds
+  module Scenarios
+    module InductionProgrammes
+      # Creates a FIP induction programme to the given school cohort.
+      # Optionally links it to the provided partnership or a fresh new one with new lead provided and delivery partner
+      #   unless partnership: :none received. Default: create a new one.
+      # Optionally sets it as the default induction programme of the school cohort. Default: true.
+      class Fip
+        attr_reader :induction_programme
+
+        def initialize(school_cohort:, partnership: nil)
+          @school_cohort = school_cohort
+          @partnership = partnership
+        end
+
+        def build(default_induction_programme: true)
+          tap do
+            @induction_programme = FactoryBot.create(:seed_induction_programme, :fip, school_cohort:, partnership:)
+            set_default_induction_programme! if default_induction_programme
+          end
+        end
+
+      private
+
+        attr_reader :school_cohort
+
+        delegate :cohort, :school, to: :school_cohort
+
+        def delivery_partner
+          @delivery_partner ||= FactoryBot.create(:seed_delivery_partner)
+        end
+
+        def lead_provider
+          @lead_provider ||= FactoryBot.create(:seed_lead_provider)
+        end
+
+        def partnership
+          return if with_no_partnership?
+
+          @partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:)
+        end
+
+        def set_default_induction_programme!
+          school_cohort.update!(default_induction_programme: induction_programme)
+        end
+
+        def with_no_partnership?
+          @with_no_partnership ||= @partnership == :none
+        end
+      end
+    end
+  end
+end

--- a/db/new_seeds/scenarios/induction_programmes/fip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/fip.rb
@@ -15,28 +15,27 @@ module NewSeeds
         end
 
         def build(default_induction_programme: true)
-          tap do
-            @induction_programme = FactoryBot.create(:seed_induction_programme, :fip, school_cohort:)
-            set_default_induction_programme! if default_induction_programme
-          end
+          @induction_programme = FactoryBot.create(:seed_induction_programme, :fip, school_cohort:)
+          set_default_induction_programme! if default_induction_programme
+
+          self
         end
 
         def with_partnership(partnership: nil)
-          tap do
-            partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:)
-            induction_programme.update!(partnership:)
-          end
+          partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:)
+          induction_programme.update!(partnership:)
+
+          self
         end
 
         def with_relationship(lead_provider:, delivery_partner:)
-          tap do
-            induction_programme.update!(partnership: FactoryBot.create(:seed_partnership,
-                                                                       :relationship,
-                                                                       cohort:,
-                                                                       school:,
-                                                                       lead_provider:,
-                                                                       delivery_partner:))
-          end
+          induction_programme.update!(partnership: FactoryBot.create(:seed_partnership,
+                                                                     :relationship,
+                                                                     cohort:,
+                                                                     school:,
+                                                                     lead_provider:,
+                                                                     delivery_partner:))
+          self
         end
 
       private

--- a/db/new_seeds/scenarios/induction_programmes/fip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/fip.rb
@@ -10,15 +10,21 @@ module NewSeeds
       class Fip
         attr_reader :induction_programme
 
-        def initialize(school_cohort:, partnership: nil)
+        def initialize(school_cohort:)
           @school_cohort = school_cohort
-          @partnership = partnership
         end
 
         def build(default_induction_programme: true)
           tap do
-            @induction_programme = FactoryBot.create(:seed_induction_programme, :fip, school_cohort:, partnership:)
+            @induction_programme = FactoryBot.create(:seed_induction_programme, :fip, school_cohort:)
             set_default_induction_programme! if default_induction_programme
+          end
+        end
+
+        def with_partnership(partnership: nil)
+          tap do
+            partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:)
+            induction_programme.update!(partnership:)
           end
         end
 
@@ -36,18 +42,8 @@ module NewSeeds
           @lead_provider ||= FactoryBot.create(:seed_lead_provider)
         end
 
-        def partnership
-          return if with_no_partnership?
-
-          @partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:)
-        end
-
         def set_default_induction_programme!
           school_cohort.update!(default_induction_programme: induction_programme)
-        end
-
-        def with_no_partnership?
-          @with_no_partnership ||= @partnership == :none
         end
       end
     end

--- a/db/new_seeds/scenarios/induction_programmes/fip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/fip.rb
@@ -28,6 +28,17 @@ module NewSeeds
           end
         end
 
+        def with_relationship(lead_provider:, delivery_partner:)
+          tap do
+            induction_programme.update!(partnership: FactoryBot.create(:seed_partnership,
+                                                                       :relationship,
+                                                                       cohort:,
+                                                                       school:,
+                                                                       lead_provider:,
+                                                                       delivery_partner:))
+          end
+        end
+
       private
 
         attr_reader :school_cohort

--- a/db/new_seeds/scenarios/participants/ects/ect.rb
+++ b/db/new_seeds/scenarios/participants/ects/ect.rb
@@ -28,12 +28,15 @@ module NewSeeds
             self
           end
 
-          def add_induction_record(induction_programme:, mentor_profile: nil, start_date: 6.months.ago, end_date: nil, induction_status: "active", training_status: "active")
+          def add_induction_record(induction_programme:, mentor_profile: nil, start_date: 6.months.ago, end_date: nil, induction_status: "active", training_status: "active", preferred_identity: nil)
+            preferred_identity ||= FactoryBot.create(:seed_participant_identity, user: participant_profile.user)
+
             FactoryBot.create(
               :seed_induction_record,
               induction_programme:,
               mentor_profile:,
               participant_profile:,
+              preferred_identity:,
               schedule: Finance::Schedule::ECF.default_for(cohort: induction_programme.cohort),
               start_date:,
               end_date:,

--- a/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
@@ -29,11 +29,14 @@ module NewSeeds
             self
           end
 
-          def add_induction_record(induction_programme:, start_date: 6.months.ago, end_date: nil, induction_status: "active", training_status: "active")
+          def add_induction_record(induction_programme:, start_date: 6.months.ago, end_date: nil, induction_status: "active", training_status: "active", preferred_identity: nil)
+            preferred_identity ||= FactoryBot.create(:seed_participant_identity, user: participant_profile.user)
+
             FactoryBot.create(
               :seed_induction_record,
               induction_programme:,
               participant_profile:,
+              preferred_identity:,
               schedule: Finance::Schedule::ECF.default_for(cohort: induction_programme.cohort),
               start_date:,
               end_date:,

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -39,8 +39,9 @@ module NewSeeds
                                              lead_provider:)
 
             @induction_programme = NewSeeds::Scenarios::InductionProgrammes::Fip
-                                     .new(school_cohort:, partnership:)
+                                     .new(school_cohort:)
                                      .build
+                                     .with_partnership(partnership:)
                                      .induction_programme
 
             @mentor ||= build_mentor

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -38,10 +38,10 @@ module NewSeeds
                                              delivery_partner:,
                                              lead_provider:)
 
-            @induction_programme = FactoryBot.create(:seed_induction_programme,
-                                                     :fip,
-                                                     school_cohort:,
-                                                     partnership:)
+            @induction_programme = NewSeeds::Scenarios::InductionProgrammes::Fip
+                                     .new(school_cohort:, partnership:)
+                                     .build
+                                     .induction_programme
 
             @mentor ||= build_mentor
 

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip.rb
@@ -19,7 +19,6 @@ module NewSeeds
           COHORT_START_YEAR = 2022
 
           attr_reader :participant_profile,
-                      :induction_programme_from,
                       :induction_programme_to
 
           def initialize(from_school: nil, to_school: nil)
@@ -27,12 +26,31 @@ module NewSeeds
             @school_to = to_school
           end
 
-        private
+          def induction_programme_from
+            @induction_programme_from ||= NewSeeds::Scenarios::SchoolCohorts::Fip
+                                            .new(cohort:, school: school_from)
+                                            .build
+                                            .with_programme
+                                            .school_cohort
+                                            .default_induction_programme
+          end
 
-          attr_reader :school_from, :school_to
+        private
 
           def cohort
             @cohort ||= Cohort.find_by!(start_year: COHORT_START_YEAR)
+          end
+
+          def create_induction_record_to
+            FactoryBot.create(:seed_induction_record,
+                              induction_programme: induction_programme_to,
+                              participant_profile:,
+                              preferred_identity: FactoryBot.create(:seed_participant_identity, user: participant_profile.user),
+                              schedule: Finance::Schedule::ECF.default_for(cohort: induction_programme_to.cohort),
+                              start_date: 6.months.ago + 10.days,
+                              school_transfer: true,
+                              induction_status: :active,
+                              training_status: :active)
           end
 
           def email
@@ -51,28 +69,30 @@ module NewSeeds
             induction_programme_to.school_cohort
           end
 
-          def setup
+          def school_from
             @school_from ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
+          end
+
+          def school_to
             @school_to ||= FactoryBot.create(:seed_school, :with_induction_coordinator)
-            @induction_programme_from = NewSeeds::Scenarios::SchoolCohorts::Fip
-                                          .new(cohort:, school: school_from)
+          end
+
+          def setup
+            @induction_programme_to ||= NewSeeds::Scenarios::SchoolCohorts::Fip
+                                          .new(cohort:, school: school_to)
                                           .build
                                           .with_programme
                                           .school_cohort
                                           .default_induction_programme
-            @induction_programme_to = NewSeeds::Scenarios::SchoolCohorts::Fip
-                                        .new(cohort:, school: school_to)
-                                        .build
-                                        .with_programme
-                                        .school_cohort
-                                        .default_induction_programme
             # a teacher to transfer
             @participant_profile = NewSeeds::Scenarios::Participants::Ects::Ect
                                      .new(school_cohort: school_cohort_from)
                                      .build
                                      .with_validation_data
                                      .with_eligibility
-                                     .with_induction_record(induction_programme: induction_programme_from)
+                                     .with_induction_record(induction_programme: induction_programme_from,
+                                                            induction_status: :leaving,
+                                                            end_date: 6.months.ago + 10.days)
                                      .participant_profile
           end
 

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
@@ -5,8 +5,6 @@ module NewSeeds
     module Participants
       module Transfers
         class FipToFipChangingTrainingProvider < FipToFip
-          attr_reader :from_school, :to_school
-
           def initialize
             Rails.logger.info("################# seeding scenario FipToFipChangingTrainingProvider")
             super
@@ -17,9 +15,11 @@ module NewSeeds
 
             Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} using the new school's training provider")
 
-            FactoryBot.create(:seed_induction_record,
-                              participant_profile:,
-                              induction_programme: induction_programme_to)
+            Induction::TransferToSchoolsProgramme.call(participant_profile:,
+                                                       induction_programme: induction_programme_to,
+                                                       start_date:,
+                                                       email:,
+                                                       mentor_profile:)
           end
         end
       end

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_changing_training_provider.rb
@@ -12,14 +12,9 @@ module NewSeeds
 
           def build
             setup
-
             Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} using the new school's training provider")
 
-            Induction::TransferToSchoolsProgramme.call(participant_profile:,
-                                                       induction_programme: induction_programme_to,
-                                                       start_date:,
-                                                       email:,
-                                                       mentor_profile:)
+            create_induction_record_to
           end
         end
       end

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
@@ -11,17 +11,20 @@ module NewSeeds
           end
 
           def build
+            relationship = FactoryBot.create(:seed_partnership,
+                                             :relationship,
+                                             cohort:,
+                                             school: school_to,
+                                             lead_provider: induction_programme_from.lead_provider,
+                                             delivery_partner: induction_programme_from.delivery_partner)
+            @induction_programme_to ||= NewSeeds::Scenarios::SchoolCohorts::Fip
+                                          .new(cohort:, school: school_to)
+                                          .build
+                                          .add_programme(default_induction_programme: false, partnership: relationship)
             setup
-
             Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} while keeping their original training provider")
 
-            @induction_programme_to = Induction::TransferAndContinueExistingFip
-                                        .call(school_cohort: school_cohort_to,
-                                              participant_profile:,
-                                              email:,
-                                              start_date:,
-                                              mentor_profile:)
-                                        .induction_programme
+            create_induction_record_to
           end
         end
       end

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
@@ -5,10 +5,6 @@ module NewSeeds
     module Participants
       module Transfers
         class FipToFipKeepingOriginalTrainingProvider < FipToFip
-          attr_reader :relationship,
-                      :relationship_induction_programme,
-                      :relationship_induction_record
-
           def initialize
             Rails.logger.debug("################# seeding scenario FipToFipKeepingOriginalTrainingProvider")
             super
@@ -17,29 +13,15 @@ module NewSeeds
           def build
             setup
 
-            # do a transfer:
-            # * there should be a Partnershp with `relationship: true` between the new school
-            #   and the lead provider of the old school
-            # * create a FIP induction programme that has the new (relationship)
-            #   partnership above set
-            @relationship = FactoryBot.create(:seed_partnership,
-                                              :relationship,
-                                              cohort: cohort(2021),
-                                              school: school_to,
-                                              delivery_partner: delivery_partner_from, # assume we want the orig DP too
-                                              lead_provider: lead_provider_from)
-
-            @relationship_induction_programme = FactoryBot.create(:seed_induction_programme,
-                                                                  :fip,
-                                                                  school_cohort: school_cohort_to,
-                                                                  partnership: relationship)
-
             Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} while keeping their original training provider")
 
-            # enrol the participant to the new programme (aka create an induction record)
-            @relationship_induction_record = FactoryBot.create(:seed_induction_record,
-                                                               participant_profile:,
-                                                               induction_programme: relationship_induction_programme)
+            @induction_programme_to = Induction::TransferAndContinueExistingFip
+                                        .call(school_cohort: school_cohort_to,
+                                              participant_profile:,
+                                              email:,
+                                              start_date:,
+                                              mentor_profile:)
+                                        .induction_programme
           end
         end
       end

--- a/db/new_seeds/scenarios/school_cohorts/cip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/cip.rb
@@ -13,9 +13,15 @@ module NewSeeds
         end
 
         def build
-          tap do
-            @school_cohort = FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:)
-          end
+          @school_cohort = FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:)
+
+          self
+        end
+
+        def with_programme(**args)
+          add_programme(**args)
+
+          self
         end
 
         # Adds a FIP induction programme to the school cohort.
@@ -23,15 +29,13 @@ module NewSeeds
         #   unless core_induction_programme: :none received. Default: create a new one.
         # Optionally sets it as the default induction programme of the school cohort. Default: true.
         # Optionally sets the core induction programme as the default for the school cohort. Default: true.
-        def with_programme(core_induction_programme: nil,
-                           default_induction_programme: true,
-                           default_core_induction_programme: true)
-          tap do
-            NewSeeds::Scenarios::InductionProgrammes::Cip
-              .new(school_cohort:)
-              .build(default_induction_programme:)
-              .with_core_induction_programme(core_induction_programme:, default_core_induction_programme:)
-          end
+        def add_programme(core_induction_programme: nil,
+                          default_induction_programme: true,
+                          default_core_induction_programme: true)
+          NewSeeds::Scenarios::InductionProgrammes::Cip
+            .new(school_cohort:)
+            .build(default_induction_programme:)
+            .with_core_induction_programme(core_induction_programme:, default_core_induction_programme:)
         end
 
       private

--- a/db/new_seeds/scenarios/school_cohorts/cip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/cip.rb
@@ -28,8 +28,9 @@ module NewSeeds
                            default_core_induction_programme: true)
           tap do
             NewSeeds::Scenarios::InductionProgrammes::Cip
-              .new(school_cohort:, core_induction_programme:)
-              .build(default_induction_programme:, default_core_induction_programme:)
+              .new(school_cohort:)
+              .build(default_induction_programme:)
+              .with_core_induction_programme(core_induction_programme:, default_core_induction_programme:)
           end
         end
 

--- a/db/new_seeds/scenarios/school_cohorts/cip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/cip.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module NewSeeds
+  module Scenarios
+    module SchoolCohorts
+      # Creates a CIP school cohort for the given cohort and the given school or a fresh new one.
+      class Cip
+        attr_reader :school_cohort
+
+        def initialize(cohort:, school: nil)
+          @cohort = cohort
+          @school = school
+        end
+
+        def build
+          tap do
+            @school_cohort = FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:)
+          end
+        end
+
+        # Adds a FIP induction programme to the school cohort.
+        # Optionally links it to the provided core_induction_programme or a fresh new one,
+        #   unless core_induction_programme: :none received. Default: create a new one.
+        # Optionally sets it as the default induction programme of the school cohort. Default: true.
+        # Optionally sets the core induction programme as the default for the school cohort. Default: true.
+        def with_programme(core_induction_programme: nil,
+                           default_induction_programme: true,
+                           default_core_induction_programme: true)
+          tap do
+            NewSeeds::Scenarios::InductionProgrammes::Cip
+              .new(school_cohort:, core_induction_programme:)
+              .build(default_induction_programme:, default_core_induction_programme:)
+          end
+        end
+
+      private
+
+        attr_reader :cohort
+
+        def school
+          @school ||= FactoryBot.create(:seed_school)
+        end
+      end
+    end
+  end
+end

--- a/db/new_seeds/scenarios/school_cohorts/fip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/fip.rb
@@ -13,19 +13,21 @@ module NewSeeds
         end
 
         def build
-          tap do
-            @school_cohort = FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:)
-          end
+          @school_cohort = FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:)
+
+          self
+        end
+
+        def with_programme(**args)
+          add_programme(**args)
+
+          self
         end
 
         # Adds a FIP induction programme to the school cohort.
         # Optionally links it to the provided partnership or a fresh new one with new lead provided and delivery partner
         #   unless partnership: :none received. Default: create a new one.
         # Optionally sets it as the default induction programme of the school cohort. Default: true.
-        def with_programme(**args)
-          tap { add_programme(**args) }
-        end
-
         def add_programme(default_induction_programme: true, partnership: nil)
           NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:)
                                                        .build(default_induction_programme:)

--- a/db/new_seeds/scenarios/school_cohorts/fip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/fip.rb
@@ -22,12 +22,15 @@ module NewSeeds
         # Optionally links it to the provided partnership or a fresh new one with new lead provided and delivery partner
         #   unless partnership: :none received. Default: create a new one.
         # Optionally sets it as the default induction programme of the school cohort. Default: true.
-        def with_programme(default_induction_programme: true, partnership: nil)
-          tap do
-            NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:)
-                                                         .build(default_induction_programme:)
-                                                         .with_partnership(partnership:)
-          end
+        def with_programme(**args)
+          tap { add_programme(**args) }
+        end
+
+        def add_programme(default_induction_programme: true, partnership: nil)
+          NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:)
+                                                       .build(default_induction_programme:)
+                                                       .with_partnership(partnership:)
+                                                       .induction_programme
         end
 
       private

--- a/db/new_seeds/scenarios/school_cohorts/fip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/fip.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module NewSeeds
+  module Scenarios
+    module SchoolCohorts
+      # Creates a FIP school cohort for the given cohort and the given school or a fresh new one.
+      class Fip
+        attr_reader :school_cohort
+
+        def initialize(cohort:, school: nil)
+          @school = school
+          @cohort = cohort
+        end
+
+        def build
+          tap do
+            @school_cohort = FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:)
+          end
+        end
+
+        # Adds a FIP induction programme to the school cohort.
+        # Optionally links it to the provided partnership or a fresh new one with new lead provided and delivery partner
+        #   unless partnership: :none received. Default: create a new one.
+        # Optionally sets it as the default induction programme of the school cohort. Default: true.
+        def with_programme(default_induction_programme: true, partnership: nil)
+          tap do
+            NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:, partnership:)
+                                                         .build(default_induction_programme:)
+          end
+        end
+
+      private
+
+        attr_reader :cohort
+
+        def school
+          @school ||= FactoryBot.create(:seed_school)
+        end
+      end
+    end
+  end
+end

--- a/db/new_seeds/scenarios/school_cohorts/fip.rb
+++ b/db/new_seeds/scenarios/school_cohorts/fip.rb
@@ -24,8 +24,9 @@ module NewSeeds
         # Optionally sets it as the default induction programme of the school cohort. Default: true.
         def with_programme(default_induction_programme: true, partnership: nil)
           tap do
-            NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:, partnership:)
+            NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:)
                                                          .build(default_induction_programme:)
+                                                         .with_partnership(partnership:)
           end
         end
 

--- a/db/new_seeds/scenarios/schools/school.rb
+++ b/db/new_seeds/scenarios/schools/school.rb
@@ -48,11 +48,11 @@ module NewSeeds
         # will also add a partnership to that cohort and induction programme
         ###
         def chosen_fip_and_partnered_in(cohort:, partnership: nil)
-          tap do
-            fip = NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort:, school:).build.with_programme(partnership:)
-            partnerships[cohort.start_year] = fip.school_cohort.default_induction_programme.partnership
-            school_cohorts[cohort.start_year] = fip.school_cohort
-          end
+          fip = NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort:, school:).build.with_programme(partnership:)
+          partnerships[cohort.start_year] = fip.school_cohort.default_induction_programme.partnership
+          school_cohorts[cohort.start_year] = fip.school_cohort
+
+          self
         end
 
         ###
@@ -60,13 +60,12 @@ module NewSeeds
         # will also add CIP materials to that school_cohort and induction programme
         ###
         def chosen_cip_with_materials_in(cohort:, materials: nil)
-          tap do
-            school_cohorts[cohort.start_year] = NewSeeds::Scenarios::SchoolCohorts::Cip
-                                                  .new(cohort:, school:)
-                                                  .build
-                                                  .with_programme(core_induction_programme: materials)
-                                                  .school_cohort
-          end
+          school_cohorts[cohort.start_year] = NewSeeds::Scenarios::SchoolCohorts::Cip
+                                                .new(cohort:, school:)
+                                                .build
+                                                .with_programme(core_induction_programme: materials)
+                                                .school_cohort
+          self
         end
 
         ###

--- a/db/new_seeds/scenarios/schools/school.rb
+++ b/db/new_seeds/scenarios/schools/school.rb
@@ -48,19 +48,11 @@ module NewSeeds
         # will also add a partnership to that cohort and induction programme
         ###
         def chosen_fip_and_partnered_in(cohort:, partnership: nil)
-          with_school_cohort_and_programme(cohort:, programme_type: :fip)
-          relevant_school_cohort = school_cohorts[cohort.start_year]
-
-          if partnership.present?
-            partnerships[cohort.start_year] = partnership
-          else
-            with_partnership_in(cohort:)
+          tap do
+            fip = NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort:, school:).build.with_programme(partnership:)
+            partnerships[cohort.start_year] = fip.school_cohort.default_induction_programme.partnership
+            school_cohorts[cohort.start_year] = fip.school_cohort
           end
-
-          partnership = partnerships[cohort.start_year]
-          relevant_school_cohort.default_induction_programme.update!(partnership:)
-
-          self
         end
 
         ###
@@ -68,15 +60,13 @@ module NewSeeds
         # will also add CIP materials to that school_cohort and induction programme
         ###
         def chosen_cip_with_materials_in(cohort:, materials: nil)
-          with_school_cohort_and_programme(cohort:, programme_type: :cip)
-          relevant_school_cohort = school_cohorts[cohort.start_year]
-
-          materials = FactoryBot.create(:seed_core_induction_programme) if materials.nil?
-
-          relevant_school_cohort.default_induction_programme.update!(core_induction_programme: materials)
-          relevant_school_cohort.update!(core_induction_programme: materials)
-
-          self
+          tap do
+            school_cohorts[cohort.start_year] = NewSeeds::Scenarios::SchoolCohorts::Cip
+                                                  .new(cohort:, school:)
+                                                  .build
+                                                  .with_programme(core_induction_programme: materials)
+                                                  .school_cohort
+          end
         end
 
         ###
@@ -110,6 +100,12 @@ module NewSeeds
 
         def partnership
           partnerships.values.first
+        end
+
+      private
+
+        def add_school_cohort(cohort:, programme_type:)
+          school_cohorts[cohort.start_year] = FactoryBot.create(:seed_school_cohort, programme_type, school:, cohort:)
         end
       end
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -645,7 +645,7 @@ ActiveRecord::Schema.define(version: 2023_02_22_142649) do
     t.boolean "sparsity_uplift"
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text, ('clawed_back'::character varying)::text]))"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying, 'clawed_back'::character varying])::text[]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"
@@ -1210,7 +1210,7 @@ ActiveRecord::Schema.define(version: 2023_02_22_142649) do
               count(*) AS count
              FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-            WHERE ((participant_profiles_1.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text]))
+            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id) duplicates ON ((duplicates.user_id = participant_identities.user_id)))
        LEFT JOIN teacher_profiles ON ((teacher_profiles.id = participant_profiles.teacher_profile_id)))
        LEFT JOIN schedules ON ((latest_induction_records.schedule_id = schedules.id)))
@@ -1222,9 +1222,9 @@ ActiveRecord::Schema.define(version: 2023_02_22_142649) do
     WHERE ((participant_identities.user_id IN ( SELECT participant_identities_1.user_id
              FROM (participant_profiles participant_profiles_1
                JOIN participant_identities participant_identities_1 ON ((participant_identities_1.id = participant_profiles_1.participant_identity_id)))
-            WHERE ((participant_profiles_1.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text]))
+            WHERE ((participant_profiles_1.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[]))
             GROUP BY participant_profiles_1.type, participant_identities_1.user_id
-           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY (ARRAY[('ParticipantProfile::ECT'::character varying)::text, ('ParticipantProfile::Mentor'::character varying)::text])))
+           HAVING (count(*) > 1))) AND ((participant_profiles.type)::text = ANY ((ARRAY['ParticipantProfile::ECT'::character varying, 'ParticipantProfile::Mentor'::character varying])::text[])))
     ORDER BY participant_identities.external_identifier, (row_number() OVER (PARTITION BY participant_identities.user_id ORDER BY
           CASE
               WHEN (((latest_induction_records.training_status)::text = 'active'::text) AND ((latest_induction_records.induction_status)::text = 'active'::text)) THEN 1

--- a/spec/factories/seeds/induction_programme_factory.rb
+++ b/spec/factories/seeds/induction_programme_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     trait(:fip) { training_programme { "full_induction_programme" } }
     trait(:cip) { training_programme { "core_induction_programme" } }
     trait(:design_our_own) { training_programme { "design_our_own" } }
-    trait(:school_funnded_fip) { training_programme { "school_funnded_fip" } }
+    trait(:school_funded_fip) { training_programme { "school_funded_fip" } }
 
     trait(:with_school_cohort) { association(:school_cohort, factory: %i[seed_school_cohort valid]) }
     trait(:with_school) { association(:school, factory: :seed_school) }


### PR DESCRIPTION
### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1301): Ensure `SchoolCohort.default_induction_programme` is set when we're seeding schools/induction programmes

### Changes proposed in this pull request

- Added new scenarios to create flexible school_cohorts and induction programmes that also set default programmes

### Guidance to review

