### PR TITLE
Fix Participant Declaration V3 query

### DIFF
--- a/app/controllers/api/v3/participant_declarations_controller.rb
+++ b/app/controllers/api/v3/participant_declarations_controller.rb
@@ -13,7 +13,7 @@ module Api
       # GET /api/v3/participant-declarations?filter[cohort]=2021,2022
       #
       def index
-        render json: serializer_class.new(paginate(participant_declarations)).serializable_hash.to_json
+        render json: serializer_class.new(participant_declarations).serializable_hash.to_json
       end
 
       # Creates new participant declaration
@@ -50,8 +50,12 @@ module Api
         current_user
       end
 
+      def paginated_results
+        paginate(participant_declarations_query.participant_declarations_for_pagination)
+      end
+
       def participant_declarations
-        @participant_declarations ||= participant_declarations_query.participant_declarations
+        @participant_declarations ||= participant_declarations_query.participant_declarations_from(paginated_results)
       end
 
       def participant_declarations_query

--- a/app/serializers/api/v3/participant_declaration_serializer.rb
+++ b/app/serializers/api/v3/participant_declaration_serializer.rb
@@ -61,7 +61,7 @@ module Api
       attribute :mentor_id do |declaration|
         if declaration.participant_profile.ect?
           if declaration.respond_to?(:mentor_user_id)
-            declaration.mentor_user_id
+            declaration.mentor_user_id&.first
           else
             latest_induction_record = declaration.participant_profile.induction_records.includes(
               induction_programme: [:partnership],

--- a/spec/serializers/api/v3/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v3/participant_declaration_serializer_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Api::V3::ParticipantDeclarationSerializer, :with_default_schedule
       context "when using mentor_user_id with query" do
         before do
           def participant_declaration.mentor_user_id
-            "test123"
+            %w[test123]
           end
         end
 

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -21,70 +21,68 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
 
   let(:delivery_partner1) { create(:delivery_partner) }
   let(:delivery_partner2) { create(:delivery_partner) }
+  let!(:participant_declaration1) do
+    create(
+      :ect_participant_declaration,
+      :paid,
+      uplifts: [:sparsity_uplift],
+      declaration_type: "started",
+      evidence_held: "training-event-attended",
+      created_at: 3.days.ago,
+      updated_at: 3.days.ago,
 
+      cpd_lead_provider: cpd_lead_provider1,
+      participant_profile: participant_profile1,
+      delivery_partner: delivery_partner1,
+    )
+  end
+  let!(:participant_declaration2) do
+    create(
+      :ect_participant_declaration,
+      :eligible,
+      declaration_type: "started",
+      created_at: 1.day.ago,
+      updated_at: 1.day.ago,
+
+      cpd_lead_provider: cpd_lead_provider1,
+      participant_profile: participant_profile2,
+      delivery_partner: delivery_partner2,
+    )
+  end
+  let!(:participant_declaration3) do
+    create(
+      :ect_participant_declaration,
+      :eligible,
+      declaration_type: "started",
+      created_at: 5.days.ago,
+      updated_at: 5.days.ago,
+
+      cpd_lead_provider: cpd_lead_provider1,
+      participant_profile: participant_profile3,
+      delivery_partner: delivery_partner2,
+    )
+  end
+  let!(:participant_declaration4) do
+    create(
+      :ect_participant_declaration,
+      :eligible,
+      declaration_type: "started",
+      created_at: 5.days.ago,
+      updated_at: 5.days.ago,
+
+      cpd_lead_provider: cpd_lead_provider2,
+      participant_profile: participant_profile4,
+      delivery_partner: delivery_partner1,
+    )
+  end
   let(:params) { {} }
 
   subject { described_class.new(cpd_lead_provider: cpd_lead_provider1, params:) }
 
-  describe "#participant_declarations" do
-    let!(:participant_declaration1) do
-      create(
-        :ect_participant_declaration,
-        :paid,
-        uplifts: [:sparsity_uplift],
-        declaration_type: "started",
-        evidence_held: "training-event-attended",
-        created_at: 3.days.ago,
-        updated_at: 3.days.ago,
-
-        cpd_lead_provider: cpd_lead_provider1,
-        participant_profile: participant_profile1,
-        delivery_partner: delivery_partner1,
-      )
-    end
-    let!(:participant_declaration2) do
-      create(
-        :ect_participant_declaration,
-        :eligible,
-        declaration_type: "started",
-        created_at: 1.day.ago,
-        updated_at: 1.day.ago,
-
-        cpd_lead_provider: cpd_lead_provider1,
-        participant_profile: participant_profile2,
-        delivery_partner: delivery_partner2,
-      )
-    end
-    let!(:participant_declaration3) do
-      create(
-        :ect_participant_declaration,
-        :eligible,
-        declaration_type: "started",
-        created_at: 5.days.ago,
-        updated_at: 5.days.ago,
-
-        cpd_lead_provider: cpd_lead_provider1,
-        participant_profile: participant_profile3,
-        delivery_partner: delivery_partner2,
-      )
-    end
-    let!(:participant_declaration4) do
-      create(
-        :ect_participant_declaration,
-        :eligible,
-        declaration_type: "started",
-        created_at: 5.days.ago,
-        updated_at: 5.days.ago,
-
-        cpd_lead_provider: cpd_lead_provider2,
-        participant_profile: participant_profile4,
-        delivery_partner: delivery_partner1,
-      )
-    end
-
+  describe "#participant_declarations_for_pagination" do
     context "empty params" do
       it "returns all participant declarations for cpd_lead_provider1" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
       end
     end
 
@@ -92,7 +90,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { cohort: cohort2.start_year.to_s } } }
 
       it "returns all participant declarations for the specific cohort" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration3])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3)
       end
     end
 
@@ -100,7 +98,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { cohort: [cohort1.start_year, cohort2.start_year].join(",") } } }
 
       it "returns all participant declarations for the specific cohort" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
       end
     end
 
@@ -108,7 +106,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { cohort: "2017" } } }
 
       it "returns no participant declarations" do
-        expect(subject.participant_declarations.to_a).to be_empty
+        expect(subject.participant_declarations_for_pagination.to_a).to be_empty
       end
     end
 
@@ -116,7 +114,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { participant_id: participant_profile1.user_id } } }
 
       it "returns participant declarations for the specific participant_id" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration1])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration1)
       end
     end
 
@@ -124,7 +122,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { participant_id: [participant_profile1.user_id, participant_profile2.user_id].join(",") } } }
 
       it "returns participant declarations for the specific participant_id" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration1, participant_declaration2])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration1, participant_declaration2)
       end
     end
 
@@ -132,7 +130,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { participant_id: "madeup" } } }
 
       it "returns no participant declarations" do
-        expect(subject.participant_declarations.to_a).to be_empty
+        expect(subject.participant_declarations_for_pagination.to_a).to be_empty
       end
     end
 
@@ -147,7 +145,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       end
 
       it "returns participant declarations for the specific updated time" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration2])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration2)
       end
     end
 
@@ -155,7 +153,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { delivery_partner_id: delivery_partner2.id } } }
 
       it "returns participant declarations for the specific delivery_partner_id" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration3, participant_declaration2])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration2)
       end
     end
 
@@ -163,7 +161,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { delivery_partner_id: [delivery_partner1.id, delivery_partner2.id].join(",") } } }
 
       it "returns participant declarations for the specific delivery_partner_id" do
-        expect(subject.participant_declarations.to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
+        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
       end
     end
 
@@ -171,7 +169,19 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { delivery_partner_id: "madeup" } } }
 
       it "returns no participant declarations" do
-        expect(subject.participant_declarations.to_a).to be_empty
+        expect(subject.participant_declarations_for_pagination.to_a).to be_empty
+      end
+    end
+  end
+
+  describe "#participant_declarations" do
+    it "returns all declarations passed in from query in the correct order" do
+      expect(subject.participant_declarations_from(ParticipantDeclaration.all).to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
+    end
+
+    context "with a subset of declarations" do
+      it "returns only the declarations that have been paginated" do
+        expect(subject.participant_declarations_from(ParticipantDeclaration.where(id: participant_declaration1.id)).to_a).to eq([participant_declaration1])
       end
     end
 
@@ -185,7 +195,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       end
 
       it "returns mentor_user_id in attribute" do
-        declarations = subject.participant_declarations.to_a
+        declarations = subject.participant_declarations_from(ParticipantDeclaration.all).to_a
         expect(declarations).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
         expect(declarations[0].mentor_user_id).to eq(nil)
         expect(declarations[1].mentor_user_id).to eq(mentor_user_id)

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -22,58 +22,54 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
   let(:delivery_partner1) { create(:delivery_partner) }
   let(:delivery_partner2) { create(:delivery_partner) }
   let!(:participant_declaration1) do
-    create(
-      :ect_participant_declaration,
-      :paid,
-      uplifts: [:sparsity_uplift],
-      declaration_type: "started",
-      evidence_held: "training-event-attended",
-      created_at: 3.days.ago,
-      updated_at: 3.days.ago,
-
-      cpd_lead_provider: cpd_lead_provider1,
-      participant_profile: participant_profile1,
-      delivery_partner: delivery_partner1,
-    )
+    travel_to(3.days.ago) do
+      create(
+        :ect_participant_declaration,
+        :paid,
+        uplifts: [:sparsity_uplift],
+        declaration_type: "started",
+        evidence_held: "training-event-attended",
+        cpd_lead_provider: cpd_lead_provider1,
+        participant_profile: participant_profile1,
+        delivery_partner: delivery_partner1,
+      )
+    end
   end
   let!(:participant_declaration2) do
-    create(
-      :ect_participant_declaration,
-      :eligible,
-      declaration_type: "started",
-      created_at: 1.day.ago,
-      updated_at: 1.day.ago,
-
-      cpd_lead_provider: cpd_lead_provider1,
-      participant_profile: participant_profile2,
-      delivery_partner: delivery_partner2,
-    )
+    travel_to(1.day.ago) do
+      create(
+        :ect_participant_declaration,
+        :eligible,
+        declaration_type: "started",
+        cpd_lead_provider: cpd_lead_provider1,
+        participant_profile: participant_profile2,
+        delivery_partner: delivery_partner2,
+      )
+    end
   end
   let!(:participant_declaration3) do
-    create(
-      :ect_participant_declaration,
-      :eligible,
-      declaration_type: "started",
-      created_at: 5.days.ago,
-      updated_at: 5.days.ago,
-
-      cpd_lead_provider: cpd_lead_provider1,
-      participant_profile: participant_profile3,
-      delivery_partner: delivery_partner2,
-    )
+    travel_to(5.days.ago) do
+      create(
+        :ect_participant_declaration,
+        :eligible,
+        declaration_type: "started",
+        cpd_lead_provider: cpd_lead_provider1,
+        participant_profile: participant_profile3,
+        delivery_partner: delivery_partner2,
+      )
+    end
   end
   let!(:participant_declaration4) do
-    create(
-      :ect_participant_declaration,
-      :eligible,
-      declaration_type: "started",
-      created_at: 5.days.ago,
-      updated_at: 5.days.ago,
-
-      cpd_lead_provider: cpd_lead_provider2,
-      participant_profile: participant_profile4,
-      delivery_partner: delivery_partner1,
-    )
+    travel_to(5.days.ago) do
+      create(
+        :ect_participant_declaration,
+        :eligible,
+        declaration_type: "started",
+        cpd_lead_provider: cpd_lead_provider2,
+        participant_profile: participant_profile4,
+        delivery_partner: delivery_partner1,
+      )
+    end
   end
   let(:params) { {} }
 
@@ -176,30 +172,45 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
 
   describe "#participant_declarations" do
     it "returns all declarations passed in from query in the correct order" do
-      expect(subject.participant_declarations_from(ParticipantDeclaration.all).to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
+      paginated_query = ParticipantDeclaration.where(cpd_lead_provider: cpd_lead_provider1)
+      expect(subject.participant_declarations_from(paginated_query).to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
     end
 
     context "with a subset of declarations" do
       it "returns only the declarations that have been paginated" do
-        expect(subject.participant_declarations_from(ParticipantDeclaration.where(id: participant_declaration1.id)).to_a).to eq([participant_declaration1])
+        paginated_query = ParticipantDeclaration.where(id: participant_declaration1.id)
+        expect(subject.participant_declarations_from(paginated_query).to_a).to eq([participant_declaration1])
       end
     end
 
     context "with mentor_user_id attribute" do
       let!(:mentor_participant_profile) { create(:mentor_participant_profile) }
+      let!(:another_mentor_participant_profile) { create(:mentor_participant_profile) }
+      let!(:another_induction_record) do
+        create(
+          :induction_record,
+          :changed,
+          participant_profile: participant_profile1,
+          preferred_identity: participant_profile1.participant_identity,
+          induction_programme: participant_profile1.induction_records.first.induction_programme,
+          mentor_profile_id: another_mentor_participant_profile.id,
+        )
+      end
       let(:mentor_user_id) { mentor_participant_profile.participant_identity.user_id }
 
       before do
-        latest_induction_record = participant_profile1.induction_records.first
+        latest_induction_record = participant_profile1.induction_records.latest
         latest_induction_record.update!(mentor_profile_id: mentor_participant_profile.id)
       end
 
-      it "returns mentor_user_id in attribute" do
-        declarations = subject.participant_declarations_from(ParticipantDeclaration.all).to_a
+      it "returns mentor_user_id in attribute with no duplicates" do
+        paginated_query = ParticipantDeclaration.where(cpd_lead_provider: cpd_lead_provider1)
+        declarations = subject.participant_declarations_from(paginated_query).to_a
+
         expect(declarations).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
-        expect(declarations[0].mentor_user_id).to eq(nil)
-        expect(declarations[1].mentor_user_id).to eq(mentor_user_id)
-        expect(declarations[2].mentor_user_id).to eq(nil)
+        expect(declarations[0].mentor_user_id).to be_empty
+        expect(declarations[1].mentor_user_id).to contain_exactly(mentor_user_id)
+        expect(declarations[2].mentor_user_id).to be_empty
       end
     end
   end


### PR DESCRIPTION
### Context
We aren't returning all declarations as in v1/v2 due to an extra `INNER JOIN on induction records`. We would like to also select the correct mentor profile id from declarations from the latest induction record only.

- Ticket: n/a

### Changes proposed in this pull request
- Paginate on smaller query for Declarations and then perform further joins on paginated subset
- Change induction record joins to outer joins to paginate correctly, and to include exact number of declarations from v1/v2
- Only get the latest induction record mentor id, and remove `nil` values in the final array
- to allow running distinct use a subquery for the `group_by` and finally select the correct fields and sort in final query

### Guidance to review
I've run the numbers on the prob backup and declaration number equals v1/v2. We are also slightly faster when returning declarations than the current version
