### PR TITLE
[Bug-fix] Prevent rendering tabs container when no categories present

### DIFF
--- a/app/services/coc_set_participant_categories.rb
+++ b/app/services/coc_set_participant_categories.rb
@@ -13,6 +13,8 @@ class CocSetParticipantCategories < BaseService
     :withdrawn,
   )
 
+  delegate :any?, to: :induction_records
+
   def ect_categories
     @ect_categories ||= categories(ParticipantProfile::ECT.name)
   end

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -20,31 +20,33 @@
     </div>
   </div>
   <div class="govuk-grid-column-full">
-    <%= govuk_tabs(title: 'Contents') do |component| %>
-      <% if participants_active?(@categories.ect_categories) %>
-        <% component.tab(label: 'ECTs') do %>
-          <%= render partial: 'ects', locals: { ect_profiles: @categories.ect_categories } %>
+    <% if @categories.any? %>
+      <%= govuk_tabs(title: 'Contents') do |component| %>
+        <% if participants_active?(@categories.ect_categories) %>
+          <% component.tab(label: 'ECTs') do %>
+            <%= render partial: 'ects', locals: { ect_profiles: @categories.ect_categories } %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% if participants_active?(@categories.mentor_categories) %>
-        <% component.tab(label: 'Mentors') do %>
-          <%= render partial: 'mentors', locals: { mentor_profiles: @categories.mentor_categories } %>
+        <% if participants_active?(@categories.mentor_categories) %>
+          <% component.tab(label: 'Mentors') do %>
+            <%= render partial: 'mentors', locals: { mentor_profiles: @categories.mentor_categories } %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% if @categories.transferring_in.any? || @categories.transferring_out.any? %>
-        <% component.tab(label: 'Moving school') do %>
-          <%= render partial: 'moving_school', locals: { transferring_in: @categories.transferring_in,
-                                                          transferring_out: @categories.transferring_out } %>
+        <% if @categories.transferring_in.any? || @categories.transferring_out.any? %>
+          <% component.tab(label: 'Moving school') do %>
+            <%= render partial: 'moving_school', locals: { transferring_in: @categories.transferring_in,
+                                                            transferring_out: @categories.transferring_out } %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <% if @categories.withdrawn.any? || @categories.ineligible.any? || @categories.transferred.any? %>
-        <% component.tab(label: 'Not training') do %>
-          <%= render partial: 'not_training', locals: { withdrawn: @categories.withdrawn,
-                                                        ineligible: @categories.ineligible,
-                                                        transferred: @categories.transferred } %>
+        <% if @categories.withdrawn.any? || @categories.ineligible.any? || @categories.transferred.any? %>
+          <% component.tab(label: 'Not training') do %>
+            <%= render partial: 'not_training', locals: { withdrawn: @categories.withdrawn,
+                                                          ineligible: @categories.ineligible,
+                                                          transferred: @categories.transferred } %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
### Context

Attempt to fix the `TypeError: Cannot read properties of undefined (reading 'setAttribute')` errors that have been appearing in Sentry recently. I believe it is down to us rendering the `govuk_tabs` container but then not adding any tabs to it in the participants view when there are no participants in the cohort, however I couldn't recreate the JS error locally.  This fix just adds a guard around the container creation.

### Changes proposed in this pull request

### Guidance to review

