### PR TITLE
Improve Partnership serialiser testing

### DIFF
--- a/app/serializers/api/v3/ecf/partnership_serializer.rb
+++ b/app/serializers/api/v3/ecf/partnership_serializer.rb
@@ -13,11 +13,11 @@ module Api
         set_type :'partnership-confirmation'
 
         attribute :cohort do |partnership|
-          partnership.cohort.start_year
+          partnership.cohort.display_name
         end
 
         attribute :urn do |partnership|
-          partnership.school&.urn
+          partnership.school.urn
         end
 
         attributes :delivery_partner_id
@@ -27,8 +27,7 @@ module Api
         end
 
         attribute :status do |partnership|
-          "active" if partnership.active?
-          "challenged" if partnership.challenged?
+          partnership.challenged? ? "challenged" : "active"
         end
 
         attribute :challenged_reason, &:challenge_reason
@@ -41,12 +40,12 @@ module Api
           partnership.school&.contact_email
         end
 
-        attribute :updated_at do |partnership|
-          partnership.updated_at.rfc3339
-        end
-
         attribute :created_at do |partnership|
           partnership.created_at.rfc3339
+        end
+
+        attribute :updated_at do |partnership|
+          partnership.updated_at.rfc3339
         end
       end
     end

--- a/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
@@ -7,36 +7,79 @@ module Api
     module ECF
       RSpec.describe PartnershipSerializer do
         describe "serialization" do
-          let(:lead_provider) { create(:cpd_lead_provider, :with_lead_provider).lead_provider }
-          let(:delivery_partner) { create(:delivery_partner, name: "First Delivery Partner") }
-          let(:cohort) { create(:cohort) }
-          let!(:provider_relationship) { create(:provider_relationship, cohort:, delivery_partner:, lead_provider:) }
-          let(:school) { create(:school, urn: "123456", name: "My first High School") }
-          let(:induction_coordinator) { create(:user, full_name: "Induction Coordinator", email: "ic@example.com") }
+          let(:cohort) { build(:cohort, start_year: 2021) }
+          let(:school) { build(:school, urn: "123456", name: "My first High School") }
+          let(:delivery_partner) { partnership.delivery_partner }
+
+          let(:induction_coordinator) { create(:user, full_name: "John Doe", email: "induction_coordinator@example.com") }
           let!(:induction_coordinator_profile) { create(:induction_coordinator_profile, schools: [school], user: induction_coordinator) }
-          let!(:partnership) { create(:partnership, :challenged, school:, cohort:, delivery_partner:, lead_provider:) }
 
-          subject { described_class.new([partnership]) }
+          let!(:partnership) { create(:partnership, school:, cohort:) }
 
-          it "returns the expected data" do
-            result = subject.serializable_hash
+          subject { described_class.new(partnership) }
 
-            expect(result[:data]).to match_array([
-              id: partnership.id,
-              type: :'partnership-confirmation',
-              attributes: {
-                cohort: cohort.start_year,
-                urn: school.urn,
-                delivery_partner_id: partnership.delivery_partner_id,
-                delivery_partner_name: partnership.delivery_partner.name,
-                status: "challenged",
-                challenged_reason: partnership.challenge_reason,
-                induction_tutor_name: school.induction_tutor.full_name,
-                induction_tutor_email: school.contact_email,
-                updated_at: partnership.updated_at.rfc3339,
-                created_at: partnership.created_at.rfc3339,
-              },
-            ])
+          it "sets the partnership id" do
+            expect(subject.serializable_hash[:data][:id]).to eq(partnership.id)
+          end
+
+          it "sets the type" do
+            expect(subject.serializable_hash[:data][:type]).to eq(:"partnership-confirmation")
+          end
+
+          it "returns the cohort start year" do
+            expect(subject.serializable_hash[:data][:attributes][:cohort]).to eq("2021")
+          end
+
+          it "returns the school urn" do
+            expect(subject.serializable_hash[:data][:attributes][:urn]).to eq("123456")
+          end
+
+          it "returns the school delivery partner id" do
+            expect(subject.serializable_hash[:data][:attributes][:delivery_partner_id]).to eq(delivery_partner.id)
+          end
+
+          it "returns the school delivery partner name" do
+            expect(subject.serializable_hash[:data][:attributes][:delivery_partner_name]).to eq(delivery_partner.name)
+          end
+
+          it "returns the induction tutor name" do
+            expect(subject.serializable_hash[:data][:attributes][:induction_tutor_name]).to eq("John Doe")
+          end
+
+          it "returns the school induction tutor email" do
+            expect(subject.serializable_hash[:data][:attributes][:induction_tutor_email]).to eq("induction_coordinator@example.com")
+          end
+
+          it "returns the partnership created_at timestamp" do
+            expect(subject.serializable_hash[:data][:attributes][:created_at]).to eq(
+              partnership.created_at.rfc3339,
+            )
+          end
+
+          it "returns the partnership updated_at timestamp" do
+            expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(partnership.updated_at.rfc3339)
+          end
+
+          context "when partnership active" do
+            it "returns an active status" do
+              expect(subject.serializable_hash[:data][:attributes][:status]).to eq("active")
+            end
+
+            it "returns no challenged_reason" do
+              expect(subject.serializable_hash[:data][:attributes][:challenged_reason]).to be_nil
+            end
+          end
+
+          context "when partnership challenged" do
+            let!(:partnership) { create(:partnership, :challenged, school:, cohort:) }
+
+            it "returns the status" do
+              expect(subject.serializable_hash[:data][:attributes][:status]).to eq("challenged")
+            end
+
+            it "returns the challenged_reason" do
+              expect(subject.serializable_hash[:data][:attributes][:challenged_reason]).to eq("mistake")
+            end
           end
         end
       end


### PR DESCRIPTION
### Context
While having a rethink of tests for v3 stumbled upon a few things we can improve in partnership testing
- Ticket: n/a

### Changes proposed in this pull request

- Return cohort as string (as set in docs)
- Always return status, default is active unless challenged
- Separate tests for each field, and add contexts for status field


### Guidance to review
Did I miss anything?
