### PR TITLE
Remove schema Rswag helper

### DIFF
--- a/spec/docs/v1/npq_applications_spec.rb
+++ b/spec/docs/v1/npq_applications_spec.rb
@@ -59,6 +59,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
       operationId :npq_applications_csv
       tags "NPQ applications"
       security [bearerAuth: []]
+      produces "text/csv"
 
       parameter name: :filter,
                 in: :query,
@@ -72,7 +73,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
                 example: CGI.unescape({ updated_since: "2020-11-13T11:21:55Z" }.to_param)
 
       response "200", "A CSV file of NPQ application" do
-        schema({ "$ref": "#/components/schemas/MultipleNPQApplicationsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleNPQApplicationsCsvResponse"
 
         run_test!
       end

--- a/spec/docs/v1/participant_declarations_spec.rb
+++ b/spec/docs/v1/participant_declarations_spec.rb
@@ -133,9 +133,10 @@ RSpec.describe "Participant Declarations", :with_default_schedules, type: :reque
       operationId :ecf_participant_declarations_csv
       tags "Participant declarations"
       security [bearerAuth: []]
+      produces "text/csv"
 
       response "200", "A CSV file of participant declarations" do
-        schema({ "$ref": "#/components/schemas/MultipleParticipantDeclarationsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleParticipantDeclarationsCsvResponse"
 
         run_test!
       end

--- a/spec/docs/v1/participants_ecf_spec.rb
+++ b/spec/docs/v1/participants_ecf_spec.rb
@@ -59,6 +59,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
       operationId :ecf_participants_csv
       tags "ECF participants"
       security [bearerAuth: []]
+      produces  "text/csv"
 
       parameter name: :filter,
                 in: :query,
@@ -72,7 +73,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v1/api_sp
                 example: CGI.unescape({ updated_since: "2020-11-13T11:21:55Z" }.to_param)
 
       response "200", "A CSV file of ECF participants" do
-        schema({ "$ref": "#/components/schemas/MultipleECFParticipantsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleECFParticipantsCsvResponse"
 
         run_test!
       end

--- a/spec/docs/v2/npq_applications_spec.rb
+++ b/spec/docs/v2/npq_applications_spec.rb
@@ -59,6 +59,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
       operationId :npq_applications_csv
       tags "NPQ applications"
       security [bearerAuth: []]
+      produces "text/csv"
 
       parameter name: :filter,
                 in: :query,
@@ -72,7 +73,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
                 example: CGI.unescape({ updated_since: "2020-11-13T11:21:55Z" }.to_param)
 
       response "200", "A CSV file of NPQ application" do
-        schema({ "$ref": "#/components/schemas/MultipleNPQApplicationsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleNPQApplicationsCsvResponse"
 
         run_test!
       end

--- a/spec/docs/v2/npq_enrolments_spec.rb
+++ b/spec/docs/v2/npq_enrolments_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/
       operationId :npq_enrolments
       tags "NPQ enrolments"
       security [bearerAuth: []]
+      produces "text/csv"
 
       parameter name: :filter,
                 in: :query,
@@ -28,7 +29,7 @@ RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/
                 example: CGI.unescape({ updated_since: "2020-11-13T11:21:55Z" }.to_param)
 
       response "200", "A list of NPQ enrolments" do
-        schema({ "$ref": "#/components/schemas/MultipleNPQEnrolmentsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleNPQEnrolmentsCsvResponse"
 
         run_test!
       end

--- a/spec/docs/v2/participant_declarations_spec.rb
+++ b/spec/docs/v2/participant_declarations_spec.rb
@@ -133,9 +133,10 @@ RSpec.describe "Participant Declarations", :with_default_schedules, type: :reque
       operationId :ecf_participant_declarations_csv
       tags "Participant declarations"
       security [bearerAuth: []]
+      produces "text/csv"
 
       response "200", "A CSV file of participant declarations" do
-        schema({ "$ref": "#/components/schemas/MultipleParticipantDeclarationsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleParticipantDeclarationsCsvResponse"
 
         run_test!
       end

--- a/spec/docs/v2/participants_ecf_spec.rb
+++ b/spec/docs/v2/participants_ecf_spec.rb
@@ -59,6 +59,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
       operationId :ecf_participants_csv
       tags "ECF participants"
       security [bearerAuth: []]
+      produces "text/csv"
 
       parameter name: :filter,
                 in: :query,
@@ -72,7 +73,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v2/api_sp
                 example: CGI.unescape({ updated_since: "2020-11-13T11:21:55Z" }.to_param)
 
       response "200", "A CSV file of ECF participants" do
-        schema({ "$ref": "#/components/schemas/MultipleECFParticipantsCsvResponse" }, content_type: "text/csv")
+        schema "$ref": "#/components/schemas/MultipleECFParticipantsCsvResponse"
 
         run_test!
       end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -69,13 +69,6 @@ end
 if defined?(Rswag::Specs)
   module Rswag
     module Specs
-      module ExampleGroupHelpers
-        def schema(value, content_type: "application/json")
-          content_hash = { content_type => { schema: value } }
-          metadata[:response][:content] = content_hash
-        end
-      end
-
       module ExampleGroupHelpersExtensions
         def curl_example(hash)
           metadata[:operation]["x-curl-examples"] ||= []


### PR DESCRIPTION
### Context

When testing our API spec, if schema was incorrect, the tests weren't failing. We can use the original schema method to ensure we test our API spec and it fails as expected, and also use the expected syntax "produces" to what the expected content type is.

- Ticket: n/a

### Changes proposed in this pull request

- Remove schema helper
- use `produces` to test expected content type
- swap out instances using old helper syntax

### Guidance to review
Did I miss anything
rswag docs: https://github.com/rswag/rswag
