### PR TITLE
Stop seeding multiple default partnerships

### DIFF
--- a/db/new_seeds/scenarios/induction_programmes/fip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/fip.rb
@@ -22,7 +22,8 @@ module NewSeeds
         end
 
         def with_partnership(partnership: nil)
-          partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:)
+          relationship = Partnership.exists?(school:, cohort:)
+          partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:, relationship:)
           induction_programme.update!(partnership:)
 
           self

--- a/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
+++ b/db/new_seeds/scenarios/participants/mentors/mentoring_multiple_ects_with_same_provider.rb
@@ -36,7 +36,8 @@ module NewSeeds
                                              cohort:,
                                              school:,
                                              delivery_partner:,
-                                             lead_provider:)
+                                             lead_provider:,
+                                             relationship: Partnership.exists?(cohort:, school:))
 
             @induction_programme = NewSeeds::Scenarios::InductionProgrammes::Fip
                                      .new(school_cohort:)


### PR DESCRIPTION
### Context

When there's already a partnership for a school on a given cohort any subsequent seeded partnerships should be set to a relationship.

| Before | After |
| ------ | ------- |
| ![image](https://user-images.githubusercontent.com/128088/230043672-4a4a3994-1524-4603-b73b-cd845314c2f7.png) |![image](https://user-images.githubusercontent.com/128088/230043180-856028bf-9f1a-463e-8df5-f54f6969226e.png) |