### PR TITLE
[CPDLP-2087] Add script to create cohort data

### DIFF
--- a/app/services/importers/create_cohort.rb
+++ b/app/services/importers/create_cohort.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Importers
+  class CreateCohort < BaseService
+    def call
+      check_headers!
+
+      logger.info "CreateCohort: Started!"
+      rows.each do |row|
+        create_cohort(row)
+      end
+      logger.info "CreateCohort: Finished!"
+    end
+
+  private
+
+    attr_reader :path_to_csv, :logger
+
+    def initialize(path_to_csv:, logger: Rails.logger)
+      @path_to_csv = path_to_csv
+      @logger = logger
+    end
+
+    def create_cohort(row)
+      start_year = row["start-year"].to_i
+      logger.info "CreateCohort: Creating cohort for starting year #{start_year}"
+
+      Cohort.find_or_create_by!(start_year:) do |c|
+        c.registration_start_date = safe_parse(row["registration-start-date"])
+        c.academic_year_start_date = safe_parse(row["academic-year-start-date"])
+        c.npq_registration_start_date = safe_parse(row["npq-registration-start-date"])
+      end
+
+      logger.info "CreateCohort: Cohort for starting year #{start_year} successfully created"
+    end
+
+    def safe_parse(date)
+      return if date.blank?
+
+      Date.parse(date)
+    rescue Date::Error
+      logger.warn "CreateCohort: Error parsing date"
+      nil
+    end
+
+    def check_headers!
+      unless %w[start-year registration-start-date academic-year-start-date npq-registration-start-date].all? { |header| rows.headers.include?(header) }
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true)
+    end
+  end
+end

--- a/app/services/importers/seed_schedule.rb
+++ b/app/services/importers/seed_schedule.rb
@@ -17,10 +17,7 @@ class Importers::SeedSchedule
       next unless row["schedule-identifier"]
 
       year = row["schedule-cohort-year"].to_i
-      cohort = Cohort.find_or_create_by!(start_year: year) do |c|
-        c.registration_start_date = Date.new(year, 5, 10)
-        c.academic_year_start_date = Date.new(year, 9, 1)
-      end
+      cohort = Cohort.find_by!(start_year: year)
 
       schedule = klass.find_or_initialize_by(
         schedule_identifier: row["schedule-identifier"],

--- a/db/data/cohorts/cohorts.csv
+++ b/db/data/cohorts/cohorts.csv
@@ -1,0 +1,5 @@
+start-year,registration-start-date,academic-year-start-date,npq-registration-start-date
+2020,2020/05/10,2020/09/01,
+2021,2021/05/10,2021/09/01,
+2022,2022/05/10,2022/09/01
+2023,2023/05/10,2023/09/01

--- a/db/legacy_seeds/initial_seed.rb
+++ b/db/legacy_seeds/initial_seed.rb
@@ -1,21 +1,9 @@
 # frozen_string_literal: true
 
-registration_month = 5
-registration_day = 10
-academic_year_start_month = 9
-academic_year_start_day = 1
+Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
 
-# Make sure Cohort 2020 exists
-Cohort.find_or_create_by!(start_year: 2020,
-                          registration_start_date: Date.new(2020, registration_month, registration_day),
-                          academic_year_start_date: Date.new(2020, academic_year_start_month, academic_year_start_day))
-
-# Create cohorts since 2021 until Cohort.next
-next_cohort_start_year = Date.current.year + (Date.current.month < academic_year_start_month ? 0 : 1)
-cohorts = (2021..next_cohort_start_year).to_a.map do |start_year|
-  Cohort.find_or_create_by!(start_year:,
-                            registration_start_date: Date.new(start_year, registration_month, registration_day),
-                            academic_year_start_date: Date.new(start_year, academic_year_start_month, academic_year_start_day))
+cohorts = (2021..Cohort.next.start_year).to_a.map do |start_year|
+  Cohort.find_by!(start_year:)
 end
 
 ambition_cip = CoreInductionProgramme.find_or_create_by!(name: "Ambition Institute")

--- a/db/legacy_seeds/schedules.rb
+++ b/db/legacy_seeds/schedules.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call
+
 ActiveRecord::Base.transaction do
   Importers::SeedSchedule.new(
     path_to_csv: Rails.root.join("db/data/schedules/npq_specialist.csv"),

--- a/db/legacy_seeds/test_data.rb
+++ b/db/legacy_seeds/test_data.rb
@@ -7,8 +7,7 @@ require "active_support/testing/time_helpers"
 include ActiveSupport::Testing::TimeHelpers
 
 DOMAIN = "@digital.education.gov.uk" # Prevent low effort email scraping
-Cohort.find_or_create_by!(start_year: 2021)
-cohort_2023 = Cohort.find_or_create_by!(start_year: 2023)
+cohort_2023 = Cohort.find_by!(start_year: 2023)
 
 local_authority = LocalAuthority.find_or_create_by!(name: "ZZ Test Local Authority", code: "ZZTEST")
 

--- a/db/new_seeds/base/add_cohorts.rb
+++ b/db/new_seeds/base/add_cohorts.rb
@@ -1,9 +1,3 @@
 # frozen_string_literal: true
 
-# Cohort 2020
-cohort_2020 = FactoryBot.create(:seed_cohort, start_year: 2020)
-
-# Ensures Cohort.next is always created
-academic_year_start_month = cohort_2020.academic_year_start_date.month
-next_cohort_start_year = Date.current.year + (Date.current.month < academic_year_start_month ? 0 : 1)
-(2021..next_cohort_start_year).to_a.each { |start_year| FactoryBot.create(:seed_cohort, start_year:) }
+Importers::CreateCohort.new(path_to_csv: Rails.root.join("db/data/cohorts/cohorts.csv")).call

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -10,16 +10,16 @@ FactoryBot.define do
     registration_start_date { Date.new(start_year.to_i, 5, 10) }
     academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
 
+    initialize_with do
+      Cohort.find_by(start_year:) || new(**attributes)
+    end
+
     trait :previous do
       start_year { Date.current.year - (Date.current.month < 9 ? 2 : 1) }
     end
 
     trait :current do
       start_year { Date.current.year - (Date.current.month < 9 ? 1 : 0) }
-
-      initialize_with do
-        Cohort.find_by(start_year:) || new(**attributes)
-      end
     end
 
     trait :next do

--- a/spec/factories/seeds/npq_application_factory.rb
+++ b/spec/factories/seeds/npq_application_factory.rb
@@ -42,8 +42,8 @@ FactoryBot.define do
       private_childcare_provider_urn { "EY#{SecureRandom.rand(100_000..999_999)}" }
     end
 
-    trait(:starting_in_2021) { cohort { Cohort.find_or_create_by!(start_year: 2021) } }
-    trait(:starting_in_2022) { cohort { Cohort.find_or_create_by!(start_year: 2022) } }
+    trait(:starting_in_2021) { cohort { create(:cohort, start_year: 2021) } }
+    trait(:starting_in_2022) { cohort { create(:cohort, start_year: 2022) } }
 
     trait(:valid) do
       with_participant_identity

--- a/spec/factories/seeds/provider_relationship_factory.rb
+++ b/spec/factories/seeds/provider_relationship_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     trait(:with_cohort_2022) do
-      cohort { Cohort.find_or_create_by!(start_year: 2022) }
+      cohort { create(:cohort, start_year: 2022) }
     end
 
     trait(:with_lead_provider) do

--- a/spec/factories/seeds/school_cohort_factory.rb
+++ b/spec/factories/seeds/school_cohort_factory.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
     trait(:fip) { induction_programme_choice { "full_induction_programme" } }
     trait(:cip) { induction_programme_choice { "core_induction_programme" } }
 
-    trait(:starting_in_2021) { cohort { Cohort.find_or_create_by!(start_year: 2021) } }
-    trait(:starting_in_2022) { cohort { Cohort.find_or_create_by!(start_year: 2022) } }
+    trait(:starting_in_2021) { cohort { create(:cohort, start_year: 2021) } }
+    trait(:starting_in_2022) { cohort { create(:cohort, start_year: 2022) } }
 
     trait(:valid) do
       with_school

--- a/spec/services/importers/create_cohort_spec.rb
+++ b/spec/services/importers/create_cohort_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::CreateCohort do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:path_to_csv) { csv.path }
+
+  subject(:importer) { described_class.new(path_to_csv:) }
+
+  describe "#call" do
+    before do
+      csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+      csv.write "\n"
+      csv.write "2020,2020/05/10,2020/09/01,"
+      csv.write "\n"
+      csv.write "2021,2021/05/10,2021/09/01,"
+      csv.write "\n"
+      csv.write "2022,2022/05/10,2022/09/01,"
+      csv.write "\n"
+      csv.write "2023,,,"
+      csv.write "\n"
+      csv.close
+    end
+
+    it "creates cohort records" do
+      expect {
+        importer.call
+      }.to change(Cohort, :count).by(4)
+    end
+
+    it "sets the correct start year on the record" do
+      importer.call
+
+      expect(Cohort.order(:start_year).last.start_year).to eq(2023)
+    end
+
+    it "sets the correct registration start date on the record" do
+      importer.call
+
+      cohort = Cohort.find_by(start_year: 2022)
+
+      expect(cohort.registration_start_date).to eq(Date.parse("10/05/2022"))
+    end
+
+    it "only creates one cohort record per year" do
+      importer.call
+
+      expect(Cohort.select("start_year").group("start_year").pluck(:start_year).size).to be 4
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2087](https://dfedigital.atlassian.net/browse/CPDLP-2087)

To support cohort 2023 for NPQ registration, records relating to the cohort need to be populated. This includes NPQ contracts, schedules and statements.

### Changes proposed in this pull request

Create a new script which will consume production data CSVs and creates a new cohort.


[CPDLP-2087]: https://dfedigital.atlassian.net/browse/CPDLP-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ