### PR TITLE
Display the profile training status in the Admin participant page

### DIFF
--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -31,6 +31,11 @@
     # )
   end
 
+  sl.row do |row|
+    row.key(text: "Training status")
+    row.value(text: @participant_profile.training_status)
+  end
+
   if @participant_profile.teacher_profile
     sl.row do |row|
       row.key(text: "TRN")


### PR DESCRIPTION
### Context

- Ticket: N/A

The profile's training status is still in use, but we don't display it anywhere. That's causing confusions with withdrawn profiles that have active training status in their Induction Records.

### Changes proposed in this pull request
Display the profile training status in the Admin -> Participant -> Details page.

### Guidance to review

