### PR TITLE
Add a CSV importer to create provider relationships

### DIFF
--- a/app/services/importers/create_provider_relationships.rb
+++ b/app/services/importers/create_provider_relationships.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Importers
+  class CreateProviderRelationships
+    def initialize(path_to_csv:, cohort_start_year:, logger: Rails.logger)
+      @path_to_csv = path_to_csv
+      @cohort_start_year = cohort_start_year.to_i
+      @logger = logger
+    end
+
+    def call
+      check_headers!
+
+      logger.info "CreateProviderRelationships: Started!"
+
+      ActiveRecord::Base.transaction do
+        rows.each do |row|
+          create_provider_relationships(row)
+        end
+      end
+
+      logger.info "CreateProviderRelationships: Finished!"
+    end
+
+  private
+
+    attr_reader :path_to_csv, :cohort_start_year, :logger
+
+    def check_headers!
+      unless %w[delivery_partner_id lead_provider_name].all? { |header| rows.headers.include?(header) }
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true)
+    end
+
+    def cohort
+      @cohort ||= Cohort.find_by_start_year!(cohort_start_year)
+    end
+
+    def delivery_partner(id)
+      DeliveryPartner.find(id)
+    end
+
+    def lead_provider(name)
+      LeadProvider.joins(:cohorts).find_by!(name:, cohorts: cohort)
+    end
+
+    def create_provider_relationships(row)
+      lead_provider = lead_provider(row["lead_provider_name"])
+      delivery_partner = delivery_partner(row["delivery_partner_id"])
+
+      logger.info "CreateProviderRelationships: Creating #{lead_provider.name} / #{delivery_partner.name} relationship in #{cohort_start_year}"
+
+      ProviderRelationship.find_or_create_by!(cohort:, lead_provider:, delivery_partner:)
+
+      logger.info "CreateProviderRelationships: #{lead_provider.name} / #{delivery_partner.name} relationship in #{cohort_start_year} successfully created"
+    end
+  end
+end

--- a/spec/services/importers/create_provider_relationships_sepc.rb
+++ b/spec/services/importers/create_provider_relationships_sepc.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::CreateProviderRelationships do
+  let(:path_to_csv) { csv.path }
+  let(:cohort_start_year) { 2021 }
+
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:headers) { "delivery_partner_id,lead_provider_name" }
+  let(:invalid_headers) { "delivery_partner_id,some_other_column" }
+
+  subject(:importer) { described_class.new(path_to_csv:, cohort_start_year:) }
+
+  describe "#call" do
+    context "when csv headers invalid" do
+      before do
+        csv.write invalid_headers
+        csv.write "\n"
+        csv.write "feea2811-6157-439e-9259-46ceb4648844,Ambition Institute"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "raises an error" do
+        expect { importer.call }.to raise_error(NameError)
+      end
+    end
+
+    context "when cohort does not exist" do
+      let!(:lead_provider) { create(:lead_provider, name: "Ambition Institute", cohorts: []) }
+      before do
+        csv.write headers
+        csv.write "\n"
+        csv.write "feea2811-6157-439e-9259-46ceb4648844,Ambition Institute"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "raises an error" do
+        expect { importer.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when lead provider does not exist" do
+      let!(:cohort_2021) { create(:cohort, start_year: 2021) }
+      before do
+        csv.write headers
+        csv.write "\n"
+        csv.write "48b7abcc-f28f-4e7d-b98c-94f42081b67f,Ambition Institute"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "raises an error" do
+        expect { importer.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when csv valid" do
+      let!(:cohort_2021) { create(:cohort, start_year: 2021) }
+      let!(:cohort_2022) { create(:cohort, start_year: 2022) }
+      let!(:delivery_partner_1) { create(:delivery_partner) }
+      let!(:delivery_partner_2) { create(:delivery_partner) }
+      let!(:lead_provider_1) { create(:lead_provider, name: "Ambition Institute", cohorts: [cohort_2021, cohort_2022]) }
+      let!(:lead_provider_2) { create(:lead_provider, name: "Best Practice Network", cohorts: [cohort_2021]) }
+
+      before do
+        csv.write headers
+        csv.write "\n"
+        csv.write "#{delivery_partner_1.id},#{lead_provider_1.name}"
+        csv.write "\n"
+        csv.write "#{delivery_partner_1.id},#{lead_provider_2.name}"
+        csv.write "\n"
+        csv.write "#{delivery_partner_2.id},#{lead_provider_1.name}"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates the provider relationships" do
+        importer.call
+
+        expect(lead_provider_1.reload.delivery_partners).to include(delivery_partner_1, delivery_partner_2)
+        expect(lead_provider_2.reload.delivery_partners).to include(delivery_partner_1)
+      end
+
+      it "doesn't create douplicate provider relationships" do
+        importer.call
+
+        expect { importer.call }.not_to change(ProviderRelationship, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: CST-1421

We have an Admin page to manually add/edit/remove Provider Relationships, but sometimes we need to create them in bulk.

### Changes proposed in this pull request
- Add a Service class to import provider relationships from a CSV file. If a relationship already exists, then it will ignore it to avoid creating duplicates.

### Guidance to review

