### PR TITLE
Remove any unwanted characters from CSV uploads

### DIFF
--- a/app/models/partnership_csv_upload.rb
+++ b/app/models/partnership_csv_upload.rb
@@ -33,7 +33,11 @@ class PartnershipCsvUpload < ApplicationRecord
   # NOTE: this method is intended for short term use while we migrate the urn
   # lists from ActiveStorage to Postgres arrays
   def sync_uploaded_urns
-    uploaded_urns = csv.download.force_encoding("UTF-8").lines(chomp: true)
+    uploaded_urns = csv.download
+      .force_encoding("UTF-8")
+      .scrub
+      .lines(chomp: true)
+      .map { |urn| urn.chars.select { |c| c =~ /\w/ }.join }
 
     return if uploaded_urns.blank?
 


### PR DESCRIPTION
### Context and changes

Some records contain unwanted characters that cause Ruby to error with "invalid byte sequence in UTF-8". The unwanted characters can appear anywhere in the line.

This approach adds a bit of safety, we're now scrubbing the file to remove invalid byte sequences and then only selecting word characters - this should leave us with only what we want.
