### PR TITLE
Create job for sending many induction tutor reminders

### DIFF
--- a/app/jobs/update_induction_tutor_reminder_job.rb
+++ b/app/jobs/update_induction_tutor_reminder_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateInductionTutorReminderJob < ApplicationJob
+  def perform(school, **kwargs)
+    UpdateInductionTutorReminder.new(school, **kwargs).send!
+  end
+end

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -85,7 +85,7 @@ class SchoolMailer < ApplicationMailer
   def remind_to_update_school_induction_tutor_details(school:, sit_name:, nomination_link:)
     template_mail(
       REMIND_GIAS_CONTACT_TO_UPDATE_INDUCTION_TUTOR_DETAILS_TEMPLATE,
-      to: [school.primary_contact_email, school.secondary_contact_email].compact,
+      to: [school.primary_contact_email, school.secondary_contact_email].compact.uniq,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: { sit_name:, nomination_link: },

--- a/app/services/update_induction_tutor_reminder.rb
+++ b/app/services/update_induction_tutor_reminder.rb
@@ -9,6 +9,12 @@ class UpdateInductionTutorReminder
   end
 
   def send!
+    if no_gias_email_addresses?
+      Rails.logger.warn("#{school.name} (#{school.urn}) has no contact email addresses")
+
+      return false
+    end
+
     if received_email_recently?
       Rails.logger.warn("#{school.name} (#{school.urn}) has been sent a nomination email reminder since #{@repeat_email_cutoff}")
 
@@ -31,6 +37,10 @@ class UpdateInductionTutorReminder
   end
 
 private
+
+  def no_gias_email_addresses?
+    school.primary_contact_email.blank? && school.secondary_contact_email.blank?
+  end
 
   def received_email_recently?
     Email

--- a/app/services/update_induction_tutor_reminder.rb
+++ b/app/services/update_induction_tutor_reminder.rb
@@ -27,7 +27,7 @@ class UpdateInductionTutorReminder
       school:,
       sit_name:,
       nomination_link:,
-    ).deliver_now
+    ).deliver_later
   end
 
 private

--- a/spec/jobs/update_induction_tutor_reminder_job_spec.rb
+++ b/spec/jobs/update_induction_tutor_reminder_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateInductionTutorReminderJob, :with_default_schedules do
+  let(:school) { FactoryBot.create(:seed_school) }
+  let(:fake_reminder) { double(UpdateInductionTutorReminder, send!: true) }
+
+  before do
+    allow(UpdateInductionTutorReminder).to receive(:new).with(any_args).and_return(fake_reminder)
+  end
+
+  describe "#perform" do
+    it "triggers the creation and sending of an UpdateInductionTutorReminder" do
+      UpdateInductionTutorReminderJob.perform_now(school)
+
+      expect(UpdateInductionTutorReminder).to have_received(:new).with(school)
+      expect(fake_reminder).to have_received(:send!)
+    end
+  end
+end

--- a/spec/services/update_induction_tutor_reminder_spec.rb
+++ b/spec/services/update_induction_tutor_reminder_spec.rb
@@ -62,5 +62,20 @@ RSpec.describe UpdateInductionTutorReminder do
         expect(Rails.logger).to have_received(:error).with(/no valid recipient/)
       end
     end
+
+    context "when the school has no email addresses" do
+      before do
+        allow(Rails.logger).to receive(:warn).with(any_args).and_return(true)
+      end
+
+      let(:school) { FactoryBot.create(:seed_school, primary_contact_email: nil, secondary_contact_email: nil) }
+
+      it "logs there is no SIT and returns false" do
+        result = subject.send!
+
+        expect(result).to be(false)
+        expect(Rails.logger).to have_received(:warn).with(/no contact email addresses/)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

This will allow us to send lots of reminder emails using the queues without taking up resources on the web instances.

### Changes proposed in this pull request

- Deliver the update induction tutor reminder later
- Remove duplicate contact email before sending
- Don't send reminders if school has contact emails

### Review guidance

Probably makes sense to go through commit-by-commit