### PR TITLE
Set NPQ course when accepting NPQ application in seeds

### DIFF
--- a/db/new_seeds/scenarios/npq.rb
+++ b/db/new_seeds/scenarios/npq.rb
@@ -38,7 +38,7 @@ module NewSeeds
           user:,
           participant_identity:,
           npq_application: application,
-
+          npq_course: application.npq_course,
           # it turns out that we don't find the NPQ application via the participant identity but
           # instead by the `has_one` on participant profile. The id of the NPQ application needs
           # to match the corresponding participant profile's id.


### PR DESCRIPTION
### Context

When accepting applications NPQ course is empty on profiles, make sure to set it to the NPQ application
- Ticket: n/a

### Changes proposed in this pull request
Set NPQ course when building a profile to the application's NPQ course

### Guidance to review

