### PR TITLE
[CPDLP-2110] Add GET /api/v3/participants/npq endpoint

### DIFF
--- a/app/controllers/api/v1/npq_participants_controller.rb
+++ b/app/controllers/api/v1/npq_participants_controller.rb
@@ -8,10 +8,20 @@ module Api
       include ApiFilter
       include ParticipantActions
 
+      # Returns a list of NPQ participants
+      # Providers can see their NPQ participants and their NPQ enrolments via this endpoint
+      #
+      # GET /api/v1/participants/npq?filter[updated_since]=2022-11-13T11:21:55Z&sort=-updated_at,full_name
+      #
       def index
         render json: serializer_class.new(paginate(npq_participants), params: { cpd_lead_provider: current_user }).serializable_hash.to_json
       end
 
+      # Returns a single of NPQ participant
+      # Providers can see a specific NPQ participant and its NPQ enrolments via this endpoint
+      #
+      # GET /api/v1/participants/npq/:id
+      #
       def show
         render json: serializer_class.new(npq_participant, params: { cpd_lead_provider: current_user }).serializable_hash.to_json
       end

--- a/app/controllers/api/v3/npq_participants_controller.rb
+++ b/app/controllers/api/v3/npq_participants_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    class NPQParticipantsController < Api::ApiController
+      include ApiTokenAuthenticatable
+      include ApiPagination
+      include ApiFilter
+      include ApiOrderable
+
+      # Return±s a list of NPQ participants
+      # Providers can see their NPQ participants and their NPQ enrolments via this endpoint
+      #
+      # GET /api/v3/participants/npq?filter[updated_since]=2022-11-13T11:21:55Z&sort=-updated_at,full_name
+      #
+      def index
+        render json: serializer_class.new(paginate(npq_participants), params: { cpd_lead_provider: current_user }).serializable_hash.to_json
+      end
+
+    private
+
+      def npq_lead_provider
+        current_api_token.cpd_lead_provider.npq_lead_provider
+      end
+
+      def npq_participants
+        @npq_participants ||= npq_participants_query.participants.order(sort_params(params, model: User))
+      end
+
+      def npq_participants_query
+        Api::V3::NPQParticipantsQuery.new(
+          npq_lead_provider:,
+          params: npq_participant_params,
+        )
+      end
+
+      def npq_participant_params
+        params
+          .with_defaults({ sort: "", filter: { updated_since: "" } })
+          .permit(:sort, filter: %i[updated_since])
+      end
+
+      def access_scope
+        LeadProviderApiToken.joins(cpd_lead_provider: [:npq_lead_provider])
+      end
+
+      def serializer_class
+        Api::V3::NPQParticipantSerializer
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/npq_participants_controller.rb
+++ b/app/controllers/api/v3/npq_participants_controller.rb
@@ -2,29 +2,17 @@
 
 module Api
   module V3
-    class NPQParticipantsController < Api::ApiController
-      include ApiTokenAuthenticatable
-      include ApiPagination
-      include ApiFilter
+    class NPQParticipantsController < V1::NPQParticipantsController
       include ApiOrderable
-
-      # Return±s a list of NPQ participants
-      # Providers can see their NPQ participants and their NPQ enrolments via this endpoint
-      #
-      # GET /api/v3/participants/npq?filter[updated_since]=2022-11-13T11:21:55Z&sort=-updated_at,full_name
-      #
-      def index
-        render json: serializer_class.new(paginate(npq_participants), params: { cpd_lead_provider: current_user }).serializable_hash.to_json
-      end
 
     private
 
-      def npq_lead_provider
-        current_api_token.cpd_lead_provider.npq_lead_provider
-      end
-
       def npq_participants
         @npq_participants ||= npq_participants_query.participants.order(sort_params(params, model: User))
+      end
+
+      def npq_participant
+        @npq_participant ||= npq_participants_query.participant
       end
 
       def npq_participants_query
@@ -37,11 +25,7 @@ module Api
       def npq_participant_params
         params
           .with_defaults({ sort: "", filter: { updated_since: "" } })
-          .permit(:sort, filter: %i[updated_since])
-      end
-
-      def access_scope
-        LeadProviderApiToken.joins(cpd_lead_provider: [:npq_lead_provider])
+          .permit(:id, :sort, filter: %i[updated_since])
       end
 
       def serializer_class

--- a/app/models/participant_profile_state.rb
+++ b/app/models/participant_profile_state.rb
@@ -11,4 +11,7 @@ class ParticipantProfileState < ApplicationRecord
   }
 
   scope :most_recent, -> { order("created_at desc").limit(1) }
+  scope :withdrawn, -> { where(state: states[:withdrawn]) }
+  scope :deferred, -> { where(state: states[:deferred]) }
+  scope :for_lead_provider, ->(cpd_lead_provider) { where(cpd_lead_provider:) }
 end

--- a/app/models/participant_profile_state.rb
+++ b/app/models/participant_profile_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ParticipantProfileState < ApplicationRecord
-  belongs_to :participant_profile
+  belongs_to :participant_profile, touch: true
   belongs_to :cpd_lead_provider, optional: true
 
   enum state: {

--- a/app/serializers/api/v3/npq_participant_serializer.rb
+++ b/app/serializers/api/v3/npq_participant_serializer.rb
@@ -9,30 +9,28 @@ module Api
       include JSONAPI::Serializer::Instrumentation
 
       class << self
-        def withdrawal(hash:, profile:, cpd_lead_provider:)
+        def withdrawal(profile:, cpd_lead_provider:)
           if profile.withdrawn_for?(cpd_lead_provider:)
-            latest_participant_profile_state = profile.participant_profile_states.where(state: ParticipantProfileState.states[:withdrawn], cpd_lead_provider:).order(created_at: :desc).first
+            latest_participant_profile_state = profile.participant_profile_states.withdrawn.for_lead_provider(cpd_lead_provider).most_recent.first
             if latest_participant_profile_state.present?
-              hash[:withdrawal] = {
+              {
                 reason: latest_participant_profile_state.reason,
                 date: latest_participant_profile_state.created_at.rfc3339,
               }
             end
           end
-          hash
         end
 
-        def deferral(hash:, profile:, cpd_lead_provider:)
+        def deferral(profile:, cpd_lead_provider:)
           if profile.deferred_for?(cpd_lead_provider:)
-            latest_participant_profile_state = profile.participant_profile_states.where(state: ParticipantProfileState.states[:deferred], cpd_lead_provider:).order(created_at: :desc).first
+            latest_participant_profile_state = profile.participant_profile_states.deferred.for_lead_provider(cpd_lead_provider).most_recent.first
             if latest_participant_profile_state.present?
-              hash[:deferral] = {
+              {
                 reason: latest_participant_profile_state.reason,
                 date: latest_participant_profile_state.created_at.rfc3339,
               }
             end
           end
-          hash
         end
       end
 
@@ -50,16 +48,10 @@ module Api
       end
 
       attribute(:npq_enrolments) do |object, params|
-        scope = object.npq_profiles
-        scope = scope.includes(:npq_course, :npq_application, :participant_identity, schedule: [:cohort])
+        object.npq_profiles.map { |profile|
+          next unless params[:cpd_lead_provider] && profile.npq_application&.npq_lead_provider&.cpd_lead_provider == params[:cpd_lead_provider]
 
-        if params[:cpd_lead_provider]
-          scope = scope.joins(npq_application: { npq_lead_provider: [:cpd_lead_provider] })
-          scope = scope.where(npq_applications: { npq_lead_providers: { cpd_lead_provider: params[:cpd_lead_provider] } })
-        end
-
-        scope.map do |profile|
-          hash = {
+          {
             email: profile.participant_identity&.email.presence || object.email,
             course_identifier: profile.npq_course.identifier,
             schedule_identifier: profile.schedule.schedule_identifier,
@@ -69,12 +61,11 @@ module Api
             training_status: profile.training_status,
             school_urn: profile.school_urn,
             targeted_delivery_funding_eligibility: profile.npq_application.targeted_delivery_funding_eligibility,
+            withdrawal: withdrawal(profile:, cpd_lead_provider: params[:cpd_lead_provider]),
+            deferral: deferral(profile:, cpd_lead_provider: params[:cpd_lead_provider]),
+            created_at: profile.created_at.rfc3339,
           }
-          hash = withdrawal(hash:, profile:, cpd_lead_provider: params[:cpd_lead_provider])
-          hash = deferral(hash:, profile:, cpd_lead_provider: params[:cpd_lead_provider])
-          hash[:created_at] = profile.created_at.rfc3339
-          hash
-        end
+        }.compact
       end
     end
   end

--- a/app/serializers/api/v3/npq_participant_serializer.rb
+++ b/app/serializers/api/v3/npq_participant_serializer.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "jsonapi/serializer/instrumentation"
+
+module Api
+  module V3
+    class NPQParticipantSerializer
+      include JSONAPI::Serializer
+      include JSONAPI::Serializer::Instrumentation
+
+      set_id :id
+      set_type :'npq-participant'
+
+      attribute :full_name
+
+      attribute(:teacher_reference_number) do |object|
+        object.teacher_profile&.trn
+      end
+
+      attribute(:updated_at) do |object|
+        object.updated_at.rfc3339
+      end
+
+      attribute(:npq_enrolments) do |object, params|
+        scope = object.npq_profiles
+        scope = scope.includes(:npq_course, :npq_application, :participant_identity, :participant_profile_states, schedule: [:cohort])
+
+        if params[:cpd_lead_provider]
+          scope = scope.joins(npq_application: { npq_lead_provider: [:cpd_lead_provider] })
+          scope = scope.where(npq_applications: { npq_lead_providers: { cpd_lead_provider: params[:cpd_lead_provider] } })
+        end
+
+        scope.map do |profile|
+          hash = {
+            email: profile.participant_identity&.email.presence || object.email,
+            course_identifier: profile.npq_course.identifier,
+            schedule_identifier: profile.schedule.schedule_identifier,
+            cohort: profile.schedule.cohort.start_year.to_s,
+            npq_application_id: profile.npq_application.id,
+            eligible_for_funding: profile.npq_application.eligible_for_funding,
+            training_status: profile.training_status,
+            school_urn: profile.school_urn,
+            targeted_delivery_funding_eligibility: profile.npq_application.targeted_delivery_funding_eligibility,
+          }
+          if profile.withdrawn_for?(cpd_lead_provider: params[:cpd_lead_provider])
+            latest_participant_profile_state = profile.participant_profile_states.where(state: ParticipantProfileState.states[:withdrawn], cpd_lead_provider: params[:cpd_lead_provider]).order(created_at: :desc).first
+            if latest_participant_profile_state.present?
+              hash[:withdrawal] = {
+                reason: latest_participant_profile_state.reason,
+                date: latest_participant_profile_state.created_at.rfc3339,
+              }
+            end
+          end
+          if profile.deferred_for?(cpd_lead_provider: params[:cpd_lead_provider])
+            latest_participant_profile_state = profile.participant_profile_states.where(state: ParticipantProfileState.states[:deferred], cpd_lead_provider: params[:cpd_lead_provider]).order(created_at: :desc).first
+            if latest_participant_profile_state.present?
+              hash[:deferral] = {
+                reason: latest_participant_profile_state.reason,
+                date: latest_participant_profile_state.created_at.rfc3339,
+              }
+            end
+          end
+          hash[:created_at] = profile.created_at.rfc3339
+          hash
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -11,10 +11,10 @@ module Api
       end
 
       def participants
-        scope = npq_lead_provider.npq_participants.includes(:teacher_profile)
+        scope = npq_lead_provider.npq_participants.includes(:teacher_profile, npq_profiles: [:npq_course, :participant_profile_states, :participant_identity, { schedule: [:cohort], npq_application: [npq_lead_provider: :cpd_lead_provider] }])
         scope = scope.where("users.updated_at > ?", updated_since) if updated_since.present?
         scope = scope.order("users.updated_at DESC") if params[:sort].blank?
-        scope
+        scope.distinct
       end
 
       def participant

--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -11,10 +11,14 @@ module Api
       end
 
       def participants
-        scope = npq_lead_provider.npq_participants
+        scope = npq_lead_provider.npq_participants.includes(:teacher_profile)
         scope = scope.where("users.updated_at > ?", updated_since) if updated_since.present?
         scope = scope.order("users.updated_at DESC") if params[:sort].blank?
         scope
+      end
+
+      def participant
+        npq_lead_provider.npq_participants.find(params[:id])
       end
 
     private

--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    class NPQParticipantsQuery
+      attr_reader :npq_lead_provider, :params
+
+      def initialize(npq_lead_provider:, params:)
+        @npq_lead_provider = npq_lead_provider
+        @params = params
+      end
+
+      def participants
+        scope = npq_lead_provider.npq_participants
+        scope = scope.where("users.updated_at > ?", updated_since) if updated_since.present?
+        scope = scope.order("users.updated_at DESC") if params[:sort].blank?
+        scope
+      end
+
+    private
+
+      def filter
+        params[:filter] ||= {}
+      end
+
+      def updated_since
+        return if filter[:updated_since].blank?
+
+        Time.iso8601(filter[:updated_since])
+      rescue ArgumentError
+        begin
+          Time.iso8601(URI.decode_www_form_component(filter[:updated_since]))
+        rescue ArgumentError
+          raise Api::Errors::InvalidDatetimeError, I18n.t(:invalid_updated_since_filter)
+        end
+      end
+    end
+  end
+end

--- a/app/validators/participant_not_withdrawn_validator.rb
+++ b/app/validators/participant_not_withdrawn_validator.rb
@@ -19,7 +19,7 @@ private
   def latest_participant_state(record)
     record.participant_profile
       .participant_profile_states
-      .where(cpd_lead_provider: record.cpd_lead_provider)
+      .for_lead_provider(record.cpd_lead_provider)
       .most_recent
       .first
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,7 @@ Rails.application.routes.draw do
       resources :statements, only: %i[index show], controller: "finance/statements"
       resources :delivery_partners, only: %i[index show], path: "delivery-partners"
       resources :partnerships, path: "partnerships/ecf", only: %i[show index create update], controller: "ecf/partnerships"
-      resources :npq_participants, only: [], path: "participants/npq" do
+      resources :npq_participants, only: %i[index], path: "participants/npq" do
         collection do
           resources :outcomes, only: %i[index], controller: "provider_outcomes"
           get ":participant_id/outcomes", to: "participant_outcomes#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,7 @@ Rails.application.routes.draw do
       resources :statements, only: %i[index show], controller: "finance/statements"
       resources :delivery_partners, only: %i[index show], path: "delivery-partners"
       resources :partnerships, path: "partnerships/ecf", only: %i[show index create update], controller: "ecf/partnerships"
-      resources :npq_participants, only: %i[index], path: "participants/npq" do
+      resources :npq_participants, only: %i[index show], path: "participants/npq" do
         collection do
           resources :outcomes, only: %i[index], controller: "provider_outcomes"
           get ":participant_id/outcomes", to: "participant_outcomes#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,7 @@ Rails.application.routes.draw do
       resources :delivery_partners, only: %i[index show], path: "delivery-partners"
       resources :partnerships, path: "partnerships/ecf", only: %i[show index create update], controller: "ecf/partnerships"
       resources :npq_participants, only: %i[index show], path: "participants/npq" do
+        concerns :participant_actions
         collection do
           resources :outcomes, only: %i[index], controller: "provider_outcomes"
           get ":participant_id/outcomes", to: "participant_outcomes#index"

--- a/db/migrate/20230414123726_add_index_to_participant_profile_states.rb
+++ b/db/migrate/20230414123726_add_index_to_participant_profile_states.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIndexToParticipantProfileStates < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :participant_profile_states, %i[participant_profile_id state cpd_lead_provider_id], algorithm: :concurrently, name: "index_on_profile_and_state_and_lead_provider"
+    add_index :participant_profile_states, %i[participant_profile_id cpd_lead_provider_id], algorithm: :concurrently, name: "index_on_profile_and_lead_provider"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_28_155851) do
+ActiveRecord::Schema.define(version: 2023_04_14_123726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -716,6 +716,8 @@ ActiveRecord::Schema.define(version: 2023_03_28_155851) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "cpd_lead_provider_id"
     t.index ["cpd_lead_provider_id"], name: "index_participant_profile_states_on_cpd_lead_provider_id"
+    t.index ["participant_profile_id", "cpd_lead_provider_id"], name: "index_on_profile_and_lead_provider"
+    t.index ["participant_profile_id", "state", "cpd_lead_provider_id"], name: "index_on_profile_and_state_and_lead_provider"
     t.index ["participant_profile_id"], name: "index_participant_profile_states_on_participant_profile_id"
   end
 

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -37,6 +37,17 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                 example: CGI.unescape({ page: { page: 1, per_page: 5 } }.to_param),
                 description: "Pagination options to navigate through the list of NPQ participants."
 
+      parameter name: :sort,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/NPQParticipantsSort",
+                },
+                style: :form,
+                explode: false,
+                required: false,
+                description: "Sort NPQ participants being returned.",
+                example: "sort=-updated_at"
+
       response "200", "A list of NPQ participants" do
         schema({ "$ref": "#/components/schemas/MultipleNPQParticipantsResponse" })
 
@@ -232,7 +243,6 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                               reason: "insufficient-capacity",
                               date: "2022-12-09T16:07:38Z",
                             },
-                            "deferral": null,
                             "created_at": "2021-05-31T02:22:32.000Z",
                           },
                         ],
@@ -353,7 +363,6 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                             "training_status": "deferred",
                             "school_urn": "123456",
                             "targeted_delivery_funding_eligibility": true,
-                            "withdrawal": nil,
                             "deferral": {
                               reason: "other",
                               date: "2022-12-09T16:07:38Z",

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -243,6 +243,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                               reason: "insufficient-capacity",
                               date: "2022-12-09T16:07:38Z",
                             },
+                            "deferral": nil,
                             "created_at": "2021-05-31T02:22:32.000Z",
                           },
                         ],
@@ -353,6 +354,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                             "training_status": "deferred",
                             "school_urn": "123456",
                             "targeted_delivery_funding_eligibility": true,
+                            "withdrawal": nil,
                             "deferral": {
                               reason: "other",
                               date: "2022-12-09T16:07:38Z",

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -2,12 +2,17 @@
 
 require "swagger_helper"
 
-describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", api_v3: true do
-  let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
-  let(:npq_lead_provider) { create(:npq_lead_provider) }
+describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+  let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
+  let(:participant_identity) { create(:participant_identity) }
+  let(:user) { participant_identity.user }
+  let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:, npq_course:, participant_identity:) }
+  let!(:participant_profile) { create(:npq_participant_profile, user:, npq_application:, npq_lead_provider:, npq_course:) }
+
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:Authorization) { "Bearer #{token}" }
-  let!(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:) }
 
   path "/api/v3/participants/npq" do
     get "<b>Note, this endpoint includes updated specifications.</b><br/>Retrieve multiple NPQ participants" do
@@ -80,7 +85,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                 }
 
       response "200", "A single NPQ participant" do
-        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:id) { npq_application.participant_identity.user_id }
 
         schema({ "$ref": "#/components/schemas/NPQParticipantResponse" })
 
@@ -88,7 +93,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
       end
 
       response "401", "Unauthorized" do
-        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:id) { npq_application.participant_identity.user_id }
         let(:Authorization) { "Bearer invalid" }
 
         schema({ "$ref": "#/components/schemas/UnauthorisedResponse" })
@@ -96,7 +101,9 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
         run_test!
       end
 
-      response "404", "Not Found" do
+      response "404", "Not Found", exceptions_app: true do
+        let(:id) { "unknown-id" }
+
         schema({ "$ref": "#/components/schemas/NotFoundResponse" })
 
         run_test!
@@ -112,22 +119,22 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                   :with_default_schedules do
     let(:participant) { npq_application }
     let(:profile)     { npq_application.profile }
-    let(:new_schedule) do
-      if Finance::Schedule::NPQLeadership::IDENTIFIERS.include?(profile.npq_course.identifier)
-        create(:npq_leadership_schedule)
-      elsif Finance::Schedule::NPQSpecialist::IDENTIFIERS.include?(profile.npq_course.identifier)
-        create(:npq_specialist_schedule)
-      else
-        create(:npq_aso_schedule)
-      end
-    end
+    let(:schedule) { create(:npq_leadership_schedule, schedule_identifier: "npq-aso-june", name: "NPQ ASO June") }
 
     let(:attributes) do
       {
-        schedule_identifier: new_schedule.schedule_identifier,
+        schedule_identifier: schedule.schedule_identifier,
         course_identifier: npq_application.npq_course.identifier,
-        cohort: new_schedule.cohort.start_year,
+        cohort: schedule.cohort.start_year,
       }
+    end
+
+    before do
+      declaration = profile.participant_declarations.first
+      schedule
+        .milestones
+        .find_by!(declaration_type: declaration.declaration_type)
+        .update!(start_date: declaration.declaration_date - 1.day)
     end
   end
 
@@ -154,7 +161,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
     let(:attributes) { { course_identifier: npq_application.npq_course.identifier } }
     before do
       DeferParticipant.new(
-        participant_id: npq_application.participant_identity.external_identifier,
+        participant_id: npq_application.participant_identity.user_id,
         reason: ParticipantProfile::DEFERRAL_REASONS.sample,
         course_identifier: npq_application.npq_course.identifier,
         cpd_lead_provider:,
@@ -187,7 +194,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                 }
 
       response "200", "The NPQ participant being withdrawn" do
-        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:id) { npq_application.participant_identity.user_id }
         let(:attributes) do
           {
             reason: ParticipantProfile::NPQ::WITHDRAW_REASONS.sample,
@@ -198,18 +205,10 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
         let(:params) do
           {
             "data": {
-              "type": "participant",
+              "type": "participant-withdraw",
               "attributes": attributes,
             },
           }
-        end
-
-        before do
-          participant_profile = npq_application.profile
-          user = npq_application.user
-          course_identifier = npq_application.npq_course.identifier
-
-          create(:npq_participant_declaration, participant_profile:, course_identifier:, user:)
         end
 
         schema({ "$ref": "#/components/schemas/NPQParticipantResponse" })
@@ -224,10 +223,11 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                   value: JSON.parse({
                     data: {
                       id: "db3a7848-7308-4879-942a-c4a70ced400a",
-                      type: "participant",
+                      type: "npq-participant",
                       attributes: {
                         "full_name": "Isabelle MacDonald",
                         "teacher_reference_number": "1234567",
+                        "updated_at": "2021-05-31T02:22:32.000Z",
                         "npq_enrolments": [
                           {
                             "email": "isabelle.macdonald2@some-school.example.com",
@@ -246,7 +246,6 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                             "created_at": "2021-05-31T02:22:32.000Z",
                           },
                         ],
-                        "updated_at": "2021-05-31T02:22:32.000Z",
                       },
                     },
                   }.to_json, symbolize_names: true),
@@ -257,12 +256,10 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
 
           example.metadata[:response][:content] = content.deep_merge(example_spec)
         end
-
-        run_test!
       end
 
       response "422", "Unprocessable entity" do
-        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:id) { npq_application.participant_identity.user_id }
         let(:attributes) do
           {
             reason: ParticipantProfile::NPQ::WITHDRAW_REASONS.sample,
@@ -273,7 +270,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
         let(:params) do
           {
             "data": {
-              "type": "participant",
+              "type": "participant-withdraw",
               "attributes": attributes,
             },
           }
@@ -311,7 +308,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                 }
 
       response "200", "The NPQ participant being deferred" do
-        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:id) { npq_application.participant_identity.user_id }
         let(:attributes) do
           {
             reason: ParticipantProfile::NPQ::DEFERRAL_REASONS.sample,
@@ -322,18 +319,10 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
         let(:params) do
           {
             "data": {
-              "type": "participant",
+              "type": "participant-defer",
               "attributes": attributes,
             },
           }
-        end
-
-        before do
-          participant_profile = npq_application.profile
-          user = npq_application.user
-          course_identifier = npq_application.npq_course.identifier
-
-          create(:npq_participant_declaration, participant_profile:, course_identifier:, user:)
         end
 
         schema({ "$ref": "#/components/schemas/NPQParticipantResponse" })
@@ -352,6 +341,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                       attributes: {
                         "full_name": "Isabelle MacDonald",
                         "teacher_reference_number": "1234567",
+                        "updated_at": "2021-05-31T02:22:32.000Z",
                         "npq_enrolments": [
                           {
                             "email": "isabelle.macdonald2@some-school.example.com",
@@ -370,7 +360,6 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
                             "created_at": "2021-05-31T02:22:32.000Z",
                           },
                         ],
-                        "updated_at": "2021-05-31T02:22:32.000Z",
                       },
                     },
                   }.to_json, symbolize_names: true),
@@ -386,7 +375,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
       end
 
       response "422", "Unprocessable entity" do
-        let(:id) { npq_application.participant_identity.external_identifier }
+        let(:id) { npq_application.participant_identity.user_id }
         let(:attributes) do
           {
             reason: ParticipantProfile::NPQ::DEFERRAL_REASONS.sample,
@@ -397,7 +386,7 @@ describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_sp
         let(:params) do
           {
             "data": {
-              "type": "participant",
+              "type": "participant-defer",
               "attributes": attributes,
             },
           }

--- a/spec/factories/participant_profiles.rb
+++ b/spec/factories/participant_profiles.rb
@@ -57,6 +57,17 @@ FactoryBot.define do
         end
       end
 
+      trait :deferred do
+        after(:create) do |participant_profile|
+          DeferParticipant.new(
+            participant_id: participant_profile.teacher_profile.user_id,
+            course_identifier: participant_profile.npq_application.npq_course.identifier,
+            cpd_lead_provider: participant_profile.npq_application.npq_lead_provider.cpd_lead_provider,
+            reason: "bereavement",
+          ).call
+        end
+      end
+
       initialize_with do
         npq_application.profile
       end

--- a/spec/models/participant_profile_state_spec.rb
+++ b/spec/models/participant_profile_state_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ParticipantProfileState, :with_default_schedules, type: :model do
+  let(:participant_profile) { create(:npq_participant_profile) }
+
+  subject(:participant_profile_state) { create(:participant_profile_state, participant_profile:) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:participant_profile).touch(true) }
+    it { is_expected.to belong_to(:cpd_lead_provider).optional }
+  end
+
+  describe "enums" do
+    it {
+      is_expected.to define_enum_for(:state).with_values(
+        active: "active",
+        deferred: "deferred",
+        withdrawn: "withdrawn",
+      ).backed_by_column_of_type(:text)
+    }
+  end
+
+  describe "scopes" do
+    describe ".most_recent" do
+      let!(:another_participant_profile_state) { create(:participant_profile_state, participant_profile:) }
+
+      before do
+        participant_profile_state.update!(created_at: 2.weeks.ago)
+      end
+
+      it "fetches the most recent record only" do
+        expect(described_class.most_recent).to eq([another_participant_profile_state])
+      end
+    end
+  end
+end

--- a/spec/models/participant_profile_state_spec.rb
+++ b/spec/models/participant_profile_state_spec.rb
@@ -34,5 +34,42 @@ RSpec.describe ParticipantProfileState, :with_default_schedules, type: :model do
         expect(described_class.most_recent).to eq([another_participant_profile_state])
       end
     end
+
+    describe ".withdrawn" do
+      let!(:another_participant_profile_state) { create(:participant_profile_state, participant_profile:) }
+
+      before do
+        participant_profile_state.update!(state: described_class.states[:withdrawn])
+      end
+
+      it "fetches withdrawn records only" do
+        expect(described_class.withdrawn).to eq([participant_profile_state])
+      end
+    end
+
+    describe ".deferred" do
+      let!(:another_participant_profile_state) { create(:participant_profile_state, participant_profile:) }
+
+      before do
+        participant_profile_state.update!(state: described_class.states[:deferred])
+      end
+
+      it "fetches deferred records only" do
+        expect(described_class.deferred).to eq([participant_profile_state])
+      end
+    end
+
+    describe ".for_lead_provider" do
+      let!(:another_participant_profile_state) { create(:participant_profile_state, participant_profile:) }
+      let(:cpd_lead_provider) { create(:cpd_lead_provider) }
+
+      before do
+        participant_profile_state.update!(cpd_lead_provider:)
+      end
+
+      it "fetches records from the given provider only" do
+        expect(described_class.for_lead_provider(cpd_lead_provider)).to eq([participant_profile_state])
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+  let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
+  let(:bearer_token) { "Bearer #{token}" }
+  let(:npq_lead_provider) { create(:npq_lead_provider) }
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
+  let(:parsed_response) { JSON.parse(response.body) }
+
+  before { default_headers[:Authorization] = bearer_token }
+
+  describe "GET /api/v3/participants/npq" do
+    let!(:npq_applications) do
+      create_list(:npq_application, 3, :accepted, :with_started_declaration, npq_lead_provider:, school_urn: "123456")
+    end
+
+    context "when authorized" do
+      let(:npq_application) { npq_applications.sample }
+      let(:npq_course)      { npq_application.npq_course }
+
+      describe "JSON Index API" do
+        let(:npq_course) { npq_applications.sample.npq_course }
+
+        it "returns correct jsonapi content type header" do
+          get "/api/v3/participants/npq"
+          expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+        end
+
+        it "returns all accepted users" do
+          get "/api/v3/participants/npq"
+          expect(parsed_response["data"].size).to eql(3)
+        end
+
+        it "returns correct type" do
+          get "/api/v3/participants/npq"
+          expect(parsed_response["data"][0]).to have_type("npq-participant")
+        end
+
+        it "returns IDs" do
+          get "/api/v3/participants/npq"
+
+          user = User.find(parsed_response["data"][0]["id"])
+          expect(parsed_response["data"][0]["id"]).to be_in(ParticipantIdentity.joins(:npq_applications).pluck(:user_id))
+          teacher_profile = user.teacher_profile
+
+          expect(parsed_response["data"][0]["attributes"]["email"]).to eql(user.email)
+          expect(parsed_response["data"][0]["attributes"]["full_name"]).to eql(user.full_name)
+          expect(parsed_response["data"][0]["attributes"]["teacher_reference_number"]).to eql(teacher_profile.trn)
+        end
+
+        it "has correct attributes" do
+          get "/api/v3/participants/npq"
+
+          expect(parsed_response["data"][0])
+            .to(have_jsonapi_attributes(
+              :email,
+              :full_name,
+              :teacher_reference_number,
+              :updated_at,
+              :npq_enrolments,
+            ).exactly)
+        end
+
+        it "can return paginated data" do
+          get "/api/v3/participants/npq", params: { page: { per_page: 2, page: 1 } }
+          expect(parsed_response["data"].size).to eql(2)
+
+          get "/api/v3/participants/npq", params: { page: { per_page: 2, page: 2 } }
+          expect(JSON.parse(response.body)["data"].size).to eql(1)
+        end
+
+        context "filtering" do
+          before do
+            travel_to 10.days.ago do
+              create_list(:npq_application, 3, :accepted, npq_lead_provider:, school_urn: "123456", npq_course:)
+            end
+          end
+
+          it "returns content updated after specified timestamp" do
+            get "/api/v3/participants/npq", params: { filter: { updated_since: 2.days.ago.iso8601 } }
+
+            expect(parsed_response["data"].size).to eq(3)
+          end
+
+          context "with invalid filter of a string" do
+            it "returns an error" do
+              get "/api/v3/participants/npq", params: { filter: 2.days.ago.iso8601 }
+              expect(response).to be_bad_request
+              expect(parsed_response).to eql(HashWithIndifferentAccess.new({
+                "errors": [
+                  {
+                    "title": "Bad parameter",
+                    "detail": "Filter must be a hash",
+                  },
+                ],
+              }))
+            end
+          end
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = "Bearer ugLPicDrpGZdD_w7hhCL"
+        get "/api/v3/participants/npq"
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when using a engage and learn token" do
+      let(:token) { EngageAndLearnApiToken.create_with_random_token! }
+
+      it "returns 401 for invalid bearer token" do
+        default_headers[:Authorization] = bearer_token
+        get "/api/v3/participants/npq"
+        expect(response.status).to eq 403
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -8,14 +8,13 @@ RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request, 
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
   let(:parsed_response) { JSON.parse(response.body) }
+  let!(:npq_applications) do
+    create_list(:npq_application, 3, :accepted, :with_started_declaration, npq_lead_provider:, school_urn: "123456")
+  end
 
   before { default_headers[:Authorization] = bearer_token }
 
   describe "GET /api/v3/participants/npq" do
-    let!(:npq_applications) do
-      create_list(:npq_application, 3, :accepted, :with_started_declaration, npq_lead_provider:, school_urn: "123456")
-    end
-
     context "when authorized" do
       let(:npq_application) { npq_applications.sample }
       let(:npq_course)      { npq_application.npq_course }
@@ -143,6 +142,143 @@ RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request, 
         get "/api/v3/participants/npq"
         expect(response.status).to eq 403
       end
+    end
+  end
+
+  describe "GET /api/v3/participants/npq/:id" do
+    let(:npq_application) { create(:npq_application, :accepted, :with_started_declaration, npq_lead_provider:) }
+    let(:npq_participant) { npq_application.profile }
+
+    before do
+      default_headers[:Authorization] = bearer_token
+      get "/api/v3/participants/npq/#{npq_participant.user_id}"
+    end
+
+    context "when authorized" do
+      it "returns correct jsonapi content type header" do
+        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+      end
+
+      it "returns 200" do
+        expect(response.status).to eq 200
+      end
+
+      it "returns correct type" do
+        expect(parsed_response["data"]).to have_type("npq-participant")
+      end
+
+      it "returns correct data" do
+        user = User.find(parsed_response["data"]["id"])
+        expect(parsed_response["data"]["id"]).to be_in(ParticipantIdentity.joins(:npq_applications).pluck(:user_id))
+        expect(parsed_response["data"]["attributes"]["full_name"]).to eql(user.full_name)
+        expect(parsed_response["data"]["attributes"]["teacher_reference_number"]).to eql(user.teacher_profile.trn)
+        expect(parsed_response["data"]["attributes"]["updated_at"]).to eql(user.updated_at.rfc3339)
+      end
+
+      it "has correct attributes" do
+        expect(parsed_response["data"])
+          .to(have_jsonapi_attributes(
+            :full_name,
+            :teacher_reference_number,
+            :updated_at,
+            :npq_enrolments,
+          ).exactly)
+      end
+    end
+
+    context "when unauthorized" do
+      let(:token) { "wrong_token" }
+
+      it "returns 401 for invalid bearer token" do
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
+  describe "PUT /api/v3/participants/npq/:id/change-schedule" do
+    let(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:) }
+    let(:profile) { npq_application.profile }
+    let(:new_schedule) do
+      if Finance::Schedule::NPQLeadership::IDENTIFIERS.include?(profile.npq_course.identifier)
+        create(:npq_leadership_schedule, schedule_identifier: SecureRandom.alphanumeric)
+      elsif Finance::Schedule::NPQSpecialist::IDENTIFIERS.include?(profile.npq_course.identifier)
+        create(:npq_specialist_schedule, schedule_identifier: SecureRandom.alphanumeric)
+      else
+        create(:npq_aso_schedule, schedule_identifier: SecureRandom.alphanumeric)
+      end
+    end
+
+    it "changes the schedules of the specified profile", :aggregate_failures do
+      put "/api/v3/participants/npq/#{npq_application.profile.user_id}/change-schedule", params: {
+        data: {
+          type: "participant-change-schedule",
+          attributes: {
+            schedule_identifier: new_schedule.schedule_identifier,
+            course_identifier: npq_application.npq_course.identifier,
+            cohort: new_schedule.cohort.start_year,
+          },
+        },
+      }
+
+      expect(response).to be_successful
+      expect(npq_application.profile.reload.schedule).to eq(new_schedule)
+    end
+  end
+
+  describe "JSON Participant Withdrawal endpoint" do
+    let(:npq_application)   { npq_applications.sample }
+    let(:npq_course)        { npq_application.npq_course }
+    let(:profile)           { npq_application.profile }
+    let(:url) { "/api/v3/participants/npq/#{npq_application.user.id}/withdraw" }
+    let(:params) do
+      { data: { attributes: { course_identifier: npq_course.identifier, reason: ParticipantProfile::NPQ::WITHDRAW_REASONS.sample } } }
+    end
+
+    context "when there is a started declaration" do
+      it_behaves_like "a participant withdraw action endpoint" do
+        it "changes the training status of a participant to withdrawn" do
+          put(url, params:)
+
+          expect(response).to be_successful
+          expect(npq_application.reload.profile.training_status).to eql("withdrawn")
+        end
+      end
+    end
+
+    context "when there are no started declarations" do
+      let(:npq_application) { create(:npq_application, :accepted, npq_lead_provider:, school_urn: "123456") }
+
+      it "returns an error message" do
+        put(url, params:)
+
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+
+  it_behaves_like "JSON Participant Deferral endpoint", "npq-participant" do
+    let(:npq_application)   { npq_applications.sample }
+    let(:npq_course)        { npq_application.npq_course }
+    let(:profile)           { npq_application.profile }
+    let(:course_identifier) { npq_course.identifier }
+    let(:url)               { "/api/v3/participants/npq/#{npq_application.user.id}/defer" }
+    let(:withdrawal_url)    { "/api/v3/participants/npq/#{npq_application.user.id}/withdraw" }
+    let(:params)            { { data: { attributes: { course_identifier:, reason: ParticipantProfile::DEFERRAL_REASONS.sample } } } }
+    let(:withdrawal_params) { { data: { attributes: { course_identifier:, reason: ParticipantProfile::NPQ::WITHDRAW_REASONS.sample } } } }
+  end
+
+  it_behaves_like "JSON Participant Resume endpoint", "npq-participant" do
+    let(:npq_application)   { npq_applications.sample }
+    let(:npq_course)        { npq_application.npq_course }
+    let(:profile)           { npq_application.profile }
+    let(:course_identifier) { npq_course.identifier }
+    let(:url)               { "/api/v3/participants/npq/#{npq_application.user.id}/resume" }
+    let(:withdrawal_url)    { "/api/v3/participants/npq/#{npq_application.user.id}/withdraw" }
+    let(:params)            { { data: { attributes: { course_identifier: } } } }
+    let(:withdrawal_params) { { data: { attributes: { course_identifier:, reason: ParticipantProfile::NPQ::WITHDRAW_REASONS.sample } } } }
+    before do
+      put "/api/v3/participants/npq/#{npq_application.user.id}/defer",
+          params: { data: { attributes: { course_identifier:, reason: ParticipantProfile::DEFERRAL_REASONS.sample } } }
     end
   end
 end

--- a/spec/serializers/api/v3/npq_participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/npq_participant_serializer_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Api
+  module V3
+    RSpec.describe NPQParticipantSerializer do
+      describe "serialization", :with_default_schedules do
+        let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+        let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+        let(:user) { create(:user) }
+        let!(:profile) { create(:npq_participant_profile, user:, npq_lead_provider:) }
+        let!(:participant) { profile.user }
+
+        subject { described_class.new([participant], params: { cpd_lead_provider: }) }
+
+        it "returns the expected data" do
+          result = subject.serializable_hash
+
+          expect(result[:data]).to match_array([
+            id: participant.id,
+            type: :'npq-participant',
+            attributes: {
+              full_name: profile.user.full_name,
+              teacher_reference_number: participant.teacher_profile.trn,
+              updated_at: profile.user.updated_at.rfc3339,
+              npq_enrolments: [{
+                email: profile.user.email,
+                course_identifier: profile.npq_course.identifier,
+                schedule_identifier: profile.schedule.schedule_identifier,
+                cohort: profile.schedule.cohort.start_year.to_s,
+                npq_application_id: profile.npq_application.id,
+                eligible_for_funding: profile.npq_application.eligible_for_funding,
+                training_status: profile.training_status,
+                school_urn: profile.school_urn,
+                targeted_delivery_funding_eligibility: profile.npq_application.targeted_delivery_funding_eligibility,
+                created_at: profile.created_at.rfc3339,
+              }],
+            },
+          ])
+        end
+
+        describe "npq_enrolments" do
+          context "when there are multiple providers involved" do
+            let(:another_cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+            let(:another_npq_lead_provider) { another_cpd_lead_provider.npq_lead_provider }
+            let!(:second_profile) { create(:npq_participant_profile, user:, npq_lead_provider: another_npq_lead_provider) }
+
+            it "only includes enrolments from the querying provider" do
+              result = subject.serializable_hash
+
+              expect(result[:data][0][:attributes][:npq_enrolments].size).to be(1)
+            end
+          end
+
+          context "when the profile is withdrawn" do
+            let!(:profile) { create(:npq_participant_profile, :withdrawn, user:, npq_lead_provider:) }
+
+            it "includes a withdrawal object" do
+              result = subject.serializable_hash
+
+              expect(result[:data][0][:attributes][:npq_enrolments][0][:withdrawal]).to eq({
+                reason: profile.participant_profile_state.reason,
+                date: profile.participant_profile_state.created_at.rfc3339,
+              })
+            end
+
+            it "does not include a deferral object" do
+              result = subject.serializable_hash
+
+              expect(result[:data][0][:attributes][:npq_enrolments][0][:deferral]).to be_nil
+            end
+          end
+
+          context "when the profile is deferred" do
+            let!(:profile) { create(:npq_participant_profile, :deferred, user:, npq_lead_provider:) }
+
+            it "includes a deferral object" do
+              result = subject.serializable_hash
+
+              expect(result[:data][0][:attributes][:npq_enrolments][0][:deferral]).to eq({
+                reason: profile.participant_profile_state.reason,
+                date: profile.participant_profile_state.created_at.rfc3339,
+              })
+            end
+
+            it "does not include a withdrawal object" do
+              result = subject.serializable_hash
+
+              expect(result[:data][0][:attributes][:npq_enrolments][0][:withdrawal]).to be_nil
+            end
+          end
+
+          it "does not include a withdrawal object" do
+            result = subject.serializable_hash
+
+            expect(result[:data][0][:attributes][:npq_enrolments][0][:withdrawal]).to be_nil
+          end
+
+          it "does not include a deferral object" do
+            result = subject.serializable_hash
+
+            expect(result[:data][0][:attributes][:npq_enrolments][0][:deferral]).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v3/npq_participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/npq_participant_serializer_spec.rb
@@ -34,6 +34,8 @@ module Api
                 training_status: profile.training_status,
                 school_urn: profile.school_urn,
                 targeted_delivery_funding_eligibility: profile.npq_application.targeted_delivery_funding_eligibility,
+                withdrawal: nil,
+                deferral: nil,
                 created_at: profile.created_at.rfc3339,
               }],
             },
@@ -64,12 +66,6 @@ module Api
                 date: profile.participant_profile_state.created_at.rfc3339,
               })
             end
-
-            it "does not include a deferral object" do
-              result = subject.serializable_hash
-
-              expect(result[:data][0][:attributes][:npq_enrolments][0][:deferral]).to be_nil
-            end
           end
 
           context "when the profile is deferred" do
@@ -83,24 +79,6 @@ module Api
                 date: profile.participant_profile_state.created_at.rfc3339,
               })
             end
-
-            it "does not include a withdrawal object" do
-              result = subject.serializable_hash
-
-              expect(result[:data][0][:attributes][:npq_enrolments][0][:withdrawal]).to be_nil
-            end
-          end
-
-          it "does not include a withdrawal object" do
-            result = subject.serializable_hash
-
-            expect(result[:data][0][:attributes][:npq_enrolments][0][:withdrawal]).to be_nil
-          end
-
-          it "does not include a deferral object" do
-            result = subject.serializable_hash
-
-            expect(result[:data][0][:attributes][:npq_enrolments][0][:deferral]).to be_nil
           end
         end
       end

--- a/spec/services/api/v3/npq_participants_query_spec.rb
+++ b/spec/services/api/v3/npq_participants_query_spec.rb
@@ -42,4 +42,28 @@ RSpec.describe Api::V3::NPQParticipantsQuery, :with_default_schedules do
       end
     end
   end
+
+  describe "#participant" do
+    context "with correct params" do
+      let(:params) { { id: participant_profile.user_id } }
+
+      it "returns a specific participant" do
+        expect(subject.participant).to eq(user)
+      end
+    end
+
+    context "with incorrect params" do
+      let(:params) { { id: SecureRandom.uuid } }
+
+      it "returns no participant" do
+        expect { subject.participant }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with no params" do
+      it "returns no participant" do
+        expect { subject.participant }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end

--- a/spec/services/api/v3/npq_participants_query_spec.rb
+++ b/spec/services/api/v3/npq_participants_query_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V3::NPQParticipantsQuery, :with_default_schedules do
+  let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
+  let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
+  let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }
+  let(:user) { create(:user, full_name: "John Doe") }
+  let(:teacher_profile) { create(:teacher_profile, user:, trn: "1234567") }
+  let!(:participant_profile) { create(:npq_participant_profile, npq_lead_provider:, npq_course:, teacher_profile:, user:) }
+
+  let(:params) { {} }
+
+  subject { described_class.new(npq_lead_provider:, params:) }
+
+  describe "#participants" do
+    it "returns all participants" do
+      expect(subject.participants).to match_array([user])
+    end
+
+    describe "updated_since filter" do
+      let!(:another_participant_profile) { create(:npq_participant_profile, npq_lead_provider:, npq_course:) }
+      let(:params) { { filter: { updated_since: 1.day.ago.iso8601 } } }
+
+      before { another_participant_profile.user.update(updated_at: 4.days.ago.iso8601) }
+
+      context "with correct value" do
+        it "returns all records for the specific updated_since filter" do
+          expect(subject.participants).to match_array([user])
+        end
+      end
+
+      context "with incorrect value" do
+        let(:params) { { filter: { updated_since: SecureRandom.uuid } } }
+
+        it "raises an error" do
+          expect {
+            subject.participants
+          }.to raise_error(Api::Errors::InvalidDatetimeError)
+        end
+      end
+    end
+  end
+end

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -959,6 +959,18 @@
             "required": false,
             "example": "page[page]=1&page[per_page]=5",
             "description": "Pagination options to navigate through the list of NPQ participants."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NPQParticipantsSort"
+            },
+            "style": "form",
+            "explode": false,
+            "required": false,
+            "description": "Sort NPQ participants being returned.",
+            "example": "sort=-updated_at"
           }
         ],
         "responses": {
@@ -1157,7 +1169,6 @@
                               "training_status": "deferred",
                               "school_urn": "123456",
                               "targeted_delivery_funding_eligibility": true,
-                              "withdrawal": null,
                               "deferral": {
                                 "reason": "other",
                                 "date": "2022-12-09T16:07:38Z"
@@ -1293,7 +1304,6 @@
                                 "reason": "insufficient-capacity",
                                 "date": "2022-12-09T16:07:38Z"
                               },
-                              "deferral": null,
                               "created_at": "2021-05-31T02:22:32.000Z"
                             }
                           ],
@@ -4752,12 +4762,14 @@
           },
           "withdrawal": {
             "nullable": true,
+            "type": "object",
             "anyOf": [
               { "$ref": "#/components/schemas/NPQWithdrawal" }
             ]
           },
           "deferral": {
             "nullable": true,
+            "type": "object",
             "anyOf": [
               { "$ref": "#/components/schemas/NPQDeferral" }
             ]
@@ -5035,18 +5047,18 @@
             "example": "1234567",
             "nullable": true
           },
+          "updated_at": {
+            "description": "The date the NPQ participant was last updated",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:22:32.000Z"
+          },
           "npq_enrolments": {
             "description": "Information about the course(s) the participant is enroled in",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/NPQEnrolment"
             }
-          },
-          "updated_at": {
-            "description": "The date the NPQ participant was last updated",
-            "type": "string",
-            "format": "date-time",
-            "example": "2021-05-31T02:22:32.000Z"
           }
         }
       },
@@ -5923,6 +5935,19 @@
             ],
             "example": "unknown"
           }
+        }
+      },
+      "NPQParticipantsSort": {
+        "description": "Sort NPQ participants being returned",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "created_at",
+            "-created_at",
+            "updated_at",
+            "-updated_at"
+          ]
         }
       },
       "NPQParticipantWithdraw": {

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -1170,6 +1170,7 @@
                               "training_status": "deferred",
                               "school_urn": "123456",
                               "targeted_delivery_funding_eligibility": true,
+                              "withdrawal": null,
                               "deferral": {
                                 "reason": "other",
                                 "date": "2022-12-09T16:07:38Z"
@@ -1305,6 +1306,7 @@
                                 "reason": "insufficient-capacity",
                                 "date": "2022-12-09T16:07:38Z"
                               },
+                              "deferral": null,
                               "created_at": "2021-05-31T02:22:32.000Z"
                             }
                           ]

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -1158,6 +1158,7 @@
                         "attributes": {
                           "full_name": "Isabelle MacDonald",
                           "teacher_reference_number": "1234567",
+                          "updated_at": "2021-05-31T02:22:32.000Z",
                           "npq_enrolments": [
                             {
                               "email": "isabelle.macdonald2@some-school.example.com",
@@ -1175,8 +1176,7 @@
                               },
                               "created_at": "2021-05-31T02:22:32.000Z"
                             }
-                          ],
-                          "updated_at": "2021-05-31T02:22:32.000Z"
+                          ]
                         }
                       }
                     }
@@ -1289,6 +1289,7 @@
                         "attributes": {
                           "full_name": "Isabelle MacDonald",
                           "teacher_reference_number": "1234567",
+                          "updated_at": "2021-05-31T02:22:32.000Z",
                           "npq_enrolments": [
                             {
                               "email": "isabelle.macdonald2@some-school.example.com",
@@ -1306,8 +1307,7 @@
                               },
                               "created_at": "2021-05-31T02:22:32.000Z"
                             }
-                          ],
-                          "updated_at": "2021-05-31T02:22:32.000Z"
+                          ]
                         }
                       }
                     }

--- a/swagger/v3/component_schemas/NPQEnrolment.yml
+++ b/swagger/v3/component_schemas/NPQEnrolment.yml
@@ -75,9 +75,11 @@ properties:
     example: true
   withdrawal:
     nullable: true
+    type: object
     $ref: "#/components/schemas/NPQWithdrawal"
   deferral:
     nullable: true
+    type: object
     $ref: "#/components/schemas/NPQDeferral"
   created_at:
     description: The date and time the NPQ participant was created

--- a/swagger/v3/component_schemas/NPQParticipantAttributes.yml
+++ b/swagger/v3/component_schemas/NPQParticipantAttributes.yml
@@ -14,13 +14,13 @@ properties:
     type: string
     example: "1234567"
     nullable: true
-  npq_enrolments:
-    description: "Information about the course(s) the participant is enroled in"
-    type: array
-    items:
-      $ref: "#/components/schemas/NPQEnrolment"
   updated_at:
     description: "The date the NPQ participant was last updated"
     type: string
     format: date-time
     example: "2021-05-31T02:22:32.000Z"
+  npq_enrolments:
+    description: "Information about the course(s) the participant is enroled in"
+    type: array
+    items:
+      $ref: "#/components/schemas/NPQEnrolment"

--- a/swagger/v3/component_schemas/NPQParticipantsSort.yml
+++ b/swagger/v3/component_schemas/NPQParticipantsSort.yml
@@ -1,0 +1,9 @@
+description: "Sort NPQ participants being returned"
+type: array
+items:
+  type: string
+  enum:
+    - created_at
+    - -created_at
+    - updated_at
+    - -updated_at


### PR DESCRIPTION
### Context

We’d like to surface NPQ participants as well as all related actions in V3.

- Ticket: [CPDLP-2110](https://dfedigital.atlassian.net/browse/CPDLP-2110)

### Changes proposed in this pull request

Add a new GET endpoint `/api/v3/participants/npq endpoint` to fetch NPQ participants and their NPQ enrolments.




[CPDLP-2110]: https://dfedigital.atlassian.net/browse/CPDLP-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ