### PR TITLE
Update NPQ application cohort when changing schedule

### DIFF
--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -155,6 +155,13 @@ RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { ex
 
     describe ".call" do
       it_behaves_like "changing the schedule of a participant"
+
+      it "updates the schedule on the relevant induction record" do
+        service.call
+        relevant_induction_record = participant_profile.current_induction_record
+
+        expect(relevant_induction_record.schedule).to eq(schedule)
+      end
     end
   end
 
@@ -175,6 +182,13 @@ RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { ex
 
     describe ".call" do
       it_behaves_like "changing the schedule of a participant"
+
+      it "updates the schedule on the relevant induction record" do
+        service.call
+        relevant_induction_record = participant_profile.current_induction_record
+
+        expect(relevant_induction_record.schedule).to eq(schedule)
+      end
     end
   end
 

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -118,7 +118,7 @@ RSpec.shared_examples "changing the schedule of a participant" do
 
     expect(latest_participant_profile_schedule).to have_attributes(
       participant_profile_id: participant_profile.id,
-      schedule_id: Finance::Schedule.where(schedule_identifier:, cohort: Cohort.current).first.id,
+      schedule_id: Finance::Schedule.where(schedule_identifier:, cohort: new_cohort).first.id,
     )
   end
 end
@@ -133,6 +133,7 @@ RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { ex
       schedule_identifier:,
     }
   end
+  let(:new_cohort) { Cohort.current }
 
   subject(:service) do
     described_class.new(params)
@@ -212,6 +213,33 @@ RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { ex
 
     describe ".call" do
       it_behaves_like "changing the schedule of a participant"
+
+      it "does not update the npq application cohort" do
+        expect { service.call }.not_to change(participant_profile.npq_application, :cohort)
+      end
+    end
+
+    context "when cohort is changed" do
+      let(:new_cohort) { Cohort.previous }
+      let(:new_schedule) { create(:npq_leadership_schedule, cohort: new_cohort) }
+      let(:params) do
+        {
+          cpd_lead_provider:,
+          participant_id:,
+          course_identifier:,
+          schedule_identifier:,
+          cohort: new_cohort.start_year,
+        }
+      end
+
+      describe ".call" do
+        it_behaves_like "changing the schedule of a participant"
+      end
+
+      it "updates the cohort on the npq application" do
+        service.call
+        expect(participant_profile.npq_application.cohort).to eq(new_cohort)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

An NPQ schedule and cohort can be changed via the API. Ensure we also update the NPQ application to keep both records aligned.

- Ticket: n/a

### Changes proposed in this pull request
- Add missing induction record tests
- Add logic to update NPQ application cohort when profile schedule and cohort are updated via API

### Guidance to review
Did I miss anything?
