### PR TITLE
Account for bad data when retrieving mentor id in declarations

### DIFF
--- a/app/serializers/api/v3/participant_declaration_serializer.rb
+++ b/app/serializers/api/v3/participant_declaration_serializer.rb
@@ -71,7 +71,7 @@ module Api
             },
           ).latest
 
-          latest_induction_record.mentor_profile&.participant_identity&.user_id
+          latest_induction_record&.mentor_profile&.participant_identity&.user_id
         end
       end
 


### PR DESCRIPTION

### Context
Bad data in sandbox causing API declarations endpoint to fail

- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2221

### Changes proposed in this pull request

Bad data in test and prod profiles where either the CPD lead provider does not match on induction records, or missing induction records will cause mentor id not to be calculated correctly. Fallback to latest IR and ensure we handle empty induction records just incase


### Guidance to review

