### PR TITLE
Safely traverse from user to admin profile

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -23,7 +23,7 @@
         Appropriate bodies
       <% end %>
     <% end %>
-    <% if current_user.admin_profile.super_user? %>
+    <% if current_user&.admin_profile&.super_user? %>
       <%= component.nav_item(path: admin_super_user_path) do %>
         Super users
       <% end %>


### PR DESCRIPTION
Despite this controller needing an admin profile to see it, [we're seeing crashes in Sentry](https://dfe-teacher-services.sentry.io/issues/4127717407/?project=5748989&referrer=slack) where `current_user.admin_profile` is nil. We should ensure the crash doesn't originate in the template and let the controller handle the permissions accordingly.
