### PR TITLE
Transfer the NPQ get_an_identity_id when deduping users

### DIFF
--- a/app/services/identity/transfer.rb
+++ b/app/services/identity/transfer.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 module Identity
+  class TransferError < StandardError; end
+
   class Transfer < BaseService
     def call
       ActiveRecord::Base.transaction do
         transfer_identities!
         transfer_induction_coordinator_profile!
+        transfer_get_an_identity_id!
       end
     end
 
@@ -39,6 +42,20 @@ module Identity
         else
           from_user.induction_coordinator_profile.update!(user: to_user)
         end
+      end
+    end
+
+    def transfer_get_an_identity_id!
+      from_id = from_user.get_an_identity_id
+      to_id = to_user.get_an_identity_id
+
+      raise TransferError.new("Identity ids present on both User records: #{from_user.id} -> #{to_user.id}") if from_id.present? && to_id.present?
+
+      if from_id.present?
+        # validations prevent changes to this value under normal circumstances
+        from_user.update_attribute(:get_an_identity_id, nil)
+        # from_user.save(validate: false)
+        to_user.update!(get_an_identity_id: from_id)
       end
     end
   end


### PR DESCRIPTION
### Context

When de-duping is performed, the `User.get_an_identity_id` value set via the NPQ reg service is not transferred during the process.  Not transferring the value means that other updates sync'd via the NPQ reg app cannot happen correctly.

### Changes proposed in this pull request

Ensure we move the `get_an_identity_id` in the transfer service when de-duping both NPQ and ECF profiles.
Raises an error if both `User` records have `get_an_identity_id` values which will rollback the whole transfer operation.

### Guidance to review

