### PR TITLE
Add pilot indicator to admin school overview 🧑‍✈️ 

### DIFF
--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -1,6 +1,16 @@
 <% content_for :title, "School detail: overview" %>
 
 <h1 class="govuk-heading-xl"><%= @school.name %></h1>
+
+<% if FeatureFlag.active?(:cohortless_dashboard, for: @school) %>
+  <p class="govuk-body-m">
+    <%= govuk_tag do %>
+      <%= tag.span("#{@school.name} is", class: "govuk-visually-hidden") %>
+      Active in cohortless dashboard pilot
+    <% end %>
+  </p>
+<% end %>
+
 <%= render partial: "admin/schools/shared/navigation" %>
 <h2 class="govuk-heading-l">Overview</h2>
 


### PR DESCRIPTION
### Context

It will probably be useful for admins to know whether schools are inside the cohortless dashboard pilot.

This change adds a tag beneath the school's name to indicate if they are. Nothing will be added to schools that aren't in it.

There's some visually hidden text to provide extra context for the tag text.

![image](https://user-images.githubusercontent.com/128088/233340556-00fdee10-db6a-4704-adf4-d85371b99dfb.png)
