### PR TITLE
[CPDLP-2260] Add fields to participant outcomes big query stream job

### DIFF
--- a/app/jobs/participant_outcomes/stream_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_big_query_job.rb
@@ -18,6 +18,8 @@ module ParticipantOutcomes
           participant_declaration_id: outcome.participant_declaration_id,
           created_at: outcome.created_at,
           updated_at: outcome.updated_at,
+          qualified_teachers_api_request_successful: outcome.qualified_teachers_api_request_successful,
+          sent_to_qualified_teachers_api_at: outcome.sent_to_qualified_teachers_api_at,
         }.stringify_keys,
       ]
 

--- a/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
+++ b/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ParticipantOutcomes::StreamBigQueryJob, :with_default_schedules do
   let(:participant_declaration) { create(:npq_participant_declaration) }
-  let(:outcome) { create(:participant_outcome, participant_declaration:) }
+  let(:outcome) { create(:participant_outcome, :sent_to_qualified_teachers_api, participant_declaration:, qualified_teachers_api_request_successful: true) }
 
   describe "#perform" do
     let(:bigquery) { double("bigquery") }
@@ -18,16 +18,20 @@ RSpec.describe ParticipantOutcomes::StreamBigQueryJob, :with_default_schedules d
     end
 
     it "sends correct data to BigQuery" do
-      described_class.perform_now(participant_outcome_id: outcome.id)
+      freeze_time do
+        described_class.perform_now(participant_outcome_id: outcome.id)
 
-      expect(table).to have_received(:insert).with([{
-        participant_outcome_id: outcome.id,
-        state: outcome.state,
-        completion_date: outcome.completion_date,
-        participant_declaration_id: outcome.participant_declaration_id,
-        created_at: outcome.created_at,
-        updated_at: outcome.updated_at,
-      }.stringify_keys], ignore_unknown: true)
+        expect(table).to have_received(:insert).with([{
+          participant_outcome_id: outcome.id,
+          state: outcome.state,
+          completion_date: outcome.completion_date,
+          participant_declaration_id: outcome.participant_declaration_id,
+          created_at: outcome.created_at,
+          updated_at: outcome.updated_at,
+          qualified_teachers_api_request_successful: outcome.qualified_teachers_api_request_successful,
+          sent_to_qualified_teachers_api_at: outcome.sent_to_qualified_teachers_api_at,
+        }.stringify_keys], ignore_unknown: true)
+      end
     end
 
     it "queues job" do


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2260](https://dfedigital.atlassian.net/browse/CPDLP-2260)

We’d like to also monitor any errors that could stem from TRNs being missing or errors returned from the TRA API.

### Changes proposed in this pull request

Add two new fields to the existing Big query streaming job ParticipantOutcomes::StreamBigQueryJob

- qualified_teachers_api_request_successful: boolean
- sent_to_qualified_teachers_api_at: timestamp

  **These new fields need to be created in Big query tables first.**



[CPDLP-2260]: https://dfedigital.atlassian.net/browse/CPDLP-2260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ