### PR TITLE
Allow magic date range everywhere except prod and test

### DIFF
--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -103,7 +103,7 @@ private
 
   # Helpers for tesing in review apps
   def magic_date_criteria_met?
-    (Rails.env.development? || Rails.env.deployed_development?) && magic_date_range.include?(date_of_birth)
+    (!Rails.env.production? && !Rails.env.test?) && magic_date_range.include?(date_of_birth)
   end
 
   def magic_date_range


### PR DESCRIPTION
### Context
To allow creating data in sandbox and other envs allow magic dates

- Ticket: n/a

### Changes proposed in this pull request
Change check to not run in prod or test

### Guidance to review

