### PR TITLE
[CPDLP-2136] API behaviour around relationships in partnerships endpoints

### DIFF
--- a/app/services/api/v3/ecf/partnerships_query.rb
+++ b/app/services/api/v3/ecf/partnerships_query.rb
@@ -12,7 +12,7 @@ module Api
         end
 
         def partnerships
-          scope = lead_provider.partnerships.includes(:cohort, :delivery_partner, school: :induction_coordinators)
+          scope = partnership_scope
           scope = scope.where(partnerships: { cohort:  with_cohorts }) if filter[:cohort].present?
           scope = scope.where("partnerships.updated_at > ?", updated_since) if updated_since.present?
           scope = scope.where(partnerships: { delivery_partner: [delivery_partner_id_filter] }) if delivery_partner_id_filter.present?
@@ -21,10 +21,16 @@ module Api
         end
 
         def partnership
-          lead_provider.partnerships.includes(:cohort, :delivery_partner, school: :induction_coordinators).find(params[:id])
+          partnership_scope.find(params[:id])
         end
 
       private
+
+        def partnership_scope
+          lead_provider.partnerships
+            .includes(:cohort, :delivery_partner, school: :induction_coordinators)
+            .where(relationship: false)
+        end
 
         def filter
           params[:filter] ||= {}

--- a/spec/services/api/v3/ecf/partnerships_query_spec.rb
+++ b/spec/services/api/v3/ecf/partnerships_query_spec.rb
@@ -89,6 +89,15 @@ RSpec.describe Api::V3::ECF::PartnershipsQuery do
         end
       end
     end
+
+    describe "ignore relationships" do
+      let(:relationship_cohort) { create(:cohort, start_year: "2051") }
+      let!(:relationship_partnership) { create(:partnership, cohort: relationship_cohort, lead_provider:, relationship: true) }
+
+      it "does not return relationship" do
+        expect(subject.partnerships).to match_array([partnership, another_partnership])
+      end
+    end
   end
 
   describe "#partnership" do
@@ -121,6 +130,15 @@ RSpec.describe Api::V3::ECF::PartnershipsQuery do
       let(:params) { {} }
 
       it "raises an exception" do
+        expect { subject.partnership }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe "ignore relationships" do
+      let!(:partnership) { create(:partnership, cohort:, lead_provider:, relationship: true) }
+      let(:params) { { id: partnership.id } }
+
+      it "does not return relationship" do
         expect { subject.partnership }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2136

### Changes proposed in this pull request

* Updated `Api::V3::ECF::PartnershipsQuery` to only return partnerships with `relationship=false`

### Guidance to review

