### PR TITLE
Refactor and tighten up CSS

### DIFF
--- a/app/assets/stylesheets/schools/dashboard.scss
+++ b/app/assets/stylesheets/schools/dashboard.scss
@@ -1,97 +1,67 @@
-@media (min-width: 40.625em) {
-  .wrapper-dashboard-v2 .govuk-summary-list__key {
-    padding-right: 10px;
-    width: 31%;
+.wrapper-dashboard-v2 {
+  @include govuk-media-query($from: tablet) {
+    .govuk-summary-list__key {
+      padding-right: 10px;
+      width: 31%;
+    }
+    .govuk-summary-list__actions {
+      width: 13%;
+    }
   }
-}
-@media (min-width: 40.625em) {
-  .wrapper-dashboard-v2 .govuk-summary-list__actions {
-    width: 13%;
-  }
-}
-.wrapper-dashboard-v2 .govuk-tabs__panel {
-  margin-bottom: 0;
-  padding: 0;
-  border: none;
-  border-top: 0;
-  padding-top: 10px;
-}
 
-@media (min-width: 40.625em) {
-  .wrapper-dashboard-v2.manage-mentors-ects .govuk-warning-text {
-    margin-bottom: 15px;
+  .manage-mentors-ects {
+    .govuk-warning-text {
+      margin-bottom: 15px;
+    }
+
+    .alert {
+      padding-left: 10px;
+      border-left: 5px solid #d4351c;
+    }
   }
-}
-.wrapper-dashboard-v2.manage-mentors-ects .alert {
-  padding-left: 10px;
-  border-left: 5px solid #d4351c;
-}
-.wrapper-dashboard-v2.manage-mentors-ects .govuk-warning-text__icon-custom-1 {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 700;
-  box-sizing: border-box;
-  display: inline-block;
-  position: relative;
-  left: 0;
-  width: 25px;
-  height: 25px;
-  margin-top: -7px;
-  border: 3px solid #0b0c0c;
-  border-radius: 50%;
-  color: #ffffff;
-  background: #0b0c0c;
-  font-size: 23px;
-  line-height: 19px;
-  text-align: center;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  margin-right: 4px;
-  forced-color-adjust: none;
-}
-.wrapper-dashboard-v2.manage-mentors-ects h3 {
-  margin-bottom: 0;
-}
-.wrapper-dashboard-v2.manage-mentors-ects .group-card {
-  border: 1px solid #B1B4B6;
-  padding: 10px;
-}
-@media (min-width: 40.625em) {
-  .wrapper-dashboard-v2.manage-mentors-ects .group-card {
-    padding: 20px;
+
+  h3 {
+    margin-bottom: 0.3em;
   }
-}
-.wrapper-dashboard-v2.manage-mentors-ects .group-card .govuk-summary-list {
-  margin-bottom: 0;
-}
-.wrapper-dashboard-v2.manage-mentors-ects .govuk-summary-list__actions {
-  width: 40%;
-  text-align: left;
-}
-.wrapper-dashboard-v2.manage-mentors-ects .govuk-summary-list--no-border .govuk-summary-list__row {
-  margin-bottom: 0;
-}
-.wrapper-dashboard-v2.manage-mentors-ects .govuk-summary-list--no-border .govuk-summary-list__key {
-  padding-top: 3px;
-  padding-bottom: 3px;
-  margin-bottom: 5px;
-}
-.wrapper-dashboard-v2.manage-mentors-ects .govuk-summary-list--no-border .govuk-summary-list__value {
-  padding-top: 3px;
-  padding-bottom: 7px;
-  margin-bottom: 5px;
-}
-@media (min-width: 40.625em) {
-  .wrapper-dashboard-v2.manage-mentors-ects .govuk-summary-list--no-border .govuk-summary-list__value {
-    padding-top: 3px;
-    padding-bottom: 14px;
-    margin-bottom: 5px;
+
+  .group-card {
+    border: 1px solid $govuk-border-colour;
+    padding: 10px;
+
+    dl + h3 {
+      margin-top: 1em;
+    }
+
+    @include govuk-media-query($from: tablet) {
+      padding: 20px;
+    }
+
+    .govuk-summary-list {
+      margin-bottom: 0;
+
+      .govuk-summary-list__actions {
+        width: 40%;
+        text-align: left;
+      }
+
+      &--no-border {
+        .govuk-summary-list__row {
+          margin-bottom: 0;
+        }
+
+        .govuk-summary-list__key,
+        .govuk-summary-list__value,
+        .govuk-summary-list__actions {
+          padding-block: 0.3em;
+        }
+      }
+    }
   }
-}
-.wrapper-dashboard-v2.manage-mentors-ects .govuk-summary-list--no-border .govuk-summary-list__actions {
-  padding-top: 3px;
-  padding-bottom: 3px;
-  margin-bottom: 5px;
+
+  .govuk-tabs__panel {
+    margin-bottom: 0;
+    padding: 0;
+    border: none;
+    padding-top: 10px;
+  }
 }


### PR DESCRIPTION
### Context

No visual changes here. The original CSS didn't use the provided GOV.UK frontend utilities and helpers and contained some repetition that can be removed thanks to Sass.

| Before | After |
| -------  | ---------- |
| ![Screenshot from 2023-04-18 15-52-47](https://user-images.githubusercontent.com/128088/232816909-e016d967-aad9-42ff-bc83-d11d147b1e7d.png) | ![Screenshot from 2023-04-18 15-52-38](https://user-images.githubusercontent.com/128088/232816941-1cecdd69-159e-4b3d-bd16-ad99776266f6.png) |
