### PR TITLE
Add the SIT reminder mailer for the pilot

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -30,6 +30,7 @@ class SchoolMailer < ApplicationMailer
   PARTICIPANT_WITHDRAWN_BY_PROVIDER = "29f94916-8c3a-4c5a-9e33-bdf3f5d7249a"
   REMIND_TO_SETUP_MENTOR_TO_ECTS = "604ca80f-b152-4682-9295-9cf1d30f74c1"
   REMIND_GIAS_CONTACT_TO_UPDATE_INDUCTION_TUTOR_DETAILS_TEMPLATE = "88cdad72-386c-40fb-be2e-11d4ae9dcdee"
+  REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "87d4720b-9e3a-46d9-95de-493295dba1dc"
 
   def remind_sit_to_set_mentor_to_ects
     sit = params[:sit]
@@ -546,5 +547,23 @@ class SchoolMailer < ApplicationMailer
       .tag(:sit_fip_provider_has_withdrawn_a_participant)
       .associate_with(induction_coordinator, as: :induction_coordinator)
       .associate_with(withdrawn_participant, as: :participant_profile)
+  end
+
+  # Pilot one-off mailers
+
+  def remind_sit_to_report_school_training_details
+    sit_profile = params[:sit_profile]
+    nomination_link = params[:nomination_link]
+
+    template_mail(
+      REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE,
+      to: sit_profile.user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sit_name: sit_profile.user.full_name,
+        nomination_link:,
+      },
+    ).tag(:sit_to_report_school_training).associate_with(sit_profile)
   end
 end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -225,4 +225,25 @@ RSpec.describe SchoolMailer, type: :mailer do
       end
     end
   end
+
+  describe "#remind_sit_to_report_school_training_details" do
+    let(:sit_profile) { create(:induction_coordinator_profile) }
+    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
+
+    let(:remind_sit_to_report_school_training_details) do
+      SchoolMailer.with(
+        sit_profile:,
+        nomination_link:,
+      ).remind_sit_to_report_school_training_details.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(remind_sit_to_report_school_training_details.to).to eq([sit_profile.user.email])
+      expect(remind_sit_to_report_school_training_details.from).to eq(["mail@example.com"])
+    end
+
+    it "uses the correct Notify template" do
+      expect(SchoolMailer::REMIND_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE).to eq("87d4720b-9e3a-46d9-95de-493295dba1dc")
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-1503

As part of the pilot release, we need to send reminders to registered SITs to report details of their school's training for ECTs.

Only the mailer is required for now.

### Changes proposed in this pull request
Add a mailer that requires the SIT profile and the SIT nomination link

### Guidance to review

