### PR TITLE
Order V3 Participant query pagination by user

### DIFF
--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -11,11 +11,12 @@ module Api
 
         def participants_for_pagination
           scope = User
-                    .select(:id)
+                    .select(:id, :created_at)
                     .joins(participant_profiles: :induction_records)
                     .joins("JOIN (#{latest_induction_records_join.to_sql}) AS latest_induction_records_join ON latest_induction_records_join.latest_id = induction_records.id")
                     .distinct
-          updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
+          scope = updated_since.present? ? scope.where(users: { updated_at: updated_since.. }) : scope
+          params[:sort].blank? ? scope.order(:created_at) : scope
         end
 
         def participants_from(paginated_join)

--- a/spec/services/api/v3/ecf/participants_query_spec.rb
+++ b/spec/services/api/v3/ecf/participants_query_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe Api::V3::ECF::ParticipantsQuery do
         expect(subject.participants_for_pagination).to match_array([user, another_user])
       end
     end
+
+    context "sorting" do
+      let(:another_participant_profile) do
+        travel_to(10.days.ago) do
+          create(:ect_participant_profile)
+        end
+      end
+
+      it "returns all user records ordered by participant profile created_at" do
+        expect(subject.participants_for_pagination).to eq([another_user, user])
+      end
+    end
   end
 
   describe "#participants_from" do


### PR DESCRIPTION
### Context
If we don't order on the initial pagination query, we will get any random first 100 users, and then order them. This avoids getting random users first and then sorting

- Ticket: n/a

### Changes proposed in this pull request
Add ordering on the pagination query using users

### Guidance to review
Did I miss anything?
