### PR TITLE
[BugFix] Fix last of the missing induction programmes in scenarios

### DIFF
--- a/db/new_seeds/scenarios/participants/induction_coordinator.rb
+++ b/db/new_seeds/scenarios/participants/induction_coordinator.rb
@@ -15,6 +15,7 @@ module NewSeeds
 
       def build
         @school_cohort = FactoryBot.create(:seed_school_cohort, induction_programme, :valid)
+        @school_cohort.update!(default_induction_programme: FactoryBot.create(:seed_induction_programme, induction_programme, school_cohort:))
         @user = FactoryBot.create(:user, email:, **user_args)
         @induction_coordinator_profile = FactoryBot.create(:seed_induction_coordinator_profile, user:)
 


### PR DESCRIPTION
### Context

There were 2 schools still being created via the scenario seeds that had a school cohort with a choice of FIP or CIP, but no induction programme. This PR fixes this.

### Guidance to review

`bundle exec rails db:seed:replant`

Then enter this in the `rails console`
`SchoolCohort.full_induction_programme.where(default_induction_programme: nil).count`
It should return `0`
`SchoolCohort.core_induction_programme.where(default_induction_programme: nil).count`
It should also return `0`
