### PR TITLE
[Bug-fix] Prevent providers from claiming FIP schools that haven't setup their cohort

### DIFF
--- a/app/models/partnership_csv_upload.rb
+++ b/app/models/partnership_csv_upload.rb
@@ -73,20 +73,21 @@ private
         errors << { urn:, message: "School not eligible for inductions", school_name: school.name, row_number: index + 1 }
       elsif school.lead_provider(cohort.start_year) == lead_provider
         errors << { urn:, message: "Your school - already confirmed", school_name: school.name, row_number: index + 1 }
-      elsif school.lead_provider(cohort.start_year).present? || has_previous_cohort_and_matching_lead_provider?(school)
+      elsif school.lead_provider(cohort.start_year).present?
         errors << { urn:, message: "Recruited by other provider", school_name: school.name, row_number: index + 1 }
+      elsif cohort_not_setup_and_previously_fip?(school)
+        errors << { urn:, message: "School programme not yet confirmed", school_name: school.name, row_number: index + 1 }
       end
     end
 
     errors
   end
 
-  def has_previous_cohort_and_matching_lead_provider?(school)
+  def cohort_not_setup_and_previously_fip?(school)
     previous_year_lead_provider = school.lead_provider(cohort.start_year - 1)
-
     return false if previous_year_lead_provider.blank?
 
-    previous_year_lead_provider != lead_provider && school.school_cohorts.find_by(cohort:).blank?
+    school.school_cohorts.find_by(cohort:).blank?
   end
 
   def strip_bom(string)

--- a/app/services/partnerships/create.rb
+++ b/app/services/partnerships/create.rb
@@ -90,17 +90,18 @@ module Partnerships
         errors.add(:school_id, :ineligible_error)
       elsif school.lead_provider(cohort_record.start_year) == lead_provider
         errors.add(:school_id, :already_confirmed)
-      elsif school.lead_provider(cohort_record.start_year).present? || has_previous_cohort_and_matching_lead_provider?
+      elsif school.lead_provider(cohort_record.start_year).present?
         errors.add(:school_id, :recruited_by_other_provider)
+      elsif cohort_not_setup_and_previously_fip?(school)
+        errors.add(:school_id, :school_programme_not_yet_confirmed)
       end
     end
 
-    def has_previous_cohort_and_matching_lead_provider?
+    def cohort_not_setup_and_previously_fip?(school)
       previous_year_lead_provider = school.lead_provider(cohort_record.start_year - 1)
-
       return false if previous_year_lead_provider.blank?
 
-      previous_year_lead_provider != lead_provider && school.school_cohorts.find_by(cohort: cohort_record).blank?
+      school.school_cohorts.find_by(cohort: cohort_record).blank?
     end
 
     def duplicate_delivery_partner_request?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,6 +488,7 @@ en:
               ineligible_error: "The school you have entered is currently ineligible for DfE funding."
               already_confirmed: "You are already confirmed to be in partnership with the school for the entered cohort."
               recruited_by_other_provider: "Another provider is already confirmed to be in partnership with the school for the entered cohort. Contact the school for more information."
+              school_programme_not_yet_confirmed: "The school you have entered has not yet confirmed they will deliver training using a DfE-funded training provider. Contact the school for more information."
             lead_provider_id:
               blank: "The attribute '#/lead_provider_id' must be included as part of partnership confirmations."
               invalid: "The '#/lead_provider_id' you have entered is invalid. Enter a valid '#/lead_provider_id' attribute in the request body for partnership confirmations."

--- a/spec/services/partnerships/create_spec.rb
+++ b/spec/services/partnerships/create_spec.rb
@@ -152,6 +152,19 @@ RSpec.describe Partnerships::Create do
       end
     end
 
+    context "school has not confirmed their programme" do
+      let(:previous_cohort) { create(:cohort, start_year: cohort.start_year - 1) }
+      let(:lead_provider2) { create :lead_provider }
+      let!(:school_cohort) { create(:school_cohort, :fip, school:, cohort: previous_cohort) }
+      let!(:partnership) { create(:partnership, school:, delivery_partner:, lead_provider: lead_provider2, cohort: previous_cohort) }
+
+      it "returns error" do
+        expect(service).to be_invalid
+
+        expect(service.errors.messages_for(:school_id)).to include("The school you have entered has not yet confirmed they will deliver training using a DfE-funded training provider. Contact the school for more information.")
+      end
+    end
+
     context "with existing challenged partnership" do
       let(:lead_provider2) { create :lead_provider }
       let!(:partnership) { create(:partnership, :challenged, school:, delivery_partner:, lead_provider: lead_provider2, cohort:) }


### PR DESCRIPTION
### Context

The rules in place currently are not 100% correct. When a provider claims a school, if that school ran FIP in the previous cohort with a partner and has not set up their next cohort, no provider should be able to claim the school.

### Changes proposed in this pull request

Fixes to the CSV uploader for reporting schools
Fixes to the Create service for partnerships used by the API.

### Guidance to review

