### PR TITLE
Check induction record schedule before raising validation error when changing schedule

### DIFF
--- a/app/services/change_schedule.rb
+++ b/app/services/change_schedule.rb
@@ -151,6 +151,14 @@ private
   def change_with_a_different_schedule
     return unless new_schedule && participant_profile && new_schedule == participant_profile.schedule
 
+    return if relevant_induction_record_has_different_schedule
+
     errors.add(:schedule_identifier, I18n.t(:schedule_already_on_the_profile))
+  end
+
+  def relevant_induction_record_has_different_schedule
+    return unless relevant_induction_record
+
+    new_schedule != relevant_induction_record.schedule
   end
 end

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -66,7 +66,7 @@ RSpec.shared_examples "validating a participant for a change schedule" do
   end
 
   context "when the schedule identifier change of the same type again" do
-    before { service.call }
+    before { described_class.new(params).call }
 
     it "is invalid and returns an error message" do
       is_expected.to be_invalid
@@ -163,6 +163,17 @@ RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { ex
 
         expect(relevant_induction_record.schedule).to eq(schedule)
       end
+
+      context "when profile schedule is not the same as the induction record" do
+        let(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider, schedule:) }
+
+        it "updates the schedule on the relevant induction record" do
+          service.call
+          relevant_induction_record = participant_profile.current_induction_record
+
+          expect(relevant_induction_record.schedule).to eq(schedule)
+        end
+      end
     end
   end
 
@@ -189,6 +200,17 @@ RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { ex
         relevant_induction_record = participant_profile.current_induction_record
 
         expect(relevant_induction_record.schedule).to eq(schedule)
+      end
+
+      context "when profile schedule is not the same as the induction record" do
+        before { participant_profile.update!(schedule:) }
+
+        it "updates the schedule on the relevant induction record" do
+          service.call
+          relevant_induction_record = participant_profile.current_induction_record
+
+          expect(relevant_induction_record.schedule).to eq(schedule)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

There are some cases where the profile schedule will be the same as the new schedule we are attempting to change to, however the induction record has a different schedule.

This can happen in transfers, when a profile is amended after a participant has transferred, leaving the induction record with an incorrect schedule, but the profile with the correct one.

Allow the change to happen to align all schedules without raising a validation error

- Ticket: n/a

### Changes proposed in this pull request
Add extra check for ECF profiles on induction record schedules to ensure they aren't equal to allow schedules to change

### Guidance to review
Did I miss anything?

