### PR TITLE
[CST-1468] Activate participant's profile training when enrolling participants

### DIFF
--- a/app/services/induction/enrol.rb
+++ b/app/services/induction/enrol.rb
@@ -5,6 +5,8 @@ class Induction::Enrol < BaseService
     ActiveRecord::Base.transaction do
       record_active_profile_participant_state!
 
+      participant_profile.training_status_active!
+
       participant_profile.induction_records.create!(
         induction_programme:,
         start_date:,

--- a/spec/components/participant_status_tag_component_spec.rb
+++ b/spec/components/participant_status_tag_component_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe ParticipantStatusTagComponent, type: :component do
       let(:participant_profile) { create(:ect_participant_profile, training_status: "withdrawn", school_cohort:) }
       let!(:ecf_participant_eligibility) { create(:ecf_participant_eligibility, participant_profile:) }
       let(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
-      let!(:induction_record) { Induction::Enrol.call(participant_profile:, induction_programme:) }
+      let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
 
       before { render_inline(component) }
 

--- a/spec/services/induction/enrol_spec.rb
+++ b/spec/services/induction/enrol_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Induction::Enrol do
       expect { subject.call(participant_profile:, induction_programme:) }.to change { ParticipantProfileState.count }.by(1)
     end
 
+    context "when the participant profile training_status is withdrawn" do
+      let(:participant_profile) { create(:ect_participant_profile, training_status: :withdrawn) }
+
+      it "it changes it to active" do
+        service.call(participant_profile:, induction_programme:)
+        expect(participant_profile.training_status).to eql "active"
+      end
+    end
+
     context "without optional params" do
       let(:induction_record) do
         service.call(participant_profile:, induction_programme:)


### PR DESCRIPTION
### Context

Ticket: [CST-1468](https://dfedigital.atlassian.net/browse/CST-1468)

Enrolling participants or changing them induction programmes does not updates the training_status in the participant's profile record.

### Changes proposed in this pull request
Set the participant_profile.training_status to active in the Enrol service class

### Guidance to review



[CST-1468]: https://dfedigital.atlassian.net/browse/CST-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ