### PR TITLE
Remove API v3 feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,7 +17,6 @@ class FeatureFlag
   # Short-lived feature flags
   TEMPORARY_FEATURE_FLAGS = %i[
     eligibility_notifications
-    api_v3
     appropriate_bodies
     prevent_2023_ect_registrations
     cohortless_dashboard

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,7 +164,7 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :v3, constraints: ->(_request) { FeatureFlag.active?(:api_v3) } do
+    namespace :v3 do
       resources :statements, only: %i[index show], controller: "finance/statements"
       resources :delivery_partners, only: %i[index show], path: "delivery-partners"
       resources :partnerships, path: "partnerships/ecf", only: %i[show index create update], controller: "ecf/partnerships"

--- a/spec/docs/v3/ecf_delivery_partners_spec.rb
+++ b/spec/docs/v3/ecf_delivery_partners_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/docs/v3/ecf_participant_transfers_spec.rb
+++ b/spec/docs/v3/ecf_participant_transfers_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }

--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:school) { create(:school) }
   let(:cohort) { create(:cohort, :current) }

--- a/spec/docs/v3/ecf_partnerships_spec.rb
+++ b/spec/docs/v3/ecf_partnerships_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
   let(:Authorization) { bearer_token }
   let!(:provider_relationship) { create(:provider_relationship, lead_provider:, delivery_partner:, cohort:) }
 
-  context "with API V3 feature flag enabled", with_feature_flags: { api_v3: "active" } do
+  context "with API V3 feature flag enabled" do
     path "/api/v3/partnerships/ecf" do
       get "<b>Note, this endpoint is new.</b><br/>Retrieve multiple ECF partnerships" do
         operationId :partnerships_ecf_get

--- a/spec/docs/v3/ecf_schools_spec.rb
+++ b/spec/docs/v3/ecf_schools_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }

--- a/spec/docs/v3/ecf_unfunded_mentors_spec.rb
+++ b/spec/docs/v3/ecf_unfunded_mentors_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/docs/v3/npq_applications_spec.rb
+++ b/spec/docs/v3/npq_applications_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/docs/v3/npq_participant_outcomes_spec.rb
+++ b/spec/docs/v3/npq_participant_outcomes_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token)         { "Bearer #{token}" }
   let(:Authorization)     { bearer_token }

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+describe "API", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider) }
   let(:npq_lead_provider) { cpd_lead_provider.npq_lead_provider }
   let(:npq_course) { create(:npq_course, identifier: "npq-senior-leadership") }

--- a/spec/docs/v3/participant_declarations_spec.rb
+++ b/spec/docs/v3/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "Participant Declarations", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "Participant Declarations", :with_default_schedules, type: :request, swagger_doc: "v3/api_spec.json" do
   let(:ect_profile) { create(:ect) }
   let(:ect_declaration_date) { ect_profile.schedule.milestones.find_by(declaration_type: "started").start_date }
   let(:user) { ect_profile.user }

--- a/spec/docs/v3/statements_spec.rb
+++ b/spec/docs/v3/statements_spec.rb
@@ -2,7 +2,7 @@
 
 require "swagger_helper"
 
-RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json", with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
   let(:cpd_lead_provider) { create(:cpd_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API Delivery Partners", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API Delivery Partners", :with_default_schedules, type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API ECF Participants", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API ECF Participants", :with_default_schedules, type: :request do
   let(:cohort_2021) { Cohort.find_by(start_year: 2021) || create(:cohort, start_year: 2021) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, lead_provider:) }
   let(:lead_provider)     { create(:lead_provider) }

--- a/spec/requests/api/v3/ecf/schools_spec.rb
+++ b/spec/requests/api/v3/ecf/schools_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API ECF schools", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API ECF schools", :with_default_schedules, type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }

--- a/spec/requests/api/v3/ecf/transfers_spec.rb
+++ b/spec/requests/api/v3/ecf/transfers_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API ECF transfers", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API ECF transfers", :with_default_schedules, type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }

--- a/spec/requests/api/v3/ecf/unfunded_mentors_spec.rb
+++ b/spec/requests/api/v3/ecf/unfunded_mentors_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API ECF Unfunded Mentors", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API ECF Unfunded Mentors", :with_default_schedules, type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
   let(:lead_provider) { cpd_lead_provider.lead_provider }
   let(:cohort) { Cohort.current || create(:cohort, :current) }

--- a/spec/requests/api/v3/npq_applications_spec.rb
+++ b/spec/requests/api/v3/npq_applications_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "NPQ Applications API", :with_default_schedules, type: :request do
   let(:npq_lead_provider) { create(:npq_lead_provider) }
   let(:cpd_lead_provider) { create(:cpd_lead_provider, npq_lead_provider:) }
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "NPQ Participants API", :with_default_schedules, type: :request do
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }
   let(:bearer_token) { "Bearer #{token}" }
   let(:npq_lead_provider) { create(:npq_lead_provider) }

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "API Participant Declarations", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "API Participant Declarations", :with_default_schedules, type: :request do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
 
   let(:token) { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider:) }

--- a/spec/requests/api/v3/participant_outcome_spec.rb
+++ b/spec/requests/api/v3/participant_outcome_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request do
   let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
   let(:bearer_token)         { "Bearer #{token}" }
   let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }

--- a/spec/requests/api/v3/provider_outcomes_spec.rb
+++ b/spec/requests/api/v3/provider_outcomes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request, with_feature_flags: { api_v3: "active" } do
+RSpec.describe "participant outcomes endpoint spec", :with_default_schedules, type: :request do
   let(:token)                { LeadProviderApiToken.create_with_random_token!(cpd_lead_provider: provider) }
   let(:bearer_token)         { "Bearer #{token}" }
   let(:provider) { create :cpd_lead_provider, :with_npq_lead_provider }

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -48,106 +48,98 @@ RSpec.describe "statements endpoint spec", type: :request do
       default_headers[:CONTENT_TYPE] = "application/json"
     end
 
-    context "with API V3 flag disabled" do
-      it "returns a 404" do
-        expect { get "/api/v3/statements", params: }.to raise_error(ActionController::RoutingError)
+    it "returns correct jsonapi content type header" do
+      get("/api/v3/statements", params:)
+
+      expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+    end
+
+    it "returns a list of all statements" do
+      get("/api/v3/statements", params:)
+      expect(parsed_response["data"].count).to eq(4)
+    end
+
+    it "returns correct type" do
+      get("/api/v3/statements", params:)
+
+      expect(parsed_response["data"][0]).to have_type("statement")
+    end
+
+    it "returns statement IDs" do
+      get("/api/v3/statements", params:)
+
+      expect(parsed_response["data"][0]["id"]).to be_in(Finance::Statement.pluck(:id))
+    end
+
+    it "has correct attributes" do
+      get("/api/v3/statements", params:)
+
+      expect(parsed_response["data"][0]).to have_jsonapi_attributes(
+        :month,
+        :year,
+        :type,
+        :cohort,
+        :created_at,
+        :updated_at,
+        :cut_off_date,
+        :payment_date,
+        :paid,
+      ).exactly
+    end
+
+    it "returns the right number of statements per page" do
+      get "/api/v3/statements", params: { page: { per_page: 3, page: 1 } }
+
+      expect(parsed_response["data"].size).to eql(3)
+    end
+
+    it "returns different statements for second page" do
+      get "/api/v3/statements", params: { page: { per_page: 3, page: 2 } }
+
+      expect(parsed_response["data"].size).to eql(1)
+    end
+
+    context "with cohort filter" do
+      let(:params) { { filter: { cohort: current_cohort.display_name } } }
+      it "returns statements within filter cohort" do
+        get("/api/v3/statements", params:)
+
+        expect(parsed_response["data"].size).to eql(2)
       end
     end
 
-    context "with API V3 flag active", with_feature_flags: { api_v3: "active" } do
-      it "returns correct jsonapi content type header" do
+    context "with type filter" do
+      let(:params) { { filter: { type: "ecf" } } }
+      it "returns statements within filter type" do
         get("/api/v3/statements", params:)
 
-        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+        expect(parsed_response["data"].size).to eql(2)
+      end
+    end
+
+    context "with updated_since filter" do
+      before do
+        ecf_statement_next_cohort.update!(updated_at: 3.days.ago)
+        ecf_statement_current_cohort.update!(updated_at: 1.day.ago)
+        npq_statement_next_cohort.update!(updated_at: 1.day.ago)
+        npq_statement_current_cohort.update!(updated_at: 6.days.ago)
       end
 
-      it "returns a list of all statements" do
+      it "returns statements updated after updated_since" do
+        get "/api/v3/statements", params: { filter: { updated_since: 2.days.ago.iso8601 } }
+
+        expect(parsed_response["data"].size).to eql(2)
+        expect(parsed_response.dig("data", 0, "id")).to eql(ecf_statement_current_cohort.id)
+        expect(parsed_response.dig("data", 1, "id")).to eql(npq_statement_next_cohort.id)
+      end
+    end
+
+    context "when unauthorized" do
+      let(:token) { "incorrect-token" }
+      it "returns 401" do
         get("/api/v3/statements", params:)
-        expect(parsed_response["data"].count).to eq(4)
-      end
 
-      it "returns correct type" do
-        get("/api/v3/statements", params:)
-
-        expect(parsed_response["data"][0]).to have_type("statement")
-      end
-
-      it "returns statement IDs" do
-        get("/api/v3/statements", params:)
-
-        expect(parsed_response["data"][0]["id"]).to be_in(Finance::Statement.pluck(:id))
-      end
-
-      it "has correct attributes" do
-        get("/api/v3/statements", params:)
-
-        expect(parsed_response["data"][0]).to have_jsonapi_attributes(
-          :month,
-          :year,
-          :type,
-          :cohort,
-          :created_at,
-          :updated_at,
-          :cut_off_date,
-          :payment_date,
-          :paid,
-        ).exactly
-      end
-
-      it "returns the right number of statements per page" do
-        get "/api/v3/statements", params: { page: { per_page: 3, page: 1 } }
-
-        expect(parsed_response["data"].size).to eql(3)
-      end
-
-      it "returns different statements for second page" do
-        get "/api/v3/statements", params: { page: { per_page: 3, page: 2 } }
-
-        expect(parsed_response["data"].size).to eql(1)
-      end
-
-      context "with cohort filter" do
-        let(:params) { { filter: { cohort: current_cohort.display_name } } }
-        it "returns statements within filter cohort" do
-          get("/api/v3/statements", params:)
-
-          expect(parsed_response["data"].size).to eql(2)
-        end
-      end
-
-      context "with type filter" do
-        let(:params) { { filter: { type: "ecf" } } }
-        it "returns statements within filter type" do
-          get("/api/v3/statements", params:)
-
-          expect(parsed_response["data"].size).to eql(2)
-        end
-      end
-
-      context "with updated_since filter" do
-        before do
-          ecf_statement_next_cohort.update!(updated_at: 3.days.ago)
-          ecf_statement_current_cohort.update!(updated_at: 1.day.ago)
-          npq_statement_next_cohort.update!(updated_at: 1.day.ago)
-          npq_statement_current_cohort.update!(updated_at: 6.days.ago)
-        end
-
-        it "returns statements updated after updated_since" do
-          get "/api/v3/statements", params: { filter: { updated_since: 2.days.ago.iso8601 } }
-
-          expect(parsed_response["data"].size).to eql(2)
-          expect(parsed_response.dig("data", 0, "id")).to eql(ecf_statement_current_cohort.id)
-          expect(parsed_response.dig("data", 1, "id")).to eql(npq_statement_next_cohort.id)
-        end
-      end
-
-      context "when unauthorized" do
-        let(:token) { "incorrect-token" }
-        it "returns 401" do
-          get("/api/v3/statements", params:)
-
-          expect(response.status).to eq 401
-        end
+        expect(response.status).to eq 401
       end
     end
   end
@@ -160,62 +152,54 @@ RSpec.describe "statements endpoint spec", type: :request do
       default_headers[:CONTENT_TYPE] = "application/json"
     end
 
-    context "with API V3 flag disabled" do
-      it "returns a 404" do
-        expect { get "/api/v3/statements/#{statement_id}", params: }.to raise_error(ActionController::RoutingError)
+    it "returns correct jsonapi content type header" do
+      get("/api/v3/statements/#{statement_id}", params:)
+
+      expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
+    end
+
+    it "returns statement with the corresponding id" do
+      get("/api/v3/statements/#{statement_id}", params:)
+      expect(parsed_response["data"]["id"]).to eq(statement_id)
+    end
+
+    it "returns correct type" do
+      get("/api/v3/statements/#{statement_id}", params:)
+
+      expect(parsed_response["data"]).to have_type("statement")
+    end
+
+    it "has correct attributes" do
+      get("/api/v3/statements/#{statement_id}", params:)
+
+      expect(parsed_response["data"]).to have_jsonapi_attributes(
+        :month,
+        :year,
+        :type,
+        :cohort,
+        :created_at,
+        :updated_at,
+        :cut_off_date,
+        :payment_date,
+        :paid,
+      ).exactly
+    end
+
+    context "when statement id is incorrect", exceptions_app: true do
+      let(:statement_id) { "incorrect-id" }
+      it "returns 404" do
+        get("/api/v3/statements/#{statement_id}", params:)
+
+        expect(response.status).to eq 404
       end
     end
 
-    context "with API V3 flag active", with_feature_flags: { api_v3: "active" } do
-      it "returns correct jsonapi content type header" do
+    context "when unauthorized" do
+      let(:token) { "incorrect-token" }
+      it "returns 401" do
         get("/api/v3/statements/#{statement_id}", params:)
 
-        expect(response.headers["Content-Type"]).to eql("application/vnd.api+json")
-      end
-
-      it "returns statement with the corresponding id" do
-        get("/api/v3/statements/#{statement_id}", params:)
-        expect(parsed_response["data"]["id"]).to eq(statement_id)
-      end
-
-      it "returns correct type" do
-        get("/api/v3/statements/#{statement_id}", params:)
-
-        expect(parsed_response["data"]).to have_type("statement")
-      end
-
-      it "has correct attributes" do
-        get("/api/v3/statements/#{statement_id}", params:)
-
-        expect(parsed_response["data"]).to have_jsonapi_attributes(
-          :month,
-          :year,
-          :type,
-          :cohort,
-          :created_at,
-          :updated_at,
-          :cut_off_date,
-          :payment_date,
-          :paid,
-        ).exactly
-      end
-
-      context "when statement id is incorrect", exceptions_app: true do
-        let(:statement_id) { "incorrect-id" }
-        it "returns 404" do
-          get("/api/v3/statements/#{statement_id}", params:)
-
-          expect(response.status).to eq 404
-        end
-      end
-
-      context "when unauthorized" do
-        let(:token) { "incorrect-token" }
-        it "returns 401" do
-          get("/api/v3/statements/#{statement_id}", params:)
-
-          expect(response.status).to eq 401
-        end
+        expect(response.status).to eq 401
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,8 +107,6 @@ RSpec.configure do |config|
   config.extend WithModel
 
   config.bisect_runner = :shell
-
-  config.filter_run_excluding api_v3: true
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
### Context

API v3 has been released, we no longer need the API v3 flag

- Ticket: n/a

### Changes proposed in this pull request

- Remove feature flag
- Remove tag to disable api v3 specs
- Remove feature flag from specs

### Guidance to review
🎉 
