### PR TITLE
Ensure school cohort combinations are unique 2

### DIFF
--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -37,6 +37,8 @@ class SchoolCohort < ApplicationRecord
   has_many :transferred_induction_records, through: :induction_programmes, class_name: "InductionRecord"
   has_many :current_participant_profiles, through: :induction_programmes, class_name: "ParticipantProfile::ECF"
 
+  validates :school_id, uniqueness: { scope: :cohort_id }
+
   scope :for_year, ->(year) { joins(:cohort).where(cohort: { start_year: year }) }
 
   delegate :description, :academic_year, :start_year, to: :cohort

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,6 +229,10 @@ en:
               cannot_change_from_accepted: Once accepted an application cannot change state
               cannot_change_from_rejected: Once rejected an application cannot change state
               declarations_exist: There are already declarations for this participant on this course, please ask provider to void and/or clawback any declarations they have made before attempting to reset the application.
+        school_cohort:
+          attributes:
+            school_id:
+              taken: The school is already linked to this cohort
 
   activemodel:
     errors:

--- a/db/migrate/20221012103024_add_unique_index_to_school_cohorts.rb
+++ b/db/migrate/20221012103024_add_unique_index_to_school_cohorts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToSchoolCohorts < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:school_cohorts, %i[school_id cohort_id], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -889,6 +889,7 @@ ActiveRecord::Schema.define(version: 2023_03_21_181937) do
     t.index ["cohort_id"], name: "index_school_cohorts_on_cohort_id"
     t.index ["core_induction_programme_id"], name: "index_school_cohorts_on_core_induction_programme_id"
     t.index ["default_induction_programme_id"], name: "index_school_cohorts_on_default_induction_programme_id"
+    t.index ["school_id", "cohort_id"], name: "index_school_cohorts_on_school_id_and_cohort_id", unique: true
     t.index ["school_id"], name: "index_school_cohorts_on_school_id"
     t.index ["updated_at"], name: "index_school_cohorts_on_updated_at"
   end

--- a/spec/models/school_cohort_spec.rb
+++ b/spec/models/school_cohort_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe SchoolCohort, type: :model do
     it { is_expected.to have_many(:transferring_out_induction_records).through(:induction_programmes) }
   end
 
+  describe "validation" do
+    it "validates the uniqueness of school_id and cohort_id in combination" do
+      school_cohort_1 = create(:school_cohort)
+      school_cohort_2 = school_cohort_1.dup
+
+      expect(school_cohort_2).to be_invalid
+      expect(school_cohort_2.errors.messages[:school_id]).to include("The school is already linked to this cohort")
+    end
+  end
+
   it "updates the updated_at on participant profiles and users when meaningfully updated" do
     freeze_time
     school_cohort = create(:school_cohort)

--- a/spec/requests/admin/schools/cohorts_spec.rb
+++ b/spec/requests/admin/schools/cohorts_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe "Admin::Schools::Cohorts", type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:school) { create(:school) }
   let(:cip) { create(:core_induction_programme, name: "CIP Programme") }
-  let(:cohorts) { create_list(:cohort, 5) }
-
   let!(:school_cohorts) do
     [
       create(:school_cohort, cohort: create(:cohort, start_year: 2021), school:, core_induction_programme: cip),

--- a/spec/requests/admin/schools/cohorts_spec.rb
+++ b/spec/requests/admin/schools/cohorts_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "Admin::Schools::Cohorts", type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:school) { create(:school) }
   let(:cip) { create(:core_induction_programme, name: "CIP Programme") }
+  let(:cohorts) { create_list(:cohort, 5) }
+
   let!(:school_cohorts) do
     [
       create(:school_cohort, cohort: create(:cohort, start_year: 2021), school:, core_induction_programme: cip),


### PR DESCRIPTION
### Context
This PR is an update of [this one](https://github.com/DFE-Digital/early-careers-framework/pull/2606) created by @peteryates a few months ago. All credits must go to him.

We had a case recently where a school had two 2021 cohort records. This should never happen. This change enforces it both at the database and model level.

### Changes proposed in this pull request

* add a unique index to `school_cohorts` on `school_id` and `cohort_id`
* add a unique constraint to the `SchoolCohort` model

### Before merging

**Don't merge this until we have no more duplicates.**

This query should return no results in prod.

```
with dupes as (
  select school_id, cohort_id
  from school_cohorts
  group by school_id, cohort_id
  having count(*) > 1
)
select urn, name, postcode
from schools
join dupes on schools.id = dupes.school_id;
```
