### PR TITLE
Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -13,4 +13,7 @@ yarn install
 echo "Creating database..."
 bin/rails db:create db:schema:load db:migrate db:seed
 
+echo "Installing documentation dependencies"
+cd docs && bundle
+
 echo "Done!"

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Setting SSH password for vscode user..."
+sudo usermod --password $(echo vscode | openssl passwd -1 -stdin) vscode
+
+echo "Updating RubyGems..."
+gem update --system
+
+echo "Installing dependencies..."
+bundle install
+yarn install
+
+echo "Creating database..."
+bin/rails db:create db:schema:load db:migrate db:seed
+
+echo "Done!"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+  "name": "Manage training for early career teachers",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {},
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "libpq-dev, libvips"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/ruby:1": {
+      "version": "3.1.3"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18.14"
+    },
+    "ghcr.io/devcontainers/features/common-utils:1": {
+      "username": "vscode",
+      "uid": 1000,
+      "gid": 1000,
+      "installZsh": true,
+      "installOhMyZsh": true,
+      "configureZshAsDefaultShell": true,
+      "upgradePackages": true
+    }
+  },
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp",
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "ms-vscode.vscode-types"
+      ]
+    }
+  },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // This can be used to network with other containers or the host.
+  "forwardPorts": [2222],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": ".devcontainer/boot.sh"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "libpq-dev, libvips"
+      "packages": "libpq-dev, libvips, entr"
     },
     "ghcr.io/devcontainers/features/git:1": {
       "version": "latest"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+
+volumes:
+  postgres-data:
+  redis-data:

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,3 +2,4 @@ web: unset PORT && bin/rails server
 jobs: bin/sidekiq
 js: yarn build --watch
 css: yarn build:css --watch
+api_docs: make -C docs

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,4 +2,3 @@ web: unset PORT && bin/rails server
 jobs: bin/sidekiq
 js: yarn build --watch
 css: yarn build:css --watch
-api_docs: make -C docs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 - Yarn 1.12.x
 - Docker
 - Redis 6.2
-- entr (available via [Homebrew](https://formulae.brew.sh/formula/entr))
 
 ### Without docker
 
@@ -40,20 +39,34 @@ Check docker-compose file for username and password to put in your `.env` file.
 If you want to seed the database you can either run `db:drop` and `db:setup` tasks with your preferred method,
 or `db:seed`.
 
+### Building the documentation
+
+The API documenation is a [Middleman](https://middlemanapp.com/) app contained in the `docs` directory. In production it's
+built at deploy time and available at [/api-reference](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference). We can't use `middleman serve` because
+the Middleman application assumes it's embedded and references the Rails application's assets, so instead we need to
+build it using the following steps:
+
+1. install [entr](https://github.com/eradman/entr) using your package manager of choice (eg. `brew install entr`)
+2. use the Makefile to keep building the documentation whenever a file is changed `make -C docs` or `cd docs && make watch`
+
 ### Govuk Notify
+
 Register on [GOV.UK Notify](https://www.notifications.service.gov.uk).
 Ask someone from the team to add you to our service.
 Generate a limited api key for yourself and set it in your `.env` file.
 
 ### Set up git hooks
+
 Run `git config core.hooksPath .githooks` to use the included git hooks.
 
 ## Running specs, linter(without auto correct) and annotate models and serializers
+
 ```
 bundle exec rake
 ```
 
 ## Running specs
+
 ```
 bundle exec rspec
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Yarn 1.12.x
 - Docker
 - Redis 6.2
+- entr (available via [Homebrew](https://formulae.brew.sh/formula/entr))
 
 ### Without docker
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,6 +23,16 @@ if ENV.key?("VCAP_SERVICES")
   end
 end
 
+if ENV.key?("REDIS_URI")
+  Sidekiq.configure_server do |config|
+    config.redis = { url: ENV.fetch("REDIS_URI") }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV.fetch("REDIS_URI") }
+  end
+end
+
 # Sidekiq Cron
 if Sidekiq.server?
   Rails.application.config.after_initialize do

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,2 @@
+watch:
+	find . | entr -rs 'bundle exec middleman build --build-dir=../public/api-reference'


### PR DESCRIPTION
This change enables Codespaces for the ECF app. This will help less technical colleagues make direct changes.

The only change that has any risk of affecting the app is the one to the initializer that lets us easily specify the `REDIS_URI` using a environment variable instead of letting it default to `localhost`.

Note, in its current form this PR adds `entr` as a dependency for running `bin/dev` - not ideal but I can't find a way of making Middleman continuously monitor for changes (like `middleman serve`) but actually output built files (like middleman build`). @DFE-Digital/teacher-cpd - any ideas?

| Preview |
| ------- |
| ![image](https://user-images.githubusercontent.com/128088/224399792-00bfad04-c6f2-4068-bfe1-885a71d7ba88.png) |
