### PR TITLE
Use new way to call mailers using "with" and deliver later

### DIFF
--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -128,7 +128,10 @@ module Schools
       end
 
       def send_added_and_validated_email(profile)
-        ParticipantMailer.sit_has_added_and_validated_participant(participant_profile: profile, school_name: school.name).deliver_later
+        ParticipantMailer.with(
+          participant_profile: profile,
+          school_name: school.name,
+        ).sit_has_added_and_validated_participant.deliver_later
       end
 
       def participant_create_args


### PR DESCRIPTION
### Context
To upgrade to ruby 3.2.2 we moved to using a new way to call mailers.
We amended this method [here](https://github.com/DFE-Digital/early-careers-framework/pull/2922/commits/728e07431b21158ae37c78bc742cc0e255bfbda2#diff-9956855e8bd74673f70598353bb7c3c2e1cc938a17c2867c670cc6ec969aa13fR333) but looks like its been moved

To resolve https://dfe-teacher-services.sentry.io/issues/4154032056/?project=5748989&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

- Ticket: n/a

### Changes proposed in this pull request
Use `with` and deliver later to ensure we are sending mail correctly to avoid errors


### Guidance to review
Did I miss anything
