### PR TITLE
Fix Invalid pagination error

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -13,6 +13,7 @@ module Api
     rescue_from ActiveRecord::RecordInvalid, with: :invalid_transition
     rescue_from Api::Errors::InvalidTransitionError, with: :invalid_transition
     rescue_from Api::Errors::InvalidDatetimeError, with: :invalid_updated_since_response
+    rescue_from Pagy::VariableError, with: :invalid_pagination_response
 
     def append_info_to_payload(payload)
       super
@@ -53,6 +54,10 @@ module Api
 
     def invalid_updated_since_response(exception)
       render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
+    end
+
+    def invalid_pagination_response(_exception)
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: I18n.t(:invalid_page_parameters)).call }, status: :bad_request
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   bad_request: "Bad request"
   bad_parameter: "Bad parameter"
   invalid_transition: "Invalid action"
+  invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid number (equal and more than 1)"
   cannot_change_cohort: "The property '#/cohort' cannot be changed"
   invalid_participant: "The property '#/participant_id' must be a valid Participant ID"
   invalid_identifier: "The property '#/course_identifier' must be an available course to '#/participant_id'"

--- a/spec/controllers/concerns/api_pagination_spec.rb
+++ b/spec/controllers/concerns/api_pagination_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestsController < Api::ApiController
+  include ApiPagination
+end
+
+class Test < ApplicationRecord; end
+
+describe "ApiPagination", type: :controller do
+  before do
+    routes.append do
+      get "index" => "tests#index"
+    end
+  end
+
+  describe "pagination" do
+    let!(:first_school)  { create(:school) }
+    let!(:second_school) { create(:school) }
+    controller TestsController do
+      def index
+        render json: { data: paginate(School.order(created_at: :asc)) }
+      end
+    end
+
+    it "returns the correct items per page" do
+      params = { page: { per_page: 1, page: 1 } }
+      get("index", params:)
+      get_response = JSON.parse(response.body)
+
+      expect(get_response["data"].size).to eq(1)
+      expect(get_response["data"].first["id"]).to eq(first_school.id)
+    end
+
+    it "returns the correct items according to page number" do
+      params = { page: { per_page: 1, page: 2 } }
+      get("index", params:)
+      get_response = JSON.parse(response.body)
+
+      expect(get_response["data"].size).to eq(1)
+      expect(get_response["data"].first["id"]).to eq(second_school.id)
+    end
+
+    it "returns an error with invalid page params" do
+      params = { page: { per_page: 1, page: "pageNum" } }
+      get("index", params:)
+
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns an error with invalid per page params" do
+      params = { page: { per_page: "pageNum", page: 1 } }
+      get("index", params:)
+
+      expect(response).not_to be_successful
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We accept pagination params in the API: `page[page]=1&page[per_page]100`
If an empty value is raised or an invalid value (a string "pageNum" as seen in this [error](https://dfe-teacher-services.sentry.io/issues/4010440797/?referrer=slack)) this is set to zero using `to_i` [here](https://github.com/DFE-Digital/early-careers-framework/blob/main/app/controllers/concerns/api_pagination.rb#L31) and then passed on to set pagination which raises an error: 

```
expected :page >= 1; got 0
```

- Ticket: n/a

To resolve this I was in two minds, either we return page 1 if anyone sets the wrong values using: `[params.dig(:page, :page).to_i, 1].max` or catch this  error and return 422  with an appropriate message

### Changes proposed in this pull request

Return bad request when wrong pagination param errors raised, error message has been approved by Hazel. This matches behaviour for updated_since param validation

### Guidance to review
