### PR TITLE
Allow filtering of NPQ applications on participant_id

### DIFF
--- a/app/controllers/api/v1/npq_applications_controller.rb
+++ b/app/controllers/api/v1/npq_applications_controller.rb
@@ -57,7 +57,7 @@ module Api
                   .includes(:cohort, :npq_course, :profile, participant_identity: [:user])
                   .where(cohort: with_cohorts)
         scope = scope.where("updated_at > ?", updated_since) if updated_since.present?
-        params[:sort].blank? ? scope.order("npq_applications.created_at ASC") : scope
+        scope.order("npq_applications.created_at ASC")
       end
 
       def access_scope

--- a/app/controllers/api/v3/npq_applications_controller.rb
+++ b/app/controllers/api/v3/npq_applications_controller.rb
@@ -8,13 +8,30 @@ module Api
       # Returns a list of NPQ applications
       # Providers can see their NPQ applications which cohorts they apply to via this endpoint
       #
-      # GET /api/v3/npq-applications?filter[cohort]=2022&sort=name,-updated_at
+      # GET /api/v3/npq-applications?filter[cohort]=2022&filter[updated_since]=2023-05-10%2015%3A00%3A00.000&filter[participant_id]=be483a5a-0bb3-4336-82fa-9bd0e4c58761&sort=name,-updated_at
       #
       def index
-        render json: json_serializer_class.new(paginate(query_scope.order(sort_params(params)))).serializable_hash.to_json
+        render json: json_serializer_class.new(paginate(npq_applications)).serializable_hash.to_json
       end
 
     private
+
+      def npq_applications
+        @npq_applications ||= npq_applications_query.applications.order(sort_params(params))
+      end
+
+      def npq_applications_query
+        Api::V3::NPQApplicationsQuery.new(
+          npq_lead_provider:,
+          params: npq_application_params,
+        )
+      end
+
+      def npq_application_params
+        params
+          .with_defaults({ sort: "", filter: { updated_since: "", cohort: "", participant_id: "" } })
+          .permit(:id, :sort, filter: %i[updated_since cohort participant_id])
+      end
 
       def json_serializer_class
         Api::V3::NPQApplicationSerializer

--- a/app/services/api/v3/npq_applications_query.rb
+++ b/app/services/api/v3/npq_applications_query.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    class NPQApplicationsQuery
+      attr_reader :npq_lead_provider, :params
+
+      def initialize(npq_lead_provider:, params:)
+        @npq_lead_provider = npq_lead_provider
+        @params = params
+      end
+
+      def applications
+        scope = all_applications
+
+        scope = apply_cohorts_filter(scope)
+        scope = apply_updated_since_filter(scope)
+        scope = apply_participant_id_filter(scope)
+        apply_default_sort(scope)
+      end
+
+    private
+
+      def filter
+        params[:filter] ||= {}
+      end
+
+      def updated_since_filter
+        filter[:updated_since]
+      end
+
+      def apply_default_sort(scope)
+        return scope if params[:sort].present?
+
+        scope.order("npq_applications.created_at ASC")
+      end
+
+      def all_applications
+        npq_lead_provider
+          .npq_applications
+          .includes(
+            :cohort,
+            :npq_course,
+            :profile,
+            participant_identity: [:user],
+          )
+      end
+
+      def apply_updated_since_filter(scope)
+        return scope if updated_since_filter.blank?
+
+        scope.where("updated_at > ?", updated_since)
+      end
+
+      def apply_participant_id_filter(scope)
+        participant_id_filter = filter[:participant_id]
+
+        return scope if participant_id_filter.blank?
+
+        scope.where(participant_identity: { users: { id: participant_id_filter } })
+      end
+
+      def apply_cohorts_filter(scope)
+        cohort_filter = filter[:cohort].to_s
+        cohorts = if cohort_filter.present?
+                    Cohort.where(start_year: cohort_filter.split(","))
+                  else
+                    Cohort.where("start_year > 2020")
+                  end
+
+        scope.where(cohort: cohorts)
+      end
+
+      def updated_since
+        Time.iso8601(updated_since_filter)
+      rescue ArgumentError
+        begin
+          Time.iso8601(URI.decode_www_form_component(updated_since_filter))
+        rescue ArgumentError
+          raise Api::Errors::InvalidDatetimeError, I18n.t(:invalid_updated_since_filter)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/npq_applications_spec.rb
+++ b/spec/requests/api/v1/npq_applications_spec.rb
@@ -126,6 +126,16 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request d
             end
           end
         end
+
+        describe "ordering" do
+          let!(:oldest_npq_application) { travel_to(1.month.ago) { create(:npq_application, :accepted, npq_lead_provider:, school_urn: "123456", npq_course:) } }
+
+          it "returns all records ordered by npq applications created_at ascending" do
+            get "/api/v1/npq-applications"
+            expect(parsed_response["data"].size).to eql(4)
+            expect(parsed_response.dig("data", 0, "id")).to eql(oldest_npq_application.id)
+          end
+        end
       end
 
       describe "CSV API" do

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -124,6 +124,19 @@ RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request, 
               expect(parsed_response["data"].pluck("id")).to match_array(@npq_applications_list.pluck("id"))
             end
           end
+
+          context "with filter[participant_id]" do
+            let(:user) { create(:user) }
+            let!(:participant_applications) do
+              create_list(:npq_application, 3, npq_lead_provider:, school_urn: "123456", user:)
+            end
+
+            it "returns applications for the given participant" do
+              get "/api/v3/npq-applications", params: { filter: { participant_id: user.id } }
+              expect(parsed_response["data"].size).to eql(participant_applications.size)
+              expect(parsed_response["data"].pluck("id")).to match_array(participant_applications.pluck("id"))
+            end
+          end
         end
 
         describe "ordering" do

--- a/spec/services/api/v3/npq_applications_query_spec.rb
+++ b/spec/services/api/v3/npq_applications_query_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V3::NPQApplicationsQuery, :with_default_schedules do
+  let(:school_urn) { "123456" }
+  let(:cohort) { Cohort.current || create(:cohort, :current) }
+  let(:pre_2021_cohort) { create(:cohort, start_year: 2020) }
+  let(:npq_lead_provider) { create(:npq_lead_provider) }
+  let(:other_npq_lead_provider) { create(:npq_lead_provider) }
+  let(:params) { {} }
+  let(:instance) { described_class.new(npq_lead_provider:, params:) }
+
+  describe "#applications" do
+    let(:oldest_application) { travel_to(1.month.ago) { create(:npq_application, npq_lead_provider:, school_urn:, cohort:) } }
+    let(:newest_application) { create(:npq_application, npq_lead_provider:, school_urn:, cohort:) }
+    let!(:applications) { [newest_application, oldest_application] }
+    let!(:other_applications) { create_list(:npq_application, 2, npq_lead_provider: other_npq_lead_provider, school_urn:, cohort:) }
+    let!(:pre_2021_applications) { create_list(:npq_application, 2, npq_lead_provider:, school_urn:, cohort: pre_2021_cohort) }
+
+    subject(:query_applications) { instance.applications }
+
+    it { is_expected.to match_array(applications) }
+
+    describe "updated_since filter" do
+      let(:updated_since) { (oldest_application.created_at + 1.day).iso8601 }
+      let(:params) { { filter: { updated_since: } } }
+
+      it { is_expected.to contain_exactly(newest_application) }
+
+      context "when passed an invalid value" do
+        let(:params) { { filter: { updated_since: "2022" } } }
+
+        it { expect { query_applications }.to raise_error(Api::Errors::InvalidDatetimeError) }
+      end
+
+      context "when passed a URL encoded date" do
+        let(:params) { { filter: { updated_since: CGI.escape(updated_since) } } }
+
+        it { is_expected.to contain_exactly(newest_application) }
+      end
+    end
+
+    describe "participant_id filter" do
+      let(:user) { create(:user) }
+      let!(:participant_applications) { create_list(:npq_application, 2, npq_lead_provider:, school_urn:, user:) }
+      let(:params) { { filter: { participant_id: user.id } } }
+
+      it { is_expected.to match_array(participant_applications) }
+    end
+
+    describe "cohort filter" do
+      let(:params) { { filter: { cohort: cohort.start_year } } }
+
+      it { is_expected.to match_array(applications) }
+
+      context "when filtering by multiple cohorts" do
+        let(:params) { { filter: { cohort: [cohort.start_year, pre_2021_cohort.start_year].join(",") } } }
+
+        it { is_expected.to match_array(applications + pre_2021_applications) }
+      end
+
+      context "when passed an invalid value" do
+        let(:params) { { filter: { cohort: "cohort1" } } }
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    describe "sorting" do
+      it "orders by application created_at ascending by default" do
+        expect(query_applications.map(&:id)).to eq([oldest_application.id, newest_application.id])
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-CPDLP-2209](https://dfedigital.atlassian.net/browse/CPDLP-2209)

### Context

The API v3 schema surfaces the ability to filter NPQ applications by `participant_id`, however we have not yet implemented the functionality.

We also want to always default the sorting of NPQ applications in the v1 API as the `sort` parameter is not supported.

### Changes proposed in this pull request

- Always sort v1 applications by created_at
- Allow filtering of applications by participant_id

### Guidance to review

Test added to v1 request specs to cover default sorting.

Migrates to a query model for consistency with other v3 endpoints.

Request test added for `participant_id` filtering, but we may want to clean up these controller tests at a later date so we're not over-testing the query models. It looks like there's also scope to DRY up the query models with a concern similar to `ApiFilter` and/or additional scopes on the core models.

Example request using the `ambition-token` auth token:

https://ecf-review-pr-3505.london.cloudapps.digital/api/v3/npq-applications?filter[participant_id]=abb6bd5f-dd1a-4352-93d0-6f3aa0a6c302