### PR TITLE
updated_at timestamp should reflect changes to relevant cohort context only

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -4,6 +4,7 @@ class Cohort < ApplicationRecord
   has_many :call_off_contracts
   has_many :npq_contracts
   has_many :partnerships
+  has_many :school_cohorts
   has_many :schedules, class_name: "Finance::Schedule"
   has_many :statements
 

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -17,6 +17,7 @@ class Partnership < ApplicationRecord
   belongs_to :delivery_partner
   has_many :partnership_notification_emails, dependent: :destroy
   has_many :event_logs, as: :owner
+  has_many :school_cohorts, through: :cohort
 
   has_paper_trail
 
@@ -56,6 +57,10 @@ class Partnership < ApplicationRecord
 
   def unchallenge!
     update!(challenged_at: nil, challenge_reason: nil, challenge_deadline: cohort_challenge_deadline)
+
+    # Ensures the updated_at timestamp exposed by the API
+    # SchoolCohortSerializer is updated when partnership status changes
+    school_cohorts.touch_all
   end
 
 private

--- a/app/serializers/api/v3/ecf/school_cohort_serializer.rb
+++ b/app/serializers/api/v3/ecf/school_cohort_serializer.rb
@@ -35,9 +35,7 @@ module Api
           school_cohort.school.partnered?(school_cohort.cohort)
         end
 
-        attribute :updated_at do |school_cohort|
-          school_cohort.school.updated_at
-        end
+        attribute :updated_at, &:updated_at
       end
     end
   end

--- a/app/services/partnerships/challenge.rb
+++ b/app/services/partnerships/challenge.rb
@@ -25,6 +25,11 @@ module Partnerships
       raise ArgumentError if challenge_reason.blank?
 
       partnership.update!(challenge_reason:, challenged_at: Time.zone.now)
+
+      # Ensures the updated_at timestamp exposed by the API
+      # SchoolCohortSerializer is updated when partnership status changes
+      partnership.school_cohorts.touch_all
+
       partnership.event_logs.create!(
         event: :challenged,
         data: {

--- a/spec/serializers/api/v3/ecf/school_cohort_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/school_cohort_serializer_spec.rb
@@ -53,7 +53,7 @@ module Api
           end
 
           it "returns the school updated_at" do
-            expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(school.updated_at)
+            expect(subject.serializable_hash[:data][:attributes][:updated_at]).to eq(school_cohort.updated_at)
           end
         end
       end

--- a/spec/services/partnerships/challenge_spec.rb
+++ b/spec/services/partnerships/challenge_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Partnerships::Challenge do
       end
     end
 
+    it "updates the school cohorts" do
+      expect { service_call }.to change { school_cohort.reload.updated_at }
+    end
+
     it "sets the event log data" do
       service_call
       created_event = partnership.event_logs.order(created_at: :desc).first


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2082

### Changes proposed in this pull request

* Exposes the `updated_at` timestamp of the `SchoolCohort` rather than the `School`. This is because the `School` timestamp is updated regularly and those changes are not always relevant to the cohort exposed on the API, which could lead to confusion for users.
* Ensures the timestamp is updated if a relevant partnership status changes.

### Guidance to review

The `updated_at` timestamp will not update if the school URN or name changes. I have left it for now as I think, likely and pragmatically, it's not relevant in the current implementation as the school name and URN are not likely to change. Usually when a school name change happens a new school record is created and the old one is retired.

If we need to do it, I think the only reliable way to achieve this would be with an `after_save` callback, touching all related `SchoolCohort`s only when those attributes have changed. However, should any other `School` attributes need to be exposed in the serializer in the future, we will have the same problem again except that all of our `updated_at` timestamps will be wrong with no way of calculating the correct timestamp. Also, we may not wish the `updated_at` timestamp to be updated on `SchoolCohort` in this event as we are not technically updating that record and it could lead to misunderstanding. We might need another attribute to track changes if we want to do that.