### PR TITLE
amend cohort also in historical induction records

### DIFF
--- a/app/views/admin/participants/change_cohort/edit.html.erb
+++ b/app/views/admin/participants/change_cohort/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link(text: "Back", href: admin_participant_cohorts_path) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@amend_participant_cohort, url: admin_participant_change_cohort_path(@participant_profile), method: "put") do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,6 +277,24 @@ en:
               invalid: "Please enter a valid end date"
               in_future: "End date cannot be in the future"
               before_start_date: "End date must be after start date"
+        induction/amend_participant_cohort:
+          attributes:
+            historical_records:
+              no_default_induction_programme: "No default induction programme set for %{start_academic_year} academic year by school %{school_name}"
+              school_cohort_not_setup: "%{start_academic_year} academic year not setup by school %{school_name}"
+            participant_declarations:
+              exist: "The participant must have no declarations"
+              billable_or_submitted: "The participant has billable or submitted declarations in the current cohort"
+              completed: "The participant has not not had a 'completed' declaration submitted against them. Therefore you cannot update their outcome"
+            participant_profile:
+              blank: "Not registered"
+              not_active: "Not active"
+            source_cohort_start_year:
+              invalid: "Invalid value. Must be an integer between %{start} and %{end}"
+            target_cohort_start_year:
+              excluded: "Invalid value. Must be different to %{year}"
+              invalid: "Invalid value. Must be an integer between %{start} and %{end}"
+
         nominate_induction_tutor_form:
           attributes:
             email:


### PR DESCRIPTION
### Context

The current service `Induction::AmendParticipantCohort` to move a participant to one cohort to another on admin only changes the `current_induction_record` of the participant. 

- Ticket: 

### Changes proposed in this pull request

- Amend not only the latest induction record but all historical records of the participant, so all of them must be consistently in the same right cohort.

### Guidance to review

