### PR TITLE
Fix failing mailers

### DIFF
--- a/app/controllers/schools/transfer_out_controller.rb
+++ b/app/controllers/schools/transfer_out_controller.rb
@@ -19,7 +19,7 @@ module Schools
 
     def check_answers
       @induction_record.leaving!(@transfer_out_form.end_date, transferring_out: true)
-      ParticipantTransferMailer.participant_transfer_out_notification(induction_record: @induction_record).deliver_later
+      ParticipantTransferMailer.with(induction_record: @induction_record).participant_transfer_out_notification.deliver_later
 
       store_form_redirect_to_next_step(:complete)
     end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,7 +3,10 @@
 class AdminMailer < ApplicationMailer
   ADMIN_ACCOUNT_CREATED_TEMPLATE = "3620d073-d2cc-4d65-9a51-e12770cf25d9"
 
-  def account_created_email(admin, url)
+  def account_created_email
+    admin = params[:admin]
+    url = params[:url]
+
     template_mail(
       ADMIN_ACCOUNT_CREATED_TEMPLATE,
       to: admin.email,

--- a/app/mailers/appropriate_body_profile_mailer.rb
+++ b/app/mailers/appropriate_body_profile_mailer.rb
@@ -3,7 +3,9 @@
 class AppropriateBodyProfileMailer < ApplicationMailer
   WELCOME_TEMPLATE_ID = "0835a51f-dd7e-4a5e-b6e2-0b143de02eeb"
 
-  def welcome(appropriate_body_profile)
+  def welcome
+    appropriate_body_profile = params[:appropriate_body_profile]
+
     template_mail(
       WELCOME_TEMPLATE_ID,
       to: appropriate_body_profile.user.email,

--- a/app/mailers/delivery_partner_profile_mailer.rb
+++ b/app/mailers/delivery_partner_profile_mailer.rb
@@ -3,7 +3,9 @@
 class DeliveryPartnerProfileMailer < ApplicationMailer
   WELCOME_TEMPLATE_ID = "d477ea16-169b-415e-a87e-1fba314b77e8"
 
-  def welcome(delivery_partner_profile)
+  def welcome
+    delivery_partner_profile = params[:delivery_partner_profile]
+
     template_mail(
       WELCOME_TEMPLATE_ID,
       to: delivery_partner_profile.user.email,

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -129,7 +129,10 @@ class SchoolMailer < ApplicationMailer
   end
 
   # This email is sent when induction tutor to be changed
-  def school_requested_signin_link_from_gias_email(school:, nomination_link:)
+  def school_requested_signin_link_from_gias_email
+    school = params[:school]
+    nomination_link = params[:nomination_link]
+
     template_mail(
       SCHOOL_REQUESTED_SIGNIN_LINK_FROM_GIAS,
       to: school.primary_contact_email,

--- a/app/models/admin_profile.rb
+++ b/app/models/admin_profile.rb
@@ -11,7 +11,7 @@ class AdminProfile < ApplicationRecord
     ActiveRecord::Base.transaction do
       user.save!
       AdminProfile.create!(user:)
-      AdminMailer.with(admin: user, url: sign_in_url).account_created_email.deliver_now
+      AdminMailer.with(admin: user, url: sign_in_url).account_created_email.deliver_later
     end
   end
 end

--- a/app/models/admin_profile.rb
+++ b/app/models/admin_profile.rb
@@ -11,7 +11,7 @@ class AdminProfile < ApplicationRecord
     ActiveRecord::Base.transaction do
       user.save!
       AdminProfile.create!(user:)
-      AdminMailer.account_created_email(user, sign_in_url).deliver_now
+      AdminMailer.with(admin: user, url: sign_in_url).account_created_email.deliver_now
     end
   end
 end

--- a/app/models/appropriate_body_profile.rb
+++ b/app/models/appropriate_body_profile.rb
@@ -12,7 +12,7 @@ class AppropriateBodyProfile < ApplicationRecord
         u.full_name = full_name
       end
       abp = AppropriateBodyProfile.create!(user:, appropriate_body:)
-      AppropriateBodyProfileMailer.welcome(abp).deliver_now
+      AppropriateBodyProfileMailer.with(appropriate_body_profile: abp).welcome.deliver_now
     end
   end
 end

--- a/app/models/delivery_partner_profile.rb
+++ b/app/models/delivery_partner_profile.rb
@@ -12,7 +12,7 @@ class DeliveryPartnerProfile < ApplicationRecord
         u.full_name = full_name
       end
       dpp = DeliveryPartnerProfile.create!(user:, delivery_partner:)
-      DeliveryPartnerProfileMailer.welcome(dpp).deliver_now
+      DeliveryPartnerProfileMailer.with(delivery_partner_profile: dpp).welcome.deliver_now
     end
   end
 end

--- a/app/models/delivery_partner_profile.rb
+++ b/app/models/delivery_partner_profile.rb
@@ -12,7 +12,7 @@ class DeliveryPartnerProfile < ApplicationRecord
         u.full_name = full_name
       end
       dpp = DeliveryPartnerProfile.create!(user:, delivery_partner:)
-      DeliveryPartnerProfileMailer.with(delivery_partner_profile: dpp).welcome.deliver_now
+      DeliveryPartnerProfileMailer.with(delivery_partner_profile: dpp).welcome.deliver_later
     end
   end
 end

--- a/app/services/induction/send_transfer_notification_emails.rb
+++ b/app/services/induction/send_transfer_notification_emails.rb
@@ -78,20 +78,20 @@ module Induction
     end
 
     def send_participant_notification!
-      ParticipantTransferMailer.participant_transfer_in_notification(induction_record:).deliver_later
+      ParticipantTransferMailer.with(induction_record:).participant_transfer_in_notification.deliver_later
     end
 
     # emails to current lead provider profiles
 
     def send_provider_transfer_in_notifications
       lead_provider_profiles_in.each do |lead_provider_profile|
-        ParticipantTransferMailer.provider_transfer_in_notification(induction_record:, lead_provider_profile:).deliver_later
+        ParticipantTransferMailer.with(induction_record:, lead_provider_profile:).provider_transfer_in_notification.deliver_later
       end
     end
 
     def send_provider_existing_school_transfer_notifications
       lead_provider_profiles_in.each do |lead_provider_profile|
-        ParticipantTransferMailer.provider_existing_school_transfer_notification(induction_record:, lead_provider_profile:).deliver_later
+        ParticipantTransferMailer.with(induction_record:, lead_provider_profile:).provider_existing_school_transfer_notification.deliver_later
       end
     end
 
@@ -99,13 +99,13 @@ module Induction
 
     def send_provider_transfer_out_notifications
       lead_provider_profiles_out.each do |lead_provider_profile|
-        ParticipantTransferMailer.provider_transfer_out_notification(induction_record:, lead_provider_profile:).deliver_later
+        ParticipantTransferMailer.with(induction_record:, lead_provider_profile:).provider_transfer_out_notification.deliver_later
       end
     end
 
     def send_provider_new_school_transfer_notifications
       lead_provider_profiles_out.each do |lead_provider_profile|
-        ParticipantTransferMailer.provider_new_school_transfer_notification(induction_record:, lead_provider_profile:).deliver_later
+        ParticipantTransferMailer.with(induction_record:, lead_provider_profile:).provider_new_school_transfer_notification.deliver_later
       end
     end
   end

--- a/app/services/invite_schools.rb
+++ b/app/services/invite_schools.rb
@@ -121,10 +121,10 @@ private
   end
 
   def send_replace_tutor_email(nomination_email)
-    notify_id = SchoolMailer.school_requested_signin_link_from_gias_email(
+    notify_id = SchoolMailer.with(
       school: nomination_email.school,
       nomination_link: nomination_email.nomination_url,
-    ).deliver_now.delivery_method.response.id
+    ).school_requested_signin_link_from_gias_email.deliver_now.delivery_method.response.id
 
     nomination_email.update!(notify_id:)
   end

--- a/app/services/update_induction_tutor_reminder.rb
+++ b/app/services/update_induction_tutor_reminder.rb
@@ -29,11 +29,11 @@ class UpdateInductionTutorReminder
       return false
     end
 
-    SchoolMailer.remind_to_update_school_induction_tutor_details(
+    SchoolMailer.with(
       school:,
       sit_name:,
       nomination_link:,
-    ).deliver_later
+    ).remind_to_update_school_induction_tutor_details.deliver_later
   end
 
 private

--- a/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
+++ b/spec/features/schools/participants/transfer_out/ppt_transferred_in_and_transferred_out_spec.rb
@@ -176,12 +176,12 @@ RSpec.describe "old and new SIT transferring the same participant", type: :featu
     end
 
     def and_the_participant_should_be_notified_that_theyre_transferred_out
-      expect(ParticipantTransferMailer).to have_received(:participant_transfer_out_notification)
-                                             .with(hash_including(induction_record: @induction_record))
+      expect(ParticipantTransferMailer).to have_received(:with)
+                                             .with(induction_record: @induction_record)
     end
 
     def allow_participant_transfer_mailers
-      allow(ParticipantTransferMailer).to receive(:participant_transfer_out_notification).and_call_original
+      allow(ParticipantTransferMailer).to receive(:with).and_call_original
     end
 
     def set_participant_data

--- a/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
+++ b/spec/features/schools/participants/transfer_out/transfer_out_only_spec.rb
@@ -150,14 +150,12 @@ RSpec.describe "transfer out participants", type: :feature, js: true, rutabaga: 
     end
 
     def and_the_participant_should_be_notified_that_theyre_transferred_out
-      expect(ParticipantTransferMailer).to have_received(:participant_transfer_out_notification)
-                                             .with(hash_including(
-                                                     induction_record: @induction_record,
-                                                   ))
+      expect(ParticipantTransferMailer).to have_received(:with)
+                                             .with(induction_record: @induction_record)
     end
 
     def allow_participant_transfer_mailers
-      allow(ParticipantTransferMailer).to receive(:participant_transfer_out_notification).and_call_original
+      allow(ParticipantTransferMailer).to receive(:with).and_call_original
     end
 
     def set_participant_data

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "transferring a withdrawn participant", :with_default_schedules, 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
 
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_schools_current_provider_is_notified_with(:provider_transfer_in_notification)
+    and_the_participant_should_be_notified
+    and_the_schools_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -213,20 +213,15 @@ RSpec.describe "transferring a withdrawn participant", :with_default_schedules, 
     expect(page).to have_text(@mentor.user.full_name)
   end
 
-  def and_the_participant_should_be_notified_with(notification_method)
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record: @participant_profile_ect.induction_records.latest,
-            ))
+  def and_the_participant_should_be_notified
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(induction_record: @participant_profile_ect.induction_records.latest)
   end
 
-  def and_the_schools_current_provider_is_notified_with(notification_method)
+  def and_the_schools_current_provider_is_notified
     induction_record = @participant_profile_ect.induction_records.latest
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record:,
-              lead_provider_profile: @lead_provider_profile,
-            ))
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(induction_record:, lead_provider_profile: @lead_provider_profile)
   end
 
   def and_i_have_selected_my_cohort_tab
@@ -234,8 +229,7 @@ RSpec.describe "transferring a withdrawn participant", :with_default_schedules, 
   end
 
   def allow_participant_transfer_mailers
-    allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_transfer_in_notification).and_call_original
+    allow(ParticipantTransferMailer).to receive(:with).and_call_original
   end
 
   def set_dqt_validation_result

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
     click_on "Confirm and add"
 
     then_i_should_be_on_the_complete_page
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_schools_current_provider_is_notified_with(:provider_transfer_in_notification)
-    and_the_participants_current_provider_is_notified_with(:provider_transfer_out_notification)
+    and_the_participant_should_be_notified
+    and_the_schools_current_provider_is_notified
+    and_the_participants_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -127,8 +127,8 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page_for_an_existing_induction
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_participants_current_provider_is_notified_with(:provider_new_school_transfer_notification)
+    and_the_participant_should_be_notified
+    and_the_participants_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -324,27 +324,27 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
     expect(page).to have_text(@mentor.user.full_name)
   end
 
-  def and_the_participant_should_be_notified_with(notification_method)
-    expect(ParticipantTransferMailer).to have_received(notification_method).with(induction_record: @participant_profile_ect.induction_records.latest)
+  def and_the_participant_should_be_notified
+    expect(ParticipantTransferMailer).to have_received(:with).with(induction_record: @participant_profile_ect.induction_records.latest)
   end
 
-  def and_the_participants_current_provider_is_notified_with(notification_method)
+  def and_the_participants_current_provider_is_notified
     induction_record = @participant_profile_ect.induction_records.latest
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record:,
-              lead_provider_profile: @lead_provider_two_profile,
-            ))
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(
+        induction_record:,
+        lead_provider_profile: @lead_provider_two_profile,
+      )
   end
 
-  def and_the_schools_current_provider_is_notified_with(notification_method)
+  def and_the_schools_current_provider_is_notified
     induction_record = @participant_profile_ect.induction_records.latest
 
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record:,
-              lead_provider_profile: @lead_provider_profile,
-            ))
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(
+        induction_record:,
+        lead_provider_profile: @lead_provider_profile,
+      )
   end
 
   def and_i_have_selected_my_cohort_tab
@@ -352,10 +352,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
   end
 
   def allow_participant_transfer_mailers
-    allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_new_school_transfer_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_transfer_out_notification).and_call_original
+    allow(ParticipantTransferMailer).to receive(:with).and_call_original
   end
 
   def set_dqt_validation_result

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
     then_the_page_should_be_accessible
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_schools_current_provider_is_notified_with(:provider_existing_school_transfer_notification)
+    and_the_participant_should_be_notified
+    and_the_schools_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -339,20 +339,20 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
     expect(page).to have_text(@mentor.user.full_name)
   end
 
-  def and_the_participant_should_be_notified_with(notification_method)
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-                                           .with(hash_including(
-                                                   induction_record: @participant_profile_ect.induction_records.latest,
-                                                 ))
+  def and_the_participant_should_be_notified
+    expect(ParticipantTransferMailer).to have_received(:with)
+                                         .with(
+                                           induction_record: @participant_profile_ect.induction_records.latest,
+                                         )
   end
 
-  def and_the_schools_current_provider_is_notified_with(notification_method)
+  def and_the_schools_current_provider_is_notified
     induction_record = @participant_profile_ect.induction_records.latest
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-                                           .with(hash_including(
-                                                   induction_record:,
-                                                   lead_provider_profile: @lead_provider_profile,
-                                                 ))
+    expect(ParticipantTransferMailer).to have_received(:with)
+                                           .with(
+                                             induction_record:,
+                                             lead_provider_profile: @lead_provider_profile,
+                                           )
   end
 
   def and_i_have_selected_my_cohort_tab
@@ -360,8 +360,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   end
 
   def allow_participant_transfer_mailers
-    allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_existing_school_transfer_notification).and_call_original
+    allow(ParticipantTransferMailer).to receive(:with).and_call_original
   end
 
   def set_dqt_validation_result

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_schools_current_provider_is_notified_with(:provider_transfer_in_notification)
-    and_the_participants_current_provider_is_notified_with(:provider_transfer_out_notification)
+    and_the_participant_should_be_notified
+    and_the_schools_current_provider_is_notified
+    and_the_participants_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -116,8 +116,8 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page_for_an_existing_induction
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_participants_current_provider_is_notified_with(:provider_new_school_transfer_notification)
+    and_the_participant_should_be_notified
+    and_the_participants_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -303,26 +303,26 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
     @participant_profile_mentor.teacher_profile.update!(trn: "1001000")
   end
 
-  def and_the_participant_should_be_notified_with(notification_method)
-    expect(ParticipantTransferMailer).to have_received(notification_method).with(induction_record: @participant_profile_mentor.induction_records.latest)
+  def and_the_participant_should_be_notified
+    expect(ParticipantTransferMailer).to have_received(:with).with(induction_record: @participant_profile_mentor.induction_records.latest)
   end
 
-  def and_the_participants_current_provider_is_notified_with(notification_method)
+  def and_the_participants_current_provider_is_notified
     induction_record = @participant_profile_mentor.induction_records.latest
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record:,
-              lead_provider_profile: @lead_provider_two_profile,
-            ))
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(
+        induction_record:,
+        lead_provider_profile: @lead_provider_two_profile,
+      )
   end
 
-  def and_the_schools_current_provider_is_notified_with(notification_method)
+  def and_the_schools_current_provider_is_notified
     induction_record = @participant_profile_mentor.induction_records.latest
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record:,
-              lead_provider_profile: @lead_provider_profile,
-            ))
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(
+        induction_record:,
+        lead_provider_profile: @lead_provider_profile,
+      )
   end
 
   def and_i_have_selected_my_cohort_tab
@@ -330,10 +330,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   end
 
   def allow_participant_transfer_mailers
-    allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_new_school_transfer_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_transfer_out_notification).and_call_original
+    allow(ParticipantTransferMailer).to receive(:with).and_call_original
   end
 
   def set_dqt_validation_result

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
 
     click_on "Confirm and add"
     then_i_should_be_on_the_complete_page
-    and_the_participant_should_be_notified_with(:participant_transfer_in_notification)
-    and_the_schools_current_provider_is_notified_with(:provider_existing_school_transfer_notification)
+    and_the_participant_should_be_notified
+    and_the_schools_current_provider_is_notified
 
     click_on "View your ECTs and mentors"
     then_i_am_taken_to_a_dashboard_page
@@ -213,21 +213,20 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
     @participant_profile_mentor.teacher_profile.update!(trn: "1001000")
   end
 
-  def and_the_participant_should_be_notified_with(notification_method)
-    expect(ParticipantTransferMailer).to have_received(notification_method).with(induction_record: @participant_profile_mentor.induction_records.latest)
+  def and_the_participant_should_be_notified
+    expect(ParticipantTransferMailer).to have_received(:with).with(induction_record: @participant_profile_mentor.induction_records.latest)
   end
 
-  def and_the_schools_current_provider_is_notified_with(notification_method)
-    expect(ParticipantTransferMailer).to have_received(notification_method)
-      .with(hash_including(
-              induction_record: @participant_profile_mentor.induction_records.latest,
-              lead_provider_profile: @lead_provider_profile,
-            ))
+  def and_the_schools_current_provider_is_notified
+    expect(ParticipantTransferMailer).to have_received(:with)
+      .with(
+        induction_record: @participant_profile_mentor.induction_records.latest,
+        lead_provider_profile: @lead_provider_profile,
+      )
   end
 
   def allow_participant_transfer_mailers
-    allow(ParticipantTransferMailer).to receive(:participant_transfer_in_notification).and_call_original
-    allow(ParticipantTransferMailer).to receive(:provider_existing_school_transfer_notification).and_call_original
+    allow(ParticipantTransferMailer).to receive(:with).and_call_original
   end
 
   def set_dqt_validation_result

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AdminMailer, type: :mailer do
 
   describe "#account_created_email" do
     let(:account_created_email) do
-      AdminMailer.account_created_email(user, sign_in_link)
+      AdminMailer.with(admin: user, url: sign_in_link).account_created_email.deliver_now
     end
 
     it "renders the right headers" do

--- a/spec/mailers/appropriate_body_profile_spec.rb
+++ b/spec/mailers/appropriate_body_profile_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe AppropriateBodyProfileMailer, type: :mailer do
 
   describe "#welcome" do
     let(:welcome_email) do
-      AppropriateBodyProfileMailer.welcome(
-        appropriate_body_profile,
-      ).deliver_now
+      AppropriateBodyProfileMailer.with(
+        appropriate_body_profile:,
+      ).welcome.deliver_now
     end
 
     it "renders the right headers" do

--- a/spec/mailers/delivery_partner_profile_spec.rb
+++ b/spec/mailers/delivery_partner_profile_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe DeliveryPartnerProfileMailer, type: :mailer do
 
   describe "#welcome" do
     let(:welcome_email) do
-      DeliveryPartnerProfileMailer.welcome(
-        delivery_partner_profile,
-      ).deliver_now
+      DeliveryPartnerProfileMailer.with(
+        delivery_partner_profile:,
+      ).welcome.deliver_now
     end
 
     it "renders the right headers" do

--- a/spec/models/admin_profile_spec.rb
+++ b/spec/models/admin_profile_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe AdminProfile, type: :model do
     end
 
     it "sends an email to the admin" do
-      allow(AdminMailer).to receive(:account_created_email).and_call_original
+      allow(AdminMailer).to receive(:with).and_call_original
 
       AdminProfile.create_admin(name, email, sign_in_url)
 
-      expect(AdminMailer).to have_received(:account_created_email).with(created_user, sign_in_url)
+      expect(AdminMailer).to have_received(:with).with(admin: created_user, url: sign_in_url)
     end
   end
 end

--- a/spec/models/appropriate_body_profile_spec.rb
+++ b/spec/models/appropriate_body_profile_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe AppropriateBodyProfile, type: :model do
     end
 
     it "sends an email to the new user" do
-      allow(AppropriateBodyProfileMailer).to receive(:welcome).and_call_original
+      allow(AppropriateBodyProfileMailer).to receive(:with).and_call_original
       AppropriateBodyProfile.create_appropriate_body_user(name, email, appropriate_body)
 
-      expect(AppropriateBodyProfileMailer).to have_received(:welcome).with(created_appropriate_body_profile)
+      expect(AppropriateBodyProfileMailer).to have_received(:with).with(appropriate_body_profile: created_appropriate_body_profile)
     end
   end
 end

--- a/spec/models/delivery_partner_profile_spec.rb
+++ b/spec/models/delivery_partner_profile_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe DeliveryPartnerProfile, type: :model do
     end
 
     it "sends an email to the new user" do
-      allow(DeliveryPartnerProfileMailer).to receive(:welcome).and_call_original
+      allow(DeliveryPartnerProfileMailer).to receive(:with).and_call_original
 
-      DeliveryPartnerProfile.create_delivery_partner_user(name, email, delivery_partner)
+      expect { DeliveryPartnerProfile.create_delivery_partner_user(name, email, delivery_partner) }.to have_enqueued_mail(DeliveryPartnerProfileMailer, :welcome)
 
-      expect(DeliveryPartnerProfileMailer).to have_received(:welcome).with(created_delivery_partner_profile)
+      expect(DeliveryPartnerProfileMailer).to have_received(:with).with(delivery_partner_profile: created_delivery_partner_profile)
     end
   end
 end

--- a/spec/requests/admin/administrators/administrators_spec.rb
+++ b/spec/requests/admin/administrators/administrators_spec.rb
@@ -94,11 +94,11 @@ RSpec.describe "Admin::Administrators::Administrators", type: :request do
 
     it "sends new admin an account created email" do
       url = "http://www.example.com/users/sign_in?utm_campaign=new-admin&utm_medium=email&utm_source=cpdservice"
-      allow(AdminMailer).to receive(:account_created_email).and_call_original
+      allow(AdminMailer).to receive(:with).and_call_original
 
-      given_a_user_is_created
+      expect { given_a_user_is_created }.to have_enqueued_mail(AdminMailer, :account_created_email)
 
-      expect(AdminMailer).to have_received(:account_created_email).with(new_user, url)
+      expect(AdminMailer).to have_received(:with).with(admin: new_user, url:)
     end
   end
 

--- a/spec/services/induction/send_transfer_notification_emails_spec.rb
+++ b/spec/services/induction/send_transfer_notification_emails_spec.rb
@@ -15,7 +15,15 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
   shared_examples "notifying the participant" do
     it "sends a 'particicpant transfter in notification' email to the participant" do
-      expect(ParticipantTransferMailer).to(have_received(:participant_transfer_in_notification).with(induction_record:))
+      expect {
+        subject.call
+      }.to have_enqueued_mail(ParticipantTransferMailer, :participant_transfer_in_notification)
+        .with(
+          params: {
+            induction_record:,
+          },
+          args: [],
+        ).once
     end
   end
 
@@ -41,8 +49,6 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
     }
   end
 
-  before { subject.call }
-
   %i[
     induction_record
     was_withdrawn_participant
@@ -63,10 +69,17 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
     it "sends 'provider transfer in notification' emails to the current lead provider profiles " do
       lead_provider_profiles_in.each do |lead_provider_profile|
-        expect(ParticipantTransferMailer).to(have_received(template).with(induction_record:, lead_provider_profile:))
+        expect {
+          subject.call
+        }.to have_enqueued_mail(ParticipantTransferMailer, template)
+          .with(
+            params: {
+              induction_record:,
+              lead_provider_profile:,
+            },
+            args: [],
+          ).once
       end
-
-      expect(provider_mailer).to have_received(:deliver_later).exactly(lead_provider_profiles_in.size).times
     end
   end
 
@@ -77,10 +90,17 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
     it "sends 'provider transfer in notification' emails to the current lead provider profiles " do
       lead_provider_profiles_in.each do |lead_provider_profile|
-        expect(ParticipantTransferMailer).to(have_received(template).with(induction_record:, lead_provider_profile:))
+        expect {
+          subject.call
+        }.to have_enqueued_mail(ParticipantTransferMailer, template)
+          .with(
+            params: {
+              induction_record:,
+              lead_provider_profile:,
+            },
+            args: [],
+          ).once
       end
-
-      expect(provider_mailer).to have_received(:deliver_later).exactly(lead_provider_profiles_in.size).times
     end
 
     include_examples "notifying the participant"
@@ -95,7 +115,16 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
       it "sends 'provider transfer in notification' emails to the current lead provider profiles " do
         lead_provider_profiles_in.each do |lead_provider_profile|
-          expect(ParticipantTransferMailer).to(have_received(template).with(induction_record:, lead_provider_profile:))
+          expect {
+            subject.call
+          }.to have_enqueued_mail(ParticipantTransferMailer, template)
+            .with(
+              params: {
+                induction_record:,
+                lead_provider_profile:,
+              },
+              args: [],
+            ).once
         end
       end
     end
@@ -105,7 +134,16 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
       it "sends 'provider transfer out notification' emails to the target lead provider profiles " do
         lead_provider_profiles_out.each do |lead_provider_profile|
-          expect(ParticipantTransferMailer).to(have_received(template).with(induction_record:, lead_provider_profile:))
+          expect {
+            subject.call
+          }.to have_enqueued_mail(ParticipantTransferMailer, template)
+            .with(
+              params: {
+                induction_record:,
+                lead_provider_profile:,
+              },
+              args: [],
+            ).once
         end
       end
     end
@@ -118,10 +156,17 @@ RSpec.describe(Induction::SendTransferNotificationEmails) do
 
     it "sends 'provider transfer in notification' emails to the current lead provider profiles " do
       lead_provider_profiles_out.each do |lead_provider_profile|
-        expect(ParticipantTransferMailer).to(have_received(template).with(induction_record:, lead_provider_profile:))
+        expect {
+          subject.call
+        }.to have_enqueued_mail(ParticipantTransferMailer, template)
+          .with(
+            params: {
+              induction_record:,
+              lead_provider_profile:,
+            },
+            args: [],
+          ).once
       end
-
-      expect(provider_mailer).to have_received(:deliver_later).exactly(lead_provider_profiles_out.size).times
     end
 
     include_examples "notifying the participant"

--- a/spec/services/invite_schools_spec.rb
+++ b/spec/services/invite_schools_spec.rb
@@ -117,11 +117,9 @@ RSpec.describe InviteSchools do
     let!(:induction_coordinator) { create(:induction_coordinator_profile, schools: [school], user:) }
 
     it "sends the change tutor email" do
-      expect(SchoolMailer).to receive(:school_requested_signin_link_from_gias_email).with(
-        hash_including(
-          school:,
-          nomination_link: String,
-        ),
+      expect(SchoolMailer).to receive(:with).with(
+        school:,
+        nomination_link: String,
       ).and_call_original
 
       invite_schools.perform [school.urn]

--- a/spec/services/update_induction_tutor_reminder_spec.rb
+++ b/spec/services/update_induction_tutor_reminder_spec.rb
@@ -16,18 +16,10 @@ RSpec.describe UpdateInductionTutorReminder do
     let(:method_name) { :remind_to_update_school_induction_tutor_details }
     subject { UpdateInductionTutorReminder.new(school) }
 
-    before do
-      allow(SchoolMailer).to(receive(method_name).and_call_original)
-    end
-
     it "calls SchoolMailer.remind_to_update_school_induction_tutor_details with the appropriate arguments" do
-      subject.send!
-
-      expect(SchoolMailer).to have_received(method_name).with(
-        school:,
-        sit_name: school.induction_tutor.full_name,
-        nomination_link: subject.instance_variable_get(:@nomination_link),
-      )
+      expect {
+        subject.send!
+      }.to have_enqueued_mail(SchoolMailer, method_name)
     end
 
     it "creates a nomination_email record" do


### PR DESCRIPTION
### Context
To resolve errors in sentry, use correct way to call mailers and fix tests

- Ticket: n/a

### Changes proposed in this pull request
- Use with instead of mailer name, and move name to be called before delivering later
- Access attributes using params in mailer methods themselves
- Fix tests with use `with` or call enqueued with.

### Guidance to review
I think in some cases we are now missing exact mailer methods to test, esp in feature tests where it's hard to expect a subject to enqueue the mailer. Open to suggestions
