### PR TITLE
allow name and email change through the npq application tab

### DIFF
--- a/app/controllers/admin/npq/applications/change_email_controller.rb
+++ b/app/controllers/admin/npq/applications/change_email_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Admin::NPQ::Applications
+  class ChangeEmailController < Admin::BaseController
+    before_action :load_npq_application
+    before_action :check_gai_status
+
+    skip_after_action :verify_policy_scoped
+
+    def edit; end
+
+    def update
+      user = @npq_application.user
+      user.assign_attributes(params.require(:user).permit(:email))
+
+      if user.save
+        set_success_message(heading: "The user’s email address has been updated")
+        redirect_to admin_npq_applications_application_path
+      else
+        render "/admin/npq/applications/change_email/edit"
+      end
+    end
+
+  private
+
+    def check_gai_status
+      redirect_to admin_npq_applications_application_path if @npq_application.user.get_an_identity_id.present?
+    end
+
+    def load_npq_application
+      authorize NPQApplication
+
+      @npq_application = NPQApplication
+        .eager_load(:profile, participant_identity: :user)
+        .find(params[:id])
+    end
+  end
+end

--- a/app/controllers/admin/npq/applications/change_name_controller.rb
+++ b/app/controllers/admin/npq/applications/change_name_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Admin::NPQ::Applications
+  class ChangeNameController < Admin::BaseController
+    before_action :load_npq_application
+    before_action :check_gai_status
+
+    skip_after_action :verify_policy_scoped
+
+    def edit; end
+
+    def update
+      if @npq_application.user.update(params.require(:user).permit(:full_name))
+        set_success_message(heading: "The user’s name has been updated")
+
+        redirect_to admin_npq_applications_application_path
+      else
+        render "/admin/npq/applications/change_name/edit"
+      end
+    end
+
+  private
+
+    def check_gai_status
+      redirect_to admin_npq_applications_application_path if @npq_application.user.get_an_identity_id.present?
+    end
+
+    def load_npq_application
+      authorize NPQApplication
+
+      @npq_application = NPQApplication
+        .eager_load(:profile, participant_identity: :user)
+        .find(params[:id])
+    end
+  end
+end

--- a/app/views/admin/npq/applications/_application_details.html.erb
+++ b/app/views/admin/npq/applications/_application_details.html.erb
@@ -33,11 +33,21 @@
     sl.row do |row|
       row.key(text: 'Email')
       row.value(text: application.user.email)
+      unless application.user.get_an_identity_id.present?
+        row.action(
+          href: edit_admin_npq_applications_change_email_path(application),
+        )
+      end
     end
 
     sl.row do |row|
       row.key(text: 'Preferred name')
       row.value(text: application.user.full_name)
+      unless application.user.get_an_identity_id.present?
+        row.action(
+          href: edit_admin_npq_applications_change_name_path(application),
+        )
+      end
     end
 
     sl.row do |row|

--- a/app/views/admin/npq/applications/change_email/edit.html.erb
+++ b/app/views/admin/npq/applications/change_email/edit.html.erb
@@ -1,0 +1,10 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_npq_applications_application_path(@npq_application)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change applicant's email address</h1>
+    <%= form_for @npq_application.user, url: admin_npq_applications_change_email_path(@npq_application), method: :put do |f| %>
+      <%= f.govuk_text_field :email, label: { text: "Email address" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/npq/applications/change_name/edit.html.erb
+++ b/app/views/admin/npq/applications/change_name/edit.html.erb
@@ -1,0 +1,10 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_npq_applications_application_path(@npq_application)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change applicant's name</h1>
+    <%= form_for @npq_application.user, url: admin_npq_applications_change_name_path(@npq_application), method: :put do |f| %>
+      <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -433,11 +433,13 @@ Rails.application.routes.draw do
 
     namespace :npq do
       resource :applications, only: [] do
-        resources :exports, only: %i[index new create], controller: "applications/exports"
         get "/eligibility_imports/example", to: "applications/eligibility_imports#example", as: :example_csv_file
-        resources :eligibility_imports, only: %i[index new create show], controller: "applications/eligibility_imports"
-
         get "/analysis", to: "applications/analysis#invalid_payments_analysis", as: :analysis
+
+        resources :change_name, controller: "applications/change_name", only: %i[edit update]
+        resources :change_email, controller: "applications/change_email", only: %i[edit update]
+        resources :exports, only: %i[index new create], controller: "applications/exports"
+        resources :eligibility_imports, only: %i[index new create show], controller: "applications/eligibility_imports"
         resources :applications, only: %i[index show]
         resources :edge_cases, controller: "applications/edge_cases", only: %i[index show]
         resources :eligible_for_funding, controller: "applications/eligible_for_funding", only: %i[edit update]

--- a/spec/requests/admin/npq/applications/change_email_spec.rb
+++ b/spec/requests/admin/npq/applications/change_email_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::NPQ::Applications::ChangeEmailController" do
+  let(:admin_user) { create(:user, :admin) }
+
+  let(:user) { create :user, email: "roland.reilly@sensible.com" }
+  let(:application) { create(:npq_application, user:) }
+
+  before { sign_in(admin_user) }
+
+  describe "GET /admin/npq/applications/change_email/:id/edit" do
+    before { get("/admin/npq/applications/change_email/#{application.id}/edit") }
+
+    it "renders the edit form for a NPQ applicants's full name" do
+      expect(response).to render_template("admin/npq/applications/change_email/edit")
+      expect(response.body).to match(%r{<form.*action="/admin/npq/applications/change_email/#{application.id}"})
+    end
+
+    it "has the correct heading" do
+      expect(response.body).to match(/Change applicant's email/)
+    end
+
+    it "has a form with a text field" do
+      expect(response.body).to match(/<input.*name="user\[email\]/)
+      expect(response.body).to match(/<button.*class="govuk-button"/)
+    end
+
+    context "when the user has a get an identity id" do
+      let(:user) { create :user, get_an_identity_id: SecureRandom.uuid }
+
+      it "redirects to the applications page" do
+        expect(application.user.get_an_identity_id.present?).to be true
+        expect(response).to redirect_to(admin_npq_applications_application_path)
+      end
+    end
+  end
+
+  describe "PATCH (UPDATE) /admin/npq/applications/change_email/:id" do
+    let(:new_email) { "random.rita@random.com" }
+    let(:params) { { user: { "email" => new_email } } }
+    let(:application_id) { application.id }
+
+    it "changes the email for the user", :aggregate_failures do
+      patch("/admin/npq/applications/change_email/#{application.id}", params:)
+
+      expect(response).to redirect_to "/admin/npq/applications/applications/#{application_id}"
+      application.user.reload
+      expect(application.user.email).to eq(new_email)
+    end
+
+    context "when the email fails to save" do
+      let(:new_email) { "" }
+      let(:old_email) { application.user.email }
+
+      it "returns to the edit page", :aggregate_failures do
+        patch("/admin/npq/applications/change_email/#{application.id}", params:)
+
+        expect(response).to render_template "admin/npq/applications/change_email/edit"
+        application.user.reload
+        expect(application.user.email).to eq(old_email)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/npq/applications/change_name_spec.rb
+++ b/spec/requests/admin/npq/applications/change_name_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::NPQ::Applications::ChangeNameController" do
+  let(:admin_user) { create(:user, :admin) }
+
+  let(:user) { create :user, full_name: "Roland Reilly" }
+  let(:application) { create(:npq_application, user:) }
+
+  before { sign_in(admin_user) }
+
+  describe "GET /admin/npq/applications/change_name/:id/edit" do
+    before { get("/admin/npq/applications/change_name/#{application.id}/edit") }
+
+    it "renders the edit form for a NPQ applicants's full name" do
+      expect(response).to render_template("admin/npq/applications/change_name/edit")
+      expect(response.body).to match(%r{<form.*action="/admin/npq/applications/change_name/#{application.id}"})
+    end
+
+    it "has the correct heading" do
+      expect(response.body).to match(/Change applicant's name/)
+    end
+
+    it "has a form with a text field" do
+      expect(response.body).to match(/<input.*name="user\[full_name\]/)
+      expect(response.body).to match(/<button.*class="govuk-button"/)
+    end
+
+    context "when the user has a get an identity id" do
+      let(:user) { create :user, get_an_identity_id: SecureRandom.uuid }
+
+      it "redirects to the applications page" do
+        expect(application.user.get_an_identity_id.present?).to be true
+        expect(response).to redirect_to(admin_npq_applications_application_path)
+      end
+    end
+  end
+
+  describe "PATCH (UPDATE) /admin/npq/applications/change_name/:id" do
+    let(:new_full_name) { "Random Rita" }
+    let(:params) { { user: { "full_name" => new_full_name } } }
+    let(:application_id) { application.id }
+
+    it "changes the name for the user", :aggregate_failures do
+      patch("/admin/npq/applications/change_name/#{application.id}", params:)
+
+      expect(response).to redirect_to "/admin/npq/applications/applications/#{application_id}"
+      application.user.reload
+      expect(application.user.full_name).to eq(new_full_name)
+    end
+
+    context "when the name fails to save" do
+      let(:new_full_name) { "" }
+      let(:old_full_name) { application.user.full_name }
+
+      it "returns to the edit page", :aggregate_failures do
+        patch("/admin/npq/applications/change_name/#{application.id}", params:)
+
+        expect(response).to render_template "admin/npq/applications/change_name/edit"
+        application.user.reload
+        expect(application.user.full_name).to eq(old_full_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-789

### Changes proposed in this pull request

Allow name and email change to non-GAI users through the application tab

