### PR TITLE
Convert any uploads to UTF-8 before using them

### DIFF
--- a/app/models/partnership_csv_upload.rb
+++ b/app/models/partnership_csv_upload.rb
@@ -33,7 +33,7 @@ class PartnershipCsvUpload < ApplicationRecord
   # NOTE: this method is intended for short term use while we migrate the urn
   # lists from ActiveStorage to Postgres arrays
   def sync_uploaded_urns
-    uploaded_urns = csv.download.lines(chomp: true)
+    uploaded_urns = csv.download.force_encoding("UTF-8").lines(chomp: true)
 
     return if uploaded_urns.blank?
 


### PR DESCRIPTION
### Context

Just a small tweak, some of the CSVs uploaded have formats other than UTF-8. Makes it easier to force them to be UTF-8 before extracting the contents.
