### PR TITLE
status for bad timeline before induction start date

### DIFF
--- a/spec/services/determine_training_record_state_spec.rb
+++ b/spec/services/determine_training_record_state_spec.rb
@@ -405,6 +405,19 @@ RSpec.describe DetermineTrainingRecordState, :with_default_schedules do
                          "active_fip_training"
       end
 
+      context "with bad timeline before induction start date",
+              skip: "logic doesn't currently work for this scenario" do
+        let!(:participant_profile) { scenarios.ect_on_fip_bad_timeline_before_records_start.participant_profile }
+
+        include_examples "determines states as",
+                         "valid",
+                         "eligible_for_induction_training",
+                         "eligible_for_fip_funding",
+                         "not_a_mentor",
+                         "active_fip_training",
+                         "active_fip_training"
+      end
+
       context "in transfer scenario" do
         let!(:current_school) { scenarios.fip_school.school }
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-1655

the service used to update details of induction records, when used before the induction start date to say assign the mentor and appropriate body was changed to update the induction record if it started in the future.

Some records were made before this change to the service and now these records have start dates that occur after the end date. 

### Changes proposed in this pull request

- replicate a production Induction Record so that tests can be built against it
- add a Training Record Status Determination Test to show that it does not work in this scenario

### Guidance to review

