### PR TITLE
Improve row copy on cohort tab, schools page

### DIFF
--- a/app/components/admin/schools/cohorts/cip_info.html.erb
+++ b/app/components/admin/schools/cohorts/cip_info.html.erb
@@ -1,10 +1,10 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Induction programme
+      Training programme
     </dt>
     <dd class="govuk-summary-list__value">
-      Use the DfE accredited materials
+      Using DfE-accredited materials
     </dd>
     <dd class="govuk-summary-list__actions">
       <%= govuk_link_to "Change", admin_school_change_programme_path(id: school_cohort.cohort.start_year, school_id: school_cohort.school.slug) %>

--- a/app/components/admin/schools/cohorts/fip_info.html.erb
+++ b/app/components/admin/schools/cohorts/fip_info.html.erb
@@ -1,10 +1,10 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Induction programme
+      Training programme
     </dt>
     <dd class="govuk-summary-list__value">
-      Use an approved training provider
+      Working with a DfE-funded provider
     </dd>
     <dd class="govuk-summary-list__actions">
       <% if school_cohort.lead_provider.nil? %>

--- a/app/components/admin/schools/cohorts/other_info.html.erb
+++ b/app/components/admin/schools/cohorts/other_info.html.erb
@@ -1,7 +1,7 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
-      Induction programme
+      Training programme
     </dt>
     <dd class="govuk-summary-list__value">
       <%= message %>

--- a/app/components/admin/schools/cohorts/other_info.rb
+++ b/app/components/admin/schools/cohorts/other_info.rb
@@ -17,15 +17,15 @@ module Admin
         attr_reader :school_cohort, :cohort
 
         MESSAGES = {
-          design_our_own: "designing own induction course",
-          school_funded_fip: "school funded full induction programme",
-          no_early_career_teachers: "no ECTs this year",
+          design_our_own: "Designing their own training",
+          school_funded_fip: "School funded full induction programme",
+          no_early_career_teachers: "No ECTs this year",
         }.freeze
 
         def message
-          return "No programme" if school_cohort.nil?
+          return "Not assigned" if school_cohort.nil?
 
-          ["Not using service", MESSAGES[school_cohort.induction_programme_choice.to_sym]].compact.join(" - ")
+          [MESSAGES[school_cohort.induction_programme_choice.to_sym]].compact.join(" - ")
         end
       end
     end

--- a/app/components/admin/schools/cohorts/other_info.rb
+++ b/app/components/admin/schools/cohorts/other_info.rb
@@ -17,15 +17,15 @@ module Admin
         attr_reader :school_cohort, :cohort
 
         MESSAGES = {
-          design_our_own: "Designing their own training",
-          school_funded_fip: "School funded full induction programme",
-          no_early_career_teachers: "No ECTs this year",
+          design_our_own: "designing their own training",
+          school_funded_fip: "school funded full induction programme",
+          no_early_career_teachers: "no ECTs this year",
         }.freeze
 
         def message
           return "Not assigned" if school_cohort.nil?
 
-          [MESSAGES[school_cohort.induction_programme_choice.to_sym]].compact.join(" - ")
+          ["Not using service", MESSAGES[school_cohort.induction_programme_choice.to_sym]].compact.join(" - ")
         end
       end
     end

--- a/config/locales/admin/induction_choice_form.yml
+++ b/config/locales/admin/induction_choice_form.yml
@@ -2,7 +2,7 @@ en:
   admin:
     induction_choice_form:
       options:
-        core_induction_programme: "Deliver their own programme using DfE accredited materials (core induction programme)"
+        core_induction_programme: "Deliver their own programme using DfE-accredited materials (core induction programme)"
         full_induction_programme: "Use a training provider, funded by the DfE (full induction programme)"
         design_our_own: "Design and deliver their own programme based on the Early Career Framework (ECF)"
         school_funded_fip: "Use a training provider funded by their school"

--- a/spec/components/admin/schools/cohorts/cip_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/cip_info_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::Schools::Cohorts::CipInfo, type: :component do
 
   it "has the correct content" do
     with_request_url "/schools/test-school" do
-      expect(rendered_content).to have_content "Use the DfE accredited materials"
+      expect(rendered_content).to have_content "Using DfE-accredited materials"
       expect(rendered_content).to have_content programme.name
     end
   end

--- a/spec/components/admin/schools/cohorts/cohort_spec.rb
+++ b/spec/components/admin/schools/cohorts/cohort_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Admin::Schools::Cohorts::Cohort, type: :component do
   subject { page }
 
   let(:cohort_content) { "#{cohort.display_name} cohort" }
-  let(:fip_specific_content) { "Use an approved training provider" }
-  let(:cip_specific_content) { "Use the DfE accredited materials" }
-  let(:generic_content) { "Induction programme" }
+  let(:fip_specific_content) { "Working with a DfE-funded provider" }
+  let(:cip_specific_content) { "Using DfE-accredited materials" }
+  let(:generic_content) { "Training programme" }
 
   context "without school cohort" do
     let(:school_cohort) { nil }

--- a/spec/components/admin/schools/cohorts/fip_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/fip_info_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::Schools::Cohorts::FipInfo, type: :component do
   end
 
   it "has the correct content" do
-    expect(rendered_content).to have_content "Use an approved training provider"
+    expect(rendered_content).to have_content "Working with a DfE-funded provider"
     expect(rendered_content).to have_content lead_provider.name
     expect(rendered_content).to have_content school_cohort.delivery_partner.name
   end

--- a/spec/components/admin/schools/cohorts/other_info_spec.rb
+++ b/spec/components/admin/schools/cohorts/other_info_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe Admin::Schools::Cohorts::OtherInfo, type: :component do
   context "without school cohort" do
     let(:school_cohort) { nil }
 
-    it { is_expected.to have_content "No programme" }
+    it { is_expected.to have_content "Not assigned" }
   end
 
   context "with design your own school cohort" do
     let(:school_cohort) { build :school_cohort, induction_programme_choice: "design_our_own" }
 
-    it { is_expected.to have_content "Not using service - designing own induction course" }
+    it { is_expected.to have_content "Not using service - designing their own training" }
   end
 
   context "with school funded fip school cohort" do


### PR DESCRIPTION
### Context

- Ticket: https://trello.com/c/kbbNZm8w/44-improve-induction-programme-row-copy-on-cohort-tab-schools-page

### Changes proposed in this pull request

Update the copy for the ‘Induction programme’ row, on the cohorts tab to change to "Training programme".

Update values to:

* Working with a DfE-funded provider
* Using DfE-accredited materials
* Designing their own training
* Not assigned
