### PR TITLE
Remove clawed back from uniq declaration index

### DIFF
--- a/db/migrate/20230419084407_amend_unique_index_participant_declaration.rb
+++ b/db/migrate/20230419084407_amend_unique_index_participant_declaration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AmendUniqueIndexParticipantDeclaration < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :participant_declarations, column: %i[cpd_lead_provider_id participant_profile_id declaration_type course_identifier state], if_exists: true
+
+    add_index :participant_declarations, %i[cpd_lead_provider_id participant_profile_id declaration_type course_identifier state], unique: true, name: :unique_declaration_index, where: "state IN ('submitted', 'eligible', 'payable', 'paid')", algorithm: :concurrently
+  end
+
+  def down
+    remove_index :participant_declarations, column: %i[cpd_lead_provider_id participant_profile_id declaration_type course_identifier state], name: :unique_declaration_index, if_exists: true
+
+    add_index :participant_declarations, %i[cpd_lead_provider_id participant_profile_id declaration_type course_identifier state], unique: true, name: :unique_declaration_index, where: "state IN ('submitted', 'eligible', 'payable', 'paid', 'clawed_back')", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_14_123726) do
+ActiveRecord::Schema.define(version: 2023_04_19_084407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -651,7 +651,7 @@ ActiveRecord::Schema.define(version: 2023_04_14_123726) do
     t.boolean "sparsity_uplift"
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text, ('clawed_back'::character varying)::text]))"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying])::text[]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"


### PR DESCRIPTION
### Context
Whilst attempting to mark statements as paid, I got the following error:
```
ERROR:  duplicate key value violates unique constraint "unique_declaration_index" (ActiveRecord::RecordNotUnique)
DETAIL:  Key (cpd_lead_provider_id, participant_profile_id, declaration_type, course_identifier, state)=(xxxx, xxxx, started, ecf-mentor, clawed_back) already exists.
```
A unique index was added to prevent double posting, but we should allow the a declaration belonging to the same profile/lead provider/state be clawed back more than once if necessary

- Ticket: n/a

### Changes proposed in this pull request

Remove clawed back from the unique index but keep the rest the same

### Guidance to review
Did I miss anything?
