### PR TITLE
CST-1591: participants transferred out and into the same school must …

### DIFF
--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -53,15 +53,17 @@ module Dashboard
     # the school in the cohorts displayed by the dashboard
     def induction_records
       @induction_records ||= dashboard_school_cohorts.flat_map do |school_cohort|
-        InductionRecordPolicy::Scope.new(
-          user,
-          school_cohort
-            .induction_records
-            .current_or_transferring_in_or_transferred
-            .eager_load(induction_programme: %i[school core_induction_programme lead_provider delivery_partner],
-                        participant_profile: %i[user ecf_participant_eligibility ecf_participant_validation_data])
-            .order("users.full_name"),
-        ).resolve.to_a
+        InductionRecordPolicy::Scope
+          .new(user,
+               school_cohort
+                 .induction_records
+                 .current_or_transferring_in_or_transferred
+                 .eager_load(induction_programme: %i[school core_induction_programme lead_provider delivery_partner],
+                             participant_profile: %i[user ecf_participant_eligibility ecf_participant_validation_data])
+                 .order("users.full_name"))
+          .resolve
+          .order(start_date: :desc, created_at: :desc)
+          .uniq(&:participant_profile_id)
       end
     end
 

--- a/spec/services/dashboard/participants_spec.rb
+++ b/spec/services/dashboard/participants_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Dashboard::Participants, :with_default_schedules do
+  describe "#ects" do
+    let!(:transfer_1) do
+      NewSeeds::Scenarios::Participants::Transfers::FipToFipChangingTrainingProvider.new
+    end
+    let!(:ect_1_induction_record_2) { transfer_1.build }
+    let!(:participant_profile) { transfer_1.participant_profile }
+    let!(:ect_1_induction_record_1) { participant_profile.induction_records.order(:created_at).first }
+    let!(:ect_1_induction_record_3) do
+      Induction::TransferToSchoolsProgramme.call(participant_profile:,
+                                                 induction_programme: ect_1_induction_record_1.induction_programme)
+    end
+    let!(:ect_2_induction_record) do
+      NewSeeds::Scenarios::Participants::Ects::Ect
+        .new(school_cohort: ect_1_induction_record_1.school_cohort)
+        .build
+        .add_induction_record(induction_programme: transfer_1.induction_programme_from, induction_status: :withdrawn)
+    end
+    let(:school_1) { ect_1_induction_record_1.school }
+    let(:user) { double(User, admin?: true) }
+
+    subject do
+      described_class.new(school: school_1, user:).ects
+    end
+
+    it "returns a unique entry per ect currently active or transferring in or transferred from the school" do
+      expect(subject).not_to include(ect_1_induction_record_1)
+      expect(subject).to include(ect_1_induction_record_3)
+      expect(subject).not_to include(ect_2_induction_record)
+    end
+  end
+end


### PR DESCRIPTION
…appear only once in the dashboard

### Context

- [Ticket](https://dfedigital.atlassian.net/browse/CST-1591)

Participants who are transferred back to a school they were already in the past appears twice in that school dashboard.

### Changes proposed in this pull request

Make the list of induction records returned by the dashboard unique by participant keeping always the most recent record of each participant.

### Guidance to review

