### PR TITLE
Update NPQ serialiser updated_at attribute to poll multiple records

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -54,7 +54,7 @@ module Api
       def query_scope
         scope = npq_lead_provider
                   .npq_applications
-                  .includes(:cohort, :npq_course, participant_identity: [:user])
+                  .includes(:cohort, :npq_course, :profile, participant_identity: [:user])
                   .where(cohort: with_cohorts)
         scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
         scope

--- a/app/serializers/api/v1/npq_application_serializer.rb
+++ b/app/serializers/api/v1/npq_application_serializer.rb
@@ -53,7 +53,12 @@ module Api
       end
 
       attribute :updated_at do |object|
-        object.updated_at.rfc3339
+        [
+          object.profile&.updated_at,
+          object.user.updated_at,
+          object.participant_identity.updated_at,
+          object.updated_at,
+        ].compact.max.rfc3339
       end
 
       attribute(:status, &:lead_provider_approval_status)

--- a/spec/serializers/api/v1/npq_application_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq_application_serializer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Api
   module V1
-    RSpec.describe NPQApplicationSerializer do
+    RSpec.describe NPQApplicationSerializer, :with_default_schedules do
       describe "serialization" do
         let(:npq_application) { create(:npq_application, targeted_delivery_funding_eligibility: true) }
 
@@ -36,6 +36,73 @@ module Api
           expect(result[:data][:attributes][:teacher_catchment_iso_country_code]).to eq(npq_application.teacher_catchment_iso_country_code)
           expect(result[:data][:attributes][:itt_provider]).to eql(npq_application.itt_provider)
           expect(result[:data][:attributes][:lead_mentor]).to eql(npq_application.lead_mentor)
+        end
+      end
+
+      describe "#updated_at" do
+        let(:npq_application) { create(:npq_application, targeted_delivery_funding_eligibility: true) }
+        let(:profile) { npq_application.profile }
+        let(:user) { npq_application.user }
+        let(:participant_identity) { npq_application.participant_identity }
+        let(:updated_at_attribute) { subject[:data][:attributes][:updated_at] }
+        subject { described_class.new(npq_application).serializable_hash }
+
+        context "when npq application touched" do
+          before do
+            ActiveRecord::Base.no_touching do
+              user.update!(updated_at: 10.days.ago)
+              participant_identity.update!(updated_at: 1.day.ago)
+            end
+          end
+
+          it "considers updated_at of the npq application" do
+            expect(Time.zone.parse(updated_at_attribute)).to be_within(1.minute).of(Time.zone.now)
+          end
+        end
+
+        context "when user touched" do
+          before do
+            ActiveRecord::Base.no_touching do
+              participant_identity.update!(updated_at: 10.days.ago)
+              npq_application.update!(updated_at: 5.days.ago)
+              user.update!(updated_at: 1.day.ago)
+            end
+          end
+
+          it "considers updated_at of user" do
+            expect(Time.zone.parse(updated_at_attribute)).to be_within(1.minute).of(1.day.ago)
+          end
+        end
+
+        context "when profile touched" do
+          let(:npq_application) { create(:npq_application, :accepted) }
+
+          before do
+            ActiveRecord::Base.no_touching do
+              user.update!(updated_at: 10.days.ago)
+              participant_identity.update!(updated_at: 10.days.ago)
+              npq_application.update!(updated_at: 5.days.ago)
+              profile.update!(updated_at: 1.day.ago)
+            end
+          end
+
+          it "considers updated_at of profile" do
+            expect(Time.zone.parse(updated_at_attribute)).to be_within(1.minute).of(1.day.ago)
+          end
+        end
+
+        context "when identity touched" do
+          before do
+            ActiveRecord::Base.no_touching do
+              user.update!(updated_at: 10.days.ago)
+              npq_application.update!(updated_at: 5.days.ago)
+              participant_identity.update!(updated_at: 1.day.ago)
+            end
+          end
+
+          it "considers updated_at of identity" do
+            expect(Time.zone.parse(updated_at_attribute)).to be_within(1.minute).of(1.day.ago)
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

If a user's email is updated, we aren't surfacing that correctly in the updated at timestamp of the NPQ application in the API which is causing issues for providers when polling for changes

- Ticket: n/a

### Changes proposed in this pull request

Use the user, identity, profile and npq application `updated_at` timestamps to surface the latest change to ensure that anything updated will be shown to providers.

Add profile to includes list for n+1s.

### Guidance to review
I noticed that although we have includes we are getting n+1s on the query `previously_funded?` on NPQ applications, will look into that separately.
