### PR TITLE
Add school_id and challenged_at attributes to the API V3 Partnership serializer

### DIFF
--- a/app/serializers/api/v3/ecf/partnership_serializer.rb
+++ b/app/serializers/api/v3/ecf/partnership_serializer.rb
@@ -20,6 +20,10 @@ module Api
           partnership.school.urn
         end
 
+        attribute :school_id do |partnership|
+          partnership.school.id
+        end
+
         attributes :delivery_partner_id
 
         attribute :delivery_partner_name do |partnership|
@@ -31,6 +35,8 @@ module Api
         end
 
         attribute :challenged_reason, &:challenge_reason
+
+        attribute :challenged_at, &:challenged_at
 
         attribute :induction_tutor_name do |partnership|
           partnership.school&.induction_tutor&.full_name

--- a/spec/requests/api/v3/ecf/partnerships_spec.rb
+++ b/spec/requests/api/v3/ecf/partnerships_spec.rb
@@ -53,11 +53,20 @@ RSpec.describe "API ECF Partinerships", :with_default_schedules, type: :request,
       it "has correct attributes" do
         get "/api/v3/partnerships/ecf"
 
-        expect(parsed_response["data"][0]).to have_jsonapi_attributes(:cohort,
-                                                                      :urn,
-                                                                      :delivery_partner_id,
-                                                                      :delivery_partner_name,
-                                                                      :status, :challenged_reason, :induction_tutor_name, :induction_tutor_email, :updated_at, :created_at).exactly
+        expect(parsed_response["data"][0]).to have_jsonapi_attributes(
+          :cohort,
+          :urn,
+          :delivery_partner_id,
+          :delivery_partner_name,
+          :school_id,
+          :status,
+          :challenged_at,
+          :challenged_reason,
+          :induction_tutor_name,
+          :induction_tutor_email,
+          :updated_at,
+          :created_at,
+        ).exactly
       end
 
       it "returns the right number of partnerships per page" do

--- a/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
@@ -8,7 +8,7 @@ module Api
       RSpec.describe PartnershipSerializer do
         describe "serialization" do
           let(:cohort) { build(:cohort, start_year: 2021) }
-          let(:school) { build(:school, urn: "123456", name: "My first High School") }
+          let(:school) { create(:school, urn: "123456", name: "My first High School") }
           let(:delivery_partner) { partnership.delivery_partner }
 
           let(:induction_coordinator) { create(:user, full_name: "John Doe", email: "induction_coordinator@example.com") }
@@ -28,6 +28,10 @@ module Api
 
           it "returns the cohort start year" do
             expect(subject.serializable_hash[:data][:attributes][:cohort]).to eq("2021")
+          end
+
+          it "returns the school ID" do
+            expect(subject.serializable_hash[:data][:attributes][:school_id]).to eq(school.id)
           end
 
           it "returns the school urn" do
@@ -68,6 +72,10 @@ module Api
             it "returns no challenged_reason" do
               expect(subject.serializable_hash[:data][:attributes][:challenged_reason]).to be_nil
             end
+
+            it "returns no challenged_at" do
+              expect(subject.serializable_hash[:data][:attributes][:challenged_at]).to be_nil
+            end
           end
 
           context "when partnership challenged" do
@@ -79,6 +87,10 @@ module Api
 
             it "returns the challenged_reason" do
               expect(subject.serializable_hash[:data][:attributes][:challenged_reason]).to eq("mistake")
+            end
+
+            it "returns the challenged_at timestamp" do
+              expect(subject.serializable_hash[:data][:attributes][:challenged_at]).to eq(partnership.challenged_at)
             end
           end
         end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2080

### Changes proposed in this pull request

* Adds two new fields to the serializer for API V3 only to implement the changes shown in the [API documentation](https://manage-training-for-early-career-teachers.education.gov.uk/api-reference/reference-v3.html#schema-ecfpartnershipattributes).

