### PR TITLE
Populate mentor_user_id for new ParticipantDeclarations

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -70,8 +70,8 @@ class InductionRecord < ApplicationRecord
 
   scope :for_school, ->(school) { joins(:school).where(school: { id: school.id }) }
 
-  scope :oldest_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END"), start_date: :asc, created_at: :asc) }
-  scope :newest_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END"), start_date: :desc, created_at: :desc) }
+  scope :oldest_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END"), start_date: :asc, end_date: :asc, created_at: :asc) }
+  scope :newest_first, -> { order(Arel.sql("CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END"), start_date: :desc, end_date: :desc, created_at: :desc) }
 
   scope :oldest, -> { oldest_first.first }
 

--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -156,8 +156,21 @@ private
       declaration_type:,
       cpd_lead_provider:,
       delivery_partner:,
+      mentor_user_id:,
       user: participant_identity.user,
     }
+  end
+
+  def mentor_user_id
+    return nil unless participant_profile.ect?
+
+    induction_record = Induction::FindBy.call(
+      participant_profile:,
+      lead_provider: cpd_lead_provider.lead_provider,
+      date_range: ..declaration_date,
+    )
+
+    induction_record&.mentor_profile&.participant_identity&.user_id
   end
 
   def delivery_partner

--- a/spec/models/induction_record_spec.rb
+++ b/spec/models/induction_record_spec.rb
@@ -268,13 +268,13 @@ RSpec.describe InductionRecord, :with_default_schedules, type: :model do
     describe "ordering" do
       describe ".oldest_first" do
         it "orders by created_at asc" do
-          expect(described_class.oldest_first.to_sql).to match(%(ORDER BY CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END, "induction_records"."start_date" ASC, "induction_records"."created_at" ASC))
+          expect(described_class.oldest_first.to_sql).to match(%(ORDER BY CASE WHEN induction_records.end_date IS NULL THEN 1 ELSE 0 END, "induction_records"."start_date" ASC, "induction_records"."end_date" ASC, "induction_records"."created_at" ASC))
         end
       end
 
       describe ".newest_first" do
         it "orders by created_at desc" do
-          expect(described_class.newest_first.to_sql).to match(%(ORDER BY CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END, "induction_records"."start_date" DESC, "induction_records"."created_at" DESC))
+          expect(described_class.newest_first.to_sql).to match(%(ORDER BY CASE WHEN induction_records.end_date IS NULL THEN 0 ELSE 1 END, "induction_records"."start_date" DESC, "induction_records"."end_date" DESC, "induction_records"."created_at" DESC))
         end
       end
     end


### PR DESCRIPTION
[Jira-2253](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2253)

### Context

The `ParticipantDeclaration` has a new foreign key `mentor_user_id` that is currently unpopulated. We want to
populate this with the induction record relative to the `declaration_date` at the time of creation.

### Changes proposed in this pull request

- Populate mentor_user_id for new declarations
- Clarify induction record date edge cases

### Guidance to review

The field is not yet referenced/read anywhere. We will backfill the existing declarations in a separate PR.

We have induction records in the database that are in an invalid/unexpected state. Until we are able to clean up the
data and ensure consistency we need to make sure the latest induction record logic is expected/documented.

Update `InductionRecord` scopes to prioritise records based on the latest `end_date` if they have the same `start_date`.

Add test coverage to the `FindBy` class to cover the following edge cases:

- Induction records with the same start date where one has a `nil` end date
- Induction records with the same start date where one has a later end date
- The expected scenario of the latest induction record having a `nil` end date