### PR TITLE
Add TrainingRecordState table and model

### DIFF
--- a/app/components/status_tags/admin_participant_status_tag.rb
+++ b/app/components/status_tags/admin_participant_status_tag.rb
@@ -31,7 +31,7 @@ module StatusTags
     end
 
     def record_state
-      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, induction_record:, school:)&.record_state || :no_longer_involved
+      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, school:)&.record_state || :no_longer_involved
     end
   end
 end

--- a/app/components/status_tags/appropriate_body_participant_status_tag.rb
+++ b/app/components/status_tags/appropriate_body_participant_status_tag.rb
@@ -35,7 +35,7 @@ module StatusTags
     end
 
     def record_state
-      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, induction_record:, appropriate_body:)&.record_state || :no_longer_involved
+      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, appropriate_body:)&.record_state || :no_longer_involved
     end
   end
 end

--- a/app/components/status_tags/delivery_partner_participant_status_tag.rb
+++ b/app/components/status_tags/delivery_partner_participant_status_tag.rb
@@ -35,7 +35,7 @@ module StatusTags
     end
 
     def record_state
-      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, induction_record:, delivery_partner:)&.record_state || :no_longer_involved
+      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, delivery_partner:)&.record_state || :no_longer_involved
     end
   end
 end

--- a/app/components/status_tags/school_participant_status_tag.rb
+++ b/app/components/status_tags/school_participant_status_tag.rb
@@ -32,7 +32,7 @@ module StatusTags
     end
 
     def record_state
-      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, induction_record:, school:)&.record_state || :no_longer_involved
+      @record_state ||= DetermineTrainingRecordState.call(participant_profile:, school:)&.record_state || :no_longer_involved
     end
   end
 end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -18,6 +18,7 @@ class DeliveryPartner < DiscardableRecord
 
   has_many :delivery_partner_profiles, dependent: :destroy
   has_many :users, through: :delivery_partner_profiles
+  has_many :training_record_states
 
   scope :name_order, -> { order("UPPER(name)") }
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -25,6 +25,7 @@ class LeadProvider < ApplicationRecord
   has_many :partnership_csv_uploads
   has_many :lead_provider_api_tokens
   has_one :call_off_contract
+  has_many :training_record_states
 
   has_many :statements, through: :cpd_lead_provider, class_name: "Finance::Statement::ECF", source: :ecf_statements
   validates :name, presence: { message: "Enter a name" }

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -68,6 +68,10 @@ class ParticipantProfile < ApplicationRecord
   # delivery_partner
   delegate :delivery_partner, to: :latest_induction_record, allow_nil: true
 
+  def sync_states
+    DetermineTrainingRecordState.new(participant_profile: self).call
+  end
+
   def duplicate?
     ecf_participant_eligibility&.duplicate_profile_reason?
   end

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -42,6 +42,7 @@ class ParticipantProfile < ApplicationRecord
   has_many :participant_profile_states
   has_many :sync_dqt_induction_start_date_errors
   has_many :validation_decisions, class_name: "ProfileValidationDecision"
+  has_many :training_record_states
 
   has_one :ecf_participant_eligibility
   has_one :ecf_participant_validation_data

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -10,6 +10,7 @@ class School < ApplicationRecord
 
   belongs_to :network, optional: true
 
+  has_many :training_record_states
   has_many :npq_applications, foreign_key: "school_urn", class_name: "NPQApplication"
   has_many :school_links, dependent: :destroy
   has_many :successor_links, -> { successor }, class_name: "SchoolLink"

--- a/app/models/training_record_state.rb
+++ b/app/models/training_record_state.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TrainingRecordState < ApplicationRecord
+  belongs_to :participant_profile
+  belongs_to :school, optional: true
+  belongs_to :lead_provider, optional: true
+  belongs_to :delivery_partner, optional: true
+  belongs_to :appropriate_body, optional: true
+end

--- a/app/models/training_record_state.rb
+++ b/app/models/training_record_state.rb
@@ -6,4 +6,20 @@ class TrainingRecordState < ApplicationRecord
   belongs_to :lead_provider, optional: true
   belongs_to :delivery_partner, optional: true
   belongs_to :appropriate_body, optional: true
+
+  scope :changed_most_recently_first, -> { order(changed_at: "desc") }
+
+  def self.latest_for(participant_profile:, school: nil, appropriate_body: nil, delivery_partner: nil, lead_provider: nil)
+    params = {
+      participant_profile_id: participant_profile.id,
+      school_id: school&.id,
+      appropriate_body_id: appropriate_body&.id,
+      delivery_partner_id: delivery_partner&.id,
+      lead_provider_id: lead_provider&.id,
+    }.compact
+
+    Rails.logger.debug("Searching with: #{params}")
+
+    where(**params).changed_most_recently_first.first
+  end
 end

--- a/app/models/training_record_state.rb
+++ b/app/models/training_record_state.rb
@@ -6,20 +6,4 @@ class TrainingRecordState < ApplicationRecord
   belongs_to :lead_provider, optional: true
   belongs_to :delivery_partner, optional: true
   belongs_to :appropriate_body, optional: true
-
-  scope :changed_most_recently_first, -> { order(changed_at: "desc") }
-
-  def self.latest_for(participant_profile:, school: nil, appropriate_body: nil, delivery_partner: nil, lead_provider: nil)
-    params = {
-      participant_profile_id: participant_profile.id,
-      school_id: school&.id,
-      appropriate_body_id: appropriate_body&.id,
-      delivery_partner_id: delivery_partner&.id,
-      lead_provider_id: lead_provider&.id,
-    }.compact
-
-    Rails.logger.debug("Searching with: #{params}")
-
-    where(**params).changed_most_recently_first.first
-  end
 end

--- a/app/services/determine_training_record_state.rb
+++ b/app/services/determine_training_record_state.rb
@@ -153,6 +153,7 @@ class DetermineTrainingRecordState < BaseService
       training_record_state.assign_attributes(**execute_query.first)
 
       training_record_state.save! if training_record_state.changed?
+      training_record_state
     else
       TrainingRecordState.create!(**execute_query.first)
     end

--- a/db/migrate/20230605110212_readd_training_record_states_as_table.rb
+++ b/db/migrate/20230605110212_readd_training_record_states_as_table.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ReaddTrainingRecordStatesAsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :training_record_states do |t|
+      t.uuid :participant_profile_id, null: false
+      t.uuid :school_id
+      t.uuid :lead_provider_id
+      t.uuid :appropriate_body_id
+      t.uuid :delivery_partner_id
+      t.datetime :changed_at, null: false
+      t.string :validation_state, null: false
+      t.string :training_eligibility_state, null: false
+      t.string :fip_funding_eligibility_state, null: false
+      t.string :mentoring_state, null: false
+      t.string :training_state, null: false
+      t.string :record_state, null: false
+
+      t.timestamps
+    end
+
+    add_index :training_record_states, :participant_profile_id
+    add_index :training_record_states, :school_id
+    add_index :training_record_states, :lead_provider_id
+    add_index :training_record_states, :delivery_partner_id
+
+    add_index :training_record_states, %i[participant_profile_id school_id lead_provider_id appropriate_body_id delivery_partner_id changed_at], unique: true, name: "index_training_record_states_unique_ids"
+
+    add_foreign_key :training_record_states, :participant_profiles, validate: false
+    add_foreign_key :training_record_states, :schools, validate: false
+    add_foreign_key :training_record_states, :lead_providers, validate: false
+    add_foreign_key :training_record_states, :delivery_partners, validate: false
+    add_foreign_key :training_record_states, :appropriate_bodies, validate: false
+  end
+end

--- a/db/migrate/20230605110212_readd_training_record_states_as_table.rb
+++ b/db/migrate/20230605110212_readd_training_record_states_as_table.rb
@@ -23,8 +23,9 @@ class ReaddTrainingRecordStatesAsTable < ActiveRecord::Migration[6.1]
     add_index :training_record_states, :school_id
     add_index :training_record_states, :lead_provider_id
     add_index :training_record_states, :delivery_partner_id
+    add_index :training_record_states, :appropriate_body_id
 
-    add_index :training_record_states, %i[participant_profile_id school_id lead_provider_id appropriate_body_id delivery_partner_id changed_at], unique: true, name: "index_training_record_states_unique_ids"
+    add_index :training_record_states, %i[participant_profile_id school_id lead_provider_id appropriate_body_id delivery_partner_id], unique: true, name: "index_training_record_states_unique_ids"
 
     add_foreign_key :training_record_states, :participant_profiles, validate: false
     add_foreign_key :training_record_states, :schools, validate: false

--- a/db/migrate/20230605154522_add_foreign_keys_to_training_record_states.rb
+++ b/db/migrate/20230605154522_add_foreign_keys_to_training_record_states.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddForeignKeysToTrainingRecordStates < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :training_record_states, :participant_profiles
+    validate_foreign_key :training_record_states, :schools
+    validate_foreign_key :training_record_states, :lead_providers
+    validate_foreign_key :training_record_states, :delivery_partners
+    validate_foreign_key :training_record_states, :appropriate_bodies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1049,9 +1049,10 @@ ActiveRecord::Schema.define(version: 2023_06_05_154522) do
     t.string "record_state", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["appropriate_body_id"], name: "index_training_record_states_on_appropriate_body_id"
     t.index ["delivery_partner_id"], name: "index_training_record_states_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_training_record_states_on_lead_provider_id"
-    t.index ["participant_profile_id", "school_id", "lead_provider_id", "appropriate_body_id", "delivery_partner_id", "changed_at"], name: "index_training_record_states_unique_ids", unique: true
+    t.index ["participant_profile_id", "school_id", "lead_provider_id", "appropriate_body_id", "delivery_partner_id"], name: "index_training_record_states_unique_ids", unique: true
     t.index ["participant_profile_id"], name: "index_training_record_states_on_participant_profile_id"
     t.index ["school_id"], name: "index_training_record_states_on_school_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_04_164057) do
+ActiveRecord::Schema.define(version: 2023_06_05_154522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1034,6 +1034,28 @@ ActiveRecord::Schema.define(version: 2023_06_04_164057) do
     t.index ["user_id"], name: "index_teacher_profiles_on_user_id", unique: true
   end
 
+  create_table "training_record_states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "participant_profile_id", null: false
+    t.uuid "school_id"
+    t.uuid "lead_provider_id"
+    t.uuid "appropriate_body_id"
+    t.uuid "delivery_partner_id"
+    t.datetime "changed_at", null: false
+    t.string "validation_state", null: false
+    t.string "training_eligibility_state", null: false
+    t.string "fip_funding_eligibility_state", null: false
+    t.string "mentoring_state", null: false
+    t.string "training_state", null: false
+    t.string "record_state", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["delivery_partner_id"], name: "index_training_record_states_on_delivery_partner_id"
+    t.index ["lead_provider_id"], name: "index_training_record_states_on_lead_provider_id"
+    t.index ["participant_profile_id", "school_id", "lead_provider_id", "appropriate_body_id", "delivery_partner_id", "changed_at"], name: "index_training_record_states_unique_ids", unique: true
+    t.index ["participant_profile_id"], name: "index_training_record_states_on_participant_profile_id"
+    t.index ["school_id"], name: "index_training_record_states_on_school_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "full_name", null: false
     t.citext "email", default: "", null: false
@@ -1160,6 +1182,11 @@ ActiveRecord::Schema.define(version: 2023_06_04_164057) do
   add_foreign_key "sync_dqt_induction_start_date_errors", "participant_profiles"
   add_foreign_key "teacher_profiles", "schools"
   add_foreign_key "teacher_profiles", "users"
+  add_foreign_key "training_record_states", "appropriate_bodies"
+  add_foreign_key "training_record_states", "delivery_partners"
+  add_foreign_key "training_record_states", "lead_providers"
+  add_foreign_key "training_record_states", "participant_profiles"
+  add_foreign_key "training_record_states", "schools"
 
   create_view "ecf_duplicates", sql_definition: <<-SQL
       SELECT participant_identities.user_id,

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe DeliveryPartner, type: :model do
     it { is_expected.to have_many(:schools).through(:active_partnerships) }
     it { is_expected.to have_many(:delivery_partner_profiles) }
     it { is_expected.to have_many(:users) }
+    it { is_expected.to have_many(:training_record_states) }
   end
 
   describe "#cohorts_with_lead_provider" do

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe LeadProvider, type: :model do
     it { is_expected.to have_many(:provider_relationships) }
     it { is_expected.to have_many(:delivery_partners).through(:provider_relationships) }
     it { is_expected.to have_many(:partnership_csv_uploads) }
+    it { is_expected.to have_many(:training_record_states) }
     it { is_expected.to have_one(:call_off_contract) }
     it { is_expected.to have_many(:statements).through(:cpd_lead_provider).class_name("Finance::Statement::ECF").source(:ecf_statements) }
 

--- a/spec/models/participant_profile_spec.rb
+++ b/spec/models/participant_profile_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ParticipantProfile, type: :model do
       withdrawn: "withdrawn",
     ).with_suffix(:record).backed_by_column_of_type(:text)
   }
+  it { is_expected.to have_many(:training_record_states) }
 
   it "updates the updated_at on the users", :with_default_schedules do
     freeze_time do

--- a/spec/models/training_record_state_spec.rb
+++ b/spec/models/training_record_state_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TrainingRecordState, type: :model do
+  describe "relationships" do
+    it { is_expected.to belong_to(:participant_profile) }
+    it { is_expected.to belong_to(:school) }
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to belong_to(:delivery_partner) }
+  end
+end


### PR DESCRIPTION
### Context

This change adds a new table called `training_record_states` that will eventually hold the various statuses for each participant profile.

Unlike the previous materialized view this one isn't related directly to an induction record because they are appended to the table so the relationship is likely to be outdated.
