### PR TITLE
[CPDLP-2203] Update the order on v3 endpoints to created_at asc

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -57,7 +57,7 @@ module Api
                   .includes(:cohort, :npq_course, :profile, participant_identity: [:user])
                   .where(cohort: with_cohorts)
         scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
-        scope
+        params[:sort].blank? ? scope.order("npq_applications.created_at ASC") : scope
       end
 
       def access_scope

--- a/app/services/api/v3/delivery_partners_query.rb
+++ b/app/services/api/v3/delivery_partners_query.rb
@@ -13,7 +13,7 @@ module Api
       def delivery_partners
         scope = lead_provider.delivery_partners
         scope = scope.where("provider_relationships.cohort_id IN (?)", with_cohorts.map(&:id)) if filter[:cohort].present?
-        scope = scope.order("delivery_partners.updated_at DESC") if params[:sort].blank?
+        scope = scope.order("delivery_partners.created_at ASC") if params[:sort].blank?
         scope.distinct
       end
 

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -34,7 +34,7 @@ module Api
                     .distinct
 
           scope = updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
-          params[:sort].blank? ? scope.order("users.updated_at ASC") : scope
+          params[:sort].blank? ? scope.order("participant_profiles_users.created_at ASC") : scope
         end
 
         def participant

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -34,7 +34,7 @@ module Api
                     .distinct
 
           scope = updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
-          params[:sort].blank? ? scope.order("participant_profiles_users.created_at ASC") : scope
+          params[:sort].blank? ? scope.order("teacher_profiles_participant_profiles.created_at ASC") : scope
         end
 
         def participant

--- a/app/services/api/v3/ecf/partnerships_query.rb
+++ b/app/services/api/v3/ecf/partnerships_query.rb
@@ -16,7 +16,7 @@ module Api
           scope = scope.where(partnerships: { cohort:  with_cohorts }) if filter[:cohort].present?
           scope = scope.where("partnerships.updated_at > ?", updated_since) if updated_since.present?
           scope = scope.where(partnerships: { delivery_partner: [delivery_partner_id_filter] }) if delivery_partner_id_filter.present?
-          scope = scope.order("partnerships.updated_at DESC") if params[:sort].blank?
+          scope = scope.order("partnerships.created_at ASC") if params[:sort].blank?
           scope.distinct
         end
 

--- a/app/services/api/v3/ecf/schools_query.rb
+++ b/app/services/api/v3/ecf/schools_query.rb
@@ -18,7 +18,7 @@ module Api
             .distinct
 
           scope = scope.where(urn: filter[:urn]) if filter[:urn].present?
-          scope = scope.order(updated_at: :desc) if params[:sort].blank?
+          scope = scope.order("schools.created_at ASC") if params[:sort].blank?
 
           if updated_since.present?
             scope = scope.where(updated_at: updated_since..).or(scope.where(school_cohorts: { updated_at: updated_since.. }))

--- a/app/services/api/v3/ecf/unfunded_mentors_query.rb
+++ b/app/services/api/v3/ecf/unfunded_mentors_query.rb
@@ -36,7 +36,7 @@ module Api
                    .where("induction_records.mentor_profile_id not in (select distinct participant_profile_id from (#{join.to_sql}) AS latest_induction_records)")
 
           scope = updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
-          params[:sort].blank? ? scope.order("users.updated_at DESC") : scope
+          params[:sort].blank? ? scope.order("users.created_at ASC") : scope
         end
 
         def unfunded_mentor

--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -13,7 +13,7 @@ module Api
       def participants
         scope = npq_lead_provider.npq_participants.includes(:teacher_profile, npq_profiles: [:npq_course, :participant_profile_states, :participant_identity, { schedule: [:cohort], npq_application: [npq_lead_provider: :cpd_lead_provider] }])
         scope = scope.where("users.updated_at > ?", updated_since) if updated_since.present?
-        scope = scope.order("users.updated_at DESC") if params[:sort].blank?
+        scope = scope.order("npq_profiles.created_at ASC") if params[:sort].blank?
         scope.distinct
       end
 

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "API Delivery Partners", :with_default_schedules, type: :request,
 
   describe "#index" do
     before :each do
-      another_delivery_partner = create(:delivery_partner, name: "Second Delivery Partner")
-      another_cohort = create(:cohort, start_year: "2050")
-      create(:provider_relationship, cohort: another_cohort, delivery_partner: another_delivery_partner, lead_provider:)
+      @another_delivery_partner = create(:delivery_partner, name: "Second Delivery Partner")
+      @another_cohort = create(:cohort, start_year: "2050")
+      create(:provider_relationship, cohort: @another_cohort, delivery_partner: @another_delivery_partner, lead_provider:)
     end
 
     context "when authorized" do
@@ -101,6 +101,20 @@ RSpec.describe "API Delivery Partners", :with_default_schedules, type: :request,
         it "returns an ordered list of delivery partners" do
           get "/api/v3/delivery-partners", params: { sort: "-updated_at,name" }
 
+          expect(parsed_response["data"].size).to eql(2)
+          expect(parsed_response.dig("data", 0, "attributes", "name")).to eql("Second Delivery Partner")
+          expect(parsed_response.dig("data", 1, "attributes", "name")).to eql("First Delivery Partner")
+        end
+      end
+
+      context "when not including sort in the params" do
+        before do
+          @another_delivery_partner.update!(created_at: 10.days.ago)
+
+          get "/api/v3/delivery-partners", params: { sort: "" }
+        end
+
+        it "returns all records ordered by npq applications created_at" do
           expect(parsed_response["data"].size).to eql(2)
           expect(parsed_response.dig("data", 0, "attributes", "name")).to eql("Second Delivery Partner")
           expect(parsed_response.dig("data", 1, "attributes", "name")).to eql("First Delivery Partner")

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -120,11 +120,13 @@ RSpec.describe "API ECF Participants", :with_default_schedules, type: :request, 
 
         it "returns different users for each page" do
           get "/api/v3/participants/ecf", params: { page: { per_page: 2, page: 1 } }
+          expect(parsed_response["data"].size).to eql(2)
           first_page_id = parsed_response["data"].first["id"]
 
           get "/api/v3/participants/ecf", params: { page: { per_page: 2, page: 2 } }
           second_parsed_response = JSON.parse(response.body)
           second_page_ids = second_parsed_response["data"].map { |item| item["id"] }
+          expect(second_parsed_response["data"].size).to eql(2)
 
           expect(second_page_ids).not_to include first_page_id
         end
@@ -132,8 +134,8 @@ RSpec.describe "API ECF Participants", :with_default_schedules, type: :request, 
         it "returns users in a consistent order" do
           get "/api/v3/participants/ecf"
 
-          expect(parsed_response["data"].first["id"]).to eq User.order(created_at: :asc).first.id
-          expect(parsed_response["data"].last["id"]).to eq User.order(created_at: :asc).last.id
+          expect(parsed_response["data"].first["id"]).to eq ParticipantProfile.order(created_at: :asc).first.user.id
+          expect(parsed_response["data"].last["id"]).to eq ParticipantProfile.order(created_at: :asc).last.user.id
         end
 
         context "when updated_since parameter is supplied" do

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -120,13 +120,12 @@ RSpec.describe "API ECF Participants", :with_default_schedules, type: :request, 
 
         it "returns different users for each page" do
           get "/api/v3/participants/ecf", params: { page: { per_page: 2, page: 1 } }
-          expect(parsed_response["data"].size).to eql(2)
           first_page_id = parsed_response["data"].first["id"]
 
           get "/api/v3/participants/ecf", params: { page: { per_page: 2, page: 2 } }
           second_parsed_response = JSON.parse(response.body)
           second_page_ids = second_parsed_response["data"].map { |item| item["id"] }
-          expect(second_parsed_response["data"].size).to eql(2)
+
           expect(second_page_ids).not_to include first_page_id
         end
 

--- a/spec/requests/api/v3/ecf/partnerships_spec.rb
+++ b/spec/requests/api/v3/ecf/partnerships_spec.rb
@@ -97,21 +97,43 @@ RSpec.describe "API ECF Partnerships", :with_default_schedules, type: :request d
         end
       end
 
-      context "when ordering by name" do
-        it "returns an ordered list of partnership" do
-          get "/api/v3/partnerships/ecf", params: { sort: "updated_at" }
+      describe "ordering" do
+        context "when ordering by updated_at ascending" do
+          let(:sort_param) { "updated_at" }
 
-          expect(parsed_response["data"].size).to eql(2)
-          expect(parsed_response.dig("data", 0, "attributes", "delivery_partner_name")).to eql("First Delivery Partner")
-          expect(parsed_response.dig("data", 1, "attributes", "delivery_partner_name")).to eql("Second Delivery Partner")
+          before { get "/api/v3/partnerships/ecf", params: { sort: sort_param, filter: { cohort: [cohort.display_name, another_cohort.display_name].join(",") } } }
+
+          it "returns an ordered list of partnership" do
+            expect(parsed_response["data"].size).to eql(2)
+            expect(parsed_response.dig("data", 0, "attributes", "delivery_partner_name")).to eql("First Delivery Partner")
+            expect(parsed_response.dig("data", 1, "attributes", "delivery_partner_name")).to eql("Second Delivery Partner")
+          end
         end
 
-        it "returns an ordered list of partnership" do
-          get "/api/v3/partnerships/ecf", params: { sort: "-updated_at" }
+        context "when ordering by updated_at descending" do
+          let(:sort_param) { "-updated_at" }
 
-          expect(parsed_response["data"].size).to eql(2)
-          expect(parsed_response.dig("data", 0, "attributes", "delivery_partner_name")).to eql("Second Delivery Partner")
-          expect(parsed_response.dig("data", 1, "attributes", "delivery_partner_name")).to eql("First Delivery Partner")
+          before { get "/api/v3/partnerships/ecf", params: { sort: sort_param, filter: { cohort: [cohort.display_name, another_cohort.display_name].join(",") } } }
+
+          it "returns an ordered list of partnership" do
+            expect(parsed_response["data"].size).to eql(2)
+            expect(parsed_response.dig("data", 0, "attributes", "delivery_partner_name")).to eql("Second Delivery Partner")
+            expect(parsed_response.dig("data", 1, "attributes", "delivery_partner_name")).to eql("First Delivery Partner")
+          end
+        end
+
+        context "when not including sort in the params" do
+          before do
+            partnership.update!(created_at: 10.days.ago)
+
+            get "/api/v3/partnerships/ecf", params: { sort: "", filter: { cohort: [cohort.display_name, another_cohort.display_name].join(",") } }
+          end
+
+          it "returns all records ordered by created_at" do
+            expect(parsed_response["data"].size).to eql(2)
+            expect(parsed_response.dig("data", 0, "attributes", "delivery_partner_name")).to eql("First Delivery Partner")
+            expect(parsed_response.dig("data", 1, "attributes", "delivery_partner_name")).to eql("Second Delivery Partner")
+          end
         end
       end
     end

--- a/spec/requests/api/v3/ecf/schools_spec.rb
+++ b/spec/requests/api/v3/ecf/schools_spec.rb
@@ -72,10 +72,10 @@ RSpec.describe "API ECF schools", :with_default_schedules, type: :request, with_
           end
         end
 
-        before { get "/api/v3/schools/ecf", params: { sort: sort_param, filter: { cohort: cohort.display_name } } }
-
         context "when ordering by updated_at ascending" do
           let(:sort_param) { "updated_at" }
+
+          before { get "/api/v3/schools/ecf", params: { sort: sort_param, filter: { cohort: cohort.display_name } } }
 
           it "returns an ordered list of schools" do
             expect(parsed_response["data"].size).to eql(2)
@@ -87,10 +87,26 @@ RSpec.describe "API ECF schools", :with_default_schedules, type: :request, with_
         context "when ordering by updated_at descending" do
           let(:sort_param) { "-updated_at" }
 
+          before { get "/api/v3/schools/ecf", params: { sort: sort_param, filter: { cohort: cohort.display_name } } }
+
           it "returns an ordered list of schools" do
             expect(parsed_response["data"].size).to eql(2)
             expect(parsed_response.dig("data", 0, "attributes", "name")).to eql(school.name)
             expect(parsed_response.dig("data", 1, "attributes", "name")).to eql(another_school.name)
+          end
+        end
+
+        context "when not including sort in the params" do
+          before do
+            another_school.update!(created_at: 10.days.ago)
+
+            get "/api/v3/schools/ecf", params: { sort: "", filter: { cohort: cohort.display_name } }
+          end
+
+          it "returns all records ordered by created_at" do
+            expect(parsed_response["data"].size).to eql(2)
+            expect(parsed_response.dig("data", 0, "attributes", "name")).to eql(another_school.name)
+            expect(parsed_response.dig("data", 1, "attributes", "name")).to eql(school.name)
           end
         end
       end

--- a/spec/requests/api/v3/ecf/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/ecf/unfunded_mentors_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe "API ECF Unfunded Mentors", :with_default_schedules, type: :reque
         let!(:another_unfunded_mentor_profile) { create(:mentor, :eligible_for_funding) }
         let!(:another_unfunded_mentor_induction_record) { create(:induction_record, induction_programme:, mentor_profile: another_unfunded_mentor_profile) }
 
-        before { get "/api/v3/unfunded-mentors/ecf", params: { sort: sort_param } }
-
         context "when ordering by updated_at ascending" do
           let(:sort_param) { "updated_at" }
+
+          before { get "/api/v3/unfunded-mentors/ecf", params: { sort: sort_param } }
 
           it "returns an ordered list of unfunded mentors" do
             expect(parsed_response["data"].size).to eql(2)
@@ -74,7 +74,23 @@ RSpec.describe "API ECF Unfunded Mentors", :with_default_schedules, type: :reque
         context "when ordering by updated_at descending" do
           let(:sort_param) { "-updated_at" }
 
+          before { get "/api/v3/unfunded-mentors/ecf", params: { sort: sort_param } }
+
           it "returns an ordered list of unfunded mentors" do
+            expect(parsed_response["data"].size).to eql(2)
+            expect(parsed_response.dig("data", 0, "attributes", "full_name")).to eql(another_unfunded_mentor_profile.user.full_name)
+            expect(parsed_response.dig("data", 1, "attributes", "full_name")).to eql(unfunded_mentor_profile.user.full_name)
+          end
+        end
+
+        context "when not including sort in the params" do
+          before do
+            another_unfunded_mentor_profile.user.update!(created_at: 10.days.ago)
+
+            get "/api/v3/unfunded-mentors/ecf", params: { sort: "" }
+          end
+
+          it "returns all records ordered by users created_at" do
             expect(parsed_response["data"].size).to eql(2)
             expect(parsed_response.dig("data", 0, "attributes", "full_name")).to eql(another_unfunded_mentor_profile.user.full_name)
             expect(parsed_response.dig("data", 1, "attributes", "full_name")).to eql(unfunded_mentor_profile.user.full_name)

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -131,12 +131,14 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request, 
 
           before do
             another_npq_application.update!(updated_at: 10.days.ago)
-
-            get "/api/v3/npq-applications", params: { sort: sort_param }
           end
 
           context "when ordering by updated_at ascending" do
             let(:sort_param) { "updated_at" }
+
+            before do
+              get "/api/v3/npq-applications", params: { sort: sort_param }
+            end
 
             it "returns an ordered list of npq applications" do
               expect(parsed_response["data"].size).to eql(4)
@@ -147,9 +149,28 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request, 
           context "when ordering by updated_at applications" do
             let(:sort_param) { "-updated_at" }
 
+            before do
+              get "/api/v3/npq-applications", params: { sort: sort_param }
+            end
+
             it "returns an ordered list of npq participants" do
               expect(parsed_response["data"].size).to eql(4)
               expect(parsed_response.dig("data", 3, "attributes", "full_name")).to eql(another_npq_application.user.full_name)
+            end
+          end
+
+          context "when not including sort in the params" do
+            let(:sort_param) { "" }
+
+            before do
+              another_npq_application.update!(created_at: 10.days.ago)
+
+              get "/api/v3/npq-applications", params: { sort: sort_param }
+            end
+
+            it "returns all records ordered by npq applications created_at" do
+              expect(parsed_response["data"].size).to eql(4)
+              expect(parsed_response.dig("data", 0, "attributes", "full_name")).to eql(another_npq_application.user.full_name)
             end
           end
         end

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -101,12 +101,14 @@ RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request, 
 
           before do
             another_npq_application.user.update!(updated_at: 5.days.ago)
-
-            get "/api/v3/participants/npq", params: { sort: sort_param }
           end
 
           context "when ordering by updated_at ascending" do
             let(:sort_param) { "updated_at" }
+
+            before do
+              get "/api/v3/participants/npq", params: { sort: sort_param }
+            end
 
             it "returns an ordered list of npq participants" do
               expect(parsed_response["data"].size).to eql(4)
@@ -117,9 +119,26 @@ RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request, 
           context "when ordering by updated_at descending" do
             let(:sort_param) { "-updated_at" }
 
+            before do
+              get "/api/v3/participants/npq", params: { sort: sort_param }
+            end
+
             it "returns an ordered list of npq participants" do
               expect(parsed_response["data"].size).to eql(4)
               expect(parsed_response.dig("data", 3, "attributes", "full_name")).to eql(another_npq_application.user.full_name)
+            end
+          end
+
+          context "when not including sort in the params" do
+            before do
+              another_npq_application.profile.update!(created_at: 10.days.ago)
+
+              get "/api/v3/participants/npq", params: { sort: "" }
+            end
+
+            it "returns all records ordered by profiles created_at" do
+              expect(parsed_response["data"].size).to eql(4)
+              expect(parsed_response.dig("data", 0, "attributes", "full_name")).to eql(another_npq_application.user.full_name)
             end
           end
         end

--- a/spec/services/api/v3/delivery_partners_query_spec.rb
+++ b/spec/services/api/v3/delivery_partners_query_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Api::V3::DeliveryPartnersQuery do
         expect(subject.delivery_partners).to match_array([delivery_partner, another_delivery_partner])
       end
     end
+
+    context "sorting" do
+      let!(:another_delivery_partner) { create(:delivery_partner, name: "Second Delivery Partner", created_at: 10.days.ago) }
+
+      it "returns all records ordered by created_at" do
+        expect(subject.delivery_partners).to eq([another_delivery_partner, delivery_partner])
+      end
+    end
   end
 
   describe "#delivery_partner" do

--- a/spec/services/api/v3/delivery_partners_query_spec.rb
+++ b/spec/services/api/v3/delivery_partners_query_spec.rb
@@ -58,7 +58,11 @@ RSpec.describe Api::V3::DeliveryPartnersQuery do
     end
 
     context "sorting" do
-      let!(:another_delivery_partner) { create(:delivery_partner, name: "Second Delivery Partner", created_at: 10.days.ago) }
+      let!(:another_delivery_partner) do
+        travel_to(10.days.ago) do
+          create(:delivery_partner, name: "Second Delivery Partner")
+        end
+      end
 
       it "returns all records ordered by created_at" do
         expect(subject.delivery_partners).to eq([another_delivery_partner, delivery_partner])

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -104,7 +104,12 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
     context "sorting" do
       let(:another_cohort) { create(:cohort, start_year: "2050") }
       let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
-      let(:another_participant_profile) { create(:ect_participant_profile, created_at: 10.days.ago) }
+      let(:another_participant_profile) do
+        travel_to(10.days.ago) do
+          create(:ect_participant_profile)
+        end
+      end
+
       let(:another_induction_programme) { create(:induction_programme, :fip, partnership: another_partnership) }
       let(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
       let!(:another_user) { another_induction_record.user }

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -100,6 +100,19 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
         end
       end
     end
+
+    context "sorting" do
+      let(:another_cohort) { create(:cohort, start_year: "2050") }
+      let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
+      let(:another_participant_profile) { create(:ect_participant_profile, created_at: 10.days.ago) }
+      let(:another_induction_programme) { create(:induction_programme, :fip, partnership: another_partnership) }
+      let(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
+      let!(:another_user) { another_induction_record.user }
+
+      it "returns all user records ordered by participant profile created_at" do
+        expect(subject.participants).to eq([another_user, user])
+      end
+    end
   end
 
   describe "#participant" do

--- a/spec/services/api/v3/ecf/partnerships_query_spec.rb
+++ b/spec/services/api/v3/ecf/partnerships_query_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe Api::V3::ECF::PartnershipsQuery do
         expect(subject.partnerships).to match_array([partnership, another_partnership])
       end
     end
+
+    context "sorting" do
+      let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:, created_at: 2.days.ago.iso8601) }
+
+      it "returns all partnerships ordered by created_at" do
+        expect(subject.partnerships).to eq([another_partnership, partnership])
+      end
+    end
   end
 
   describe "#partnership" do

--- a/spec/services/api/v3/ecf/partnerships_query_spec.rb
+++ b/spec/services/api/v3/ecf/partnerships_query_spec.rb
@@ -100,7 +100,11 @@ RSpec.describe Api::V3::ECF::PartnershipsQuery do
     end
 
     context "sorting" do
-      let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:, created_at: 2.days.ago.iso8601) }
+      let!(:another_partnership) do
+        travel_to(2.days.ago) do
+          create(:partnership, cohort: another_cohort, lead_provider:)
+        end
+      end
 
       it "returns all partnerships ordered by created_at" do
         expect(subject.partnerships).to eq([another_partnership, partnership])

--- a/spec/services/api/v3/ecf/schools_query_spec.rb
+++ b/spec/services/api/v3/ecf/schools_query_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe Api::V3::ECF::SchoolsQuery do
           end
         end
       end
+
+      context "sorting" do
+        let!(:eligible_school) { create(:school, :eligible) }
+        let!(:another_eligible_school) { create(:school, :eligible, created_at: 10.days.ago) }
+
+        it "returns all records ordered by created_at" do
+          expect(subject.schools).to eq([another_eligible_school, eligible_school])
+        end
+      end
     end
 
     context "with updated_since filter" do

--- a/spec/services/api/v3/ecf/schools_query_spec.rb
+++ b/spec/services/api/v3/ecf/schools_query_spec.rb
@@ -107,7 +107,11 @@ RSpec.describe Api::V3::ECF::SchoolsQuery do
 
       context "sorting" do
         let!(:eligible_school) { create(:school, :eligible) }
-        let!(:another_eligible_school) { create(:school, :eligible, created_at: 10.days.ago) }
+        let!(:another_eligible_school) do
+          travel_to(10.days.ago) do
+            create(:school, :eligible)
+          end
+        end
 
         it "returns all records ordered by created_at" do
           expect(subject.schools).to eq([another_eligible_school, eligible_school])

--- a/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
+++ b/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
@@ -54,7 +54,11 @@ RSpec.describe Api::V3::ECF::UnfundedMentorsQuery, :with_default_schedules do
     end
 
     context "sorting" do
-      let(:user) { create(:user, email: "mary.lewis@example.com", created_at: 10.days.ago) }
+      let(:user) do
+        travel_to(10.days.ago) do
+          create(:user, email: "mary.lewis@example.com")
+        end
+      end
       let!(:another_unfunded_mentor_profile) { create(:mentor, :eligible_for_funding, user:) }
       let!(:another_unfunded_mentor_induction_record) { create(:induction_record, induction_programme:, mentor_profile: another_unfunded_mentor_profile) }
 

--- a/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
+++ b/spec/services/api/v3/ecf/unfunded_mentors_query_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe Api::V3::ECF::UnfundedMentorsQuery, :with_default_schedules do
         end
       end
     end
+
+    context "sorting" do
+      let(:user) { create(:user, email: "mary.lewis@example.com", created_at: 10.days.ago) }
+      let!(:another_unfunded_mentor_profile) { create(:mentor, :eligible_for_funding, user:) }
+      let!(:another_unfunded_mentor_induction_record) { create(:induction_record, induction_programme:, mentor_profile: another_unfunded_mentor_profile) }
+
+      it "returns all unfunded mentors ordered by users created_at" do
+        expect(subject.unfunded_mentors.map(&:user_id)).to eq([another_unfunded_mentor_profile.user.id, unfunded_mentor_profile_user_id])
+      end
+    end
   end
 
   describe "#unfunded_mentor" do

--- a/spec/services/api/v3/npq_participants_query_spec.rb
+++ b/spec/services/api/v3/npq_participants_query_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Api::V3::NPQParticipantsQuery, :with_default_schedules do
         end
       end
     end
+
+    context "sorting" do
+      let!(:another_participant_profile) { create(:npq_participant_profile, npq_lead_provider:, npq_course:, created_at: 10.days.ago) }
+
+      it "returns all records ordered by participant profile created_at" do
+        expect(subject.participants.map(&:id)).to eq([another_participant_profile.user_id, participant_profile.user_id])
+      end
+    end
   end
 
   describe "#participant" do

--- a/spec/services/api/v3/npq_participants_query_spec.rb
+++ b/spec/services/api/v3/npq_participants_query_spec.rb
@@ -43,7 +43,11 @@ RSpec.describe Api::V3::NPQParticipantsQuery, :with_default_schedules do
     end
 
     context "sorting" do
-      let!(:another_participant_profile) { create(:npq_participant_profile, npq_lead_provider:, npq_course:, created_at: 10.days.ago) }
+      let!(:another_participant_profile) do
+        travel_to(10.days.ago) do
+          create(:npq_participant_profile, npq_lead_provider:, npq_course:)
+        end
+      end
 
       it "returns all records ordered by participant profile created_at" do
         expect(subject.participants.map(&:id)).to eq([another_participant_profile.user_id, participant_profile.user_id])


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2203](https://dfedigital.atlassian.net/browse/CPDLP-2203)

We would like to sort all endpoints consistently in v3 as currently they are different

### Changes proposed in this pull request

Make sorting consistent across v3 endpoints sorting it by created_at: :asc



[CPDLP-2203]: https://dfedigital.atlassian.net/browse/CPDLP-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ