### PR TITLE
Shift NPQ default schedules to match new NPQ registration opening

### DIFF
--- a/app/models/finance/schedule/npq_leadership.rb
+++ b/app/models/finance/schedule/npq_leadership.rb
@@ -33,14 +33,14 @@ module Finance
       end
 
       def self.spring_schedule?(date)
-        # Between: Dec 26 to Apr 15
-        (Date.new(date.year, 1, 1)..Date.new(date.year, 4, 15)).include?(date) ||
+        # Between: Dec 26 to Apr 2
+        (Date.new(date.year, 1, 1)..Date.new(date.year, 4, 2)).include?(date) ||
           (Date.new(date.year, 12, 26)..Date.new(date.year, 12, 31)).include?(date)
       end
 
       def self.autumn_schedule?(date)
-        # Between: Apr 16 to Dec 25
-        (Date.new(date.year, 4, 16)..Date.new(date.year, 12, 25)).include?(date)
+        # Between: Apr 3 to Dec 25
+        (Date.new(date.year, 4, 3)..Date.new(date.year, 12, 25)).include?(date)
       end
     end
   end

--- a/app/models/finance/schedule/npq_specialist.rb
+++ b/app/models/finance/schedule/npq_specialist.rb
@@ -33,14 +33,14 @@ module Finance
       end
 
       def self.spring_schedule?(date)
-        # Between: Dec 26 to Apr 15
-        (Date.new(date.year, 1, 1)..Date.new(date.year, 4, 15)).include?(date) ||
+        # Between: Dec 26 to Apr 2
+        (Date.new(date.year, 1, 1)..Date.new(date.year, 4, 2)).include?(date) ||
           (Date.new(date.year, 12, 26)..Date.new(date.year, 12, 31)).include?(date)
       end
 
       def self.autumn_schedule?(date)
-        # Between: Apr 16 to Dec 25
-        (Date.new(date.year, 4, 16)..Date.new(date.year, 12, 25)).include?(date)
+        # Between: Apr 3 to Dec 25
+        (Date.new(date.year, 4, 3)..Date.new(date.year, 12, 25)).include?(date)
       end
     end
   end

--- a/spec/models/finance/schedule/npq_leadership_spec.rb
+++ b/spec/models/finance/schedule/npq_leadership_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Finance::Schedule::NPQLeadership, type: :model do
       it "returns NPQ Leadership Autumn schedule" do
         expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-leadership-autumn")
 
-        travel_to Date.new(cohort_start_year + 1, 4, 16) do
+        travel_to Date.new(cohort_start_year + 1, 4, 3) do
           expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
         end
       end
@@ -77,17 +77,17 @@ RSpec.describe Finance::Schedule::NPQLeadership, type: :model do
   end
 
   describe ".spring_schedule?" do
-    it "returns true when date between Dec 26 to Apr 15" do
+    it "returns true when date between Dec 26 to Apr 2" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-12-26".to_date)..("#{year + 1}-04-15".to_date)).each do |date|
+        (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(described_class.spring_schedule?(date)).to be(true)
         end
       end
     end
 
-    it "returns false when date between Apr 16 to Dec 25" do
+    it "returns false when date between Apr 3 to Dec 25" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-04-16".to_date)..("#{year}-12-25".to_date)).each do |date|
+        (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(described_class.spring_schedule?(date)).to be(false)
         end
       end
@@ -95,17 +95,17 @@ RSpec.describe Finance::Schedule::NPQLeadership, type: :model do
   end
 
   describe ".autumn_schedule?" do
-    it "returns true when date between Apr 16 to Dec 25" do
+    it "returns true when date between Apr 3 to Dec 25" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-04-16".to_date)..("#{year}-12-25".to_date)).each do |date|
+        (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(described_class.autumn_schedule?(date)).to be(true)
         end
       end
     end
 
-    it "returns false when date between Dec 26 to Apr 15" do
+    it "returns false when date between Dec 26 to Apr 2" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-12-26".to_date)..("#{year + 1}-04-15".to_date)).each do |date|
+        (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(described_class.autumn_schedule?(date)).to be(false)
         end
       end

--- a/spec/models/finance/schedule/npq_specialist_spec.rb
+++ b/spec/models/finance/schedule/npq_specialist_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Finance::Schedule::NPQSpecialist, type: :model do
       it "returns NPQ Specialist Autumn schedule" do
         expected_schedule = described_class.find_by(cohort:, schedule_identifier: "npq-specialist-autumn")
 
-        travel_to Date.new(cohort_start_year + 1, 4, 16) do
+        travel_to Date.new(cohort_start_year + 1, 4, 3) do
           expect(described_class.schedule_for(cohort:)).to eq(expected_schedule)
         end
       end
@@ -77,17 +77,17 @@ RSpec.describe Finance::Schedule::NPQSpecialist, type: :model do
   end
 
   describe ".spring_schedule?" do
-    it "returns true when date between Dec 26 to Apr 15" do
+    it "returns true when date between Dec 26 to Apr 2" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-12-26".to_date)..("#{year + 1}-04-15".to_date)).each do |date|
+        (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(described_class.spring_schedule?(date)).to be(true)
         end
       end
     end
 
-    it "returns false when date between Apr 16 to Dec 25" do
+    it "returns false when date between Apr 3 to Dec 25" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-04-16".to_date)..("#{year}-12-25".to_date)).each do |date|
+        (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(described_class.spring_schedule?(date)).to be(false)
         end
       end
@@ -95,17 +95,17 @@ RSpec.describe Finance::Schedule::NPQSpecialist, type: :model do
   end
 
   describe ".autumn_schedule?" do
-    it "returns true when date between Apr 16 to Dec 25" do
+    it "returns true when date between Apr 3 to Dec 25" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-04-16".to_date)..("#{year}-12-25".to_date)).each do |date|
+        (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(described_class.autumn_schedule?(date)).to be(true)
         end
       end
     end
 
-    it "returns false when date between Dec 26 to Apr 15" do
+    it "returns false when date between Dec 26 to Apr 2" do
       (2.years.ago.year..Date.current.year).each do |year|
-        (("#{year}-12-26".to_date)..("#{year + 1}-04-15".to_date)).each do |date|
+        (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(described_class.autumn_schedule?(date)).to be(false)
         end
       end


### PR DESCRIPTION
### Context
NPQ registration is opening on 3/4/2023, we need to ensure candidates are on the Autumn schedule

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2124

### Changes proposed in this pull request

Amend both NPQ leadership and Specialist schedules to shift to Autumn earlier:

Given today’s date is betweeen 1 June 2022 and 25 December 2022, then the schedule will be npq-specialist-autumn or npq-leadership-autumn
Given today’s date is betweeen 26 December 2022 and 2 April 2023, then the schedule will be npq-specialist-spring or npq-leadership-spring
Given today’s date is between 3 April 2023 and 25 December 2023, then the schedule will be npq-specialist-autumn or npq-leadership-autumn
Given today’s date is betweeen 25 December 2023 ad 15 April 2024, then the schedule will be npq-specialist-spring or npq-leadership-spring


### Guidance to review
Did I miss anything?
