### PR TITLE
Set explicit school names to avoid flakey test when looking up by partial name

### DIFF
--- a/spec/services/admin/npq_applications/applications_search_spec.rb
+++ b/spec/services/admin/npq_applications/applications_search_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Admin::NPQApplications::ApplicationsSearch, :with_default_schedules do
   let(:search) { Admin::NPQApplications::ApplicationsSearch }
 
-  let(:school_1) { create(:school) }
-  let(:school_2) { create(:school) }
+  let(:school_1) { create(:school, name: "Greendale School") }
+  let(:school_2) { create(:school, name: "Westview School") }
   let!(:application_1) { create(:npq_application, school_urn: school_1.urn) }
   let!(:application_2) { create(:npq_application, school_urn: school_2.urn) }
   let(:user_1) { application_1.user }


### PR DESCRIPTION
### Context

We are getting a flakey test failure https://github.com/DFE-Digital/early-careers-framework/actions/runs/4353661772/jobs/7607987362 
This is due to the school names being set up randomly and can be similar, causing both records to be returned when searching by partial names of the first school

- Ticket: n/a

### Changes proposed in this pull request

Set explicit names on the school setup, so searching by name won't return both results.

### Guidance to review
Did I miss anything?