### PR TITLE
Add a rake task to send the comms to the pilot schools

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -557,19 +557,19 @@ class SchoolMailer < ApplicationMailer
   # Pilot one-off mailers
 
   def pilot_ask_sit_to_report_school_training_details
-    sit_profile = params[:sit_profile]
+    sit_user = params[:sit_user]
     nomination_link = params[:nomination_link]
 
     template_mail(
       PILOT_ASK_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE,
-      to: sit_profile.user.email,
+      to: sit_user.email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        sit_name: sit_profile.user.full_name,
+        name: sit_user.full_name,
         nomination_link:,
       },
-    ).tag(:pilot_ask_sit_to_report_school_training_details).associate_with(sit_profile)
+    ).tag(:pilot_ask_sit_to_report_school_training_details).associate_with(sit_user)
   end
 
   def pilot_ask_gias_contact_to_report_school_training_details
@@ -589,19 +589,19 @@ class SchoolMailer < ApplicationMailer
   end
 
   def launch_ask_sit_to_report_school_training_details
-    sit_profile = params[:sit_profile]
+    sit_user = params[:sit_user]
     nomination_link = params[:nomination_link]
 
     template_mail(
       LAUNCH_ASK_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE,
-      to: sit_profile.user.email,
+      to: sit_user.email,
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        sit_name: sit_profile.user.full_name,
+        name: sit_user.full_name,
         nomination_link:,
       },
-    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(sit_profile)
+    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(sit_user)
   end
 
   def launch_ask_gias_contact_to_report_school_training_details

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -569,10 +569,11 @@ class SchoolMailer < ApplicationMailer
         sit_name: sit_profile.user.full_name,
         nomination_link:,
       },
-    ).tag(:pilot_sit_to_report_school_training).associate_with(sit_profile)
+    ).tag(:pilot_ask_sit_to_report_school_training_details).associate_with(sit_profile)
   end
 
   def pilot_ask_gias_contact_to_report_school_training_details
+    school = params[:school]
     gias_contact_email = params[:gias_contact_email]
     nomination_link = params[:nomination_link]
 
@@ -584,7 +585,7 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         nomination_link:,
       },
-    ).tag(:pilot_gias_contact_to_report_school_training).associate_with(gias_contact_email)
+    ).tag(:pilot_ask_gias_contact_to_report_school_training_details).associate_with(school)
   end
 
   def launch_ask_sit_to_report_school_training_details
@@ -600,10 +601,11 @@ class SchoolMailer < ApplicationMailer
         sit_name: sit_profile.user.full_name,
         nomination_link:,
       },
-    ).tag(:launch_sit_to_report_school_training).associate_with(sit_profile)
+    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(sit_profile)
   end
 
   def launch_ask_gias_contact_to_report_school_training_details
+    school = params[:school]
     gias_contact_email = params[:gias_contact_email]
     nomination_link = params[:nomination_link]
 
@@ -615,6 +617,6 @@ class SchoolMailer < ApplicationMailer
       personalisation: {
         nomination_link:,
       },
-    ).tag(:launch_gias_contact_to_report_school_training).associate_with(gias_contact_email)
+    ).tag(:launch_ask_gias_contact_to_report_school_training_details).associate_with(school)
   end
 end

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'csv'
+require "csv"
 
 namespace :comms do
   desc "Send the comms to the schools in the pilot"
@@ -49,7 +49,7 @@ namespace :comms do
 
         SchoolMailer
           .with(
-            school: school,
+            school:,
             gias_contact_email: school.primary_contact_email,
             nomination_link: get_gias_nomination_url(token: nomination_token),
           )

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -34,6 +34,7 @@ namespace :comms do
 
           if Email.tagged_with(:pilot_ask_sit_to_report_school_training_details).associated_with(sit_user).any?
             logger.info "The user with id #{sit_user.id} has been already contacted"
+            next
           end
 
           nomination_token = create_nomination_token(school, sit_user.email)
@@ -51,6 +52,7 @@ namespace :comms do
 
         if Email.tagged_with(:pilot_ask_gias_contact_to_report_school_training_details).associated_with(school).any?
           logger.info "The school's primary GIAS has been already contacted"
+          next
         end
 
         nomination_token = create_nomination_token(school, school.primary_contact_email)

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -81,5 +81,5 @@ def create_nomination_token(school, user)
     sent_at: Time.zone.now,
     sent_to: user,
     school:,
-  )
+  ).token
 end

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+namespace :comms do
+  desc "Send the comms to the schools in the pilot"
+  task :send_pilot, [:path_to_csv] => :environment do |_task, args|
+    logger = Logger.new($stdout)
+
+    rows ||= CSV.read(args.path_to_csv, headers: true)
+
+    rows.each do |school|
+      school_urn = school["urn"]
+      school_name = school["name"]
+
+      school = School.find_by_urn(school_urn)
+
+      if school.nil?
+        logger.error "Unable to find school with URN: #{school_urn}"
+        next
+      end
+
+      if school.name != school_name
+        logger.error "The school with URN #{school_urn} does not matches the school name: #{school_name}"
+        next
+      end
+
+      logger.info "Adding school with urn #{school_urn} to the pilot"
+      FeatureFlag.activate(:cohortless_dashboard, for: school)
+
+      if school.induction_coordinators.any?
+        school.induction_coordinators.each do |sit_user|
+          logger.info "Sending comms to the school's SIT: #{sit_user.email}"
+
+          nomination_token = create_nomination_token(school, sit_user.email)
+
+          SchoolMailer
+            .with(
+              sit_user:,
+              nomination_link: get_sit_nomination_url(token: nomination_token),
+            )
+            .pilot_ask_sit_to_report_school_training_details
+            .deliver_later
+        end
+      else
+        logger.info "Sending comms to the school's primary GIAS contact"
+
+        nomination_token = create_nomination_token(school, school.primary_contact_email)
+
+        SchoolMailer
+          .with(
+            school: school,
+            gias_contact_email: school.primary_contact_email,
+            nomination_link: get_gias_nomination_url(token: nomination_token),
+          )
+          .pilot_ask_gias_contact_to_report_school_training_details
+          .deliver_later
+      end
+    end
+  end
+end
+
+def get_sit_nomination_url(token:)
+  Rails
+    .application
+    .routes
+    .url_helpers
+    .start_nominate_induction_coordinator_url(token:, host: Rails.application.config.domain)
+end
+
+def get_gias_nomination_url(token:)
+  Rails
+    .application
+    .routes
+    .url_helpers
+    .start_nomination_nominate_induction_coordinator_url(token:, host: Rails.application.config.domain)
+end
+
+def create_nomination_token(school, user)
+  NominationEmail.create_nomination_email(
+    sent_at: Time.zone.now,
+    sent_to: user,
+    school:,
+  )
+end

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -30,7 +30,7 @@ namespace :comms do
 
       if school.induction_coordinators.any?
         school.induction_coordinators.each do |sit_user|
-          logger.info "Sending comms to the school's SIT: #{sit_user.email}"
+          logger.info "Sending comms to the school's SIT with user id: #{sit_user.id}"
 
           nomination_token = create_nomination_token(school, sit_user.email)
 

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -32,6 +32,10 @@ namespace :comms do
         school.induction_coordinators.each do |sit_user|
           logger.info "Sending comms to the school's SIT with user id: #{sit_user.id}"
 
+          if Email.tagged_with(:pilot_ask_sit_to_report_school_training_details).associated_with(sit_user).any?
+            logger.info "The user with id #{sit_user.id} has been already contacted"
+          end
+
           nomination_token = create_nomination_token(school, sit_user.email)
 
           SchoolMailer
@@ -44,6 +48,10 @@ namespace :comms do
         end
       else
         logger.info "Sending comms to the school's primary GIAS contact"
+
+        if Email.tagged_with(:pilot_ask_gias_contact_to_report_school_training_details).associated_with(school).any?
+          logger.info "The school's primary GIAS has been already contacted"
+        end
 
         nomination_token = create_nomination_token(school, school.primary_contact_email)
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -232,18 +232,18 @@ RSpec.describe SchoolMailer, type: :mailer do
   end
 
   describe "#pilot_ask_sit_to_report_school_training_details" do
-    let(:sit_profile) { create(:induction_coordinator_profile) }
+    let(:sit_user) { create(:user, :induction_coordinator) }
     let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:pilot_ask_sit_to_report_school_training_details) do
       SchoolMailer.with(
-        sit_profile:,
+        sit_user:,
         nomination_link:,
       ).pilot_ask_sit_to_report_school_training_details.deliver_now
     end
 
     it "renders the right headers" do
-      expect(pilot_ask_sit_to_report_school_training_details.to).to eq([sit_profile.user.email])
+      expect(pilot_ask_sit_to_report_school_training_details.to).to eq([sit_user.email])
       expect(pilot_ask_sit_to_report_school_training_details.from).to eq(["mail@example.com"])
     end
 
@@ -253,11 +253,13 @@ RSpec.describe SchoolMailer, type: :mailer do
   end
 
   describe "#pilot_ask_gias_contact_to_report_school_training_details" do
-    let(:gias_contact_email) { "contact@example.com" }
+    let(:school) { create(:school) }
+    let(:gias_contact_email) { school.primary_contact_email }
     let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:pilot_ask_gias_contact_to_report_school_training_details) do
       SchoolMailer.with(
+        school:,
         gias_contact_email:,
         nomination_link:,
       ).pilot_ask_gias_contact_to_report_school_training_details.deliver_now
@@ -274,18 +276,18 @@ RSpec.describe SchoolMailer, type: :mailer do
   end
 
   describe "#launch_ask_sit_to_report_school_training_details" do
-    let(:sit_profile) { create(:induction_coordinator_profile) }
+    let(:sit_user) { create(:user, :induction_coordinator) }
     let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:launch_ask_sit_to_report_school_training_details) do
       SchoolMailer.with(
-        sit_profile:,
+        sit_user:,
         nomination_link:,
       ).launch_ask_sit_to_report_school_training_details.deliver_now
     end
 
     it "renders the right headers" do
-      expect(launch_ask_sit_to_report_school_training_details.to).to eq([sit_profile.user.email])
+      expect(launch_ask_sit_to_report_school_training_details.to).to eq([sit_user.email])
       expect(launch_ask_sit_to_report_school_training_details.from).to eq(["mail@example.com"])
     end
 
@@ -295,11 +297,13 @@ RSpec.describe SchoolMailer, type: :mailer do
   end
 
   describe "#launch_ask_gias_contact_to_report_school_training_details" do
-    let(:gias_contact_email) { "contact@example.com" }
+    let(:school) { create(:school) }
+    let(:gias_contact_email) { school.primary_contact_email }
     let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:launch_ask_gias_contact_to_report_school_training_details) do
       SchoolMailer.with(
+        school:,
         gias_contact_email:,
         nomination_link:,
       ).launch_ask_gias_contact_to_report_school_training_details.deliver_now


### PR DESCRIPTION
### Context

- Ticket: CST-1551

We need a one off task to send the comms to the pilot schools.

### Changes proposed in this pull request
- Refactor the mailers to simplify them and associate them with the correct objects
- Add a rake task to send the pilot comms. It reads a list of schools from a CSV file, adds them in the pilot and sends the comms either to the school's SIT or GIAS primary contact.

### Guidance to review

