### PR TITLE
[CPDLP-2121] Add in additional states to the NPQ transfer service functionality

### DIFF
--- a/app/forms/finance/npq/change_lead_provider_form.rb
+++ b/app/forms/finance/npq/change_lead_provider_form.rb
@@ -34,7 +34,7 @@ module Finance
       end
 
       def change_lead_provider?
-        participant_profile.participant_declarations.where(state: %w[submitted eligible payable paid]).exists?
+        participant_profile.participant_declarations.where(state: %w[submitted eligible payable paid awaiting_clawback clawed_back]).exists?
       end
 
       def lead_provider

--- a/spec/forms/finance/npq/change_lead_provider_form_spec.rb
+++ b/spec/forms/finance/npq/change_lead_provider_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Finance::NPQ::ChangeLeadProviderForm, :with_default_schedules, ty
 
     describe ".save" do
       context "valid params" do
-        it "should change lead provider" do
+        it "changes lead provider" do
           expect(form.save).to be true
           expect(participant_profile.npq_application.reload.npq_lead_provider).to eql(lead_provider)
         end
@@ -24,7 +24,7 @@ RSpec.describe Finance::NPQ::ChangeLeadProviderForm, :with_default_schedules, ty
       context "invalid params" do
         let(:params) { { participant_profile:, lead_provider_id: nil } }
 
-        it "should not change lead provider" do
+        it "does not change lead provider" do
           old_lead_provider = participant_profile.npq_application.npq_lead_provider
           expect(form.save).to be false
           expect(participant_profile.npq_application.reload.npq_lead_provider).to eql(old_lead_provider)


### PR DESCRIPTION

### Context

- Ticket: [CPDLP-2121](https://dfedigital.atlassian.net/browse/CPDLP-2121)

Currently, the transfer functionality only shows when there are declarations that are submitted, eligible, payable or paid.

### Changes proposed in this pull request

We will need to add `awaiting_clawback` and `clawed_back` to the list of states that should surface the transfer functionality.




[CPDLP-2121]: https://dfedigital.atlassian.net/browse/CPDLP-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ