### PR TITLE
Stop loading all the NPQ applications at once

### DIFF
--- a/app/controllers/admin/npq/applications_controller.rb
+++ b/app/controllers/admin/npq/applications_controller.rb
@@ -11,7 +11,8 @@ module Admin
 
         results = Admin::NPQApplications::ApplicationsSearch
           .new(policy_scope(NPQApplication), query_string:).call
-        @pagy, @applications = pagy_array(results, page: params[:page], items: 20)
+
+        @pagy, @applications = pagy(results, page: params[:page], items: 20)
         @page = @pagy.page
         @total_pages = @pagy.pages
       end

--- a/app/services/admin/npq_applications/applications_search.rb
+++ b/app/services/admin/npq_applications/applications_search.rb
@@ -37,6 +37,8 @@ private
 
   def left_outer_joins
     [
+      :npq_course,
+      :npq_lead_provider,
       :participant_identity,
       :school,
       { participant_identity: :user },


### PR DESCRIPTION
### Context

We had poor performance on the NPQ applications list page because we were loading all the applications into memory before paginating. Pagy should run the query so it can apply the pagination in SQL.

### Changes proposed in this pull request

- Switch from pagy_array to pagy
- Squash a couple of n+1s on the npq applications list
