### PR TITLE
add Statuscake alert for SSL expiry date

### DIFF
--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -20,3 +20,24 @@ resource "statuscake_uptime_check" "alert" {
     address = each.value.website_url
   }
 }
+
+resource "statuscake_ssl_check" "domain-alert" {
+  count = var.statuscake_ssl_contact_group != null ? 1 : 0
+
+  check_interval   = 3600 # Check once per hour
+  contact_groups   = [var.statuscake_ssl_contact_group]
+  follow_redirects = true
+
+  alert_config {
+    alert_at = [3, 7, 30] # Alert 1 month, 1 week then 3 days before expiration
+
+    on_reminder = true
+    on_expiry   = true
+    on_broken   = true
+    on_mixed    = true
+  }
+
+  monitored_resource {
+    address = "https://${var.domain}"
+  }
+}

--- a/terraform/app/modules/statuscake/main.tf
+++ b/terraform/app/modules/statuscake/main.tf
@@ -38,6 +38,6 @@ resource "statuscake_ssl_check" "domain-alert" {
   }
 
   monitored_resource {
-    address = "https://${var.domain}"
+    address = "https://${var.statuscake_domain}"
   }
 }

--- a/terraform/app/modules/statuscake/variables.tf
+++ b/terraform/app/modules/statuscake/variables.tf
@@ -7,3 +7,13 @@ variable "service_name" {
 variable "statuscake_alerts" {
   description = "Define Statuscake alerts with the attributes below"
 }
+
+variable "statuscake_domain" {
+  type        = string
+  description = "Domain for SSL check"
+}
+
+variable "statuscake_ssl_contact_group" {
+  type        = string
+  description = "ID of the StatusCake contact group. If empty, SSL check is not enabled"
+}

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -68,4 +68,5 @@ module "statuscake" {
   service_name                 = local.service_name
   statuscake_alerts            = var.statuscake_alerts
   statuscake_ssl_contact_group = var.statuscake_ssl_contact_group
+  statuscake_domain            = var.statuscake_domain
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -64,8 +64,8 @@ module paas {
 module "statuscake" {
   source = "./modules/statuscake"
 
-  environment       = var.environment
-  service_name      = local.service_name
-  statuscake_alerts = var.statuscake_alerts
+  environment                  = var.environment
+  service_name                 = local.service_name
+  statuscake_alerts            = var.statuscake_alerts
   statuscake_ssl_contact_group = var.statuscake_ssl_contact_group
 }

--- a/terraform/app/terraform.tf
+++ b/terraform/app/terraform.tf
@@ -67,4 +67,5 @@ module "statuscake" {
   environment       = var.environment
   service_name      = local.service_name
   statuscake_alerts = var.statuscake_alerts
+  statuscake_ssl_contact_group = var.statuscake_ssl_contact_group
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -114,6 +114,12 @@ variable "statuscake_alerts" {
 variable statuscake_api_token {
 }
 
+variable statuscake_domain {
+  type        = string
+  default     = null
+  description = "Domain for SSL check"
+}
+
 variable "statuscake_ssl_contact_group" {
   type        = string
   default     = null

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -114,6 +114,12 @@ variable "statuscake_alerts" {
 variable statuscake_api_token {
 }
 
+variable "statuscake_ssl_contact_group" {
+  type        = string
+  default     = null
+  description = "ID of the StatusCake contact group. If empty, SSL check is not enabled"
+}
+
 locals {
   paas_app_env_yml_values = yamldecode(file("${path.module}/../workspace-variables/${var.app_environment}_app_env.yml"))
   paas_app_env_values = merge(

--- a/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
@@ -16,6 +16,5 @@
         }
       }
     }
-  },
-  "statuscake_ssl_contact_group": 249142
+  }
 }

--- a/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
+++ b/terraform/custom_domains/environment_domains/workspace_variables/cpd_ecf_production.tfvars.json
@@ -16,5 +16,6 @@
         }
       }
     }
-  }
+  },
+  "statuscake_ssl_contact_group": 249142
 }

--- a/terraform/workspace-variables/production.tfvars
+++ b/terraform/workspace-variables/production.tfvars
@@ -17,6 +17,9 @@ paas_sidekiq_worker_app_start_command = "bundle exec sidekiq -C config/sidekiq.y
 paas_redis_service_plan = "tiny-ha-6_x"
 govuk_hostnames = ["manage-training-for-early-career-teachers"]
 
+statuscake_ssl_contact_group = 249142
+statuscake_domain = "manage-training-for-early-career-teachers.education.gov.uk"
+
 statuscake_alerts = {
   "prod" = {
     website_name  = "manage-training-for-early-career-teachers-production"


### PR DESCRIPTION
### Context

Apex domains are not automatically renewed by Azure front door. We should monitor them via statuscake.

- Ticket: https://trello.com/c/2pEuVuNa/773-monitor-front-door-apex-domain-expiration-dates

### Changes proposed in this pull request

Add a new check for statuscake to monitor SSL expiry.

### Guidance to review

