### PR TITLE
[CST-1550] setup survey comms

### DIFF
--- a/app/controllers/schools/cohort_setup_controller.rb
+++ b/app/controllers/schools/cohort_setup_controller.rb
@@ -74,7 +74,7 @@ module Schools
                                    current_user:,
                                    default_step_name:,
                                    school:,
-                                   session:,
+                                   data_store:,
                                    submitted_params:)
     end
 
@@ -101,6 +101,10 @@ module Schools
 
     def wizard_class
       Schools::Cohorts::SetupWizard
+    end
+
+    def data_store
+      @data_store ||= FormData::CohortSetupStore.new(session:, form_key: wizard_class)
     end
   end
 end

--- a/app/forms/schools/cohorts/setup_wizard/success.rb
+++ b/app/forms/schools/cohorts/setup_wizard/success.rb
@@ -21,7 +21,7 @@ module Schools
               SchoolMailer
                 .with(sit_user: current_user)
                 .cohortless_pilot_2023_survey_email
-                .deliver_later(wait: 1.hour)
+                .deliver_later(wait: 3.hours)
             end
           end
         end

--- a/app/forms/schools/cohorts/setup_wizard/success.rb
+++ b/app/forms/schools/cohorts/setup_wizard/success.rb
@@ -16,6 +16,13 @@ module Schools
             else
               set_cohort_induction_programme!(how_will_you_run_training)
             end
+
+            if should_send_the_pilot_survey?
+              SchoolMailer
+                .with(sit_user: current_user)
+                .cohortless_pilot_2023_survey_email
+                .deliver_later(wait: 1.hour)
+            end
           end
         end
 
@@ -88,6 +95,11 @@ module Schools
             change_to_core_induction_programme: :core_induction_programme,
             change_to_design_our_own: :design_our_own,
           }[what_changes.to_sym]
+        end
+
+        def should_send_the_pilot_survey?
+          cohort.start_year == 2023 && FeatureFlag.active?(:cohortless_dashboard, for: school) &&
+            expect_any_ects? && current_user.induction_coordinator?
         end
       end
     end

--- a/app/forms/wizard.rb
+++ b/app/forms/wizard.rb
@@ -23,7 +23,6 @@ class Wizard
   def initialize(data_store:, current_step:, current_user:, default_step_name:, submitted_params: {}, **opts)
     @current_user = current_user
     @default_step_name = default_step_name
-    # @data_store = data_store_class.new(session:, form_key: to_key)
     @data_store = data_store
     @previous_step = nil
     @return_point = nil

--- a/app/forms/wizard.rb
+++ b/app/forms/wizard.rb
@@ -20,10 +20,11 @@ class Wizard
   delegate :changing_answer?, :complete?, :last_visited_step, :return_point,
            to: :data_store
 
-  def initialize(session:, current_step:, current_user:, default_step_name:, submitted_params: {}, **opts)
+  def initialize(data_store:, current_step:, current_user:, default_step_name:, submitted_params: {}, **opts)
     @current_user = current_user
     @default_step_name = default_step_name
-    @data_store = data_store_class.new(session:, form_key: to_key)
+    # @data_store = data_store_class.new(session:, form_key: to_key)
+    @data_store = data_store
     @previous_step = nil
     @return_point = nil
     @submitted_params = submitted_params

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -36,8 +36,8 @@ class SchoolMailer < ApplicationMailer
   LAUNCH_ASK_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "f4dfee2a-2cc3-4d32-97f9-8adca41343bf"
   COHORTLESS_PILOT_2023_SURVEY_TEMPLATE = "5f6dc6bf-62c5-4cf1-8cc8-1440453f4a2d"
 
-  def send_cohortless_pilot_2023_survey_to_sit
-    sit_user = params[:sit]
+  def cohortless_pilot_2023_survey_email
+    sit_user = params[:sit_user]
 
     template_mail(
       COHORTLESS_PILOT_2023_SURVEY_TEMPLATE,
@@ -47,7 +47,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         name: sit_user.full_name,
       },
-    ).tag(:cohortless_pilot_2023_survey).associate_with(sit.induction_coordinator_profile)
+    ).tag(:cohortless_pilot_2023_survey).associate_with(sit_user.induction_coordinator_profile)
   end
 
   def remind_sit_to_set_mentor_to_ects

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -34,6 +34,21 @@ class SchoolMailer < ApplicationMailer
   PILOT_ASK_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "ae925ff1-edc3-4d5c-a120-baa3a79c73af"
   LAUNCH_ASK_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "1f796f27-9ba4-4705-a7c9-57462bd1e0b7"
   LAUNCH_ASK_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "f4dfee2a-2cc3-4d32-97f9-8adca41343bf"
+  COHORTLESS_PILOT_2023_SURVEY_TEMPLATE = "5f6dc6bf-62c5-4cf1-8cc8-1440453f4a2d"
+
+  def send_cohortless_pilot_2023_survey_to_sit
+    sit_user = params[:sit]
+
+    template_mail(
+      COHORTLESS_PILOT_2023_SURVEY_TEMPLATE,
+      to: sit_user.email,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name: sit_user.full_name,
+      },
+    ).tag(:cohortless_pilot_2023_survey).associate_with(sit.induction_coordinator_profile)
+  end
 
   def remind_sit_to_set_mentor_to_ects
     sit = params[:sit]

--- a/spec/forms/schools/cohorts/setup_wizard_spec.rb
+++ b/spec/forms/schools/cohorts/setup_wizard_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
+  let(:cohort) { Cohort.current || create(:cohort, :current) }
+  let(:current_step) { :email }
+  let(:data_store) { instance_double(FormData::CohortSetupStore) }
+  let(:school) { create(:seed_school, :with_induction_coordinator) }
+  let(:school_cohort) { create(:seed_school_cohort, :fip, cohort:, school:) }
+  let(:sit_user) { school.induction_coordinators.first }
+  let(:submitted_params) { {} }
+
+  subject(:wizard) { described_class.new(current_step:, data_store:, current_user: sit_user, school:, submitted_params:) }
+
+  before do
+    allow(data_store).to receive(:store).and_return({ something: "is here" })
+    allow(data_store).to receive(:current_user).and_return(sit_user)
+    allow(data_store).to receive(:school_id).and_return(school.slug)
+    allow(data_store).to receive(:set)
+  end
+

--- a/spec/forms/schools/cohorts/setup_wizard_spec.rb
+++ b/spec/forms/schools/cohorts/setup_wizard_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
   let(:school) { create(:seed_school, :with_induction_coordinator) }
   let(:school_cohort) { create(:seed_school_cohort, :fip, cohort:, school:) }
   let(:sit_user) { school.induction_coordinators.first }
-  let(:default_step_name) { :what_we_need } 
+  let(:default_step_name) { :what_we_need }
   let(:submitted_params) { {} }
   let(:start_year) { cohort.start_year }
 
@@ -74,12 +74,10 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
 
     context "when the SIT chooses to keep providers" do
       let(:expect_any_ects) { true }
-      let(:what_changes) { ["something"] }
-      let(:what_changes_programme) { :fip }
+      let(:what_changes) { "change_lead_provider" }
 
       before do
-        expect(wizard).to receive(:what_changes_programme).and_return(what_changes_programme)
-        expect(wizard).to receive(:set_cohort_induction_programme!).with(what_changes_programme)
+        expect(wizard).to receive(:set_cohort_induction_programme!).with(:full_induction_programme)
         expect(wizard).to receive(:previously_fip?).and_return(false)
       end
 

--- a/spec/forms/schools/cohorts/setup_wizard_spec.rb
+++ b/spec/forms/schools/cohorts/setup_wizard_spec.rb
@@ -1,20 +1,101 @@
 # frozen_string_literal: true
 
-RSpec.xdescribe Schools::Cohorts::SetupWizard, type: :model do
+RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
   let(:cohort) { Cohort.current || create(:cohort, :current) }
-  let(:current_step) { :email }
+  let(:current_step) { :what_we_need }
   let(:data_store) { instance_double(FormData::CohortSetupStore) }
   let(:school) { create(:seed_school, :with_induction_coordinator) }
   let(:school_cohort) { create(:seed_school_cohort, :fip, cohort:, school:) }
   let(:sit_user) { school.induction_coordinators.first }
+  let(:default_step_name) { :what_we_need } 
   let(:submitted_params) { {} }
+  let(:start_year) { cohort.start_year }
 
-  subject(:wizard) { described_class.new(current_step:, data_store:, current_user: sit_user, school:, submitted_params:) }
+  subject(:wizard) { described_class.new(current_step:, data_store:, current_user: sit_user, default_step_name:, cohort:, school:, submitted_params:) }
 
   before do
     allow(data_store).to receive(:store).and_return({ something: "is here" })
     allow(data_store).to receive(:current_user).and_return(sit_user)
     allow(data_store).to receive(:school_id).and_return(school.slug)
     allow(data_store).to receive(:set)
+    allow(data_store).to receive(:bulk_get).and_return({})
+    allow(data_store).to receive(:clean)
+    allow(data_store).to receive(:cohort_start_year).and_return(start_year)
+  end
+
+  shared_context "sending the pilot survey" do
+    it "does not send the pilot survey" do
+      expect {
+        wizard.success
+      }.not_to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
+    end
+
+    context "when the school is in the pilot", with_feature_flag: { cohortless_dashboard: "active" }, travel_to: Date.new(2023, 7, 1) do
+      it "sends the pilot survey" do
+        expect {
+          wizard.success
+        }.not_to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
+      end
+    end
+  end
+
+  describe "#success" do
+    let(:expect_any_ects) { false }
+    let(:keep_providers) { false }
+    let(:what_changes) { nil }
+
+    before do
+      allow(wizard).to receive(:expect_any_ects?).and_return(expect_any_ects)
+      allow(wizard).to receive(:keep_providers?).and_return(keep_providers)
+      allow(wizard).to receive(:what_changes).and_return(what_changes)
+    end
+
+    context "when the SIT does not expect any ECTs" do
+      it "does not send the pilot survey" do
+        expect(wizard).to receive(:set_cohort_induction_programme!).with(:no_early_career_teachers, opt_out_of_updates: true)
+
+        expect {
+          wizard.success
+        }.not_to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
+      end
+    end
+
+    context "when the SIT chooses to keep providers" do
+      let(:expect_any_ects) { true }
+      let(:keep_providers) { true }
+
+      before do
+        expect(wizard).to receive(:active_partnership?).and_return(true)
+        expect(wizard).to receive(:save_appropriate_body).once
+      end
+
+      include_context "sending the pilot survey"
+    end
+
+    context "when the SIT chooses to keep providers" do
+      let(:expect_any_ects) { true }
+      let(:what_changes) { ["something"] }
+      let(:what_changes_programme) { :fip }
+
+      before do
+        expect(wizard).to receive(:what_changes_programme).and_return(what_changes_programme)
+        expect(wizard).to receive(:set_cohort_induction_programme!).with(what_changes_programme)
+        expect(wizard).to receive(:previously_fip?).and_return(false)
+      end
+
+      include_context "sending the pilot survey"
+    end
+
+    context "when the SIT chooses to change something" do
+      let(:expect_any_ects) { true }
+      let(:what_changes) { "change_lead_provider" }
+
+      before do
+        expect(wizard).to receive(:set_cohort_induction_programme!).with(:full_induction_programme)
+        expect(wizard).to receive(:previously_fip?).and_return(false)
+      end
+
+      include_context "sending the pilot survey"
+    end
   end
 end

--- a/spec/forms/schools/cohorts/setup_wizard_spec.rb
+++ b/spec/forms/schools/cohorts/setup_wizard_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
+RSpec.xdescribe Schools::Cohorts::SetupWizard, type: :model do
   let(:cohort) { Cohort.current || create(:cohort, :current) }
   let(:current_step) { :email }
   let(:data_store) { instance_double(FormData::CohortSetupStore) }
@@ -17,4 +17,4 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
     allow(data_store).to receive(:school_id).and_return(school.slug)
     allow(data_store).to receive(:set)
   end
-
+end

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -3,6 +3,19 @@
 require "rails_helper"
 
 RSpec.describe SchoolMailer, type: :mailer do
+  describe "#cohortless_pilot_2023_survey_email" do
+    let(:sit_user) { create(:seed_induction_coordinator_profile, :with_user).user }
+
+    let(:email) do
+      SchoolMailer.with(sit_user:).cohortless_pilot_2023_survey_email.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(email.from).to eq(["mail@example.com"])
+      expect(email.to).to eq [sit_user.email]
+    end
+  end
+
   describe "#nomination_email" do
     let(:school) { instance_double School, name: "Great Ouse Academy" }
     let(:primary_contact_email) { "contact@example.com" }


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1550)
Send out an email once a SIT has made their choice for 2023 cohort for pilot schools.  The email is delayed for 3 hours to give the SIT the opportunity to use the service once their choice has been made.

### Changes proposed in this pull request
Add a new mailer
Trigger mailer in the cohort setup wizard once the cohort choice is made. Does not trigger if No ECTs is chosen.

### Guidance to review

Example test email from Notify
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/3b66e35f-e71a-4c5f-a0b8-6c92da87d369)

