### PR TITLE
Use default NPQ schedule helper in specs

### DIFF
--- a/spec/features/finance/change_lead_provider_approval_status_spec.rb
+++ b/spec/features/finance/change_lead_provider_approval_status_spec.rb
@@ -2,9 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Finance users NPQ application change lead_provider_approval_status", type: :feature do
-  let!(:cohort) { create :cohort }
-  let!(:schedule) { create :npq_leadership_schedule, cohort: }
+RSpec.feature "Finance users NPQ application change lead_provider_approval_status", :with_default_schedules, type: :feature do
   let(:npq_course) { create :npq_course, identifier: "npq-senior-leadership" }
   let(:npq_lead_provider) { create :npq_lead_provider }
 
@@ -19,8 +17,7 @@ RSpec.feature "Finance users NPQ application change lead_provider_approval_statu
       create(
         :npq_application, :accepted,
         npq_lead_provider:,
-        npq_course:,
-        cohort:
+        npq_course:
       )
     end
     let!(:user) { npq_application.user }

--- a/spec/features/finance/npq/view_contract_spec.rb
+++ b/spec/features/finance/npq/view_contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "NPQ view contract" do
+RSpec.feature "NPQ view contract", :with_default_schedules do
   include FinanceHelper
 
   scenario "see the contract information for all courses of an NPQ lead provider" do

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NPQApplication, type: :model do
+RSpec.describe NPQApplication, :with_default_schedules, type: :model do
   it {
     is_expected.to define_enum_for(:headteacher_status).with_values(
       no: "no",

--- a/spec/models/npq_course_spec.rb
+++ b/spec/models/npq_course_spec.rb
@@ -8,29 +8,26 @@ RSpec.describe NPQCourse do
 
     context "when a course is one of NPQCourse::LEADERSHIP_IDENTIFIER" do
       let(:identifier) { Finance::Schedule::NPQLeadership::IDENTIFIERS.sample }
-      let!(:cohort_schedule) { create(:npq_leadership_schedule, cohort:) }
 
       it "returns the default NPQ leadership schedule" do
         expect(described_class.schedule_for(npq_course:, cohort:))
-          .to eq(Finance::Schedule::NPQLeadership.default_for(cohort:))
+          .to eq(Finance::Schedule::NPQLeadership.schedule_for(cohort:))
       end
 
       context "when requesting for next cohort" do
         let(:next_cohort) { Cohort.next || create(:cohort, :next) }
-        let!(:next_cohort_schedule) { create(:npq_leadership_schedule, cohort: next_cohort) }
 
         it "uses next cohort schedule" do
-          expect(described_class.schedule_for(npq_course:, cohort: next_cohort)).to eql(next_cohort_schedule)
+          expect(described_class.schedule_for(npq_course:, cohort: next_cohort)).to eql(Finance::Schedule::NPQLeadership.schedule_for(cohort: next_cohort))
         end
       end
     end
 
     context "when a course is one of NPQCourse::SPECIALIST_IDENTIFIER" do
       let(:identifier) { Finance::Schedule::NPQSpecialist::IDENTIFIERS.sample }
-      let!(:cohort_schedule) { create(:npq_specialist_schedule, cohort:) }
 
       it "returns the default NPQ specialist schedule" do
-        expect(described_class.schedule_for(npq_course:, cohort:)).to eq(Finance::Schedule::NPQSpecialist.default_for(cohort:))
+        expect(described_class.schedule_for(npq_course:, cohort:)).to eq(Finance::Schedule::NPQSpecialist.schedule_for(cohort:))
       end
     end
 
@@ -46,11 +43,9 @@ RSpec.describe NPQCourse do
       let(:identifier) { "npq-early-headship-coaching-offer" }
 
       it "returns the default NPQ EHCO schedule" do
-        expected_schedule = Finance::Schedule::NPQEhco.find_by(schedule_identifier: "npq-ehco-december")
+        expected_schedule = Finance::Schedule::NPQEhco.schedule_for(cohort:)
 
-        travel_to Date.new(Cohort.current.start_year, 12, 1) do
-          expect(described_class.schedule_for(npq_course:)).to eq(expected_schedule)
-        end
+        expect(described_class.schedule_for(npq_course:)).to eq(expected_schedule)
       end
     end
 

--- a/spec/serializers/api/v1/npq_participant_serializer_spec.rb
+++ b/spec/serializers/api/v1/npq_participant_serializer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Api
   module V1
-    RSpec.describe NPQParticipantSerializer do
+    RSpec.describe NPQParticipantSerializer, :with_default_schedules do
       describe "serialization" do
         let(:participant) { create(:user) }
 

--- a/spec/services/npq/application/accept_spec.rb
+++ b/spec/services/npq/application/accept_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe NPQ::Application::Accept, :with_default_schedules do
 
         profile = user.teacher_profile.npq_profiles.first
 
-        expect(profile.schedule).to eql(Finance::Schedule::NPQLeadership.default_for(cohort: cohort_2021))
+        expect(profile.schedule).to eql(Finance::Schedule::NPQLeadership.schedule_for(cohort: cohort_2021))
         expect(profile.npq_course).to eql(npq_application.npq_course)
         expect(profile.teacher_profile).to eql(user.teacher_profile)
         expect(profile.user).to eql(user)

--- a/spec/support/with_default_schedules.rb
+++ b/spec/support/with_default_schedules.rb
@@ -7,18 +7,16 @@ RSpec.shared_context "with default schedules", shared_context: :metadata do
     (2020..end_year).each do |start_year|
       cohort = Cohort.find_by(start_year:) || create(:cohort, start_year:)
       Finance::Schedule::ECF.default_for(cohort:) || create(:ecf_schedule, cohort:)
-    end
 
-    # create extra schedules for the current cohort
-    cohort = Cohort.current
-    {
-      npq_specialist_schedule: %w[npq-specialist-spring npq-specialist-autumn],
-      npq_leadership_schedule: %w[npq-leadership-spring npq-leadership-autumn],
-      npq_aso_schedule:        %w[npq-aso-december],
-      npq_ehco_schedule:       %w[npq-ehco-november npq-ehco-december npq-ehco-march npq-ehco-june],
-    }.each do |schedule_type, schedule_identifiers|
-      schedule_identifiers.each do |schedule_identifier|
-        Finance::Schedule.find_by(cohort:, schedule_identifier:) || create(schedule_type, cohort:, schedule_identifier:)
+      {
+        npq_specialist_schedule: %w[npq-specialist-spring npq-specialist-autumn],
+        npq_leadership_schedule: %w[npq-leadership-spring npq-leadership-autumn],
+        npq_aso_schedule:        %w[npq-aso-december],
+        npq_ehco_schedule:       %w[npq-ehco-november npq-ehco-december npq-ehco-march npq-ehco-june],
+      }.each do |schedule_type, schedule_identifiers|
+        schedule_identifiers.each do |schedule_identifier|
+          Finance::Schedule.find_by(cohort:, schedule_identifier:) || create(schedule_type, cohort:, schedule_identifier:)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
There are failures on main due to the switch in default NPQ schedules. The failures are because we are using default schedule lookups rather than the new `schedule_for` method. Also we are creating all schedules across multiple cohorts

- Ticket: 

### Changes proposed in this pull request
- With default schedules creates schedules across cohorts
- Add helper in tests to avoid creating schedules in the setup
- Remove use of default schedule for schedule for to avoid future failures


### Guidance to review
I will spend more time with this after to try to ensure we cleanup all tests so this doesn't happen again