### PR TITLE
Limit providers from adding partnerships unless cohort registration open

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -3,7 +3,7 @@
     <% if current_user.lead_provider? %>
       <%= render partial: "navigation" %>
       <h1 class="govuk-heading-xl"><%= @lead_provider.name %></h1>
-      <% @lead_provider.cohorts.each do |cohort| %>
+      <% @lead_provider.cohorts.where(start_year: ..Cohort.active_registration_cohort.start_year).each do |cohort| %>
         <h2 class="govuk-heading-m">
           <%= govuk_link_to "Confirm your schools for the #{cohort.description} academic year", lead_providers_report_schools_start_path(cohort: cohort) %>
         </h2>

--- a/spec/features/lead_providers/dashboard_page_spec.rb
+++ b/spec/features/lead_providers/dashboard_page_spec.rb
@@ -6,7 +6,8 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
   let(:email_address) { "test-lead-provider@example.com" }
   let(:lead_provider_name) { "Test Lead Provider" }
 
-  let!(:cohort) { create :cohort, start_year: 2021 }
+  let!(:cohort) { create :cohort, start_year: 2021, registration_start_date: 1.day.ago }
+  let!(:cohort_next) { create :cohort, start_year: 2022, registration_start_date: 1.day.from_now }
   let!(:ecf_lead_provider) do
     ecf_lead_provider = create(:lead_provider, name: lead_provider_name)
     create :cpd_lead_provider, lead_provider: ecf_lead_provider, name: lead_provider_name
@@ -32,6 +33,7 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
   scenario "Confirming schools" do
     given_i_sign_in_as_the_user_with_the_email email_address
     and_i_am_on_the_lead_provider_dashboard
+    and_i_do_not_see_next_cohort_schools_confirmation
 
     when_i_confirm_schools_from_the_lead_provider_dashboard
 
@@ -44,5 +46,9 @@ RSpec.feature "Lead Provider Dashboard", type: :feature, js: true, rutabaga: fal
     when_i_check_schools_from_the_lead_provider_dashboard
 
     then_i_am_on_the_check_schools_page
+  end
+
+  def and_i_do_not_see_next_cohort_schools_confirmation
+    expect(page).not_to have_content("Confirm your schools for the 2022 to 2023 academic year")
   end
 end


### PR DESCRIPTION

### Context

If the next cohort registration isn't open do not surface ability to create partnerships


- Ticket: n/a

### Changes proposed in this pull request
Only show cohorts up to the Cohort open for registration

### Guidance to review

