### PR TITLE
[CST-1531] Update emails that might get trigger during the pilot

### DIFF
--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe SchoolMailer, type: :mailer do
   describe "#nomination_email" do
+    let!(:cohort) { Cohort.current || create(:cohort, :current) }
     let(:school) { instance_double School, name: "Great Ouse Academy" }
     let(:primary_contact_email) { "contact@example.com" }
     let(:nomination_url) { "https://ecf-dev.london.cloudapps/nominations?token=abc123" }
@@ -18,8 +19,19 @@ RSpec.describe SchoolMailer, type: :mailer do
     end
 
     it "renders the right headers" do
+        expect(Cohort).to receive(:current).and_return(cohort).once
       expect(nomination_email.from).to eq(["mail@example.com"])
       expect(nomination_email.to).to eq([primary_contact_email])
+    end
+
+    context "when the pilot is active", with_feature_flags: { cohortless_dashboard: "active" }, travel_to: Date.new(2023, 7, 1) do
+      let!(:cohort_next) { Cohort.next || create(:cohort, :next) }
+
+      it "renders the right headers" do
+        expect(Cohort).to receive(:active_registration_cohort).and_return(cohort_next).once
+        expect(nomination_email.from).to eq(["mail@example.com"])
+        expect(nomination_email.to).to eq([primary_contact_email])
+      end
     end
   end
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SchoolMailer, type: :mailer do
     end
 
     it "renders the right headers" do
-        expect(Cohort).to receive(:current).and_return(cohort).once
+      expect(Cohort).to receive(:current).and_return(cohort).once
       expect(nomination_email.from).to eq(["mail@example.com"])
       expect(nomination_email.to).to eq([primary_contact_email])
     end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1531)

Both of these templates in Notify are hard-coded for the 2022-23 academic year. This PR makes these a placeholder provided by the mailer.

I have duplicated the 2 templates in Notify for the emails and referenced them from the existing code to prevent out-of-sync issues happening before the code is deployed [here](https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/bfc43b20-922f-4323-8775-a6e05f06e24a) and [here](https://www.notifications.service.gov.uk/services/d1207ebf-ac0c-47b8-b1bf-16dc899e0923/templates/123eb3e6-401f-4c1d-b81e-113cb6580fc9)

### Changes proposed in this pull request
Added `academic_year` placeholders to the duplicate Notify templates
Derived the correct `academic_year` in the mailers

### Guidance to review
Tests from Notify:
Not in the pilot
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/2a08d5b5-357b-4666-93bf-408640ff7b8b)
In the pilot
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/9e177421-7891-44cb-9fa0-4f9a8d3dbb4a)

Partnership notification for 2023/24 (existing partnership so challenge date wrong but to demonstrate the academic year part)
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/f8a3273b-6f80-42db-b65f-5a97127e60e7)

Partnership notification for 2022/23 (existing partnership so challenge date wrong but to demonstrate the academic year part)
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/7c011e87-dd3e-4cca-a7df-21df2182c91c)
