### PR TITLE
Display the Profile id in the admin participant details

### DIFF
--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -39,7 +39,12 @@
   end
 
   sl.row do |row|
-    row.key(text: "ID")
+    row.key(text: "Profile ID")
+    row.value(text: tag.code(@participant_profile.id))
+  end
+
+  sl.row do |row|
+    row.key(text: "User ID")
     row.value(text: tag.code(@user.id))
   end
 


### PR DESCRIPTION
### Context

- Ticket: N/A

I want an easy way for us to find and distinct the Profile id from the User id and External id in the Admin->Participant pages.

Currently we use it in the url params, but is not obvious which id is it and can be easily confused with the user id or external id.

### Changes proposed in this pull request
- Rename the `ID` label to `User ID` to be more explicit
- Display the Profile ID in the Admin->Participant->Details page.

### Guidance to review

