### PR TITLE
Improve training record spec run time

### DIFF
--- a/spec/services/determine_training_record_state_spec.rb
+++ b/spec/services/determine_training_record_state_spec.rb
@@ -8,43 +8,16 @@ RSpec.describe DetermineTrainingRecordState, :with_training_record_state_example
   subject(:determined_state) { described_class.call(participant_profile:, school: current_school) }
 
   shared_examples "determines states as" do |validation_state, training_eligibility_state, fip_funding_eligibility_state, training_state, record_state|
-    it "#validation_state is set to \":#{validation_state}\"" do
+    it "sets the correct states" do
       expect(determined_state.validation_state).to eq validation_state
-    end
-
-    it "#training_eligibility_state is set to \":#{training_eligibility_state}\"" do
       expect(determined_state.training_eligibility_state).to eq training_eligibility_state
-    end
-
-    it "#fip_funding_eligibility_state is set to \":#{fip_funding_eligibility_state}\"" do
       expect(determined_state.fip_funding_eligibility_state).to eq fip_funding_eligibility_state
-    end
-
-    it "#training_state is set to \":#{training_state}\"" do
       expect(determined_state.training_state).to eq training_state
-    end
-
-    it "#record_state is set to \":#{record_state}\"" do
       expect(determined_state.record_state).to eq record_state
-    end
-
-    it "Each StatusTag has a language file entry for the record_state of \"#{record_state}\"" do
       expect(I18n.t("status_tags.admin_participant_status").keys).to include record_state
-    end
-
-    it "StatusTags::AppropriateBodyParticipantStatusTag has a language file entry for the record_state of \"#{record_state}\"" do
       expect(I18n.t("status_tags.appropriate_body_participant_status").keys).to include record_state
-    end
-
-    it "StatusTags::DeliveryPartnerParticipantStatusTag has a language file entry for the record_state of \"#{record_state}\"" do
       expect(I18n.t("status_tags.delivery_partner_participant_status").keys).to include record_state
-    end
-
-    it "StatusTags::SchoolParticipantStatusTag has a language file entry for the record_state of \"#{record_state}\"" do
       expect(I18n.t("status_tags.school_participant_status").keys).to include record_state
-    end
-
-    it "StatusTags::SchoolParticipantStatusTag has a detailed language file entry for the record_state of \"#{record_state}\"" do
       expect(I18n.t("status_tags.school_participant_status_detailed").keys).to include record_state
     end
   end


### PR DESCRIPTION
### Context
The spec takes 15 minutes to run. This is causing long integration test times
- Ticket: n/a

### Changes proposed in this pull request
Combine expectations in one block to cut times from 15 minutes to around 2 minutes

### Guidance to review
We might need to revisit later for more improvement
