### PR TITLE
Fix bug preventing NPQs from being added as mentors

### DIFF
--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -136,7 +136,7 @@ module Schools
 
       def email_in_use?
         @email_owner ||= Identity.find_user_by(email: data_store.email)
-        return false if @email_owner.nil?
+        return false if @email_owner.nil? || !@email_owner.participant?
         return true unless transfer?
 
         @email_owner != existing_user


### PR DESCRIPTION
### Context

- Ticket: [CST-1428](https://dfedigital.atlassian.net/browse/CST-1428)

This PR fixes a bug that was recently introduced by the "add and transfer" journey, which prevents NPQs from being added as mentors.

### Guidance to review
Impersonate a SIT and add a new mentor in a school by providing the email of a NPQ user with no ECF profiles.

[CST-1428]: https://dfedigital.atlassian.net/browse/CST-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ