### PR TITLE
Filter PII attributes from models

### DIFF
--- a/app/models/ecf_participant_validation_data.rb
+++ b/app/models/ecf_participant_validation_data.rb
@@ -4,7 +4,7 @@ class ECFParticipantValidationData < ApplicationRecord
   belongs_to :participant_profile, class_name: "ParticipantProfile", touch: true
   validate :belongs_to_ecf_participant
 
-  self.filter_attributes += [:full_name]
+  self.filter_attributes += %i[full_name trn]
 
   def can_validate_participant?
     date_of_birth.present? && (trn.present? || nino.present?)

--- a/app/models/ecf_participant_validation_data.rb
+++ b/app/models/ecf_participant_validation_data.rb
@@ -4,6 +4,8 @@ class ECFParticipantValidationData < ApplicationRecord
   belongs_to :participant_profile, class_name: "ParticipantProfile", touch: true
   validate :belongs_to_ecf_participant
 
+  self.filter_attributes += [:full_name]
+
   def can_validate_participant?
     date_of_birth.present? && (trn.present? || nino.present?)
   end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -51,6 +51,8 @@ class NPQApplication < ApplicationRecord
   delegate :id, :name, to: :npq_course, prefix: true
   delegate :id, :name, to: :npq_lead_provider, prefix: true
 
+  self.filter_attributes += [:teacher_reference_number]
+
   # this builds upon #eligible_for_funding
   # eligible_for_funding is solely based on what NPQ app knows
   # eg school, course etc

--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -18,6 +18,8 @@ class ParticipantIdentity < ApplicationRecord
   scope :original, -> { where("participant_identities.external_identifier = participant_identities.user_id") }
   scope :secondary, -> { where("participant_identities.external_identifier != participant_identities.user_id") }
 
+  self.filter_attributes += [:email]
+
   def self.email_matches(search_term)
     return none if search_term.blank?
 

--- a/app/models/teacher_profile.rb
+++ b/app/models/teacher_profile.rb
@@ -18,6 +18,8 @@ class TeacherProfile < ApplicationRecord
   has_many :npq_profiles, class_name: "ParticipantProfile::NPQ"
   # end: TODO
 
+  self.filter_attributes += [:trn]
+
   def self.trn_matches(search_term)
     return none if search_term.blank?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,8 @@ class User < ApplicationRecord
             on: :update,
             if: -> { get_an_identity_id_was.present? }
 
+  self.filter_attributes += %i[email full_name]
+
   # changed from has_many :npq_applications as these now live on participant_identities
   # and it is possible that there are applications on one or more of the user's
   # participant_identity records


### PR DESCRIPTION
### Context

To avoid PII bubbling up in exception errors us the `filter_attributes` on select models

- Ticket: n/a

### Changes proposed in this pull request

- `filter_attributes` filters selected columns when calling #inspect, add to models with PII

### Guidance to review
Did I miss anything?
