### PR TITLE
[CPDLP-2222] Record given evidence_held in declarations table

### DIFF
--- a/app/services/record_declaration.rb
+++ b/app/services/record_declaration.rb
@@ -101,6 +101,7 @@ private
         declaration_type:,
         cpd_lead_provider:,
         user:,
+        evidence_held:,
       )
     end
   end
@@ -158,6 +159,7 @@ private
       delivery_partner:,
       mentor_user_id:,
       user: participant_identity.user,
+      evidence_held:,
     }
   end
 

--- a/spec/requests/api/v1/participant_declarations_spec.rb
+++ b/spec/requests/api/v1/participant_declarations_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
             post "/api/v1/participant-declarations", params: params.to_json
 
             expect(response).to be_successful
-            expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
+            expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to eq("test")
           end
         end
 

--- a/spec/requests/api/v2/participant_declarations_spec.rb
+++ b/spec/requests/api/v2/participant_declarations_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "participant-declarations endpoint spec", :with_default_schedules
         post "/api/v2/participant-declarations", params: build_params(valid_params.merge(evidence_held: "test"))
 
         expect(response.status).to eq 200
-        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
+        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to eq("test")
       end
 
       it "returns 422 when supplied an incorrect course type" do

--- a/spec/requests/api/v3/participant_declarations_spec.rb
+++ b/spec/requests/api/v3/participant_declarations_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe "API Participant Declarations", :with_default_schedules, type: :r
         post "/api/v3/participant-declarations", params: build_params(valid_params.merge(evidence_held: "test"))
 
         expect(response.status).to eq 200
-        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to be_nil
+        expect(ParticipantDeclaration.order(created_at: :desc).first.evidence_held).to eq("test")
       end
 
       it "returns 422 when supplied an incorrect course type" do


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2222](https://dfedigital.atlassian.net/browse/CPDLP-2222)

For some reason we're not recording `evidence_held` value submitted in request body for ECF retained and completed declarations.

### Changes proposed in this pull request

Forward fix so future ECF declarations record `evidence_held` in declarations table.

[CPDLP-2222]: https://dfedigital.atlassian.net/browse/CPDLP-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ