### PR TITLE
Ensure seeded mentors have validation data

### DIFF
--- a/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentor_with_no_ects.rb
@@ -5,7 +5,12 @@ module NewSeeds
     module Participants
       module Mentors
         class MentorWithNoEcts
-          attr_reader :participant_profile
+          attr_reader :participant_profile,
+                      :participant_identity,
+                      :new_user_attributes,
+                      :school_cohort,
+                      :teacher_profile,
+                      :user
 
           def initialize(school_cohort: nil, full_name: nil, email: nil, teacher_profile: nil, participant_identity: nil)
             @school_cohort = school_cohort
@@ -86,14 +91,6 @@ module NewSeeds
 
             FactoryBot.create(:seed_ecf_participant_eligibility, **eligibility_data.compact)
           end
-
-        private
-
-          attr_reader :new_user_attributes,
-                      :school_cohort,
-                      :teacher_profile,
-                      :participant_identity,
-                      :user
         end
       end
     end

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -57,6 +57,7 @@ module NewSeeds
               .new(school_cohort:)
               .build
               .with_induction_record(induction_programme:)
+              .with_validation_data
               .participant_profile
           end
 


### PR DESCRIPTION
### Context

Minor change, add mentor validation data to seed

### Changes proposed in this pull request

- Make all the scenario attributes public
- Add with_validation_data call in mentor scenario
