### PR TITLE
Add search bar to admin suppliers and delivery partners pages

### DIFF
--- a/app/assets/stylesheets/search_box.scss
+++ b/app/assets/stylesheets/search_box.scss
@@ -1,6 +1,7 @@
 .search-box {
   background-color: govuk-colour("light-grey");
   padding: govuk-spacing(4) govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
 
   &__button {
     margin-bottom: 0;

--- a/app/controllers/admin/delivery_partners/users_controller.rb
+++ b/app/controllers/admin/delivery_partners/users_controller.rb
@@ -8,8 +8,8 @@ module Admin
       before_action :set_delivery_partner_profile_and_authorize, only: %i[edit update delete destroy]
 
       def index
+        @query = params[:query]
         authorize DeliveryPartnerProfile
-        scoped = policy_scope(DeliveryPartnerProfile).includes(:user).order("users.full_name asc")
         @pagy, @delivery_partner_profiles = pagy(scoped, page: params[:page], items: 20)
       end
 
@@ -66,6 +66,14 @@ module Admin
       def set_delivery_partner_profile_and_authorize
         @delivery_partner_profile = DeliveryPartnerProfile.find(params[:id])
         authorize @delivery_partner_profile.user
+      end
+
+      def scoped
+        return policy_scope(DeliveryPartnerProfile).includes(:user).order("users.full_name asc") if params[:query].blank?
+
+        ::DeliveryPartnerProfiles::SearchQuery
+          .new(query: params[:query], scope: policy_scope(DeliveryPartnerProfile))
+          .call
       end
     end
   end

--- a/app/controllers/admin/suppliers/supplier_users_controller.rb
+++ b/app/controllers/admin/suppliers/supplier_users_controller.rb
@@ -10,8 +10,8 @@ module Admin
       before_action :form_from_session, only: %i[user_details review create]
 
       def index
-        sorted_users = User.for_lead_provider.sort_by(&:full_name)
-        @pagy, @users = pagy_array(sorted_users, page: params[:page], items: 20)
+        @query = params[:query]
+        @pagy, @lead_providers = pagy_array(scoped_lead_providers, page: params[:page], items: 20)
         @page = @pagy.page
         @total_pages = @pagy.pages
       end
@@ -81,6 +81,14 @@ module Admin
 
       def form_from_session
         @supplier_user_form = SupplierUserForm.new(session[:supplier_user_form])
+      end
+
+      def scoped_lead_providers
+        return policy_scope(LeadProviderProfile).includes(:user).order("users.full_name asc") if params[:query].blank?
+
+        ::LeadProviderProfiles::SearchQuery
+          .new(query: params[:query], scope: policy_scope(LeadProviderProfile))
+          .call
       end
     end
   end

--- a/app/controllers/admin/suppliers/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers/suppliers_controller.rb
@@ -6,14 +6,21 @@ module Admin
       skip_after_action :verify_authorized, only: :index
 
       def index
-        suppliers_search = delivery_partners_search + lead_providers_search
         @query = params[:query]
+        @type = params[:type]
         @pagy, @suppliers = pagy_array(suppliers_search, page: params[:page], items: 20)
         @page = @pagy.page
         @total_pages = @pagy.pages
       end
 
     private
+
+      def suppliers_search
+        return delivery_partners_search if params[:type] == "delivery_partner"
+        return lead_providers_search if params[:type] == "lead_provider"
+
+        delivery_partners_search + lead_providers_search
+      end
 
       def delivery_partners_search
         ::DeliveryPartners::SearchQuery

--- a/app/controllers/admin/suppliers/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers/suppliers_controller.rb
@@ -6,12 +6,25 @@ module Admin
       skip_after_action :verify_authorized, only: :index
 
       def index
-        lead_providers = policy_scope(LeadProvider).sort_by(&:name)
-        delivery_partners = policy_scope(DeliveryPartner).sort_by(&:name)
-        sorted_suppliers = (lead_providers + delivery_partners)
-        @pagy, @suppliers = pagy_array(sorted_suppliers, page: params[:page], items: 20)
+        suppliers_search = delivery_partners_search + lead_providers_search
+        @query = params[:query]
+        @pagy, @suppliers = pagy_array(suppliers_search, page: params[:page], items: 20)
         @page = @pagy.page
         @total_pages = @pagy.pages
+      end
+
+    private
+
+      def delivery_partners_search
+        ::DeliveryPartners::SearchQuery
+          .new(query: params[:query], scope: policy_scope(DeliveryPartner))
+          .call
+      end
+
+      def lead_providers_search
+        ::LeadProviders::SearchQuery
+          .new(query: params[:query], scope: policy_scope(LeadProvider))
+          .call
       end
     end
   end

--- a/app/queries/delivery_partner_profiles/search_query.rb
+++ b/app/queries/delivery_partner_profiles/search_query.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module DeliveryPartnerProfiles
+  class SearchQuery
+    attr_reader :query, :scope
+
+    def initialize(query:, scope: DeliveryPartnerProfile.all)
+      @query = query.strip
+      @scope = scope
+    end
+
+    def call
+      scope
+        .includes(:user, :delivery_partner)
+        .where("users.full_name ILIKE ?", "%#{query}%")
+        .or(scope.where("users.email ILIKE ?", "%#{query}%"))
+        .or(scope.where("delivery_partners.name ILIKE ?", "%#{query}%"))
+        .order("users.full_name ASC")
+    end
+  end
+end

--- a/app/queries/delivery_partners/search_query.rb
+++ b/app/queries/delivery_partners/search_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DeliveryPartners
+  class SearchQuery
+    attr_reader :query, :scope
+
+    def initialize(query:, scope: DeliveryPartner.all)
+      @query = query
+      @scope = scope
+    end
+
+    def call
+      scope
+        .distinct
+        .ransack(name_cont: query)
+        .result
+        .order(:name)
+    end
+  end
+end

--- a/app/queries/lead_provider_profiles/search_query.rb
+++ b/app/queries/lead_provider_profiles/search_query.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module LeadProviderProfiles
+  class SearchQuery
+    attr_reader :query, :scope
+
+    def initialize(query:, scope: LeadProviderProfile.all)
+      @query = query.strip
+      @scope = scope
+    end
+
+    def call
+      scope
+        .includes(:user, :lead_provider)
+        .where("users.full_name ILIKE ?", "%#{query}%")
+        .or(scope.where("users.email ILIKE ?", "%#{query}%"))
+        .or(scope.where("lead_providers.name ILIKE ?", "%#{query}%"))
+        .order("users.full_name ASC")
+    end
+  end
+end

--- a/app/queries/lead_providers/search_query.rb
+++ b/app/queries/lead_providers/search_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module LeadProviders
+  class SearchQuery
+    attr_reader :query, :scope
+
+    def initialize(query:, scope: LeadProvider.all)
+      @query = query
+      @scope = scope
+    end
+
+    def call
+      scope
+        .distinct
+        .ransack(name_cont: query)
+        .result
+        .order(:name)
+    end
+  end
+end

--- a/app/views/admin/delivery_partners/users/index.html.erb
+++ b/app/views/admin/delivery_partners/users/index.html.erb
@@ -2,7 +2,14 @@
 
 <%= render "admin/delivery_partners/heading" %>
 
+<%= render SearchBox.new(
+  query: @query,
+  title: "Search delivery partner users",
+  hint: "Enter the user’s name, email address or delivery partner"
+) %>
+
 <%= govuk_button_link_to "Add a new user", new_admin_delivery_partners_user_path %>
+
 <table class="govuk-table">
   <thead>
     <tr class="govuk-table__row">

--- a/app/views/admin/suppliers/supplier_users/index.html.erb
+++ b/app/views/admin/suppliers/supplier_users/index.html.erb
@@ -1,6 +1,14 @@
 <% content_for :title, "Users" %>
 <%= render "admin/suppliers/suppliers/layout", locals = { page: "users" } %>
+
+<%= render SearchBox.new(
+  query: @query,
+  title: "Search supplier users",
+  hint: "Enter the user's name, email address or supplier",
+) %>
+
 <%= govuk_button_link_to "Add a new user", new_admin_supplier_user_path %>
+
 <table class="govuk-table">
   <thead>
     <tr class="govuk-table__row">
@@ -10,7 +18,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @users.each do |user| %>
+    <% @lead_providers.map(&:user).each do |user| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= govuk_link_to user.full_name, admin_edit_user_path(user), "data-test": "edit-supplier-user-link" %></td>
         <td class="govuk-table__cell"><%= user.email %></td>
@@ -19,4 +27,5 @@
     <% end %>
   </tbody>
 </table>
+
 <%== govuk_pagination(pagy: @pagy) %>

--- a/app/views/admin/suppliers/suppliers/index.html.erb
+++ b/app/views/admin/suppliers/suppliers/index.html.erb
@@ -1,7 +1,10 @@
 <% content_for :title, "Suppliers" %>
-<%= render "layout", locals = { page: "suppliers" } %>
 
+<%= render "layout", locals = { page: "suppliers" } %>
 <p class="govuk-body-l">Manage your lead providers and delivery partners supplying training.</p>
+
+<%= render SearchBox.new(query: @query, title: "Search suppliers", hint: "Enter the supplier's name") %>
+
 
 <%= govuk_button_link_to "Add a new delivery partner", choose_name_admin_delivery_partners_path %>
 

--- a/app/views/admin/suppliers/suppliers/index.html.erb
+++ b/app/views/admin/suppliers/suppliers/index.html.erb
@@ -1,10 +1,23 @@
 <% content_for :title, "Suppliers" %>
 
 <%= render "layout", locals = { page: "suppliers" } %>
-<p class="govuk-body-l">Manage your lead providers and delivery partners supplying training.</p>
 
-<%= render SearchBox.new(query: @query, title: "Search suppliers", hint: "Enter the supplier's name") %>
-
+<%= render SearchBox.new(
+  query: @query,
+  title: "Search suppliers",
+  hint: "Enter the name of the lead provider or delivery partner",
+  filters: [
+    {
+      field: :type,
+      value: @type,
+      options: [
+        OpenStruct.new(id: "", name: ""),
+        OpenStruct.new(id: "delivery_partner", name: "Delivery Partner"),
+        OpenStruct.new(id: "lead_provider", name: "Lead Provider"),
+      ],
+    },
+  ]
+) %>
 
 <%= govuk_button_link_to "Add a new delivery partner", choose_name_admin_delivery_partners_path %>
 

--- a/app/views/admin/suppliers/suppliers/index.html.erb
+++ b/app/views/admin/suppliers/suppliers/index.html.erb
@@ -12,8 +12,8 @@
       value: @type,
       options: [
         OpenStruct.new(id: "", name: ""),
-        OpenStruct.new(id: "delivery_partner", name: "Delivery Partner"),
-        OpenStruct.new(id: "lead_provider", name: "Lead Provider"),
+        OpenStruct.new(id: "delivery_partner", name: "Delivery partner"),
+        OpenStruct.new(id: "lead_provider", name: "Lead provider"),
       ],
     },
   ]


### PR DESCRIPTION
### Context

'being able to search supplier / delivery partners would be useful. 'Cause at the moment you can't search and it's just alphabetical and you have to guess what page suppliers starting with the letter T would be on'

- Ticket: https://trello.com/c/Ae4uONdB/10-add-search-bar-on-supplier-and-dp-page
