### PR TITLE
Redirect the step-by-step page to gov.uk

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -710,7 +710,7 @@ Rails.application.routes.draw do
   get "/ministerial-letter", to: redirect("ECF%20Letter.pdf")
   get "/ecf-leaflet", to: redirect("ECFleaflet2021.pdf")
 
-  get "/how-to-set-up-your-programme", to: "step_by_step#show", as: :step_by_step
+  get "/how-to-set-up-your-programme", to: redirect("https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers")
 
   get "/assets/govuk/assets/fonts/:name.:extension", to: redirect("/api-reference/assets/govuk/assets/fonts/%{name}.%{extension}")
   get "/assets/govuk/assets/images/:name.:extension", to: redirect("/api-reference/assets/govuk/assets/images/%{name}.%{extension}")


### PR DESCRIPTION
### Context

- Ticket: CST-1524

Redirect the [step-by-step page](https://manage-training-for-early-career-teachers.education.gov.uk/how-to-set-up-your-programme)  to the [new guidance](https://www.gov.uk/guidance/how-to-set-up-training-for-early-career-teachers).

 
### Changes proposed in this pull request
- Change the route to a redirect

### Guidance to review

