### PR TITLE
Trigger outcomes callbacks when sending it to TRA

### DIFF
--- a/app/services/qualified_teachers_api_sender.rb
+++ b/app/services/qualified_teachers_api_sender.rb
@@ -36,8 +36,8 @@ private
   end
 
   def set_sent_to_qualified_teachers_api_at
-    participant_outcome.update_column(
-      :sent_to_qualified_teachers_api_at, Time.zone.now
+    participant_outcome.update(
+      sent_to_qualified_teachers_api_at: Time.zone.now,
     )
   end
 
@@ -56,8 +56,8 @@ private
   end
 
   def set_qualified_teachers_api_request_successful
-    participant_outcome.update_column(
-      :qualified_teachers_api_request_successful, SUCCESS_CODES.include?(api_response.response.code)
+    participant_outcome.update(
+      qualified_teachers_api_request_successful: SUCCESS_CODES.include?(api_response.response.code),
     )
   end
 


### PR DESCRIPTION
### Context

- Ticket: 

We need to trigger the outcomes callbacks when updating those records in order to sync those with big query correctly.

### Changes proposed in this pull request

Trigger outcomes callbacks when sending it to TRA.. so use `update` instead of `update_column` which will trigger callbacks.

