### PR TITLE
Fix blank mailer template issue

### DIFF
--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -128,10 +128,14 @@ module Schools
       end
 
       def send_added_and_validated_email(profile)
-        ParticipantMailer.with(
-          participant_profile: profile,
-          school_name: school.name,
-        ).sit_has_added_and_validated_participant.deliver_later
+        # appears perhaps the SIT doesn't always choose add mentor profile to self or perhaps
+        # rare occaision where there are multiple SITs and one is adding to another
+        unless profile.user.induction_coordinator?
+          ParticipantMailer.with(
+            participant_profile: profile,
+            school_name: school.name,
+          ).sit_has_added_and_validated_participant.deliver_later
+        end
       end
 
       def participant_create_args

--- a/app/mailers/participant_mailer.rb
+++ b/app/mailers/participant_mailer.rb
@@ -163,8 +163,11 @@ class ParticipantMailer < ApplicationMailer
     participant_profile = params[:participant_profile]
     school_name = params[:school_name]
 
+    template_id = PARTICIPANT_TEMPLATES[sit_validation_template participant_profile]
+    return if template_id.blank?
+
     template_mail(
-      PARTICIPANT_TEMPLATES[sit_validation_template participant_profile],
+      template_id,
       to: participant_profile.user.email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,


### PR DESCRIPTION
### Context

Seen issues in Sentry regarding a blank template id in a mailer. It appears this is down to a data-driven lookup that doesn't consider a SIT Mentor, so have added guards to prevent it happening.

