### PR TITLE
[WIP ] Spike Part 2 - Schools Transfer

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -27,6 +27,8 @@ class LeadProvider < ApplicationRecord
   has_one :call_off_contract
 
   has_many :statements, through: :cpd_lead_provider, class_name: "Finance::Statement::ECF", source: :ecf_statements
+  has_many :leaving_school_transfers, foreign_key: "leaving_provider_id", class_name: "SchoolTransfer"
+  has_many :joining_school_transfers, foreign_key: "joining_provider_id", class_name: "SchoolTransfer"
   validates :name, presence: { message: "Enter a name" }
 
   def next_output_fee_statement(cohort)

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -48,6 +48,7 @@ class ParticipantProfile < ApplicationRecord
     merge(ParticipantProfileState.most_recent)
   }, class_name: "ParticipantProfileState"
   has_one :user, through: :teacher_profile
+  has_many :school_transfers
 
   # Scopes
   scope :ecf, -> { where(type: [ECT.name, Mentor.name]) }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -47,6 +47,8 @@ class School < ApplicationRecord
   has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user
 
   has_many :additional_school_emails
+  has_many :leaving_school_transfers, foreign_key: "leaving_school_id", class_name: "SchoolTransfer"
+  has_many :joining_school_transfers, foreign_key: "joining_school_id", class_name: "SchoolTransfer"
 
   scope :with_local_authority, lambda { |local_authority|
     joins(%i[school_local_authorities local_authorities])

--- a/app/models/school_transfer.rb
+++ b/app/models/school_transfer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SchoolTransfer < ApplicationRecord
+  has_paper_trail
+
+  # Associations
+  belongs_to :participant_profile, class_name: "ParticipantProfile::ECF", touch: true
+  belongs_to :leaving_school, class_name: "School"
+  belongs_to :joining_school, class_name: "School", optional: true
+  belongs_to :leaving_provider, class_name: "LeadProvider"
+  belongs_to :joining_provider, class_name: "LeadProvider", optional: true
+
+  # Validations
+  validates :leaving_date, presence: true
+end

--- a/app/services/induction/transfer_and_continue_existing_fip.rb
+++ b/app/services/induction/transfer_and_continue_existing_fip.rb
@@ -26,6 +26,29 @@ class Induction::TransferAndContinueExistingFip < BaseService
                                                mentor_profile:,
                                                school_transfer: true)
 
+      ## Create new school transfer, this data depends who triggers the transfer:
+      ## participant_profile.school_transfer.create!(
+      ##  leaving_school:,
+      ##  joining_school:,
+      ##  leaving_provider:,
+      ##  joining_provider:,
+      ##  leaving_date: end_date,
+      ##  joining_date: start_date,
+      # #)
+      ##
+      ## or
+      ##
+      ## update school transfer, this data depends who triggers the transfer:
+      ## participant_profile.school_transfer.where(
+      ##  leaving_school:,
+      ##  leaving_provider:,
+      ##  joining_date: nil,
+      ## ).update(
+      ##   joining_date: start_date,
+      ##   joining_school:,
+      ##   joining_provider:,
+      ## )
+
       if participant_profile.mentor?
         Mentors::ChangeSchool.call(mentor_profile: participant_profile,
                                    from_school: old_school,

--- a/db/migrate/20230403113148_create_school_transfer.rb
+++ b/db/migrate/20230403113148_create_school_transfer.rb
@@ -1,0 +1,16 @@
+class CreateSchoolTransfer < ActiveRecord::Migration[6.1]
+  def change
+    create_table :school_transfers do |t|
+      t.datetime :joining_date, null: true
+      t.datetime :leaving_date, null: false
+
+      t.references :participant_profile, null: false, foreign_key: true, type: :uuid
+      t.references :leaving_school, null: false, foreign_key: { to_table: :schools }, type: :uuid
+      t.references :joining_school, null: true, foreign_key: { to_table: :schools }, type: :uuid
+      t.references :leaving_provider, null: false, foreign_key: { to_table: :lead_providers }, type: :uuid
+      t.references :joining_provider, null: true, foreign_key: { to_table: :lead_providers }, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_28_155851) do
+ActiveRecord::Schema.define(version: 2023_04_03_113148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -944,6 +944,38 @@ ActiveRecord::Schema.define(version: 2023_03_28_155851) do
     t.index ["school_id"], name: "index_school_mentors_on_school_id"
   end
 
+  create_table "school_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "joining_date", null: false
+    t.datetime "leaving_date"
+    t.uuid "school_id", null: false
+    t.uuid "participant_profile_id", null: false
+    t.uuid "joining_induction_record_id", null: false
+    t.uuid "leaving_induction_record_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["joining_induction_record_id"], name: "index_school_records_on_joining_induction_record_id"
+    t.index ["leaving_induction_record_id"], name: "index_school_records_on_leaving_induction_record_id"
+    t.index ["participant_profile_id"], name: "index_school_records_on_participant_profile_id"
+    t.index ["school_id"], name: "index_school_records_on_school_id"
+  end
+
+  create_table "school_transfers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "joining_date"
+    t.datetime "leaving_date", null: false
+    t.uuid "participant_profile_id", null: false
+    t.uuid "leaving_school_id", null: false
+    t.uuid "joining_school_id"
+    t.uuid "leaving_provider_id", null: false
+    t.uuid "joining_provider_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["joining_provider_id"], name: "index_school_transfers_on_joining_provider_id"
+    t.index ["joining_school_id"], name: "index_school_transfers_on_joining_school_id"
+    t.index ["leaving_provider_id"], name: "index_school_transfers_on_leaving_provider_id"
+    t.index ["leaving_school_id"], name: "index_school_transfers_on_leaving_school_id"
+    t.index ["participant_profile_id"], name: "index_school_transfers_on_participant_profile_id"
+  end
+
   create_table "schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -1144,6 +1176,15 @@ ActiveRecord::Schema.define(version: 2023_03_28_155851) do
   add_foreign_key "school_mentors", "participant_identities", column: "preferred_identity_id"
   add_foreign_key "school_mentors", "participant_profiles"
   add_foreign_key "school_mentors", "schools"
+  add_foreign_key "school_records", "induction_records", column: "joining_induction_record_id"
+  add_foreign_key "school_records", "induction_records", column: "leaving_induction_record_id"
+  add_foreign_key "school_records", "participant_profiles"
+  add_foreign_key "school_records", "schools"
+  add_foreign_key "school_transfers", "lead_providers", column: "joining_provider_id"
+  add_foreign_key "school_transfers", "lead_providers", column: "leaving_provider_id"
+  add_foreign_key "school_transfers", "participant_profiles"
+  add_foreign_key "school_transfers", "schools", column: "joining_school_id"
+  add_foreign_key "school_transfers", "schools", column: "leaving_school_id"
   add_foreign_key "schools", "networks"
   add_foreign_key "teacher_profiles", "schools"
   add_foreign_key "teacher_profiles", "users"


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2123
slack thread: https://ukgovernmentdfe.slack.com/archives/C01J1J4FM50/p1679580199266459

We'd like to investigate adding new concepts to participant profiles to reduce the conflation of data in induction records.
We discussed adding a school "tenureship", as well as investigate having transfer records.

In this PR I've created school transfers, which only holds a transfer's data. PR for school tenureship can be found [here](https://github.com/DFE-Digital/early-careers-framework/pull/3212)

### Changes proposed in this pull request

- add new school transfer record
- suggest fields and associations
- example of how this can work with transfers

### Guidance to review
This is an investigation, so please feel free to break down all the solutions proposed

Im not sure how this solution works with solving induction record problems, but it does resolve our API issues with transfers

There is also the overhead of having to backfill any old data, and what the new induction record world will look like
