### PR TITLE
Add mentor_user_id to ParticipantDeclaration

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -8,6 +8,7 @@ class ParticipantDeclaration < ApplicationRecord
   belongs_to :participant_profile
   belongs_to :superseded_by, class_name: "ParticipantDeclaration", optional: true
   belongs_to :delivery_partner, optional: true
+  belongs_to :mentor_user, class_name: "User", optional: true
 
   has_many :declaration_states
   has_many :participant_declaration_attempts, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,8 @@ class User < ApplicationRecord
   has_many :appropriate_body_profiles, dependent: :destroy
   has_many :appropriate_bodies, through: :appropriate_body_profiles
 
+  has_many :mentee_participant_declarations, class_name: "ParticipantDeclaration", foreign_key: :mentor_user_id
+
   # TODO: Legacy associations, to be removed
   has_many :participant_profiles, through: :teacher_profile
   has_one :early_career_teacher_profile, through: :teacher_profile

--- a/app/serializers/api/v3/participant_declaration_serializer.rb
+++ b/app/serializers/api/v3/participant_declaration_serializer.rb
@@ -60,8 +60,8 @@ module Api
 
       attribute :mentor_id do |declaration|
         if declaration.participant_profile.ect?
-          if declaration.respond_to?(:mentor_user_id)
-            declaration.mentor_user_id&.first
+          if declaration.respond_to?(:transient_mentor_user_id)
+            declaration.transient_mentor_user_id&.first
           else
             latest_induction_record = declaration.participant_profile.induction_records.includes(
               induction_programme: [:partnership],

--- a/app/services/api/v3/participant_declarations_query.rb
+++ b/app/services/api/v3/participant_declarations_query.rb
@@ -36,7 +36,7 @@ module Api
 
       def participant_declarations_from(paginated_join)
         sub_query = ParticipantDeclaration
-          .select("participant_declarations.*", "COALESCE(jsonb_agg(DISTINCT participant_identities_mentor_profiles.user_id) FILTER (WHERE participant_identities_mentor_profiles.user_id IS NOT NULL), '[]') AS mentor_user_id")
+          .select("participant_declarations.*", "COALESCE(jsonb_agg(DISTINCT participant_identities_mentor_profiles.user_id) FILTER (WHERE participant_identities_mentor_profiles.user_id IS NOT NULL), '[]') AS transient_mentor_user_id")
           .joins("INNER JOIN (#{paginated_join.to_sql}) as tmp on tmp.id = participant_declarations.id")
           .joins(left_outer_join_participant_profiles)
           .joins(left_outer_join_induction_records)

--- a/db/migrate/20230612140808_add_mentor_user_id_to_participant_declarations.rb
+++ b/db/migrate/20230612140808_add_mentor_user_id_to_participant_declarations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddMentorUserIdToParticipantDeclarations < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :participant_declarations, :mentor_user, type: :uuid, index: { algorithm: :concurrently }
+    add_foreign_key :participant_declarations, :users, column: :mentor_user_id, validate: false
+  end
+end

--- a/db/migrate/20230613072254_validate_foreign_key_on_participant_declarations_to_mentor_users.rb
+++ b/db/migrate/20230613072254_validate_foreign_key_on_participant_declarations_to_mentor_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateForeignKeyOnParticipantDeclarationsToMentorUsers < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :participant_declarations, :users, column: :mentor_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_04_164057) do
+ActiveRecord::Schema.define(version: 2023_06_13_072254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -654,10 +654,12 @@ ActiveRecord::Schema.define(version: 2023_06_04_164057) do
     t.boolean "sparsity_uplift"
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
+    t.uuid "mentor_user_id"
     t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying])::text[]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"
+    t.index ["mentor_user_id"], name: "index_participant_declarations_on_mentor_user_id"
     t.index ["participant_profile_id"], name: "index_participant_declarations_on_participant_profile_id"
     t.index ["superseded_by_id"], name: "superseded_by_index"
     t.index ["user_id"], name: "index_participant_declarations_on_user_id"
@@ -1117,6 +1119,7 @@ ActiveRecord::Schema.define(version: 2023_06_04_164057) do
   add_foreign_key "participant_declarations", "participant_declarations", column: "superseded_by_id"
   add_foreign_key "participant_declarations", "participant_profiles"
   add_foreign_key "participant_declarations", "users"
+  add_foreign_key "participant_declarations", "users", column: "mentor_user_id"
   add_foreign_key "participant_identities", "users"
   add_foreign_key "participant_outcome_api_requests", "participant_outcomes"
   add_foreign_key "participant_outcomes", "participant_declarations"

--- a/spec/models/participant_declaration_spec.rb
+++ b/spec/models/participant_declaration_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ParticipantDeclaration, :with_default_schedules, type: :model do
     it { is_expected.to belong_to(:cpd_lead_provider) }
     it { is_expected.to belong_to(:participant_profile) }
     it { is_expected.to have_many(:declaration_states) }
+    it { is_expected.to belong_to(:mentor_user).class_name("User").optional }
   end
 
   describe "state transitions" do

--- a/spec/models/participant_profile/mentor_spec.rb
+++ b/spec/models/participant_profile/mentor_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ParticipantProfile::Mentor, type: :model do
+  let(:instance) { described_class.new }
+
+  describe "associations" do
+    it { is_expected.to have_many(:mentee_profiles).class_name("ParticipantProfile::ECT").with_foreign_key(:mentor_profile_id).dependent(:nullify) }
+    it { is_expected.to have_many(:mentees).through(:mentee_profiles).source(:user) }
+    it { is_expected.to have_many(:school_mentors).dependent(:destroy).with_foreign_key(:participant_profile_id) }
+    it { is_expected.to have_many(:schools).through(:school_mentors) }
+  end
+
+  describe "#mentor" do
+    it { expect(instance).to be_mentor }
+  end
+
+  describe "#role" do
+    it { expect(instance.role).to eq("Mentor") }
+  end
+
+  describe "#participant_type" do
+    it { expect(instance.participant_type).to eq(:mentor) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "associations" do
+    it { is_expected.to have_many(:mentee_participant_declarations).class_name("ParticipantDeclaration").with_foreign_key(:mentor_user_id) }
     it { is_expected.to have_many(:participant_profiles) }
     it { is_expected.to have_one(:admin_profile) }
     it { is_expected.to have_one(:finance_profile) }

--- a/spec/serializers/api/v3/participant_declaration_serializer_spec.rb
+++ b/spec/serializers/api/v3/participant_declaration_serializer_spec.rb
@@ -106,21 +106,21 @@ RSpec.describe Api::V3::ParticipantDeclarationSerializer, :with_default_schedule
         participant_declaration.participant_profile.induction_records.first.update!(mentor_profile_id: mentor_participant_profile.id)
       end
 
-      context "when not using mentor_user_id" do
+      context "when not using transient_mentor_user_id" do
         it "returns mentor_id" do
           attrs = subject.serializable_hash[:data][:attributes]
           expect(attrs[:mentor_id]).to eq(mentor_user_id)
         end
       end
 
-      context "when using mentor_user_id with query" do
+      context "when using transient_mentor_user_id with query" do
         before do
-          def participant_declaration.mentor_user_id
+          def participant_declaration.transient_mentor_user_id
             %w[test123]
           end
         end
 
-        it "returns mentor_user_id" do
+        it "returns transient_mentor_user_id" do
           attrs = subject.serializable_hash[:data][:attributes]
           expect(attrs[:mentor_id]).to eq("test123")
         end

--- a/spec/services/api/v3/participant_declarations_query_spec.rb
+++ b/spec/services/api/v3/participant_declarations_query_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
       end
     end
 
-    context "with mentor_user_id attribute" do
+    context "with transient_mentor_user_id attribute" do
       let!(:mentor_participant_profile) { create(:mentor_participant_profile) }
       let!(:another_mentor_participant_profile) { create(:mentor_participant_profile) }
       let!(:another_induction_record) do
@@ -263,14 +263,14 @@ RSpec.describe Api::V3::ParticipantDeclarationsQuery, :with_default_schedules do
         latest_induction_record.update!(mentor_profile_id: mentor_participant_profile.id)
       end
 
-      it "returns mentor_user_id in attribute with no duplicates" do
+      it "returns transient_mentor_user_id in attribute with no duplicates" do
         paginated_query = ParticipantDeclaration.where(cpd_lead_provider: cpd_lead_provider1)
         declarations = subject.participant_declarations_from(paginated_query).to_a
 
         expect(declarations).to eq([participant_declaration3, participant_declaration1, participant_declaration2])
-        expect(declarations[0].mentor_user_id).to be_empty
-        expect(declarations[1].mentor_user_id).to contain_exactly(mentor_user_id)
-        expect(declarations[2].mentor_user_id).to be_empty
+        expect(declarations[0].transient_mentor_user_id).to be_empty
+        expect(declarations[1].transient_mentor_user_id).to contain_exactly(mentor_user_id)
+        expect(declarations[2].transient_mentor_user_id).to be_empty
       end
     end
   end


### PR DESCRIPTION
[Jira-2253](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2253)

### Context

In order to optimise and simplify queries that reference a declaration `mentor_id` we are going to store the value on the
model directly. We will be populating this when the declaration is created and backfill existing declarations.

### Changes proposed in this pull request

- Add `mentor_user_id` to `ParticipantDeclaration`

### Guidance to review

In the `ParticipantDeclarationQuery` we compute the `mentor_user_id` as an optimisation; to avoid a clash with the
new attribute name (as both `ParticipantDeclaration` and query results can filter through the serializer) the computed
attribute has been renamed `transient_mentor_user_id` and will be removed in a future commit.

Also adds test coverage to the `Mentor` model.
