### PR TITLE
redirect schools that didn't set the previous cohort to set it up

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -27,12 +27,15 @@ private
   def redirect_to_setup_cohort
     return unless current_user.induction_coordinator?
     return unless active_school
-    return if active_school.chosen_programme?(Dashboard::LatestManageableCohort.call(active_school))
 
-    if Dashboard::LatestManageableCohort.call(active_school) == Cohort.active_registration_cohort
-      redirect_to schools_cohort_setup_start_path(cohort_id: Dashboard::LatestManageableCohort.call(active_school))
+    latest_manageable_cohort = Dashboard::LatestManageableCohort.call(active_school)
+    return if active_school.chosen_programme?(latest_manageable_cohort)
+
+    if latest_manageable_cohort == Cohort.active_registration_cohort
+      redirect_to schools_cohort_setup_start_path(cohort_id: latest_manageable_cohort)
     else
-      redirect_to schools_choose_programme_path(school_id: active_school.slug, cohort_id: active_cohort.id)
+      cohort_id = (active_cohort || latest_manageable_cohort)&.id
+      redirect_to schools_choose_programme_path(school_id: active_school.slug, cohort_id:)
     end
   end
 


### PR DESCRIPTION
### Context

  Schools that didn't have 2022 setup get an error in the redirection to set it up, now that 2023 registration is open for pilot schools and we have become cohortless (so the cohort year is not being specified by the params)

- Ticket: 

### Changes proposed in this pull request:
 - determine the cohort to setup based in the latest manageable cohort of the school if not cohort_id is specified by the params in the request.

### Guidance to review

