### PR TITLE
Make it clearer in which schools a mentor is mentoring at

### DIFF
--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -49,7 +49,7 @@
         row.value do
           ["<ul class='govuk-list govuk-list--bullet'>",
           @latest_induction_record.participant_profile.school_mentors.map do |school_mentor|
-            "<li>#{govuk_link_to(school_mentor.school.name, admin_school_path(school_mentor.school.friendly_id))}</li>"
+            "<li>#{govuk_link_to(school_mentor.school.slug.titleize, admin_school_path(school_mentor.school.friendly_id))}</li>"
           end,
           "</ul>"].flatten.join.html_safe
         end


### PR DESCRIPTION
in the admin pages.

Schools can have multiple `School` records, but only one active. In such cases, the mentors may still be in the Mentor Pools of the inactive school records with no clear indication in the Admin pages -> Mentor profile -> School tab. That can mislead us to think everything is OK when SITs will be actually blocked from assigning mentors to ECTs.

### Context

- Ticket: N/A

### Changes proposed in this pull request
We don't see this issue very often, so it  should help for now to visually identify such issues by displaying both the school URN and the school name in the `Mentoring at` list.

### Guidance to review
| before | after
|-|-|
|![before](https://user-images.githubusercontent.com/951947/223752197-3855ab10-2eec-4de1-89ec-8894fa1fa402.png)|![after](https://user-images.githubusercontent.com/951947/223756185-d04af10a-66d0-49bf-be33-815cb42d7c05.png)|


