### PR TITLE
Validate Admins are moving participants to new school

### DIFF
--- a/app/forms/admin/school_transfer_form.rb
+++ b/app/forms/admin/school_transfer_form.rb
@@ -12,6 +12,7 @@ class Admin::SchoolTransferForm
   validate :participant_profile_present
   validates :new_school_urn, presence: true, on: :select_school
   validate :new_school_exists, on: :select_school
+  validate :moving_to_new_school, on: :select_school
   validate :start_date_is_valid, on: :start_date
   validates :email, presence: true, notify_email: true, on: :email
   validate :email_is_not_in_use, on: :email
@@ -182,6 +183,10 @@ private
 
   def new_school_exists
     errors.add(:new_school_urn, :invalid, urn: new_school_urn) if new_school.nil?
+  end
+
+  def moving_to_new_school
+    errors.add(:new_school_urn, :same_school, urn: new_school_urn) if participant_profile.school == new_school
   end
 
   def new_school_programmes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,6 +238,7 @@ en:
             new_school_urn:
               blank: "Enter the URN of the school the participant will transfer to"
               invalid: "Cannot find a school with the URN ‘%{urn}’"
+              same_school: "Enter the URN of the school the participant is joining"
             transfer_choice:
               blank: "Select which programme the participant will join"
             start_date:

--- a/spec/forms/admin/school_transfer_form_spec.rb
+++ b/spec/forms/admin/school_transfer_form_spec.rb
@@ -161,6 +161,11 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
         form.new_school_urn = school.urn
         expect(form.valid?(:select_school)).to be true
       end
+
+      it "checks the urn provided is from a new school" do
+        form.new_school_urn = participant_profile.school.urn
+        expect(form.valid?(:select_school)).to be false
+      end
     end
 
     context "when :start_date step" do


### PR DESCRIPTION

### Context

- Ticket: CST-1352

The transfer school form in the Admin pages accepts URNs from any existing schools and raises an exception, which results to a 404 page when submitting it with the participant's current school urn.
 

### Changes proposed in this pull request
Add an ActiveModel validation to display a meaningful error message when the submitted URN is not from a new school

### Guidance to review
1. visit the to Admin pages
2. pick a participant
3. visit the School tab
4. click Transfer to another school
5. type in the the URN of the school the participant is already at
6. the form should display a validation error message instead of letting you continue