### PR TITLE
Remove-references-to-step-by-step

### DIFF
--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -17,9 +17,9 @@
               :name,
               legend: { text: "How do you want to run your training in #{@induction_choice_form.cohort.start_year} to #{@induction_choice_form.cohort.start_year + 1}?", size: "xl", tag: "h1" }
             ) do %>
-              <p class="govuk-body">If you’re not sure which option to choose,
-                <%= govuk_link_to "check our guidance on statutory changes and new training programmes (opens in new tab)",
-                                  "https://www.gov.uk/government/publications/early-career-framework-reforms-overview/early-career-framework-reforms-overview",
+              <p class="govuk-body">To learn more about your training options, visit
+                <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",
+                                  "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers",
                                   target: :_blank,
                                   rel: "noopener noreferrer",
                                   no_visited_state: true %>
@@ -27,7 +27,7 @@
               <p class="govuk-body">You can also contact your
                 <% unless @school.cip_only? %>
                   <%= govuk_link_to "local teaching school hub (opens in a new tab)",
-                                    "https://www.gov.uk/guidance/teaching-school-hubs#find-a-teaching-school-hub",
+                                    "https://www.gov.uk/guidance/teaching-school-hubs",
                                     target: :_blank,
                                     rel: "noopener noreferrer",
                                     no_visited_state: true %>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -19,7 +19,7 @@
             ) do %>
               <p class="govuk-body">To learn more about your training options, visit
                 <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",
-                                  "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers",
+                                  guidance_for_how_to_setup_programme_url,
                                   target: :_blank,
                                   rel: "noopener noreferrer",
                                   no_visited_state: true %>
@@ -27,14 +27,14 @@
               <p class="govuk-body">You can also contact your
                 <% unless @school.cip_only? %>
                   <%= govuk_link_to "local teaching school hub (opens in a new tab)",
-                                    "https://www.gov.uk/guidance/teaching-school-hubs",
+                                    guidance_for_teaching_school_hubs_url,
                                     target: :_blank,
                                     rel: "noopener noreferrer",
                                     no_visited_state: true %>
                   or
                 <% end %>
                 <%= govuk_link_to "appropriate body (opens in new tab)",
-                                  "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework",
+                                  guidance_for_appropriate_bodies_url,
                                   target: :_blank,
                                   rel: "noopener noreferrer",
                                   no_visited_state: true %>.
@@ -44,6 +44,5 @@
             <%= f.hidden_field(:add_participant_after_complete) %>
             <%= f.govuk_submit "Continue" %>
         <% end %>
-
     </div>
 </div>

--- a/app/views/schools/choose_programme/show.html.erb
+++ b/app/views/schools/choose_programme/show.html.erb
@@ -19,7 +19,7 @@
             ) do %>
               <p class="govuk-body">To learn more about your training options, visit
                 <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",
-                                  guidance_for_how_to_setup_programme_url,
+                                  guidance_for_how_to_setup_training_url,
                                   target: :_blank,
                                   rel: "noopener noreferrer",
                                   no_visited_state: true %>

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -12,8 +12,8 @@
     
       <p class="govuk-body">As you’re using a training provider to deliver your training, you must first contact your lead provider <%= @school_cohort.lead_provider&.name %> to discuss any changes.</p>
       <h2 class="govuk-heading-m">Help with making changes</h2>
-      <p class="govuk-body">Read our guidance and the step-by-step instructions for       
-      <%= govuk_link_to "making changes to an existing training programme (opens in new tab)", "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training#making-changes-to-an-existing-training-programme", target: "_blank", rel: "noopener noreferrer" %>.</p>    
+      <p class="govuk-body">Visit       
+      <%= govuk_link_to "How to manage early career teacher training (opens in new tab)", "https://www.gov.uk/guidance/how-to-manage-early-career-teacher-training", target: "_blank", rel: "noopener noreferrer" %> to learn more about making changes.</p>    
 
     <% elsif @school_cohort.school_funded_fip? %>
     

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -26,7 +26,7 @@
       <%= govuk_link_to "How to manage early career teacher training (opens in new tab)",
         guidance_for_manage_ect_training_url,
         target: "_blank",
-        rel: "noopener noreferrer" %>.</p>    
+        rel: "noopener noreferrer" %> to learn more about making changes.</p>    
 
     <% elsif @school_cohort.cip? %>      
 

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -22,9 +22,9 @@
     
       <p class="govuk-body">As you’re using a training provider to deliver your training, you must first contact your lead provider <%= @school_cohort.lead_provider&.name %> to discuss any changes.</p>
       <h2 class="govuk-heading-m">Help with making changes</h2>
-      <p class="govuk-body">Read our guidance and the step-by-step instructions for       
-      <%= govuk_link_to "making changes to an existing training programme (opens in new tab)",
-        guidance_for_making_changes_to_an_existing_programme_url,
+      <p class="govuk-body">Visit       
+      <%= govuk_link_to "How to manage early career teacher training (opens in new tab)",
+        guidance_for_manage_ect_training_url,
         target: "_blank",
         rel: "noopener noreferrer" %>.</p>    
 

--- a/app/views/schools/cohorts/change_programme.html.erb
+++ b/app/views/schools/cohorts/change_programme.html.erb
@@ -13,14 +13,20 @@
       <p class="govuk-body">As you’re using a training provider to deliver your training, you must first contact your lead provider <%= @school_cohort.lead_provider&.name %> to discuss any changes.</p>
       <h2 class="govuk-heading-m">Help with making changes</h2>
       <p class="govuk-body">Visit       
-      <%= govuk_link_to "How to manage early career teacher training (opens in new tab)", "https://www.gov.uk/guidance/how-to-manage-early-career-teacher-training", target: "_blank", rel: "noopener noreferrer" %> to learn more about making changes.</p>    
+      <%= govuk_link_to "How to manage early career teacher training (opens in new tab)",
+        guidance_for_manage_ect_training_url,
+        target: "_blank",
+        rel: "noopener noreferrer" %> to learn more about making changes.</p>    
 
     <% elsif @school_cohort.school_funded_fip? %>
     
       <p class="govuk-body">As you’re using a training provider to deliver your training, you must first contact your lead provider <%= @school_cohort.lead_provider&.name %> to discuss any changes.</p>
       <h2 class="govuk-heading-m">Help with making changes</h2>
       <p class="govuk-body">Read our guidance and the step-by-step instructions for       
-      <%= govuk_link_to "making changes to an existing training programme (opens in new tab)", "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training#making-changes-to-an-existing-training-programme", target: "_blank", rel: "noopener noreferrer" %>.</p>    
+      <%= govuk_link_to "making changes to an existing training programme (opens in new tab)",
+        guidance_for_making_changes_to_an_existing_programme_url,
+        target: "_blank",
+        rel: "noopener noreferrer" %>.</p>    
 
     <% elsif @school_cohort.cip? %>      
 

--- a/app/views/schools/setup_school_cohort/_change_delivery_partner_submitted.html.erb
+++ b/app/views/schools/setup_school_cohort/_change_delivery_partner_submitted.html.erb
@@ -13,10 +13,3 @@
   <li>add the new ECTs and mentors to this service so we can check their eligibility for DfE funding</li>
   <li>use this service to tell us which mentor has been assigned to each ECT</li>
 </ul>
-
-<p>
-  <a href="<%= step_by_step_path %>" rel="noreferrer noopener" target="_blank">
-    Read our step by step guidance (opens in new tab)
-  </a>
-  if you need more help.
-</p>

--- a/app/views/schools/setup_school_cohort/_change_lead_provider_submitted.html.erb
+++ b/app/views/schools/setup_school_cohort/_change_lead_provider_submitted.html.erb
@@ -15,9 +15,4 @@
   <li>use this service to tell us which mentor has been assigned to each ECT</li>
 </ul>
 
-<p>
-  <a href="<%= step_by_step_path %>" rel="noreferrer noopener" target="_blank">
-    Read our step by step guidance (opens in new tab)
-  </a>
-  if you need more help.
-</p>
+

--- a/app/views/schools/setup_school_cohort/change_provider.html.erb
+++ b/app/views/schools/setup_school_cohort/change_provider.html.erb
@@ -25,7 +25,11 @@
             <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Your delivery partner</h2>
             <p class="govuk-body"><%= previous_cohort.delivery_partner&.name %></p>
 
-            <p class="govuk-body">Visit <a href="https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers" target="_blank" class="govuk-link">How to set up training for early career teachers (opens in new tab)</a> to learn more about providers.</p>
+            <p class="govuk-body">Visit <%= govuk_link_to "How to set up training for early career teachers (opens in new tab)",
+              guidance_for_how_to_setup_training_url,
+              target: "_blank",
+              rel: "noopener noreferrer" %>
+            to learn more about providers.</p>
         <% end %>
 
         <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/setup_school_cohort/change_provider.html.erb
+++ b/app/views/schools/setup_school_cohort/change_provider.html.erb
@@ -25,7 +25,7 @@
             <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Your delivery partner</h2>
             <p class="govuk-body"><%= previous_cohort.delivery_partner&.name %></p>
 
-            <p class="govuk-body">Read our guidance to <a href="https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training" target="_blank" class="govuk-link">check your options (opens in new tab)</a>.</p>
+            <p class="govuk-body">Visit <a href="https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers" target="_blank" class="govuk-link">How to set up training for early career teachers (opens in new tab)</a> to learn more about providers.</p>
         <% end %>
 
         <%= f.govuk_submit "Continue" %>

--- a/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
+++ b/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
@@ -22,9 +22,9 @@
 
         <p class="govuk-body">This choice will only apply for ECTs and mentors starting in the <%= registration_cohort %> academic year.</p>
         <p class="govuk-body">
-          Read our guidance to
-          <%= govuk_link_to 'check your options (opens in new tab)',
-          "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training",
+          To learn more about your options, visit
+          <%= govuk_link_to 'How to set up training for early career teachers (opens in new tab)',
+          "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers",
           target: :_blank,
           rel: "noopener noreferrer" %>.
         </p>

--- a/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
+++ b/app/views/schools/setup_school_cohort/how_will_you_run_training.html.erb
@@ -24,9 +24,9 @@
         <p class="govuk-body">
           To learn more about your options, visit
           <%= govuk_link_to 'How to set up training for early career teachers (opens in new tab)',
-          "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers",
-          target: :_blank,
-          rel: "noopener noreferrer" %>.
+            guidance_for_how_to_setup_training_url,
+            target: :_blank,
+            rel: "noopener noreferrer" %>.
         </p>
 
       <% end %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -32,18 +32,18 @@
       <nav role="navigation" aria-labelledby="subsection-title">
         <ul class="govuk-list">
           <li>
-            <%= govuk_link_to "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers", target: :_blank, rel: "noopener noreferrer" do %>
+            <%= govuk_link_to guidance_for_how_to_setup_training_url, target: :_blank, rel: "noopener noreferrer" do %>
               Find out how to set up training for early career teachers <span class="govuk-visually-hidden">(opens in new tab)</span>
             <% end %>
           </li>
           <li>
-            <%= govuk_link_to "https://www.gov.uk/government/collections/induction-training-and-support-for-early-career-teachers-ects", target: :_blank, rel: "noopener noreferrer" do %>
+            <%= govuk_link_to guidance_for_induction_training_and_support_for_ects_url, target: :_blank, rel: "noopener noreferrer" do %>
               Read our guidance for early career teachers <span class="govuk-visually-hidden">(opens in new tab)</span>
             <% end %>
             for more information about the programme and your entitlements.
           </li>
           <li>
-            <%= govuk_link_to "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training", target: :_blank, rel: "noopener noreferrer" do %>
+            <%= govuk_link_to guidance_for_how_to_manage_ecf_based_training_url, target: :_blank, rel: "noopener noreferrer" do %>
               Read our guidance for mentors <span class="govuk-visually-hidden">(opens in new tab)</span>
             <% end %>
             for more information about how to support early career teachers.

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -32,10 +32,9 @@
       <nav role="navigation" aria-labelledby="subsection-title">
         <ul class="govuk-list">
           <li>
-            <%= govuk_link_to step_by_step_path, target: :_blank do %>
-              Read our step by step guidance <span class="govuk-visually-hidden">(opens in new tab)</span>
+            <%= govuk_link_to "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers", target: :_blank, rel: "noopener noreferrer" do %>
+              Find out how to set up training for early career teachers <span class="govuk-visually-hidden">(opens in new tab)</span>
             <% end %>
-            for more information about setting up your training.
           </li>
           <li>
             <%= govuk_link_to "https://www.gov.uk/government/collections/induction-training-and-support-for-early-career-teachers-ects", target: :_blank, rel: "noopener noreferrer" do %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -27,26 +27,12 @@
     <aside class="app-related-items" role="complementary">
       <h2 class="govuk-heading-m" id="subsection-title">Guidance</h2>
 
-      <p>The following links open in a new tab.</p>
-
       <nav role="navigation" aria-labelledby="subsection-title">
         <ul class="govuk-list">
           <li>
             <%= govuk_link_to guidance_for_how_to_setup_training_url, target: :_blank, rel: "noopener noreferrer" do %>
-              Find out how to set up training for early career teachers <span class="govuk-visually-hidden">(opens in new tab)</span>
+              Find out how to set up training for early career teachers (opens in new tab)
             <% end %>
-          </li>
-          <li>
-            <%= govuk_link_to guidance_for_induction_training_and_support_for_ects_url, target: :_blank, rel: "noopener noreferrer" do %>
-              Read our guidance for early career teachers <span class="govuk-visually-hidden">(opens in new tab)</span>
-            <% end %>
-            for more information about the programme and your entitlements.
-          </li>
-          <li>
-            <%= govuk_link_to guidance_for_how_to_manage_ecf_based_training_url, target: :_blank, rel: "noopener noreferrer" do %>
-              Read our guidance for mentors <span class="govuk-visually-hidden">(opens in new tab)</span>
-            <% end %>
-            for more information about how to support early career teachers.
           </li>
         </ul>
       </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,12 +32,6 @@ Rails.application.routes.draw do
   direct :guidance_for_manage_ect_training do
     "https://www.gov.uk/guidance/how-to-manage-early-career-teacher-training"
   end
-  direct :guidance_for_induction_training_and_support_for_ects do
-    "https://www.gov.uk/government/collections/induction-training-and-support-for-early-career-teachers-ects"
-  end
-  direct :guidance_for_how_to_manage_ecf_based_training do
-    "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training"
-  end
 
   scope :pages, controller: "pages" do
     get "/ect-additional-information", to: redirect("https://www.gov.uk/guidance/guidance-for-early-career-teachers-ects-ecf-based-training")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,9 +32,6 @@ Rails.application.routes.draw do
   direct :guidance_for_manage_ect_training do
     "https://www.gov.uk/guidance/how-to-manage-early-career-teacher-training"
   end
-  direct :guidance_for_making_changes_to_an_existing_programme do
-    "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training#making-changes-to-an-existing-training-programme"
-  end
   direct :guidance_for_induction_training_and_support_for_ects do
     "https://www.gov.uk/government/collections/induction-training-and-support-for-early-career-teachers-ects"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,29 @@ Rails.application.routes.draw do
     "https://forms.office.com/e/3xCevHRKXx"
   end
 
+  # External guidance URLs
+  direct :guidance_for_how_to_setup_training do
+    "https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers"
+  end
+  direct :guidance_for_teaching_school_hubs do
+    "https://www.gov.uk/guidance/teaching-school-hubs"
+  end
+  direct :guidance_for_appropriate_bodies do
+    "https://www.gov.uk/government/publications/appropriate-bodies-guidance-induction-and-the-early-career-framework"
+  end
+  direct :guidance_for_manage_ect_training do
+    "https://www.gov.uk/guidance/how-to-manage-early-career-teacher-training"
+  end
+  direct :guidance_for_making_changes_to_an_existing_programme do
+    "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training#making-changes-to-an-existing-training-programme"
+  end
+  direct :guidance_for_induction_training_and_support_for_ects do
+    "https://www.gov.uk/government/collections/induction-training-and-support-for-early-career-teachers-ects"
+  end
+  direct :guidance_for_how_to_manage_ecf_based_training do
+    "https://www.gov.uk/guidance/guidance-for-schools-how-to-manage-ecf-based-training"
+  end
+
   scope :pages, controller: "pages" do
     get "/ect-additional-information", to: redirect("https://www.gov.uk/guidance/guidance-for-early-career-teachers-ects-ecf-based-training")
     get "/mentor-additional-information", to: redirect("https://www.gov.uk/guidance/guidance-for-mentors-how-to-support-ecf-based-training")


### PR DESCRIPTION
Remove references to step by step guidance and update link text where needed

Update links to old gov.uk guidance with new links and link text where needed