### PR TITLE
Admin cohort redesign

### DIFF
--- a/app/components/admin/schools/cohorts/cip_info.html.erb
+++ b/app/components/admin/schools/cohorts/cip_info.html.erb
@@ -34,8 +34,7 @@
       <%= school_cohort&.appropriate_body&.name %>
     </dd>
   </div>
-
-  <%= content %>
+  <%= summary_list_rows %>
 </dl>
 
 <%= content %>

--- a/app/components/admin/schools/cohorts/cip_info.html.erb
+++ b/app/components/admin/schools/cohorts/cip_info.html.erb
@@ -37,3 +37,5 @@
 
   <%= content %>
 </dl>
+
+<%= content %>

--- a/app/components/admin/schools/cohorts/cip_info.rb
+++ b/app/components/admin/schools/cohorts/cip_info.rb
@@ -4,6 +4,8 @@ module Admin
   module Schools
     module Cohorts
       class CipInfo < BaseComponent
+        renders_one :summary_list_rows
+
         attr_accessor :school
 
         def initialize(school_cohort:)

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -18,8 +18,10 @@
       %>
     <% end %>
 
-    <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, partnership), secondary: true) do %>
-      Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
+    <% if helpers.policy(partnership).challenge? %>
+      <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, partnership), secondary: true) do %>
+        Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
+      <% end %>
     <% end %>
   <% end %>
 
@@ -53,8 +55,10 @@
         end
       %>
 
-      <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, relationship), secondary: true) do %>
-        Challenge <%= tag.span("relationship", class: "govuk-visually-hidden") %>
+      <% if helpers.policy(relationship).challenge? %>
+        <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, relationship), secondary: true) do %>
+          Challenge <%= tag.span("relationship", class: "govuk-visually-hidden") %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -2,22 +2,21 @@
   <%= cohort.display_name %> partnership
 </h2>
 
-<%= render cohort_info do %>
+<%= render cohort_info do |ci| %>
   <% if partnership %>
-    <%# TODO: include these values in the outer summary list %>
-    <%=
-      govuk_summary_list do |sl|
-        sl.row do |row|
+    <% ci.summary_list_rows do %>
+      <%=
+        render(GovukComponent::SummaryListComponent::RowComponent.new) do |row|
           row.key(text: "Lead provider")
           row.value(text: partnership.lead_provider.name)
         end
 
-        sl.row do |row|
+        render(GovukComponent::SummaryListComponent::RowComponent.new) do |row|
           row.key(text: "Delivery partner")
           row.value(text: partnership.delivery_partner.name)
         end
-      end
-    %>
+      %>
+    <% end %>
 
     <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, partnership), secondary: true) do %>
       Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -1,29 +1,62 @@
-<h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-  <%= cohort.display_name %> cohort
-</h3>
+<h2 class="govuk-heading-l govuk-!-margin-bottom-2">
+  <%= cohort.display_name %> partnership
+</h2>
 
 <%= render cohort_info do %>
-  <% if partnerships.present? %>
-     <% partnerships.each do |p| %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <% if not p.relationship %>
-            Default Partnership
-          <% else %>
-            Relationship
-          <% end %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <strong>Lead provider:</strong> <%= p.lead_provider.name %><br>
-          <strong>Delivery partner:</strong> <%= p.delivery_partner.name %>
-          </ul>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, p)) do %>
-            Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
-          <% end %>
-        </dd>
-      </div>
+  <% if partnership %>
+    <%# TODO: include these values in the outer summary list %>
+    <%=
+      govuk_summary_list do |sl|
+        sl.row do |row|
+          row.key(text: "Lead provider")
+          row.value(text: partnership.lead_provider.name)
+        end
+
+        sl.row do |row|
+          row.key(text: "Delivery partner")
+          row.value(text: partnership.delivery_partner.name)
+        end
+      end
+    %>
+
+    <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, partnership), secondary: true) do %>
+      Challenge <%= tag.span("partnership", class: "govuk-visually-hidden") %>
+    <% end %>
+  <% end %>
+
+  <% if relationships.any? %>
+    <h3>Additional relationships</h3>
+
+    <% relationships.each do |relationship| %>
+      <%=
+        govuk_summary_list do |sl|
+          sl.row do |row|
+            row.key(text: "Lead provider")
+            row.value(text: relationship.lead_provider.name)
+          end
+
+          sl.row do |row|
+            row.key(text: "Delivery partner")
+            row.value(text: relationship.delivery_partner.name)
+          end
+
+          sl.row do |row|
+            row.key(text: "Participants")
+            row.value do
+              helpers.html_list(
+                relationship
+                  .induction_programmes
+                  .flat_map(&:participant_profiles)
+                  .map { |pp| helpers.govuk_link_to(pp.full_name, admin_participant_path(pp)) }
+              )
+            end
+          end
+        end
+      %>
+
+      <%= govuk_button_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, relationship), secondary: true) do %>
+        Challenge <%= tag.span("relationship", class: "govuk-visually-hidden") %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -14,8 +14,8 @@
           <% end %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <strong>Delivery partner:</strong> <%= p.delivery_partner.name %><br>
-          <strong>Lead provider:</strong> <%= p.lead_provider.name %>
+          <strong>Lead provider:</strong> <%= p.lead_provider.name %><br>
+          <strong>Delivery partner:</strong> <%= p.delivery_partner.name %>
           </ul>
         </dd>
         <dd class="govuk-summary-list__actions">

--- a/app/components/admin/schools/cohorts/cohort.rb
+++ b/app/components/admin/schools/cohorts/cohort.rb
@@ -4,13 +4,14 @@ module Admin
   module Schools
     module Cohorts
       class Cohort < BaseComponent
-        attr_reader :partnerships, :school
+        attr_reader :partnership, :school, :relationships
 
         def initialize(school:, cohort:, school_cohort:, partnerships: [])
           @school = school
           @cohort = cohort
           @school_cohort = school_cohort
-          @partnerships = partnerships
+          @partnership = partnerships&.find(&:relationship?)
+          @relationships = partnerships&.select(&:relationship?) || []
         end
 
       private

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -40,8 +40,7 @@
       <%= school_cohort&.appropriate_body&.name %>
     </dd>
   </div>
-
-  <%= content %>
+  <%= summary_list_rows %>
 </dl>
 
 <%= content %>

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -9,7 +9,7 @@
     <dd class="govuk-summary-list__actions">
       <% if school_cohort.lead_provider.nil? %>
         <%= govuk_link_to "Change", admin_school_change_programme_path(id: school_cohort.cohort.start_year, school_id: school_cohort.school) %>
-        <span class="govuk-visually-hidden"> induction programme</span>
+        <span class="govuk-visually-hidden"> training programme</span>
       <% end %>
     </dd>
   </div>
@@ -25,19 +25,22 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
+      Lead provider
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= school_cohort.lead_provider&.name %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
       Delivery partner
     </dt>
     <dd class="govuk-summary-list__value">
       <%= school_cohort.delivery_partner&.name %>
     </dd>
-    <dd class="govuk-summary-list__actions"></dd>
-  </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Appropriate body
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= school_cohort&.appropriate_body&.name %>
+    <dd class="govuk-summary-list__actions">
     </dd>
   </div>
   <%= summary_list_rows %>

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -15,10 +15,10 @@
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Lead provider
+      Appropriate body
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= school_cohort.lead_provider&.name %>
+      <%= school_cohort.appropriate_body&.name %>
     </dd>
     <dd class="govuk-summary-list__actions">
     </dd>
@@ -43,3 +43,5 @@
 
   <%= content %>
 </dl>
+
+<%= content %>

--- a/app/components/admin/schools/cohorts/fip_info.rb
+++ b/app/components/admin/schools/cohorts/fip_info.rb
@@ -4,6 +4,8 @@ module Admin
   module Schools
     module Cohorts
       class FipInfo < BaseComponent
+        renders_one :summary_list_rows
+
         def initialize(school_cohort:)
           @school_cohort = school_cohort
         end

--- a/app/components/admin/schools/cohorts/other_info.html.erb
+++ b/app/components/admin/schools/cohorts/other_info.html.erb
@@ -19,8 +19,7 @@
       <%= school_cohort&.appropriate_body&.name %>
     </dd>
   </div>
-
-  <%= content %>
+  <%= summary_list_rows %>
 </dl>
 
 <%= content %>

--- a/app/components/admin/schools/cohorts/other_info.html.erb
+++ b/app/components/admin/schools/cohorts/other_info.html.erb
@@ -11,7 +11,6 @@
       <span class="govuk-visually-hidden"> induction programme</span>
     </dd>
   </div>
-
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Appropriate body
@@ -23,3 +22,5 @@
 
   <%= content %>
 </dl>
+
+<%= content %>

--- a/app/components/admin/schools/cohorts/other_info.rb
+++ b/app/components/admin/schools/cohorts/other_info.rb
@@ -26,9 +26,8 @@ module Admin
 
         def message
           return "Not assigned" if school_cohort.nil?
-          return "Not using service" if school_cohort.induction_programme_choice.blank?
 
-          MESSAGES[school_cohort.induction_programme_choice.to_sym]
+          MESSAGES.fetch(school_cohort.induction_programme_choice.to_sym, "Not using service")
         end
       end
     end

--- a/app/components/admin/schools/cohorts/other_info.rb
+++ b/app/components/admin/schools/cohorts/other_info.rb
@@ -4,6 +4,8 @@ module Admin
   module Schools
     module Cohorts
       class OtherInfo < BaseComponent
+        renders_one :summary_list_rows
+
         attr_accessor :school
 
         def initialize(school:, cohort:, school_cohort:)

--- a/app/components/admin/schools/cohorts/other_info.rb
+++ b/app/components/admin/schools/cohorts/other_info.rb
@@ -19,15 +19,16 @@ module Admin
         attr_reader :school_cohort, :cohort
 
         MESSAGES = {
-          design_our_own: "designing their own training",
-          school_funded_fip: "school funded full induction programme",
-          no_early_career_teachers: "no ECTs this year",
+          design_our_own: "Designing their own training",
+          school_funded_fip: "School-funded full induction programme",
+          no_early_career_teachers: "No ECTs this year",
         }.freeze
 
         def message
           return "Not assigned" if school_cohort.nil?
+          return "Not using service" if school_cohort.induction_programme_choice.blank?
 
-          ["Not using service", MESSAGES[school_cohort.induction_programme_choice.to_sym]].compact.join(" - ")
+          MESSAGES[school_cohort.induction_programme_choice.to_sym]
         end
       end
     end

--- a/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
+++ b/app/controllers/admin/schools/cohorts/challenge_partnership_controller.rb
@@ -10,7 +10,7 @@ module Admin
         def new
           school = School.friendly.find params[:school_id]
           partnership = Partnership.find(params[:partnership_id])
-          authorize partnership, :update?
+          authorize partnership, :challenge?
 
           @challenge_partnership_form = ChallengePartnershipForm.new(
             school_name: school.name,
@@ -19,12 +19,12 @@ module Admin
         end
 
         def confirm
-          authorize @challenge_partnership_form.partnership, :update?
+          authorize @challenge_partnership_form.partnership, :challenge?
           render :new unless @challenge_partnership_form.valid?
         end
 
         def create
-          authorize @challenge_partnership_form.partnership, :update?
+          authorize @challenge_partnership_form.partnership, :challenge?
           @challenge_partnership_form.challenge!
           set_success_message heading: "Induction programme has been challenged"
           redirect_to admin_school_cohorts_path

--- a/app/controllers/admin/schools/cohorts_controller.rb
+++ b/app/controllers/admin/schools/cohorts_controller.rb
@@ -12,7 +12,7 @@ module Admin
           .where(school: @school)
 
         # We do not display the 2020 cohort, because it is non-standard
-        @cohorts = Cohort.where.not(start_year: 2020).where(start_year: ..Cohort.active_registration_cohort.start_year).order(start_year: :asc)
+        @cohorts = Cohort.where.not(start_year: 2020).where(start_year: ..Cohort.active_registration_cohort.start_year).order(start_year: :desc)
       end
 
     private

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -19,6 +19,7 @@ class Partnership < ApplicationRecord
   belongs_to :delivery_partner
   has_many :partnership_notification_emails, dependent: :destroy
   has_many :event_logs, as: :owner
+  has_many :induction_programmes
 
   after_save do |partnership|
     unless partnership.saved_changes.empty?

--- a/app/policies/partnership_policy.rb
+++ b/app/policies/partnership_policy.rb
@@ -8,6 +8,10 @@ class PartnershipPolicy < ApplicationPolicy
     user.schools.include?(record.school)
   end
 
+  def challenge?
+    super_user?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/views/admin/schools/cohorts/index.html.erb
+++ b/app/views/admin/schools/cohorts/index.html.erb
@@ -2,7 +2,6 @@
 
 <h1 class="govuk-heading-xl"><%= @school.name %></h1>
 <%= render partial: "admin/schools/shared/navigation" %>
-<h2 class="govuk-heading-l">Cohorts</h2>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% @cohorts.each do |cohort| %>

--- a/spec/components/admin/schools/cohorts/cohort_spec.rb
+++ b/spec/components/admin/schools/cohorts/cohort_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Admin::Schools::Cohorts::Cohort, type: :component do
   let(:component) { described_class.new cohort:, school_cohort:, school: }
   subject { page }
 
-  let(:cohort_content) { "#{cohort.display_name} cohort" }
+  let(:cohort_content) { "#{cohort.display_name} partnership" }
   let(:fip_specific_content) { "Working with a DfE-funded provider" }
   let(:cip_specific_content) { "Using DfE-accredited materials" }
   let(:generic_content) { "Training programme" }

--- a/spec/components/admin/schools/cohorts/fip_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/fip_info_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Admin::Schools::Cohorts::FipInfo, type: :component do
 
   it "has the correct content" do
     expect(rendered_content).to have_content "Working with a DfE-funded provider"
+    expect(rendered_content).to have_content lead_provider.name
     expect(rendered_content).to have_content school_cohort.delivery_partner.name
   end
 

--- a/spec/components/admin/schools/cohorts/fip_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/fip_info_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Admin::Schools::Cohorts::FipInfo, type: :component do
 
   it "has the correct content" do
     expect(rendered_content).to have_content "Working with a DfE-funded provider"
-    expect(rendered_content).to have_content lead_provider.name
     expect(rendered_content).to have_content school_cohort.delivery_partner.name
   end
 

--- a/spec/components/admin/schools/cohorts/other_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/other_info_spec.rb
@@ -20,19 +20,19 @@ RSpec.describe Admin::Schools::Cohorts::OtherInfo, type: :component do
   context "with design your own school cohort" do
     let(:school_cohort) { build :school_cohort, induction_programme_choice: "design_our_own" }
 
-    it { is_expected.to have_content "Not using service - designing their own training" }
+    it { is_expected.to have_content "Designing their own training" }
   end
 
   context "with school funded fip school cohort" do
     let(:school_cohort) { build :school_cohort, induction_programme_choice: "school_funded_fip" }
 
-    it { is_expected.to have_content "Not using service - school funded full induction programme" }
+    it { is_expected.to have_content "School-funded full induction programme" }
   end
 
   context "with no_early_career_teachers school cohort" do
     let(:school_cohort) { build :school_cohort, induction_programme_choice: "no_early_career_teachers" }
 
-    it { is_expected.to have_content "Not using service - no ECTs this year" }
+    it { is_expected.to have_content "No ECTs this year" }
   end
 
   context "with school cohort of unknown type" do

--- a/spec/factories/admin_profiles.rb
+++ b/spec/factories/admin_profiles.rb
@@ -3,5 +3,9 @@
 FactoryBot.define do
   factory :admin_profile do
     user
+
+    trait(:super_user) do
+      super_user { true }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       admin_profile
     end
 
+    trait :super_user do
+      admin_profile { create(:admin_profile, :super_user) }
+    end
+
     trait :induction_coordinator do
       induction_coordinator_profile
 

--- a/spec/features/admin/schools/changing_provision_spec.rb
+++ b/spec/features/admin/schools/changing_provision_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Admin managing school provision", js: true, rutabaga: false do
     given_there_is_a_fip_school_in_2021
     and_i_am_signed_in_as_an_admin
     when_i_visit the_school_cohorts_page
-    and_i_click_the_link_containing "Change"
+    and_i_click_the_change_training_programme_link
     then_i_should_be_on the_change_programme_page
     and_the_page_should_be_accessible
 
@@ -43,5 +43,11 @@ private
 
   def the_confirm_page
     confirm_admin_school_change_programme_path(school_id: @school_cohort.school.slug, id: @school_cohort.cohort.start_year)
+  end
+
+  def and_i_click_the_change_training_programme_link
+    href = admin_school_change_programme_path(@school_cohort.school.slug, @school_cohort.cohort.start_year)
+
+    page.find(%(a[href='#{href}'])).click
   end
 end

--- a/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
+++ b/spec/requests/admin/schools/cohorts/challenge_partnership_spec.rb
@@ -7,66 +7,81 @@ RSpec.describe "Admin::Schools::Cohorts::ChangeProgramme", type: :request do
   let(:school) { partnership.school }
   let(:cohort) { partnership.cohort }
 
-  before do
-    sign_in create(:user, :admin)
-  end
+  context "when the user is a super user" do
+    before do
+      sign_in create(:user, :super_user)
+    end
 
-  describe "GET /admin/schools/:school_slug/cohorts/:id/challenge-partnership/new" do
-    it "renders the new template" do
-      get "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/new"
-      expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
+    describe "GET /admin/schools/:school_slug/cohorts/:id/challenge-partnership/new" do
+      it "renders the new template" do
+        get "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/new"
+        expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
+      end
+    end
+
+    describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership/confirm" do
+      it "shows an error message if no reason is selected" do
+        post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/confirm", params: {
+          challenge_partnership_form: {
+            partnership_id: partnership.id,
+            challenge_reason: "",
+          },
+        }
+
+        expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
+        expect(response.body).to include "Select a reason why you think this confirmation is incorrect"
+      end
+
+      it "shows a confirmation message" do
+        post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/confirm", params: {
+          challenge_partnership_form: {
+            partnership_id: partnership.id,
+            lead_provider_name: partnership.lead_provider.name,
+            challenge_reason: "mistake",
+          },
+        }
+
+        expect(response).to render_template "admin/schools/cohorts/challenge_partnership/confirm"
+      end
+    end
+
+    describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership" do
+      it "call Partnerships::Challenge with the correct arguments" do
+        expect(Partnerships::Challenge).to receive(:call).with(partnership:, challenge_reason: "mistake")
+
+        post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership", params: {
+          challenge_partnership_form: {
+            partnership_id: partnership.id,
+            challenge_reason: "mistake",
+          },
+        }
+      end
+
+      it "redirects to the cohorts page and shows a success message" do
+        post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership", params: {
+          challenge_partnership_form: {
+            partnership_id: partnership.id,
+            challenge_reason: "mistake",
+          },
+        }
+
+        expect(response).to redirect_to "/admin/schools/#{school.slug}/cohorts"
+        follow_redirect!
+        expect(response.body).to include "Induction programme has been challenged"
+      end
     end
   end
 
-  describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership/confirm" do
-    it "shows an error message if no reason is selected" do
-      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/confirm", params: {
-        challenge_partnership_form: {
-          partnership_id: partnership.id,
-          challenge_reason: "",
-        },
-      }
-
-      expect(response).to render_template "admin/schools/cohorts/challenge_partnership/new"
-      expect(response.body).to include "Select a reason why you think this confirmation is incorrect"
+  context "when the user isn't a superuser" do
+    before do
+      sign_in create(:user, :admin)
     end
 
-    it "shows a confirmation message" do
-      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/confirm", params: {
-        challenge_partnership_form: {
-          partnership_id: partnership.id,
-          lead_provider_name: partnership.lead_provider.name,
-          challenge_reason: "mistake",
-        },
-      }
-
-      expect(response).to render_template "admin/schools/cohorts/challenge_partnership/confirm"
-    end
-  end
-
-  describe "POST /admin/schools/:school_slug/cohorts/:id/challenge-partnership" do
-    it "call Partnerships::Challenge with the correct arguments" do
-      expect(Partnerships::Challenge).to receive(:call).with(partnership:, challenge_reason: "mistake")
-
-      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership", params: {
-        challenge_partnership_form: {
-          partnership_id: partnership.id,
-          challenge_reason: "mistake",
-        },
-      }
-    end
-
-    it "redirects to the cohorts page and shows a success message" do
-      post "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership", params: {
-        challenge_partnership_form: {
-          partnership_id: partnership.id,
-          challenge_reason: "mistake",
-        },
-      }
-
-      expect(response).to redirect_to "/admin/schools/#{school.slug}/cohorts"
-      follow_redirect!
-      expect(response.body).to include "Induction programme has been challenged"
+    describe "GET /admin/schools/:school_slug/cohorts/:id/challenge-partnership/new" do
+      it "triggers a policy error" do
+        path = "/admin/schools/#{school.slug}/partnerships/#{partnership.id}/challenge-partnership/new"
+        expect { get(path) }.to raise_error(Pundit::NotAuthorizedError, "not allowed to challenge? this Partnership")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

This is an attempt to make the school cohorts tab easier to understand. The default partnership is now displayed more prominently and the other relationships are clearly labelled and the participant information is listed.

### Changes proposed in this pull request

- Order the cohorts latest first
- Switch ordering of lead provider/delivery partner
- Reorganise the admin school cohorts page

### What's changed?

Current on the left, proposed on the right:

![image](https://github.com/DFE-Digital/early-careers-framework/assets/128088/7dfdd563-1845-4f63-af3e-7ce22c0ae2ee)


The 'Challenge' buttons are now only visible when the logged in user is a super user.