### PR TITLE
[CPDLP-2086] Add new registration start date field to cohorts table for NPQ

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -16,6 +16,10 @@ class Cohort < ApplicationRecord
     where(registration_start_date: ..Date.current).order(start_year: :desc).first
   end
 
+  def self.active_npq_registration_cohort
+    where(npq_registration_start_date: ..Date.current).order(start_year: :desc).first.presence || current
+  end
+
   def self.current
     starting_within(Date.current - 1.year + 1.day, Date.current)
   end

--- a/db/migrate/20230314120416_add_npq_registration_start_date_to_cohorts.rb
+++ b/db/migrate/20230314120416_add_npq_registration_start_date_to_cohorts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNPQRegistrationStartDateToCohorts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :cohorts, :npq_registration_start_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_04_184644) do
+ActiveRecord::Schema.define(version: 2023_03_14_120416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 2023_03_04_184644) do
     t.integer "start_year", limit: 2, null: false
     t.datetime "registration_start_date"
     t.datetime "academic_year_start_date"
+    t.datetime "npq_registration_start_date"
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -106,4 +106,57 @@ RSpec.describe Cohort, type: :model do
       expect(subject.schedules).to include(schedule)
     end
   end
+
+  describe ".active_registration_cohort" do
+    describe "when the current date matches the registration start date" do
+      it "returns the cohort with start_year the current year" do
+        Timecop.freeze(Date.new(2022, 5, 10)) do
+          expect(Cohort.active_registration_cohort).to eq cohort_2022
+        end
+      end
+    end
+
+    describe "when the current date is before the registration start date of the next cohort" do
+      it "returns the cohort with start_year the previous year" do
+        Timecop.freeze(Date.new(2022, 5, 11)) do
+          expect(Cohort.active_npq_registration_cohort).to eq cohort_2021
+        end
+      end
+    end
+  end
+
+  describe ".active_npq_registration_cohort" do
+    context "when npq_registration_start_date is nil" do
+      it "returns Cohort.current" do
+        Timecop.freeze(Date.new(2023, 3, 14)) do
+          expect(Cohort.active_npq_registration_cohort).to eq cohort_2022
+        end
+      end
+    end
+
+    context "when npq_registration_start_date is not nil" do
+      before do
+        cohort_2021.update!(npq_registration_start_date: Date.new(2021, 3, 14))
+        cohort_2022.update!(npq_registration_start_date: Date.new(2022, 3, 14))
+        cohort_2023.update!(npq_registration_start_date: Date.new(2023, 3, 14))
+        cohort_2024.update!(npq_registration_start_date: Date.new(2024, 3, 14))
+      end
+
+      describe "when the current date matches the npq registration start date" do
+        it "returns the cohort with start_year the current year" do
+          Timecop.freeze(Date.new(2023, 3, 14)) do
+            expect(Cohort.active_npq_registration_cohort).to eq cohort_2023
+          end
+        end
+      end
+
+      describe "when the current date is before the npq registration start date of the next cohort" do
+        it "returns the cohort with start_year the previous year" do
+          Timecop.freeze(Date.new(2023, 3, 13)) do
+            expect(Cohort.active_npq_registration_cohort).to eq cohort_2022
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2086](https://dfedigital.atlassian.net/browse/CPDLP-2086)

We need to add a new field for NPQ registration_start_date as the current one is more for ECF related stuff.
If we were to add a new cohort and use registration_start_date to determine the next cohort for NPQ registration this would impact ECF which is not ready for the new cohort.

### Changes proposed in this pull request

We have agreed adding a new field to the cohorts table will help resolve the issue.

[CPDLP-2086]: https://dfedigital.atlassian.net/browse/CPDLP-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ