### PR TITLE
Add new script to create ECF cohort

### DIFF
--- a/app/services/importers/create_cohort.rb
+++ b/app/services/importers/create_cohort.rb
@@ -31,11 +31,17 @@ module Importers
       start_year = row["start-year"].to_i
       logger.info "CreateCohort: Creating cohort for starting year #{start_year}"
 
-      Cohort.find_or_create_by!(start_year:) do |c|
-        c.registration_start_date = safe_parse(row["registration-start-date"])
-        c.academic_year_start_date = safe_parse(row["academic-year-start-date"])
-        c.npq_registration_start_date = safe_parse(row["npq-registration-start-date"])
-      end
+      Cohort.upsert(
+        {
+          start_year:,
+          registration_start_date: safe_parse(row["registration-start-date"]),
+          academic_year_start_date: safe_parse(row["academic-year-start-date"]),
+          npq_registration_start_date: safe_parse(row["npq-registration-start-date"]),
+          created_at: Time.zone.now,
+          updated_at: Time.zone.now,
+        },
+        unique_by: :start_year,
+      )
 
       logger.info "CreateCohort: Cohort for starting year #{start_year} successfully created"
     end

--- a/app/services/importers/create_new_ecf_cohort.rb
+++ b/app/services/importers/create_new_ecf_cohort.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Importers
+  class CreateNewECFCohort
+    def call
+      logger.info "CreateNewECFCohort: Started!"
+      check_csvs!
+
+      run_ecf_cohort_scripts
+      logger.info "CreateNewECFCohort: Finished!"
+    end
+
+  private
+
+    attr_reader :cohort_csv, :cohort_lead_provider_csv, :contract_csv, :schedule_csv, :statement_csv, :logger
+
+    def initialize(cohort_csv:, cohort_lead_provider_csv:, contract_csv:, schedule_csv:, statement_csv:, logger: Rails.logger)
+      @cohort_csv = cohort_csv
+      @cohort_lead_provider_csv = cohort_lead_provider_csv
+      @contract_csv = contract_csv
+      @schedule_csv = schedule_csv
+      @statement_csv = statement_csv
+      @logger = logger
+    end
+
+    def check_csvs!
+      return if cohort_csv.present? && cohort_lead_provider_csv.present? && contract_csv.present? && schedule_csv.present? && statement_csv.present?
+
+      raise "All scripts need to be present to create a new ECF cohort"
+    end
+
+    def run_ecf_cohort_scripts
+      logger.info "CreateNewECFCohort: Running CreateCohort with: '#{cohort_csv}'"
+      CreateCohort.new(path_to_csv: cohort_csv).call
+
+      logger.info "CreateNewECFCohort: Running AddCohortToLeadProvider with: '#{cohort_lead_provider_csv}'"
+      AddCohortToLeadProvider.new(path_to_csv: cohort_lead_provider_csv).call
+
+      logger.info "CreateNewECFCohort: Running CreateCallOffContract with: '#{contract_csv}'"
+      CreateCallOffContract.new(path_to_csv: contract_csv).call
+
+      logger.info "CreateNewECFCohort: Running CreateSchedule with: '#{schedule_csv}'"
+      CreateSchedule.new(path_to_csv: schedule_csv).call
+
+      logger.info "CreateNewECFCohort: Running CreateStatement with: '#{statement_csv}'"
+      CreateStatement.new(path_to_csv: statement_csv).call
+    end
+  end
+end

--- a/spec/services/importers/create_cohort_spec.rb
+++ b/spec/services/importers/create_cohort_spec.rb
@@ -9,44 +9,69 @@ RSpec.describe Importers::CreateCohort do
   subject(:importer) { described_class.new(path_to_csv:) }
 
   describe "#call" do
-    before do
-      csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
-      csv.write "\n"
-      csv.write "2020,2020/05/10,2020/09/01,"
-      csv.write "\n"
-      csv.write "2021,2021/05/10,2021/09/01,"
-      csv.write "\n"
-      csv.write "2022,2022/05/10,2022/09/01,"
-      csv.write "\n"
-      csv.write "2023,2023/05/10,2023/09/01,"
-      csv.write "\n"
-      csv.close
-    end
+    context "with new cohorts" do
+      before do
+        csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+        csv.write "\n"
+        csv.write "2020,2020/05/10,2020/09/01,"
+        csv.write "\n"
+        csv.write "2021,2021/05/10,2021/09/01,"
+        csv.write "\n"
+        csv.write "2022,2022/05/10,2022/09/01,"
+        csv.write "\n"
+        csv.write "2023,2023/05/10,2023/09/01,"
+        csv.write "\n"
+        csv.close
+      end
 
-    it "creates cohort records" do
-      expect {
+      it "creates cohort records" do
+        expect {
+          importer.call
+        }.to change(Cohort, :count).by(4)
+      end
+
+      it "sets the correct start year on the record" do
         importer.call
-      }.to change(Cohort, :count).by(4)
+
+        expect(Cohort.order(:start_year).last.start_year).to eq(2023)
+      end
+
+      it "sets the correct registration start date on the record" do
+        importer.call
+
+        cohort = Cohort.find_by(start_year: 2022)
+
+        expect(cohort.registration_start_date).to eq(Date.parse("10/05/2022"))
+      end
+
+      it "only creates one cohort record per year" do
+        importer.call
+
+        expect(Cohort.select("start_year").group("start_year").pluck(:start_year).size).to be 4
+      end
     end
 
-    it "sets the correct start year on the record" do
-      importer.call
+    context "with existing cohorts" do
+      let!(:cohort_2023) { create(:cohort, start_year: 2023, registration_start_date: Date.new(2023, 5, 1), academic_year_start_date: Date.new(2023, 8, 31)) }
 
-      expect(Cohort.order(:start_year).last.start_year).to eq(2023)
-    end
+      before do
+        csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+        csv.write "\n"
+        csv.write "2023,2023/05/10,2023/09/01,2023/04/01"
+        csv.write "\n"
+        csv.close
+      end
 
-    it "sets the correct registration start date on the record" do
-      importer.call
+      it "updates the cohort values" do
+        importer.call
 
-      cohort = Cohort.find_by(start_year: 2022)
-
-      expect(cohort.registration_start_date).to eq(Date.parse("10/05/2022"))
-    end
-
-    it "only creates one cohort record per year" do
-      importer.call
-
-      expect(Cohort.select("start_year").group("start_year").pluck(:start_year).size).to be 4
+        expect(Cohort.count).to eq(1)
+        expect(cohort_2023.reload).to have_attributes(
+          registration_start_date: Date.new(2023, 5, 10),
+          academic_year_start_date: Date.new(2023, 9, 1),
+          npq_registration_start_date: Date.new(2023, 4, 1),
+        )
+      end
     end
   end
 end

--- a/spec/services/importers/create_new_ecf_cohort_spec.rb
+++ b/spec/services/importers/create_new_ecf_cohort_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::CreateNewECFCohort do
+  describe "#call" do
+    let(:cohort_csv) do
+      csv = Tempfile.new("cohort_csv_data.csv")
+      csv.write "start-year,registration-start-date,academic-year-start-date,npq-registration-start-date"
+      csv.write "\n"
+      csv.write "2023,2023/05/10,2023/09/01"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    let(:cohort_lead_provider_csv) do
+      csv = Tempfile.new("cohort_lead_provider_csv_data.csv")
+      csv.write "lead-provider-name,cohort-start-year"
+      csv.write "\n"
+      csv.write "Ambition Institute,2023"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    let(:contract_csv) do
+      csv = Tempfile.new("contract_csv_data.csv")
+      csv.write "lead-provider-name,cohort-start-year,uplift-target,uplift-amount,recruitment-target,revised-target,set-up-fee,band-a-min,band-a-max,band-a-per-participant,band-b-min,band-b-max,band-b-per-participant,band-c-min,band-c-max,band-c-per-participant,band-d-min,band-d-max,band-d-per-participant"
+      csv.write "\n"
+      csv.write "Ambition Institute,2023,0.44,200,4600,4790,0,0,90,895,91,199,700,200,299,600,300,400,500"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    let(:schedule_csv) do
+      csv = Tempfile.new("schedule_csv_data.csv")
+      csv.write "type,schedule-identifier,schedule-name,schedule-cohort-year,milestone-name,milestone-declaration-type,milestone-start-date,milestone-date,milestone-payment-date"
+      csv.write "\n"
+      csv.write "ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 1 - Participant Start,started,2023/09/01,2023/11/30,2023/11/30"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    let(:statement_csv) do
+      csv = Tempfile.new("statement_csv_data.csv")
+      csv.write "type,name,cohort,deadline_date,payment_date,output_fee"
+      csv.write "\n"
+      csv.write "ecf,September 2023,2023,2023-09-01,2023-11-25,true"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    let(:lead_provider) { create(:lead_provider, name: "Ambition Institute", cohorts: []) }
+    let!(:cpd_lead_provider) { create(:cpd_lead_provider, name: "Ambition Institute", lead_provider:) }
+
+    subject do
+      described_class.new(cohort_csv:, cohort_lead_provider_csv:, contract_csv:, schedule_csv:, statement_csv:)
+    end
+
+    context "with missing csvs" do
+      let(:statement_csv) {}
+
+      it "raises an error" do
+        expect { subject.call }.to raise_error("All scripts need to be present to create a new ECF cohort")
+      end
+    end
+
+    context "create new ECF cohort" do
+      it "creates cohort" do
+        expect(Cohort.count).to eql(0)
+        subject.call
+        expect(Cohort.count).to eql(1)
+        expect(Cohort.first.start_year).to eq(2023)
+      end
+
+      it "adds lead provider to cohort" do
+        expect(lead_provider.cohorts).to be_empty
+        subject.call
+        expect(lead_provider.reload.cohorts).to contain_exactly(Cohort.find_by(start_year: 2023))
+      end
+
+      it "creates Call off Contract and bands" do
+        expect(CallOffContract.count).to eql(0)
+        expect(ParticipantBand.count).to eql(0)
+        subject.call
+        expect(CallOffContract.count).to eql(1)
+        expect(ParticipantBand.count).to eql(4)
+      end
+
+      it "creates schedule" do
+        expect(Finance::Schedule::ECF.count).to eql(0)
+        subject.call
+        expect(Finance::Schedule::ECF.count).to eql(1)
+        expect(Finance::Schedule::ECF.first.name).to eql("ECF Standard September")
+      end
+
+      it "creates statement" do
+        expect(Finance::Statement::ECF.count).to eql(0)
+        subject.call
+        expect(Finance::Statement::ECF.count).to eql(1)
+        expect(Finance::Statement::ECF.first.name).to eql("September 2023")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The script receives all csvs for other scripts and creates a standalone ECF cohort

### Context

To support cohort 2023 for ECF, records relating to the cohort need to be populated. This includes ECF contracts, schedules, statements and cohort.

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2139

### Changes proposed in this pull request

 - Add new script that consumes CSVs and runs all required services to create an ECF cohort
 - Update Cohort script to create or update existing cohorts, as we need to update fields on existing cohort 2023 in prod

### Guidance to review
Did I miss anything?
