### PR TITLE
Ensure school/mentor relationships are seeded

### DIFF
--- a/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
@@ -13,13 +13,19 @@ module NewSeeds
           end
 
           def build(**profile_args)
+            school = school_cohort.school
+
             @user = FactoryBot.create(:seed_user, **new_user_attributes)
-            @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school: school_cohort.school)
+            @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school:)
             @participant_profile = FactoryBot.create(:seed_mentor_participant_profile,
                                                      participant_identity: FactoryBot.create(:seed_participant_identity, user:),
                                                      school_cohort:,
                                                      teacher_profile:,
                                                      **profile_args)
+
+            preferred_identity = participant_profile.participant_identity
+
+            @school_mentors = Array.wrap(FactoryBot.create(:seed_school_mentor, school:, participant_profile:, preferred_identity:))
 
             self
           end

--- a/spec/factories/seeds/school_mentor_factory.rb
+++ b/spec/factories/seeds/school_mentor_factory.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_school_mentor, class: "SchoolMentor") do
+    trait(:with_school) do
+      association(:school, factory: :seed_school)
+    end
+
+    trait(:with_participant_profile) do
+      association(:participant_profile, factory: %i[seed_mentor_participant_profile valid])
+    end
+
+    trait(:with_preferred_identity) do
+      association(:preferred_identity, factory: %i[seed_participant_identity valid])
+    end
+
+    # this trait ensures the participant profile and preferred identity are linked to
+    # each other rather than generated in isolation
+    trait(:with_participant_profile_and_identity) do
+      association(:participant_profile, factory: %i[seed_mentor_participant_profile valid])
+
+      preferred_identity { |sm| sm.participant_profile.participant_identity }
+    end
+
+    trait(:valid) do
+      with_school
+      with_participant_profile_and_identity
+    end
+
+    after(:build) do |sm|
+      if sm.school.present? && sm.participant_profile.present?
+        Rails.logger.debug("seeded school_mentor for #{sm.participant_profile.full_name} at #{sm.school.name}")
+      else
+        Rails.logger.debug("seeded incomplete school mentor record")
+      end
+    end
+  end
+end

--- a/spec/seeds/seed_factories/school_mentor_factory_spec.rb
+++ b/spec/seeds/seed_factories/school_mentor_factory_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "./shared_factory_examples"
+
+RSpec.describe("seed_school_mentor") do
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_school_mentor }
+    let(:factory_class) { SchoolMentor }
+  end
+end


### PR DESCRIPTION
### Context

Following on from the tech debt chat this morning, this change ensures that the link table between schools and mentors is populated. Previously only the induction record link was set (saying the mentor is mentoring someone at a school) but this one marks the mentor as _being_ at that school.

### Changes proposed in this pull request

- Add seed factory for the school_mentors link table
- Add school mentor to mentor with no ects scenario
