### PR TITLE
Backfill mentor_user_id on ParticipantDeclaration

### DIFF
--- a/lib/backfill_mentor_user_id.rb
+++ b/lib/backfill_mentor_user_id.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class BackfillMentorUserId
+  attr_reader :dry_run
+
+  def initialize(dry_run: true)
+    @dry_run = dry_run
+  end
+
+  def run
+    log_start
+    process_declarations
+    log_finish
+  end
+
+private
+
+  def log_start
+    logger.info("~~DRY RUN~~") if dry_run
+    logger.info("Backfilling #{total_declarations} declarations")
+  end
+
+  def process_declarations
+    declarations.find_each.with_index do |declaration, index|
+      throttle_backfill
+      log_progress(index + 1)
+
+      induction_record = find_induction_record(declaration)
+      mentor_user_id = extract_mentor_user_id(induction_record)
+
+      if mentor_user_id.present? && !dry_run
+        declaration.update!(mentor_user_id:)
+      end
+    end
+  end
+
+  def log_progress(count)
+    logger.info("#{count}/#{total_declarations}") if (count % 10).zero?
+  end
+
+  def log_finish
+    logger.info("Finished backfilling declarations")
+  end
+
+  def throttle_backfill
+    sleep(0.0025)
+  end
+
+  def total_declarations
+    @total_declarations ||= declarations.count
+  end
+
+  def find_induction_record(declaration)
+    Induction::FindBy.call(
+      participant_profile: declaration.participant_profile,
+      lead_provider: declaration.cpd_lead_provider.lead_provider,
+      date_range: (..declaration.declaration_date),
+    )
+  end
+
+  def extract_mentor_user_id(induction_record)
+    induction_record&.mentor_profile&.participant_identity&.user_id
+  end
+
+  def declarations
+    @declarations ||=
+      ParticipantDeclaration::ECF
+        .includes(:participant_profile, cpd_lead_provider: :lead_provider)
+        .where(mentor_user_id: nil)
+  end
+
+  def logger
+    Logger.new($stdout)
+  end
+end

--- a/lib/tasks/backfill_mentor_user_id.rake
+++ b/lib/tasks/backfill_mentor_user_id.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rake"
+require "backfill_mentor_user_id"
+
+namespace :backfill do
+  desc "Backfill the mentor_user_id foreign key on ParticipantDeclaration"
+  task :mentor_user_id, [:dry_run] => :environment do |_task, args|
+    dry_run = ActiveModel::Type::Boolean.new.cast(args[:dry_run] || true)
+    BackfillMentorUserId.new(dry_run:).run
+  end
+end

--- a/spec/lib/backfill_mentor_user_id_spec.rb
+++ b/spec/lib/backfill_mentor_user_id_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "backfill_mentor_user_id"
+
+describe BackfillMentorUserId, :with_default_schedules do
+  let(:instance) { described_class.new(dry_run:) }
+  let(:dry_run) { false }
+
+  let(:mentor_profile) { create(:mentor_participant_profile) }
+  let(:mentor_user_id) { mentor_profile.participant_identity.user_id }
+  let(:participant_profile) { declaration.participant_profile }
+  let(:declaration) { create(:ect_participant_declaration) }
+  let(:logger) { instance_double(Logger, info: nil) }
+  let(:latest_induction_record) { participant_profile.induction_records.latest }
+
+  before do
+    allow(Logger).to receive(:new) { logger }
+    latest_induction_record.update!(mentor_profile:)
+  end
+
+  describe "#run" do
+    subject(:run) { instance.run }
+
+    it "updates the mentor_user_id on declarations" do
+      run
+
+      expect(logger).to have_received(:info).with("Backfilling 1 declarations")
+      expect(declaration.reload).to have_attributes(mentor_user_id:)
+      expect(logger).to have_received(:info).with("Finished backfilling declarations")
+    end
+
+    it "throttles the backfill process" do
+      instance.stub(:sleep)
+      run
+      expect(instance).to have_received(:sleep).with(0.0025)
+    end
+
+    context "when declarations already have a mentor_user_id" do
+      before { declaration.update!(mentor_user_id:) }
+
+      it "does not change the declarations" do
+        expect { run }.not_to change { declaration.mentor_user_id }
+
+        expect(logger).to have_received(:info).with("Backfilling 0 declarations")
+        expect(logger).to have_received(:info).with("Finished backfilling declarations")
+      end
+    end
+
+    context "when the mentor was assigned after the declaration_date" do
+      let(:declaration_date) { declaration.declaration_date }
+
+      before { latest_induction_record.update!(start_date: declaration_date + 1.month) }
+
+      it "does not change the declarations" do
+        expect { run }.not_to change { declaration.mentor_user_id }
+
+        expect(logger).to have_received(:info).with("Backfilling 1 declarations")
+        expect(logger).to have_received(:info).with("Finished backfilling declarations")
+      end
+    end
+
+    context "when there are more than 10 declarations" do
+      before do
+        create_list(:ect_participant_declaration, 10)
+      end
+
+      it "logs progress after every 10 declarations processed" do
+        run
+
+        expect(logger).to have_received(:info).with("Backfilling 11 declarations")
+        expect(logger).to have_received(:info).with("10/11")
+        expect(logger).to have_received(:info).with("Finished backfilling declarations")
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      it "does not update the mentor_user_id on declarations" do
+        expect { run }.not_to change { declaration.mentor_user_id }
+
+        expect(logger).to have_received(:info).with("~~DRY RUN~~")
+        expect(logger).to have_received(:info).with("Backfilling 1 declarations")
+        expect(logger).to have_received(:info).with("Finished backfilling declarations")
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-2253](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2253)

### Context

We have a new `mentor_user_id` attribute on `ParticipantDeclaration` that is currently only being populated for new declarations. We want to backfill all the ECF declarations so that we can start referencing the `mentor_user_id` field.

### Changes proposed in this pull request

- Add rake task to backfill mentor_user_id on ParticipantDeclaration

### Guidance to review

I thought about doing a rake task that spawns jobs for each of the update operations, but assuming there aren't _loads_ of declarations and updating them is a relatively short operation then doing it from the dev console should be fine/less complex.

Example usage:

Dry run: `rake backfill:mentor_user_id`
Run (updates records): `rake 'backfill:mentor_user_id[false]'`