### PR TITLE
Remove `external_identifier_to_user_id_lookup` feature flag

### DIFF
--- a/app/mailers/participant_transfer_mailer.rb
+++ b/app/mailers/participant_transfer_mailer.rb
@@ -90,7 +90,7 @@ class ParticipantTransferMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         joining_date: induction_record.start_date.to_date.to_s(:govuk),
-        external_participant_id: induction_record.participant_profile.participant_identity.user_id_or_external_identifier,
+        external_participant_id: induction_record.participant_profile.participant_identity.user_id,
       },
     ).tag(:provider_transfer_out_notification).associate_with(lead_provider_profile, as: :lead_provider_profile)
   end
@@ -106,7 +106,7 @@ class ParticipantTransferMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         joining_date: induction_record.start_date.to_date.to_s(:govuk),
-        external_participant_id: induction_record.participant_profile.participant_identity.user_id_or_external_identifier,
+        external_participant_id: induction_record.participant_profile.participant_identity.user_id,
       },
     ).tag(:provider_transfer_in_notification).associate_with(lead_provider_profile, as: :lead_provider_profile)
   end
@@ -123,7 +123,7 @@ class ParticipantTransferMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         joining_date: induction_record.start_date.to_date.to_s(:govuk),
-        external_participant_id: induction_record.participant_profile.participant_identity.user_id_or_external_identifier,
+        external_participant_id: induction_record.participant_profile.participant_identity.user_id,
       },
     ).tag(:provider_new_school_transfer_notification).associate_with(lead_provider_profile, as: :lead_provider_profile)
   end
@@ -139,7 +139,7 @@ class ParticipantTransferMailer < ApplicationMailer
       rails_mail_template: action_name,
       personalisation: {
         joining_date: induction_record.start_date.to_s(:govuk),
-        external_participant_id: induction_record.participant_profile.participant_identity.user_id_or_external_identifier,
+        external_participant_id: induction_record.participant_profile.participant_identity.user_id,
       },
     ).tag(:provider_existing_school_transfer_notification).associate_with(lead_provider_profile, as: :lead_provider_profile)
   end

--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -45,10 +45,4 @@ class ParticipantIdentity < ApplicationRecord
   def additional_identity?
     secondary_identity? && participant_profiles.blank?
   end
-
-  def user_id_or_external_identifier
-    return self[:external_identifier] unless FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-
-    self[:user_id]
-  end
 end

--- a/app/serializers/api/v1/npq_application_csv_serializer.rb
+++ b/app/serializers/api/v1/npq_application_csv_serializer.rb
@@ -59,7 +59,7 @@ module Api
       def to_row(record)
         [
           record.id,
-          record.participant_identity.user_id_or_external_identifier,
+          record.participant_identity.user_id,
           record.participant_identity.user.full_name,
           record.participant_identity.email,
           true,

--- a/app/serializers/api/v1/npq_application_serializer.rb
+++ b/app/serializers/api/v1/npq_application_serializer.rb
@@ -27,7 +27,7 @@ module Api
                  :works_in_school
 
       attribute(:participant_id) do |object|
-        object.participant_identity.user_id_or_external_identifier
+        object.participant_identity.user_id
       end
 
       attribute(:teacher_reference_number_validated, &:teacher_reference_number_verified)

--- a/app/serializers/api/v1/participant_from_induction_record_serializer.rb
+++ b/app/serializers/api/v1/participant_from_induction_record_serializer.rb
@@ -29,7 +29,7 @@ module Api
       set_type :participant
 
       set_id :id do |induction_record|
-        induction_record.participant_profile.participant_identity.user_id_or_external_identifier
+        induction_record.participant_profile.participant_identity.user_id
       end
 
       attribute :email do |induction_record|
@@ -43,7 +43,7 @@ module Api
 
       attribute :mentor_id do |induction_record|
         if induction_record.participant_profile.ect?
-          induction_record.mentor_profile&.participant_identity&.user_id_or_external_identifier
+          induction_record.mentor_profile&.participant_identity&.user_id
         end
       end
 

--- a/app/serializers/api/v1/participant_from_query_serializer.rb
+++ b/app/serializers/api/v1/participant_from_query_serializer.rb
@@ -28,13 +28,7 @@ module Api
 
       set_type :participant
 
-      set_id :id do |induction_record|
-        if FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-          induction_record.user_id
-        else
-          induction_record.external_identifier
-        end
-      end
+      set_id :id, &:user_id
 
       attribute :email do |induction_record|
         induction_record.preferred_identity_email ||
@@ -45,11 +39,7 @@ module Api
 
       attribute :mentor_id do |induction_record|
         if induction_record.participant_profile_type == "ParticipantProfile::ECT"
-          if FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-            induction_record.mentor_user_id
-          else
-            induction_record.mentor_external_identifier
-          end
+          induction_record.mentor_user_id
         end
       end
 

--- a/app/serializers/api/v1/participant_outcome_serializer.rb
+++ b/app/serializers/api/v1/participant_outcome_serializer.rb
@@ -21,7 +21,7 @@ module Api
       end
 
       attribute :participant_id do |outcome|
-        outcome.participant_declaration.participant_profile.participant_identity.user_id_or_external_identifier
+        outcome.participant_declaration.participant_profile.participant_identity.user_id
       end
 
       attribute :created_at do |outcome|

--- a/app/serializers/api/v2/npq_application_csv_serializer.rb
+++ b/app/serializers/api/v2/npq_application_csv_serializer.rb
@@ -56,7 +56,7 @@ module Api
       def to_row(record)
         [
           record.id,
-          record.participant_identity.user_id_or_external_identifier,
+          record.participant_identity.user_id,
           record.participant_identity.user.full_name,
           record.participant_identity.email,
           true,

--- a/app/services/api/v1/ecf/participants_query.rb
+++ b/app/services/api/v1/ecf/participants_query.rb
@@ -46,13 +46,8 @@ module Api
         end
 
         def induction_record
-          if FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-            induction_records
-              .find_by!(participant_profile: { participant_identities: { user_id: params[:id] } })
-          else
-            induction_records
-              .find_by!(participant_profile: { participant_identities: { external_identifier: params[:id] } })
-          end
+          induction_records
+            .find_by!(participant_profile: { participant_identities: { user_id: params[:id] } })
         end
 
       private

--- a/app/services/api/v1/participant_outcomes_query.rb
+++ b/app/services/api/v1/participant_outcomes_query.rb
@@ -32,11 +32,7 @@ module Api
       end
 
       def participant_scope
-        if FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-          ParticipantIdentity.where(user_id: participant_external_id)
-        else
-          ParticipantIdentity.where(external_identifier: participant_external_id)
-        end
+        ParticipantIdentity.where(user_id: participant_external_id)
       end
     end
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,7 +19,6 @@ class FeatureFlag
     eligibility_notifications
     api_v3
     appropriate_bodies
-    external_identifier_to_user_id_lookup
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).index_with { |name|

--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -20,7 +20,7 @@ module Finance
           <<~EOSQL
             SELECT
               pd.id                                                            AS id,
-              #{user_id_or_external_identifier}                                AS participant_id,
+              pi.user_id                                                       AS participant_id,
               u.full_name                                                      AS participant_name,
               tp.trn                                                           AS trn,
               pp.type                                                          AS participant_type,
@@ -87,12 +87,6 @@ module Finance
 
         def where_values
           ParticipantDeclaration::ECF.sanitize_sql_for_conditions(["clp.id = ? AND s.id = ?", statement.cpd_lead_provider_id, statement.id])
-        end
-
-        def user_id_or_external_identifier
-          return "pi.external_identifier" unless FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-
-          "pi.user_id"
         end
       end
     end

--- a/app/services/finance/npq/assurance_report/query.rb
+++ b/app/services/finance/npq/assurance_report/query.rb
@@ -20,7 +20,7 @@ module Finance
           <<~EOSQL
             SELECT
               pd.id                                   AS id,
-              #{user_id_or_external_identifier}       AS participant_id,
+              pi.user_id                              AS participant_id,
               u.full_name                             AS participant_name,
               tp.trn                                  AS trn,
               c.identifier                            AS course_identifier,
@@ -65,12 +65,6 @@ module Finance
 
         def where_values
           ParticipantDeclaration::NPQ.sanitize_sql_for_conditions(["clp.id = ? AND s.id = ?", statement.cpd_lead_provider_id, statement.id])
-        end
-
-        def user_id_or_external_identifier
-          return "pi.external_identifier" unless FeatureFlag.active?(:external_identifier_to_user_id_lookup)
-
-          "pi.user_id"
         end
       end
     end

--- a/app/services/participant_identity_resolver.rb
+++ b/app/services/participant_identity_resolver.rb
@@ -13,7 +13,6 @@ class ParticipantIdentityResolver
 
   def call
     return if participant_id.blank?
-    return participant_identity unless FeatureFlag.active?(:external_identifier_to_user_id_lookup)
 
     if ParticipantProfile::ECT::COURSE_IDENTIFIERS.include?(course_identifier)
       ParticipantIdentity
@@ -40,8 +39,4 @@ class ParticipantIdentityResolver
 private
 
   attr_reader :participant_id, :course_identifier, :cpd_lead_provider
-
-  def participant_identity
-    @participant_identity ||= ParticipantIdentity.find_by(external_identifier: participant_id)
-  end
 end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -233,7 +233,7 @@ private
     NPQ::CreateParticipantOutcome.new(
       cpd_lead_provider:,
       course_identifier:,
-      participant_external_id: participant_identity.user_id_or_external_identifier,
+      participant_external_id: participant_identity.user_id,
       completion_date: declaration_date,
       state: participant_outcome_state,
     ).call

--- a/spec/serializers/api/v1/npq_application_csv_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq_application_csv_serializer_spec.rb
@@ -2,35 +2,6 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a v1 csv serialised npq application" do
-  it "returns expected data", :aggregate_failures do
-    expect(rows[0]["course_identifier"]).to eql(npq_application.npq_course.identifier)
-    expect(rows[0]["email"]).to eql(npq_application.participant_identity.email)
-    expect(rows[0]["email_validated"]).to eql("true")
-    expect(rows[0]["employer_name"]).to eql(npq_application.employer_name)
-    expect(rows[0]["employment_role"]).to eql(npq_application.employment_role)
-    expect(rows[0]["full_name"]).to eql(npq_application.participant_identity.user.full_name)
-    expect(rows[0]["funding_choice"]).to eql(npq_application.funding_choice)
-    expect(rows[0]["headteacher_status"]).to eql(npq_application.headteacher_status)
-    expect(rows[0]["ineligible_for_funding_reason"]).to eql(npq_application.ineligible_for_funding_reason)
-    expect(rows[0]["participant_id"]).to eql(npq_application.participant_identity.user_id_or_external_identifier)
-    expect(rows[0]["private_childcare_provider_urn"]).to eql(npq_application.private_childcare_provider_urn)
-    expect(rows[0]["teacher_reference_number"]).to eql(npq_application.teacher_reference_number)
-    expect(rows[0]["teacher_reference_number_validated"]).to eql(npq_application.teacher_reference_number_verified.to_s)
-    expect(rows[0]["school_urn"]).to eql(npq_application.school_urn)
-    expect(rows[0]["school_ukprn"]).to eql(npq_application.school_ukprn)
-    expect(rows[0]["status"]).to eql(npq_application.lead_provider_approval_status)
-    expect(rows[0]["works_in_school"]).to eql(npq_application.works_in_school.to_s)
-    expect(rows[0]["eligible_for_funding"]).to eql(npq_application.eligible_for_dfe_funding.to_s)
-    expect(rows[0]["targeted_delivery_funding_eligibility"]).to eql(npq_application.targeted_delivery_funding_eligibility.to_s)
-    expect(rows[0]["teacher_catchment"]).to eq "true"
-    expect(rows[0]["teacher_catchment_country"]).to eql("United Kingdom of Great Britain and Northern Ireland")
-    expect(rows[0]["teacher_catchment_iso_country_code"]).to eql("GBR")
-    expect(rows[0]["itt_provider"]).to eql(npq_application.itt_provider)
-    expect(rows[0]["lead_mentor"]).to eql(npq_application.lead_mentor.to_s)
-  end
-end
-
 module Api
   module V1
     RSpec.describe NPQApplicationCsvSerializer, :with_default_schedules do
@@ -40,12 +11,31 @@ module Api
         let(:npq_application) { create(:npq_application, targeted_delivery_funding_eligibility: true) }
         let(:rows) { CSV.parse(subject, headers: true) }
 
-        context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-          it_behaves_like "a v1 csv serialised npq application"
-        end
-
-        context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-          it_behaves_like "a v1 csv serialised npq application"
+        it "returns expected data", :aggregate_failures do
+          expect(rows[0]["course_identifier"]).to eql(npq_application.npq_course.identifier)
+          expect(rows[0]["email"]).to eql(npq_application.participant_identity.email)
+          expect(rows[0]["email_validated"]).to eql("true")
+          expect(rows[0]["employer_name"]).to eql(npq_application.employer_name)
+          expect(rows[0]["employment_role"]).to eql(npq_application.employment_role)
+          expect(rows[0]["full_name"]).to eql(npq_application.participant_identity.user.full_name)
+          expect(rows[0]["funding_choice"]).to eql(npq_application.funding_choice)
+          expect(rows[0]["headteacher_status"]).to eql(npq_application.headteacher_status)
+          expect(rows[0]["ineligible_for_funding_reason"]).to eql(npq_application.ineligible_for_funding_reason)
+          expect(rows[0]["participant_id"]).to eql(npq_application.participant_identity.user_id)
+          expect(rows[0]["private_childcare_provider_urn"]).to eql(npq_application.private_childcare_provider_urn)
+          expect(rows[0]["teacher_reference_number"]).to eql(npq_application.teacher_reference_number)
+          expect(rows[0]["teacher_reference_number_validated"]).to eql(npq_application.teacher_reference_number_verified.to_s)
+          expect(rows[0]["school_urn"]).to eql(npq_application.school_urn)
+          expect(rows[0]["school_ukprn"]).to eql(npq_application.school_ukprn)
+          expect(rows[0]["status"]).to eql(npq_application.lead_provider_approval_status)
+          expect(rows[0]["works_in_school"]).to eql(npq_application.works_in_school.to_s)
+          expect(rows[0]["eligible_for_funding"]).to eql(npq_application.eligible_for_dfe_funding.to_s)
+          expect(rows[0]["targeted_delivery_funding_eligibility"]).to eql(npq_application.targeted_delivery_funding_eligibility.to_s)
+          expect(rows[0]["teacher_catchment"]).to eq "true"
+          expect(rows[0]["teacher_catchment_country"]).to eql("United Kingdom of Great Britain and Northern Ireland")
+          expect(rows[0]["teacher_catchment_iso_country_code"]).to eql("GBR")
+          expect(rows[0]["itt_provider"]).to eql(npq_application.itt_provider)
+          expect(rows[0]["lead_mentor"]).to eql(npq_application.lead_mentor.to_s)
         end
       end
 

--- a/spec/serializers/api/v1/npq_application_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq_application_serializer_spec.rb
@@ -2,35 +2,6 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a v1 serialised npq application" do
-  it "returns expected data", :aggregate_failures do
-    expect(result[:data][:attributes][:course_identifier]).to eql(npq_application.npq_course.identifier)
-    expect(result[:data][:attributes][:email]).to eql(npq_application.participant_identity.email)
-    expect(result[:data][:attributes][:email_validated]).to eql(true)
-    expect(result[:data][:attributes][:employer_name]).to eql(npq_application.employer_name)
-    expect(result[:data][:attributes][:employment_role]).to eql(npq_application.employment_role)
-    expect(result[:data][:attributes][:full_name]).to eql(npq_application.participant_identity.user.full_name)
-    expect(result[:data][:attributes][:funding_choice]).to eql(npq_application.funding_choice)
-    expect(result[:data][:attributes][:headteacher_status]).to eql(npq_application.headteacher_status)
-    expect(result[:data][:attributes][:ineligible_for_funding_reason]).to eql(npq_application.ineligible_for_funding_reason)
-    expect(result[:data][:attributes][:participant_id]).to eql(npq_application.participant_identity.user_id_or_external_identifier)
-    expect(result[:data][:attributes][:private_childcare_provider_urn]).to eql(npq_application.private_childcare_provider_urn)
-    expect(result[:data][:attributes][:teacher_reference_number]).to eql(npq_application.teacher_reference_number)
-    expect(result[:data][:attributes][:teacher_reference_number_validated]).to eql(npq_application.teacher_reference_number_verified)
-    expect(result[:data][:attributes][:school_urn]).to eql(npq_application.school_urn)
-    expect(result[:data][:attributes][:school_ukprn]).to eql(npq_application.school_ukprn)
-    expect(result[:data][:attributes][:status]).to eql(npq_application.lead_provider_approval_status)
-    expect(result[:data][:attributes][:works_in_school]).to eql(npq_application.works_in_school)
-    expect(result[:data][:attributes][:eligible_for_funding]).to eql(npq_application.eligible_for_dfe_funding)
-    expect(result[:data][:attributes][:targeted_delivery_funding_eligibility]).to eql(npq_application.targeted_delivery_funding_eligibility)
-    expect(result[:data][:attributes][:teacher_catchment]).to eq(npq_application.teacher_catchment.present?)
-    expect(result[:data][:attributes][:teacher_catchment_country]).to eq(npq_application.teacher_catchment_country)
-    expect(result[:data][:attributes][:teacher_catchment_iso_country_code]).to eq(npq_application.teacher_catchment_iso_country_code)
-    expect(result[:data][:attributes][:itt_provider]).to eql(npq_application.itt_provider)
-    expect(result[:data][:attributes][:lead_mentor]).to eql(npq_application.lead_mentor)
-  end
-end
-
 module Api
   module V1
     RSpec.describe NPQApplicationSerializer, :with_default_schedules do
@@ -40,12 +11,31 @@ module Api
         let(:npq_application) { create(:npq_application, targeted_delivery_funding_eligibility: true) }
         let(:rows) { CSV.parse(subject, headers: true) }
 
-        context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-          it_behaves_like "a v1 serialised npq application"
-        end
-
-        context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-          it_behaves_like "a v1 serialised npq application"
+        it "returns expected data", :aggregate_failures do
+          expect(result[:data][:attributes][:course_identifier]).to eql(npq_application.npq_course.identifier)
+          expect(result[:data][:attributes][:email]).to eql(npq_application.participant_identity.email)
+          expect(result[:data][:attributes][:email_validated]).to eql(true)
+          expect(result[:data][:attributes][:employer_name]).to eql(npq_application.employer_name)
+          expect(result[:data][:attributes][:employment_role]).to eql(npq_application.employment_role)
+          expect(result[:data][:attributes][:full_name]).to eql(npq_application.participant_identity.user.full_name)
+          expect(result[:data][:attributes][:funding_choice]).to eql(npq_application.funding_choice)
+          expect(result[:data][:attributes][:headteacher_status]).to eql(npq_application.headteacher_status)
+          expect(result[:data][:attributes][:ineligible_for_funding_reason]).to eql(npq_application.ineligible_for_funding_reason)
+          expect(result[:data][:attributes][:participant_id]).to eql(npq_application.participant_identity.user_id)
+          expect(result[:data][:attributes][:private_childcare_provider_urn]).to eql(npq_application.private_childcare_provider_urn)
+          expect(result[:data][:attributes][:teacher_reference_number]).to eql(npq_application.teacher_reference_number)
+          expect(result[:data][:attributes][:teacher_reference_number_validated]).to eql(npq_application.teacher_reference_number_verified)
+          expect(result[:data][:attributes][:school_urn]).to eql(npq_application.school_urn)
+          expect(result[:data][:attributes][:school_ukprn]).to eql(npq_application.school_ukprn)
+          expect(result[:data][:attributes][:status]).to eql(npq_application.lead_provider_approval_status)
+          expect(result[:data][:attributes][:works_in_school]).to eql(npq_application.works_in_school)
+          expect(result[:data][:attributes][:eligible_for_funding]).to eql(npq_application.eligible_for_dfe_funding)
+          expect(result[:data][:attributes][:targeted_delivery_funding_eligibility]).to eql(npq_application.targeted_delivery_funding_eligibility)
+          expect(result[:data][:attributes][:teacher_catchment]).to eq(npq_application.teacher_catchment.present?)
+          expect(result[:data][:attributes][:teacher_catchment_country]).to eq(npq_application.teacher_catchment_country)
+          expect(result[:data][:attributes][:teacher_catchment_iso_country_code]).to eq(npq_application.teacher_catchment_iso_country_code)
+          expect(result[:data][:attributes][:itt_provider]).to eql(npq_application.itt_provider)
+          expect(result[:data][:attributes][:lead_mentor]).to eql(npq_application.lead_mentor)
         end
       end
 

--- a/spec/serializers/api/v1/participant_from_query_serializer_spec.rb
+++ b/spec/serializers/api/v1/participant_from_query_serializer_spec.rb
@@ -18,22 +18,11 @@ module Api
       subject { described_class.new(query_result) }
 
       describe "#id" do
-        context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-          let(:external_identifier) { Faker::Internet.uuid }
-          let(:fields) { { external_identifier: } }
+        let(:user_id) { Faker::Internet.uuid }
+        let(:fields) { { user_id: } }
 
-          it "returns the external identifier" do
-            expect(subject.serializable_hash[:data][:id]).to eql(external_identifier)
-          end
-        end
-
-        context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-          let(:user_id) { Faker::Internet.uuid }
-          let(:fields) { { user_id: } }
-
-          it "returns the user id" do
-            expect(subject.serializable_hash[:data][:id]).to eql(user_id)
-          end
+        it "returns the user id" do
+          expect(subject.serializable_hash[:data][:id]).to eql(user_id)
         end
       end
 
@@ -75,63 +64,31 @@ module Api
       end
 
       describe "#mentor_id" do
-        context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-          let(:external_identifier) { Faker::Internet.uuid }
+        let(:user_id) { Faker::Internet.uuid }
 
-          context "when participant is an ECT" do
-            let(:fields) do
-              {
-                mentor_external_identifier: external_identifier,
-                participant_profile_type: "ParticipantProfile::ECT",
-              }
-            end
-
-            it "returns the mentor external identifier" do
-              expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to eql(external_identifier)
-            end
+        context "when participant is an ECT" do
+          let(:fields) do
+            {
+              mentor_user_id: user_id,
+              participant_profile_type: "ParticipantProfile::ECT",
+            }
           end
 
-          context "when participant is a Mentor" do
-            let(:fields) do
-              {
-                mentor_external_identifier: external_identifier,
-                participant_profile_type: "ParticipantProfile::Mentor",
-              }
-            end
-
-            it "returns nil" do
-              expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to be_nil
-            end
+          it "returns the mentor user id" do
+            expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to eql(user_id)
           end
         end
 
-        context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-          let(:user_id) { Faker::Internet.uuid }
-
-          context "when participant is an ECT" do
-            let(:fields) do
-              {
-                mentor_user_id: user_id,
-                participant_profile_type: "ParticipantProfile::ECT",
-              }
-            end
-
-            it "returns the mentor user id" do
-              expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to eql(user_id)
-            end
+        context "when participant is a Mentor" do
+          let(:fields) do
+            {
+              mentor_user_id: user_id,
+              participant_profile_type: "ParticipantProfile::Mentor",
+            }
           end
 
-          context "when participant is a Mentor" do
-            let(:fields) do
-              {
-                mentor_user_id: user_id,
-                participant_profile_type: "ParticipantProfile::Mentor",
-              }
-            end
-
-            it "returns nil" do
-              expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to be_nil
-            end
+          it "returns nil" do
+            expect(subject.serializable_hash[:data][:attributes][:mentor_id]).to be_nil
           end
         end
       end

--- a/spec/serializers/api/v2/npq_application_csv_serializer_spec.rb
+++ b/spec/serializers/api/v2/npq_application_csv_serializer_spec.rb
@@ -2,32 +2,6 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a v2 csv serialised npq application" do
-  it "returns expected data", :aggregate_failures do
-    expect(rows[0]["course_identifier"]).to eql(npq_application.npq_course.identifier)
-    expect(rows[0]["email"]).to eql(npq_application.participant_identity.email)
-    expect(rows[0]["email_validated"]).to eql("true")
-    expect(rows[0]["employer_name"]).to eql(npq_application.employer_name)
-    expect(rows[0]["employment_role"]).to eql(npq_application.employment_role)
-    expect(rows[0]["full_name"]).to eql(npq_application.participant_identity.user.full_name)
-    expect(rows[0]["funding_choice"]).to eql(npq_application.funding_choice)
-    expect(rows[0]["headteacher_status"]).to eql(npq_application.headteacher_status)
-    expect(rows[0]["ineligible_for_funding_reason"]).to eql(npq_application.ineligible_for_funding_reason)
-    expect(rows[0]["participant_id"]).to eql(npq_application.participant_identity.user_id_or_external_identifier)
-    expect(rows[0]["private_childcare_provider_urn"]).to eql(npq_application.private_childcare_provider_urn)
-    expect(rows[0]["teacher_reference_number"]).to eql(npq_application.teacher_reference_number)
-    expect(rows[0]["teacher_reference_number_validated"]).to eql(npq_application.teacher_reference_number_verified.to_s)
-    expect(rows[0]["school_urn"]).to eql(npq_application.school_urn)
-    expect(rows[0]["school_ukprn"]).to eql(npq_application.school_ukprn)
-    expect(rows[0]["status"]).to eql(npq_application.lead_provider_approval_status)
-    expect(rows[0]["works_in_school"]).to eql(npq_application.works_in_school.to_s)
-    expect(rows[0]["eligible_for_funding"]).to eql(npq_application.eligible_for_dfe_funding.to_s)
-    expect(rows[0]["targeted_delivery_funding_eligibility"]).to eql(npq_application.targeted_delivery_funding_eligibility.to_s)
-    expect(rows[0]["itt_provider"]).to eql(npq_application.itt_provider)
-    expect(rows[0]["lead_mentor"]).to eql(npq_application.lead_mentor.to_s)
-  end
-end
-
 module Api
   module V2
     RSpec.describe NPQApplicationCsvSerializer, :with_default_schedules do
@@ -37,12 +11,28 @@ module Api
         let(:npq_application) { create(:npq_application, targeted_delivery_funding_eligibility: true) }
         let(:rows) { CSV.parse(subject, headers: true) }
 
-        context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-          it_behaves_like "a v2 csv serialised npq application"
-        end
-
-        context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-          it_behaves_like "a v2 csv serialised npq application"
+        it "returns expected data", :aggregate_failures do
+          expect(rows[0]["course_identifier"]).to eql(npq_application.npq_course.identifier)
+          expect(rows[0]["email"]).to eql(npq_application.participant_identity.email)
+          expect(rows[0]["email_validated"]).to eql("true")
+          expect(rows[0]["employer_name"]).to eql(npq_application.employer_name)
+          expect(rows[0]["employment_role"]).to eql(npq_application.employment_role)
+          expect(rows[0]["full_name"]).to eql(npq_application.participant_identity.user.full_name)
+          expect(rows[0]["funding_choice"]).to eql(npq_application.funding_choice)
+          expect(rows[0]["headteacher_status"]).to eql(npq_application.headteacher_status)
+          expect(rows[0]["ineligible_for_funding_reason"]).to eql(npq_application.ineligible_for_funding_reason)
+          expect(rows[0]["participant_id"]).to eql(npq_application.participant_identity.user_id)
+          expect(rows[0]["private_childcare_provider_urn"]).to eql(npq_application.private_childcare_provider_urn)
+          expect(rows[0]["teacher_reference_number"]).to eql(npq_application.teacher_reference_number)
+          expect(rows[0]["teacher_reference_number_validated"]).to eql(npq_application.teacher_reference_number_verified.to_s)
+          expect(rows[0]["school_urn"]).to eql(npq_application.school_urn)
+          expect(rows[0]["school_ukprn"]).to eql(npq_application.school_ukprn)
+          expect(rows[0]["status"]).to eql(npq_application.lead_provider_approval_status)
+          expect(rows[0]["works_in_school"]).to eql(npq_application.works_in_school.to_s)
+          expect(rows[0]["eligible_for_funding"]).to eql(npq_application.eligible_for_dfe_funding.to_s)
+          expect(rows[0]["targeted_delivery_funding_eligibility"]).to eql(npq_application.targeted_delivery_funding_eligibility.to_s)
+          expect(rows[0]["itt_provider"]).to eql(npq_application.itt_provider)
+          expect(rows[0]["lead_mentor"]).to eql(npq_application.lead_mentor.to_s)
         end
       end
 

--- a/spec/serializers/api/v2/npq_application_serializer_spec.rb
+++ b/spec/serializers/api/v2/npq_application_serializer_spec.rb
@@ -2,32 +2,6 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a v2 serialised npq application" do
-  it "returns expected data", :aggregate_failures do
-    expect(result[:data][:attributes][:course_identifier]).to eql(npq_application.npq_course.identifier)
-    expect(result[:data][:attributes][:email]).to eql(npq_application.participant_identity.email)
-    expect(result[:data][:attributes][:email_validated]).to eql(true)
-    expect(result[:data][:attributes][:employer_name]).to eql(npq_application.employer_name)
-    expect(result[:data][:attributes][:employment_role]).to eql(npq_application.employment_role)
-    expect(result[:data][:attributes][:full_name]).to eql(npq_application.participant_identity.user.full_name)
-    expect(result[:data][:attributes][:funding_choice]).to eql(npq_application.funding_choice)
-    expect(result[:data][:attributes][:headteacher_status]).to eql(npq_application.headteacher_status)
-    expect(result[:data][:attributes][:ineligible_for_funding_reason]).to eql(npq_application.ineligible_for_funding_reason)
-    expect(result[:data][:attributes][:participant_id]).to eql(npq_application.participant_identity.external_identifier)
-    expect(result[:data][:attributes][:private_childcare_provider_urn]).to eql(npq_application.private_childcare_provider_urn)
-    expect(result[:data][:attributes][:teacher_reference_number]).to eql(npq_application.teacher_reference_number)
-    expect(result[:data][:attributes][:teacher_reference_number_validated]).to eql(npq_application.teacher_reference_number_verified)
-    expect(result[:data][:attributes][:school_urn]).to eql(npq_application.school_urn)
-    expect(result[:data][:attributes][:school_ukprn]).to eql(npq_application.school_ukprn)
-    expect(result[:data][:attributes][:status]).to eql(npq_application.lead_provider_approval_status)
-    expect(result[:data][:attributes][:works_in_school]).to eql(npq_application.works_in_school)
-    expect(result[:data][:attributes][:eligible_for_funding]).to eql(npq_application.eligible_for_dfe_funding)
-    expect(result[:data][:attributes][:itt_provider]).to eql(npq_application.itt_provider)
-    expect(result[:data][:attributes][:lead_mentor]).to eql(npq_application.lead_mentor)
-    expect(result[:data][:attributes][:targeted_delivery_funding_eligibility]).to eql(npq_application.targeted_delivery_funding_eligibility)
-  end
-end
-
 module Api
   module V2
     RSpec.describe NPQApplicationSerializer, :with_default_schedules do
@@ -36,12 +10,28 @@ module Api
       describe "serialization" do
         let(:npq_application) { create(:npq_application, targeted_delivery_funding_eligibility: true) }
 
-        context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-          it_behaves_like "a v2 serialised npq application"
-        end
-
-        context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-          it_behaves_like "a v2 serialised npq application"
+        it "returns expected data", :aggregate_failures do
+          expect(result[:data][:attributes][:course_identifier]).to eql(npq_application.npq_course.identifier)
+          expect(result[:data][:attributes][:email]).to eql(npq_application.participant_identity.email)
+          expect(result[:data][:attributes][:email_validated]).to eql(true)
+          expect(result[:data][:attributes][:employer_name]).to eql(npq_application.employer_name)
+          expect(result[:data][:attributes][:employment_role]).to eql(npq_application.employment_role)
+          expect(result[:data][:attributes][:full_name]).to eql(npq_application.participant_identity.user.full_name)
+          expect(result[:data][:attributes][:funding_choice]).to eql(npq_application.funding_choice)
+          expect(result[:data][:attributes][:headteacher_status]).to eql(npq_application.headteacher_status)
+          expect(result[:data][:attributes][:ineligible_for_funding_reason]).to eql(npq_application.ineligible_for_funding_reason)
+          expect(result[:data][:attributes][:participant_id]).to eql(npq_application.participant_identity.user_id)
+          expect(result[:data][:attributes][:private_childcare_provider_urn]).to eql(npq_application.private_childcare_provider_urn)
+          expect(result[:data][:attributes][:teacher_reference_number]).to eql(npq_application.teacher_reference_number)
+          expect(result[:data][:attributes][:teacher_reference_number_validated]).to eql(npq_application.teacher_reference_number_verified)
+          expect(result[:data][:attributes][:school_urn]).to eql(npq_application.school_urn)
+          expect(result[:data][:attributes][:school_ukprn]).to eql(npq_application.school_ukprn)
+          expect(result[:data][:attributes][:status]).to eql(npq_application.lead_provider_approval_status)
+          expect(result[:data][:attributes][:works_in_school]).to eql(npq_application.works_in_school)
+          expect(result[:data][:attributes][:eligible_for_funding]).to eql(npq_application.eligible_for_dfe_funding)
+          expect(result[:data][:attributes][:itt_provider]).to eql(npq_application.itt_provider)
+          expect(result[:data][:attributes][:lead_mentor]).to eql(npq_application.lead_mentor)
+          expect(result[:data][:attributes][:targeted_delivery_funding_eligibility]).to eql(npq_application.targeted_delivery_funding_eligibility)
         end
 
         describe "#updated_at" do

--- a/spec/services/change_schedule_spec.rb
+++ b/spec/services/change_schedule_spec.rb
@@ -123,7 +123,7 @@ RSpec.shared_examples "changing the schedule of a participant" do
   end
 end
 
-RSpec.describe ChangeSchedule, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe ChangeSchedule, :with_default_schedules do
   let(:participant_id) { participant_profile.participant_identity.external_identifier }
   let(:params) do
     {

--- a/spec/services/defer_participant_spec.rb
+++ b/spec/services/defer_participant_spec.rb
@@ -136,7 +136,7 @@ RSpec.shared_examples "deferring an ECF participant" do
   end
 end
 
-RSpec.describe DeferParticipant, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe DeferParticipant, :with_default_schedules do
   let(:participant_id) { participant_profile.participant_identity.external_identifier }
   let(:reason) { "other" }
   let(:params) do

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::ECF::AssuranceReport::Query, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe Finance::ECF::AssuranceReport::Query, :with_default_schedules do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:statement)         { create(:ecf_statement, cpd_lead_provider:) }
 
@@ -29,7 +29,7 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, :with_default_schedules, wi
 
     it "surfaces the preferred external identifier" do
       participant_declarations = query.participant_declarations
-      expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id_or_external_identifier)
+      expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id)
     end
 
     context "with multiple participant identities" do
@@ -48,7 +48,7 @@ RSpec.describe Finance::ECF::AssuranceReport::Query, :with_default_schedules, wi
 
       it "surfaces the preferred external identifier" do
         participant_declarations = query.participant_declarations
-        expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id_or_external_identifier)
+        expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id)
       end
     end
   end

--- a/spec/services/finance/npq/assurance_report/query_spec.rb
+++ b/spec/services/finance/npq/assurance_report/query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Finance::NPQ::AssuranceReport::Query, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe Finance::NPQ::AssuranceReport::Query, :with_default_schedules do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:statement)         { create(:npq_statement, cpd_lead_provider:) }
 
@@ -28,7 +28,7 @@ RSpec.describe Finance::NPQ::AssuranceReport::Query, :with_default_schedules, wi
 
     it "surfaces the preferred external identifier" do
       participant_declarations = query.participant_declarations
-      expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id_or_external_identifier)
+      expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id)
     end
 
     context "with multiple participant identities" do
@@ -53,7 +53,7 @@ RSpec.describe Finance::NPQ::AssuranceReport::Query, :with_default_schedules, wi
 
       it "surfaces the preferred external identifier" do
         participant_declarations = query.participant_declarations
-        expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id_or_external_identifier)
+        expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id)
       end
     end
   end

--- a/spec/services/participant_identity_resolver_spec.rb
+++ b/spec/services/participant_identity_resolver_spec.rb
@@ -2,74 +2,7 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a participant identity resolver service" do
-  context "when participant has both ECT and NPQ profiles" do
-    let!(:ect_profile) { create(:ect, lead_provider:, user:) }
-    let!(:participant_identity) { ect_profile.participant_identity }
-    let(:another_participant_identity) { create(:participant_identity, :secondary, user:, email: Faker::Internet.email) }
-    let!(:npq_application) { create(:npq_application, :accepted, participant_identity: another_participant_identity, npq_lead_provider:) }
-
-    context "for npq course" do
-      let(:course_identifier) { npq_application.npq_course.identifier }
-      let(:participant_id) { another_participant_identity.user_id }
-
-      it "correctly selects npq participant identity" do
-        result = subject.call
-
-        expect(result).to eql(another_participant_identity)
-      end
-    end
-
-    context "for ect course" do
-      let(:participant_id) { participant_identity.user_id }
-
-      it "correctly selects ect participant identity" do
-        result = subject.call
-
-        expect(result).to eql(participant_identity)
-      end
-    end
-  end
-
-  context "when participant has mentor profile" do
-    let(:additional_identity) { create(:participant_identity, user:, email: Faker::Internet.email) }
-    let!(:participant_profile) { create(:mentor_participant_profile, participant_identity: additional_identity, teacher_profile:) }
-    let(:course_identifier) { "ecf-mentor" }
-
-    before { participant_profile.update!(participant_identity: additional_identity) }
-
-    it "correctly selects mentor participant identity" do
-      result = subject.call
-
-      expect(result).to eql(additional_identity)
-    end
-  end
-
-  context "when participant has ECT profile" do
-    let(:ect_profile) { create(:ect, lead_provider:, user:) }
-    let!(:participant_identity) { ect_profile.participant_identity }
-
-    it "correctly selects ect participant identity" do
-      result = subject.call
-
-      expect(result).to eql(participant_identity)
-    end
-  end
-
-  context "when participant has npq profile" do
-    let(:participant_identity) { create(:participant_identity, user:, email: Faker::Internet.email) }
-    let(:npq_application) { create(:npq_application, :accepted, participant_identity:, npq_lead_provider:) }
-    let!(:course_identifier) { npq_application.npq_course.identifier }
-
-    it "correctly selects npq participant identity" do
-      result = subject.call
-
-      expect(result).to eql(participant_identity)
-    end
-  end
-end
-
-RSpec.describe ParticipantIdentityResolver, :with_default_schedules, :with_support_for_ect_examples, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe ParticipantIdentityResolver, :with_default_schedules, :with_support_for_ect_examples do
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, npq_lead_provider:) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
@@ -97,12 +30,69 @@ RSpec.describe ParticipantIdentityResolver, :with_default_schedules, :with_suppo
   end
 
   describe "#call" do
-    context "when feature flag is on", with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
-      it_behaves_like "a participant identity resolver service"
+    context "when participant has both ECT and NPQ profiles" do
+      let!(:ect_profile) { create(:ect, lead_provider:, user:) }
+      let!(:participant_identity) { ect_profile.participant_identity }
+      let(:another_participant_identity) { create(:participant_identity, :secondary, user:, email: Faker::Internet.email) }
+      let!(:npq_application) { create(:npq_application, :accepted, participant_identity: another_participant_identity, npq_lead_provider:) }
+
+      context "for npq course" do
+        let(:course_identifier) { npq_application.npq_course.identifier }
+        let(:participant_id) { another_participant_identity.user_id }
+
+        it "correctly selects npq participant identity" do
+          result = subject.call
+
+          expect(result).to eql(another_participant_identity)
+        end
+      end
+
+      context "for ect course" do
+        let(:participant_id) { participant_identity.user_id }
+
+        it "correctly selects ect participant identity" do
+          result = subject.call
+
+          expect(result).to eql(participant_identity)
+        end
+      end
     end
 
-    context "when feature flag is off", with_feature_flags: { external_identifier_to_user_id_lookup: nil } do
-      it_behaves_like "a participant identity resolver service"
+    context "when participant has mentor profile" do
+      let(:additional_identity) { create(:participant_identity, user:, email: Faker::Internet.email) }
+      let!(:participant_profile) { create(:mentor_participant_profile, participant_identity: additional_identity, teacher_profile:) }
+      let(:course_identifier) { "ecf-mentor" }
+
+      before { participant_profile.update!(participant_identity: additional_identity) }
+
+      it "correctly selects mentor participant identity" do
+        result = subject.call
+
+        expect(result).to eql(additional_identity)
+      end
+    end
+
+    context "when participant has ECT profile" do
+      let(:ect_profile) { create(:ect, lead_provider:, user:) }
+      let!(:participant_identity) { ect_profile.participant_identity }
+
+      it "correctly selects ect participant identity" do
+        result = subject.call
+
+        expect(result).to eql(participant_identity)
+      end
+    end
+
+    context "when participant has npq profile" do
+      let(:participant_identity) { create(:participant_identity, user:, email: Faker::Internet.email) }
+      let(:npq_application) { create(:npq_application, :accepted, participant_identity:, npq_lead_provider:) }
+      let!(:course_identifier) { npq_application.npq_course.identifier }
+
+      it "correctly selects npq participant identity" do
+        result = subject.call
+
+        expect(result).to eql(participant_identity)
+      end
     end
   end
 end

--- a/spec/services/participant_identity_resolver_spec.rb
+++ b/spec/services/participant_identity_resolver_spec.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "a participant identity resolver service" do
 
     context "for npq course" do
       let(:course_identifier) { npq_application.npq_course.identifier }
-      let(:participant_id) { another_participant_identity.user_id_or_external_identifier }
+      let(:participant_id) { another_participant_identity.user_id }
 
       it "correctly selects npq participant identity" do
         result = subject.call
@@ -21,7 +21,7 @@ RSpec.shared_examples "a participant identity resolver service" do
     end
 
     context "for ect course" do
-      let(:participant_id) { participant_identity.user_id_or_external_identifier }
+      let(:participant_id) { participant_identity.user_id }
 
       it "correctly selects ect participant identity" do
         result = subject.call

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -244,7 +244,7 @@ RSpec.shared_examples "creates participant declaration attempt" do
   end
 end
 
-RSpec.describe RecordDeclaration, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe RecordDeclaration, :with_default_schedules do
   let(:cpd_lead_provider)     { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider) }
   let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, :with_npq_lead_provider, name: "Unknown") }
   let(:declaration_type)      { "started" }

--- a/spec/services/resume_participant_spec.rb
+++ b/spec/services/resume_participant_spec.rb
@@ -115,7 +115,7 @@ RSpec.shared_examples "resuming an ECF participant" do
   end
 end
 
-RSpec.describe ResumeParticipant, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe ResumeParticipant, :with_default_schedules do
   let(:participant_id) { participant_profile.participant_identity.external_identifier }
   let(:params) do
     {

--- a/spec/services/withdraw_participant_spec.rb
+++ b/spec/services/withdraw_participant_spec.rb
@@ -150,7 +150,7 @@ RSpec.shared_examples "withdrawing a NPQ participant" do
   end
 end
 
-RSpec.describe WithdrawParticipant, :with_default_schedules, with_feature_flags: { external_identifier_to_user_id_lookup: "active" } do
+RSpec.describe WithdrawParticipant, :with_default_schedules do
   let(:participant_id) { participant_profile.participant_identity.external_identifier }
   let(:induction_record) { participant_profile.induction_records.first }
   let(:reason) { "other" }


### PR DESCRIPTION
### Context

- Ticket: n/a

We would like to fully enable this feature in production

### Changes proposed in this pull request
- Fully switch to using `user_id` in the API
- remove feature flag and any instances it's used
- Switch back to one place in testing

### Guidance to review
This is based off @leandroalemao's excellent work in: https://github.com/DFE-Digital/early-careers-framework/pull/3075
