### PR TITLE
[CPLD-2211] Small improvement to NPQ participant endpoints

### DIFF
--- a/app/serializers/api/v3/ecf/participant_serializer.rb
+++ b/app/serializers/api/v3/ecf/participant_serializer.rb
@@ -32,7 +32,12 @@ module Api
 
           def withdrawal(profile:, cpd_lead_provider:, latest_induction_record:)
             if latest_induction_record.training_status_withdrawn?
-              latest_participant_profile_state = profile.participant_profile_states.sort_by(&:created_at).reverse!.find { |pps| pps.state == ParticipantProfileState.states[:withdrawn] && pps.cpd_lead_provider_id == cpd_lead_provider.id }
+              # We are doing this in memory to avoid running those as queries on each request
+              latest_participant_profile_state = profile
+                .participant_profile_states
+                .sort_by(&:created_at)
+                .reverse!
+                .find { |pps| pps.state == ParticipantProfileState.states[:withdrawn] && pps.cpd_lead_provider_id == cpd_lead_provider.id }
               if latest_participant_profile_state.present?
                 {
                   reason: latest_participant_profile_state.reason,
@@ -44,7 +49,12 @@ module Api
 
           def deferral(profile:, cpd_lead_provider:, latest_induction_record:)
             if latest_induction_record.training_status_deferred?
-              latest_participant_profile_state = profile.participant_profile_states.sort_by(&:created_at).reverse!.find { |pps| pps.state == ParticipantProfileState.states[:deferred] && pps.cpd_lead_provider_id == cpd_lead_provider.id }
+              # We are doing this in memory to avoid running those as queries on each request
+              latest_participant_profile_state = profile
+                .participant_profile_states
+                .sort_by(&:created_at)
+                .reverse!
+                .find { |pps| pps.state == ParticipantProfileState.states[:deferred] && pps.cpd_lead_provider_id == cpd_lead_provider.id }
               if latest_participant_profile_state.present?
                 {
                   reason: latest_participant_profile_state.reason,


### PR DESCRIPTION
### Context
We are adding extra queries when calculating withdrawals/deferrals per profile

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2211

### Changes proposed in this pull request
Calculate the states in memory to avoid too many extra queries. Those are a small number and shouldn't cause any overhead

### Guidance to review

