### PR TITLE
[CST-1624] Ensure safe induction record navigation

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -48,7 +48,7 @@ module Admin
     end
 
     def historical_induction_records
-      @historical_induction_records ||= induction_records[1..]
+      @historical_induction_records ||= induction_records[1..].presence || []
     end
 
     def latest_induction_record

--- a/app/controllers/concerns/admin/participants/find_induction_records.rb
+++ b/app/controllers/concerns/admin/participants/find_induction_records.rb
@@ -10,7 +10,7 @@ module Admin
       end
 
       def historical_induction_records
-        induction_records[1..]
+        induction_records[1..].presence || []
       end
 
       def all_induction_records

--- a/app/presenters/admin/participant_presenter.rb
+++ b/app/presenters/admin/participant_presenter.rb
@@ -70,7 +70,7 @@ class Admin::ParticipantPresenter
   end
 
   def historical_induction_records
-    induction_records[1..]
+    induction_records[1..].presence || []
   end
 
   def all_induction_records

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -43,7 +43,7 @@
 
     sl.row do |row|
       row.key(text: "Training record state")
-      row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status, colour: "grey"))
+      row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
     end
   end %>
 <% end %>
@@ -114,12 +114,12 @@ end %>
 <%= govuk_summary_list(actions: true) do |sl|
   sl.row do |row|
     row.key(text: "induction status")
-    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status, colour: "grey"))
+    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status || "No Induction Record Found", colour: "grey"))
   end
 
   sl.row do |row|
     row.key(text: "training status")
-    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status, colour: "grey"))
+    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
   end
 end %>
 

--- a/spec/presenters/admin/participant_presenter_spec.rb
+++ b/spec/presenters/admin/participant_presenter_spec.rb
@@ -144,6 +144,14 @@ RSpec.describe(Admin::ParticipantPresenter, :with_default_schedules) do
 
           expect(subject.historical_induction_records.pluck(:id)).to match_array(expected.map(&:id))
         end
+
+        context "when participant is missing their induction records" do
+          before { participant_profile.induction_records.destroy_all }
+
+          it "returns an empty array" do
+            expect(subject.historical_induction_records).to be_empty
+          end
+        end
       end
     end
 

--- a/spec/requests/admin/participants/school_spec.rb
+++ b/spec/requests/admin/participants/school_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Participants::School", :with_default_schedules, type: :request do
+  let(:admin_user) { create(:user, :admin) }
+
+  let!(:mentor_profile)               { create(:mentor) }
+  let!(:ect_profile)                  { create(:ect, mentor_profile_id: mentor_profile.id) }
+  let!(:npq_profile)                  { create(:npq_participant_profile) }
+  let!(:withdrawn_ect_profile_record) { create(:ect, :withdrawn_record) }
+  let!(:induction_programme)          { create(:induction_programme, :fip) }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /admin/participants" do
+    let(:route) { "/admin/participants/#{mentor_profile.id}/school" }
+
+    it "renders without errors" do
+      get route
+      expect(response).to render_template "admin/participants/school/show"
+    end
+
+    context "when participant is missing their induction records" do
+      before do
+        mentor_profile.induction_records.destroy_all
+      end
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/school/show"
+      end
+    end
+  end
+end

--- a/spec/requests/admin/participants/statuses_spec.rb
+++ b/spec/requests/admin/participants/statuses_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Participants::Statuses", :with_default_schedules, type: :request do
+  let(:admin_user) { create(:user, :admin) }
+
+  let!(:mentor_profile)               { create(:mentor) }
+  let!(:ect_profile)                  { create(:ect, mentor_profile_id: mentor_profile.id) }
+  let!(:npq_profile)                  { create(:npq_participant_profile) }
+  let!(:withdrawn_ect_profile_record) { create(:ect, :withdrawn_record) }
+  let!(:induction_programme)          { create(:induction_programme, :fip) }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /admin/participants" do
+    let(:route) { "/admin/participants/#{mentor_profile.id}/statuses" }
+
+    it "renders without errors" do
+      get route
+      expect(response).to render_template "admin/participants/statuses/show"
+    end
+
+    context "when participant is missing their induction records" do
+      before do
+        mentor_profile.induction_records.destroy_all
+      end
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/statuses/show"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket:  https://dfedigital.atlassian.net/browse/CST-1624

In several places there is the assumption of at least one induction record for a participant profile and even when safe navigation is used it is assumed that a nil value is acceptable.

### Changes proposed in this pull request

Removes the assumption that one-to-many induction_record relations will always return at least one value and return an empty array if the result would be nil.

Sends fallback text to `govuk_tag` when induction records are missing.

### Guidance to review

#### Replication steps

1. Visit /admin/participants/:participant_id/school for a participant without an induction record
2. The above page will produce a 500 error

1. Visit /admin/participants/:participant_id/statuses for a participant without an induction record
2. The above page will produce a 500 error

#### Post fix behavior

The above pages render correctly for these participant profiles