### PR TITLE
Bug fix: ECT-register an NPQ+1

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -11,18 +11,14 @@ class Schools::ParticipantsController < Schools::BaseController
   helper_method :can_appropriate_body_be_changed?, :participant_has_appropriate_body?
 
   def index
-    @participants = Dashboard::Participants.new(school: @school,
-                                                user: current_user,
-                                                latest_year: Dashboard::LatestManageableCohort.call(@school).start_year)
+    @participants = Dashboard::Participants.new(school: @school, user: current_user)
   end
 
   def show
     @induction_record = @profile.induction_records.for_school(@school).latest
     @first_induction_record = @profile.induction_records.oldest
     @mentor_profile = @induction_record.mentor_profile
-    @ects = Dashboard::Participants.new(school: @school,
-                                        user: current_user,
-                                        latest_year: Dashboard::LatestManageableCohort.call(@school).start_year)
+    @ects = Dashboard::Participants.new(school: @school, user: current_user)
                                    .ects_mentored_by(@profile)
   end
 

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -9,8 +9,6 @@ module Schools
       class AlreadyInitialised < StandardError; end
       class InvalidStep < StandardError; end
 
-      NPQ_PLUS_1_COHORT_START_YEAR = 2020
-
       attr_reader :current_step, :submitted_params, :data_store, :current_user, :participant_profile, :school
 
       delegate :before_render, to: :form
@@ -363,7 +361,7 @@ module Schools
           existing_participant_cohort || existing_participant_profile&.schedule&.cohort
         elsif ect_participant? && induction_start_date.present?
           Cohort.containing_date(induction_start_date).tap do |cohort|
-            return Cohort.current if cohort.start_year <= NPQ_PLUS_1_COHORT_START_YEAR
+            return Cohort.current if cohort.blank? || cohort.npq_plus_one_or_earlier?
           end
         elsif Cohort.within_automatic_assignment_period?
           # true from 1/9 to end of automatic assignment period

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -9,6 +9,8 @@ module Schools
       class AlreadyInitialised < StandardError; end
       class InvalidStep < StandardError; end
 
+      NPQ_PLUS_1_COHORT_START_YEAR = 2020
+
       attr_reader :current_step, :submitted_params, :data_store, :current_user, :participant_profile, :school
 
       delegate :before_render, to: :form
@@ -360,7 +362,9 @@ module Schools
         if transfer?
           existing_participant_cohort || existing_participant_profile&.schedule&.cohort
         elsif ect_participant? && induction_start_date.present?
-          Cohort.containing_date(induction_start_date)
+          Cohort.containing_date(induction_start_date).tap do |cohort|
+            return Cohort.current if cohort.start_year <= NPQ_PLUS_1_COHORT_START_YEAR
+          end
         elsif Cohort.within_automatic_assignment_period?
           # true from 1/9 to end of automatic assignment period
           Cohort.current

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -3,6 +3,8 @@
 class Cohort < ApplicationRecord
   has_paper_trail
 
+  NPQ_PLUS_1_YEAR = 2020
+
   has_many :call_off_contracts
   has_many :npq_contracts
   has_many :partnerships
@@ -70,6 +72,10 @@ class Cohort < ApplicationRecord
 
   def next
     self.class.find_by(start_year: start_year + 1)
+  end
+
+  def npq_plus_one_or_earlier?
+    start_year <= NPQ_PLUS_1_YEAR
   end
 
   def previous

--- a/app/services/dashboard/mentor.rb
+++ b/app/services/dashboard/mentor.rb
@@ -4,7 +4,7 @@ module Dashboard
   class Mentor
     attr_reader :induction_record, :participant_profile
 
-    def initialize(induction_record:, participant_profile: induction_record&.participant_profile)
+    def initialize(induction_record:, participant_profile:)
       @induction_record = induction_record
       @participant_profile = participant_profile
     end

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -4,8 +4,8 @@ module Dashboard
   class Participants
     attr_reader :mentors, :orphan_ects, :school, :user, :latest_year
 
-    def initialize(school:, user:, latest_year:)
-      @latest_year = latest_year
+    def initialize(school:, user:)
+      @latest_year = Dashboard::LatestManageableCohort.call(school).start_year
       @orphan_ects = []
       @school = school
       @user = user


### PR DESCRIPTION
### Context

The service returns an error when the cohort calculated based on the induction start date of a participant is < 2021 due to lack of default Schedule instance for those cohorts.

### Changes proposed in this pull request
Place these participants in Cohort.current instead.

### Guidance to review

