### PR TITLE
Fix flakey NPQ application request and search specs

### DIFF
--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -17,12 +17,14 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
     let(:other_npq_lead_provider) { create(:npq_lead_provider) }
 
     before :each do
-      list = []
-      list << create_list(:npq_application, 3, :in_private_childcare_provider, npq_lead_provider:, school_urn: "123456", npq_course:, cohort:)
-      list << create_list(:npq_application, 2, npq_lead_provider: other_npq_lead_provider, school_urn: "123456", npq_course:, cohort:)
+      Timecop.freeze(Time.zone.now) do
+        list = []
+        list << create_list(:npq_application, 3, :in_private_childcare_provider, npq_lead_provider:, school_urn: "123456", npq_course:, cohort:)
+        list << create_list(:npq_application, 2, npq_lead_provider: other_npq_lead_provider, school_urn: "123456", npq_course:, cohort:)
 
-      list.flatten.each do |npq_application|
-        NPQ::Application::Accept.new(npq_application:).call
+        list.flatten.each do |npq_application|
+          NPQ::Application::Accept.new(npq_application:).call
+        end
       end
     end
 

--- a/spec/requests/api/v2/npq_applications_spec.rb
+++ b/spec/requests/api/v2/npq_applications_spec.rb
@@ -17,12 +17,14 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
     let(:other_npq_lead_provider) { create(:npq_lead_provider) }
 
     before :each do
-      list = []
-      list << create_list(:npq_application, 3, npq_lead_provider:, school_urn: "123456", npq_course:, cohort:)
-      list << create_list(:npq_application, 2, npq_lead_provider: other_npq_lead_provider, school_urn: "123456", npq_course:, cohort:)
+      Timecop.freeze(Time.zone.now) do
+        list = []
+        list << create_list(:npq_application, 3, npq_lead_provider:, school_urn: "123456", npq_course:, cohort:)
+        list << create_list(:npq_application, 2, npq_lead_provider: other_npq_lead_provider, school_urn: "123456", npq_course:, cohort:)
 
-      list.flatten.each do |npq_application|
-        NPQ::Application::Accept.new(npq_application:).call
+        list.flatten.each do |npq_application|
+          NPQ::Application::Accept.new(npq_application:).call
+        end
       end
     end
 

--- a/spec/services/admin/npq_applications/applications_search_spec.rb
+++ b/spec/services/admin/npq_applications/applications_search_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Admin::NPQApplications::ApplicationsSearch, :with_default_schedul
 
   let(:school_1) { create(:school, name: "Greendale School") }
   let(:school_2) { create(:school, name: "Westview School") }
-  let!(:application_1) { create(:npq_application, school_urn: school_1.urn) }
-  let!(:application_2) { create(:npq_application, school_urn: school_2.urn) }
-  let(:user_1) { application_1.user }
+  let!(:application_1) { create(:npq_application, user: user_1, school_urn: school_1.urn) }
+  let!(:application_2) { create(:npq_application, user: user_2, school_urn: school_2.urn) }
+  let(:user_1) { create(:user, full_name: "John Doe") }
+  let(:user_2) { create(:user, full_name: "Jane Doe") }
 
   subject { described_class.new(query_string:) }
 
@@ -39,10 +40,6 @@ RSpec.describe Admin::NPQApplications::ApplicationsSearch, :with_default_schedul
     end
 
     context "when partial name match" do
-      before do
-        user_1.update(full_name: Faker::Name.name)
-      end
-
       let(:query_string) { user_1.full_name[0, 3] }
 
       it "returns the hit" do


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/early-careers-framework/actions/runs/4378534706/jobs/7663398663

To avoid flakey tests with `updated_at` field, freeze time to avoid different times. This is because we now have multiple values to choose from when calculating the NPQ application `updated_at` field.

https://github.com/DFE-Digital/early-careers-framework/actions/runs/4374663161/jobs/7654373465

Explicitly set user name when setting up applications, to avoid flakey tests when users have similar names

- Ticket: N/A

### Changes proposed in this pull request

- Freeze time when setting up NPQ applications to avoid different times
- Set exact names on users to avoid accidentally looking up multiple records

### Guidance to review
Did I miss anything?
