### PR TITLE
Fix failing version table creation in review app

### DIFF
--- a/db/migrate/20210302031858_add_cohorts_to_partnerships.rb
+++ b/db/migrate/20210302031858_add_cohorts_to_partnerships.rb
@@ -2,6 +2,10 @@
 
 class AddCohortsToPartnerships < ActiveRecord::Migration[6.1]
   def change
+    PaperTrail.request.disable_model(Cohort)
+
     add_reference :partnerships, :cohort, null: false, default: Cohort.find_or_create_by!(start_year: 2021).id, foreign_key: true
+
+    PaperTrail.request.enable_model(Cohort)
   end
 end


### PR DESCRIPTION
### Context
Adding papertrail to cohorts caused failures in migrations where versions table was expected but didn't exist
- Ticket: n/a

### Changes proposed in this pull request
Ignore papertrail in the particular migration to avoid failures when creating review apps

### Guidance to review

