### PR TITLE
Prefer participant profile ID on V1/V2 API participant endpoints

### DIFF
--- a/app/jobs/create_new_fake_sandbox_data_job.rb
+++ b/app/jobs/create_new_fake_sandbox_data_job.rb
@@ -10,9 +10,9 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
 
     @provider_name = provider_name
 
-    if ecf_lead_provider.present?
+    if ecf_lead_provider.present? && random_school_cohort.present?
       10.times do
-        name = Faker::Name.name
+        name = ::Faker::Name.name
         EarlyCareerTeachers::Create.call(
           full_name: name,
           email: Faker::Internet.email(name:),
@@ -22,7 +22,7 @@ class CreateNewFakeSandboxDataJob < ApplicationJob
       end
     end
 
-    if npq_lead_provider.present?
+    if npq_lead_provider.present? && random_school.present?
       10.times do
         name = Faker::Name.name
         user = User.create!(full_name: name, email: Faker::Internet.email(name:))

--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -94,6 +94,8 @@ module Api
 
       attribute :training_status, &:training_status
 
+      attribute :training_record_id, &:participant_profile_id
+
       attribute :schedule_identifier do |induction_record|
         induction_record.schedule&.schedule_identifier
       end

--- a/app/serializers/api/v1/participant_from_query_serializer.rb
+++ b/app/serializers/api/v1/participant_from_query_serializer.rb
@@ -88,6 +88,8 @@ module Api
 
       attribute :training_status, &:training_status
 
+      attribute :training_record_id, &:participant_profile_id
+
       attribute :schedule_identifier, &:schedule_identifier
 
       attribute :updated_at do |induction_record|

--- a/app/services/api/v1/ecf/participants_query.rb
+++ b/app/services/api/v1/ecf/participants_query.rb
@@ -46,13 +46,11 @@ module Api
         end
 
         def induction_record
-          induction_records
-            .where(participant_profile: { id: params[:id], type: ParticipantProfile::ECT.name })
-            .or(
-              induction_records
-                .where(participant_profile: { participant_identities: { user_id: params[:id] } }),
-            )
-            .first
+          scope = induction_records
+            .where(participant_profile: { participant_identities: { user_id: params[:id] } })
+          scope = scope.where(participant_profile: { type: "ParticipantProfile::ECT" }) if scope.size > 1
+
+          scope.first.presence || raise(ActiveRecord::RecordNotFound)
         end
 
       private

--- a/app/services/api/v1/ecf/participants_query.rb
+++ b/app/services/api/v1/ecf/participants_query.rb
@@ -47,7 +47,12 @@ module Api
 
         def induction_record
           induction_records
-            .find_by!(participant_profile: { participant_identities: { user_id: params[:id] } })
+            .where(participant_profile: { id: params[:id], type: ParticipantProfile::ECT.name })
+            .or(
+              induction_records
+                .where(participant_profile: { participant_identities: { user_id: params[:id] } }),
+            )
+            .first
         end
 
       private

--- a/config/seed_quantities.yml
+++ b/config/seed_quantities.yml
@@ -11,9 +11,12 @@
 # SEED_NPQ_APPLICATIONS_EHCO=10
 # SEED_NPQ_APPLICATIONS_SPECIALIST=10
 # SEED_NPQ_APPLICATIONS_LEADERSHIP=10
+# SEED_NPQ_APPLICATIONS_EDGE_CASES=10
 # SEED_FIP_TO_FIP_TRANSFERS_KEEPING_ORIGINAL_PROVIDER=2
 # SEED_FIP_TO_FIP_TRANSFERS_CHANGING_PROVIDER=2
 # SEED_SCHOOL_INVITATIONS=10
+# SEED_NPQ_APPLICATIONS_ELIGIBLE_FOR_TRANSFER=10
+# SEED_ECTS_BECOMING_MENTORS=10
 ---
 default: &default
   local_authorities: 10
@@ -29,6 +32,7 @@ default: &default
   school_invitations: 10
   npq_applications_eligible_for_transfer: 10
   npq_applications_edge_cases: 25
+  ects_becoming_mentors: 10
 
 development:
   <<: *default

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -2,10 +2,6 @@ session_trim:
   cron: "0 1 * * *"
   class: "SessionTrimJob"
   queue: default
-create_new_fake_sandbox_data:
-  cron: "0 2 * * *"
-  class: "CreateNewFakeSandboxDataJob"
-  queue: default
 stream_big_query_participant_declarations:
   cron: "0 * * * *"
   class: "StreamBigQueryParticipantDeclarationsJob"

--- a/db/new_seeds/base/add_ects_becoming_mentors.rb
+++ b/db/new_seeds/base/add_ects_becoming_mentors.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+@cohorts = [Cohort.previous, Cohort.current]
+# select providers with API tokens for API testing
+@lead_providers = LeadProvider.where(name: ["Ambition Institute", "Best Practice Network", "Capita", "Education Development Trust"])
+
+seed_quantity(:ects_becoming_mentors).times do
+  lead_provider = @lead_providers.sample
+  cohort = @cohorts.sample
+  school = NewSeeds::Scenarios::Schools::School
+    .new
+    .build
+    .with_partnership_in(cohort:, lead_provider:)
+    .chosen_fip_and_partnered_in(cohort:)
+
+  mentor_school = NewSeeds::Scenarios::Schools::School
+    .new
+    .build
+    .with_partnership_in(cohort:, lead_provider:)
+    .chosen_fip_and_partnered_in(cohort:)
+
+  NewSeeds::Scenarios::Participants::Ects::Ect
+    .new(school_cohort: school.school_cohort)
+    .build
+    .with_validation_data
+    .with_eligibility
+    .with_induction_record(induction_programme: school.induction_programme)
+    .with_becoming_a_mentor(
+      mentor_school_cohort: mentor_school.school_cohort,
+      mentor_induction_programme: mentor_school.induction_programme,
+    )
+end

--- a/db/new_seeds/base/add_ects_becoming_mentors.rb
+++ b/db/new_seeds/base/add_ects_becoming_mentors.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-@cohorts = [Cohort.previous, Cohort.current]
 # select providers with API tokens for API testing
 @lead_providers = LeadProvider.where(name: ["Ambition Institute", "Best Practice Network", "Capita", "Education Development Trust"])
 
 seed_quantity(:ects_becoming_mentors).times do
   lead_provider = @lead_providers.sample
-  cohort = @cohorts.sample
+  cohort_ect = Cohort.previous
+  cohort_mentor = Cohort.current
   school = NewSeeds::Scenarios::Schools::School
     .new
     .build
-    .with_partnership_in(cohort:, lead_provider:)
-    .chosen_fip_and_partnered_in(cohort:)
+    .with_partnership_in(cohort: cohort_ect, lead_provider:)
+    .chosen_fip_and_partnered_in(cohort: cohort_ect)
 
   mentor_school = NewSeeds::Scenarios::Schools::School
     .new
     .build
-    .with_partnership_in(cohort:, lead_provider:)
-    .chosen_fip_and_partnered_in(cohort:)
+    .with_partnership_in(cohort: cohort_mentor, lead_provider:)
+    .chosen_fip_and_partnered_in(cohort: cohort_mentor)
 
   NewSeeds::Scenarios::Participants::Ects::Ect
     .new(school_cohort: school.school_cohort)

--- a/db/new_seeds/run.rb
+++ b/db/new_seeds/run.rb
@@ -39,6 +39,7 @@ end
   "add_api_tokens.rb",
   "add_feature_flags.rb",
   "add_sit_nominations.rb",
+  "add_ects_becoming_mentors.rb",
 ].each do |file|
   Rails.logger.info("seeding #{file}")
   load_base_file(file)

--- a/db/new_seeds/scenarios/participants/ects/ect.rb
+++ b/db/new_seeds/scenarios/participants/ects/ect.rb
@@ -15,8 +15,9 @@ module NewSeeds
           def build(**_profile_args)
             @user = FactoryBot.create(:seed_user, **new_user_attributes)
             @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school: school_cohort.school)
+            @participant_identity = FactoryBot.create(:seed_participant_identity, user:)
             @participant_profile = FactoryBot.create(:seed_ect_participant_profile,
-                                                     participant_identity: FactoryBot.create(:seed_participant_identity, user:),
+                                                     participant_identity:,
                                                      teacher_profile:,
                                                      school_cohort:)
 
@@ -80,11 +81,25 @@ module NewSeeds
             FactoryBot.create(:seed_ecf_participant_eligibility, **eligibility_data.compact)
           end
 
+          def with_becoming_a_mentor(mentor_school_cohort:, mentor_induction_programme:)
+            Mentors::MentorWithNoEcts
+              .new(
+                school_cohort: mentor_school_cohort,
+                participant_identity:,
+                teacher_profile:,
+              )
+              .build(schedule: Finance::Schedule::ECF.default_for(cohort: mentor_school_cohort.cohort))
+              .with_validation_data
+              .with_eligibility
+              .with_induction_record(induction_programme: mentor_induction_programme)
+          end
+
         private
 
           attr_reader :new_user_attributes,
                       :school_cohort,
                       :teacher_profile,
+                      :participant_identity,
                       :user
         end
       end

--- a/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
@@ -7,18 +7,21 @@ module NewSeeds
         class MentorWithNoEcts
           attr_reader :participant_profile
 
-          def initialize(school_cohort: nil, full_name: nil, email: nil)
+          def initialize(school_cohort: nil, full_name: nil, email: nil, teacher_profile: nil, participant_identity: nil)
             @school_cohort = school_cohort
             @new_user_attributes = { full_name:, email: }.compact
+            @supplied_teacher_profile = teacher_profile
+            @supplied_participant_identity = participant_identity
           end
 
           def build(**profile_args)
             school = school_cohort.school
+            @user = @supplied_participant_identity&.user || FactoryBot.create(:seed_user, **new_user_attributes)
+            @participant_identity = @supplied_participant_identity || FactoryBot.create(:seed_participant_identity, user:)
 
-            @user = FactoryBot.create(:seed_user, **new_user_attributes)
-            @teacher_profile = FactoryBot.create(:seed_teacher_profile, user:, school:)
+            @teacher_profile = @supplied_teacher_profile || FactoryBot.create(:seed_teacher_profile, user:, school:)
             @participant_profile = FactoryBot.create(:seed_mentor_participant_profile,
-                                                     participant_identity: FactoryBot.create(:seed_participant_identity, user:),
+                                                     participant_identity:,
                                                      school_cohort:,
                                                      teacher_profile:,
                                                      **profile_args)
@@ -89,6 +92,7 @@ module NewSeeds
           attr_reader :new_user_attributes,
                       :school_cohort,
                       :teacher_profile,
+                      :participant_identity,
                       :user
         end
       end

--- a/db/new_seeds/scenarios/schools/school.rb
+++ b/db/new_seeds/scenarios/schools/school.rb
@@ -48,7 +48,11 @@ module NewSeeds
         # will also add a partnership to that cohort and induction programme
         ###
         def chosen_fip_and_partnered_in(cohort:, partnership: nil)
-          fip = NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort:, school:).build.with_programme(partnership:)
+          supplied_partnership = partnership
+          fip = NewSeeds::Scenarios::SchoolCohorts::Fip
+            .new(cohort:, school:)
+            .build
+            .with_programme(partnership: supplied_partnership || partnerships[cohort.start_year])
           partnerships[cohort.start_year] = fip.school_cohort.default_induction_programme.partnership
           school_cohorts[cohort.start_year] = fip.school_cohort
 

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,21 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 24th March 2023
+
+To enable the scenario where a participant needs to be registered as a mentor after having already been trained as an ECT by a given provider, a new `training_record_id` attribute has been added to the [ECF participant schema](/api-reference/reference-v1.html#schema-ecfparticipant).
+
+The `training_record_id` value will be unique to each registration that a participant has for ECF-based training, as either an ECT or mentor.
+
+Induction tutors have not yet been able to register participants as mentors if they were already registered as ECTs. Given the likely scenario that ECTs will go on to become mentors, the `training_record_id` attribute will soon allow the service to recognise and differentiate registrations. Note, DfE does not expect induction tutors to begin registering ECTs as mentors until June. For the moment, we have added examples to provider sandbox environments.
+
+* When using the endpoint GET /api/v1/participants/ecf, providers will receive an API response with all the ECF-based training registrations. Where a given participant is registered as both an ECT and a mentor, they will see multiple responses that each have the same participant_id, but which have unique `training_record_ids` for the mentor and ECT response.
+* When using the endpoint GET /api/v1/participants/ecf/{id}, providers will only receive a single response for a given participant. Where a given participant is registered as both an ECT and a mentor, this will be associated with the participant’s ECT registration, not their mentor registration. Note, when API version 3.0.0 is released and integrated with, providers will receive all registrations for the participant ‘nested’ under the relevant `training_record_id`.
+
+Specifications for the `‘nested’ participant response` can be found in the [draft API version 3.0.0. documentation](/api-reference/reference-v3.html#api-v3-participants-ecf-get).
+
+Note, if the DfE has been in touch regarding consolidating inconsistent participant_ids (see the [release note on 15 March 2023](/api-reference/release-notes.html#15th-march-2023)), the `training_record_id` would not change as it is unique to a registration.
+
 ## 15th March 2023
 
 Providers will see reduced errors and inconsistencies associated with `participant_id` values.

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,7 +7,7 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## 24th March 2023
+## 13th April 2023
 
 To enable the scenario where a participant needs to be registered as a mentor after having already been trained as an ECT by a given provider, a new `training_record_id` attribute has been added to the [ECF participant schema](/api-reference/reference-v1.html#schema-ecfparticipant).
 

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
     before do
       default_headers[:Authorization] = bearer_token
       travel_to Time.zone.local(2022, 7, 22, 11, 30, 0) do
-        get "/api/v1/participants/ecf/#{early_career_teacher_profile.id}"
+        get "/api/v1/participants/ecf/#{early_career_teacher_profile.user.id}"
       end
     end
 

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -423,13 +423,13 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
     end
   end
 
-  describe "GET /api/v1/participants/ecf/:id", :with_default_schedules do
+  describe "GET /api/v1/participants/ecf/:id", :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
     let(:parsed_response) { JSON.parse(response.body) }
 
     before do
       default_headers[:Authorization] = bearer_token
       travel_to Time.zone.local(2022, 7, 22, 11, 30, 0) do
-        get "/api/v1/participants/ecf/#{early_career_teacher_profile.user.id}"
+        get "/api/v1/participants/ecf/#{early_career_teacher_profile.id}"
       end
     end
 

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
     end
   end
 
-  describe "GET /api/v1/participants/ecf/:id", :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+  describe "GET /api/v1/participants/ecf/:id", :with_default_schedules do
     let(:parsed_response) { JSON.parse(response.body) }
 
     before do

--- a/spec/requests/api/v1/ecf_participants_spec.rb
+++ b/spec/requests/api/v1/ecf_participants_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
               :pupil_premium_uplift,
               :sparsity_uplift,
               :training_status,
+              :training_record_id,
               :schedule_identifier,
               :updated_at,
             ).exactly)
@@ -286,27 +287,29 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
                pupil_premium_uplift
                sparsity_uplift
                training_status
+               training_record_id
                schedule_identifier
                updated_at],
           )
         end
 
         it "returns the correct values" do
-          mentor = ParticipantProfile::Mentor.first.user
-          mentor_row = parsed_response.find { |row| row["id"] == mentor.id }
+          mentor = ParticipantProfile::Mentor.first
+          mentor_row = parsed_response.find { |row| row["id"] == mentor.user_id }
           expect(mentor_row).not_to be_nil
-          expect(mentor_row["email"]).to eql mentor.email
-          expect(mentor_row["full_name"]).to eql mentor.full_name
+          expect(mentor_row["email"]).to eql mentor.user.email
+          expect(mentor_row["full_name"]).to eql mentor.user.full_name
           expect(mentor_row["mentor_id"]).to eql ""
-          expect(mentor_row["school_urn"]).to eql mentor.participant_profiles[0].induction_records[0].school_cohort.school.urn
+          expect(mentor_row["school_urn"]).to eql mentor.induction_records[0].school_cohort.school.urn
           expect(mentor_row["participant_type"]).to eql "mentor"
-          expect(mentor_row["cohort"]).to eql mentor.mentor_profile.current_induction_record.schedule.cohort.start_year.to_s
+          expect(mentor_row["cohort"]).to eql mentor.current_induction_record.schedule.cohort.start_year.to_s
           expect(mentor_row["teacher_reference_number"]).to be_empty
           expect(mentor_row["teacher_reference_number_validated"]).to be_empty
           expect(mentor_row["eligible_for_funding"]).to be_empty
           expect(mentor_row["pupil_premium_uplift"]).to eql "false"
           expect(mentor_row["sparsity_uplift"]).to eql "false"
           expect(mentor_row["training_status"]).to eql "active"
+          expect(mentor_row["training_record_id"]).to eql mentor.id
 
           ect = InductionRecord
                   .active_induction_status
@@ -314,21 +317,21 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
                   .where(participant_profile: { type: "ParticipantProfile::ECT" })
                   .first
                   .participant_profile
-                  .user
-          ect_row = parsed_response.find { |row| row["id"] == ect.id }
+          ect_row = parsed_response.find { |row| row["id"] == ect.user_id }
           expect(ect_row).not_to be_nil
-          expect(ect_row["email"]).to eql ect.email
-          expect(ect_row["full_name"]).to eql ect.full_name
-          expect(ect_row["mentor_id"]).to eql mentor.id
-          expect(ect_row["school_urn"]).to eql mentor.mentor_profile.current_induction_record.school_cohort.school.urn
+          expect(ect_row["email"]).to eql ect.user.email
+          expect(ect_row["full_name"]).to eql ect.user.full_name
+          expect(ect_row["mentor_id"]).to eql mentor.user_id
+          expect(ect_row["school_urn"]).to eql mentor.current_induction_record.school_cohort.school.urn
           expect(ect_row["participant_type"]).to eql "ect"
-          expect(ect_row["cohort"]).to eql mentor.mentor_profile.current_induction_record.schedule.cohort.start_year.to_s
+          expect(ect_row["cohort"]).to eql mentor.current_induction_record.schedule.cohort.start_year.to_s
           expect(ect_row["teacher_reference_number"]).to be_empty
           expect(ect_row["teacher_reference_number_validated"]).to be_empty
           expect(ect_row["eligible_for_funding"]).to be_empty
           expect(ect_row["pupil_premium_uplift"]).to eql "false"
           expect(ect_row["sparsity_uplift"]).to eql "false"
           expect(ect_row["training_status"]).to eql "active"
+          expect(ect_row["training_record_id"]).to eql ect.id
 
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
@@ -344,6 +347,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
           expect(withdrawn_record_row["pupil_premium_uplift"]).to eql(withdrawn_ect_profile_record.pupil_premium_uplift.to_s)
           expect(withdrawn_record_row["sparsity_uplift"]).to eql(withdrawn_ect_profile_record.sparsity_uplift.to_s)
           expect(withdrawn_record_row["training_status"]).to eql(withdrawn_ect_profile_record.induction_records.first.training_status)
+          expect(withdrawn_record_row["training_record_id"]).to eql(withdrawn_ect_profile_record.id)
         end
 
         it "ignores pagination parameters" do
@@ -449,6 +453,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
               "pupil_premium_uplift" => early_career_teacher_profile.pupil_premium_uplift,
               "sparsity_uplift" => early_career_teacher_profile.sparsity_uplift,
               "training_status" => early_career_teacher_profile.training_status,
+              "training_record_id" => early_career_teacher_profile.id,
               "schedule_identifier" => early_career_teacher_profile.induction_records[0].schedule&.schedule_identifier,
               "updated_at" => Time.zone.local(2022, 7, 22, 11, 30, 0).rfc3339,
             },

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -392,13 +392,13 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
     end
   end
 
-  describe "GET /api/v2/participants/ecf/:id", :with_default_schedules do
+  describe "GET /api/v2/participants/ecf/:id", :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
     let(:parsed_response) { JSON.parse(response.body) }
 
     before do
       default_headers[:Authorization] = bearer_token
       travel_to Time.zone.local(2022, 7, 22, 11, 30, 0) do
-        get "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}"
+        get "/api/v2/participants/ecf/#{early_career_teacher_profile.id}"
       end
     end
 

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
     before do
       default_headers[:Authorization] = bearer_token
       travel_to Time.zone.local(2022, 7, 22, 11, 30, 0) do
-        get "/api/v2/participants/ecf/#{early_career_teacher_profile.id}"
+        get "/api/v2/participants/ecf/#{early_career_teacher_profile.user.id}"
       end
     end
 

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -392,7 +392,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
     end
   end
 
-  describe "GET /api/v2/participants/ecf/:id", :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+  describe "GET /api/v2/participants/ecf/:id", :with_default_schedules do
     let(:parsed_response) { JSON.parse(response.body) }
 
     before do

--- a/spec/requests/api/v2/ecf_participants_spec.rb
+++ b/spec/requests/api/v2/ecf_participants_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
               :pupil_premium_uplift,
               :sparsity_uplift,
               :training_status,
+              :training_record_id,
               :schedule_identifier,
               :updated_at,
             ).exactly)
@@ -259,19 +260,20 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
                pupil_premium_uplift
                sparsity_uplift
                training_status
+               training_record_id
                schedule_identifier
                updated_at],
           )
         end
 
         it "returns the correct values" do
-          mentor = ParticipantProfile::Mentor.first.user
-          mentor_row = parsed_response.find { |row| row["id"] == mentor.id && row["participant_type"] == "mentor" }
+          mentor = ParticipantProfile::Mentor.first
+          mentor_row = parsed_response.find { |row| row["id"] == mentor.user_id && row["participant_type"] == "mentor" }
           expect(mentor_row).not_to be_nil
-          expect(mentor_row["email"]).to eql mentor.email
-          expect(mentor_row["full_name"]).to eql mentor.full_name
+          expect(mentor_row["email"]).to eql mentor.user.email
+          expect(mentor_row["full_name"]).to eql mentor.user.full_name
           expect(mentor_row["mentor_id"]).to eql ""
-          expect(mentor_row["school_urn"]).to eql mentor.participant_profiles[0].induction_records[0].school_cohort.school.urn
+          expect(mentor_row["school_urn"]).to eql mentor.induction_records[0].school_cohort.school.urn
           expect(mentor_row["participant_type"]).to eql "mentor"
           expect(mentor_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(mentor_row["teacher_reference_number"]).to be_empty
@@ -280,22 +282,24 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
           expect(mentor_row["pupil_premium_uplift"]).to eql "false"
           expect(mentor_row["sparsity_uplift"]).to eql "false"
           expect(mentor_row["training_status"]).to eql "active"
+          expect(mentor_row["training_record_id"]).to eql mentor.id
 
-          ect = ect_profile.user
-          ect_row = parsed_response.find { |row| row["id"] == ect.id }
+          ect = ect_profile
+          ect_row = parsed_response.find { |row| row["id"] == ect.user_id }
           expect(ect_row).not_to be_nil
-          expect(ect_row["email"]).to eql ect.email
-          expect(ect_row["full_name"]).to eql ect.full_name
-          expect(ect_row["mentor_id"]).to eql mentor.id
-          expect(ect_row["school_urn"]).to eql mentor.participant_profiles[0].induction_records[0].school_cohort.school.urn
+          expect(ect_row["email"]).to eql ect.user.email
+          expect(ect_row["full_name"]).to eql ect.user.full_name
+          expect(ect_row["mentor_id"]).to eql mentor.user_id
+          expect(ect_row["school_urn"]).to eql mentor.induction_records[0].school_cohort.school.urn
           expect(ect_row["participant_type"]).to eql "ect"
           expect(ect_row["cohort"]).to eql partnership.cohort.start_year.to_s
           expect(ect_row["teacher_reference_number"]).to be_empty
           expect(ect_row["teacher_reference_number_validated"]).to be_empty
-          expect(mentor_row["eligible_for_funding"]).to be_empty
-          expect(mentor_row["pupil_premium_uplift"]).to eql "false"
-          expect(mentor_row["sparsity_uplift"]).to eql "false"
-          expect(mentor_row["training_status"]).to eql "active"
+          expect(ect_row["eligible_for_funding"]).to be_empty
+          expect(ect_row["pupil_premium_uplift"]).to eql "false"
+          expect(ect_row["sparsity_uplift"]).to eql "false"
+          expect(ect_row["training_status"]).to eql "active"
+          expect(ect_row["training_record_id"]).to eql ect.id
 
           withdrawn_record_row = parsed_response.find { |row| row["id"] == withdrawn_ect_profile_record.user.id }
           expect(withdrawn_record_row).not_to be_nil
@@ -311,6 +315,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
           expect(withdrawn_record_row["pupil_premium_uplift"]).to eql(withdrawn_ect_profile_record.pupil_premium_uplift.to_s)
           expect(withdrawn_record_row["sparsity_uplift"]).to eql(withdrawn_ect_profile_record.sparsity_uplift.to_s)
           expect(withdrawn_record_row["training_status"]).to eql(withdrawn_ect_profile_record.induction_records.first.training_status)
+          expect(withdrawn_record_row["training_record_id"]).to eql(withdrawn_ect_profile_record.id)
         end
 
         it "ignores pagination parameters" do
@@ -417,6 +422,7 @@ RSpec.describe "Participants API", :with_default_schedules, type: :request do
               "pupil_premium_uplift" => early_career_teacher_profile.pupil_premium_uplift,
               "sparsity_uplift" => early_career_teacher_profile.sparsity_uplift,
               "training_status" => early_career_teacher_profile.training_status,
+              "training_record_id" => early_career_teacher_profile.id,
               "schedule_identifier" => early_career_teacher_profile.induction_records[0].schedule&.schedule_identifier,
               "updated_at" => Time.zone.local(2022, 7, 22, 11, 30, 0).rfc3339,
             },

--- a/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_induction_record_serializer_spec.rb
@@ -64,6 +64,14 @@ module Api
         end
       end
 
+      describe "#training_record_id" do
+        subject { described_class.new(ect.reload.current_induction_record) }
+
+        it "returns the training_status" do
+          expect(subject.serializable_hash[:data][:attributes][:training_record_id]).to eql(ect.id)
+        end
+      end
+
       describe "#updated_at" do
         let(:user) { induction_record.participant_profile.user }
         let(:profile) { induction_record.participant_profile }

--- a/spec/serializers/api/v1/participant_from_query_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_query_serializer_spec.rb
@@ -336,6 +336,15 @@ module Api
         end
       end
 
+      describe "#training_record_id" do
+        let(:participant_profile_id) { Faker::Internet.uuid }
+        let(:fields) { { participant_profile_id: } }
+
+        it "returns the training_status" do
+          expect(subject.serializable_hash[:data][:attributes][:training_record_id]).to eql(participant_profile_id)
+        end
+      end
+
       describe "#schedule_identifier" do
         let(:fields) { { schedule_identifier: "ecf-standard-september" } }
 

--- a/spec/services/api/v1/ecf/participants_query_spec.rb
+++ b/spec/services/api/v1/ecf/participants_query_spec.rb
@@ -102,18 +102,6 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
   describe "#induction_record" do
     describe "id filter" do
-      context "with correct value" do
-        let(:another_participant_profile) { create(:ect_participant_profile) }
-        let(:another_induction_programme) { create(:induction_programme, :fip, partnership:) }
-        let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
-
-        let(:params) { { id: another_participant_profile.participant_identity.user_id } }
-
-        it "returns the correct induction record" do
-          expect(subject.induction_record).to eql(another_induction_record)
-        end
-      end
-
       context "using user ID" do
         context "with correct value" do
           let(:another_participant_profile) { create(:ect_participant_profile) }
@@ -122,7 +110,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
           let(:params) { { id: another_participant_profile.participant_identity.external_identifier } }
 
-          it "returns a specific induction record" do
+          it "returns the correct induction record" do
             expect(subject.induction_record).to eql(another_induction_record)
           end
         end

--- a/spec/services/api/v1/ecf/participants_query_spec.rb
+++ b/spec/services/api/v1/ecf/participants_query_spec.rb
@@ -109,66 +109,70 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
         let(:params) { { id: another_participant_profile.participant_identity.user_id } }
 
-        it "returns a specific induction record" do
+        it "returns the correct induction record" do
           expect(subject.induction_record).to eql(another_induction_record)
         end
       end
 
-      context "with multiple induction records with no end date" do
-        let!(:latest_induction_record) do
-          travel_to(1.day.ago) do
-            create(:induction_record, induction_programme:, participant_profile:, end_date: nil)
+      context "using user ID" do
+        context "with correct value" do
+          let(:another_participant_profile) { create(:ect_participant_profile) }
+          let(:another_induction_programme) { create(:induction_programme, :fip, partnership:) }
+          let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
+
+          let(:params) { { id: another_participant_profile.participant_identity.external_identifier } }
+
+          it "returns a specific induction record" do
+            expect(subject.induction_record).to eql(another_induction_record)
           end
         end
 
-        let!(:induction_record) { create(:induction_record, :with_end_date, induction_programme:, participant_profile:) }
+        context "with multiple induction records with no end date" do
+          let!(:latest_induction_record) do
+            travel_to(1.day.ago) do
+              create(:induction_record, induction_programme:, participant_profile:, end_date: nil)
+            end
+          end
 
-        let(:params) { { id: participant_profile.participant_identity.user_id } }
+          let!(:induction_record) { create(:induction_record, :with_end_date, induction_programme:, participant_profile:) }
 
-        it "returns the induction record with no end date" do
-          expect(subject.induction_record).to eql(latest_induction_record)
-        end
-      end
+          let(:params) { { id: participant_profile.participant_identity.user_id } }
 
-      context "with multiple induction records starting at different times" do
-        let!(:induction_record) do
-          create(:induction_record, induction_programme:, participant_profile:, start_date: Time.zone.now)
-        end
-
-        let!(:latest_induction_record) do
-          create(:induction_record, :future_start_date, induction_programme:, participant_profile:)
-        end
-
-        let(:params) { { id: participant_profile.participant_identity.user_id } }
-
-        it "returns the induction record with the latest start date" do
-          expect(subject.induction_record).to eql(latest_induction_record)
-        end
-      end
-
-      context "with multiple induction records created at different times" do
-        let!(:induction_record) do
-          travel_to(1.day.ago) do
-            create(:induction_record, induction_programme:, participant_profile:)
+          it "returns the induction record with no end date" do
+            expect(subject.induction_record).to eql(latest_induction_record)
           end
         end
 
-        let!(:latest_induction_record) { create(:induction_record, induction_programme:, participant_profile:) }
+        context "with multiple induction records starting at different times" do
+          let!(:induction_record) do
+            create(:induction_record, induction_programme:, participant_profile:, start_date: Time.zone.now)
+          end
 
-        let(:params) { { id: participant_profile.participant_identity.user_id } }
+          let!(:latest_induction_record) do
+            create(:induction_record, :future_start_date, induction_programme:, participant_profile:)
+          end
 
-        it "returns the induction record with the latest timestamp" do
-          expect(subject.induction_record).to eql(latest_induction_record)
+          let(:params) { { id: participant_profile.participant_identity.user_id } }
+
+          it "returns the induction record with the latest start date" do
+            expect(subject.induction_record).to eql(latest_induction_record)
+          end
         end
-      end
 
-      context "with incorrect value" do
-        let(:params) { { id: SecureRandom.uuid } }
+        context "with multiple induction records created at different times" do
+          let!(:induction_record) do
+            travel_to(1.day.ago) do
+              create(:induction_record, induction_programme:, participant_profile:)
+            end
+          end
 
-        it "raises an error" do
-          expect {
-            subject.induction_record
-          }.to raise_error(ActiveRecord::RecordNotFound)
+          let!(:latest_induction_record) { create(:induction_record, induction_programme:, participant_profile:) }
+
+          let(:params) { { id: participant_profile.participant_identity.user_id } }
+
+          it "returns the induction record with the latest timestamp" do
+            expect(subject.induction_record).to eql(latest_induction_record)
+          end
         end
       end
     end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1686,6 +1686,7 @@
           "cohort",
           "status",
           "training_status",
+          "training_record_id",
           "schedule_identifier",
           "updated_at"
         ],
@@ -1774,6 +1775,13 @@
               "deferred",
               "withdrawn"
             ]
+          },
+          "training_record_id": {
+            "description": "The unique identifier of the ECF participant profile",
+            "type": "string",
+            "nullable": true,
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid"
           },
           "schedule_identifier": {
             "description": "The schedule of the ECF participant",

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1777,9 +1777,8 @@
             ]
           },
           "training_record_id": {
-            "description": "The unique identifier of the ECF participant profile",
+            "description": "The unique identifier of the participant training record",
             "type": "string",
-            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
             "format": "uuid"
           },
@@ -2202,6 +2201,7 @@
           "cohort",
           "status",
           "training_status",
+          "training_record_id",
           "schedule_identifier",
           "updated_at"
         ],
@@ -2299,6 +2299,12 @@
               "deferred",
               "withdrawn"
             ]
+          },
+          "training_record_id": {
+            "description": "The unique identifier of the participant training record",
+            "type": "string",
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid"
           },
           "schedule_identifier": {
             "description": "The schedule of the ECF participant",
@@ -3216,7 +3222,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,updated_at\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,2021-05-31T02:22:32.000Z\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false,deferred,2021-05-31T02:22:32.000Z\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\",withdrawn\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,training_record_id,schedule_identifier,updated_at\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,b339d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false,deferred,c449d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\",withdrawn,a239d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2022-06-31T02:22:32.000Z\n"
       },
       "MultipleECFParticipantsResponse": {
         "description": "A list of ECF participants",

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -82,9 +82,8 @@ properties:
       - deferred
       - withdrawn
   training_record_id:
-    description: "The unique identifier of the ECF participant profile"
+    description: "The unique identifier of the participant training record"
     type: string
-    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
   schedule_identifier:

--- a/swagger/v1/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v1/component_schemas/ECFParticipantAttributes.yml
@@ -8,6 +8,7 @@ required:
   - cohort
   - status
   - training_status
+  - training_record_id
   - schedule_identifier
   - updated_at
 properties:
@@ -80,6 +81,12 @@ properties:
       - active
       - deferred
       - withdrawn
+  training_record_id:
+    description: "The unique identifier of the ECF participant profile"
+    type: string
+    nullable: true
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
   schedule_identifier:
     description: "The schedule of the ECF participant"
     type: string

--- a/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v1/component_schemas/ECFParticipantCsvRow.yml
@@ -10,6 +10,7 @@ required:
   - cohort
   - status
   - training_status
+  - training_record_id
   - schedule_identifier
   - updated_at
 properties:
@@ -88,6 +89,11 @@ properties:
       - active
       - deferred
       - withdrawn
+  training_record_id:
+    description: "The unique identifier of the participant training record"
+    type: string
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
   schedule_identifier:
     description: "The schedule of the ECF participant"
     type: string

--- a/swagger/v1/component_schemas/MultipleECFParticipantsCsvResponse.yml
+++ b/swagger/v1/component_schemas/MultipleECFParticipantsCsvResponse.yml
@@ -8,7 +8,7 @@ properties:
     items:
       $ref: "#/components/schemas/ECFParticipantCsvRow"
 example: |
-  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,updated_at
-  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,2021-05-31T02:22:32.000Z
-  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,"",false,false,false,false,deferred,2021-05-31T02:22:32.000Z
-  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,"","","","",ect,"",withdrawn,"","","","","",withdrawn
+  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,training_record_id,schedule_identifier,updated_at
+  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,b339d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z
+  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,"",false,false,false,false,deferred,c449d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z
+  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,"","","","",ect,"",withdrawn,"","","","","",withdrawn,a239d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2022-06-31T02:22:32.000Z

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -1633,9 +1633,8 @@
             ]
           },
           "training_record_id": {
-            "description": "The unique identifier of the ECF participant profile",
+            "description": "The unique identifier of the participant training record",
             "type": "string",
-            "nullable": true,
             "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
             "format": "uuid"
           },
@@ -2058,6 +2057,7 @@
           "cohort",
           "status",
           "training_status",
+          "training_record_id",
           "schedule_identifier",
           "updated_at"
         ],
@@ -2154,6 +2154,12 @@
               "deferred",
               "withdrawn"
             ]
+          },
+          "training_record_id": {
+            "description": "The unique identifier of the participant training record",
+            "type": "string",
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid"
           },
           "schedule_identifier": {
             "description": "The schedule of the ECF participant",
@@ -3077,7 +3083,7 @@
             }
           }
         },
-        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,updated_at\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,2021-05-31T02:22:32.000Z\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false,deferred,2021-05-31T02:22:32.000Z\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\",withdrawn\n"
+        "example": "id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,training_record_id,schedule_identifier,updated_at\ndb3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,b339d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z\nbb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,\"\",false,false,false,false,deferred,c449d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z\neb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,\"\",\"\",\"\",\"\",ect,\"\",withdrawn,\"\",\"\",\"\",\"\",\"\",withdrawn,a239d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2022-06-31T02:22:32.000Z\n"
       },
       "MultipleECFParticipantsResponse": {
         "description": "A list of ECF participants",

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -1542,6 +1542,7 @@
           "cohort",
           "status",
           "training_status",
+          "training_record_id",
           "schedule_identifier",
           "updated_at"
         ],
@@ -1630,6 +1631,13 @@
               "deferred",
               "withdrawn"
             ]
+          },
+          "training_record_id": {
+            "description": "The unique identifier of the ECF participant profile",
+            "type": "string",
+            "nullable": true,
+            "example": "bb36d74a-68a7-47b6-86b6-1fd0d141c590",
+            "format": "uuid"
           },
           "schedule_identifier": {
             "description": "The schedule of the ECF participant",

--- a/swagger/v2/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v2/component_schemas/ECFParticipantAttributes.yml
@@ -82,9 +82,8 @@ properties:
       - deferred
       - withdrawn
   training_record_id:
-    description: "The unique identifier of the ECF participant profile"
+    description: "The unique identifier of the participant training record"
     type: string
-    nullable: true
     example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
     format: uuid
   schedule_identifier:

--- a/swagger/v2/component_schemas/ECFParticipantAttributes.yml
+++ b/swagger/v2/component_schemas/ECFParticipantAttributes.yml
@@ -8,6 +8,7 @@ required:
   - cohort
   - status
   - training_status
+  - training_record_id
   - schedule_identifier
   - updated_at
 properties:
@@ -80,6 +81,12 @@ properties:
       - active
       - deferred
       - withdrawn
+  training_record_id:
+    description: "The unique identifier of the ECF participant profile"
+    type: string
+    nullable: true
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
   schedule_identifier:
     description: "The schedule of the ECF participant"
     type: string

--- a/swagger/v2/component_schemas/ECFParticipantCsvRow.yml
+++ b/swagger/v2/component_schemas/ECFParticipantCsvRow.yml
@@ -10,6 +10,7 @@ required:
   - cohort
   - status
   - training_status
+  - training_record_id
   - schedule_identifier
   - updated_at
 properties:
@@ -87,6 +88,11 @@ properties:
       - active
       - deferred
       - withdrawn
+  training_record_id:
+    description: "The unique identifier of the participant training record"
+    type: string
+    example: bb36d74a-68a7-47b6-86b6-1fd0d141c590
+    format: uuid
   schedule_identifier:
     description: "The schedule of the ECF participant"
     type: string

--- a/swagger/v2/component_schemas/MultipleECFParticipantsCsvResponse.yml
+++ b/swagger/v2/component_schemas/MultipleECFParticipantsCsvResponse.yml
@@ -8,7 +8,7 @@ properties:
     items:
       $ref: "#/components/schemas/ECFParticipantCsvRow"
 example: |
-  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,updated_at
-  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,2021-05-31T02:22:32.000Z
-  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,"",false,false,false,false,deferred,2021-05-31T02:22:32.000Z
-  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,"","","","",ect,"",withdrawn,"","","","","",withdrawn
+  id,type,email,full_name,mentor_id,school_urn,participant_type,cohort,status,teacher_reference_number,teacher_reference_number_validated,eligible_for_funding,pupil_premium_uplift,sparsity_uplift,training_status,training_record_id,schedule_identifier,updated_at
+  db3a7848-7308-4879-942a-c4a70ced400a,participant,jane.smith@some-school.example.com,Jane Smith,bb36d74a-68a7-47b6-86b6-1fd0d141c590,106286,ect,2021,active,0012345,true,true,true,true,active,b339d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z
+  bb36d74a-68a7-47b6-86b6-1fd0d141c590,participant,martin.jones@some-school.example.com,Martin Jones,,106286,mentor,2021,active,"",false,false,false,false,deferred,c449d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2021-05-31T02:22:32.000Z
+  eb475531-bf08-48ae-b0ef-c2ff5e5bdef0,participant,"","","","",ect,"",withdrawn,"","","","","",withdrawn,a239d7a3-97a4-49c2-9ba2-8e0514276f5b,ecf-standard-september,2022-06-31T02:22:32.000Z


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2078
- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2119

### Changes proposed in this pull request

* Exposes the participant profile ID as `training_record_id` on API V1/V2 endpoints.
* Allow the user to query by participant profile ID

### Guidance to review

This relies on the `external_identifier_to_user_id_lookup` feature flag to avoid duplication with redundant functionality. This flag (and the redundant code) is due to be removed soon.

Otherwise, please check whether I've understood the intent correctly! 🤞 