### PR TITLE
Fix updated_at/created_at partnership definitions in API v3

### DIFF
--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -3790,13 +3790,13 @@
             "example": "john.doe@example.com"
           },
           "updated_at": {
-            "description": "The date the partnership was reported by you",
+            "description": "The date the partnership was last updated",
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"
           },
           "created_at": {
-            "description": "The date the partnership was last updated",
+            "description": "The date the partnership was reported by you",
             "type": "string",
             "format": "date-time",
             "example": "2021-05-31T02:22:32.000Z"

--- a/swagger/v3/component_schemas/ECFPartnershipAttributes.yml
+++ b/swagger/v3/component_schemas/ECFPartnershipAttributes.yml
@@ -63,12 +63,12 @@ properties:
     type: string
     example: "john.doe@example.com"
   updated_at:
-    description: "The date the partnership was reported by you"
+    description: "The date the partnership was last updated"
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
   created_at:
-    description: "The date the partnership was last updated"
+    description: "The date the partnership was reported by you"
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"


### PR DESCRIPTION
### Context

The definitions were reported to be flipped for created and updated at.
- Ticket: n/a

### Changes proposed in this pull request
Amend the field definitions to be correct for `updated_at` and `created_at` for partnerships in API v3

### Guidance to review
Did I miss anything?
