### PR TITLE
[CPLD-2205] Improve participant query performance

### DIFF
--- a/app/controllers/api/v3/ecf/participants_controller.rb
+++ b/app/controllers/api/v3/ecf/participants_controller.rb
@@ -12,7 +12,7 @@ module Api
         # GET /api/v3/participants/ecf?filter[cohort]=2021,2022
         #
         def index
-          render json: serializer_class.new(paginate(participants), params: { cpd_lead_provider: current_user }).serializable_hash.to_json
+          render json: serializer_class.new(participants, params: { cpd_lead_provider: current_user }).serializable_hash.to_json
         end
 
         # Returns a single of ECF participant
@@ -29,8 +29,14 @@ module Api
           Api::V3::ECF::ParticipantSerializer
         end
 
+        def paginated_results
+          paginate(
+            ecf_participant_query.participants_for_pagination,
+          )
+        end
+
         def participants
-          @participants ||= ecf_participant_query.participants.order(sort_params(params, model: User))
+          @participants ||= ecf_participant_query.participants_from(paginated_results).order(sort_params(params, model: User))
         end
 
         def participant

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -36,7 +36,7 @@ module Api
             .from("(#{sub_query.to_sql}) as users")
             .distinct
 
-          params[:sort].blank? ? scope.order("teacher_profiles_participant_profiles.created_at ASC") : scope
+          params[:sort].blank? ? scope.order("participant_profiles_induction_records.created_at ASC") : scope
         end
 
         def participant

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -9,36 +9,38 @@ module Api
           @params = params
         end
 
-        def participants
-          join = InductionRecord
-                   .select(Arel.sql("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id, induction_records.training_status"))
-                   .joins(:participant_profile, :schedule, { induction_programme: :partnership })
-                   .where(
-                     schedule: { cohort_id: with_cohorts.map(&:id) },
-                     induction_programme: {
-                       partnerships: {
-                         lead_provider_id: lead_provider.id,
-                         challenged_at: nil,
-                         challenge_reason: nil,
-                       },
-                     },
-                   )
+        def participants_for_pagination
+          scope = User
+                    .select(:id)
+                    .joins(participant_profiles: :induction_records)
+                    .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
+                    .distinct
+          updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
+        end
+
+        def participants_from(paginated_join)
+          # add subquery to allow grouping by user, to calculate latest induction records for multiple profiles correctly
+          sub_query = User
+                  .select("users.*", "COALESCE(jsonb_agg(DISTINCT latest_induction_records.latest_id), '[]') AS latest_induction_records")
+                  .joins(left_outer_join_teacher_profiles)
+                  .joins(left_outer_join_participant_profiles)
+                  .joins(left_outer_join_induction_records)
+                  .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
+                  .joins("INNER JOIN (#{paginated_join.to_sql}) as tmp on tmp.id = users.id")
+                  .group("users.id")
+                  .distinct
 
           scope = User
-                    .includes(:participant_identities, :teacher_profile, participant_profiles: %i[participant_profile_states schedule teacher_profile ecf_participant_eligibility ecf_participant_validation_data])
-                    .eager_load(participant_profiles: :induction_records)
-                    .joins(left_outer_join_participant_profiles)
-                    .joins(left_outer_join_participant_identities)
-                    .joins("JOIN (#{join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
-                    .joins(left_outer_join_participant_profile_states)
-                    .distinct
+            .select("users.*")
+            .includes(:participant_identities, :teacher_profile, participant_profiles: [:participant_profile_states, :schedule, :teacher_profile, :ecf_participant_eligibility, :ecf_participant_validation_data, { induction_records: [:preferred_identity, :schedule, :delivery_partner, :participant_profile, { mentor_profile: :participant_identity, induction_programme: [school_cohort: %i[school cohort]] }] }])
+            .from("(#{sub_query.to_sql}) as users")
+            .distinct
 
-          scope = updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
           params[:sort].blank? ? scope.order("teacher_profiles_participant_profiles.created_at ASC") : scope
         end
 
         def participant
-          participants.find(params[:id])
+          participants_from(participants_for_pagination).find(params[:id])
         end
 
       private
@@ -47,6 +49,22 @@ module Api
 
         def filter
           params[:filter] ||= {}
+        end
+
+        def latest_induction_records_join
+          InductionRecord
+          .select(Arel.sql("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id"))
+          .joins(:participant_profile, :schedule, { induction_programme: :partnership })
+          .where(
+            schedule: { cohort_id: with_cohorts.map(&:id) },
+            induction_programme: {
+              partnerships: {
+                lead_provider_id: lead_provider.id,
+                challenged_at: nil,
+                challenge_reason: nil,
+              },
+            },
+          )
         end
 
         def with_cohorts
@@ -80,16 +98,16 @@ module Api
           SQL
         end
 
+        def left_outer_join_teacher_profiles
+          "LEFT OUTER JOIN teacher_profiles ON users.id = teacher_profiles.user_id"
+        end
+
         def left_outer_join_participant_profiles
-          "LEFT OUTER JOIN participant_profiles ON participant_profiles.id = induction_records.participant_profile_id"
+          "LEFT OUTER JOIN participant_profiles ON participant_profiles.teacher_profile_id = teacher_profiles.id"
         end
 
-        def left_outer_join_participant_identities
-          "LEFT OUTER JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id"
-        end
-
-        def left_outer_join_participant_profile_states
-          "LEFT OUTER JOIN participant_profile_states pps on participant_profiles.id = pps.participant_profile_id"
+        def left_outer_join_induction_records
+          "LEFT OUTER JOIN induction_records ON participant_profiles.id = induction_records.participant_profile_id"
         end
       end
     end

--- a/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
+++ b/spec/serializers/api/v3/ecf/participant_serializer_spec.rb
@@ -122,6 +122,23 @@ module Api
                 })
               end
             end
+
+            context "when the user is built by a query" do
+              let(:latest_induction_record) { ect_profile.induction_records.latest }
+              let(:participant_from_query) { OpenStruct.new(results) }
+              let(:results) do
+                {
+                  latest_induction_records: [latest_induction_record.id],
+                  participant_profiles: [ect_profile],
+                  participant_identities: participant.participant_identities,
+                }.merge(participant.attributes)
+              end
+              subject { described_class.new([participant_from_query], params: { cpd_lead_provider: }) }
+
+              it "selects the latest induction record correctly" do
+                expect(result[:data][0][:attributes][:ecf_enrolments][0][:email]).to eq(latest_induction_record.preferred_identity.email)
+              end
+            end
           end
         end
       end

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -16,23 +16,150 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
 
   subject { described_class.new(lead_provider:, params:) }
 
-  describe "#participants" do
-    it "returns all induction records" do
-      expect(subject.participants).to match_array([user])
+  describe "#participants_for_pagination" do
+    let(:another_cohort) { create(:cohort, start_year: "2050") }
+    let(:another_schedule) { create(:schedule, name: "ECF September 2050", cohort: another_cohort) }
+    let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
+    let(:another_participant_profile) { create(:ect_participant_profile) }
+    let(:another_induction_programme) { create(:induction_programme, :fip, partnership: another_partnership) }
+    let(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile, schedule: another_schedule) }
+    let!(:another_user) { another_induction_record.user }
+
+    it "returns all users" do
+      expect(subject.participants_for_pagination).to match_array([user, another_user])
+    end
+
+    context "with multiple providers" do
+      let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider).lead_provider }
+      let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider: another_lead_provider) }
+
+      it "returns all users that belong to a provider" do
+        expect(subject.participants_for_pagination).to match_array([user])
+      end
+    end
+
+    context "with cohort filter" do
+      let(:params) { { filter: { cohort: cohort.start_year.to_s } } }
+
+      it "returns all users that belong to a provider" do
+        expect(subject.participants_for_pagination).to match_array([user])
+      end
+    end
+
+    context "with updated_since filter" do
+      let(:params) { { filter: { updated_since: 1.day.ago.iso8601 } } }
+      let(:another_induction_record) do
+        travel_to(10.days.ago) do
+          create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile, schedule: another_schedule)
+        end
+      end
+
+      it "returns all user records for the specific updated_since filter" do
+        expect(subject.participants_for_pagination).to match_array([user])
+      end
+    end
+
+    context "with ect becoming mentor" do
+      let(:mentor_participant_profile) { create(:mentor_participant_profile, participant_identity: user.participant_identities.first, teacher_profile: participant_profile.teacher_profile) }
+      let(:mentor_induction_programme) { create(:induction_programme, :fip, partnership:) }
+      let!(:mentor_induction_record) { create(:induction_record, induction_programme: mentor_induction_programme, participant_profile: mentor_participant_profile, preferred_identity: user.participant_identities.first) }
+
+      it "returns all users without duplicates" do
+        expect(subject.participants_for_pagination).to match_array([user, another_user])
+      end
+    end
+  end
+
+  describe "#participants_from" do
+    let(:another_cohort) { create(:cohort, start_year: "2050") }
+    let(:another_schedule) { create(:schedule, name: "ECF September 2050", cohort: another_cohort) }
+    let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
+    let(:another_participant_profile) { create(:ect_participant_profile) }
+    let(:another_induction_programme) { create(:induction_programme, :fip, partnership: another_partnership) }
+    let(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile, schedule: another_schedule) }
+    let!(:another_user) { another_induction_record.user }
+
+    it "returns all users passed in from query" do
+      expect(subject.participants_from(User.all)).to match_array([user, another_user])
+    end
+
+    it "returns the correct latest induction record per user" do
+      result = subject.participants_from(User.all)
+
+      expect(result.detect { |u| u.id == user.id }.latest_induction_records).to contain_exactly(induction_record.id)
+      expect(result.detect { |u| u.id == another_user.id }.latest_induction_records).to contain_exactly(another_induction_record.id)
+    end
+
+    context "with multiple providers" do
+      let(:another_lead_provider) { create(:cpd_lead_provider, :with_lead_provider).lead_provider }
+      let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider: another_lead_provider) }
+      let!(:older_induction_record) do
+        travel_to(10.days.ago) do
+          create(:induction_record, induction_programme:, participant_profile:, induction_status: "changed")
+        end
+      end
+
+      it "returns all users that belong to a provider" do
+        expect(subject.participants_from(User.where(id: user.id))).to match_array([user])
+      end
+
+      it "returns the latest induction record" do
+        expect(subject.participants_from(User.where(id: user.id)).first.latest_induction_records).to contain_exactly(induction_record.id)
+      end
+    end
+
+    context "with ect becoming mentor" do
+      let(:mentor_participant_profile) { create(:mentor_participant_profile, participant_identity: user.participant_identities.first, teacher_profile: participant_profile.teacher_profile) }
+      let(:mentor_induction_programme) { create(:induction_programme, :fip, partnership:) }
+      let!(:mentor_induction_record) { create(:induction_record, induction_programme: mentor_induction_programme, participant_profile: mentor_participant_profile, preferred_identity: user.participant_identities.first) }
+      let!(:older_induction_record) do
+        travel_to(10.days.ago) do
+          create(:induction_record, induction_programme:, participant_profile:, induction_status: "changed")
+        end
+      end
+      let!(:older_mentor_induction_record) do
+        travel_to(10.days.ago) do
+          create(:induction_record, induction_programme: mentor_induction_programme, participant_profile: mentor_participant_profile, preferred_identity: user.participant_identities.first, induction_status: "changed")
+        end
+      end
+
+      it "returns users without duplicates" do
+        expect(subject.participants_from(User.where(id: user.id))).to match_array([user])
+      end
+
+      it "returns the latest induction records for the user" do
+        expect(subject.participants_from(User.where(id: user.id)).first.latest_induction_records).to contain_exactly(
+          induction_record.id,
+          mentor_induction_record.id,
+        )
+      end
+    end
+
+    context "sorting" do
+      let(:another_participant_profile) do
+        travel_to(10.days.ago) do
+          create(:ect_participant_profile)
+        end
+      end
+
+      it "returns all user records ordered by participant profile created_at" do
+        expect(subject.participants_from(User.all)).to eq([another_user, user])
+      end
     end
 
     context "with preferred identity" do
       let(:preferred_email) { Faker::Internet.email }
       let(:preferred_identity) { create(:participant_identity, :secondary, user: participant_profile.user, email: preferred_email) }
-      let!(:another_induction_record) { create(:induction_record, induction_programme:, participant_profile:, preferred_identity:) }
+      let!(:induction_record) { create(:induction_record, induction_programme:, participant_profile:, preferred_identity:) }
       let(:user_id) { participant_profile.participant_identity.user_id }
 
       it "returns the user id of the participant identity" do
-        expect(subject.participants.first.id).to eq(user_id)
+        expect(subject.participants_from(User.where(id: user.id)).first.id).to eq(user_id)
       end
 
       it "returns the preferred email" do
-        expect(subject.participants.first.participant_profiles.first.induction_records.first.preferred_identity.email).to eq(preferred_email)
+        results = subject.participants_from(User.where(id: user.id))
+        expect(results.first.participant_profiles.first.induction_records.first.preferred_identity.email).to eq(preferred_email)
       end
     end
 
@@ -44,11 +171,13 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
       let!(:induction_record) { create(:induction_record, induction_programme:, participant_profile:, mentor_profile_id: mentor_participant_profile.id) }
 
       it "returns the mentor user id" do
-        expect(subject.participants.first.participant_profiles.first.mentor.id).to eq(mentor_user_id)
+        result = subject.participants_from(User.where(id: user.id))
+        expect(result.first.participant_profiles.first.mentor.id).to eq(mentor_user_id)
       end
 
       it "returns the user id" do
-        expect(subject.participants.first.id).to eq(user_id)
+        result = subject.participants_from(User.where(id: user.id))
+        expect(result.first.id).to eq(user_id)
       end
     end
 
@@ -57,22 +186,15 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
         let(:params) { { filter: { cohort: cohort.display_name } } }
 
         it "returns all user records for the specific cohort" do
-          expect(subject.participants).to match_array([user])
+          expect(subject.participants_from(User.all)).to match_array([user])
         end
       end
 
       context "with multiple values" do
-        let(:another_cohort) { create(:cohort, start_year: "2050") }
-        let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
-        let(:another_participant_profile) { create(:ect_participant_profile) }
-        let(:another_induction_programme) { create(:induction_programme, :fip, partnership: another_partnership) }
-        let(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
-        let!(:another_user) { another_induction_record.user }
-
         let(:params) { { filter: { cohort: "#{cohort.start_year},#{another_cohort.start_year}" } } }
 
         it "returns all user records for the specific cohort" do
-          expect(subject.participants).to match_array([user, another_user])
+          expect(subject.participants_from(User.all)).to match_array([user, another_user])
         end
       end
 
@@ -80,23 +202,7 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
         let(:params) { { filter: { cohort: "2017" } } }
 
         it "returns no user records" do
-          expect(subject.participants).to be_empty
-        end
-      end
-    end
-
-    describe "updated_since filter" do
-      context "with correct value" do
-        let(:another_participant_profile) { create(:ect_participant_profile) }
-        let(:another_induction_programme) { create(:induction_programme, :fip, partnership:) }
-        let!(:another_induction_record) { create(:induction_record, induction_programme: another_induction_programme, participant_profile: another_participant_profile) }
-
-        let(:params) { { filter: { updated_since: 1.day.ago.iso8601 } } }
-
-        before { another_participant_profile.user.update(updated_at: 4.days.ago.iso8601) }
-
-        it "returns all user records for the specific updated_since filter" do
-          expect(subject.participants).to match_array([user])
+          expect(subject.participants_from(User.all)).to be_empty
         end
       end
     end
@@ -115,7 +221,7 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
       let!(:another_user) { another_induction_record.user }
 
       it "returns all user records ordered by participant profile created_at" do
-        expect(subject.participants).to eq([another_user, user])
+        expect(subject.participants_from(User.all)).to eq([another_user, user])
       end
     end
   end


### PR DESCRIPTION
### Context

We currently calculate the latest induction record on each profile which has significant performance implications

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2205

### Changes proposed in this pull request
- Paginate users on a small query first to get the user ids
- After pagination is done we join on the resulting query and calculate the users, we also group by user to surface an array of the latest induction record
- After that is calculated we finally perform the outer query for ordering the users
- I couldn't get this to work with the `sort` filter which sorts on further fields

### Guidance to review
I compared the records from the previous and current query on prod data and they are the same records to make sure we aren't missing anythign