### PR TITLE
Pass in `user_id` instead of `external_id` to change participant status

### DIFF
--- a/app/forms/finance/ecf/change_training_status_form.rb
+++ b/app/forms/finance/ecf/change_training_status_form.rb
@@ -38,7 +38,7 @@ module Finance
         params = {
           cpd_lead_provider:,
           course_identifier:,
-          participant_id: participant_profile.participant_identity.external_identifier,
+          participant_id: participant_profile.participant_identity.user_id,
         }
 
         case training_status

--- a/app/forms/finance/npq/change_training_status_form.rb
+++ b/app/forms/finance/npq/change_training_status_form.rb
@@ -37,7 +37,7 @@ module Finance
         params = {
           cpd_lead_provider: participant_profile.npq_application.npq_lead_provider.cpd_lead_provider,
           course_identifier: participant_profile.npq_application.npq_course.identifier,
-          participant_id: participant_profile.participant_identity.external_identifier,
+          participant_id: participant_profile.participant_identity.user_id,
         }
 
         case training_status

--- a/app/services/api/v1/ecf/participants_query.rb
+++ b/app/services/api/v1/ecf/participants_query.rb
@@ -150,11 +150,9 @@ module Api
 
         def participant_identity_fields
           [
-            "participant_identities.external_identifier as external_identifier",
             "participant_identities.user_id as user_id",
             "participant_identities.updated_at AS participant_identity_updated_at",
             "preferred_identities.email AS preferred_identity_email",
-            "participant_identities_mentor_profiles.external_identifier AS mentor_external_identifier",
             "participant_identities_mentor_profiles.user_id AS mentor_user_id",
           ]
         end

--- a/spec/forms/finance/ecf/change_training_status_form_spec.rb
+++ b/spec/forms/finance/ecf/change_training_status_form_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Finance::ECF::ChangeTrainingStatusForm, :with_default_schedules, 
 
   describe "EarlyCareerTeacher" do
     let!(:participant_declaration) { create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:) }
-    let(:participant_profile) { create(:ect, lead_provider: cpd_lead_provider.lead_provider) }
+    let(:user) { create(:participant_identity, :secondary).user }
+    let(:participant_profile) { create(:ect, user:, lead_provider: cpd_lead_provider.lead_provider) }
 
     it { is_expected.to validate_inclusion_of(:training_status).in_array(ParticipantProfile.training_statuses.values) }
     it { is_expected.to validate_inclusion_of(:reason).in_array(ParticipantProfile::DEFERRAL_REASONS) }
@@ -36,7 +37,8 @@ RSpec.describe Finance::ECF::ChangeTrainingStatusForm, :with_default_schedules, 
 
   describe "Mentor" do
     let!(:participant_declaration) { create(:mentor_participant_declaration, participant_profile:, cpd_lead_provider:) }
-    let(:participant_profile)      { create(:mentor, lead_provider: cpd_lead_provider.lead_provider) }
+    let(:user) { create(:participant_identity, :secondary).user }
+    let(:participant_profile) { create(:mentor, user:, lead_provider: cpd_lead_provider.lead_provider) }
 
     it { is_expected.to validate_inclusion_of(:training_status).in_array(ParticipantProfile.training_statuses.values) }
     it { is_expected.to validate_inclusion_of(:reason).in_array(ParticipantProfile::DEFERRAL_REASONS) }

--- a/spec/forms/finance/npq/change_training_status_form_spec.rb
+++ b/spec/forms/finance/npq/change_training_status_form_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Finance::NPQ::ChangeTrainingStatusForm, :with_default_schedules, 
   subject(:form) { described_class.new(params) }
 
   describe "NPQ" do
-    let(:participant_profile) { create(:npq_participant_profile, training_status: "active") }
+    let(:user) { create(:participant_identity, :secondary).user }
+    let(:participant_profile) { create(:npq_participant_profile, user:, training_status: "active") }
     let(:params) { { participant_profile:, training_status: "deferred", reason: "bereavement" } }
 
     it { is_expected.to validate_inclusion_of(:training_status).in_array(ParticipantProfile.training_statuses.values) }

--- a/spec/services/api/v1/ecf/participants_query_spec.rb
+++ b/spec/services/api/v1/ecf/participants_query_spec.rb
@@ -24,15 +24,10 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
       let(:preferred_email) { Faker::Internet.email }
       let(:preferred_identity) { create(:participant_identity, :secondary, user: participant_profile.user, email: preferred_email) }
       let!(:another_induction_record) { create(:induction_record, induction_programme:, participant_profile:, preferred_identity:) }
-      let(:external_identifier) { participant_profile.participant_identity.external_identifier }
       let(:user_id) { participant_profile.participant_identity.user_id }
 
       it "returns the user id of the participant identity" do
         expect(subject.induction_records.first.user_id).to eq(user_id)
-      end
-
-      it "returns the original external identifier of the participant identity" do
-        expect(subject.induction_records.first.external_identifier).to eq(external_identifier)
       end
 
       it "returns the preferred email" do
@@ -43,15 +38,9 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
     context "with mentor profile" do
       let(:mentor_participant_profile) { create(:mentor_participant_profile) }
       let(:participant_profile) { create(:ect_participant_profile, mentor_profile_id: mentor_participant_profile.id) }
-      let(:mentor_external_identifier) { mentor_participant_profile.participant_identity.external_identifier }
-      let(:external_identifier) { participant_profile.participant_identity.external_identifier }
       let(:user_id) { participant_profile.participant_identity.user_id }
       let(:mentor_user_id) { mentor_participant_profile.participant_identity.user_id }
       let!(:induction_record) { create(:induction_record, induction_programme:, participant_profile:, mentor_profile_id: mentor_participant_profile.id) }
-
-      it "returns the mentor external identifier" do
-        expect(subject.induction_records.first.mentor_external_identifier).to eq(mentor_external_identifier)
-      end
 
       it "returns the mentor user id" do
         expect(subject.induction_records.first.mentor_user_id).to eq(mentor_user_id)
@@ -59,10 +48,6 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
       it "returns the user id" do
         expect(subject.induction_records.first.user_id).to eq(user_id)
-      end
-
-      it "returns the external identifier" do
-        expect(subject.induction_records.first.external_identifier).to eq(external_identifier)
       end
     end
 
@@ -122,7 +107,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
         let(:another_induction_programme) { create(:induction_programme, :fip, partnership:) }
         let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
 
-        let(:params) { { id: another_participant_profile.participant_identity.external_identifier } }
+        let(:params) { { id: another_participant_profile.participant_identity.user_id } }
 
         it "returns a specific induction record" do
           expect(subject.induction_record).to eql(another_induction_record)
@@ -138,7 +123,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
         let!(:induction_record) { create(:induction_record, :with_end_date, induction_programme:, participant_profile:) }
 
-        let(:params) { { id: participant_profile.participant_identity.external_identifier } }
+        let(:params) { { id: participant_profile.participant_identity.user_id } }
 
         it "returns the induction record with no end date" do
           expect(subject.induction_record).to eql(latest_induction_record)
@@ -154,7 +139,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
           create(:induction_record, :future_start_date, induction_programme:, participant_profile:)
         end
 
-        let(:params) { { id: participant_profile.participant_identity.external_identifier } }
+        let(:params) { { id: participant_profile.participant_identity.user_id } }
 
         it "returns the induction record with the latest start date" do
           expect(subject.induction_record).to eql(latest_induction_record)
@@ -170,7 +155,7 @@ RSpec.describe Api::V1::ECF::ParticipantsQuery do
 
         let!(:latest_induction_record) { create(:induction_record, induction_programme:, participant_profile:) }
 
-        let(:params) { { id: participant_profile.participant_identity.external_identifier } }
+        let(:params) { { id: participant_profile.participant_identity.user_id } }
 
         it "returns the induction record with the latest timestamp" do
           expect(subject.induction_record).to eql(latest_induction_record)


### PR DESCRIPTION
### Context
If a profile user is different than the participant identity changing training status is failing due to us switching services to use `user_id`

- Ticket: n/a

### Changes proposed in this pull request
Switch forms to use `user_id` instead of `external_id`

### Guidance to review

