### PR TITLE
Remove back link from admin console page

### DIFF
--- a/app/views/admin/participants/_nav.html.erb
+++ b/app/views/admin/participants/_nav.html.erb
@@ -1,7 +1,3 @@
-<% content_for :before_content do %>
-  <%= govuk_back_link(href: admin_participants_path) %>
-<% end %>
-
 <%= render SubnavComponent.new do |component| %>
   <%= component.nav_item(path: admin_participant_details_path(@participant_profile)) do %>
     Details


### PR DESCRIPTION
### Context

> ‘If you click the 'Back’ button on the admin console page it forgets the search you'd done/school page you were on etc so you had to re-search for where you were before (this came up a lot when I was on a really specific participant trying to figure out what had gone wrong)' (highlighted afterwards that this issue was probably the most frustrating)

*Current behaviour*: When investigating issue with participant, and searching via their school, the _Back_ button does not follow expected behaviour i.e. go back a step in the user journey.

This PR removes the back button until we can implement a more useful solution, e.g. breadcrumbs.

- Ticket: https://trello.com/c/xorlDVRo/18-back-button

