### PR TITLE
Mentors from another school do not have induction record in the dashb…

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -23,7 +23,7 @@ class Schools::ParticipantsController < Schools::BaseController
     @ects = Dashboard::Participants.new(school: @school,
                                         user: current_user,
                                         latest_year: Dashboard::LatestManageableCohort.call(@school).start_year)
-                                   .mentors[@induction_record]
+                                   .ects_mentored_by(@profile)
   end
 
   def edit_name

--- a/app/jobs/enrol_school_cohorts_job.rb
+++ b/app/jobs/enrol_school_cohorts_job.rb
@@ -23,6 +23,7 @@ class EnrolSchoolCohortsJob < ApplicationJob
           induction_record.update!(induction_status: profile.status,
                                    training_status: profile.training_status,
                                    mentor_profile_id: profile.mentor_profile_id)
+          Mentors::AddToSchool.call(school: sc.school, mentor_profile: profile) if profile.mentor?
         end
         sc.update!(default_induction_programme: programme)
 

--- a/app/services/dashboard/mentor.rb
+++ b/app/services/dashboard/mentor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class Mentor
+    attr_reader :induction_record, :participant_profile
+
+    def initialize(induction_record:, participant_profile: induction_record&.participant_profile)
+      @induction_record = induction_record
+      @participant_profile = participant_profile
+    end
+
+    def name
+      induction_record&.participant_full_name || participant_profile.full_name
+    end
+
+    def participant_profile_id
+      induction_record&.participant_profile_id || participant_profile.id
+    end
+  end
+end

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -12,8 +12,16 @@ module Dashboard
       @mentors = process_participants
     end
 
+    def dashboard_school_cohorts
+      SchoolCohort.dashboard_for_school(school:, latest_year:)
+    end
+
     def ects
       @ects ||= mentors.values.flatten.compact + orphan_ects
+    end
+
+    def ects_mentored_by(mentor)
+      mentors[dashboard_mentoring_mentor(mentor)]
     end
 
     def no_qts
@@ -21,14 +29,25 @@ module Dashboard
     end
 
     def orphan_mentors
-      @orphan_mentors ||= induction_records.select(&:mentor?) - mentors.keys
-    end
-
-    def dashboard_school_cohorts
-      SchoolCohort.dashboard_for_school(school:, latest_year:)
+      @orphan_mentors ||= school_mentors_not_mentoring.map do |school_mentor|
+        dashboard_mentor(school_mentor.participant_profile_id)
+      end
     end
 
   private
+
+    def dashboard_mentoring_mentor(mentor)
+      return mentor if mentor.is_a?(Dashboard::Mentor)
+
+      mentors.keys.detect { |dashboard_mentor| dashboard_mentor.participant_profile_id == mentor.id }
+    end
+
+    def dashboard_mentor(profile_id)
+      induction_record = induction_records.detect { |ir| ir.participant_profile_id == profile_id }
+      participant_profile = ParticipantProfile.find(profile_id)
+
+      Dashboard::Mentor.new(induction_record:, participant_profile:)
+    end
 
     # List of relevant (current or transferring_in or transferred) induction record of each of the participant of
     # the school in the cohorts displayed by the dashboard
@@ -46,12 +65,6 @@ module Dashboard
       end
     end
 
-    def induction_record_of_profile(profile_id)
-      induction_records.detect do |induction_record|
-        induction_record.participant_profile_id == profile_id
-      end
-    end
-
     def no_qts?(induction_record)
       !induction_record.training_status_withdrawn? &&
         (induction_record.active? || induction_record.claimed_by_another_school?) &&
@@ -60,16 +73,26 @@ module Dashboard
         induction_record.participant_no_qts?
     end
 
+    def profile_ids_of_mentors_mentoring
+      mentors.keys.map(&:participant_profile_id)
+    end
+
     def process_participants
       induction_records
         .select(&:ect?)
         .group_by(&:mentor_profile_id)
         .each_with_object({}) do |(mentor_profile_id, ects), hash|
         if mentor_profile_id
-          hash[induction_record_of_profile(mentor_profile_id)] = ects
+          hash[dashboard_mentor(mentor_profile_id)] = ects
         else
           @orphan_ects = ects
         end
+      end
+    end
+
+    def school_mentors_not_mentoring
+      school.school_mentors.reject do |school_mentor|
+        profile_ids_of_mentors_mentoring.include?(school_mentor.participant_profile_id)
       end
     end
   end

--- a/app/services/induction/change_programme.rb
+++ b/app/services/induction/change_programme.rb
@@ -10,6 +10,13 @@ class Induction::ChangeProgramme < BaseService
                             start_date:,
                             preferred_email:,
                             mentor_profile:)
+      if participant_profile.mentor?
+        Mentors::ChangeSchool.call(from_school: current_induction_record.school,
+                                   to_school: new_induction_programme.school,
+                                   remove_on_date: start_date,
+                                   mentor_profile: participant_profile,
+                                   preferred_email:)
+      end
     end
   end
 

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -30,34 +30,33 @@
         <% end %>
       <% end %>
 
-      <% @participants.mentors.keys.sort_by(&:participant_full_name).each do |mentor| %>
+      <% @participants.mentors.keys.sort_by(&:name).each do |mentor| %>
         <div class="group-card" aria-label="Mentor group">
           <h2 class="govuk-visually-hidden">Mentor group</h2>
 
           <h3 class="govuk-heading-s">
-            Mentor <span class="govuk-visually-hidden">- <%= mentor.participant_full_name %></span>
+            Mentor <span class="govuk-visually-hidden">- <%= mentor.name %></span>
           </h3>
           <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
             <% list.row do |row| %>
-              <% row.key(text: govuk_link_to(mentor.participant_full_name,
-                                             school_participant_path(id: mentor.participant_profile_id,
-                                                                      school_id: @school),
+              <% row.key(text: govuk_link_to(mentor.name,
+                                             school_participant_path(id: mentor.participant_profile_id, school_id: @school),
                                              no_visited_state: true),
                          classes: ["govuk-!-font-weight-regular"]) %>
               <% row.value(
                    text: render(StatusTags::SchoolParticipantStatusTag.new(
                      participant_profile: mentor.participant_profile,
-                     induction_record: mentor,
+                     induction_record: mentor.induction_record,
                      display_description: false))) %>
             <% end %>
           <% end %>
 
           <h3 class="govuk-heading-s">
-            ECTs <span class="govuk-visually-hidden">mentored by <%= mentor.participant_full_name %></span>
+            ECTs <span class="govuk-visually-hidden">mentored by <%= mentor.name %></span>
           </h3>
 
           <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
-            <% @participants.mentors[mentor].sort_by(&:participant_full_name).each do |ect| %>
+            <% @participants.ects_mentored_by(mentor).sort_by(&:participant_full_name).each do |ect| %>
               <% list.row do |row| %>
                 <% row.key(text: govuk_link_to("#{ect.participant_full_name}",
                                                school_participant_path(id: ect.participant_profile_id,
@@ -83,9 +82,9 @@
         </h3>
 
         <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
-          <% @participants.orphan_mentors.sort_by(&:participant_full_name).each do |mentor| %>
+          <% @participants.orphan_mentors.sort_by(&:name).each do |mentor| %>
             <% list.row do |row| %>
-              <% row.key(text: govuk_link_to(mentor.participant_full_name,
+              <% row.key(text: govuk_link_to(mentor.name,
                                              school_participant_path(id: mentor.participant_profile_id,
                                                                       school_id: @school),
                                              no_visited_state: true),
@@ -93,7 +92,7 @@
               <% row.value(
                    text: render(StatusTags::SchoolParticipantStatusTag.new(
                      participant_profile: mentor.participant_profile,
-                     induction_record: mentor,
+                     induction_record: mentor.induction_record,
                      display_description: false)),
                    classes: ["govuk-\!-padding-bottom-static-0"]) %>
             <% end %>

--- a/spec/cypress/app_commands/scenarios/admin/school_participants.rb
+++ b/spec/cypress/app_commands/scenarios/admin/school_participants.rb
@@ -32,6 +32,7 @@ ect_2 = FactoryBot.create :ect_participant_profile,
     start_date: 2.months.ago,
     mentor_profile: ppt.ect? ? mentor_1 : nil,
   )
+  Mentors::AddToSchool.call(school:, mentor_profile: ppt) if ppt.mentor?
 end
 
 another_school = FactoryBot.create(:school, name: "Some other school", urn: "222222")

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -156,6 +156,7 @@ module ParticipantSteps
   def and_i_have_added_a_mentor
     @participant_profile_mentor = create(:mentor_participant_profile, user: create(:user, full_name: "Billy Mentor", email: "billy-mentor@example.com"), school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @participant_profile_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(school: @school, mentor_profile: @participant_profile_mentor)
   end
 
   def and_the_mentor_is_mentoring_the_ect

--- a/spec/features/schools/participants/remove_from_cohort_spec.rb
+++ b/spec/features/schools/participants/remove_from_cohort_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "SIT removing participants from the cohort", js: true, with_featu
   before do
     Induction::SetCohortInductionProgramme.call(school_cohort:, programme_choice: "full_induction_programme")
     Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme)
+    Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile:)
     Induction::Enrol.call(participant_profile: ect_profile, induction_programme: school_cohort.default_induction_programme, mentor_profile:)
     Induction::Enrol.call(participant_profile: ineligible_ect_profile, induction_programme: school_cohort.default_induction_programme)
     privacy_policy.accept!(sit_profile.user)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -242,6 +242,7 @@ module ManageTrainingSteps
   def and_i_have_added_an_eligible_mentor
     @eligible_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Eligible mentor"), school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @eligible_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: @eligible_mentor, school: @school)
   end
 
   def and_i_have_added_an_ineligible_ect_with_mentor
@@ -254,6 +255,7 @@ module ManageTrainingSteps
     @ineligible_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "Ineligible mentor"), school_cohort: @school_cohort)
     @ineligible_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "active_flags")
     Induction::Enrol.call(participant_profile: @ineligible_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: @ineligible_mentor, school: @school)
   end
 
   def and_i_have_added_a_contacted_for_info_ect_with_mentor
@@ -265,6 +267,7 @@ module ManageTrainingSteps
     @ero_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "ero mentor"), school_cohort: @school_cohort)
     @ero_mentor.ecf_participant_eligibility.update!(status: "ineligible", reason: "previous_participation")
     Induction::Enrol.call(participant_profile: @ero_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: @ero_mentor, school: @school)
   end
 
   def and_i_have_added_a_contacted_for_info_ect_without_mentor
@@ -435,6 +438,7 @@ module ManageTrainingSteps
   def and_i_have_added_a_contacted_for_info_mentor
     @contacted_for_info_mentor = create(:mentor_participant_profile, :email_sent, request_for_details_sent_at: 5.days.ago, user: create(:user, full_name: "CFI Mentor"), school_cohort: @school_cohort)
     Induction::Enrol.call(participant_profile: @contacted_for_info_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: @contacted_for_info_mentor, school: @school)
   end
 
   def and_i_am_signed_in_as_an_induction_coordinator_for_multiple_schools
@@ -479,6 +483,7 @@ module ManageTrainingSteps
     @details_being_checked_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "DBC Mentor"), school_cohort: @school_cohort)
     @details_being_checked_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "different_trn")
     Induction::Enrol.call(participant_profile: @details_being_checked_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: @details_being_checked_mentor, school: @school)
   end
 
   def and_i_have_added_a_no_qts_ect_with_mentor
@@ -497,6 +502,7 @@ module ManageTrainingSteps
     @no_qts_mentor = create(:mentor_participant_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, user: create(:user, full_name: "No-qts Mentor"), school_cohort: @school_cohort)
     @no_qts_mentor.ecf_participant_eligibility.update!(status: "manual_check", reason: "no_qts")
     Induction::Enrol.call(participant_profile: @no_qts_mentor, induction_programme: @induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: @no_qts_mentor, school: @school)
   end
 
   def and_it_should_not_allow_a_sit_to_edit_the_participant_details

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -233,6 +233,17 @@ module Steps
         Induction::Enrol.call participant_profile:,
                               induction_programme: school_cohort.default_induction_programme,
                               start_date: 1.day.from_now
+        if participant_profile.mentor?
+          if current_induction_record
+            Mentors::ChangeSchool.call(from_school: participant_profile.current_induction_record.school,
+                                       to_school: school,
+                                       mentor_profile: participant_profile,
+                                       remove_on_date: 1.day.from_now,
+                                       preferred_email: participant_profile.participant_identity.email)
+          else
+            Mentors::AddToSchool.call(mentor_profile: participant_profile, school:)
+          end
+        end
 
         travel_to 2.days.from_now
       end
@@ -262,6 +273,17 @@ module Steps
         Induction::Enrol.call participant_profile:,
                               induction_programme: school_cohort.default_induction_programme,
                               start_date: 1.day.from_now
+        if participant_profile.mentor?
+          if current_induction_record
+            Mentors::ChangeSchool.call(from_school: participant_profile.current_induction_record.school,
+                                       to_school: school,
+                                       mentor_profile: participant_profile,
+                                       remove_on_date: 1.day.from_now,
+                                       preferred_email: participant_profile.participant_identity.email)
+          else
+            Mentors::AddToSchool.call(mentor_profile: participant_profile, school:)
+          end
+        end
 
         travel_to 2.days.from_now
       end
@@ -291,6 +313,17 @@ module Steps
         Induction::Enrol.call participant_profile:,
                               induction_programme: school_cohort.default_induction_programme,
                               start_date: 1.day.from_now
+        if participant_profile.mentor?
+          if current_induction_record
+            Mentors::ChangeSchool.call(from_school: participant_profile.current_induction_record.school,
+                                       to_school: school,
+                                       mentor_profile: participant_profile,
+                                       remove_on_date: 1.day.from_now,
+                                       preferred_email: participant_profile.participant_identity.email)
+          else
+            Mentors::AddToSchool.call(mentor_profile: participant_profile, school:)
+          end
+        end
 
         travel_to 2.days.from_now
       end

--- a/spec/support/with_support_for_ect_examples.rb
+++ b/spec/support/with_support_for_ect_examples.rb
@@ -37,6 +37,7 @@ RSpec.shared_context "with Support for ECTs example profiles", shared_context: :
     user = create(:user, full_name: "FIP Mentor Only")
     participant_profile = create(:mentor_participant_profile, user:, school_cohort: fip_school_cohort)
     Induction::Enrol.call(participant_profile:, induction_programme: fip_induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: participant_profile, school: fip_school_cohort.school)
     participant_profile
   end
 
@@ -44,6 +45,7 @@ RSpec.shared_context "with Support for ECTs example profiles", shared_context: :
     user = create(:user, full_name: "CIP Mentor Only")
     participant_profile = create(:mentor_participant_profile, user:, school_cohort: cip_school_cohort, core_induction_programme:)
     Induction::Enrol.call(participant_profile:, induction_programme: cip_induction_programme)
+    Mentors::AddToSchool.call(mentor_profile: participant_profile, school: cip_school_cohort.school)
     participant_profile
   end
 
@@ -117,6 +119,7 @@ RSpec.shared_context "with Support for ECTs example profiles", shared_context: :
     mentor_identity = create(:participant_identity, :secondary, user:, email: "mentor_1@example.com")
     mentor_profile = create(:mentor_participant_profile, teacher_profile:, school_cohort: fip_school_cohort, participant_identity: mentor_identity)
     Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: fip_induction_programme, start_date: 3.months.ago)
+    Mentors::AddToSchool.call(mentor_profile:, school: fip_induction_programme.school)
 
     { ect_profile:, mentor_profile: }
   end


### PR DESCRIPTION
…oarded school

### Context

The dasboard breaks when one of the mentors do not belong to the shool of the dashboard.

- Ticket: 

### Changes proposed in this pull request
The dashboard is made based on the induction records of all their participants.
Mentors from another school teaching ECTs in the school of the dashboard do not have induction record in it.

- This PR will take this into account and check the mentor pool instead for mentors.
- Also, make sure mentors get added to school mentor pool thoughout the code when they are created/moved to a school.



