### PR TITLE
Display the participant profile status in the admin pages

### DIFF
--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -7,6 +7,7 @@ class Admin::ParticipantPresenter
            :user,
            :participant_identity,
            :training_status,
+           :status,
            :notes,
            :notes?,
            :ect?,

--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -31,6 +31,11 @@
     row.value(text: @participant_presenter.training_status)
   end
 
+  sl.row do |row|
+    row.key(text: "Profile status")
+    row.value(text: @participant_presenter.status)
+  end
+
   if @participant_presenter.teacher_profile
     sl.row do |row|
       row.key(text: "TRN")


### PR DESCRIPTION
### Context

- Ticket: N/A

I want to know the participant's profile status in their admin details page.

This will make it clearer why the service complains when the participant is not active.

### Changes proposed in this pull request
- Display the status in the details page

### Guidance to review
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/951947/234036849-8ce3334b-4f09-4332-b484-e01d870efba7.png)|![image](https://user-images.githubusercontent.com/951947/234036131-eab155df-f4f2-46ea-9c18-dcbe127bbea2.png)|

