### PR TITLE
[CPDLP-2106] Improve NPQ participant seeds

### DIFF
--- a/config/seed_quantities.yml
+++ b/config/seed_quantities.yml
@@ -23,6 +23,7 @@ default: &default
   fip_to_fip_transfers_keeping_original_provider: 2
   fip_to_fip_transfers_changing_provider: 2
   school_invitations: 10
+  npq_applications_eligible_for_transfer: 10
 
 development:
   <<: *default
@@ -39,6 +40,7 @@ test:
   npq_applications_pending_aso: 1
   npq_applications_pending_ehco: 1
   school_invitations: 1
+  npq_applications_eligible_for_transfer: 1
 
 deployed_development:
   <<: *default

--- a/config/seed_quantities.yml
+++ b/config/seed_quantities.yml
@@ -7,8 +7,10 @@
 # SEED_NPQ_APPLICATIONS_PENDING=10
 # SEED_NPQ_APPLICATION_WITH_DECLARATIONS=10
 # SEED_NPQ_APPLICATIONS_REJECTED=10
-# SEED_NPQ_APPLICATIONS_PENDING_ASO=10
-# SEED_NPQ_APPLICATIONS_PENDING_ECHO=10
+# SEED_NPQ_APPLICATIONS_ASO=10
+# SEED_NPQ_APPLICATIONS_EHCO=10
+# SEED_NPQ_APPLICATIONS_SPECIALIST=10
+# SEED_NPQ_APPLICATIONS_LEADERSHIP=10
 # SEED_FIP_TO_FIP_TRANSFERS_KEEPING_ORIGINAL_PROVIDER=2
 # SEED_FIP_TO_FIP_TRANSFERS_CHANGING_PROVIDER=2
 # SEED_SCHOOL_INVITATIONS=10
@@ -18,12 +20,15 @@ default: &default
   npq_applications_pending: 10
   npq_application_with_declarations: 10
   npq_applications_rejected: 10
-  npq_applications_pending_aso: 10
-  npq_applications_pending_ehco: 10
+  npq_applications_aso: 10
+  npq_applications_ehco: 10
+  npq_applications_specialist: 10
+  npq_applications_leadership: 10
   fip_to_fip_transfers_keeping_original_provider: 2
   fip_to_fip_transfers_changing_provider: 2
   school_invitations: 10
   npq_applications_eligible_for_transfer: 10
+  npq_applications_edge_cases: 25
 
 development:
   <<: *default
@@ -37,10 +42,13 @@ test:
   npq_applications_pending: 1
   npq_application_with_declarations: 1
   npq_applications_rejected: 1
-  npq_applications_pending_aso: 1
-  npq_applications_pending_ehco: 1
+  npq_applications_aso: 1
+  npq_applications_ehco: 1
+  npq_applications_specialist: 1
+  npq_applications_leadership: 1
   school_invitations: 1
   npq_applications_eligible_for_transfer: 1
+  npq_applications_edge_cases: 1
 
 deployed_development:
   <<: *default

--- a/db/new_seeds/base/add_npq_registrations.rb
+++ b/db/new_seeds/base/add_npq_registrations.rb
@@ -1,143 +1,107 @@
 # frozen_string_literal: true
 
 npq_lead_providers = NPQLeadProvider.all
-cohort_2022 = Cohort.find_by(start_year: 2022)
-cohort_2023 = Cohort.find_by(start_year: 2023)
+[Cohort.previous, Cohort.current, Cohort.next].map do |cohort|
+  # Create pending NPQ applications
+  seed_quantity(:npq_applications_pending).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        cohort:,
+      )
+      .build
+  end
 
-# Create pending NPQ applications
-seed_quantity(:npq_applications_pending).times do
-  NewSeeds::Scenarios::NPQ
-    .new(lead_provider: npq_lead_providers.sample)
-    .build
-end
+  # Create accepted NPQ applications with participant profiles
+  # and a declaration
+  seed_quantity(:npq_application_with_declarations).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        cohort:,
+      )
+      .build
+      .accept_application
+      .add_declaration
+  end
 
-# Create accepted NPQ applications with participant profiles
-# and a declaration
-seed_quantity(:npq_application_with_declarations).times do
-  NewSeeds::Scenarios::NPQ
-    .new(lead_provider: npq_lead_providers.sample)
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
+  # Create rejected NPQ applications
+  seed_quantity(:npq_applications_rejected).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        cohort:,
+      )
+      .build
+      .reject_application
+  end
 
-# Create rejected NPQ applications
-seed_quantity(:npq_applications_rejected).times do
-  NewSeeds::Scenarios::NPQ
-    .new(lead_provider: npq_lead_providers.sample)
-    .build
-    .reject_application
-end
+  # Create pending NPQ applications to ASO NPQ course
+  seed_quantity(:npq_applications_aso).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        npq_course: NPQCourse.find_by(identifier: "npq-additional-support-offer"),
+        cohort:,
+      )
+      .build
+  end
 
-# Create pending NPQ applications to ASO NPQ course
-seed_quantity(:npq_applications_pending_aso).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: "npq-additional-support-offer"),
-    )
-    .build
-end
+  # Create pending NPQ applications to EHCO NPQ course
+  seed_quantity(:npq_applications_ehco).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        npq_course: NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer"),
+        cohort:,
+      )
+      .build
+  end
 
-# Create pending NPQ applications to EHCO NPQ course
-seed_quantity(:npq_applications_pending_ehco).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer"),
-    )
-    .build
-end
+  # Create NPQLeadership applications with participant profile and declaration
+  seed_quantity(:npq_applications_leadership).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQLeadership::IDENTIFIERS.sample),
+        cohort:,
+      )
+      .build
+      .accept_application
+  end
 
-# Create NPQLeadership applications with participant profile and declaration for cohort 2022
-seed_quantity(:npq_applications_eligible_for_transfer).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQLeadership::IDENTIFIERS.sample),
-      cohort: cohort_2022,
-    )
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
+  # Create NPQSpecialist applications with participant profile and declaration
+  seed_quantity(:npq_applications_specialist).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample),
+        cohort:,
+      )
+      .build
+      .accept_application
+  end
 
-# Create NPQSpecialist applications with participant profile and declaration for cohort 2022
-seed_quantity(:npq_applications_eligible_for_transfer).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample),
-      cohort: cohort_2022,
-    )
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
+  # Create NPQEhco applications with participant profile and declaration
+  seed_quantity(:npq_applications_ehco).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQEhco::IDENTIFIERS.sample),
+        cohort:,
+      )
+      .build
+      .accept_application
+  end
 
-# Create NPQEhco applications with participant profile and declaration for cohort 2022
-seed_quantity(:npq_applications_eligible_for_transfer).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQEhco::IDENTIFIERS.sample),
-      cohort: cohort_2022,
-    )
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
-
-# Create NPQLeadership applications with participant profile and declaration for cohort 2023
-seed_quantity(:npq_applications_eligible_for_transfer).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQLeadership::IDENTIFIERS.sample),
-      cohort: cohort_2023,
-    )
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
-
-# Create NPQSpecialist applications with participant profile and declaration for cohort 2023
-seed_quantity(:npq_applications_eligible_for_transfer).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample),
-      cohort: cohort_2023,
-    )
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
-
-# Create NPQEhco applications with participant profile and declaration for cohort 2023
-seed_quantity(:npq_applications_eligible_for_transfer).times do
-  NewSeeds::Scenarios::NPQ
-    .new(
-      lead_provider: npq_lead_providers.sample,
-      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQEhco::IDENTIFIERS.sample),
-      cohort: cohort_2023,
-    )
-    .build
-    .accept_application
-    .add_declaration
-    .add_statement_line_items
-end
-
-# Create edge case NPQ applications
-25.times do
-  NewSeeds::Scenarios::NPQ
-    .new(lead_provider: npq_lead_providers.sample)
-    .build
-    .edge_cases
+  # Create edge case NPQ applications
+  seed_quantity(:npq_applications_edge_cases).times do
+    NewSeeds::Scenarios::NPQ
+      .new(
+        lead_provider: npq_lead_providers.sample,
+        cohort:,
+      )
+      .build
+      .edge_cases
+  end
 end

--- a/db/new_seeds/base/add_npq_registrations.rb
+++ b/db/new_seeds/base/add_npq_registrations.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 npq_lead_providers = NPQLeadProvider.all
+cohort_2022 = Cohort.find_by(start_year: 2022)
+cohort_2023 = Cohort.find_by(start_year: 2023)
 
 # Create pending NPQ applications
 seed_quantity(:npq_applications_pending).times do
@@ -17,6 +19,7 @@ seed_quantity(:npq_application_with_declarations).times do
     .build
     .accept_application
     .add_declaration
+    .add_statement_line_items
 end
 
 # Create rejected NPQ applications
@@ -45,6 +48,90 @@ seed_quantity(:npq_applications_pending_ehco).times do
       npq_course: NPQCourse.find_by(identifier: "npq-early-headship-coaching-offer"),
     )
     .build
+end
+
+# Create NPQLeadership applications with participant profile and declaration for cohort 2022
+seed_quantity(:npq_applications_eligible_for_transfer).times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQLeadership::IDENTIFIERS.sample),
+      cohort: cohort_2022,
+    )
+    .build
+    .accept_application
+    .add_declaration
+    .add_statement_line_items
+end
+
+# Create NPQSpecialist applications with participant profile and declaration for cohort 2022
+seed_quantity(:npq_applications_eligible_for_transfer).times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample),
+      cohort: cohort_2022,
+    )
+    .build
+    .accept_application
+    .add_declaration
+    .add_statement_line_items
+end
+
+# Create NPQEhco applications with participant profile and declaration for cohort 2022
+seed_quantity(:npq_applications_eligible_for_transfer).times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQEhco::IDENTIFIERS.sample),
+      cohort: cohort_2022,
+    )
+    .build
+    .accept_application
+    .add_declaration
+    .add_statement_line_items
+end
+
+# Create NPQLeadership applications with participant profile and declaration for cohort 2023
+seed_quantity(:npq_applications_eligible_for_transfer).times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQLeadership::IDENTIFIERS.sample),
+      cohort: cohort_2023,
+    )
+    .build
+    .accept_application
+    .add_declaration
+    .add_statement_line_items
+end
+
+# Create NPQSpecialist applications with participant profile and declaration for cohort 2023
+seed_quantity(:npq_applications_eligible_for_transfer).times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample),
+      cohort: cohort_2023,
+    )
+    .build
+    .accept_application
+    .add_declaration
+    .add_statement_line_items
+end
+
+# Create NPQEhco applications with participant profile and declaration for cohort 2023
+seed_quantity(:npq_applications_eligible_for_transfer).times do
+  NewSeeds::Scenarios::NPQ
+    .new(
+      lead_provider: npq_lead_providers.sample,
+      npq_course: NPQCourse.find_by(identifier: Finance::Schedule::NPQEhco::IDENTIFIERS.sample),
+      cohort: cohort_2023,
+    )
+    .build
+    .accept_application
+    .add_declaration
+    .add_statement_line_items
 end
 
 # Create edge case NPQ applications

--- a/db/new_seeds/scenarios/npq.rb
+++ b/db/new_seeds/scenarios/npq.rb
@@ -3,28 +3,30 @@
 module NewSeeds
   module Scenarios
     class NPQ
-      attr_reader :user, :application, :participant_identity, :participant_profile, :npq_lead_provider, :npq_course
+      attr_reader :user, :application, :participant_identity, :npq_lead_provider, :npq_course, :cohort, :declaration
 
-      def initialize(user: nil, lead_provider: nil, npq_course: nil)
+      def initialize(user: nil, lead_provider: nil, npq_course: nil, cohort: nil)
         @supplied_user = user
         @supplied_lead_provider = lead_provider
         @supplied_npq_course = npq_course
+        @supplied_cohort = cohort
       end
 
       def build
         @user = @supplied_user || FactoryBot.create(:seed_user, :valid)
         @npq_lead_provider = @supplied_lead_provider || FactoryBot.create(:seed_npq_lead_provider, :valid)
         @npq_course = @supplied_npq_course || FactoryBot.create(:seed_npq_course, :valid)
+        @cohort = @supplied_cohort || Cohort.current || FactoryBot.create(:seed_cohort, :valid)
 
         @participant_identity = user&.participant_identities&.sample ||
           FactoryBot.create(:seed_participant_identity, user:)
 
         @application = FactoryBot.create(
-          :seed_npq_application,
-          :valid,
+          :npq_application,
           participant_identity:,
           npq_lead_provider:,
           npq_course:,
+          cohort:,
         )
 
         self
@@ -33,25 +35,26 @@ module NewSeeds
       def accept_application
         raise(StandardError, "no npq application, call #build first") if application.blank?
 
-        @participant_profile = FactoryBot.create(
-          :seed_npq_participant_profile,
-          user:,
-          participant_identity:,
-          npq_application: application,
-          npq_course: application.npq_course,
-          # it turns out that we don't find the NPQ application via the participant identity but
-          # instead by the `has_one` on participant profile. The id of the NPQ application needs
-          # to match the corresponding participant profile's id.
-          id: application.id,
-        )
-
-        application.update!(lead_provider_approval_status: "accepted")
+        ::NPQ::Application::Accept.new(npq_application: application).call
 
         self
       end
 
+      def participant_profile
+        @participant_profile ||=
+          ParticipantProfileResolver.call(
+            participant_identity:,
+            course_identifier: application.npq_course.identifier,
+            cpd_lead_provider: application.npq_lead_provider.cpd_lead_provider,
+          )
+      end
+
       def reject_application
-        application.update!(lead_provider_approval_status: "rejected")
+        raise(StandardError, "no npq application, call #build first") if application.blank?
+
+        ::NPQ::Application::Reject.new(npq_application: application)
+
+        self
       end
 
       def edge_cases
@@ -82,7 +85,7 @@ module NewSeeds
       def add_declaration
         raise(StandardError, "no participant_profile, call #accept_application first") if participant_profile.blank?
 
-        FactoryBot.create(
+        @declaration = FactoryBot.create(
           :seed_npq_participant_declaration,
           user:,
           participant_profile:,
@@ -90,7 +93,30 @@ module NewSeeds
           cpd_lead_provider: npq_lead_provider.cpd_lead_provider,
         )
 
+        return self if [true, false].sample
+
+        declaration.make_eligible!
+        return self if [true, false].sample
+
+        declaration.make_payable!
+        return self if [true, false].sample
+
+        declaration.make_paid!
+
         self
+      end
+
+      def add_statement_line_items
+        return self if declaration.submitted?
+
+        line_item = Finance::StatementLineItem.find_or_initialize_by(
+          participant_declaration: declaration,
+          statement: npq_lead_provider.statements.upto_current.where(cohort:).sample,
+        )
+
+        line_item.update!(
+          state: declaration.state,
+        )
       end
     end
   end

--- a/spec/factories/seeds/npq_application_factory.rb
+++ b/spec/factories/seeds/npq_application_factory.rb
@@ -44,6 +44,7 @@ FactoryBot.define do
 
     trait(:starting_in_2021) { cohort { create(:cohort, start_year: 2021) } }
     trait(:starting_in_2022) { cohort { create(:cohort, start_year: 2022) } }
+    trait(:starting_in_2023) { cohort { create(:cohort, start_year: 2023) } }
 
     trait(:valid) do
       with_participant_identity

--- a/spec/factories/seeds/participant_profile_state_factory.rb
+++ b/spec/factories/seeds/participant_profile_state_factory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_abstract_participant_profile_state, class: "ParticipantProfileState") do
+    factory(:seed_npq_participant_profile_state) do
+      trait(:with_participant_profile) do
+        association(:participant_profile, factory: %i[seed_npq_participant_profile valid])
+      end
+    end
+
+    factory(:seed_ect_participant_profile_state) do
+      trait(:with_participant_profile) do
+        association(:participant_profile, factory: %i[seed_ect_participant_profile valid])
+      end
+    end
+
+    state { "active" }
+
+    trait(:valid) do
+      with_participant_profile
+    end
+
+    after(:build) do
+      Rails.logger.debug("seeded participant profile state")
+    end
+  end
+end

--- a/spec/seeds/seed_factories/participant_profile_state_factory_spec.rb
+++ b/spec/seeds/seed_factories/participant_profile_state_factory_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "./shared_factory_examples"
+
+RSpec.describe("seed_ect_participant_profile_state, seed_npq_participant_profile_state") do
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_ect_participant_profile_state }
+    let(:factory_class) { ParticipantProfileState }
+  end
+
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_npq_participant_profile_state }
+    let(:factory_class) { ParticipantProfileState }
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2106](https://dfedigital.atlassian.net/browse/CPDLP-2106)

We currently have two sets of seeds:

Legacy seeds: used in tests and used to populate review apps before being deprecated

New seeds: populate review apps

The new seeds do not have as much data as the old seeds, where we are missing some key data.

In order for Tom/Shahad to test single endpoints and then whole journeys, also for us to later prep some seed data for providers on sandbox, we need to ensure that our seed data is adequate.

### Changes proposed in this pull request

"New seeds" checked for NPQ participants (npq application and profiles) and if they are adequate for testing our endpoints and journeys.




[CPDLP-2106]: https://dfedigital.atlassian.net/browse/CPDLP-2106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ