### PR TITLE
Restrict cohort changes to super user admins

### DIFF
--- a/app/controllers/admin/participants/change_cohort_controller.rb
+++ b/app/controllers/admin/participants/change_cohort_controller.rb
@@ -2,8 +2,12 @@
 
 module Admin::Participants
   class ChangeCohortController < Admin::BaseController
+    include Pundit::Authorization
+
     def edit
       @participant_profile = retrieve_participant_profile
+      authorize @participant_profile, :edit_cohort?
+
       @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new
@@ -11,6 +15,8 @@ module Admin::Participants
 
     def update
       @participant_profile = retrieve_participant_profile
+      authorize @participant_profile, :update_cohort?
+
       @latest_induction_record = @participant_profile.latest_induction_record
 
       @amend_participant_cohort = Induction::AmendParticipantCohort.new(

--- a/app/policies/participant_profile_policy.rb
+++ b/app/policies/participant_profile_policy.rb
@@ -9,6 +9,13 @@ class ParticipantProfilePolicy < ApplicationPolicy
     admin?
   end
 
+  def change_cohort?
+    super_user_only
+  end
+
+  alias_method :edit_cohort?, :change_cohort?
+  alias_method :update_cohort?, :change_cohort?
+
   alias_method :withdraw_record?, :destroy?
   alias_method :remove?, :destroy?
 

--- a/app/views/admin/participants/_cohorts.html.erb
+++ b/app/views/admin/participants/_cohorts.html.erb
@@ -14,4 +14,6 @@
   end
 end %>
 
-<%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(latest_induction_record.participant_profile), secondary: true) %>
+<% if policy(@participant_profile).edit_cohort? %>
+  <%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(latest_induction_record.participant_profile), secondary: true) %>
+<% end %>

--- a/app/views/admin/participants/cohorts/show.html.erb
+++ b/app/views/admin/participants/cohorts/show.html.erb
@@ -23,4 +23,6 @@
   end
 end %>
 
-<%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(@participant_presenter.participant_profile), secondary: true) %>
+<% if policy(@participant_profile).edit_cohort? %>
+  <%= govuk_button_link_to("Change cohort", edit_admin_participant_change_cohort_path(@participant_presenter.participant_profile), secondary: true) %>
+<% end %>

--- a/spec/features/admin/participants/participant_steps.rb
+++ b/spec/features/admin/participants/participant_steps.rb
@@ -216,6 +216,9 @@ module ParticipantSteps
 
   def and_i_should_see_the_participant_cohorts
     expect(page).to have_text("Cohort")
+  end
+
+  def and_i_should_see_the_change_cohort_action
     expect(page).to have_link("Change cohort")
   end
 

--- a/spec/policies/participant_profile_policy_spec.rb
+++ b/spec/policies/participant_profile_policy_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ParticipantProfilePolicy, :with_default_schedules, type: :policy 
   context "being an admin" do
     let(:user) { create(:user, :admin) }
     it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_actions(%i[edit_cohort update_cohort]) }
 
     context "NPQ" do
       let(:participant_profile) { create(:npq_participant_profile) }
@@ -21,6 +22,14 @@ RSpec.describe ParticipantProfilePolicy, :with_default_schedules, type: :policy 
     let(:user) { create(:user) }
     it { is_expected.to forbid_action(:show) }
     it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to forbid_actions(%i[edit_cohort update_cohort]) }
+  end
+
+  context "being a super user admin" do
+    let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build.with_super_user }
+    let(:user) { scenario.user }
+
+    it { is_expected.to permit_actions(%i[edit_cohort update_cohort]) }
   end
 
   describe described_class::Scope do

--- a/spec/requests/admin/participants/change_cohort_spec.rb
+++ b/spec/requests/admin/participants/change_cohort_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
-  let(:admin_user) { create(:user, :admin) }
+  let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build.with_super_user }
+
+  let(:admin_user) { scenario.user }
   let(:user) { create :user, full_name: "Elza Smith" }
   let!(:mentor_profile) { create :mentor, user: }
   let!(:ect_profile) { create :ect, mentor_profile_id: mentor_profile.id }
@@ -11,20 +13,30 @@ RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
   before { sign_in(admin_user) }
 
   describe "GET /admin/participants/:participant_id/change_cohort/edit" do
-    before { get("/admin/participants/#{mentor_profile.id}/change_cohort/edit") }
+    context "when being a super user admin" do
+      before { get("/admin/participants/#{mentor_profile.id}/change_cohort/edit") }
 
-    it "renders the edit form for a participant's cohort" do
-      expect(response).to render_template("admin/participants/change_cohort/edit")
-      expect(response.body).to match(%r{<form.*action="/admin/participants/#{mentor_profile.id}/change_cohort"})
+      it "renders the edit form for a participant's cohort" do
+        expect(response).to render_template("admin/participants/change_cohort/edit")
+        expect(response.body).to match(%r{<form.*action="/admin/participants/#{mentor_profile.id}/change_cohort"})
+      end
+
+      it "has the correct heading" do
+        expect(response.body).to match(/Change #{mentor_profile.user.full_name}.* cohort/)
+      end
+
+      it "has a form with a select element and button" do
+        expect(response.body).to match(/<select.*"induction_amend_participant_cohort\[target_cohort_start_year\]/)
+        expect(response.body).to match(/<button.*class="govuk-button"/)
+      end
     end
 
-    it "has the correct heading" do
-      expect(response.body).to match(/Change #{mentor_profile.user.full_name}.* cohort/)
-    end
+    context "when being a standard admin user" do
+      let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build }
 
-    it "has a form with a select element and button" do
-      expect(response.body).to match(/<select.*"induction_amend_participant_cohort\[target_cohort_start_year\]/)
-      expect(response.body).to match(/<button.*class="govuk-button"/)
+      it "raises an forbidden exception" do
+        expect { get("/admin/participants/#{mentor_profile.id}/change_cohort/edit") }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
   end
 
@@ -32,28 +44,38 @@ RSpec.describe "Admin::Participants", :with_default_schedules, type: :request do
     let(:next_cohort) { Cohort.next || create(:cohort, :next) }
     let(:params) { { induction_amend_participant_cohort: { target_cohort_start_year: next_cohort.start_year } } }
 
-    it "initializes an Induction::AmendParticipantCohort" do
-      expect_any_instance_of(Induction::AmendParticipantCohort).to receive(:save).and_return(true)
-      allow(Induction::AmendParticipantCohort).to receive(:new).and_call_original
+    context "when being a super user admin" do
+      it "initializes an Induction::AmendParticipantCohort" do
+        expect_any_instance_of(Induction::AmendParticipantCohort).to receive(:save).and_return(true)
+        allow(Induction::AmendParticipantCohort).to receive(:new).and_call_original
 
-      put("/admin/participants/#{mentor_profile.id}/change_cohort", params:)
-
-      expect(Induction::AmendParticipantCohort).to have_received(:new).with(
-        source_cohort_start_year: Cohort.current.start_year,
-        target_cohort_start_year: next_cohort.display_name, # string because this one is passed in from the form
-        participant_profile: mentor_profile,
-      )
-
-      expect(response).to redirect_to(admin_participant_path(mentor_profile))
-    end
-
-    context "when there is an error" do
-      let(:params) { { induction_amend_participant_cohort: { target_cohort_start_year: "a bad value" } } }
-
-      it "displays the error summary and re-renders :edit" do
         put("/admin/participants/#{mentor_profile.id}/change_cohort", params:)
 
-        expect(response.body).to include("Must be an integer")
+        expect(Induction::AmendParticipantCohort).to have_received(:new).with(
+          source_cohort_start_year: Cohort.current.start_year,
+          target_cohort_start_year: next_cohort.display_name, # string because this one is passed in from the form
+          participant_profile: mentor_profile,
+        )
+
+        expect(response).to redirect_to(admin_participant_path(mentor_profile))
+      end
+
+      context "when there is an error" do
+        let(:params) { { induction_amend_participant_cohort: { target_cohort_start_year: "a bad value" } } }
+
+        it "displays the error summary and re-renders :edit" do
+          put("/admin/participants/#{mentor_profile.id}/change_cohort", params:)
+
+          expect(response.body).to include("Must be an integer")
+        end
+      end
+    end
+
+    context "when being a standard admin user" do
+      let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build }
+
+      it "raises an forbidden exception" do
+        expect { put("/admin/participants/#{mentor_profile.id}/change_cohort", params:) }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: CST-1520

We want only admins with super user permissions to be able to change the participant's cohort in the admin pages.

### Changes proposed in this pull request
- Update the participant_profile_policy
- Update the controller and the views to check if the current user is authorised to edit/update the participant's cohort

### Guidance to review
Check the
1.  `change cohort` action in the admin -> participant -> cohorts is visible only to admins with super user permissions.
2. non super user admins can't visit the edit cohort path

