### PR TITLE
Spike: add mentor_id to ParticipantDeclaration

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -5,6 +5,7 @@ class ParticipantDeclaration < ApplicationRecord
 
   belongs_to :cpd_lead_provider
   belongs_to :user
+  belongs_to :mentor, class_name: "ParticipantProfile::Mentor", optional: true
   belongs_to :participant_profile
   belongs_to :superseded_by, class_name: "ParticipantDeclaration", optional: true
   belongs_to :delivery_partner, optional: true

--- a/app/models/participant_profile/mentor.rb
+++ b/app/models/participant_profile/mentor.rb
@@ -14,6 +14,8 @@ class ParticipantProfile < ApplicationRecord
 
     has_many :school_mentors, dependent: :destroy, foreign_key: :participant_profile_id
     has_many :schools, through: :school_mentors
+    # TODO: causes a validation error, not sure why
+    # has_many :participant_declarations
 
     def mentor?
       true

--- a/app/serializers/api/v3/participant_declaration_serializer.rb
+++ b/app/serializers/api/v3/participant_declaration_serializer.rb
@@ -11,7 +11,7 @@ module Api
       set_id :id
       set_type :'participant-declaration'
 
-      attributes :participant_id, :declaration_type, :course_identifier
+      attributes :participant_id, :declaration_type, :course_identifier, :mentor_id
 
       attribute :declaration_date do |declaration|
         declaration.declaration_date.rfc3339
@@ -54,27 +54,6 @@ module Api
             "duplicate_declaration"
           else
             reason
-          end
-        end
-      end
-
-      attribute :mentor_id do |declaration|
-        if declaration.participant_profile.ect?
-          if declaration.respond_to?(:mentor_user_id)
-            declaration.mentor_user_id&.first
-          else
-            latest_induction_record = declaration.participant_profile.induction_records.includes(
-              induction_programme: [:partnership],
-            ).where(
-              induction_programme: {
-                partnerships: {
-                  lead_provider_id: declaration.cpd_lead_provider.lead_provider_id,
-                  # We've not filtered out challenged as we want to return everything
-                },
-              },
-            ).latest
-
-            latest_induction_record&.mentor_profile&.participant_identity&.user_id
           end
         end
       end

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -149,6 +149,12 @@ private
     }
   end
 
+  def mentor_id
+    return nil unless participant_profile.ect?
+
+    latest_induction_record&.mentor_profile&.participant_identity&.user_id
+  end
+
   def declaration_parameters
     {
       course_identifier:,
@@ -156,12 +162,17 @@ private
       declaration_type:,
       cpd_lead_provider:,
       delivery_partner:,
+      mentor_id:,
       user: participant_identity.user,
     }
   end
 
-  def delivery_partner
+  def latest_induction_record
     Induction::FindBy.call(participant_profile:, lead_provider: cpd_lead_provider.lead_provider)
+  end
+
+  def delivery_partner
+    latest_induction_record
       &.induction_programme
       &.partnership
       &.delivery_partner

--- a/db/migrate/20230609092031_add_mentor_id_to_participant_declarations.rb
+++ b/db/migrate/20230609092031_add_mentor_id_to_participant_declarations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddMentorIdToParticipantDeclarations < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :participant_declarations, :mentor, type: :uuid, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_04_164057) do
+ActiveRecord::Schema.define(version: 2023_06_09_092031) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -654,10 +654,12 @@ ActiveRecord::Schema.define(version: 2023_06_04_164057) do
     t.boolean "sparsity_uplift"
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying])::text[]))"
+    t.uuid "mentor_id"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"
+    t.index ["mentor_id"], name: "index_participant_declarations_on_mentor_id"
     t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
     t.index ["superseded_by_id"], name: "superseded_by_index"
     t.index ["user_id"], name: "index_participant_declarations_on_user_id"


### PR DESCRIPTION
[Jira-2209](https://dfedigital.atlassian.net/browse/CPDLP-2209)

### Context

In a number of places we traverse multiple models to identify the `mentor_id`; this is expensive and complicated. To improve performance and readability of the code we want to look into adding `mentor_id` to the `ParticipantDeclaration` model.

### Changes proposed in this pull request

- Add `mentor_id` to `ParticipantDeclaration`
- Persist `mentor_id` on declaration creation
- Use `mentor_id` field in serializer

### Spike notes

We will need to coordinate a number of changes to roll this out:

1. Add `mentor_id` to `ParticipantDeclaration` (as an optional field).
2. Populate `mentor_id` from induction records during creation in `RecordDeclaration`.
  * We currently use the **latest** induction record to determine the mentor, however we should obtain the induction record relative to the `deducation_date` so we get the mentor at the time of the deduction.
3. Backfill `mentor_id` for existing `ParticipantDeclaration` models.
4. Update `ParticipantDeclarationSerializer` to use the `mentor_id` field instead of computing it on-demand.
5. Optimize `ParticipantDeclarationQuery` using the new `mentor_id` field.
6. Identity and optimise any other queries that could make use of the new attribute.
7. Investigate if this should also apply to delivery partners in a similar way.
