### PR TITLE
Update teacher_profile trn when using the manual script

### DIFF
--- a/app/services/importers/npq_manual_validation.rb
+++ b/app/services/importers/npq_manual_validation.rb
@@ -11,14 +11,22 @@ class Importers::NPQManualValidation
     check_headers
 
     rows.each do |row|
-      data = NPQApplication.find_by(id: row["application_ecf_id"])
+      npq_application_id = row["application_ecf_id"]
+      trn = row["validated_trn"]
 
-      puts "no NPQApplication found for #{row['application_ecf_id']}" if data.nil?
-      next if data.nil?
+      npq_application = NPQApplication.find_by(id: npq_application_id)
 
-      puts "updating trn for NPQApplication: #{row['application_ecf_id']} with trn: #{row['validated_trn']}"
+      puts "No NPQApplication found for #{npq_application_id}" if npq_application.nil?
+      next if npq_application.nil?
 
-      data.update!(teacher_reference_number: row["validated_trn"], teacher_reference_number_verified: true)
+      puts "Updating TRN for NPQApplication: #{npq_application_id} with TRN: #{trn}"
+      npq_application.update!(teacher_reference_number: row["validated_trn"], teacher_reference_number_verified: true)
+
+      teacher_profile = npq_application.profile.try(:teacher_profile)
+      next if teacher_profile.nil?
+
+      puts "Updating TeacherProfile for NPQApplication: #{npq_application_id} with TRN: #{trn}"
+      teacher_profile.update!(trn:)
     end
   end
 

--- a/spec/services/importers/npq_manual_validation_spec.rb
+++ b/spec/services/importers/npq_manual_validation_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Importers::NPQManualValidation, :with_default_schedules do
-  let(:npq_course)      { create(:npq_course, identifier: "npq-senior-leadership") }
-  let(:npq_application) { create(:npq_application, :accepted, npq_course:, teacher_reference_number_verified: false) }
-  let(:file)            { Tempfile.new("test.csv") }
+  let(:npq_course)       { create(:npq_course, identifier: "npq-senior-leadership") }
+  let(:npq_application)  { create(:npq_application, :accepted, npq_course:, teacher_reference_number_verified: false) }
+  let(:file)             { Tempfile.new("test.csv") }
+  let!(:teacher_profile) { npq_application.profile.teacher_profile }
 
   around do |example|
     original_stdout = $stdout
@@ -35,6 +36,12 @@ RSpec.describe Importers::NPQManualValidation, :with_default_schedules do
         expect {
           subject.call
         }.to change { npq_application.reload.teacher_reference_number }.to("7654321")
+      end
+
+      it "updates the teacher profile trn" do
+        expect {
+          subject.call
+        }.to change { teacher_profile.reload.trn }.to("7654321")
       end
 
       it "updates teacher_reference_number_verified to true" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-970

We dont update the TRN on the teacher profile during the manual validation process and this has had to be done manually for a lot of users. This will ensure future users get updated. 

