### PR TITLE
Handle deleted record entities in participant change log

### DIFF
--- a/app/components/admin/participants/audit_trail_component.html.erb
+++ b/app/components/admin/participants/audit_trail_component.html.erb
@@ -1,0 +1,14 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Time</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarter">Event</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% audits.each do |audit| %>
+      <%= render Admin::Participants::AuditTrailItemComponent.new(audit: audit) %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/admin/participants/audit_trail_component.rb
+++ b/app/components/admin/participants/audit_trail_component.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# copied from https://github.com/DFE-Digital/apply-for-teacher-training/blob/54899ba5ddd67958a09c9b2c2ec5818ad675dd6c/app/components/support_interface/audit_trail_component.rb
+
+module Admin
+  module Participants
+    class AuditTrailComponent < ViewComponent::Base
+      def initialize(audited_thing:)
+        @audited_thing = audited_thing
+      end
+
+      Changes = Struct.new(
+        :id,
+        :action,
+        :created_at,
+        :type,
+        :username,
+        :user_type,
+        :audited_changes,
+        keyword_init: true,
+      )
+
+      def audits
+        audits = audited_thing.group_by do |event|
+          {
+            id: event.id,
+            action: event.action,
+            date: event.date,
+            type: event.type,
+            reporter: event.reporter,
+          }
+        end
+
+        audits.map do |event, changes|
+          audited_changes = changes.map { |change| { attribute: change.predicate, values: change.value } }
+
+          Changes.new(
+            id: event[:id],
+            action: event[:action],
+            created_at: event[:date],
+            type: event[:type],
+            username: event[:reporter],
+            user_type: nil,
+            audited_changes:,
+          )
+        end
+      end
+
+      attr_reader :audited_thing
+    end
+  end
+end

--- a/app/components/admin/participants/audit_trail_component.rb
+++ b/app/components/admin/participants/audit_trail_component.rb
@@ -14,7 +14,7 @@ module Admin
         :action,
         :created_at,
         :type,
-        :username,
+        :user,
         :user_type,
         :audited_changes,
         keyword_init: true,
@@ -27,7 +27,7 @@ module Admin
             action: event.action,
             date: event.date,
             type: event.type,
-            reporter: event.reporter,
+            user: event.user,
           }
         end
 
@@ -39,7 +39,7 @@ module Admin
             action: event[:action],
             created_at: event[:date],
             type: event[:type],
-            username: event[:reporter],
+            user: event[:user],
             user_type: nil,
             audited_changes:,
           )

--- a/app/components/admin/participants/audit_trail_item_component.html.erb
+++ b/app/components/admin/participants/audit_trail_item_component.html.erb
@@ -1,0 +1,20 @@
+<tr class="govuk-table__row" data-qa="audit-trail-item">
+  <td class="govuk-table__cell" title="<%= l(audit.created_at, format: "%e %B %Y %H:%M:%S") %>">
+    <%= l(audit.created_at.to_date, format: "%e %B %Y") %> <br><%= l(audit.created_at, format: "%H:%M") %>
+  </td>
+  <td class="govuk-table__cell">
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+      <%= audit_entry_event_label %>
+      <span class="govuk-caption-m"><%= audit_entry_user_label %></span>
+    </h2>
+
+    <%= govuk_summary_list(classes: 'govuk-!-font-size-16') do |summary_list| %>
+      <% changes.each do |change| %>
+        <% summary_list.with_row do |summary_list_row| %>
+          <% summary_list_row.with_key { change.attribute.humanize } %>
+          <% summary_list_row.with_value { change.formatted_values } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/components/admin/participants/audit_trail_item_component.rb
+++ b/app/components/admin/participants/audit_trail_item_component.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# copied from https://github.com/DFE-Digital/apply-for-teacher-training/blob/54899ba5ddd67958a09c9b2c2ec5818ad675dd6c/app/components/support_interface/audit_trail_item_component.rb
+
+module Admin
+  module Participants
+    class AuditTrailItemComponent < ViewComponent::Base
+      def initialize(audit:)
+        @audit = audit
+      end
+
+      def audit_entry_event_label
+        "#{audit.action.capitalize} #{audit.type.to_s.titlecase} ##{audit.id}"
+      end
+
+      def audit_entry_user_label
+        if audit.user_type == "ApiUser"
+          "#{audit.user.email_address} (Vendor API)"
+        elsif audit.user_type == "SupportUser"
+          "#{audit.user.email_address} (Support user)"
+        elsif audit.user_type == "LeadProviderUser"
+          "#{audit.user.email_address} (Provider user)"
+        elsif audit.user_type == "SchoolUser"
+          "#{audit.user.email_address} (School user)"
+        elsif audit.username.present?
+          audit.username
+        else
+          "(Unknown User)"
+        end
+      end
+
+      def changes
+        interesting_changes = audit.audited_changes.reject { |change| change[:attribute] == "id" }.compact_blank
+
+        interesting_changes.sort_by { |change| change[:date] }.reverse!.map do |change|
+          AuditTrailChange.new(attribute: change[:attribute], values: change[:values])
+        end
+      end
+
+      def comment_change
+        { "comment" => audit.comment }
+      end
+
+      attr_reader :audit
+
+      class AuditTrailChange
+        REDACTED_ATTRIBUTES = %w[sex disabilities ethnic_group ethnic_background hesa_sex hesa_disabilities hesa_ethnicity].freeze
+
+        attr_reader :values, :attribute
+
+        def initialize(attribute:, values:)
+          @attribute = attribute
+          @values = values
+        end
+
+        def formatted_values
+          return "[REDACTED]" if REDACTED_ATTRIBUTES.include?(@attribute)
+          return values.map { |v| redact_hash_data(v) || "nil" }.join(" → ") if values.is_a?(Array)
+
+          (redact_hash_data(values) || "nil").to_s
+        end
+
+      private
+
+        def redact_hash_data(value)
+          return value unless value.is_a? Hash
+
+          REDACTED_ATTRIBUTES.each do |field|
+            next unless value[field]
+
+            value[field] = "[REDACTED]"
+          end
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/app/components/admin/participants/audit_trail_item_component.rb
+++ b/app/components/admin/participants/audit_trail_item_component.rb
@@ -5,27 +5,39 @@
 module Admin
   module Participants
     class AuditTrailItemComponent < ViewComponent::Base
+      include AdminHelper
+
       def initialize(audit:)
         @audit = audit
       end
 
       def audit_entry_event_label
-        "#{audit.action.capitalize} #{audit.type.to_s.titlecase} ##{audit.id}"
+        type = admin_participant_role_name(audit.type.to_s)
+        type = audit.type.to_s.titlecase if type == "unknown"
+
+        "#{audit.action.capitalize} #{type} ##{audit.id}"
       end
 
       def audit_entry_user_label
-        if audit.user_type == "ApiUser"
-          "#{audit.user.email_address} (Vendor API)"
-        elsif audit.user_type == "SupportUser"
-          "#{audit.user.email_address} (Support user)"
-        elsif audit.user_type == "LeadProviderUser"
-          "#{audit.user.email_address} (Provider user)"
-        elsif audit.user_type == "SchoolUser"
-          "#{audit.user.email_address} (School user)"
-        elsif audit.username.present?
-          audit.username
+        user = audit.user
+
+        return "(Unknown User)" if user.nil?
+        return user if user.is_a?(String)
+
+        if user.induction_coordinator?
+          "#{user.email_address} (SIT user)"
+        elsif audit.admin?
+          "#{user.email_address} (Support user)"
+        elsif audit.finance?
+          "#{user.email_address} (Finance user)"
+        elsif audit.delivery_partner?
+          "#{user.email_address} (DP user)"
+        elsif audit.appropriate_body?
+          "#{user.email_address} (AB user)"
+        elsif audit.lead_provider?
+          "#{user.supplier_name} (LP user)"
         else
-          "(Unknown User)"
+          audit.user.email_address
         end
       end
 

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -179,7 +179,7 @@ private
     value = value.is_a?(Array) ? value[1] : value
 
     if key == "school_cohort_id"
-      school_cohort = SchoolCohort.find value
+      school_cohort = SchoolCohort.find_by(id: value)
 
       unless school_cohort.nil?
         record_school_cohort_events(school_cohort)
@@ -187,7 +187,7 @@ private
     end
 
     if key == "teacher_profile_id"
-      teacher_profile = TeacherProfile.find value
+      teacher_profile = TeacherProfile.find_by(id: value)
 
       unless teacher_profile.nil?
         record_teacher_record_events(teacher_profile)
@@ -209,53 +209,55 @@ private
     @events.push ParticipantEvent.new(@user.id, date, description, actor, value)
   end
 
-  def get_user_label(whodunnit)
-    user = User.find whodunnit unless whodunnit.nil?
-    return whodunnit || "Unknown" if user.nil?
+  def get_user_label(user_id)
+    return "Unknown" if user_id.nil?
+
+    user = User.find_by(id: user_id)
+    return user_id if user.nil?
 
     parts = user.email.split("@")
     parts[1] || parts[0]
   end
 
   def get_lead_provider_label(lead_provider_id)
-    lead_provider = LeadProvider.find lead_provider_id
+    lead_provider = LeadProvider.find_by(id: lead_provider_id)
     return lead_provider_id if lead_provider.nil?
 
     lead_provider.name
   end
 
   def get_delivery_partner_label(delivery_partner_id)
-    delivery_partner = DeliveryPartner.find delivery_partner_id
+    delivery_partner = DeliveryPartner.find_by(id: delivery_partner_id)
     return delivery_partner_id if delivery_partner.nil?
 
     delivery_partner.name
   end
 
   def get_schedule_label(schedule_id)
-    schedule = Finance::Schedule.find schedule_id
+    schedule = Finance::Schedule.find_by(id: schedule_id)
     return schedule_id if schedule.nil?
 
     schedule.schedule_identifier
   end
 
   def get_appropriate_body_label(appropriate_body_id)
-    appropriate_body = AppropriateBody.find appropriate_body_id
+    appropriate_body = AppropriateBody.find_by(id: appropriate_body_id)
     return appropriate_body_id if appropriate_body.nil?
 
     appropriate_body.name
   end
 
   def get_cohort_label(cohort_id)
-    cohort = Cohort.find cohort_id
+    cohort = Cohort.find_by(id: cohort_id)
     return cohort_id if cohort.nil?
 
     cohort.academic_year
   end
 
   def get_induction_programme_label(induction_programme_id)
-    induction_programme = InductionProgramme.find induction_programme_id
+    induction_programme = InductionProgramme.find_by(id: induction_programme_id)
     return induction_programme_id if induction_programme.nil?
 
-    "#{induction_programme.training_programme}|#{induction_programme.lead_provider.name}|#{induction_programme.delivery_partner.name}|#{induction_programme.cohort.academic_year}"
+    "#{induction_programme.training_programme} | #{induction_programme.lead_provider.name} | #{induction_programme.delivery_partner.name} | #{induction_programme.cohort.academic_year}"
   end
 end

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -175,7 +175,7 @@ private
     entity.versions&.each do |version|
       # TODO: if the version is of type "created" then we need to record the default values that were not overridden
 
-      user = User.find_by(id: version.whodunnit)
+      user = User.find_by(id: version.whodunnit) || version.whodunnit
 
       version.object_changes&.each do |key, value|
         record_event(version.created_at, version.event, entity, key, value, user)

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -266,7 +266,7 @@ private
       induction_programme.training_programme,
       induction_programme.lead_provider&.name,
       induction_programme.delivery_partner&.name,
-      induction_programme.cohort.academic_year,
-    ].filter(&present?).join(" | ")
+      induction_programme.cohort&.academic_year,
+    ].filter(&:present?).join(" | ")
   end
 end

--- a/app/views/admin/participants/change_log/show.html.erb
+++ b/app/views/admin/participants/change_log/show.html.erb
@@ -8,18 +8,38 @@
 <%= render partial: "admin/participants/nav" %>
 
 <% if @event_list.present? %>
-  <%= govuk_table(
-    caption: "Change log",
-    head: %w[Description Value Reporter Date],
-    rows: @event_list.map do |r|
-      [
-        r.predicate,
-        r.value,
-        r.reporter,
-        r.date&.to_s(:govuk),
-      ]
-    end,
-  ) %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Time</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-three-quarter">Event</th>
+    </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+    <% @event_list.group_by { |event| [event.date, event.type]} .each do |type, events| %>
+      <tr class="govuk-table__row" data-qa="audit-trail-item">
+        <td class="govuk-table__cell" title="<%= events[0].date&.strftime("%e %B %Y %H:%M:%S") %>">
+          <%= events[0].date&.strftime("%e %B %Y") %> <br><%= events[0].date&.strftime("%H:%M") %>
+        </td>
+        <td class="govuk-table__cell">
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <%= events[0].type.to_s.snakecase.humanize %>
+            <span class="govuk-caption-m"><%= events[0].reporter %></span>
+          </h2>
+          <%= govuk_summary_list(classes: 'govuk-!-font-size-16') do |summary_list| %>
+            <% events.each do |event| %>
+              <% summary_list.with_row do |summary_list_row| %>
+                <% summary_list_row.with_key { event.predicate.humanize } %>
+                <% summary_list_row.with_value { event.value } %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
 <% else %>
   <p>No event history for <%= @participant_profile.full_name %>.</p>
 <% end %>

--- a/app/views/admin/participants/change_log/show.html.erb
+++ b/app/views/admin/participants/change_log/show.html.erb
@@ -1,45 +1,14 @@
 <%=
   admin_participant_header_and_title(
     profile: @participant_profile,
-    section: "Change log"
+    section: "Audit trail"
   )
 %>
 
 <%= render partial: "admin/participants/nav" %>
 
 <% if @event_list.present? %>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Time</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-three-quarter">Event</th>
-    </tr>
-    </thead>
-
-    <tbody class="govuk-table__body">
-    <% @event_list.group_by { |event| [event.date, event.type]} .each do |type, events| %>
-      <tr class="govuk-table__row" data-qa="audit-trail-item">
-        <td class="govuk-table__cell" title="<%= events[0].date&.strftime("%e %B %Y %H:%M:%S") %>">
-          <%= events[0].date&.strftime("%e %B %Y") %> <br><%= events[0].date&.strftime("%H:%M") %>
-        </td>
-        <td class="govuk-table__cell">
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-            <%= events[0].type.to_s.snakecase.humanize %>
-            <span class="govuk-caption-m"><%= events[0].reporter %></span>
-          </h2>
-          <%= govuk_summary_list(classes: 'govuk-!-font-size-16') do |summary_list| %>
-            <% events.each do |event| %>
-              <% summary_list.with_row do |summary_list_row| %>
-                <% summary_list_row.with_key { event.predicate.humanize } %>
-                <% summary_list_row.with_value { event.value } %>
-              <% end %>
-            <% end %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-    </tbody>
-  </table>
+  <%= render Admin::Participants::AuditTrailComponent.new(audited_thing: @event_list) %>
 <% else %>
-  <p>No event history for <%= @participant_profile.full_name %>.</p>
+  <p>No audit trail available for <%= @participant_profile.full_name %>.</p>
 <% end %>

--- a/spec/services/participants/history_builder_spec.rb
+++ b/spec/services/participants/history_builder_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
     end
 
     it "handles whodunnit entries that are names rather than IDs" do
-      travel_to(Time.current - 1.minute) do
+      travel_to(Time.zone.now - 1.minute) do
         fip_ect_only
 
         fip_ect_only.versions.last.update!(whodunnit: console_user_name)

--- a/spec/services/participants/history_builder_spec.rb
+++ b/spec/services/participants/history_builder_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
 
       attributes_changed = event_list.map { |event| "#{event.type}.#{event.predicate}" }
       expect(attributes_changed).to match_array %w[
+        InductionRecord.id
+        InductionRecord.induction_programme_id
+        InductionRecord.induction_status
+        InductionRecord.training_status
+        InductionRecord.participant_profile_id
+        InductionRecord.preferred_identity_id
+        InductionRecord.schedule_id
         ParticipantIdentity.email
         ParticipantProfile::ECT.id
         ParticipantProfile::ECT.participant_identity_id
@@ -96,7 +103,7 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
       event_list = described_class.from_participant_profile(fip_ect_only).events
 
       induction_programme_entries = event_list.filter { |ev| ev.type.to_s == "InductionRecord" and ev.predicate == "induction_programme_id" }
-      expect(induction_programme_entries.first.value).to include "full_induction_programme | Teach First"
+      expect(induction_programme_entries.first.value).to include "Teach First TF Delivery Partner (2022/23)"
     end
 
     it "records a name change at the end" do
@@ -154,11 +161,12 @@ RSpec.describe Participants::HistoryBuilder, :with_support_for_ect_examples do
       travel_to(Time.zone.now - 1.minute) do
         fip_ect_only
 
-        fip_ect_only.versions.last.update!(whodunnit: console_user_name)
+        fip_ect_only.versions.each { |version| version.update!(whodunnit: console_user_name) }
       end
 
       event_list = described_class.from_participant_profile(fip_ect_only).events
-      reporters = event_list.map(&:reporter)
+      reporters = event_list.map(&:user)
+
       expect(reporters).to include console_user_name
     end
   end

--- a/spec/support/with_support_for_ect_examples.rb
+++ b/spec/support/with_support_for_ect_examples.rb
@@ -5,12 +5,13 @@ RSpec.shared_context "with Support for ECTs example profiles", shared_context: :
 
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider, name: "Teach First") }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
+  let(:delivery_partner) { create :delivery_partner, name: "TF Delivery Partner" }
 
   let(:core_induction_programme) { create(:core_induction_programme, name: lead_provider.name) }
   let(:cip_school_cohort) { create :school_cohort, induction_programme_choice: "core_induction_programme" }
   let(:cip_induction_programme) { create(:induction_programme, core_induction_programme:, training_programme: "core_induction_programme", school_cohort: cip_school_cohort) }
 
-  let(:fip_partnership) { create :partnership, lead_provider: }
+  let(:fip_partnership) { create :partnership, lead_provider:, delivery_partner: }
   let(:fip_school_cohort) { create :school_cohort, lead_provider:, induction_programme_choice: "full_induction_programme" }
   let(:fip_induction_programme) { create(:induction_programme, partnership: fip_partnership, training_programme: "full_induction_programme", school_cohort: fip_school_cohort) }
 


### PR DESCRIPTION
### Context

- Ticket: fix change log page broken due to missing user entities

### Changes proposed in this pull request

use find_by when looking for entities from history rather than find which raises exceptions
