### PR TITLE
[CST-1626] Handle lack of induction record in school transfer form gracefully

### DIFF
--- a/app/forms/admin/school_transfer_form.rb
+++ b/app/forms/admin/school_transfer_form.rb
@@ -10,6 +10,7 @@ class Admin::SchoolTransferForm
   STEPS = %i[select_school transfer_options start_date email check_answers].freeze
 
   validate :participant_profile_present
+  validates :latest_induction_record, presence: { message: "Participant must have induction record to proceed" }
   validates :new_school_urn, presence: true, on: :select_school
   validate :new_school_exists, on: :select_school
   validate :moving_to_new_school, on: :select_school
@@ -149,6 +150,10 @@ private
 
   def participant_profile_present
     raise "Participant profile id missing" if participant_profile_id.blank?
+  end
+
+  def induction_record_present
+    raise "Participant Induction Record missing" if latest_induction_record.blank?
   end
 
   def partnership_details(induction_programme)

--- a/spec/forms/admin/school_transfer_form_spec.rb
+++ b/spec/forms/admin/school_transfer_form_spec.rb
@@ -166,6 +166,12 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
         form.new_school_urn = participant_profile.school.urn
         expect(form.valid?(:select_school)).to be false
       end
+
+      it "checks that the participant has a induction record" do
+        participant_profile.induction_records.destroy_all
+        expect(form.valid?(:select_school)).to be false
+        expect(form.errors[:latest_induction_record]).to be_present
+      end
     end
 
     context "when :start_date step" do
@@ -175,6 +181,12 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
         form.start_date = 2.days.ago
         expect(form.valid?(:start_date)).to be false
         expect(form.errors[:start_date]).to be_present
+      end
+
+      it "checks that the participant has a induction record" do
+        participant_profile.induction_records.destroy_all
+        expect(form.valid?(:start_date)).to be false
+        expect(form.errors[:latest_induction_record]).to be_present
       end
     end
 
@@ -209,6 +221,18 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
           form.email = user.email
           expect(form.valid?(:email)).to be false
           expect(form.errors[:email]).to be_present
+        end
+      end
+
+      context "when participant is missing their induction record" do
+        before do
+          participant_profile.induction_records.destroy_all
+        end
+
+        it "returns false" do
+          form.email = "jackmiller@example.com"
+          expect(form.valid?(:email)).to be false
+          expect(form.errors[:latest_induction_record]).to be_present
         end
       end
     end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-1626

When attempting to complete the form without an induction record the user will encounter an unhandled error.

### Changes proposed in this pull request

This adds that requirement as a validation check so the user is informed why they are not able to complete the form.

### Guidance to review

#### Replication Steps

1. Visit /admin/participants/:participant_id/school for a participant without an induction record
2. Click Transfer to Another School
3. Proceed and attempt to complete the Start Date form.
4. The app will encounter an error due to a missing induction record (currently suppressed by CST-1625)

#### Expected behaviour

The user is shown an error message that explains why the user cannot be transferred.

Here's a screenshot from the seed data triggering the error page now that it's been fixed:
<img width="987" alt="Screenshot of the error page using seed data. The screenshot is of a form asking for a School URN. The form has an error stating: The Participant must have an Induction Record to proceed." src="https://github.com/DFE-Digital/early-careers-framework/assets/1465268/bd782aab-7c95-4cdf-a614-f0c512b123b6">



