### PR TITLE
Improve Participant declaration queries

### DIFF
--- a/app/serializers/api/v3/participant_declaration_serializer.rb
+++ b/app/serializers/api/v3/participant_declaration_serializer.rb
@@ -89,7 +89,7 @@ module Api
 
       attribute :has_passed do |declaration|
         if declaration.npq?
-          declaration.outcomes.latest&.has_passed?
+          declaration.outcomes.sort_by(&:created_at).reverse!&.first&.has_passed?
         end
       end
     end

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -25,7 +25,10 @@ module Api
           scope = scope.where(delivery_partner_id: delivery_partner_ids)
         end
 
-        scope.select(:id).distinct
+        scope
+          .select(:id, :created_at)
+          .order(:created_at)
+          .distinct
       end
 
       def participant_declarations_from(paginated_join)

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -11,10 +11,7 @@ module Api
       end
 
       def participant_declarations_for_pagination
-        scope = ActiveRecordUnion.new(
-          declarations_scope,
-          previous_declarations_scope,
-        ).call
+        scope = declarations_scope.or(previous_declarations_scope)
 
         if participant_ids.present?
           scope = scope.where(user_id: participant_ids)
@@ -28,7 +25,7 @@ module Api
           scope = scope.where(delivery_partner_id: delivery_partner_ids)
         end
 
-        scope.distinct
+        scope.select(:id).distinct
       end
 
       def participant_declarations_from(paginated_join)
@@ -51,9 +48,14 @@ module Api
               :cpd_lead_provider,
             )
             .from("(#{sub_query.to_sql}) as participant_declarations")
+            .order(:created_at)
             .distinct
 
-        scope.order(:created_at)
+        preloader = ActiveRecord::Associations::Preloader.new
+        preloader.preload(scope.select { |p| p.type == "ParticipantDeclaration::NPQ" }, :outcomes)
+        preloader.preload(scope.select { |p| p.type == "ParticipantDeclaration::NPQ" }, participant_profile: :npq_application)
+
+        scope
       end
 
     private

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -21,61 +21,70 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
 
   let(:delivery_partner1) { create(:delivery_partner) }
   let(:delivery_partner2) { create(:delivery_partner) }
-  let!(:participant_declaration1) do
-    travel_to(3.days.ago) do
-      create(
-        :ect_participant_declaration,
-        :paid,
-        uplifts: [:sparsity_uplift],
-        declaration_type: "started",
-        evidence_held: "training-event-attended",
-        cpd_lead_provider: cpd_lead_provider1,
-        participant_profile: participant_profile1,
-        delivery_partner: delivery_partner1,
-      )
-    end
-  end
-  let!(:participant_declaration2) do
-    travel_to(1.day.ago) do
-      create(
-        :ect_participant_declaration,
-        :eligible,
-        declaration_type: "started",
-        cpd_lead_provider: cpd_lead_provider1,
-        participant_profile: participant_profile2,
-        delivery_partner: delivery_partner2,
-      )
-    end
-  end
-  let!(:participant_declaration3) do
-    travel_to(5.days.ago) do
-      create(
-        :ect_participant_declaration,
-        :eligible,
-        declaration_type: "started",
-        cpd_lead_provider: cpd_lead_provider1,
-        participant_profile: participant_profile3,
-        delivery_partner: delivery_partner2,
-      )
-    end
-  end
-  let!(:participant_declaration4) do
-    travel_to(5.days.ago) do
-      create(
-        :ect_participant_declaration,
-        :eligible,
-        declaration_type: "started",
-        cpd_lead_provider: cpd_lead_provider2,
-        participant_profile: participant_profile4,
-        delivery_partner: delivery_partner1,
-      )
-    end
-  end
   let(:params) { {} }
 
   subject { described_class.new(cpd_lead_provider: cpd_lead_provider1, params:) }
 
   describe "#participant_declarations_for_pagination" do
+    let!(:participant_declaration1) do
+      travel_to(3.days.ago) do
+        declaration = create(
+          :ect_participant_declaration,
+          :paid,
+          uplifts: [:sparsity_uplift],
+          declaration_type: "started",
+          evidence_held: "training-event-attended",
+          cpd_lead_provider: cpd_lead_provider1,
+          participant_profile: participant_profile1,
+          delivery_partner: delivery_partner1,
+        )
+
+        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+      end
+    end
+    let!(:participant_declaration2) do
+      travel_to(1.day.ago) do
+        declaration = create(
+          :ect_participant_declaration,
+          :eligible,
+          declaration_type: "started",
+          cpd_lead_provider: cpd_lead_provider1,
+          participant_profile: participant_profile2,
+          delivery_partner: delivery_partner2,
+        )
+
+        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+      end
+    end
+    let!(:participant_declaration3) do
+      travel_to(5.days.ago) do
+        declaration = create(
+          :ect_participant_declaration,
+          :eligible,
+          declaration_type: "started",
+          cpd_lead_provider: cpd_lead_provider1,
+          participant_profile: participant_profile3,
+          delivery_partner: delivery_partner2,
+        )
+
+        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+      end
+    end
+    let!(:participant_declaration4) do
+      travel_to(5.days.ago) do
+        declaration = create(
+          :ect_participant_declaration,
+          :eligible,
+          declaration_type: "started",
+          cpd_lead_provider: cpd_lead_provider2,
+          participant_profile: participant_profile4,
+          delivery_partner: delivery_partner1,
+        )
+
+        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+      end
+    end
+
     context "empty params" do
       it "returns all participant declarations for cpd_lead_provider1" do
         expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
@@ -134,10 +143,10 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { updated_since: 2.days.ago.iso8601 } } }
 
       before do
-        participant_declaration1.update!(updated_at: 3.days.ago)
-        participant_declaration2.update!(updated_at: 1.day.ago)
-        participant_declaration3.update!(updated_at: 5.days.ago)
-        participant_declaration4.update!(updated_at: 6.days.ago)
+        ParticipantDeclaration.find(participant_declaration1.id).update!(updated_at: 3.days.ago)
+        ParticipantDeclaration.find(participant_declaration2.id).update!(updated_at: 1.day.ago)
+        ParticipantDeclaration.find(participant_declaration3.id).update!(updated_at: 5.days.ago)
+        ParticipantDeclaration.find(participant_declaration4.id).update!(updated_at: 6.days.ago)
       end
 
       it "returns participant declarations for the specific updated time" do
@@ -171,6 +180,57 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
   end
 
   describe "#participant_declarations" do
+    let!(:participant_declaration1) do
+      travel_to(3.days.ago) do
+        create(
+          :ect_participant_declaration,
+          :paid,
+          uplifts: [:sparsity_uplift],
+          declaration_type: "started",
+          evidence_held: "training-event-attended",
+          cpd_lead_provider: cpd_lead_provider1,
+          participant_profile: participant_profile1,
+          delivery_partner: delivery_partner1,
+        )
+      end
+    end
+    let!(:participant_declaration2) do
+      travel_to(1.day.ago) do
+        create(
+          :ect_participant_declaration,
+          :eligible,
+          declaration_type: "started",
+          cpd_lead_provider: cpd_lead_provider1,
+          participant_profile: participant_profile2,
+          delivery_partner: delivery_partner2,
+        )
+      end
+    end
+    let!(:participant_declaration3) do
+      travel_to(5.days.ago) do
+        create(
+          :ect_participant_declaration,
+          :eligible,
+          declaration_type: "started",
+          cpd_lead_provider: cpd_lead_provider1,
+          participant_profile: participant_profile3,
+          delivery_partner: delivery_partner2,
+        )
+      end
+    end
+    let!(:participant_declaration4) do
+      travel_to(5.days.ago) do
+        create(
+          :ect_participant_declaration,
+          :eligible,
+          declaration_type: "started",
+          cpd_lead_provider: cpd_lead_provider2,
+          participant_profile: participant_profile4,
+          delivery_partner: delivery_partner1,
+        )
+      end
+    end
+
     it "returns all declarations passed in from query in the correct order" do
       paginated_query = ParticipantDeclaration.where(cpd_lead_provider: cpd_lead_provider1)
       expect(subject.participant_declarations_from(paginated_query).to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
           delivery_partner: delivery_partner1,
         )
 
-        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+        ParticipantDeclaration.where(id: declaration.id).select(:id, :created_at).first
       end
     end
     let!(:participant_declaration2) do
@@ -53,7 +53,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
           delivery_partner: delivery_partner2,
         )
 
-        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+        ParticipantDeclaration.where(id: declaration.id).select(:id, :created_at).first
       end
     end
     let!(:participant_declaration3) do
@@ -67,7 +67,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
           delivery_partner: delivery_partner2,
         )
 
-        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+        ParticipantDeclaration.where(id: declaration.id).select(:id, :created_at).first
       end
     end
     let!(:participant_declaration4) do
@@ -81,13 +81,13 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
           delivery_partner: delivery_partner1,
         )
 
-        ParticipantDeclaration.where(id: declaration.id).select(:id).first
+        ParticipantDeclaration.where(id: declaration.id).select(:id, :created_at).first
       end
     end
 
     context "empty params" do
       it "returns all participant declarations for cpd_lead_provider1" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
       end
     end
 
@@ -95,7 +95,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { cohort: cohort2.start_year.to_s } } }
 
       it "returns all participant declarations for the specific cohort" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration3])
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { cohort: [cohort1.start_year, cohort2.start_year].join(",") } } }
 
       it "returns all participant declarations for the specific cohort" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
       end
     end
 
@@ -119,7 +119,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { participant_id: participant_profile1.user_id } } }
 
       it "returns participant declarations for the specific participant_id" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration1)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration1])
       end
     end
 
@@ -127,7 +127,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { participant_id: [participant_profile1.user_id, participant_profile2.user_id].join(",") } } }
 
       it "returns participant declarations for the specific participant_id" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration1, participant_declaration2)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration1, participant_declaration2])
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       end
 
       it "returns participant declarations for the specific updated time" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration2)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration2])
       end
     end
 
@@ -158,7 +158,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { delivery_partner_id: delivery_partner2.id } } }
 
       it "returns participant declarations for the specific delivery_partner_id" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration2)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration3, participant_declaration2])
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       let(:params) { { filter: { delivery_partner_id: [delivery_partner1.id, delivery_partner2.id].join(",") } } }
 
       it "returns participant declarations for the specific delivery_partner_id" do
-        expect(subject.participant_declarations_for_pagination.to_a).to contain_exactly(participant_declaration3, participant_declaration1, participant_declaration2)
+        expect(subject.participant_declarations_for_pagination.to_a).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
       end
     end
 


### PR DESCRIPTION
### Context
Participant declaration queries are causing db load, improve them in all versions of the API

- Ticket: n/a

### Changes proposed in this pull request
- Use OR instead of union
- Only select IDs in v3 to improve performance
- Eager load NPQ associations to avoid n+1s in v3

### Guidance to review
Tested before and after numbers for v1/v2/v3 and they match up
also tested filters for all endpoints
