### PR TITLE
Switch super_user? check over to policy

### DIFF
--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -21,7 +21,7 @@
     end
   end
 
-  if current_user.admin_profile.super_user?
+  if policy(:super_user).show?
     sl.row do |row|
       row.key(text: "Participant identity")
       row.value(text: @participant_presenter.participant_identity.email)


### PR DESCRIPTION
### Context

In response to [this Sentry report](https://dfe-teacher-services.sentry.io/issues/4135058711/?project=5748989&referrer=slack), use policy instead of chaining `#super_user?`
