### PR TITLE
Add request access link to the start page

### DIFF
--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -19,7 +19,7 @@
     <div class="govuk-button-group">
       <%= govuk_button_link_to "Sign in", new_user_session_path %>
       <span class="govuk-!-margin-right-2">or</span>
-      <%= govuk_link_to "request a link to use the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>
+      <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>
     </div>
   </div>
 

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -2,9 +2,11 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Manage training for early career teachers</h1>
 
-    <p>Use this service to set up ECF-based training for your early career teachers (ECTs) or tell us about a change at your school.</p>
+    <p class="govuk-body">Use this service to set up ECF-based training for your early career teachers (ECTs) or tell us about a change at your school.</p>
 
-    <p>You need to tell us:</p>
+    <h2 class="govuk-heading-m">Set up and manage your training</h2>
+
+    <p class="govuk-body">Tell us:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>how you want to run your training</li>
@@ -12,11 +14,13 @@
       <li>which ECTs and mentors will take part</li>
     </ul>
 
-    <p>Your school must complete these steps before your ECTs can start their statutory induction programme.</p>
+    <p class="govuk-body">Your school must complete these steps before your ECTs can start their statutory induction programme.</p>
 
-    <p>Tell us about any changes, for example, nominating a new Induction tutor.</p>
+    <h2 class="govuk-heading-m">Tell us about changes at your school</h2>
 
-    <div class="govuk-button-group">
+    <p class="govuk-body">Tell us about any changes, for example, nominating a new Induction tutor.</p>
+
+    <div class="govuk-button-group govuk-!-margin-top-7">
       <%= govuk_button_link_to "Sign in", new_user_session_path %>
       <span class="govuk-!-margin-right-2">or</span>
       <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -4,9 +4,7 @@
 
     <p>Use this service to set up ECF-based training for your early career teachers (ECTs) or tell us about a change at your school.</p>
 
-    <h2 class="govuk-heading-m">Set up and manage your training</h2>
-
-    <p>Sign in to tell us:</p>
+    <p>You need to tell us:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>how you want to run your training</li>
@@ -16,11 +14,13 @@
 
     <p>Your school must complete these steps before your ECTs can start their statutory induction programme.</p>
 
-    <h2 class="govuk-heading-m">Tell us about changes at your school</h2>
-
     <p>Tell us about any changes, for example, nominating a new Induction tutor.</p>
 
-    <%= govuk_start_button text: "Sign in", href: new_user_session_path %>
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to "Sign in", new_user_session_path %>
+      <span class="govuk-!-margin-right-2">or</span>
+      <%= govuk_link_to "request a link to use the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>
+    </div>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -23,7 +23,7 @@
     <div class="govuk-button-group govuk-!-margin-top-7">
       <%= govuk_button_link_to "Sign in", new_user_session_path %>
       <span class="govuk-!-margin-right-2">or</span>
-      <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>
+      <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, no_visited_state: true %>
     </div>
   </div>
 

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -18,7 +18,7 @@
 
     <h2 class="govuk-heading-m">Tell us about changes at your school</h2>
 
-    <p class="govuk-body">Tell us about any changes, for example, nominating a new Induction tutor.</p>
+    <p class="govuk-body">Tell us about any changes, for example, nominating a new induction tutor.</p>
 
     <div class="govuk-button-group govuk-!-margin-top-7">
       <%= govuk_button_link_to "Sign in", new_user_session_path %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -13,8 +13,5 @@
             </div>
             <%= f.govuk_submit "Sign in" %>
         <% end %>
-
-        <p class="govuk-body"><%= govuk_link_to "Request a link to sign in or change the induction tutor", resend_email_request_nomination_invite_path, class: "govuk-link govuk-link--no-visited-state" %></p>
-
     </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -13,5 +13,8 @@
             </div>
             <%= f.govuk_submit "Sign in" %>
         <% end %>
+
+        <p class="govuk-body">Or <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>
+        </p>
     </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Sign in" %>
-<% content_for :before_content %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: root_path) %>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -14,7 +14,7 @@
             <%= f.govuk_submit "Sign in" %>
         <% end %>
 
-        <p class="govuk-body">Or <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, class: " govuk-link--no-visited-state" %>
+        <p class="govuk-body">Or <%= govuk_link_to "request access to the service", resend_email_request_nomination_invite_path, no_visited_state: true %>
         </p>
     </div>
 </div>


### PR DESCRIPTION
Conversations with the support team have revealed that users are getting in touch with them to request access, without realising that they can get access by requesting an link be sent to their school email address.

This is possibly because the link to request access was only available on the Sign in page, and wasn't signposted from the service start page.

This PR adds the link to the service start page.

A missing back link is also added to the Sign in page, and the link text made consistent with the new link on the start page.

## Screenshots

| Before | After|
|---|---|
| ![before](https://github.com/DFE-Digital/early-careers-framework/assets/30665/c6baed96-d0dc-4eaf-b5da-a11bc69aea9a) | ![after](https://github.com/DFE-Digital/early-careers-framework/assets/30665/1e338283-dc69-47a7-a4d6-e75ef0abfc8e) |
| ![sign-in-before](https://github.com/DFE-Digital/early-careers-framework/assets/30665/40a87912-b102-4b9e-a33a-90204c4db108) | ![sign-in-after](https://github.com/DFE-Digital/early-careers-framework/assets/30665/265f967d-f571-4303-8baf-2e2ae4580d41) |





## Alternatives

Alternatively, we could re-label the "Sign in" button on the first page as "Start", and then keep the link where it is. However on balance I think it's probably clear to highlight both options on the first page.