### PR TITLE
Remove NQT+1 materials link path from reminders

### DIFF
--- a/app/mailers/ineligible_participant_mailer.rb
+++ b/app/mailers/ineligible_participant_mailer.rb
@@ -77,7 +77,6 @@ class IneligibleParticipantMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         ineligible_ECT_name: participant_profile.user.full_name,
-        "NQT+1_materials_link": start_schools_year_2020_url(school_id: participant_profile.school.slug),
       },
     ).tag(:ineligible_participant).associate_with(participant_profile, as: :participant_profile)
   end
@@ -92,7 +91,6 @@ class IneligibleParticipantMailer < ApplicationMailer
       personalisation: {
         SIT_name: sit.full_name,
         ineligible_ECT_name: participant_profile.user.full_name,
-        "NQT+1_materials_link": start_schools_year_2020_url(school_id: participant_profile.school.slug),
       },
     ).tag(:ineligible_participant).associate_with(participant_profile, as: :participant_profile)
   end


### PR DESCRIPTION
### Context

We're seeing some crashes in prod when processing the reminder email jobs that contain `NQT+1_materials_link`.

### Changes proposed in this pull request

`NQT+1_materials_link` placeholder has now been removed from the templates in Notify so removing the corresponding calls from the mailer should prevent the crashes we're still seeing while building the `start_schools_year_2020_url` path.

### Pre-merge checks

* [x] ensure the `NQT+1_materials_link` placeholder is removed from [the final template](https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/1f8d7f15-b29d-4a2e-9a2c-57fb5fc9ca1f). (thanks @contentdesign101!)