### PR TITLE
Move CSV uploads from ActiveStorage to an array of URNs

### DIFF
--- a/app/controllers/lead_providers/report_schools/csv_controller.rb
+++ b/app/controllers/lead_providers/report_schools/csv_controller.rb
@@ -19,6 +19,7 @@ module LeadProviders
             cohort_id: report_schools_form.cohort_id,
             lead_provider_id: current_user.lead_provider_profile.lead_provider.id,
             delivery_partner_id: report_schools_form.delivery_partner_id,
+            uploaded_urns: upload_params[:csv].read.lines(chomp: true),
           ),
         )
 

--- a/app/jobs/sync_partnership_csv_upload_job.rb
+++ b/app/jobs/sync_partnership_csv_upload_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# NOTE: This job is intended to be used temporarily while we migrate
+# PartnershipCsvUpload away from active storage to using an PostgreSQL array.
+class SyncPartnershipCsvUploadJob < ApplicationJob
+  def perform(partnership_csv_upload_id:)
+    PartnershipCsvUpload.find(partnership_csv_upload_id).sync_uploaded_urns
+  end
+end

--- a/app/models/partnership_csv_upload.rb
+++ b/app/models/partnership_csv_upload.rb
@@ -30,6 +30,16 @@ class PartnershipCsvUpload < ApplicationRecord
                  .uniq
   end
 
+  # NOTE: this method is intended for short term use while we migrate the urn
+  # lists from ActiveStorage to Postgres arrays
+  def sync_uploaded_urns
+    uploaded_urns = csv.download.lines(chomp: true)
+
+    return if uploaded_urns.blank?
+
+    update!(uploaded_urns:)
+  end
+
 private
 
   def csv_validation

--- a/db/migrate/20230304184644_add_urns_array_to_partnership_csv_upload.rb
+++ b/db/migrate/20230304184644_add_urns_array_to_partnership_csv_upload.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUrnsArrayToPartnershipCsvUpload < ActiveRecord::Migration[6.1]
+  def change
+    add_column :partnership_csv_uploads, :uploaded_urns, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_22_142649) do
+ActiveRecord::Schema.define(version: 2023_03_04_184644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -753,6 +753,7 @@ ActiveRecord::Schema.define(version: 2023_02_22_142649) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "delivery_partner_id", null: false
     t.uuid "cohort_id"
+    t.string "uploaded_urns", array: true
     t.index ["cohort_id"], name: "index_partnership_csv_uploads_on_cohort_id"
     t.index ["delivery_partner_id"], name: "index_partnership_csv_uploads_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_partnership_csv_uploads_on_lead_provider_id"

--- a/spec/jobs/sync_partnership_csv_upload_job_spec.rb
+++ b/spec/jobs/sync_partnership_csv_upload_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "SyncPartnershipCsvUploadJob" do
+  describe "#perform" do
+    let(:upload) { create(:partnership_csv_upload, :with_csv) }
+
+    let(:perform) do
+      SyncPartnershipCsvUploadJob
+        .perform_now(partnership_csv_upload_id: upload.id)
+    end
+
+    it "writes the CSV content to the uploaded_urns field" do
+      expect(upload.uploaded_urns).to be_nil
+
+      perform
+
+      expect(upload.reload.uploaded_urns).to eql(upload.csv.download.lines(chomp: true))
+    end
+  end
+end

--- a/spec/models/partnership_csv_upload_spec.rb
+++ b/spec/models/partnership_csv_upload_spec.rb
@@ -171,6 +171,19 @@ RSpec.describe PartnershipCsvUpload, type: :model do
     end
   end
 
+  describe "#sync_uploaded_urns" do
+    it "populates the uploaded_urns field with the CSV contents" do
+      urns = [1, 1, 2, 2, 3, 3]
+      given_the_csv_contains_urns(urns)
+
+      expect(@subject.uploaded_urns).to be_blank
+
+      @subject.sync_uploaded_urns
+
+      expect(@subject.uploaded_urns).to eql(urns.map(&:to_s))
+    end
+  end
+
 private
 
   def given_the_csv_contains_urns(urns, cohort = current_cohort)

--- a/spec/requests/lead_providers/report_schools/csv_spec.rb
+++ b/spec/requests/lead_providers/report_schools/csv_spec.rb
@@ -51,8 +51,12 @@ RSpec.describe "Lead Provider school reporting: uploading csv", type: :request d
         expect(response).to redirect_to errors_lead_providers_report_schools_csv_path
 
         expect(PartnershipCsvUpload.count).to eq 1
-        expect(PartnershipCsvUpload.last.lead_provider_id).to eq(user.lead_provider_profile.lead_provider.id)
-        expect(PartnershipCsvUpload.last.delivery_partner_id).to eq(delivery_partner.id)
+
+        PartnershipCsvUpload.last.tap do |upload|
+          expect(upload.lead_provider_id).to eq(user.lead_provider_profile.lead_provider.id)
+          expect(upload.delivery_partner_id).to eq(delivery_partner.id)
+          expect(upload.uploaded_urns).to eql(file_fixture("school_urns.csv").read.lines(chomp: true))
+        end
       end
 
       it "redirects to the confirm page when there are no errors" do


### PR DESCRIPTION
### Context

We will soon be migrating the ECF app from GOV.UK PaaS to Azure. The application's data is currently spread across four places:

- Production database (PostgreSQL)
- analytics database (PostgreSQL)
- Sidekiq database (Redis)
- File storage (S3 via PaaS)

The first three are easy to migrate and will involve a restore of the database in the new environment.

The file storage move is difficult because S3 and Azure Blob Storage aren't identical. We'd need to use ActiveStorage mirrors and rely on a syncing process before switching the 'master' copy.

The uploaded CSVs only contain a single column of URNs. We can easily use PostgreSQL's array functionality to save the provided list of URNs. This will make the migration considerably easier and remove a unnecessary infrastrucutre component in the process.

### Changes proposed in this pull request

- Add new column for uploaded partnership URNs
- Add PartnershipCsvUpload#sync_uploaded_urns
- Write uploaded urns to the uploaded_urns field
- Add a job that performs the CSV to array sync

### After merge

This is designed to be run using something like:

```
PartnershipCsvUpload.find_in_batches do |batch|
  batch.each do |partnership_csv_upload|
    SyncPartnershipCsvUploadJob.perform_now(partnership_csv_upload_id: partnership_csv_upload.id)
  end
end
```
