### PR TITLE
Enable configuration of seed quantities per env

### DIFF
--- a/config/seed_quantities.yml
+++ b/config/seed_quantities.yml
@@ -1,0 +1,44 @@
+# These values can be overridden locally by creating an environment variable
+# with a matching name prefixed by `SEED_`
+#
+# Add the following snippet to your .env file and adjust:
+#
+# SEED_LOCAL_AUTHORITIES=10
+# SEED_NPQ_APPLICATIONS_PENDING=10
+# SEED_NPQ_APPLICATION_WITH_DECLARATIONS=10
+# SEED_NPQ_APPLICATIONS_REJECTED=10
+# SEED_NPQ_APPLICATIONS_PENDING_ASO=10
+# SEED_NPQ_APPLICATIONS_PENDING_ECHO=10
+# SEED_FIP_TO_FIP_TRANSFERS_KEEPING_ORIGINAL_PROVIDER=2
+# SEED_FIP_TO_FIP_TRANSFERS_CHANGING_PROVIDER=2
+# SEED_SCHOOL_INVITATIONS=10
+---
+default: &default
+  local_authorities: 10
+  npq_applications_pending: 10
+  npq_application_with_declarations: 10
+  npq_applications_rejected: 10
+  npq_applications_pending_aso: 10
+  npq_applications_pending_ehco: 10
+  fip_to_fip_transfers_keeping_original_provider: 2
+  fip_to_fip_transfers_changing_provider: 2
+  school_invitations: 10
+
+development:
+  <<: *default
+
+sandbox:
+  <<: *default
+
+test:
+  <<: *default
+  local_authorities: 1
+  npq_applications_pending: 1
+  npq_application_with_declarations: 1
+  npq_applications_rejected: 1
+  npq_applications_pending_aso: 1
+  npq_applications_pending_ehco: 1
+  school_invitations: 1
+
+deployed_development:
+  <<: *default

--- a/db/new_seeds/base/add_npq_registrations.rb
+++ b/db/new_seeds/base/add_npq_registrations.rb
@@ -3,7 +3,7 @@
 npq_lead_providers = NPQLeadProvider.all
 
 # Create pending NPQ applications
-15.times do
+seed_quantity(:npq_applications_pending).times do
   NewSeeds::Scenarios::NPQ
     .new(lead_provider: npq_lead_providers.sample)
     .build
@@ -11,7 +11,7 @@ end
 
 # Create accepted NPQ applications with participant profiles
 # and a declaration
-30.times do
+seed_quantity(:npq_application_with_declarations).times do
   NewSeeds::Scenarios::NPQ
     .new(lead_provider: npq_lead_providers.sample)
     .build
@@ -20,7 +20,7 @@ end
 end
 
 # Create rejected NPQ applications
-15.times do
+seed_quantity(:npq_applications_rejected).times do
   NewSeeds::Scenarios::NPQ
     .new(lead_provider: npq_lead_providers.sample)
     .build
@@ -28,7 +28,7 @@ end
 end
 
 # Create pending NPQ applications to ASO NPQ course
-10.times do
+seed_quantity(:npq_applications_pending_aso).times do
   NewSeeds::Scenarios::NPQ
     .new(
       lead_provider: npq_lead_providers.sample,
@@ -38,7 +38,7 @@ end
 end
 
 # Create pending NPQ applications to EHCO NPQ course
-10.times do
+seed_quantity(:npq_applications_pending_ehco).times do
   NewSeeds::Scenarios::NPQ
     .new(
       lead_provider: npq_lead_providers.sample,

--- a/db/new_seeds/base/add_schools_and_local_authorities.rb
+++ b/db/new_seeds/base/add_schools_and_local_authorities.rb
@@ -30,7 +30,7 @@ def add_school_to_local_authority(school:, local_authority:, lead_providers:, co
 end
 
 # create some local authorities
-local_authorities = FactoryBot.create_list(:local_authority, 10)
+local_authorities = FactoryBot.create_list(:local_authority, seed_quantity(:local_authorities))
 
 cohorts = Cohort.where(start_year: [2021, 2022])
 lead_providers = LeadProvider.all

--- a/db/new_seeds/base/add_sit_nominations.rb
+++ b/db/new_seeds/base/add_sit_nominations.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 FactoryBot
-  .create_list(:seed_school, 15)
+  .create_list(:seed_school, seed_quantity(:school_invitations))
   .map { |school| NewSeeds::Scenarios::School::InviteSchool.new(school:).invite! }

--- a/db/new_seeds/base/add_transfer_scenarios.rb
+++ b/db/new_seeds/base/add_transfer_scenarios.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
-NewSeeds::Scenarios::Participants::Transfers::FipToFipKeepingOriginalTrainingProvider.new.build
-NewSeeds::Scenarios::Participants::Transfers::FipToFipChangingTrainingProvider.new.build
+seed_quantity(:fip_to_fip_transfers_keeping_original_provider).times do
+  NewSeeds::Scenarios::Participants::Transfers::FipToFipKeepingOriginalTrainingProvider.new.build
+end
+
+seed_quantity(:fip_to_fip_transfers_changing_provider).times do
+  NewSeeds::Scenarios::Participants::Transfers::FipToFipChangingTrainingProvider.new.build
+end

--- a/db/new_seeds/run.rb
+++ b/db/new_seeds/run.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+SEED_QUANTITIES = YAML.load_file(Rails.root.join("config/seed_quantities.yml"), aliases: true).fetch(Rails.env).freeze
+
 Faker::Config.locale = "en-GB"
 
 Dir.glob(Rails.root.join("db/new_seeds/scenarios/**/*.rb")).each do |scenario|
@@ -13,6 +15,12 @@ def load_base_file(file)
 end
 
 Rails.logger.info("Seeding database")
+
+def seed_quantity(key)
+  name = key.to_s
+
+  ENV.fetch("SEED_#{name.upcase}") { SEED_QUANTITIES.fetch(name) }
+end
 
 [
   "add_cohorts.rb",


### PR DESCRIPTION
### Context

The quantity of seeded records was hard coded. This worked well but it:

- didn't account for personal preference
- isn't environment specific
- doesn't make it easy to get an overview of what's being created

This change adds some config and an method that pulls values from it. It also allows those values to be overridden locally with environment variables.

The configuration key will be overridden by a matching environment variable that's uppercase and prefixed with `SEED_`, so to override `local_authorities: 3` we can set `SEED_LOCAL_AUTHORITIES=10`.
