### PR TITLE
Send impersonator back to starting point when done impersonating

### DIFF
--- a/app/controllers/admin/impersonates_controller.rb
+++ b/app/controllers/admin/impersonates_controller.rb
@@ -11,13 +11,13 @@ module Admin
 
     def create
       impersonate_user(@user)
-
+      store_location_for(:impersonation_start, request.referer)
       redirect_to after_sign_in_path_for(@user)
     end
 
     def destroy
       stop_impersonating_user
-      redirect_to after_sign_in_path_for(current_user)
+      redirect_to stored_location_for(:impersonation_start)
     end
 
   private
@@ -29,14 +29,14 @@ module Admin
     def check_self_impersonation
       if params[:impersonated_user_id] == current_user.id.to_s
         flash[:warning] = "You cannot impersonate yourself"
-        redirect_to(after_sign_in_path_for(current_user))
+        redirect_to URI(request.referer).path
       end
     end
 
     def check_admin_user_impersonation
       if @user.admin?
         flash[:warning] = "You cannot impersonate another admin user"
-        redirect_to(after_sign_in_path_for(current_user))
+        redirect_to URI(request.referer).path
       end
     end
 

--- a/spec/cypress/integration/admin/SchoolManagment.feature
+++ b/spec/cypress/integration/admin/SchoolManagment.feature
@@ -51,4 +51,4 @@ Feature: Admin user managing schools
     Then "notification banner" should contain "You are impersonating Sarah Smith"
     And "notification banner" should contain "Stop impersonating"
     When I click on "stop impersonating button"
-    Then I should be on "admin schools" page
+    Then I should be on "admin school overview" page

--- a/spec/requests/admin/impersonates_spec.rb
+++ b/spec/requests/admin/impersonates_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Admin::Participants", type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:other_admin_user) { create(:user, :admin) }
   let!(:cohort) { create(:cohort, :current) }
-  let!(:user) { create(:user, :induction_coordinator) }
+  let!(:induction_coordinator) { create(:user, :induction_coordinator) }
 
   before do
     sign_in admin_user
@@ -14,54 +14,51 @@ RSpec.describe "Admin::Participants", type: :request do
 
   describe "POST /admin/impersonate" do
     it "sets impersonation session" do
-      when_i_impersonate(user)
-      expect(session[:impersonated_user_id]).to eql(user.id.to_s)
+      when_i_impersonate(induction_coordinator)
+      expect(session[:impersonated_user_id]).to eql(induction_coordinator.id.to_s)
     end
 
     it "redirects to impersonated user start page" do
-      when_i_impersonate(user)
+      when_i_impersonate(induction_coordinator)
       follow_redirect!
-      expect(response).to redirect_to(schools_choose_programme_path(user.school, cohort.start_year))
+      expect(response).to redirect_to(schools_choose_programme_path(induction_coordinator.school, cohort.start_year))
     end
 
     it "errors if you impersonate yourself" do
       when_i_impersonate(admin_user)
-      follow_redirect!
-      expect(response).to redirect_to "/admin/schools"
+      expect(response).to redirect_to(admin_school_path(induction_coordinator.school))
       expect(flash[:warning]).to eql("You cannot impersonate yourself")
     end
 
     it "errors if you impersonate an admin" do
       when_i_impersonate(other_admin_user)
-      follow_redirect!
-      expect(response).to redirect_to "/admin/schools"
+      expect(response).to redirect_to(admin_school_path(induction_coordinator.school))
       expect(flash[:warning]).to eql("You cannot impersonate another admin user")
     end
   end
 
   describe "DELETE /admin/impersonate" do
     before do
-      when_i_impersonate(user)
+      when_i_impersonate(induction_coordinator)
     end
 
     it "clears impersonation session" do
-      when_i_stop_impersonating(user)
+      when_i_stop_impersonating(induction_coordinator)
       expect(session[:impersonated_user_id]).to be_blank
     end
 
-    it "redirects to support user start page" do
-      when_i_stop_impersonating(user)
-      follow_redirect!
-      expect(response).to redirect_to("/admin/schools")
+    it "redirects to impersonation starting point" do
+      when_i_stop_impersonating(induction_coordinator)
+      expect(response).to redirect_to(admin_school_path(induction_coordinator.school))
     end
   end
 
 private
 
   def when_i_impersonate(user)
-    post "/admin/impersonate", params: {
-      impersonated_user_id: user&.id,
-    }
+    post "/admin/impersonate",
+         params: { impersonated_user_id: user&.id },
+         headers: { "HTTP_REFERER" => admin_school_path(induction_coordinator.school) }
   end
 
   def when_i_stop_impersonating(user)


### PR DESCRIPTION
### Current issue

When impersonating an induction tutor, clicking "stop impersonating" takes the impersonator back to the original home page rather than to the admin view of the impersonated user's school.

## Fix

When the admin user begins impersonating, we store the impersonation start location. When ending the impersonation, the admin user is sent back to the stored impersonation start location.

- Ticket: https://trello.com/c/r7QYqHjS/9-sit-impersonation