### PR TITLE
Patch show relevant training status

### DIFF
--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -6,8 +6,6 @@ class Admin::ParticipantPresenter
   delegate :id,
            :user,
            :participant_identity,
-           :training_status,
-           :status,
            :notes,
            :notes?,
            :ect?,
@@ -87,6 +85,14 @@ class Admin::ParticipantPresenter
 
   def mentor_profile
     relevant_induction_record&.mentor_profile
+  end
+
+  def training_status
+    relevant_induction_record&.training_status || participant_profile.training_status
+  end
+
+  def status
+    relevant_induction_record&.induction_status || participant_profile.status
   end
 
   def mentor_full_name

--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -6,6 +6,8 @@ class Admin::ParticipantPresenter
   delegate :id,
            :user,
            :participant_identity,
+           :training_status,
+           :status,
            :notes,
            :notes?,
            :ect?,
@@ -85,14 +87,6 @@ class Admin::ParticipantPresenter
 
   def mentor_profile
     relevant_induction_record&.mentor_profile
-  end
-
-  def training_status
-    relevant_induction_record&.training_status || participant_profile.training_status
-  end
-
-  def status
-    relevant_induction_record&.induction_status || participant_profile.status
   end
 
   def mentor_full_name

--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -34,13 +34,8 @@
   end
 
   sl.row do |row|
-    row.key(text: "Training status")
-    row.value(text: @participant_presenter.training_status)
-  end
-
-  sl.row do |row|
-    row.key(text: "Profile status")
-    row.value(text: @participant_presenter.status)
+    row.key(text: "Training record state")
+    row.value(text: render(StatusTags::AdminParticipantStatusTag.new(participant_profile: @participant_profile, school: @participant_presenter.school)))
   end
 
   if @participant_presenter.teacher_profile
@@ -68,11 +63,6 @@
   sl.row do |row|
     row.key(text: "Associated email addresses")
     row.value(text: html_list(all_emails_associated_with_a_user(@participant_profile.user)))
-  end
-
-  sl.row do |row|
-    row.key(text: "Training record state")
-    row.value(text: render(StatusTags::AdminParticipantStatusTag.new(participant_profile: @participant_profile, school: @participant_presenter.school)))
   end
 
   sl.row do |row|

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -43,7 +43,7 @@
 
     sl.row do |row|
       row.key(text: "Training record state")
-      row.value(text: @participant_presenter.relevant_induction_record&.training_status)
+      row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status, colour: "grey"))
     end
   end %>
 <% end %>
@@ -86,26 +86,54 @@
 <%= govuk_summary_list(actions: true) do |sl|
   sl.row do |row|
     row.key(text: "Validation status")
-    row.value(text: states.validation_state)
+    row.value(text: govuk_tag(text: states.validation_state.humanize, colour: "grey"))
   end
 
   sl.row do |row|
     row.key(text: "Training eligibility status")
-    row.value(text: states.training_eligibility_state)
+    row.value(text: govuk_tag(text: states.training_eligibility_state.humanize, colour: "grey"))
   end
 
   sl.row do |row|
     row.key(text: "FIP funding eligibility status")
-    row.value(text: states.fip_funding_eligibility_state)
+    row.value(text: govuk_tag(text: states.fip_funding_eligibility_state.humanize, colour: "grey"))
   end
 
   sl.row do |row|
     row.key(text: "Mentoring status")
-    row.value(text: states.mentoring_state)
+    row.value(text: govuk_tag(text: states.mentoring_state.humanize, colour: "grey"))
   end
 
   sl.row do |row|
     row.key(text: "Training status")
-    row.value(text: states.training_state)
+    row.value(text: govuk_tag(text: states.training_state.humanize, colour: "grey"))
+  end
+end %>
+
+<h3 class="govuk-heading-m">Relevant induction record statuses</h3>
+<%= govuk_summary_list(actions: true) do |sl|
+  sl.row do |row|
+    row.key(text: "induction status")
+    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status, colour: "grey"))
+  end
+
+  sl.row do |row|
+    row.key(text: "training status")
+    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status, colour: "grey"))
+  end
+end %>
+
+<h3 class="govuk-heading-m">Participant profile statuses</h3>
+<%= govuk_summary_list(actions: true) do |sl|
+  sl.row do |row|
+    row.key(text: "status")
+    row.value(text: govuk_tag(text: @participant_presenter.participant_profile.status, colour: "grey") +
+      "<p class=\"govuk-body-s\">A historical status used if the induction_records induction_status is not set. Note: a status of Withdrawn indicates a 'soft delete' of this record.</p>".html_safe)
+  end
+
+  sl.row do |row|
+    row.key(text: "training status")
+    row.value(text: govuk_tag(text: @participant_presenter.participant_profile.training_status, colour: "grey") +
+      "<p class=\"govuk-body-s\">A historical status used if the induction_records training_status is not set.</p>".html_safe)
   end
 end %>


### PR DESCRIPTION
### Context

Moves participant status and training status to the statuses page so that it is easier to see all statuses on one page

### Guidance to review

![screenshot of admin participant status display](https://github.com/DFE-Digital/early-careers-framework/assets/259493/0afd3edb-70a3-4e62-9533-051aeebbf2c6)


