### PR TITLE
Show school's appropriate body in admin interface

### DIFF
--- a/app/components/admin/schools/cohorts/cip_info.html.erb
+++ b/app/components/admin/schools/cohorts/cip_info.html.erb
@@ -26,6 +26,14 @@
       <span class="govuk-visually-hidden"> training materials</span>
     </dd>
   </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Appropriate body
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= school_cohort&.appropriate_body&.name %>
+    </dd>
+  </div>
 
   <%= content %>
 </dl>

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -32,6 +32,14 @@
     </dd>
     <dd class="govuk-summary-list__actions"></dd>
   </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Appropriate body
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= school_cohort&.appropriate_body&.name %>
+    </dd>
+  </div>
 
   <%= content %>
 </dl>

--- a/app/components/admin/schools/cohorts/other_info.html.erb
+++ b/app/components/admin/schools/cohorts/other_info.html.erb
@@ -12,5 +12,14 @@
     </dd>
   </div>
 
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Appropriate body
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= school_cohort&.appropriate_body&.name %>
+    </dd>
+  </div>
+
   <%= content %>
 </dl>

--- a/spec/components/admin/schools/cohorts/cohort_spec.rb
+++ b/spec/components/admin/schools/cohorts/cohort_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Admin::Schools::Cohorts::Cohort, type: :component do
   end
 
   context "with school cohort that is neither CIP nor FIP" do
-    let(:school_cohort) { instance_double(SchoolCohort, induction_programme_choice: Faker::Lorem.words.join("_")) }
+    let(:school_cohort) { instance_double(SchoolCohort, induction_programme_choice: Faker::Lorem.words.join("_"), appropriate_body: build(:seed_appropriate_body)) }
 
     before { render_inline(component) }
 

--- a/spec/components/admin/schools/cohorts/other_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/other_info_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Admin::Schools::Cohorts::OtherInfo, type: :component do
   let(:cohort) { instance_double Cohort, start_year: rand(2020..2030) }
   let(:school) { instance_double School, slug: "xyz" }
-  let(:school_cohort) { instance_double(SchoolCohort, induction_programme_choice: Faker::Lorem.words.join("_")) if rand < 0.5 }
+  let(:school_cohort) { FactoryBot.build(:seed_school_cohort) }
 
   before { render_inline(described_class.new(cohort:, school_cohort:, school:)) }
 
@@ -36,7 +36,7 @@ RSpec.describe Admin::Schools::Cohorts::OtherInfo, type: :component do
   end
 
   context "with school cohort of unknown type" do
-    let(:school_cohort) { instance_double SchoolCohort, induction_programme_choice: Faker::Lorem.words.join("_") }
+    let(:school_cohort) { instance_double SchoolCohort, induction_programme_choice: Faker::Lorem.words.join("_"), appropriate_body: FactoryBot.build(:seed_appropriate_body) }
 
     it { is_expected.to have_content "Not using service" }
   end


### PR DESCRIPTION
### Context

The AB is now displayed per cohort on the cohorts index page.

![image](https://user-images.githubusercontent.com/128088/229172945-6be4b4e0-7063-4023-af00-50ace575cd00.png)
