### PR TITLE
Push cohort rolling into next year to avoid failures

### DIFF
--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
   factory :cohort do
     start_year { Faker::Number.unique.between(from: 2022, to: 2100) }
-    registration_start_date { Date.new(start_year.to_i, 5, 10) }
+    registration_start_date { Date.new(start_year.to_i, 6, 5) }
     academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
 

--- a/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./choose_programme_steps"
 
-RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0) do
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
   include ChooseProgrammeSteps
 
   before do

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./choose_programme_steps"
 
-RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0) do
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
   include ChooseProgrammeSteps
 
   scenario "A school chooses no ECTs expected in next academic year" do

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
     and_the_page_should_be_accessible
   end
 
-  context "Multiple cohorts when the new cohort is open for registrations", travel_to: Time.zone.local(2022, 5, 10, 16, 15, 0) do
+  context "Multiple cohorts when the new cohort is open for registrations", travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
     before do
       given_there_is_a_school_that_has_chosen_cip_for_2021
       and_cohort_2022_is_created

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Cohort, type: :model do
   describe ".active_registration_cohort" do
     describe "when the current date matches the registration start date" do
       it "returns the cohort with start_year the current year" do
-        Timecop.freeze(Date.new(2022, 5, 10)) do
+        Timecop.freeze(cohort_2022.registration_start_date) do
           expect(Cohort.active_registration_cohort).to eq cohort_2022
         end
       end


### PR DESCRIPTION

### Context

This is a temp fix to unblock failures on main. We need to amend the tests to be cohort agnostic
Today is the 10th of May, and we rolled into next cohort. Until we fix the cypress scenarios push the date to the future to avoid failures

- Ticket: n/a

### Changes proposed in this pull request
Amend factory to avoid rolling into cohort 2023.
This is a temp fix and we need to properly fix this soon

### Guidance to review
Don't judge
