### PR TITLE
Create provider relationships for partnerships in seeds

### DIFF
--- a/db/new_seeds/scenarios/induction_programmes/fip.rb
+++ b/db/new_seeds/scenarios/induction_programmes/fip.rb
@@ -22,6 +22,7 @@ module NewSeeds
         end
 
         def with_partnership(partnership: nil)
+          create_provider_relationship
           relationship = Partnership.exists?(school:, cohort:)
           partnership ||= FactoryBot.create(:seed_partnership, cohort:, school:, delivery_partner:, lead_provider:, relationship:)
           induction_programme.update!(partnership:)
@@ -30,6 +31,7 @@ module NewSeeds
         end
 
         def with_relationship(lead_provider:, delivery_partner:)
+          create_provider_relationship
           induction_programme.update!(partnership: FactoryBot.create(:seed_partnership,
                                                                      :relationship,
                                                                      cohort:,
@@ -55,6 +57,15 @@ module NewSeeds
 
         def set_default_induction_programme!
           school_cohort.update!(default_induction_programme: induction_programme)
+        end
+
+        def create_provider_relationship
+          FactoryBot.create(
+            :seed_provider_relationship,
+            lead_provider:,
+            delivery_partner:,
+            cohort:,
+          )
         end
       end
     end

--- a/db/new_seeds/scenarios/schools/school.rb
+++ b/db/new_seeds/scenarios/schools/school.rb
@@ -85,6 +85,13 @@ module NewSeeds
 
           partnerships[cohort.start_year] = FactoryBot.create(:seed_partnership, *traits, **options)
 
+          FactoryBot.create(
+            :seed_provider_relationship,
+            cohort:,
+            lead_provider: partnerships[cohort.start_year].lead_provider,
+            delivery_partner: partnerships[cohort.start_year].delivery_partner,
+          )
+
           self
         end
 


### PR DESCRIPTION
### Context

In order for a partnership to be valid, a relationship needs to exist between the lead provider/cohort/delivery partner. Create those in the seeds

- Ticket: n/a

### Changes proposed in this pull request
Add provider relationships everywhere we create partnerships.

### Guidance to review
This is required for the partnership testing endpoints
