### PR TITLE
Prevent cohort transfer if any billable/submitted declarations exist

### DIFF
--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -148,7 +148,6 @@ module Induction
       @participant_declarations ||= participant_profile
                                       .participant_declarations
                                       .billable_or_changeable
-                                      .declared_as_between(source_cohort_start_date, source_cohort_end_date)
                                       .exists?
     end
 
@@ -158,14 +157,6 @@ module Induction
 
     def source_cohort
       @source_cohort ||= Cohort.find_by(start_year: source_cohort_start_year)
-    end
-
-    def source_cohort_start_date
-      @source_cohort_start_date ||= source_cohort.academic_year_start_date
-    end
-
-    def source_cohort_end_date
-      @source_cohort_end_date ||= source_cohort_start_date + 1.year - 1.day
     end
 
     def start_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,7 +288,7 @@ en:
               school_cohort_not_setup: "%{start_academic_year} academic year not setup by school %{school_name}"
             participant_declarations:
               exist: "The participant must have no declarations"
-              billable_or_submitted: "The participant has billable or submitted declarations in the current cohort"
+              billable_or_submitted: "The participant has billable or submitted declarations"
               completed: "The participant has not not had a 'completed' declaration submitted against them. Therefore you cannot update their outcome"
             participant_profile:
               blank: "Not registered"

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe Induction::AmendParticipantCohort do
       end
 
       %i[submitted eligible payable paid].each do |declaration_state|
-        context "when the participant has #{declaration_state} declarations for the current cohort" do
+        context "when the participant has #{declaration_state} declarations" do
           before do
-            participant_profile.participant_declarations.create!(declaration_date: Date.new(2021, 10, 10),
+            participant_profile.participant_declarations.create!(declaration_date: Date.new(2020, 10, 10),
                                                                  declaration_type: :started,
                                                                  state: declaration_state,
                                                                  course_identifier: "ecf-induction",
@@ -130,7 +130,7 @@ RSpec.describe Induction::AmendParticipantCohort do
           it "returns false and set errors" do
             expect(form.save).to be_falsey
             expect(form.errors.first.attribute).to eq(:participant_declarations)
-            expect(form.errors.first.message).to eq("The participant has billable or submitted declarations in the current cohort")
+            expect(form.errors.first.message).to eq("The participant has billable or submitted declarations")
           end
         end
       end


### PR DESCRIPTION
[Jira-CPDLP-1996](https://dfedigital.atlassian.net/browse/CPDLP-1996)

### Context

We currently allow a participant to transfer to another cohort as long as they don't have any billable/submitted declarations **in the current cohort window**. This means a participant can transfer if they have billable/submitted declarations in another cohort, and this has caused issues.

### Changes proposed in this pull request

Prevent participant cohort transfer if billable/submitted declarations exist regardless of date/cohort the declarations apply for.

### Guidance to review

We have similar logic around transferring a participant between schools. I'm unsure if this should also be updated to prevent transferring between schools if billable/submitted declarations exist in another cohort:

https://github.com/DFE-Digital/early-careers-framework/blob/508c00536d170b60644a3fa0869c6622472858c2/app/forms/schools/participant_transferable_to_school_form.rb#L47-L55

I thought about testing declarations in a billable/submitted state both inside and outside the current cohort window but that felt like overkill; instead I updated the test to use a declaration in another cohort year as its unlikely that query would be updated to filter on other cohort years explicitly.