### PR TITLE
[CST-1486] Add mentors who are ECTs

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -170,7 +170,7 @@ module Participants
     end
 
     def change_participant_cohort_and_induction_start_date!
-      Participants::SyncDqtInductionStartDate.call(dqt_response[:induction_start_date], participant_profile) unless dqt_response.blank?
+      Participants::SyncDqtInductionStartDate.call(dqt_response[:induction_start_date], participant_profile) if dqt_response.present?
     end
 
     def store_analytics!

--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -170,7 +170,7 @@ module Participants
     end
 
     def change_participant_cohort_and_induction_start_date!
-      Participants::SyncDqtInductionStartDate.call(dqt_response[:induction_start_date], participant_profile)
+      Participants::SyncDqtInductionStartDate.call(dqt_response[:induction_start_date], participant_profile) unless dqt_response.blank?
     end
 
     def store_analytics!

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -101,7 +101,11 @@ module Schools
         # Finish enroll process and send notification emails
         profile = nil
         ActiveRecord::Base.transaction do
-          profile = if ect_participant?
+          profile = if ect_mentor?
+                      Mentors::AddProfileToECT.call(ect_profile: existing_participant_profile,
+                                                    school_cohort:,
+                                                    preferred_email: email)
+                    elsif ect_participant?
                       EarlyCareerTeachers::Create.call(**participant_create_args)
                     else
                       Mentors::Create.call(**participant_create_args.except(:induction_start_date, :mentor_profile_id))

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -19,6 +19,7 @@ module Schools
                :induction_start_date, :nino, :ect_participant?, :mentor_id, :continue_current_programme?, :participant_profile,
                :sit_mentor?, :mentor_participant?, :appropriate_body_confirmed?, :appropriate_body_id, :known_by_another_name?,
                :same_provider?, :was_withdrawn_participant?, :complete?, :start_date, :start_term, :last_visited_step,
+               :ect_mentor?,
                to: :data_store
 
       def initialize(current_step:, data_store:, current_user:, school:, submitted_params: {})
@@ -89,6 +90,10 @@ module Schools
         else
           data_store.email
         end
+      end
+
+      def set_ect_mentor
+        data_store.set(:ect_mentor, true)
       end
 
       def join_school_programme?
@@ -503,6 +508,7 @@ module Schools
           last_visited_step
           school_cohort_id
           school_id
+          ect_mentor
         ].each do |key|
           data_store.set(key, nil)
         end

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -149,7 +149,14 @@ module Schools
 
       def email_in_use?
         @email_owner ||= Identity.find_user_by(email: data_store.email)
-        return false if @email_owner.nil? || !@email_owner.participant?
+        return false if @email_owner.nil?
+
+        if ect_mentor?
+          # email_owner must be the same as existing ECT user
+          return @email_owner != existing_user
+        end
+
+        return false unless @email_owner.participant?
         return true unless transfer?
 
         @email_owner != existing_user

--- a/app/forms/schools/add_participants/wizard_steps/who_to_add_participant_checks.rb
+++ b/app/forms/schools/add_participants/wizard_steps/who_to_add_participant_checks.rb
@@ -6,39 +6,69 @@ module Schools
       module WhoToAddParticipantChecks
         def next_step_after_participant_check
           if wizard.participant_exists?
-            if wizard.existing_participant_is_a_different_type?
-              if wizard.ect_participant?
-                # trying to add an ECT who is already a mentor
-                :cannot_add_ect_because_already_a_mentor
-              else
-                # trying to add a mentor who is already an ECT
-                :cannot_add_mentor_because_already_an_ect
-              end
-            elsif wizard.already_enrolled_at_school?
-              :cannot_add_already_enrolled_at_school
-            elsif wizard.ect_participant?
-              :confirm_transfer
+            existing_participant_checks
+          else
+            new_participant_checks
+          end
+        end
+
+        def existing_participant_checks
+          if adding_a_mentor_profile_to_an_ect?
+            if wizard.already_enrolled_at_school?
+              wizard.set_ect_mentor
+              cohort_checks
             else
-              :confirm_mentor_transfer
+              # FIXME: not the right thing but to enable a happy path to work
+              :cannot_add_mentor_because_already_an_ect
             end
-          elsif wizard.dqt_record_has_different_name?
+          elsif adding_an_ect_profile_to_a_mentor?
+            :cannot_add_ect_because_already_a_mentor
+          elsif wizard.already_enrolled_at_school?
+            :cannot_add_already_enrolled_at_school
+          else
+            transfer_step_for_type
+          end
+        end
+
+        def new_participant_checks
+          if wizard.dqt_record_has_different_name?
             :known_by_another_name
           elsif wizard.found_participant_in_dqt? || wizard.sit_mentor?
-            if wizard.needs_to_confirm_start_term?
-              # we're not sure at this point which cohort is needed
-              # so allow to procedd at this point
-              :none
-            elsif !wizard.registration_open_for_participant_cohort?
-              # we know the cohort at this point (only if induction start date set)
-              :cannot_add_registration_not_yet_open
-            elsif wizard.need_training_setup?
-              # check that there is a school_cohort to join (can be FIP or CIP)
-              :need_training_setup
-            else
-              :none
-            end
+            cohort_checks
           else
             :cannot_find_their_details
+          end
+        end
+
+        def adding_a_mentor_profile_to_an_ect?
+          wizard.existing_participant_is_a_different_type? && wizard.mentor_participant?
+        end
+
+        def adding_an_ect_profile_to_a_mentor?
+          wizard.existing_participant_is_a_different_type? && wizard.ect_participant?
+        end
+
+        def transfer_step_for_type
+          if wizard.ect_participant?
+            :confirm_transfer
+          else
+            :confirm_mentor_transfer
+          end
+        end
+
+        def cohort_checks
+          if wizard.needs_to_confirm_start_term?
+            # we're not sure at this point which cohort is needed
+            # so allow to procedd at this point
+            :none
+          elsif !wizard.registration_open_for_participant_cohort?
+            # we know the cohort at this point (only if induction start date set)
+            :cannot_add_registration_not_yet_open
+          elsif wizard.need_training_setup?
+            # check that there is a school_cohort to join (can be FIP or CIP)
+            :need_training_setup
+          else
+            :none
           end
         end
       end

--- a/app/models/participant_profile/npq.rb
+++ b/app/models/participant_profile/npq.rb
@@ -102,6 +102,11 @@ class ParticipantProfile < ApplicationRecord
       ParticipantProfile::NPQPolicy
     end
 
+    def role
+      # not sure what this should be but incase it's needed in the dashboard it won't break
+      "NPQ"
+    end
+
   private
 
     def push_profile_to_big_query

--- a/app/services/form_data/add_participant_store.rb
+++ b/app/services/form_data/add_participant_store.rb
@@ -132,5 +132,9 @@ module FormData
     def history_stack
       get(:history_stack) || []
     end
+
+    def ect_mentor?
+      get(:ect_mentor) == true
+    end
   end
 end

--- a/app/services/mentors/add_profile_to_ect.rb
+++ b/app/services/mentors/add_profile_to_ect.rb
@@ -17,7 +17,6 @@ module Mentors
           sparsity_uplift: sparsity_uplift?(start_year),
           pupil_premium_uplift: pupil_premium_uplift?(start_year),
           school_cohort:,
-          start_term:,
         )
 
         ParticipantProfileState.create!(participant_profile: mentor_profile,
@@ -40,12 +39,11 @@ module Mentors
 
   private
 
-    attr_reader :ect_profile, :preferred_email, :start_term, :school_cohort, :start_date
+    attr_reader :ect_profile, :preferred_email, :school_cohort, :start_date
 
-    def initialize(ect_profile:, school_cohort:, preferred_email: nil, start_term: nil, start_date: nil)
+    def initialize(ect_profile:, school_cohort:, preferred_email: nil, start_date: nil)
       @ect_profile = ect_profile
       @preferred_email = preferred_email || ect_profile.participant_identity.email
-      @start_term = start_term || school_cohort.cohort.start_term_options.first
       @start_date = start_date
       @school_cohort = school_cohort
     end

--- a/app/services/mentors/add_profile_to_ect.rb
+++ b/app/services/mentors/add_profile_to_ect.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Mentors
+  class AddProfileToECT < BaseService
+    include SchoolCohortDelegator
+
+    def call
+      check_no_mentor_profiles_exist!
+
+      mentor_profile = nil
+
+      ActiveRecord::Base.transaction do
+        mentor_profile = ParticipantProfile::Mentor.create!(
+          teacher_profile: ect_profile.teacher_profile,
+          participant_identity: ect_profile.participant_identity,
+          schedule: Finance::Schedule::ECF.default_for(cohort: school_cohort.cohort),
+          sparsity_uplift: sparsity_uplift?(start_year),
+          pupil_premium_uplift: pupil_premium_uplift?(start_year),
+          school_cohort:,
+          start_term:,
+        )
+
+        ParticipantProfileState.create!(participant_profile: mentor_profile,
+                                        cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+
+        if school_cohort.default_induction_programme.present?
+          Induction::Enrol.call(participant_profile: mentor_profile,
+                                induction_programme: school_cohort.default_induction_programme,
+                                preferred_email:,
+                                start_date:)
+        end
+
+        Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile:, preferred_email:)
+
+        validate! mentor_profile
+      end
+
+      mentor_profile
+    end
+
+  private
+
+    attr_reader :ect_profile, :preferred_email, :start_term, :school_cohort, :start_date
+
+    def initialize(ect_profile:, school_cohort:, preferred_email: nil, start_term: nil, start_date: nil)
+      @ect_profile = ect_profile
+      @preferred_email = preferred_email || ect_profile.participant_identity.email
+      @start_term = start_term || school_cohort.cohort.start_term_options.first
+      @start_date = start_date
+      @school_cohort = school_cohort
+    end
+
+    def validate!(mentor_profile)
+      return if ect_profile.ecf_participant_validation_data.blank?
+
+      validation_data = ect_profile.ecf_participant_validation_data.dup
+      validation_data.participant_profile = mentor_profile
+      validation_data.save!
+
+      Participants::ParticipantValidationForm.call(mentor_profile)
+    end
+
+    def check_no_mentor_profiles_exist!
+      raise "Mentor profile exists" if ect_profile.teacher_profile.ecf_profiles.mentors.any?
+    end
+
+    def start_year
+      @start_year ||= school_cohort.cohort.start_year
+    end
+  end
+end

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl"><%= @profile.full_name %></h1>
 
-    <h2 class="govuk-heading-l"><%= @profile.user_description %></h2>
+    <h2 class="govuk-heading-l"><%= @profile.role %></h2>
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-7">
       <div class="govuk-summary-list__row">

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -13,15 +13,27 @@ FactoryBot.define do
     administrative_district_code { "E123" }
 
     trait :pupil_premium_uplift do
-      pupil_premiums { [build(:pupil_premium, :uplift)] }
+      transient do
+        start_year { 2021 }
+      end
+
+      pupil_premiums { [build(:pupil_premium, :uplift, start_year:)] }
     end
 
     trait :sparsity_uplift do
-      pupil_premiums { [build(:pupil_premium, :sparse)] }
+      transient do
+        start_year { 2021 }
+      end
+
+      pupil_premiums { [build(:pupil_premium, :sparse, start_year:)] }
     end
 
     trait :pupil_premium_and_sparsity_uplift do
-      pupil_premiums { [build(:pupil_premium, :uplift, :sparse)] }
+      transient do
+        start_year { 2021 }
+      end
+
+      pupil_premiums { [build(:pupil_premium, :uplift, :sparse, start_year:)] }
     end
 
     trait :with_local_authority do

--- a/spec/factories/school.rb
+++ b/spec/factories/school.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     trait :pupil_premium_uplift do
       transient do
-        start_year { 2021 }
+        start_year { build(:cohort, :current).start_year }
       end
 
       pupil_premiums { [build(:pupil_premium, :uplift, start_year:)] }
@@ -22,7 +22,7 @@ FactoryBot.define do
 
     trait :sparsity_uplift do
       transient do
-        start_year { 2021 }
+        start_year { build(:cohort, :current).start_year }
       end
 
       pupil_premiums { [build(:pupil_premium, :sparse, start_year:)] }
@@ -30,7 +30,7 @@ FactoryBot.define do
 
     trait :pupil_premium_and_sparsity_uplift do
       transient do
-        start_year { 2021 }
+        start_year { build(:cohort, :current).start_year }
       end
 
       pupil_premiums { [build(:pupil_premium, :uplift, :sparse, start_year:)] }

--- a/spec/factories/seeds/induction_programme_factory.rb
+++ b/spec/factories/seeds/induction_programme_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
 
     trait(:with_school_cohort) { association(:school_cohort, factory: %i[seed_school_cohort valid]) }
     trait(:with_school) { association(:school, factory: :seed_school) }
-    trait(:with_partnership) { association(:partnership, factory: :seed_partnership) }
+    trait(:with_partnership) { association(:partnership, factory: %i[seed_partnership valid]) }
 
     trait(:valid) { with_school_cohort }
 

--- a/spec/factories/seeds/pupil_premium_factory.rb
+++ b/spec/factories/seeds/pupil_premium_factory.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_pupil_premium, class: "PupilPremium") do
+    start_year { build(:cohort, :current).start_year }
+    pupil_premium_incentive { false }
+    sparsity_incentive { false }
+
+    trait :with_school do
+      association(:school, factory: %i[seed_school valid])
+    end
+
+    trait(:with_pupil_premiums) do
+      pupil_premium_incentive { true }
+    end
+
+    trait(:with_sparsity) do
+      sparsity_incentive { true }
+    end
+
+    trait(:with_uplifts) do
+      with_pupil_premiums
+      with_sparsity
+    end
+
+    trait(:valid) do
+      with_school
+    end
+
+    after(:build) { |pp| Rails.logger.debug("seeded pupil_premium for #{pp.start_year}") }
+  end
+end

--- a/spec/factories/seeds/school_factory.rb
+++ b/spec/factories/seeds/school_factory.rb
@@ -27,6 +27,30 @@ FactoryBot.define do
     trait(:cip_only) { school_type_code { GiasTypes::CIP_ONLY_TYPE_CODES.sample } }
     trait(:ineligible) { school_type_code { 10 } }
 
+    trait(:with_pupil_premium_uplift) do
+      transient do
+        start_year { build(:cohort, :current).start_year }
+      end
+
+      pupil_premiums { [build(:seed_pupil_premium, :with_pupil_premiums, start_year:)] }
+    end
+
+    trait(:with_sparsity_uplift) do
+      transient do
+        start_year { build(:cohort, :current).start_year }
+      end
+
+      pupil_premiums { [build(:seed_pupil_premium, :with_sparsity, start_year:)] }
+    end
+
+    trait(:with_uplifts) do
+      transient do
+        start_year { build(:cohort, :current).start_year }
+      end
+
+      pupil_premiums { [build(:seed_pupil_premium, :with_uplifts, start_year:)] }
+    end
+
     trait(:valid) {}
 
     after(:build) { |s| Rails.logger.debug("seeded school #{s.name}") }

--- a/spec/forms/schools/add_participants/add_wizard_spec.rb
+++ b/spec/forms/schools/add_participants/add_wizard_spec.rb
@@ -1,154 +1,76 @@
 # frozen_string_literal: true
 
 # TODO: needs refactoring for new wizard form
-RSpec.xdescribe Schools::AddParticipants::AddWizard, type: :model do
-  let(:school_cohort) { create(:school_cohort) }
-  let(:school) { school_cohort.school }
-  let(:user) { create :user }
+RSpec.describe Schools::AddParticipants::AddWizard, type: :model do
+  let(:cohort) { Cohort.current || create(:cohort, :current) }
+  let(:current_step) { :email }
+  let(:data_store) { instance_double(FormData::AddParticipantStore) }
+  let(:school) { create(:seed_school, :with_induction_coordinator) }
+  let(:school_cohort) { create(:seed_school_cohort, :fip, cohort:, school:) }
+  let!(:induction_programme) { create(:seed_induction_programme, :fip, :with_partnership, school_cohort:, school:, cohort:) }
+  let(:sit_user) { school.induction_coordinators.first }
+  let(:submitted_params) { {} }
 
-  let!(:cohort) { Cohort.current || create(:cohort, :current) }
-  let!(:dqt_response) do
-    {
-      trn: "1234567",
-      full_name: "Danny DeVito",
-      nino: "AB 12 34 56 D",
-      dob: Date.new(1990, 1, 1),
-      config: {},
-    }
+  subject(:wizard) { described_class.new(current_step:, data_store:, current_user: sit_user, school:, submitted_params:) }
+
+  before do
+    allow(data_store).to receive(:store).and_return({ something: "is here" })
+    allow(data_store).to receive(:current_user).and_return(sit_user)
+    allow(data_store).to receive(:school_id).and_return(school.slug)
+    allow(data_store).to receive(:set)
   end
 
-  subject(:form) { described_class.new(current_user_id: user.id, school_cohort_id: school_cohort.id) }
+  describe "email_in_use?" do
+    let(:ect_mentor) { false }
+    let(:transfer) { false }
+    let(:confirmed_trn) { "0012345" }
 
-  it { is_expected.to validate_presence_of(:full_name).on(:name).with_message("Enter a full name") }
-  it { is_expected.to validate_presence_of(:trn).on(:trn).with_message("Enter the teacher reference number (TRN)") }
-  it { is_expected.to validate_presence_of(:date_of_birth).on(:dob) }
-  it { is_expected.to validate_presence_of(:nino).on(:nino).with_message("Enter the national insurance number (NINo)") }
-  it { is_expected.to validate_presence_of(:email).on(:email).with_message("Enter an email address") }
-  it { is_expected.to validate_presence_of(:start_date).on(:start_date) }
-  it { is_expected.to validate_presence_of(:transfer).on(:transfer) }
-
-  describe "start_date validation" do
-    it "permits dates from 1/9/2021" do
-      form.start_date = Date.new(2021, 9, 1)
-      expect(form.valid?(:start_date)).to be true
-    end
-
-    it "permits dates up to 1 year from now" do
-      form.start_date = Date.current + 1.year
-      expect(form.valid?(:start_date)).to be true
-    end
-
-    it "does not permit a date prior to 1/9/2021" do
-      form.start_date = Date.new(2021, 8, 31)
-      expect(form.valid?(:start_date)).to be false
-      expect(form.errors[:start_date]).to be_present
-    end
-
-    it "does not permit a date more that 1 year in the future" do
-      form.start_date = Date.current + 1.year + 1.day
-      expect(form.valid?(:start_date)).to be false
-      expect(form.errors[:start_date]).to be_present
-    end
-  end
-
-  describe "when a record matches the validation data" do
     before do
-      form.trn = "1234567"
-      form.date_of_birth = Date.new(1990, 1, 1)
-      form.full_name = "Danny DeVito"
-      allow(ParticipantValidationService).to receive(:validate).and_return(dqt_response)
-    end
-
-    it "returns a response from the dqt" do
-      form.complete_step(:dob, date_of_birth: form.date_of_birth)
-      expect(form.dqt_record).to eq(dqt_response)
-    end
-  end
-
-  describe "mentor_options" do
-    it "does not include mentors with withdrawn records" do
-      create(:ecf_schedule)
-      withdrawn_mentor_record = create(:mentor, :withdrawn_record, school_cohort:).user
-
-      expect(form.mentor_options).not_to include(withdrawn_mentor_record)
-    end
-
-    it "includes active mentors" do
-      create(:ecf_schedule)
-      active_mentor_record = create(:mentor, school_cohort:).user
-
-      expect(form.mentor_options).to include(active_mentor_record)
-    end
-
-    context "when multiple cohorts are active" do
-      let(:previous_cohort) { Cohort.previous || create(:cohort, :previous) }
-      let(:school_cohort_2) { create(:school_cohort, school:, cohort: previous_cohort) }
-
-      context "when there are mentors in the school mentor pool" do
-        let(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
-        let(:mentor_profile_2) { create(:mentor_participant_profile, school_cohort: school_cohort_2) }
-
-        before do
-          Mentors::AddToSchool.call(school:, mentor_profile:)
-          Mentors::AddToSchool.call(school:, mentor_profile: mentor_profile_2)
-        end
-
-        it "includes to mentors in the pool" do
-          expect(form.mentor_options).to match_array [mentor_profile.user, mentor_profile_2.user]
-        end
-      end
-
-      context "when there are no mentors in the school mentor pool" do
-        it "does not return any mentors" do
-          expect(form.mentor_options).to be_empty
-        end
-      end
-    end
-  end
-
-  describe "email_already_taken?" do
-    before do
-      form.email = "ray.clemence@example.com"
+      allow(data_store).to receive(:email).and_return("ray.clemence@example.com")
+      allow(data_store).to receive(:ect_mentor?).and_return(ect_mentor)
+      allow(data_store).to receive(:transfer?).and_return(transfer)
+      allow(data_store).to receive(:confirmed_trn).and_return(confirmed_trn)
     end
 
     context "when the email is not already in use" do
       it "returns false" do
-        expect(form).not_to be_email_already_taken
+        expect(wizard).not_to be_email_in_use
       end
     end
 
-    context "when the email is in use by an ECT user" do
+    context "when the email is in use by an ECF user" do
       let(:user) { create(:user, email: "ray.clemence@example.com") }
-      let(:teacher_profile) { create(:teacher_profile, user:) }
+      let(:teacher_profile) { create(:teacher_profile, user:, trn: confirmed_trn) }
       let!(:ect_profile) { create(:ect_participant_profile, teacher_profile:) }
 
       it "returns true" do
-        expect(form).to be_email_already_taken
+        expect(wizard).to be_email_in_use
       end
 
-      context "when the ECT profile record is withdrawn" do
+      context "when adding a mentor profile to an ECT" do
+        let(:ect_mentor) { true }
+
+        it "returns false" do
+          expect(wizard).not_to be_email_in_use
+        end
+
+        context "when the email owner is different ECF participant" do
+          let(:user) { create(:seed_user, email: "nigel.martyn@example.com") }
+          let(:email_owner) { create(:seed_user, email: "ray.clemence@example.com") }
+          let(:owner_teacher_profile) { create(:seed_teacher_profile, user: email_owner, trn: "1234567") }
+          let!(:owner_profile) { create(:ect_participant_profile, teacher_profile: owner_teacher_profile) }
+
+          it "returns true" do
+            expect(wizard).to be_email_in_use
+          end
+        end
+      end
+
+      context "when the profile record is withdrawn" do
         let!(:ect_profile) { create(:ect_participant_profile, :withdrawn_record, teacher_profile:) }
 
         it "returns false" do
-          expect(form).not_to be_email_already_taken
-        end
-      end
-    end
-
-    context "when the email is in use by a Mentor" do
-      let(:user) { create(:user, email: "ray.clemence@example.com") }
-      let(:teacher_profile) { create(:teacher_profile, user:) }
-      let!(:mentor_profile) { create(:mentor_participant_profile, teacher_profile:) }
-
-      it "returns true" do
-        expect(form).to be_email_already_taken
-      end
-
-      context "when the mentor profile record is withdrawn" do
-        let!(:mentor_profile) { create(:mentor_participant_profile, :withdrawn_record, teacher_profile:) }
-
-        it "returns false" do
-          expect(form).not_to be_email_already_taken
+          expect(wizard).not_to be_email_in_use
         end
       end
     end
@@ -159,126 +81,8 @@ RSpec.xdescribe Schools::AddParticipants::AddWizard, type: :model do
       let!(:npq_profile) { create(:npq_participant_profile, teacher_profile:) }
 
       it "returns false" do
-        expect(form).not_to be_email_already_taken
+        expect(wizard).not_to be_email_in_use
       end
-    end
-  end
-
-  describe "can_add_self?" do
-    context "when the user is not a mentor" do
-      it "returns true" do
-        expect(form.can_add_self?).to be true
-      end
-    end
-
-    context "when the user is a mentor at another school" do
-      before do
-        create(:mentor_participant_profile, user:)
-      end
-
-      it "returns false" do
-        expect(form.can_add_self?).to be false
-      end
-    end
-
-    context "when the user is a mentor at this school" do
-      before do
-        create(:mentor_participant_profile, user:, school_cohort:)
-      end
-
-      it "returns false" do
-        expect(form.can_add_self?).to be false
-      end
-    end
-  end
-
-  describe "#display_name" do
-    it "returns your" do
-      form.assign_attributes(type: :self)
-      expect(form.display_name).to eql("your")
-    end
-
-    it "returns the name of the participant who's being added" do
-      form.assign_attributes(type: :mentor, full_name: user.full_name)
-      expect(form.display_name).to eql("#{user.full_name}’s")
-    end
-  end
-
-  describe "#save!" do
-    before do
-      response = {
-        trn: form.trn,
-        full_name: form.full_name,
-        nino: form.formatted_nino,
-        date_of_birth: form.date_of_birth,
-        config: {},
-      }
-
-      form.type = %i[ect mentor].sample
-      form.full_name = Faker::Name.name
-      form.email = Faker::Internet.email
-      form.trn = "1234567"
-      form.date_of_birth = Date.new(1990, 1, 1)
-      form.nino = "AB123456D"
-      form.start_date = Date.new(2022, 9, 1)
-      form.dqt_record = dqt_response
-      form.mentor_id = (form.mentor_options.pluck(:id) + %w[later]).sample if form.type == :ect
-      allow(ParticipantValidationService).to receive(:validate).and_return(response)
-
-      create(:ecf_schedule)
-    end
-
-    context "Participant has been added" do
-      context "When participant details validated against the DQT" do
-        it "creates new participant record" do
-          expect { form.save! }.to change(ParticipantProfile::ECF, :count).by 1
-        end
-
-        it "creates new validation data" do
-          expect { form.save! }.to change(ECFParticipantValidationData, :count).by 1
-        end
-
-        it "does not send a participant added mail" do
-          expect { form.save! }.not_to have_enqueued_mail(ParticipantMailer, :participant_added)
-        end
-
-        it "sends the SIT an email saying they have been added and validated" do
-          expect { form.save! }
-            .to have_enqueued_mail(ParticipantMailer, :sit_has_added_and_validated_participant)
-              .with(
-                params: {
-                  school_name: school_cohort.school.name,
-                },
-                args: [],
-              )
-        end
-      end
-
-      context "A SIT is adding themselves as a mentor and type is not self" do
-        it "does not send the SIT an email saying they have been added and validated" do
-          create(:induction_coordinator_profile, user:)
-          expect { form.save! }.not_to have_enqueued_mail(ParticipantMailer, :sit_has_added_and_validated_participant)
-        end
-      end
-
-      context "A SIT is adding themselves as a mentor and type is set to self" do
-        it "does not send the SIT an email saying they have been added and validated" do
-          form.type = :self
-          expect { form.save! }.not_to have_enqueued_mail(ParticipantMailer, :sit_has_added_and_validated_participant)
-        end
-      end
-    end
-  end
-
-  describe "sit_adding_themselves?" do
-    it "returns true when type is set to self" do
-      form.type = :self
-      expect(form.sit_adding_themselves?).to be true
-    end
-
-    it "returns false when type is not self" do
-      form.type = :mentor
-      expect(form.sit_adding_themselves?).to be false
     end
   end
 end

--- a/spec/forms/schools/add_participants/wizard_steps/nino_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/nino_step_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
     let(:participant_exists) { false }
     let(:different_participant_type) { false }
     let(:ect_participant) { false }
+    let(:mentor_participant) { false }
     let(:already_at_school) { false }
     let(:different_name) { false }
     let(:found_dqt_record) { false }
@@ -31,6 +32,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
       allow(wizard).to receive(:participant_exists?).and_return(participant_exists)
       allow(wizard).to receive(:existing_participant_is_a_different_type?).and_return(different_participant_type)
       allow(wizard).to receive(:ect_participant?).and_return(ect_participant)
+      allow(wizard).to receive(:mentor_participant?).and_return(mentor_participant)
       allow(wizard).to receive(:already_enrolled_at_school?).and_return(already_at_school)
       allow(wizard).to receive(:dqt_record_has_different_name?).and_return(different_name)
       allow(wizard).to receive(:found_participant_in_dqt?).and_return(found_dqt_record)
@@ -38,6 +40,38 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
       allow(wizard).to receive(:registration_open_for_participant_cohort?).and_return(registration_open)
       allow(wizard).to receive(:need_training_setup?).and_return(need_setup)
       allow(wizard).to receive(:needs_to_confirm_start_term?).and_return(confirm_start_term)
+    end
+
+    shared_examples "cohort and registration checks" do
+      context "when registration is available" do
+        let(:registration_open) { true }
+
+        it "returns :none" do
+          expect(step.next_step).to eql :none
+        end
+
+        context "when the participant will be asked the start_term question" do
+          let(:confirm_start_term) { true }
+
+          it "returns :none" do
+            expect(step.next_step).to eql :none
+          end
+        end
+
+        context "when the cohort needs to be set up" do
+          let(:need_setup) { true }
+
+          it "returns :need_training_setup" do
+            expect(step.next_step).to eql :need_training_setup
+          end
+        end
+      end
+
+      context "when registration is not open" do
+        it "returns :cannot_add_registration_not_yet_open" do
+          expect(step.next_step).to eql :cannot_add_registration_not_yet_open
+        end
+      end
     end
 
     context "when the participant exists in the service" do
@@ -55,8 +89,20 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
         end
 
         context "when the new participant is a mentor" do
+          let(:mentor_participant) { true }
+
           it "returns :cannot_add_mentor_because_already_an_ECT" do
             expect(step.next_step).to eql :cannot_add_mentor_because_already_an_ect
+          end
+
+          context "when the ECT is already enrolled at the school" do
+            let(:already_at_school) { true }
+
+            before do
+              allow(wizard).to receive(:set_ect_mentor)
+            end
+
+            include_examples "cohort and registration checks"
           end
         end
       end
@@ -95,35 +141,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::NinoStep, type: :model do
     context "when a matching dqt record has been found" do
       let(:found_dqt_record) { true }
 
-      context "when registration is not open" do
-        it "returns :cannot_add_registration_not_yet_open" do
-          expect(step.next_step).to eql :cannot_add_registration_not_yet_open
-        end
-      end
-
-      context "when registration is open" do
-        let(:registration_open) { true }
-
-        it "returns :none" do
-          expect(step.next_step).to eql :none
-        end
-
-        context "when the participant will be asked the start_term question" do
-          let(:confirm_start_term) { true }
-
-          it "returns :none" do
-            expect(step.next_step).to eql :none
-          end
-        end
-
-        context "when the cohort needs to be set up" do
-          let(:need_setup) { true }
-
-          it "returns :need_training_setup" do
-            expect(step.next_step).to eql :need_training_setup
-          end
-        end
-      end
+      include_examples "cohort and registration checks"
     end
 
     context "when adding a sit_mentor" do

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
 
       context "when the participant is also a mentor" do
         let(:user) { ect_profile.user }
-        let(:mentor_profile) { create(:mentor, :eligible_for_funding, lead_provider: cpd_lead_provider.lead_provider, user:) }
+        let!(:mentor_profile) { create(:mentor, :eligible_for_funding, lead_provider: cpd_lead_provider.lead_provider, user:) }
         let(:mentor_valid_params) do
           {
             participant_id: user.id,

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -149,6 +149,37 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
         end
       end
 
+      context "when the participant is also a mentor" do
+        let(:user) { ect_profile.user }
+        let(:mentor_profile) { create(:mentor, :eligible_for_funding, lead_provider: cpd_lead_provider.lead_provider, user:) }
+        let(:mentor_valid_params) do
+          {
+            participant_id: user.id,
+            declaration_type: "started",
+            declaration_date: declaration_date.rfc3339,
+            course_identifier: "ecf-mentor",
+          }
+        end
+
+        it "can create declaration records for the ect profile", :aggregate_failures do
+          params = build_params(valid_params)
+          expect { post "/api/v2/participant-declarations", params: }
+            .to change { ect_profile.participant_declarations.count }.by(1)
+            .and change { ParticipantDeclarationAttempt.where(user:).count }.by(1)
+          expect(response.status).to eq 200
+          expect(parsed_response["data"]["id"]).to eq(ect_profile.participant_declarations.order(:created_at).last.id)
+        end
+
+        it "can create declaration records for the mentor profile", :aggregate_failures do
+          params = build_params(mentor_valid_params)
+          expect { post "/api/v2/participant-declarations", params: }
+            .to change { mentor_profile.participant_declarations.count }.by(1)
+            .and change { ParticipantDeclarationAttempt.where(user:).count }.by(1)
+          expect(response.status).to eq 200
+          expect(parsed_response["data"]["id"]).to eq(mentor_profile.participant_declarations.order(:created_at).last.id)
+        end
+      end
+
       it "returns 422 when trying to create for an invalid user id" do
         # Expects the user uuid. Pass the early_career_teacher_profile_id
         invalid_user_id = valid_params.merge({ participant_id: ect_profile.id })

--- a/spec/services/early_career_teachers/create_spec.rb
+++ b/spec/services/early_career_teachers/create_spec.rb
@@ -3,9 +3,10 @@
 RSpec.describe EarlyCareerTeachers::Create, :with_default_schedules do
   let!(:user) { create :user }
   let(:school_cohort) { create :school_cohort }
-  let(:pupil_premium_school) { create :school, :pupil_premium_uplift }
-  let(:sparsity_school) { create :school, :sparsity_uplift }
-  let(:uplift_school) { create :school, :pupil_premium_and_sparsity_uplift }
+  let(:start_year) { school_cohort.cohort.start_year }
+  let(:pupil_premium_school) { create :seed_school, :with_pupil_premium_uplift, start_year: }
+  let(:sparsity_school) { create :seed_school, :with_sparsity_uplift, start_year: }
+  let(:uplift_school) { create :seed_school, :with_uplifts, start_year: }
   let!(:mentor_profile) { create :mentor_participant_profile }
   let!(:npq_participant) { create(:npq_participant_profile).teacher_profile.user }
 

--- a/spec/services/mentors/add_profile_to_ect_spec.rb
+++ b/spec/services/mentors/add_profile_to_ect_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+RSpec.describe Mentors::AddProfileToECT, :with_default_schedules do
+  let(:school) { create(:school) }
+  let(:pupil_premium_school) { create :school, :pupil_premium_uplift, start_year: 2022 }
+  let(:sparsity_school) { create :school, :sparsity_uplift, start_year: 2022 }
+  let(:uplift_school) { create :school, :pupil_premium_and_sparsity_uplift, start_year: 2022 }
+  let(:school_cohort_21) { create(:school_cohort, :fip, :with_ecf_standard_schedule, school:, cohort: Cohort.find_or_create_by!(start_year: 2021)) }
+  let(:school_cohort_22) { create(:school_cohort, :fip, :with_ecf_standard_schedule, school:, cohort: Cohort.find_or_create_by!(start_year: 2022)) }
+  let(:ect_profile) { create(:ect_participant_profile, :ecf_participant_validation_data, :ecf_participant_eligibility, school_cohort: school_cohort_21) }
+  let(:preferred_email) { "mary.mentor@example.com" }
+
+  let(:validation_result) do
+    {
+      trn: ect_profile.teacher_profile.trn,
+      qts: false,
+      active_alert: false,
+      previous_participation: false,
+      previous_induction: false,
+      no_induction: false,
+      exempt_from_induction: false,
+    }
+  end
+
+  subject(:service_call) { described_class.call(ect_profile:, school_cohort: school_cohort_22, preferred_email:) }
+
+  before do
+    allow(ParticipantValidationService).to receive(:validate).and_return(validation_result)
+  end
+
+  it "creates a Mentor record" do
+    expect { service_call }.to change { ect_profile.teacher_profile.ecf_profiles.mentors.count }.by(1)
+  end
+
+  it "adds the mentor to the school mentors pool" do
+    expect { service_call }.to change { school.school_mentors.count }.by(1)
+  end
+
+  it "is created under the same participant identity as the ECT" do
+    mentor_profile = service_call
+    expect(mentor_profile.participant_identity_id).to eq ect_profile.participant_identity_id
+  end
+
+  it "copies the validation data from the ECT profile" do
+    mentor_profile = service_call
+    expect(mentor_profile.ecf_participant_validation_data.attributes).to match(
+      hash_including(ect_profile.ecf_participant_validation_data.attributes.except(*%w[id participant_profile_id created_at updated_at])),
+    )
+  end
+
+  it "reevaluates the participants eligibility" do
+    StoreValidationResult.call(participant_profile: ect_profile, validation_data: nil, dqt_response: validation_result)
+    expect(ect_profile.reload).not_to be_fundable
+
+    mentor_profile = service_call
+    expect(mentor_profile.reload).to be_fundable
+  end
+
+  context "when default induction programme is set on the school cohort" do
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort_22) }
+
+    before do
+      school_cohort_22.update_column(:default_induction_programme_id, induction_programme.id)
+    end
+
+    it "enrolls the mentor into the default induction programme for the school cohort" do
+      expect { service_call }.to change { induction_programme.induction_records.count }.by(1)
+    end
+
+    it "enrolls the mentor with the preferred email address" do
+      mentor_profile = service_call
+      expect(mentor_profile.current_induction_record.preferred_identity.email).to eq preferred_email
+    end
+
+    context "when preferred_email is not set" do
+      let(:preferred_email) { nil }
+
+      it "enrolls the mentor with the participant_identity email" do
+        mentor_profile = service_call
+        expect(mentor_profile.current_induction_record.preferred_identity.email).to eq mentor_profile.participant_identity.email
+      end
+    end
+  end
+
+  context "when there is no default induction programme set" do
+    it "does not enrol the mentor" do
+      expect { service_call }.not_to change { InductionRecord.count }
+    end
+  end
+
+  context "when the school does not have uplifts" do
+    it "does not set any uplift flags on the profile" do
+      mentor_profile = service_call
+      expect(mentor_profile).not_to be_pupil_premium_uplift
+      expect(mentor_profile).not_to be_sparsity_uplift
+    end
+  end
+
+  context "when the school has pupil premium uplift" do
+    let(:school_cohort_22) { create(:school_cohort, :fip, :with_ecf_standard_schedule, school: pupil_premium_school, cohort: Cohort.find_or_create_by!(start_year: 2022)) }
+
+    it "sets pupil_premium_uplift on the profile" do
+      mentor_profile = service_call
+      expect(mentor_profile).to be_pupil_premium_uplift
+      expect(mentor_profile).not_to be_sparsity_uplift
+    end
+  end
+
+  context "when the school has sparsity uplift" do
+    let(:school_cohort_22) { create(:school_cohort, :fip, :with_ecf_standard_schedule, school: sparsity_school, cohort: Cohort.find_or_create_by!(start_year: 2022)) }
+
+    it "sets sparsity_uplift on the profile" do
+      mentor_profile = service_call
+      expect(mentor_profile).not_to be_pupil_premium_uplift
+      expect(mentor_profile).to be_sparsity_uplift
+    end
+  end
+
+  context "when the school has pupil premium and sparsity uplifts" do
+    let(:school_cohort_22) { create(:school_cohort, :fip, :with_ecf_standard_schedule, school: uplift_school, cohort: Cohort.find_or_create_by!(start_year: 2022)) }
+
+    it "sets both sparsity_uplift and pupil_premium_uplift on the profile" do
+      mentor_profile = service_call
+      expect(mentor_profile).to be_pupil_premium_uplift
+      expect(mentor_profile).to be_sparsity_uplift
+    end
+  end
+
+  it "records the profile for analytics" do
+    # creates and updates to ect and mentor profiles are recorded
+    expect { service_call }.to have_enqueued_job(Analytics::UpsertECFParticipantProfileJob).at_least(2).times
+  end
+end


### PR DESCRIPTION
### Context

- Current Tickets:
  - [CST-1486](https://dfedigital.atlassian.net/browse/CST-1486)
  - [CST-1485](https://dfedigital.atlassian.net/browse/CST-1485)
  - [CST-1487](https://dfedigital.atlassian.net/browse/CST-1487)
- Original Ticket: [CST-1016](https://dfedigital.atlassian.net/browse/CST-1016)

Enable an ECT to become a mentor.  The mentor profile should be exposed to providers with the same ID as the ECT profile.
This means that there will be 2 participants with the same ID in the participants API endpoint, they will however be different types and (presumably) be in a different cohort year.
There are a small number of requests for this coming through support so this is the initial step to help us get those mentors in and available for training (and iron out any issues that we may not have thought of). Adding the mentor profile will be a developer task for now (using the `Mentors::AddProfileToECT` service in this PR).

### Changes proposed in this pull request
Adds a new service that:
 * Adds a mentor profile under the same `ParticipantIdentity` as the ECT profile
 * Enrols the mentor profile into the `default_induction_programme` of the `school_cohort` if available
 * Adds the mentor profile to the school's mentor pool
 * Copies the validation data from the ECT and evaluates the eligibility as a mentor

Changes the add participant journey to enable a mentor to be added to an existing ECT __at the same school only__ for the moment

### Guidance to review
* You should be able to add a mentor profile to any existing ECT from add participant journey UI (providing the ECT is at the same school).
* You should be able to add a mentor profile to any existing ECT from the console using the new service.
* In the UI you should see 2 profiles for the user
* You should be able to select the mentor to mentor ECTs at the selected school
* In the participants API endpoint you should see 2 entries for the external_identifier for the user
* You should be able to post declarations to the ECT and mentor profiles individually.



[CST-1486]: https://dfedigital.atlassian.net/browse/CST-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CST-1485]: https://dfedigital.atlassian.net/browse/CST-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CST-1487]: https://dfedigital.atlassian.net/browse/CST-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CST-1016]: https://dfedigital.atlassian.net/browse/CST-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ