### PR TITLE
Add fallback for participant identity resolver

### DIFF
--- a/app/services/participant_identity_resolver.rb
+++ b/app/services/participant_identity_resolver.rb
@@ -14,26 +14,29 @@ class ParticipantIdentityResolver
   def call
     return if participant_id.blank?
 
-    if ParticipantProfile::ECT::COURSE_IDENTIFIERS.include?(course_identifier)
-      ParticipantIdentity
-        .joins(:participant_profiles)
-        .where(participant_profiles: { type: "ParticipantProfile::ECT" })
-        .where(user_id: participant_id)
-        .first
-    elsif ParticipantProfile::Mentor::COURSE_IDENTIFIERS.include?(course_identifier)
-      ParticipantIdentity
-        .joins(:participant_profiles)
-        .where(participant_profiles: { type: "ParticipantProfile::Mentor" })
-        .where(user_id: participant_id)
-        .first
-    elsif NPQCourse.identifiers.include?(course_identifier)
-      ParticipantIdentity
-        .joins(:npq_participant_profiles, npq_applications: [:npq_course, { npq_lead_provider: :cpd_lead_provider }])
-        .where(npq_courses: { identifier: course_identifier })
-        .where(npq_applications: { npq_lead_providers: { cpd_lead_provider: } })
-        .where(user_id: participant_id)
-        .first
-    end
+    participant_identity =
+      if ParticipantProfile::ECT::COURSE_IDENTIFIERS.include?(course_identifier)
+        ParticipantIdentity
+         .joins(:participant_profiles)
+         .where(participant_profiles: { type: "ParticipantProfile::ECT" })
+         .where(user_id: participant_id)
+         .first
+      elsif ParticipantProfile::Mentor::COURSE_IDENTIFIERS.include?(course_identifier)
+        ParticipantIdentity
+         .joins(:participant_profiles)
+         .where(participant_profiles: { type: "ParticipantProfile::Mentor" })
+         .where(user_id: participant_id)
+         .first
+      elsif NPQCourse.identifiers.include?(course_identifier)
+        ParticipantIdentity
+         .joins(:npq_participant_profiles, npq_applications: [:npq_course, { npq_lead_provider: :cpd_lead_provider }])
+         .where(npq_courses: { identifier: course_identifier })
+         .where(npq_applications: { npq_lead_providers: { cpd_lead_provider: } })
+         .where(user_id: participant_id)
+         .first
+      end
+
+    participant_identity.presence || ParticipantIdentity.find_by(external_identifier: participant_id)
   end
 
 private

--- a/spec/services/defer_participant_spec.rb
+++ b/spec/services/defer_participant_spec.rb
@@ -72,18 +72,6 @@ RSpec.shared_examples "validating deferring a participant attributes" do
       expect(service.errors.messages_for(:participant_id)).to include("The property '#/participant_id' must be a valid Participant ID")
     end
   end
-
-  context "when the participant has a different user ID to external ID" do
-    let(:participant_identity) { create(:participant_identity, :secondary) }
-
-    before { participant_profile.update!(participant_identity:) }
-
-    it "is invalid and returns an error message" do
-      is_expected.to be_invalid
-
-      expect(service.errors.messages_for(:participant_id)).to include("The property '#/participant_id' must be a valid Participant ID")
-    end
-  end
 end
 
 RSpec.shared_examples "validating a participant is not already deferred" do
@@ -119,6 +107,16 @@ RSpec.shared_examples "deferring a participant" do
 
   it "marks the participant profiles as deferred" do
     expect { service.call }.to change { participant_profile.reload.training_status }.from("active").to("deferred")
+  end
+
+  context "when the participant has a different user ID to external ID" do
+    let(:participant_identity) { create(:participant_identity, :secondary) }
+
+    before { participant_profile.update!(participant_identity:) }
+
+    it "marks the participant profiles as deferred" do
+      expect { service.call }.to change { participant_profile.reload.training_status }.from("active").to("deferred")
+    end
   end
 end
 

--- a/spec/services/participant_identity_resolver_spec.rb
+++ b/spec/services/participant_identity_resolver_spec.rb
@@ -94,5 +94,17 @@ RSpec.describe ParticipantIdentityResolver, :with_default_schedules, :with_suppo
         expect(result).to eql(participant_identity)
       end
     end
+
+    context "when participant external identifier does not equal user id" do
+      let(:ect_profile) { create(:ect, lead_provider:, user:) }
+      let!(:participant_identity) { create(:participant_identity, :secondary, user:) }
+      let(:participant_id) { participant_identity.external_identifier }
+
+      it "correctly selects ect participant identity" do
+        result = subject.call
+
+        expect(result).to eql(participant_identity)
+      end
+    end
   end
 end

--- a/spec/services/record_declaration_spec.rb
+++ b/spec/services/record_declaration_spec.rb
@@ -225,13 +225,8 @@ RSpec.shared_examples "creates participant declaration attempt" do
 
     before { participant_profile.update!(participant_identity:) }
 
-    it "has a meaningful error", :aggregate_failures do
-      expect(service).to be_invalid
-      expect(service.errors.messages_for(:participant_id)).to eq(["The property '#/participant_id' must be a valid Participant ID"])
-    end
-
-    it "does not create the relevant participant declaration" do
-      expect { subject.call }.not_to change(ParticipantDeclarationAttempt, :count)
+    it "creates the relevant participant declaration" do
+      expect { subject.call }.to change(ParticipantDeclarationAttempt, :count).by(1)
     end
   end
 

--- a/spec/services/resume_participant_spec.rb
+++ b/spec/services/resume_participant_spec.rb
@@ -52,18 +52,6 @@ RSpec.shared_examples "validating resuming a participant attributes" do
       expect(service.errors.messages_for(:participant_id)).to include("The property '#/participant_id' must be a valid Participant ID")
     end
   end
-
-  context "when the participant has a different user ID to external ID" do
-    let(:participant_identity) { create(:participant_identity, :secondary) }
-
-    before { participant_profile.update!(participant_identity:) }
-
-    it "is invalid and returns an error message" do
-      is_expected.to be_invalid
-
-      expect(service.errors.messages_for(:participant_id)).to include("The property '#/participant_id' must be a valid Participant ID")
-    end
-  end
 end
 
 RSpec.shared_examples "validating a participant is not already active" do
@@ -98,6 +86,16 @@ RSpec.shared_examples "resuming a participant" do
 
   it "marks the participant profiles as active" do
     expect { service.call }.to change { participant_profile.reload.training_status }.from("deferred").to("active")
+  end
+
+  context "when the participant has a different user ID to external ID" do
+    let(:participant_identity) { create(:participant_identity, :secondary) }
+
+    before { participant_profile.update!(participant_identity:) }
+
+    it "marks the participant profiles as active" do
+      expect { service.call }.to change { participant_profile.reload.training_status }.from("deferred").to("active")
+    end
   end
 end
 

--- a/spec/services/withdraw_participant_spec.rb
+++ b/spec/services/withdraw_participant_spec.rb
@@ -72,18 +72,6 @@ RSpec.shared_examples "validating a participant to be withdrawn" do
       expect(service.errors.messages_for(:participant_id)).to include("The property '#/participant_id' must be a valid Participant ID")
     end
   end
-
-  context "when the participant has a different user ID to external ID" do
-    let(:participant_identity) { create(:participant_identity, :secondary) }
-
-    before { participant_profile.update!(participant_identity:) }
-
-    it "is invalid and returns an error message" do
-      is_expected.to be_invalid
-
-      expect(service.errors.messages_for(:participant_id)).to include("The property '#/participant_id' must be a valid Participant ID")
-    end
-  end
 end
 
 RSpec.shared_examples "validating a participant is not already withdrawn for a withdraw" do
@@ -111,6 +99,16 @@ RSpec.shared_examples "withdrawing a participant" do
 
   it "marks the participant profile as withdrawn" do
     expect { service.call }.to change { participant_profile.reload.training_status }.from("active").to("withdrawn")
+  end
+
+  context "when the participant has a different user ID to external ID" do
+    let(:participant_identity) { create(:participant_identity, :secondary) }
+
+    before { participant_profile.update!(participant_identity:) }
+
+    it "marks the participant profile as withdrawn" do
+      expect { service.call }.to change { participant_profile.reload.training_status }.from("active").to("withdrawn")
+    end
   end
 end
 


### PR DESCRIPTION
### Context

Some providers could not update their ids in time, add a fallback to allow them to submit their declarations in time

- Ticket: n/a

### Changes proposed in this pull request

Fallback to participant identity, where we use external identifier to find the participant id. We're not amending all endpoints for the fallback, mainly the action endpoints.

### Guidance to review
Did I miss anything
