### PR TITLE
[CPDLP-2137] Add lead provider to cohort script

### DIFF
--- a/app/services/importers/add_cohort_to_lead_provider.rb
+++ b/app/services/importers/add_cohort_to_lead_provider.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Importers
+  class AddCohortToLeadProvider < BaseService
+    def call
+      check_headers!
+
+      logger.info "AddCohortToLeadProvider: Started!"
+
+      ActiveRecord::Base.transaction do
+        rows.each do |row|
+          add_cohort_to_lead_provider(row)
+        end
+      end
+
+      logger.info "AddCohortToLeadProvider: Finished!"
+    end
+
+  private
+
+    attr_reader :path_to_csv, :logger
+
+    def initialize(path_to_csv:, logger: Rails.logger)
+      @path_to_csv = path_to_csv
+      @logger = logger
+    end
+
+    def add_cohort_to_lead_provider(row)
+      start_year = row["cohort-start-year"].to_i
+      lead_provider_name = row["lead-provider-name"]
+      logger.info "AddCohortToLeadProvider: Adding Lead Provider: #{lead_provider_name} to cohort: #{start_year}"
+
+      cohort = Cohort.find_by!(start_year:)
+      lead_provider = LeadProvider.find_by!(name: lead_provider_name)
+
+      lead_provider.cohorts << cohort
+
+      logger.info "AddCohortToLeadProvider: Cohort #{start_year} added to Lead Provider: #{lead_provider_name} successfully"
+    end
+
+    def check_headers!
+      unless %w[lead-provider-name cohort-start-year].all? { |header| rows.headers.include?(header) }
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true)
+    end
+  end
+end

--- a/spec/services/importers/add_cohort_to_lead_provider_spec.rb
+++ b/spec/services/importers/add_cohort_to_lead_provider_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::AddCohortToLeadProvider do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:path_to_csv) { csv.path }
+
+  subject(:importer) { described_class.new(path_to_csv:) }
+
+  describe "#call" do
+    context "when csv headers invalid" do
+      before do
+        csv.write "some-other-column,cohort-start-year"
+        csv.write "\n"
+        csv.write "Ambition Institute,2021"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "raises an error" do
+        expect { importer.call }.to raise_error(NameError)
+      end
+    end
+
+    context "when cohort does not exist" do
+      let!(:lead_provider) { create(:lead_provider, name: "Ambition Institute", cohorts: []) }
+      before do
+        csv.write "lead-provider-name,cohort-start-year"
+        csv.write "\n"
+        csv.write "Ambition Institute,2021"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "raises an error" do
+        expect { importer.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when lead provider does not exist" do
+      let!(:cohort_2021) { create(:cohort, start_year: 2021) }
+      before do
+        csv.write "lead-provider-name,cohort-start-year"
+        csv.write "\n"
+        csv.write "Ambition Institute,2021"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "raises an error" do
+        expect { importer.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when csv valid" do
+      let!(:lead_provider_1) { create(:lead_provider, name: "Ambition Institute", cohorts: []) }
+      let!(:lead_provider_2) { create(:lead_provider, name: "Best Practice Network", cohorts: []) }
+      let!(:cohort_2021) { create(:cohort, start_year: 2021) }
+      let!(:cohort_2022) { create(:cohort, start_year: 2022) }
+      let!(:cohort_2023) { create(:cohort, start_year: 2023) }
+
+      before do
+        csv.write "lead-provider-name,cohort-start-year"
+        csv.write "\n"
+        csv.write "Ambition Institute,2021"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022"
+        csv.write "\n"
+        csv.write "Ambition Institute,2023"
+        csv.write "\n"
+        csv.write "Best Practice Network,2023"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "adds cohorts to lead providers" do
+        importer.call
+
+        expect(lead_provider_1.reload.cohorts).to contain_exactly(cohort_2021, cohort_2022, cohort_2023)
+        expect(lead_provider_2.reload.cohorts).to contain_exactly(cohort_2023)
+      end
+    end
+
+    context "when lead provider already belongs to cohorts" do
+      let!(:cohort_2021) { create(:cohort, start_year: 2021) }
+      let!(:cohort_2022) { create(:cohort, start_year: 2022) }
+      let!(:cohort_2023) { create(:cohort, start_year: 2023) }
+      let!(:lead_provider_1) { create(:lead_provider, name: "Ambition Institute", cohorts: [cohort_2021, cohort_2023]) }
+
+      before do
+        csv.write "lead-provider-name,cohort-start-year"
+        csv.write "\n"
+        csv.write "Ambition Institute,2022"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "adds new cohorts while maintaining old cohorts" do
+        importer.call
+
+        expect(lead_provider_1.reload.cohorts).to contain_exactly(cohort_2021, cohort_2022, cohort_2023)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
  
We need to populate Cohort 2023 for ECF. To allow this we need to append the new cohort to existing lead providers 

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2137

### Changes proposed in this pull request

Add script which receives a csv with cohort start year to lead a provider's name. This will append the cohort to the lead provider, both the cohort and lead provider need to exist

### Guidance to review
I did not add this to the seeds as it didn't feel right to since we are creating new lead providers dynamically.
