### PR TITLE
Use request.headers['HTTP_REFERER'] instead of request.referer

### DIFF
--- a/app/controllers/admin/impersonates_controller.rb
+++ b/app/controllers/admin/impersonates_controller.rb
@@ -11,6 +11,16 @@ module Admin
 
     def create
       impersonate_user(@user)
+
+      Sentry.with_scope do |scope|
+        scope.set_tags(
+          request_dot_referer: request.referer,
+          request_headers_http_referer: request.headers["HTTP_REFERER"],
+          request_headers_referer: request.headers["Referer"],
+        )
+        Sentry.capture_message("User was impersonated")
+      end
+
       session[:impersonation_start_path] = referer
       redirect_to after_sign_in_path_for(@user)
     end

--- a/app/controllers/admin/impersonates_controller.rb
+++ b/app/controllers/admin/impersonates_controller.rb
@@ -11,7 +11,7 @@ module Admin
 
     def create
       impersonate_user(@user)
-      session[:impersonation_start_path] = request.referer
+      session[:impersonation_start_path] = referer
       redirect_to after_sign_in_path_for(@user)
     end
 
@@ -29,19 +29,23 @@ module Admin
     def check_self_impersonation
       if params[:impersonated_user_id] == current_user.id.to_s
         flash[:warning] = "You cannot impersonate yourself"
-        redirect_to URI(request.referer).path
+        redirect_to URI(referer).path
       end
     end
 
     def check_admin_user_impersonation
       if @user.admin?
         flash[:warning] = "You cannot impersonate another admin user"
-        redirect_to URI(request.referer).path
+        redirect_to URI(referer).path
       end
     end
 
     def pundit_user
       true_user
+    end
+
+    def referer
+      request.headers["HTTP_REFERER"]
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/b/va81LwGU/cpd-admin-interface

### Changes proposed in this pull request

From my research, I was unable to find `request.referer` anywhere in the Rails documentation, so this PR replaces it with the surer and [documented](https://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-headers) `request.headers['HTTP_REFERER']` instead of `request.referer`.

