### PR TITLE
[CPDLP-2063] Delete participant schedules when moving an npq application to pending

### DIFF
--- a/app/services/npq/change_to_pending.rb
+++ b/app/services/npq/change_to_pending.rb
@@ -28,6 +28,7 @@ module NPQ
       ActiveRecord::Base.transaction do
         if profile
           profile.participant_profile_states.destroy_all
+          profile.participant_profile_schedules.destroy_all
           profile.participant_declarations.destroy_all
           profile.destroy!
         end

--- a/spec/services/npq/change_to_pending_spec.rb
+++ b/spec/services/npq/change_to_pending_spec.rb
@@ -40,6 +40,42 @@ RSpec.describe NPQ::ChangeToPending, :with_default_schedules do
       end
     end
 
+    context "when application has a schedule changed" do
+      let(:application_status) { :accepted }
+
+      before do
+        participant_profile.participant_profile_schedules.create!(schedule: participant_profile.schedule)
+        described_class.new(npq_application:).call
+      end
+
+      it "changes to pending" do
+        subject.call
+
+        npq_application.reload
+        expect(npq_application).to be_pending
+        expect(npq_application.profile).to be_nil
+        expect(ParticipantProfileSchedule.where(participant_profile_id: participant_profile.id)).to be_empty
+      end
+    end
+
+    context "when application has it's state changed" do
+      let(:application_status) { :accepted }
+
+      before do
+        participant_profile.participant_profile_states.create!(state: "active")
+        described_class.new(npq_application:).call
+      end
+
+      it "changes to pending" do
+        subject.call
+
+        npq_application.reload
+        expect(npq_application).to be_pending
+        expect(npq_application.profile).to be_nil
+        expect(ParticipantProfileState.where(participant_profile_id: participant_profile.id)).to be_empty
+      end
+    end
+
     # Should fail
     %w[eligible payable paid awaiting_clawback].each do |dec_state|
       context "accepted application with #{dec_state} declaration" do


### PR DESCRIPTION
### Context
When attempting to move an NPQ applicaton back to pending we are getting an error as we aren't destroying all associated 
records to the profile

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2063

### Changes proposed in this pull request

When changing a schedule we create a `ParticipantProfileSchedule`. Ensure we delete those records when deleting the profile.

### Guidance to review
Did I miss anything?
