### PR TITLE
[CST-1625] Handle errors in school transfer gracefully

### DIFF
--- a/app/controllers/admin/participants/school_transfer_controller.rb
+++ b/app/controllers/admin/participants/school_transfer_controller.rb
@@ -72,13 +72,19 @@ module Admin::Participants
 
     def step_valid?
       @school_transfer_form.valid? action_name.to_sym
-    rescue StandardError
+    end
+
+    def handle_form_error(error)
       clear_session_data
+      Sentry.capture_exception(error)
+      flash[:alert] = "There was a problem processing your request. If this problem persists please contact an administrator."
       redirect_to admin_participants_path
     end
 
     def validate_request_or_render
       render unless (request.put? || request.post?) && step_valid?
+    rescue StandardError => e
+      handle_form_error(e)
     end
 
     def validate_and_proceed_or_render
@@ -87,6 +93,8 @@ module Admin::Participants
       else
         render
       end
+    rescue StandardError => e
+      handle_form_error(e)
     end
 
     def should_restart_process?


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-1625

When attempting to complete the School Transfer form in a way that triggers an unhandled error in the validation the controller attempts to redirect/render twice, triggering a 500 error that suppresses the actual error from being reported to Sentry and is not handled gracefully for the user.

### Changes proposed in this pull request

Move the error handling onto the methods calling `step_valid?` so that the error handling properly takes over flow control.

### Guidance to review

#### Replication steps

1. Visit /admin/participants/:participant_id/school for a participant where validation will encounter an unhandled error, the best way to do this is to visit for a participant without an induction record
2. Click Transfer to Another School
3. Proceed and attempt to complete the form.
4. The app will encounter a AbstractController::DoubleRenderError with the message Render and/or redirect were called multiple times in this action.
5. The DoubleRenderError is reported to Sentry instead of the real error.

#### Post change error

The actual error encountered is not suppressed by the double render error and is reported to sentry. 

The user is presented with an error message rather than a 500 page.

