### PR TITLE
Display the profile identity in the Admin pages

### DIFF
--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -21,6 +21,13 @@
     end
   end
 
+  if current_user.admin_profile.super_user?
+    sl.row do |row|
+      row.key(text: "Participant identity")
+      row.value(text: @participant_presenter.participant_identity.email)
+    end
+  end
+
   sl.row do |row|
     row.key(text: "Date of birth")
     row.value(text: @participant_presenter&.ecf_participant_validation_data&.date_of_birth&.to_s(:govuk))

--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -11,7 +11,7 @@
   end
 
   sl.row do |row|
-    row.key(text: "Email address")
+    row.key(text: "User email address")
     row.value(text: @participant_presenter.email)
     unless @participant_profile.user.get_an_identity_id.present?
       row.action(


### PR DESCRIPTION
### Context

- Ticket: N/A

The identity linked to the participant's profile is important as we expose participants to Lead Providers base on that. Problem is that we don't display it anywhere in the Admin pages, making it hard to troubleshoot.

### Changes proposed in this pull request
- Display the profile's identity to super users only, to avoid confusing the admins with too many emails
- Rename the `Email address` label to `User email address` to be clearer where it's coming from

### Guidance to review

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/951947/234297586-ffe8cc41-5cd3-4c3d-971c-9b37c900b0a1.png)| ![image](https://user-images.githubusercontent.com/951947/234297630-c74ed47e-d0ea-4ad4-bc58-4b4b2c85b5e7.png)|