### PR TITLE
Add reminder for updating induction tutor

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -30,6 +30,7 @@ class SchoolMailer < ApplicationMailer
   SCHOOL_PRETERM_REMINDER = "a7cc4d19-c0cb-4187-a71b-1b1ea029924f"
   PARTICIPANT_WITHDRAWN_BY_PROVIDER = "29f94916-8c3a-4c5a-9e33-bdf3f5d7249a"
   REMIND_TO_SETUP_MENTOR_TO_ECTS = "604ca80f-b152-4682-9295-9cf1d30f74c1"
+  REMIND_GIAS_CONTACT_TO_UPDATE_INDUCTION_TUTOR_DETAILS_TEMPLATE = "88cdad72-386c-40fb-be2e-11d4ae9dcdee"
 
   def remind_sit_to_set_mentor_to_ects(sit:, ect_names:, campaign: nil)
     campaign_tracking = campaign ? UTMService.email(campaign, campaign) : {}
@@ -78,6 +79,17 @@ class SchoolMailer < ApplicationMailer
         expiry_date:,
       },
     ).tag(:request_to_nominate_sit).associate_with(school)
+  end
+
+  # This email lets the GIAS contact at a school update their induction tutor
+  def remind_to_update_school_induction_tutor_details(school:, sit_name:, nomination_link:)
+    template_mail(
+      REMIND_GIAS_CONTACT_TO_UPDATE_INDUCTION_TUTOR_DETAILS_TEMPLATE,
+      to: school.primary_contact_email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: { sit_name:, nomination_link: },
+    ).tag(:remind_to_update_induction_tutor).associate_with(school)
   end
 
   # This email is sent to newly appointed SIT

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -85,7 +85,7 @@ class SchoolMailer < ApplicationMailer
   def remind_to_update_school_induction_tutor_details(school:, sit_name:, nomination_link:)
     template_mail(
       REMIND_GIAS_CONTACT_TO_UPDATE_INDUCTION_TUTOR_DETAILS_TEMPLATE,
-      to: school.primary_contact_email,
+      to: [school.primary_contact_email, school.secondary_contact_email].compact,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: { sit_name:, nomination_link: },

--- a/app/services/update_induction_tutor_reminder.rb
+++ b/app/services/update_induction_tutor_reminder.rb
@@ -9,10 +9,19 @@ class UpdateInductionTutorReminder
   end
 
   def send!
+    if received_email_recently?
+      Rails.logger.warn("#{school.name} (#{school.urn}) has been sent a nomination email reminder since #{@repeat_email_cutoff}")
+
+      return false
+    end
+
     sit_name = school&.induction_tutor&.full_name
 
-    return if sit_name.blank?
-    return if received_email_recently?
+    if sit_name.blank?
+      Rails.logger.error("no valid recipient for nomination reminder email to #{school.name} (#{school.urn})")
+
+      return false
+    end
 
     SchoolMailer.remind_to_update_school_induction_tutor_details(
       school:,
@@ -32,7 +41,7 @@ private
   end
 
   def nomination_link
-    Rails
+    @nomination_link ||= Rails
       .application
       .routes
       .url_helpers

--- a/app/services/update_induction_tutor_reminder.rb
+++ b/app/services/update_induction_tutor_reminder.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class UpdateInductionTutorReminder
+  attr_reader :school
+
+  def initialize(school, repeat_email_cutoff: 1.week.ago)
+    @school = school
+    @repeat_email_cutoff = repeat_email_cutoff
+  end
+
+  def send!
+    sit_name = school&.induction_tutor&.full_name
+
+    return if sit_name.blank?
+    return if received_email_recently?
+
+    SchoolMailer.remind_to_update_school_induction_tutor_details(
+      school:,
+      sit_name:,
+      nomination_link:,
+    ).deliver_now
+  end
+
+private
+
+  def received_email_recently?
+    Email
+      .associated_with(school)
+      .tagged_with(:remind_to_update_induction_tutor)
+      .where(created_at: @repeat_email_cutoff..)
+      .exists?
+  end
+
+  def nomination_link
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .start_nomination_nominate_induction_coordinator_url(
+        token: nomination_email.token,
+        host: Rails.application.config.domain,
+      )
+  end
+
+  def nomination_email
+    @nomination_email ||= NominationEmail.create_nomination_email(
+      sent_at: Time.zone.now,
+      sent_to: school.primary_contact_email,
+      school:,
+      partnership_notification_email: nil,
+    )
+  end
+end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe SchoolMailer, type: :mailer do
     end
   end
 
+  describe "#remind_to_update_school_induction_tutor_details" do
+    let(:school) { instance_double School, name: "Great Ouse Academy", primary_contact_email: "hello@example.com", secondary_contact_email: "goodbye@example.com" }
+    let(:sit_name) { "Mrs SIT" }
+    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations?token=abc123" }
+
+    let(:nomination_email) do
+      SchoolMailer.remind_to_update_school_induction_tutor_details(
+        nomination_link:,
+        school:,
+        sit_name:,
+      ).deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(nomination_email.from).to eq(["mail@example.com"])
+      expect(nomination_email.to).to eq([school.primary_contact_email, school.secondary_contact_email])
+    end
+  end
+
   describe "#cip_only_invite_email" do
     let(:primary_contact_email) { "contact@example.com" }
     let(:nomination_url) { "https://ecf-dev.london.cloudapps/nominations?token=abc123" }

--- a/spec/services/update_induction_tutor_reminder_spec.rb
+++ b/spec/services/update_induction_tutor_reminder_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateInductionTutorReminder do
+  let(:school) { FactoryBot.create(:seed_school, :with_induction_coordinator) }
+
+  describe "initialization" do
+    it "can be initialized with just a school" do
+      reminder = UpdateInductionTutorReminder.new(school)
+      expect(reminder.school).to eql(school)
+    end
+  end
+
+  describe "#send!" do
+    let(:method_name) { :remind_to_update_school_induction_tutor_details }
+    subject { UpdateInductionTutorReminder.new(school) }
+
+    before do
+      allow(SchoolMailer).to(receive(method_name).and_call_original)
+    end
+
+    it "calls SchoolMailer.remind_to_update_school_induction_tutor_details with the appropriate arguments" do
+      subject.send!
+
+      expect(SchoolMailer).to have_received(method_name).with(
+        school:,
+        sit_name: school.induction_tutor.full_name,
+        nomination_link: subject.instance_variable_get(:@nomination_link),
+      )
+    end
+
+    it "creates a nomination_email record" do
+      expect { subject.send! }.to(change { NominationEmail.count }.by(1))
+    end
+
+    context "when an email has been sent recently" do
+      before do
+        allow(Rails.logger).to receive(:warn).with(any_args).and_return(true)
+        Email.create!(tags: %i[remind_to_update_induction_tutor]).create_association_with(school)
+      end
+
+      it "only sends one email within the permitted timeframe" do
+        result = subject.send!
+
+        expect(result).to be(false)
+        expect(Rails.logger).to have_received(:warn).with(/has been sent a nomination email reminder/)
+      end
+    end
+
+    context "when there is no SIT" do
+      before do
+        allow(Rails.logger).to receive(:error).with(any_args).and_return(true)
+      end
+
+      let(:school) { FactoryBot.create(:seed_school) }
+
+      it "logs there is no SIT and returns false" do
+        result = subject.send!
+
+        expect(result).to be(false)
+        expect(Rails.logger).to have_received(:error).with(/no valid recipient/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-1422

We want to send reminders to GIAS contacts at schools so they can update their induction tutor if required. This change adds a service class that allows us to perform that using the console.

Suggested way to use it is:

```ruby
schools = School.where(urn: SOME_LIST_OF_URNS_FROM_SPREADSHEET)

schools.each { |s| UpdateInductionTutorReminder.new(s).send! }
```

### Changes proposed in this pull request

- Add method to trigger induction tutor update email
- Add service class for sending update reminders
