### PR TITLE
Return distinct delivery partners in API response

### DIFF
--- a/app/services/api/v3/delivery_partners_query.rb
+++ b/app/services/api/v3/delivery_partners_query.rb
@@ -14,7 +14,7 @@ module Api
         scope = lead_provider.delivery_partners
         scope = scope.where("provider_relationships.cohort_id IN (?)", with_cohorts.map(&:id)) if filter[:cohort].present?
         scope = scope.order("delivery_partners.updated_at DESC") if params[:sort].blank?
-        scope
+        scope.distinct
       end
 
       def delivery_partner

--- a/spec/services/api/v3/delivery_partners_query_spec.rb
+++ b/spec/services/api/v3/delivery_partners_query_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe Api::V3::DeliveryPartnersQuery do
         expect(subject.delivery_partners).to be_empty
       end
     end
+
+    context "when delivery_partners belongs in multiple cohorts" do
+      before do
+        create(:provider_relationship, cohort: another_cohort, delivery_partner:, lead_provider:)
+        create(:provider_relationship, cohort:, delivery_partner: another_delivery_partner, lead_provider:)
+      end
+
+      it "returns each delivery partner only once" do
+        expect(subject.delivery_partners).to match_array([delivery_partner, another_delivery_partner])
+      end
+    end
   end
 
   describe "#delivery_partner" do


### PR DESCRIPTION
### Context

Avoid duplicate records from delivery partner query if delivery partner is in a relationship across multiple cohorts.

- Ticket: n/a

### Changes proposed in this pull request
Add `distinct` to delivery partner query for API v3

### Guidance to review
Did I miss anything?
