### PR TITLE
CST-1281: search for existing participant in TeacherProfile rather th…

### DIFF
--- a/app/components/schools/participants/remove_from_cohort_component.html.erb
+++ b/app/components/schools/participants/remove_from_cohort_component.html.erb
@@ -1,5 +1,5 @@
 <% if manual_removal_possible? %>
-<%= govuk_link_to "Remove #{name} from this cohort", schools_participant_remove_path(school_id: induction_record.school, cohort_id: induction_record.school_cohort.cohort, participant_id: induction_record.participant_profile) %>
+  <%= govuk_link_to "Remove #{name} from this cohort", schools_participant_remove_path(school_id: induction_record.school, cohort_id: induction_record.school_cohort.cohort, participant_id: induction_record.participant_profile) %>
 <% elsif fip? %>
   <% if lead_provider %>
     Contact <%= lead_provider.name %> if you want to remove <%= name %> from this cohort.

--- a/app/forms/schools/add_participant_form.rb
+++ b/app/forms/schools/add_participant_form.rb
@@ -213,11 +213,10 @@ module Schools
     end
 
     def check_for_existing_profile
-      self.existing_participant_profile = ParticipantProfile
-                                            .ecf
-                                            .joins(:ecf_participant_validation_data)
-                                            .where(ecf_participant_validation_data: { trn: formatted_trn })
-                                            .first
+      self.existing_participant_profile = ParticipantProfile.ecf
+                                                            .joins(:teacher_profile)
+                                                            .where(teacher_profile: { trn: formatted_trn })
+                                                            .first
     end
 
     def validate_dqt_record

--- a/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
@@ -126,7 +126,7 @@ private
   def and_i_fill_in_all_info
     allow(ParticipantValidationService).to receive(:validate).and_return(
       {
-        trn: "AB123445A",
+        trn: "5234457",
         full_name: "George ECT",
         nino: nil,
         dob: Date.new(1998, 11, 22),
@@ -136,7 +136,7 @@ private
 
     fill_in "schools_add_participant_form[full_name]", with: "George ECT"
     click_on "Continue"
-    fill_in "schools_add_participant_form[trn]", with: "AB123445A"
+    fill_in "schools_add_participant_form[trn]", with: "5234457"
     click_on "Continue"
     fill_in_date("What’s George ECT’s date of birth?", with: "1998-11-22")
     click_on "Continue"

--- a/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/happy_path_sit_adds_self_as_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_adding_self_as_mentor/happy_path_sit_adds_self_as_mentor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Add participants", js: true do
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_click_on("2021 to 2022")
     then_i_am_taken_to_fip_induction_dashboard
-    set_dqt_validation_result
+    set_sit_dqt_validation_result
   end
 
   scenario "Induction tutor can add themselves as a mentor and validates" do
@@ -36,6 +36,7 @@ RSpec.describe "Add participants", js: true do
     then_i_am_taken_to_add_your_dob_page
     when_i_add_my_date_of_birth
     click_on "Continue"
+
     then_i_am_taken_to_check_details_page
     when_i_click_confirm_and_add
     then_i_am_taken_to_yourself_as_mentor_confirmation_page
@@ -43,6 +44,7 @@ RSpec.describe "Add participants", js: true do
     sign_out
     when_i_sign_back_in
     and_i_choose_induction_coordinator_and_mentor_role
+
     and_i_click_on("2021 to 2022")
     then_i_am_taken_to_fip_induction_dashboard
     then_the_page_should_be_accessible

--- a/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/already_enrolled_at_school_spec.rb
@@ -200,8 +200,12 @@ RSpec.describe "Transferring participants", type: :feature, js: true, rutabaga: 
   end
 
   def and_they_have_already_added_this_ect
-    @participant_profile_ect = create(:ect_participant_profile, user: create(:user, full_name: "Sally Teacher"), school_cohort: @school_cohort_one)
+    @participant_profile_ect = create(:ect_participant_profile,
+                                      user: create(:user, full_name: "Sally Teacher"),
+                                      school_cohort: @school_cohort_one,
+                                      teacher_profile: create(:teacher_profile, trn: "1001000"))
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1001000", date_of_birth: Date.new(1990, 10, 24))
+
     Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_one)
   end
 

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -225,7 +225,7 @@ module ManageTrainingSteps
 
   def given_a_participant_from_the_same_school_is_already_on_ecf
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
-    teacher_profile = create(:teacher_profile, user:)
+    teacher_profile = create(:teacher_profile, user:, trn: "1234567")
     @participant_profile_ect = create(:ect_participant_profile, teacher_profile:, school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme)
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1234567", date_of_birth: Date.new(1998, 3, 22))
@@ -237,7 +237,7 @@ module ManageTrainingSteps
     @induction_programme_three = create(:induction_programme, :fip, school_cohort: @school_cohort_three)
 
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
-    teacher_profile = create(:teacher_profile, user:)
+    teacher_profile = create(:teacher_profile, user:, trn: "1234567")
     @participant_profile_ect = create(:ect_participant_profile, teacher_profile:, school_cohort: @school_cohort_three)
     Induction::Enrol.call(participant_profile: @participant_profile_ect, induction_programme: @induction_programme_three)
     create(:ecf_participant_validation_data, participant_profile: @participant_profile_ect, full_name: "Sally Teacher", trn: "1234567", date_of_birth: Date.new(1998, 3, 22))

--- a/spec/requests/schools/add_participants_spec.rb
+++ b/spec/requests/schools/add_participants_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe "Schools::AddParticipant", type: :request do
       context "when participant is a transfer" do
         let(:induction_programme) { create(:induction_programme, :fip, school_cohort: create(:school_cohort, cohort: participant_cohort)) }
         let(:ecf_participant_validation_data) { create(:ecf_participant_validation_data, trn: "3333333") }
-        let(:participant_profile) { create(:ect_participant_profile, ecf_participant_validation_data:) }
+        let(:teacher_profile) { create(:teacher_profile, trn: "3333333") }
+        let(:participant_profile) { create(:ect_participant_profile, teacher_profile:, ecf_participant_validation_data:) }
 
         before do
           Induction::Enrol.call(participant_profile:, induction_programme:)


### PR DESCRIPTION
…an validation data

### Context

  To detect wether a participant already exists at registration time we actually check the trn stored in ECFParticipantValidationData. This is preventing the registration of teachers whose details have been used by the SIT to register a different person.

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1281)

### Changes proposed in this pull request
  
 Search for existing participants in TeacherProfile instead.

### Guidance to review

