### PR TITLE
Allow bin/dev to run without jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 2. Run `yarn` to install node dependencies
 3. Create `.env` file - copy `.env.template`. Set your database password and user in the `.env` file
 4. Run `bin/rails db:setup` to set up the database development and test schemas, and seed with test data
-6. Run `./bin/dev` to launch the app on http://localhost:3000, sidekiq and auto-compile assets
+6. Run `./bin/dev` to launch the app on http://localhost:3000, sidekiq and auto-compile assets. To run with a Sidekiq worker enabled run `./bin/dev -j`
 7. For most work, you will need to seed the database with `rails db:seed`. For school data, see [Importing School data](#importing-school-data)
 
 ### With docker

--- a/bin/dev
+++ b/bin/dev
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
 
-suppress_jobs=false
+run_jobs=false
 
 while getopts ":j" opt; do
   case $opt in
-    j) suppress_jobs=true
+    j) run_jobs=true
     ;;
   esac
 done
@@ -14,8 +14,8 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
-if $suppress_jobs; then
-  exec foreman start -m "web=1,js=1,css=1" -f Procfile.dev
+if $run_jobs; then
+  exec foreman start -m "web=1,js=1,css=1,jobs=1" -f Procfile.dev
 else
-  exec foreman start -f Procfile.dev "$@"
+  exec foreman start -m "web=1,js=1,css=1,jobs=0" -f Procfile.dev
 fi

--- a/bin/dev
+++ b/bin/dev
@@ -1,8 +1,21 @@
 #!/usr/bin/env sh
 
+suppress_jobs=false
+
+while getopts ":j" opt; do
+  case $opt in
+    j) suppress_jobs=true
+    ;;
+  esac
+done
+
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
 
-exec foreman start -f Procfile.dev "$@"
+if $suppress_jobs; then
+  exec foreman start -m "web=1,js=1,css=1" -f Procfile.dev
+else
+  exec foreman start -f Procfile.dev "$@"
+fi


### PR DESCRIPTION

### Context

Running bin/dev is really noisy, mainly with failed email sending and background data sync. I don't usually want it.

With this change, passing in a `-j` argument to bin/dev (`bin/dev -j`) now only runs the web, css and js portions of Procfile.dev, which allows for a noise free experience when jobs aren't needed.

Tested on Linux. I assume this will work on macOS, definitely needs testing before merge!
