### PR TITLE
Update partnership API spec

### DIFF
--- a/app/serializers/api/v3/ecf/partnership_serializer.rb
+++ b/app/serializers/api/v3/ecf/partnership_serializer.rb
@@ -10,7 +10,7 @@ module Api
         include JSONAPI::Serializer::Instrumentation
 
         set_id :id
-        set_type :'partnership-confirmation'
+        set_type :partnership
 
         attribute :cohort do |partnership|
           partnership.cohort.display_name

--- a/spec/docs/v3/ecf_partnerships_spec.rb
+++ b/spec/docs/v3/ecf_partnerships_spec.rb
@@ -135,6 +135,41 @@ RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
         response "200", "Create an ECF partnership" do
           schema({ "$ref": "#/components/schemas/ECFPartnershipResponse" })
 
+          after do |example|
+            content = example.metadata[:response][:content] || {}
+
+            example_spec = {
+              "application/json" => {
+                examples: {
+                  success: {
+                    value: JSON.parse({
+                      data: {
+                        id: "cd3a12347-7308-4879-942a-c4a70ced400a",
+                        type: "partnership",
+                        attributes: {
+                          cohort: 2021,
+                          urn: "123456",
+                          school_id: "dd4a11347-7308-4879-942a-c4a70ced400v",
+                          delivery_partner_id: "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+                          delivery_partner_name: "Delivery Partner Example",
+                          status: "active",
+                          challenged_reason: nil,
+                          challenged_at: nil,
+                          induction_tutor_name: "John Doe",
+                          induction_tutor_email: "john.doe@example.com",
+                          updated_at: "2021-05-31T02:22:32.000Z",
+                          created_at: "2021-05-31T02:22:32.000Z",
+                        },
+                      },
+                    }.to_json, symbolize_names: true),
+                  },
+                },
+              },
+            }
+
+            example.metadata[:response][:content] = content.deep_merge(example_spec)
+          end
+
           run_test!
         end
 
@@ -198,34 +233,36 @@ RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
           # TODO: replace with actual implementation once implemented
           after do |example|
             content = example.metadata[:response][:content] || {}
+
             example_spec = {
               "application/json" => {
                 examples: {
-                  update_partnership: {
-                    value: {
+                  success: {
+                    value: JSON.parse({
                       data: {
                         id: "cd3a12347-7308-4879-942a-c4a70ced400a",
                         type: "partnership",
                         attributes: {
                           cohort: 2021,
                           urn: "123456",
-                          delivery_partner_name: "Delivery partner name",
-                          delivery_partner_id: "28c461ee-ffc0-4e56-96bd-788579a0ed75",
-                          school_id: "dd3a12347-7308-4879-942a-c4a70ced400a",
+                          school_id: "dd4a11347-7308-4879-942a-c4a70ced400v",
+                          delivery_partner_id: "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+                          delivery_partner_name: "Delivery Partner Example",
                           status: "active",
                           challenged_reason: nil,
-                          challenged_at: "2021-05-31T02:22:32.000Z",
+                          challenged_at: nil,
                           induction_tutor_name: "John Doe",
                           induction_tutor_email: "john.doe@example.com",
                           updated_at: "2021-05-31T02:22:32.000Z",
                           created_at: "2021-05-31T02:22:32.000Z",
                         },
                       },
-                    },
+                    }.to_json, symbolize_names: true),
                   },
                 },
               },
             }
+
             example.metadata[:response][:content] = content.deep_merge(example_spec)
           end
 

--- a/spec/requests/api/v3/ecf/partnerships_spec.rb
+++ b/spec/requests/api/v3/ecf/partnerships_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "API ECF Partnerships", :with_default_schedules, type: :request d
       it "returns correct type" do
         get "/api/v3/partnerships/ecf"
 
-        expect(parsed_response["data"][0]).to have_type("partnership-confirmation")
+        expect(parsed_response["data"][0]).to have_type("partnership")
       end
 
       it "returns IDs" do
@@ -164,7 +164,7 @@ RSpec.describe "API ECF Partnerships", :with_default_schedules, type: :request d
       end
 
       it "returns correct type" do
-        expect(parsed_response["data"]).to have_type("partnership-confirmation")
+        expect(parsed_response["data"]).to have_type("partnership")
       end
 
       it "has correct attributes" do
@@ -252,7 +252,7 @@ RSpec.describe "API ECF Partnerships", :with_default_schedules, type: :request d
           expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
           expect(response.status).to eq 200
 
-          expect(parsed_response["data"]).to have_type("partnership-confirmation")
+          expect(parsed_response["data"]).to have_type("partnership")
           expect(parsed_response["data"]).to have_jsonapi_attributes(
             :cohort,
             :urn,

--- a/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/partnership_serializer_spec.rb
@@ -23,7 +23,7 @@ module Api
           end
 
           it "sets the type" do
-            expect(subject.serializable_hash[:data][:type]).to eq(:"partnership-confirmation")
+            expect(subject.serializable_hash[:data][:type]).to eq(:partnership)
           end
 
           it "returns the cohort start year" do

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -235,6 +235,30 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ECFPartnershipResponse"
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "data": {
+                        "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+                        "type": "partnership",
+                        "attributes": {
+                          "cohort": 2021,
+                          "urn": "123456",
+                          "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+                          "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+                          "delivery_partner_name": "Delivery Partner Example",
+                          "status": "active",
+                          "challenged_reason": null,
+                          "challenged_at": null,
+                          "induction_tutor_name": "John Doe",
+                          "induction_tutor_email": "john.doe@example.com",
+                          "updated_at": "2021-05-31T02:22:32.000Z",
+                          "created_at": "2021-05-31T02:22:32.000Z"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -351,6 +375,30 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ECFPartnershipResponse"
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "data": {
+                        "id": "cd3a12347-7308-4879-942a-c4a70ced400a",
+                        "type": "partnership",
+                        "attributes": {
+                          "cohort": 2021,
+                          "urn": "123456",
+                          "school_id": "dd4a11347-7308-4879-942a-c4a70ced400v",
+                          "delivery_partner_id": "db2fbf67-b7b7-454f-a1b7-0020411e2314",
+                          "delivery_partner_name": "Delivery Partner Example",
+                          "status": "active",
+                          "challenged_reason": null,
+                          "challenged_at": null,
+                          "induction_tutor_name": "John Doe",
+                          "induction_tutor_email": "john.doe@example.com",
+                          "updated_at": "2021-05-31T02:22:32.000Z",
+                          "created_at": "2021-05-31T02:22:32.000Z"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
### Context

@hazelyule has pointed out some incorrect API responses for POST and PUT partnership endpoints

- Ticket: n/a

### Changes proposed in this pull request

- Add manual examples to the v3 API spec for POST and PUT partnership endpoints which are not challenged to avoid confusion 
- Amend partnership response type to match API spec

### Guidance to review
Did I miss anything?
