### PR TITLE
[WIP ] Spike Part 1 - Schools record

### DIFF
--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -37,6 +37,7 @@ class ParticipantProfile < ApplicationRecord
   has_many :current_induction_records, -> { current }, class_name: "InductionRecord"
   has_many :deleted_duplicates, class_name: "Finance::ECF::DeletedDuplicate", foreign_key: :primary_participant_profile_id
   has_many :induction_records
+  has_many :school_records
   has_many :participant_declarations
   has_many :participant_profile_schedules
   has_many :participant_profile_states

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,6 +47,7 @@ class School < ApplicationRecord
   has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user
 
   has_many :additional_school_emails
+  has_many :school_records
 
   scope :with_local_authority, lambda { |local_authority|
     joins(%i[school_local_authorities local_authorities])

--- a/app/models/school_record.rb
+++ b/app/models/school_record.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SchoolRecord < ApplicationRecord
+  has_paper_trail
+
+  # Associations
+  belongs_to :school
+  belongs_to :participant_profile, class_name: "ParticipantProfile::ECF", touch: true
+  belongs_to :joining_induction_record, class_name: "InductionRecord"
+  belongs_to :leaving_induction_record, class_name: "InductionRecord", optional: true
+
+  # Validations
+  validates :joining_date, presence: true
+end

--- a/app/services/early_career_teachers/create.rb
+++ b/app/services/early_career_teachers/create.rb
@@ -29,6 +29,12 @@ module EarlyCareerTeachers
                                 mentor_profile:,
                                 start_date:,
                                 appropriate_body_id:)
+          ## Create School record:
+          ## SchoolRecord::Enrol.new(
+          ##  school: school_cohort.school,
+          ##  participant_profile: profile,
+          ##  joining_date: start_date
+          # #).call
         end
       end
 

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -25,6 +25,13 @@ class Induction::TransferAndContinueExistingFip < BaseService
                                                preferred_email: email,
                                                mentor_profile:,
                                                school_transfer: true)
+      ## Update old School record and create new one for new school:
+      ## SchoolRecord::Enrol.new(
+      ##  school: school_cohort.school,
+      ##  participant_profile:,
+      ##  joining_date: start_date,
+      ##  leaving_date: end_date,
+      # #).call
 
       if participant_profile.mentor?
         Mentors::ChangeSchool.call(mentor_profile: participant_profile,

--- a/app/services/school_record/enrol.rb
+++ b/app/services/school_record/enrol.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class SchoolRecord::Enrol < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      if leaving_date
+        # update previous school record. Might need to pass school from/to
+        previous_school_record.update(leaving_date:)
+      end
+
+      participant_profile.school_records.create!(
+        school:,
+        joining_date:,
+      )
+    end
+  end
+
+private
+
+  attr_reader :participant_profile, :school, :joining_date, :leaving_date
+
+  def initialize(participant_profile:, school:, joining_date:, leaving_date: nil)
+    @participant_profile = participant_profile
+    @school = school
+    @joining_date = joining_date
+    @leaving_date = leaving_date
+  end
+
+  def previous_school_record
+    # participant_profile.school_records.latest
+  end
+end

--- a/db/migrate/20230402191059_create_school_record.rb
+++ b/db/migrate/20230402191059_create_school_record.rb
@@ -1,0 +1,14 @@
+class CreateSchoolRecord < ActiveRecord::Migration[6.1]
+  def change
+    create_table :school_records do |t|
+      t.datetime :joining_date, null: false
+      t.datetime :leaving_date, null: true
+
+      t.references :school, null: false, foreign_key: true, type: :uuid
+      t.references :participant_profile, null: false, foreign_key: true, type: :uuid
+      t.references :joining_induction_record, null: false, foreign_key: { to_table: :induction_records }, type: :uuid
+      t.references :leaving_induction_record, null: true, foreign_key: { to_table: :induction_records }, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230402191059_create_school_record.rb
+++ b/db/migrate/20230402191059_create_school_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSchoolRecord < ActiveRecord::Migration[6.1]
   def change
     create_table :school_records do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_28_155851) do
+ActiveRecord::Schema.define(version: 2023_04_02_191059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -944,6 +944,21 @@ ActiveRecord::Schema.define(version: 2023_03_28_155851) do
     t.index ["school_id"], name: "index_school_mentors_on_school_id"
   end
 
+  create_table "school_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "joining_date", null: false
+    t.datetime "leaving_date"
+    t.uuid "school_id", null: false
+    t.uuid "participant_profile_id", null: false
+    t.uuid "joining_induction_record_id", null: false
+    t.uuid "leaving_induction_record_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["joining_induction_record_id"], name: "index_school_records_on_joining_induction_record_id"
+    t.index ["leaving_induction_record_id"], name: "index_school_records_on_leaving_induction_record_id"
+    t.index ["participant_profile_id"], name: "index_school_records_on_participant_profile_id"
+    t.index ["school_id"], name: "index_school_records_on_school_id"
+  end
+
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -1144,6 +1159,10 @@ ActiveRecord::Schema.define(version: 2023_03_28_155851) do
   add_foreign_key "school_mentors", "participant_identities", column: "preferred_identity_id"
   add_foreign_key "school_mentors", "participant_profiles"
   add_foreign_key "school_mentors", "schools"
+  add_foreign_key "school_records", "induction_records", column: "joining_induction_record_id"
+  add_foreign_key "school_records", "induction_records", column: "leaving_induction_record_id"
+  add_foreign_key "school_records", "participant_profiles"
+  add_foreign_key "school_records", "schools"
   add_foreign_key "schools", "networks"
   add_foreign_key "teacher_profiles", "schools"
   add_foreign_key "teacher_profiles", "users"


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2123
slack thread: https://ukgovernmentdfe.slack.com/archives/C01J1J4FM50/p1679580199266459

We'd like to investigate adding new concepts to participant profiles to reduce the conflation of data in induction records.
We discussed adding a school "tenureship", as well as investigate having transfer records.

In this PR I've created school records, which hold data involving a participant's time in a school, with joining and leaving dates.

### Changes proposed in this pull request

- add new school record
- suggest fields and associations
- example of how this can work with enrolments

### Guidance to review
This is an investigation, so please feel free to break down all the solutions proposed

This solution feels like it has similar problems to induction records. This will require some work for us to integrate into our API as well.

There is also the overhead of having to backfill any old data, and what the new induction record world will look like
