### PR TITLE
Fix rolling into next cohort year failures

### DIFF
--- a/db/new_seeds/scenarios/participants/training_record_states.rb
+++ b/db/new_seeds/scenarios/participants/training_record_states.rb
@@ -400,7 +400,7 @@ module NewSeeds
         def ect_on_fip_leaving
           school_cohort = fip_school.school_cohort
 
-          transfer_date = school_cohort.cohort.next.registration_start_date + 1.day
+          transfer_date = 1.month.from_now
 
           @ect_on_fip_leaving ||= NewSeeds::Scenarios::Participants::Ects::Ect
             .new(school_cohort:, full_name: "ECT on FIP: leaving a FIP school")
@@ -429,7 +429,7 @@ module NewSeeds
           school_cohort = fip_school.school_cohort
           school_cohort_2 = cip_school.school_cohort
 
-          transfer_date = school_cohort.cohort.next.registration_start_date + 1.day
+          transfer_date = 1.month.from_now
 
           @ect_on_fip_transferring ||= NewSeeds::Scenarios::Participants::Ects::Ect
             .new(school_cohort:, full_name: "ECT on FIP: transferring from a FIP school")
@@ -461,7 +461,7 @@ module NewSeeds
           school_cohort = cip_school.school_cohort
           school_cohort_2 = fip_school.school_cohort
 
-          transfer_date = school_cohort.cohort.next.registration_start_date + 1.day
+          transfer_date = 1.month.from_now
 
           @ect_on_fip_joining ||= NewSeeds::Scenarios::Participants::Ects::Ect
             .new(school_cohort:, full_name: "ECT on FIP: joining a FIP school")

--- a/spec/cypress/app_commands/scenarios/lead_provider_with_delivery_partners.rb
+++ b/spec/cypress/app_commands/scenarios/lead_provider_with_delivery_partners.rb
@@ -3,7 +3,7 @@
 profile = LeadProviderProfile.last
 lead_provider = profile.lead_provider
 delivery_partner = FactoryBot.create(:delivery_partner, name: "Delivery Partner 1")
-ProviderRelationship.create!(delivery_partner:, lead_provider:, cohort: Cohort.active_registration_cohort)
+ProviderRelationship.create!(delivery_partner:, lead_provider:, cohort: Cohort.find_by(start_year: 2022))
 
 FactoryBot.create(:school, :with_local_authority, name: "First school", urn: 123_456)
 FactoryBot.create(:school, :with_local_authority, name: "Second school", urn: "012345")

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
   factory :cohort do
     start_year { Faker::Number.unique.between(from: 2022, to: 2100) }
-    registration_start_date { Date.new(start_year.to_i, 6, 15) }
+    registration_start_date { Date.new(start_year.to_i, 6, 5) }
     academic_year_start_date { Date.new(start_year.to_i, 9, 1) }
     automatic_assignment_period_end_date { Date.new(start_year.to_i + 1, 3, 31) }
 

--- a/spec/features/schools/add_appropriate_body_spec.rb
+++ b/spec/features/schools/add_appropriate_body_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Add a school cohort appropriate body", type: :feature, js: true,
                with_feature_flags: { cohortless_dashboard: "active" },
-               travel_to: Time.zone.local(2023, 6, 15, 16, 15, 0) do
+               travel_to: Time.zone.local(2023, 6, 5, 16, 15, 0) do
   context "When appropriate body setup was not done for the cohort" do
     scenario "The appropriate body can be added" do
       given_there_is_a_school_and_an_induction_coordinator

--- a/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_invalid_provider_relationship_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./choose_programme_steps"
 
-RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 15, 16, 15, 0) do
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
   include ChooseProgrammeSteps
 
   before do

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "./choose_programme_steps"
 
-RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 15, 16, 15, 0) do
+RSpec.feature "Schools should be able to choose their programme", type: :feature, js: true, rutabaga: false, travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
   include ChooseProgrammeSteps
 
   scenario "A school chooses no ECTs expected in next academic year" do

--- a/spec/features/schools/training_dashboard/manage_schools_spec.rb
+++ b/spec/features/schools/training_dashboard/manage_schools_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "School Tutors should be able to manage schools", type: :feature, 
     and_the_page_should_be_accessible
   end
 
-  context "Multiple cohorts when the new cohort is open for registrations", travel_to: Time.zone.local(2022, 6, 15, 16, 15, 0) do
+  context "Multiple cohorts when the new cohort is open for registrations", travel_to: Time.zone.local(2022, 6, 5, 16, 15, 0) do
     scenario "Start setting up the new cohort" do
       given_there_is_a_school_that_has_chosen_cip_for_2021(pilot: true)
       and_cohort_2022_is_created


### PR DESCRIPTION
### Context
When the next cohort rolls in, we get failures in the specs. Fix those not to rely on the current cohort start date
- Ticket: n/a

### Changes proposed in this pull request
- Amend existing cohort factory to be in the past and set specific specs to that date
- Amend feature setup to always point at specific cohort to avoid failures, as the cohort year is set up in the query param
- Amend training state scenarios to look into the future rather than the cohort start to avoid failures

### Guidance to review
Need to merge before tomorrow when the cohort year rolls again 😅 
