### PR TITLE
Allow nil cohort in NPQApplication

### DIFF
--- a/app/jobs/npq/stream_big_query_enrollment_job.rb
+++ b/app/jobs/npq/stream_big_query_enrollment_job.rb
@@ -13,7 +13,7 @@ module NPQ
       rows = [
         {
           "application_ecf_id" => npq_application.id,
-          "cohort" => npq_application.cohort.start_year,
+          "cohort" => npq_application.cohort&.start_year,
           "status" => npq_application.lead_provider_approval_status,
           "updated_at" => npq_application.updated_at,
           "employer_name" => npq_application.employer_name,

--- a/spec/factories/services/npq/npq_application.rb
+++ b/spec/factories/services/npq/npq_application.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
           funding_eligiblity_status_code:,
           itt_provider:,
           lead_mentor:,
-          cohort: cohort.start_year,
+          cohort: cohort&.start_year,
         },
         npq_course_id: npq_course.id,
         npq_lead_provider_id: npq_lead_provider.id,

--- a/spec/jobs/npq/stream_big_query_enrollment_job_spec.rb
+++ b/spec/jobs/npq/stream_big_query_enrollment_job_spec.rb
@@ -32,5 +32,22 @@ RSpec.describe NPQ::StreamBigQueryEnrollmentJob do
         "employment_role" => employment_role,
       }], ignore_unknown: true)
     end
+
+    context "when there is no cohort" do
+      let(:npq_application) { create(:npq_application, cohort: nil, employment_role:, employer_name:) }
+
+      it "sends correct data to BigQuery" do
+        described_class.perform_now(npq_application_id: npq_application.id)
+
+        expect(table).to have_received(:insert).with([{
+          "application_ecf_id" => npq_application.id,
+          "cohort" => nil,
+          "status" => "pending",
+          "updated_at" => npq_application.updated_at,
+          "employer_name" => employer_name,
+          "employment_role" => employment_role,
+        }], ignore_unknown: true)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2066

### Changes proposed in this pull request

In sandbox and staging environments we have a number of `NPQApplication` records with no `cohort` association. This caused some jobs to fail and retry. I note that this is specified as an `optional` association so this is now fixed.

