### PR TITLE
Add an Admin page for assigning mentors to other schools

### DIFF
--- a/app/controllers/admin/participants/add_to_school_mentor_pool_controller.rb
+++ b/app/controllers/admin/participants/add_to_school_mentor_pool_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class AddToSchoolMentorPoolController < Admin::BaseController
+    include RetrieveProfile
+
+    def new
+      @add_mentor_to_school = Admin::Participants::AddMentorToSchoolForm.new(mentor_profile: @participant_profile)
+    end
+
+    def create
+      @add_mentor_to_school = Admin::Participants::AddMentorToSchoolForm.new(mentor_profile: @participant_profile, school_urn: school_mentor_pool_params[:school_urn])
+
+      if @add_mentor_to_school.save
+        set_success_message content: "Mentor has been added to the school's mentor pool"
+        redirect_to admin_participant_school_path(@participant_profile)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def school_mentor_pool_params
+      params.require(:admin_participants_add_mentor_to_school_form).permit(:school_urn)
+    end
+  end
+end

--- a/app/forms/admin/participants/add_mentor_to_school_form.rb
+++ b/app/forms/admin/participants/add_mentor_to_school_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Admin::Participants
+  class AddMentorToSchoolForm < Admin::BaseForm
+    attr_accessor :mentor_profile, :school_urn
+
+    validate :school_exists
+    validate :mentoring_in_school
+    validates :school_urn, presence: true
+
+    def save
+      return false if invalid?
+
+      return true if Mentors::AddToSchool.call(mentor_profile:, school:)
+    end
+
+  private
+
+    def school
+      @school ||= School.find_by_urn(school_urn)
+    end
+
+    def school_exists
+      errors.add(:school_urn, :school_missing) if school.nil?
+    end
+
+    def mentoring_in_school
+      errors.add(:school_urn, :already_in_mentor_pool) if mentor_profile.school_mentors.where(school:).exists?
+    end
+  end
+end

--- a/app/views/admin/participants/add_to_school_mentor_pool/new.html.erb
+++ b/app/views/admin/participants/add_to_school_mentor_pool/new.html.erb
@@ -1,0 +1,15 @@
+<% title = "Adding mentor to a school mentor pool" %>
+<% content_for :title, title %>
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_school_path(@participant_profile)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <span class="govuk-caption-xl">Adding <%=  @participant_profile.user.full_name %> to a school mentor pool</span>
+    <h1 class="govuk-heading-xl">What’s the URN of the school</h1>
+    <%= form_for @add_mentor_to_school, url: admin_participant_add_to_school_mentor_pool_path(@participant_profile), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :school_urn, label: { text: "School URN" }, hint: { text: "Enter the 6-digit URN of the new school, for example 123456" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/add_to_school_mentor_pool/new.html.erb
+++ b/app/views/admin/participants/add_to_school_mentor_pool/new.html.erb
@@ -9,7 +9,7 @@
     <%= form_for @add_mentor_to_school, url: admin_participant_add_to_school_mentor_pool_path(@participant_profile), method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :school_urn, label: { text: "School URN" }, hint: { text: "Enter the 6-digit URN of the new school, for example 123456" } %>
-      <%= f.govuk_submit %>
+      <%= f.govuk_submit "Add to school" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -64,4 +64,12 @@
       secondary: true,
     )
   %>
+
+  <%=
+    govuk_button_link_to(
+      "Add to a school mentor pool",
+      new_admin_participant_add_to_school_mentor_pool_path(@participant_profile),
+      secondary: true,
+    ) if @latest_induction_record.participant_profile.mentor?
+  %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -237,6 +237,11 @@ en:
   activemodel:
     errors:
       models:
+        admin/participants/add_mentor_to_school_form:
+          attributes:
+            school_urn:
+              school_missing: "Could not find the school"
+              already_in_mentor_pool: "The mentor is already mentoring in this school"
         admin/school_transfer_form:
           attributes:
             new_school_urn:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,8 @@ Rails.application.routes.draw do
       resource :change_name, only: %i[edit update], controller: "participants/change_name", path: "name"
       resource :change_email, only: %i[edit update], controller: "participants/change_email", path: "email"
 
+      resource :add_to_school_mentor_pool, only: %i[new create], controller: "participants/add_to_school_mentor_pool"
+
       resource :npq_change_full_name, only: %i[edit update], controller: "participants/npq/change_full_name"
       resource :npq_change_email, only: %i[edit update], controller: "participants/npq/change_email"
 

--- a/spec/forms/admin/participants/add_mentor_to_school_form_spec.rb
+++ b/spec/forms/admin/participants/add_mentor_to_school_form_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Participants::AddMentorToSchoolForm, type: :model do
+  let(:school) { create(:school) }
+  let(:school_urn) { school.urn }
+  let(:mentor_profile) { create(:mentor_participant_profile) }
+
+  subject { described_class.new(mentor_profile:, school_urn:) }
+
+  describe "validation" do
+    it { is_expected.to have_attributes(mentor_profile:, school_urn:) }
+    it { is_expected.to validate_presence_of(:school_urn) }
+
+    context "when mentor is new to the school" do
+      it { is_expected.to be_valid }
+    end
+
+    context "when the school does not exists" do
+      let(:school_urn) { "000000" }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the mentor is already mentoring in the school" do
+      before do
+        mentor_profile.school_mentors.create(school: mentor_profile.school, preferred_identity: mentor_profile.participant_identity)
+      end
+
+      let(:school_urn) { mentor_profile.school_mentors.first.school.urn }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  # rubocop:disable Rails/SaveBang
+  describe "#save" do
+    context "when the form is valid" do
+      it "returns true" do
+        expect(subject.save).to be true
+      end
+
+      it "adds the mentor to the school's mentor pool" do
+        subject.save
+        expect(school.mentor_profiles).to include mentor_profile
+      end
+    end
+
+    context "when the form is invalid" do
+      let(:school_urn) { nil }
+
+      it "returns false" do
+        expect(subject.save).to be false
+      end
+
+      it "doesn't add the mentor to the school's mentor pool" do
+        subject.save
+        expect(school.mentor_profiles).not_to include mentor_profile
+      end
+    end
+  end
+  # rubocop:enable Rails/SaveBang
+end


### PR DESCRIPTION
### Context

- Ticket: CST-1360

We need an admin page to enable Admins to assign Mentors to mentor in other schools.

### Changes proposed in this pull request
- Add a button in the Admin -> Participants -> Schools page to add the mentor to another school
- Add a new page asking for the school urn of the new school
- Add a form obj to validate
  - the form input
  - the school urn corresponds to an existing school
  - the mentor is not already mentoring in the school

The form obj uses the `Mentor::AddToSchool` service obj to add the mentor to the school's mentor pool.

### Guidance to review
1. go to the admin pages
2. pick a mentor
3. click to school tab
4. click the `add to a school mentor pool` button
5. type in a urn from an new school and submit the form or

To see the validation errors:  Follow steps 1-4 from above and in step 5 type in incorrect urns or urns from schools the mentor is already mentoring.
