### PR TITLE
Store impersonation start path in cookies rather than ActiveRecord::SessionStore::Session

### DIFF
--- a/app/controllers/admin/impersonates_controller.rb
+++ b/app/controllers/admin/impersonates_controller.rb
@@ -11,13 +11,13 @@ module Admin
 
     def create
       impersonate_user(@user)
-      session[:impersonation_start_path] = request.referer
+      cookies[:impersonation_start_path] = request.referer
       redirect_to after_sign_in_path_for(@user)
     end
 
     def destroy
       stop_impersonating_user
-      redirect_to session.delete(:impersonation_start_path) || after_sign_in_path_for(current_user)
+      redirect_to cookies.delete(:impersonation_start_path) || after_sign_in_path_for(current_user)
     end
 
   private

--- a/spec/requests/admin/impersonates_spec.rb
+++ b/spec/requests/admin/impersonates_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Admin::Participants", type: :request do
   describe "POST /admin/impersonate" do
     it "sets impersonation session" do
       when_i_impersonate(induction_coordinator)
+      expect(cookies[:impersonation_start_path]).to eql(admin_school_path(induction_coordinator.school))
       expect(session[:impersonated_user_id]).to eql(induction_coordinator.id.to_s)
     end
 
@@ -44,6 +45,7 @@ RSpec.describe "Admin::Participants", type: :request do
 
     it "clears impersonation session" do
       when_i_stop_impersonating(induction_coordinator)
+      expect(cookies[:impersonation_start_path]).to be_blank
       expect(session[:impersonated_user_id]).to be_blank
     end
 


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/c/r7QYqHjS/9-sit-impersonation

### Changes proposed in this pull request

Store impersonation start path in cookies rather than ActiveRecord::SessionStore::Session.

### Guidance to review

