### PR TITLE
[CST-1622] Fix moving mentors with Induction::ChangeProgramme

### DIFF
--- a/app/services/induction/change_programme.rb
+++ b/app/services/induction/change_programme.rb
@@ -22,10 +22,11 @@ class Induction::ChangeProgramme < BaseService
 
 private
 
-  attr_reader :participant_profile, :new_induction_programme, :start_date, :end_date, :mentor_profile
+  attr_reader :participant_profile, :current_induction_record, :new_induction_programme, :start_date, :end_date, :mentor_profile
 
   def initialize(participant_profile:, end_date:, new_induction_programme:, start_date: Time.zone.now, mentor_profile: nil)
     @participant_profile = participant_profile
+    @current_induction_record = participant_profile.current_induction_record
     @new_induction_programme = new_induction_programme
     @start_date = start_date
     @end_date = end_date
@@ -41,10 +42,6 @@ private
     return true if participant_profile.schedule.nil?
 
     new_induction_programme.cohort_id == participant_profile.schedule.cohort_id
-  end
-
-  def current_induction_record
-    participant_profile.current_induction_record
   end
 
   def preferred_email

--- a/app/services/induction/change_programme.rb
+++ b/app/services/induction/change_programme.rb
@@ -10,7 +10,8 @@ class Induction::ChangeProgramme < BaseService
                             start_date:,
                             preferred_email:,
                             mentor_profile:)
-      if participant_profile.mentor?
+
+      if participant_profile.mentor? && participant_is_moving_schools?
         Mentors::ChangeSchool.call(from_school: current_induction_record.school,
                                    to_school: new_induction_programme.school,
                                    remove_on_date: start_date,
@@ -46,5 +47,9 @@ private
 
   def preferred_email
     current_induction_record&.preferred_identity&.email || participant_profile.participant_identity.email
+  end
+
+  def participant_is_moving_schools?
+    current_induction_record.school != new_induction_programme.school
   end
 end

--- a/spec/services/induction/change_programme_spec.rb
+++ b/spec/services/induction/change_programme_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Induction::ChangeProgramme do
     let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
     let!(:induction_record) { Induction::Enrol.call(induction_programme:, participant_profile:, start_date: 6.months.ago) }
     let(:action_date) { Time.zone.now }
-    let(:mentor_profile) { create(:mentor_participant_profile) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
 
     subject(:service) { described_class }
 
@@ -40,6 +40,29 @@ RSpec.describe Induction::ChangeProgramme do
         expect(induction_record.start_date).to be_within(1.second).of action_date
         expect(induction_record.participant_profile).to eq participant_profile
         expect(induction_record.mentor_profile).to eq mentor_profile
+      end
+    end
+
+    context "when the participant is a Mentor" do
+      let(:participant_profile) { create(:mentor_participant_profile, school_cohort:) }
+
+      context "when the mentor is not moving to another school" do
+        it "doesn't remove the mentor from the shcool mentor pool" do
+          expect(Mentors::ChangeSchool).not_to receive(:call)
+
+          service.call(participant_profile:, end_date: action_date, new_induction_programme:, start_date: action_date)
+        end
+      end
+
+      context "when then mentor is moving to another school" do
+        let(:school_cohort_of_a_another_school) { create :school_cohort }
+        let(:new_induction_programme) { create(:induction_programme, :fip, school_cohort: school_cohort_of_a_another_school) }
+
+        it "removes the mentor from the shcool mentor pool" do
+          expect(Mentors::ChangeSchool).to receive(:call)
+
+          service.call(participant_profile:, end_date: action_date, new_induction_programme:, start_date: action_date)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: CST-1622

There are a few bugs when using the `Induction::ChangeProgramme` with mentors:
1. When mentors are moving schools, it will remove them from the new school's mentor pool
2. When the mentors are not moving schools, it will remove them from the school's mentor pool and will also remove them from their mentees by updating their induction records.

### Changes proposed in this pull request

1. Store the participant_profile.current_induction_record before reuse it, so it always returns the correct induction record
2. Create an additional check to determine if the mentor is actually moving school

### Guidance to review

