### PR TITLE
Change preferred identity

### DIFF
--- a/app/controllers/admin/participants/induction_records_controller.rb
+++ b/app/controllers/admin/participants/induction_records_controller.rb
@@ -4,6 +4,8 @@ module Admin::Participants
   class InductionRecordsController < Admin::BaseController
     include RetrieveProfile
 
+    before_action :load_induction_record, only: %i[edit_preferred_email update_preferred_email]
+
     def show
       @participant_presenter = Admin::ParticipantPresenter.new(@participant_profile)
 
@@ -13,10 +15,31 @@ module Admin::Participants
       )
     end
 
+    def edit_preferred_email
+      @participant_identities = @participant_profile.user.participant_identities
+    end
+
+    def update_preferred_email
+      if @induction_record.update(induction_params)
+        set_success_message(heading: "The induction records has been updated")
+        redirect_to admin_participant_induction_records_path(@participant_profile)
+      else
+        render "admin/participants/induction_records/edit_preferred_email"
+      end
+    end
+
   private
+
+    def load_induction_record
+      @induction_record = @participant_profile.induction_records.find(params[:induction_record_id])
+    end
 
     def school
       @school ||= @participant_profile.school
+    end
+
+    def induction_params
+      params.require(:induction_record).permit(:preferred_identity_id)
     end
   end
 end

--- a/app/controllers/admin/participants/induction_records_controller.rb
+++ b/app/controllers/admin/participants/induction_records_controller.rb
@@ -2,6 +2,7 @@
 
 module Admin::Participants
   class InductionRecordsController < Admin::BaseController
+    include Pundit::Authorization
     include RetrieveProfile
 
     before_action :load_induction_record, only: %i[edit_preferred_email update_preferred_email]
@@ -16,10 +17,14 @@ module Admin::Participants
     end
 
     def edit_preferred_email
+      authorize @induction_record
+
       @participant_identities = @participant_profile.user.participant_identities
     end
 
     def update_preferred_email
+      authorize @induction_record
+
       if @induction_record.update(induction_params)
         set_success_message(heading: "The induction records has been updated")
         redirect_to admin_participant_induction_records_path(@participant_profile)

--- a/app/policies/induction_record_policy.rb
+++ b/app/policies/induction_record_policy.rb
@@ -13,6 +13,13 @@ class InductionRecordPolicy < ApplicationPolicy
     admin?
   end
 
+  def change_preferred_email?
+    super_user_only
+  end
+
+  alias_method :edit_preferred_email?, :change_preferred_email?
+  alias_method :update_preferred_email?, :change_preferred_email?
+
   alias_method :withdraw_record?, :destroy?
   alias_method :remove?, :destroy?
 

--- a/app/views/admin/participants/induction_records/edit_preferred_email.html.erb
+++ b/app/views/admin/participants/induction_records/edit_preferred_email.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_content, govuk_back_link( text: "Back", href: admin_participant_path(@participant_profile)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change the preferred email for this induction record</h1>
+    <%= form_for @induction_record, url: update_preferred_email_admin_participant_induction_records_path(@participant_profile, @induction_record), method: :put do |f| %>
+
+      <%= f.govuk_collection_select :preferred_identity_id,
+        @participant_identities,
+        :id,
+        :email,
+        label: { text: "Select email" },
+        options: { selected: @induction_record.preferred_identity_id }
+      %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/participants/induction_records/edit_preferred_email.html.erb
+++ b/app/views/admin/participants/induction_records/edit_preferred_email.html.erb
@@ -12,7 +12,7 @@
         options: { selected: @induction_record.preferred_identity_id }
       %>
 
-      <%= f.govuk_submit %>
+      <%= f.govuk_submit "Submit" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -38,10 +38,12 @@
         sl.row do |row|
           row.key(text: "Preferred email")
           row.value(text: induction_record.participant_email)
-          row.action(
-            href: edit_preferred_email_admin_participant_induction_records_path(@participant_profile, induction_record),
-            visually_hidden_text: "preferred email"
-          )
+          if policy(induction_record).edit_preferred_email?
+            row.action(
+              href: edit_preferred_email_admin_participant_induction_records_path(@participant_profile, induction_record),
+              visually_hidden_text: "preferred email"
+            )
+          end
         end
 
         sl.row do |row|

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -38,6 +38,10 @@
         sl.row do |row|
           row.key(text: "Preferred email")
           row.value(text: induction_record.participant_email)
+          row.action(
+            href: edit_preferred_email_admin_participant_induction_records_path(@participant_profile, induction_record),
+            visually_hidden_text: "preferred email"
+          )
         end
 
         sl.row do |row|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,12 @@ Rails.application.routes.draw do
       resource :details, only: :show, controller: "participants/details"
       resource :school, only: :show, controller: "participants/school"
       resource :history, only: :show, controller: "participants/history"
-      resource :induction_records, only: :show, controller: "participants/induction_records"
+      resource :induction_records, only: :show, controller: "participants/induction_records" do
+        member do
+          get ":induction_record_id/edit_preferred_email", action: :edit_preferred_email, as: :edit_preferred_email
+          put ":induction_record_id/update_preferred_email", action: :update_preferred_email, as: :update_preferred_email
+        end
+      end
       resource :cohorts, only: :show, controller: "participants/cohorts"
       resource :declaration_history, only: :show, controller: "participants/declaration_history"
       resource :identities, only: :show, controller: "participants/identities"

--- a/spec/features/admin/participants/participant_induction_records_spec.rb
+++ b/spec/features/admin/participants/participant_induction_records_spec.rb
@@ -6,9 +6,14 @@ require_relative "./participant_steps"
 RSpec.feature "Admin should be able to see the participant's induction records", js: true, rutabaga: false do
   include ParticipantSteps
 
-  before { setup_participant }
-
   scenario "I should be able to see the list of induction records" do
+    given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+    and_i_am_signed_in_as_an_admin
+    and_i_have_added_an_ect
+    and_i_have_added_a_mentor
+    when_i_visit_admin_participants_dashboard
+    then_i_should_see_a_list_of_participants
+
     when_i_click_on_the_participants_name "Sally Teacher"
     then_i_should_see_the_ects_details
 
@@ -16,5 +21,19 @@ RSpec.feature "Admin should be able to see the participant's induction records",
     then_i_should_be_on_the_participant_induction_records_page
     and_i_should_see_the_participant_induction_records
     and_the_page_title_should_be("Sally Teacher - Induction records")
+  end
+
+  context "when super user" do
+    context "when changing the preferred identity of an Induction Record"
+    scenario "I should be able to see only the user's identities" do
+      given_there_is_a_school_that_has_chosen_fip_for_2021_and_partnered
+      given_i_sign_in_as_a_super_user_admin
+      and_i_have_added_an_ect
+      when_i_visit_admin_participants_dashboard
+      when_i_click_on_the_participants_name "Sally Teacher"
+      when_i_click_on_tab("Induction records")
+      when_i_click_change_preferred_identity_link
+      then_i_should_see_all_the_user_participant_identities
+    end
   end
 end

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -237,4 +237,14 @@ module ParticipantSteps
   def and_the_page_title_should_be(expected_title)
     expect(page.title).to start_with(expected_title)
   end
+
+  def when_i_click_change_preferred_identity_link
+    within(page.find("dt", text: /^Preferred email$/).ancestor(".govuk-summary-list__row").find_all("dd")[1]) do
+      click_on("Change")
+    end
+  end
+
+  def then_i_should_see_all_the_user_participant_identities
+    expect(page).to have_select("Select email", options: @participant_profile_ect.user.participant_identities.map(&:email))
+  end
 end

--- a/spec/policies/induction_record_policy_spec.rb
+++ b/spec/policies/induction_record_policy_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InductionRecordPolicy, type: :policy do
+  subject { described_class.new(user, induction_record) }
+
+  let(:user) { scenario.user }
+  let(:induction_record) { create(:induction_record) }
+
+  context "being a super user admin" do
+    let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build.with_super_user }
+
+    it { is_expected.to permit_actions(%i[edit_preferred_email update_preferred_email]) }
+  end
+
+  context "not being a super user admin" do
+    let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build }
+
+    it { is_expected.to forbid_actions(%i[edit_preferred_email update_preferred_email]) }
+  end
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -30,6 +30,13 @@ module UserHelper
   alias_method :given_i_am_logged_in_as_an_admin_user, :given_i_sign_in_as_an_admin_user
   alias_method :and_i_am_signed_in_as_an_admin, :given_i_sign_in_as_an_admin_user
 
+  def given_i_sign_in_as_a_super_user_admin
+    @logged_in_admin_user = FactoryBot.create(:admin_profile, super_user: true).user
+
+    visit users_confirm_sign_in_path(login_token: @logged_in_admin_user.login_token)
+    click_button "Continue"
+  end
+
   def given_i_sign_in_as_a_finance_user
     token = "test-finance-token-#{Time.zone.now.to_f}"
     create :user,


### PR DESCRIPTION
### Context

- Ticket: N/A

This PR adds a new Admin page for super users only, to change the preferred identity of induction records.

### Changes proposed in this pull request
- Display a link in each Induction Record to change the preferred email
- Add a page to select the new email. All the emails listed are taken from the user's participant identities

### Guidance to review
1. Visit a ECF participant as a super user
2. Go to Induction Records tab
3. Click the `Change` link in the preferred email row
4. Confirm all the email in the dropdown emails are from the User's participant identities
5. Pick a new email and click `Submit`
6. Confirm the Induction Record's new preferred email

| Screenshots  |
|--------|
| ![image](https://user-images.githubusercontent.com/951947/234601039-8ab9e66b-75b3-45e5-88a6-1f149c4357d4.png ) |
| ![image](https://user-images.githubusercontent.com/951947/234601173-592769d4-4d6d-4323-9edb-f2eb3beed9d7.png) | 