### PR TITLE
Default cohort filtering to exclude pre-2021 cohorts

### DIFF
--- a/app/services/api/v3/delivery_partners_query.rb
+++ b/app/services/api/v3/delivery_partners_query.rb
@@ -12,7 +12,7 @@ module Api
 
       def delivery_partners
         scope = lead_provider.delivery_partners
-        scope = scope.where("provider_relationships.cohort_id IN (?)", with_cohorts.map(&:id)) if filter[:cohort].present?
+        scope = scope.where("provider_relationships.cohort_id IN (?)", with_cohorts.map(&:id))
         scope = scope.order("delivery_partners.created_at ASC") if params[:sort].blank?
         scope.distinct
       end

--- a/app/services/api/v3/ecf/partnerships_query.rb
+++ b/app/services/api/v3/ecf/partnerships_query.rb
@@ -13,7 +13,7 @@ module Api
 
         def partnerships
           scope = partnership_scope
-          scope = scope.where(partnerships: { cohort:  with_cohorts }) if filter[:cohort].present?
+          scope = scope.where(partnerships: { cohort:  with_cohorts })
           scope = scope.where("partnerships.updated_at > ?", updated_since) if updated_since.present?
           scope = scope.where(partnerships: { delivery_partner: [delivery_partner_id_filter] }) if delivery_partner_id_filter.present?
           scope = scope.order("partnerships.created_at ASC") if params[:sort].blank?

--- a/spec/services/api/v3/ecf/partnerships_query_spec.rb
+++ b/spec/services/api/v3/ecf/partnerships_query_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Api::V3::ECF::PartnershipsQuery do
   describe "#partnerships" do
     let(:another_cohort) { create(:cohort, start_year: "2050") }
     let!(:another_partnership) { create(:partnership, cohort: another_cohort, lead_provider:) }
+    let(:pre_2021_cohort) { create(:cohort, start_year: 2020) }
+    let!(:pre_2021_partnership) { create(:partnership, cohort: pre_2021_cohort, lead_provider:) }
 
     it "returns all partnerships" do
       expect(subject.partnerships).to match_array([partnership, another_partnership])
@@ -22,10 +24,10 @@ RSpec.describe Api::V3::ECF::PartnershipsQuery do
 
     describe "cohort filter" do
       context "with correct value" do
-        let(:params) { { filter: { cohort: cohort.display_name } } }
+        let(:params) { { filter: { cohort: pre_2021_cohort.display_name } } }
 
         it "returns all partnerships for the specific cohort" do
-          expect(subject.partnerships).to match_array([partnership])
+          expect(subject.partnerships).to match_array([pre_2021_partnership])
         end
       end
 


### PR DESCRIPTION
### Context

If a `cohort` filter is not supplied we should default to filtering out cohorts earlier than 2021. Due to a bug in these query models if `cohort` was not specified we would return all models irrespective of cohort.

### Changes proposed in this pull request

Default cohort filtering to exclude pre-2021 cohorts and add test coverage.

### Guidance to review

