### PR TITLE
[CPDLP-2158] Fix double counting uplift clawbacks bug within the uplift fee summary calculation

### DIFF
--- a/app/services/finance/ecf/statement_calculator.rb
+++ b/app/services/finance/ecf/statement_calculator.rb
@@ -124,7 +124,10 @@ module Finance
         previous_uplift_amount = previous_uplift_count * uplift_fee_per_declaration
 
         delta_uplift_count = output_calculator.uplift_breakdown[:count]
-        delta_uplift_amount = delta_uplift_count * uplift_fee_per_declaration
+
+        # uplift_clawback_deductions is a negative number so doing a double negative --
+        # we're adding it back as we had subtracted from adjustments_total
+        delta_uplift_amount = delta_uplift_count * uplift_fee_per_declaration - uplift_clawback_deductions
 
         available = [(statement.contract.uplift_cap - previous_uplift_amount), 0].max
 

--- a/spec/services/finance/ecf/statement_calculator_spec.rb
+++ b/spec/services/finance/ecf/statement_calculator_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Finance::ECF::StatementCalculator, :with_default_schedules do
       end
 
       it do
-        expect(subject.total_for_uplift).to eql(200)
+        expect(subject.total_for_uplift).to eql(400)
       end
     end
 
@@ -354,7 +354,7 @@ RSpec.describe Finance::ECF::StatementCalculator, :with_default_schedules do
       end
 
       it do
-        expect(subject.total_for_uplift).to eql(-300)
+        expect(subject.total_for_uplift).to eql(0)
       end
     end
 


### PR DESCRIPTION
### Context

In ‘fixing’ the adjustments table on one part of the statement, we’ve neglected to remove a calculation elsewhere which accounts for clawback uplift payments. In effect, netting out ‘adjustments’ as the sum of declaration and uplift clawbacks, we’ve created a bug where uplift clawbacks are double counted.

- Ticket: [CPDLP-2158](https://dfedigital.atlassian.net/browse/CPDLP-2158)

### Changes proposed in this pull request

- We only count ‘uplift clawbacks’ once 
- The ‘adjustments total’ should be the same at the bottom of the statement as in the summary


[CPDLP-2158]: https://dfedigital.atlassian.net/browse/CPDLP-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ