### PR TITLE
Fix the user associated emails in the participant's admin page

### DIFF
--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -67,7 +67,7 @@
 
   sl.row do |row|
     row.key(text: "Associated email addresses")
-    row.value(text: html_list(all_emails_associated_with_a_user(@user)))
+    row.value(text: html_list(all_emails_associated_with_a_user(@participant_profile.user)))
   end
 
   sl.row do |row|


### PR DESCRIPTION
### Context

- Ticket: N/A

The `@user` is no longer available in the Admin details page of the participants, so the associated emails list is always empty.

### Changes proposed in this pull request
- Get the user from the @participant_profile

### Guidance to review
| Before | After |
|--------|--------|
|![image](https://user-images.githubusercontent.com/951947/234309571-329a2ff4-3d85-43d3-a5b1-0dca13d45cf9.png)|![image](https://user-images.githubusercontent.com/951947/234309617-25847f8f-571e-4605-bc75-5902aa129adf.png)| 
