### PR TITLE
Set default induction programme when creating school cohorts

### DIFF
--- a/db/legacy_seeds/test_data.rb
+++ b/db/legacy_seeds/test_data.rb
@@ -96,11 +96,12 @@ School.find_or_create_by!(urn: "000005") do |school|
   school_cohort = SchoolCohort.find_or_create_by!(cohort: Cohort.current, school:, induction_programme_choice: "full_induction_programme")
   delivery_partner = DeliveryPartner.find_or_create_by!(name: "Test Delivery Partner")
   partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner:, school:, lead_provider:, challenge_deadline: 2.weeks.from_now)
-  InductionProgramme.find_or_create_by!(
+  ip = InductionProgramme.find_or_create_by!(
     school_cohort:,
     partnership:,
     training_programme: "full_induction_programme",
   )
+  school_cohort.update!(default_induction_programme: ip)
   PartnershipNotificationEmail.find_or_create_by!(
     partnership:,
     sent_to: "cpd-test+tutor-2#{DOMAIN}",
@@ -156,11 +157,13 @@ end
     school_cohort = SchoolCohort.find_or_create_by!(cohort: Cohort.current, school:, induction_programme_choice: "full_induction_programme")
     delivery_partner = DeliveryPartner.find_or_create_by!(name: "Mega Delivery Partner")
     partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner:, school:, lead_provider:, challenge_deadline: 2.weeks.from_now)
-    InductionProgramme.find_or_create_by!(
+    ip = InductionProgramme.find_or_create_by!(
       school_cohort:,
       partnership:,
       training_programme: "full_induction_programme",
     )
+    school_cohort.update!(default_induction_programme: ip)
+
     PartnershipNotificationEmail.find_or_create_by!(
       partnership:,
       sent_to: "cpd-test+tutor-3#{DOMAIN}",
@@ -193,11 +196,13 @@ School.find_or_create_by!(urn: "000006") do |school|
   school_cohort = SchoolCohort.find_or_create_by!(cohort: Cohort.current, school:, induction_programme_choice: "full_induction_programme")
   delivery_partner = DeliveryPartner.find_or_create_by!(name: "Mega Delivery Partner")
   partnership = Partnership.find_or_create_by!(cohort: Cohort.current, delivery_partner:, school:, lead_provider:)
-  InductionProgramme.find_or_create_by!(
+  ip = InductionProgramme.find_or_create_by!(
     school_cohort:,
     partnership:,
     training_programme: "full_induction_programme",
   )
+  school_cohort.update!(default_induction_programme: ip)
+
   PartnershipNotificationEmail.find_or_create_by!(
     partnership:,
     sent_to: "cpd-test+tutor-3#{DOMAIN}",
@@ -454,11 +459,12 @@ Induction::Enrol.call(participant_profile:, induction_programme:)
     school_cohort = SchoolCohort.find_or_create_by!(cohort: Cohort.current, school:, induction_programme_choice: "core_induction_programme")
     partnership = Partnership.find_or_create_by!(cohort: school_cohort.cohort, school:, lead_provider:, delivery_partner:)
 
-    InductionProgramme.find_or_create_by!(
+    ip = InductionProgramme.find_or_create_by!(
       school_cohort:,
       partnership:,
       training_programme: "full_induction_programme",
     )
+    school_cohort.update!(default_induction_programme: ip)
   end
 end
 

--- a/db/new_seeds/base/add_schools_and_local_authorities.rb
+++ b/db/new_seeds/base/add_schools_and_local_authorities.rb
@@ -11,7 +11,20 @@ def add_school_to_local_authority(school:, local_authority:, nomination_email: f
     FactoryBot.create(:seed_induction_coordinator_profiles_school, induction_coordinator_profile:, school:)
 
     @cohorts.sample(@cohorts.length).each do |cohort|
-      FactoryBot.create(:seed_school_cohort, school:, cohort:)
+      school_cohort = FactoryBot.create(:seed_school_cohort, school:, cohort:)
+      if school_cohort.fip?
+        induction_programme = NewSeeds::Scenarios::InductionProgrammes::Fip.new(school_cohort:)
+          .build
+          .with_partnership
+          .induction_programme
+        school_cohort.update!(default_induction_programme: induction_programme)
+      elsif school_cohort.cip?
+        induction_programme = NewSeeds::Scenarios::InductionProgrammes::Cip.new(school_cohort:)
+          .build
+          .with_core_induction_programme
+          .induction_programme
+        school_cohort.update!(default_induction_programme: induction_programme)
+      end
     end
 
     @lead_providers.sample.tap do |lead_provider|

--- a/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
+++ b/db/new_seeds/scenarios/participants/transfers/fip_to_fip_keeping_original_training_provider.rb
@@ -17,11 +17,16 @@ module NewSeeds
                                              school: school_to,
                                              lead_provider: induction_programme_from.lead_provider,
                                              delivery_partner: induction_programme_from.delivery_partner)
-            @induction_programme_to ||= NewSeeds::Scenarios::SchoolCohorts::Fip
-                                          .new(cohort:, school: school_to)
-                                          .build
-                                          .add_programme(default_induction_programme: false, partnership: relationship)
+            # really want the destination school to have a properly set up school_cohort and induction programme
             setup
+
+            # create an additional induction programme as non-default with a relationship
+            @induction_programme_to = NewSeeds::Scenarios::InductionProgrammes::Fip
+              .new(school_cohort: school_cohort_to)
+              .build(default_induction_programme: false)
+              .with_partnership(partnership: relationship)
+              .induction_programme
+
             Rails.logger.info("seeded transfer of #{participant_profile.full_name} from #{school_from.name} to #{school_to.name} while keeping their original training provider")
 
             create_induction_record_to


### PR DESCRIPTION
### Context

Fix (most of) the occurrences in seeds where a school cohort with a CIP or FIP choice is created but is missing either or both:
- An `InductionProgramme` for the programme
- The programme set as the `SchoolCohort.default_induction_programme`