### PR TITLE
[CPDLP-2132] Add uplift clawbacks in adjustments totals on financial statements page

### DIFF
--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -131,8 +131,12 @@ module Finance
         [available, delta_uplift_amount].min
       end
 
+      def uplift_clawback_deductions
+        uplift_deductions_count * -uplift_fee_per_declaration
+      end
+
       def adjustments_total
-        -clawback_deductions
+        -clawback_deductions + uplift_clawback_deductions
       end
 
       def clawback_deductions

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -197,7 +197,7 @@
               <% row.cell(text: "Uplift clawbacks") %>
               <% row.cell(text: @calculator.uplift_deductions_count) %>
               <% row.cell(text: number_to_pounds(-@calculator.uplift_fee_per_declaration), numeric: true) %>
-              <% row.cell(text: number_to_pounds(@calculator.uplift_deductions_count * -@calculator.uplift_fee_per_declaration), numeric: true) %>
+              <% row.cell(text: number_to_pounds(@calculator.uplift_clawback_deductions), numeric: true) %>
             <% end %>
 
             <% @calculator.send(:output_calculator).banding_breakdown.each do |hash| %>

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Finance::ECF::StatementCalculator, :with_default_schedules do
         allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
       end
 
-      it "does not include uplift adjustments" do
-        expect(subject.adjustments_total).to eql(0)
+      it "includes uplift adjustments" do
+        expect(subject.adjustments_total).to eql(-200)
       end
     end
 
@@ -165,6 +165,105 @@ RSpec.describe Finance::ECF::StatementCalculator, :with_default_schedules do
 
       it "includes clawback adjustments" do
         expect(subject.adjustments_total).to eql(-288)
+      end
+    end
+
+    context "when there are uplifts and clawbacks" do
+      let(:uplift_breakdown) do
+        {
+          previous_count: 0,
+          count: 2,
+          additions: 4,
+          subtractions: 2,
+        }
+      end
+
+      let(:banding_breakdown) do
+        [
+          {
+            band: :a,
+            min: 1,
+            max: 2,
+
+            previous_started_count: 1,
+            started_count: 1,
+            started_additions: 1,
+            started_subtractions: 0,
+
+            previous_retained_1_count: 1,
+            retained_1_count: 1,
+            retained_1_additions: 1,
+            retained_1_subtractions: 0,
+
+            previous_retained_2_count: 1,
+            retained_2_count: 1,
+            retained_2_additions: 1,
+            retained_2_subtractions: 0,
+
+            previous_retained_3_count: 1,
+            retained_3_count: 1,
+            retained_3_additions: 1,
+            retained_3_subtractions: 0,
+
+            previous_retained_4_count: 1,
+            retained_4_count: 1,
+            retained_4_additions: 1,
+            retained_4_subtractions: 0,
+
+            previous_completed_count: 1,
+            completed_count: 1,
+            completed_additions: 1,
+            completed_subtractions: 0,
+          },
+          {
+            band: :b,
+            min: 3,
+            max: 4,
+
+            previous_started_count: 0,
+            started_count: 1,
+            started_additions: 2,
+            started_subtractions: 1,
+
+            previous_retained_1_count: 0,
+            retained_1_count: 1,
+            retained_1_additions: 2,
+            retained_1_subtractions: 1,
+
+            previous_retained_2_count: 0,
+            retained_2_count: 1,
+            retained_2_additions: 2,
+            retained_2_subtractions: 1,
+
+            previous_retained_3_count: 0,
+            retained_3_count: 1,
+            retained_3_additions: 2,
+            retained_3_subtractions: 1,
+
+            previous_retained_4_count: 0,
+            retained_4_count: 1,
+            retained_4_additions: 2,
+            retained_4_subtractions: 1,
+
+            previous_completed_count: 0,
+            completed_count: 1,
+            completed_additions: 2,
+            completed_subtractions: 1,
+          },
+        ]
+      end
+
+      let(:output_calculator) { instance_double("Finance::ECF::OutputCalculator", uplift_breakdown:, banding_breakdown:) }
+
+      let!(:contract) { create(:call_off_contract, lead_provider:) }
+
+      before do
+        allow(Finance::ECF::OutputCalculator).to receive(:new).and_return(output_calculator)
+        allow(output_calculator).to receive(:fee_for_declaration).and_return(48)
+      end
+
+      it "includes clawback and uplift adjustments" do
+        expect(subject.adjustments_total).to eql(-488)
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2132](https://dfedigital.atlassian.net/browse/CPDLP-2132)

Assurance made Digital aware that the adjustment section in the statements was not adding up the figures between uplift clawback and clawback adjustments in the adjustments table for ECF financial statements.

As this information is processed and passed to providers, we must ensure that our data is accurate.

### Changes proposed in this pull request

When the statement has both uplift clawback and clawback from a declaration.. they should be aggregated to the total value in the adjustment table and in the summary table under the adjustments line item.



[CPDLP-2132]: https://dfedigital.atlassian.net/browse/CPDLP-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ