### PR TITLE
Add overview admin page

### DIFF
--- a/app/components/primary_nav_component.html.erb
+++ b/app/components/primary_nav_component.html.erb
@@ -1,5 +1,5 @@
 <div class="primary-nav-container">
-  <div class="govuk-width-container">
+  <div class="govuk-width-container <%= "govuk-width-container__wide" if wide %>">
     <div class="primary-nav">
       <% nav_items.each do |item| %>
         <%= item %>

--- a/app/components/primary_nav_component.rb
+++ b/app/components/primary_nav_component.rb
@@ -13,13 +13,14 @@ class PrimaryNavComponent < ViewComponent::Base
   class NavItemComponent < ViewComponent::Base
     attr_reader :path
 
-    def initialize(path:, selected: false)
+    def initialize(path:, selected: nil)
       @path = path
       @selected = selected
     end
 
     def current_section?(path)
-      @selected || request.path.include?(path)
+      return request.path.include?(path) if @selected.nil?
+      @selected
     end
   end
 end

--- a/app/components/primary_nav_component.rb
+++ b/app/components/primary_nav_component.rb
@@ -2,8 +2,12 @@
 
 class PrimaryNavComponent < ViewComponent::Base
   include ViewComponent::SlotableV2
-
+  attr_reader :wide
   renders_many :nav_items, "NavItemComponent"
+
+  def initialize(wide: false)
+    @wide = wide
+  end
 
   class NavItemComponent < ViewComponent::Base
     attr_reader :path

--- a/app/components/primary_nav_component.rb
+++ b/app/components/primary_nav_component.rb
@@ -3,6 +3,7 @@
 class PrimaryNavComponent < ViewComponent::Base
   include ViewComponent::SlotableV2
   attr_reader :wide
+
   renders_many :nav_items, "NavItemComponent"
 
   def initialize(wide: false)

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -5,7 +5,45 @@ module Admin
     skip_after_action :verify_authorized, only: :show
     skip_after_action :verify_policy_scoped, only: :show
 
-    # this isn't used yet
-    def show; end
+    # show 2023 pilot stats
+    def show
+      @pilot_stats = get_pilot_stats
+    end
+
+  private
+
+    def get_pilot_stats
+      choices = programme_choices
+
+      OpenStruct.new({
+        cip_total: choices.fetch("core_induction_programme", 0),
+        diy_total: choices.fetch("design_our_own", 0),
+        fip_total: choices.fetch("full_induction_programme", 0),
+        no_ects_total: choices.fetch("no_early_career_teachers", 0),
+        total: choices.values.sum,
+        partnership_totals:,
+      })
+    end
+
+    def programme_choices
+      SchoolCohort.where(cohort:).group(:induction_programme_choice).count
+        .reject { |choice| choice.in? %w[school_funded_fip not_yet_known] }
+    end
+
+    def partnership_totals
+      totals = Partnership.unchallenged.where(cohort:).group(:lead_provider_id).count
+
+      providers.map do |provider|
+        { name: provider.name, total: totals.fetch(provider.id, 0) }
+      end
+    end
+
+    def providers
+      LeadProvider.where(id: ProviderRelationship.where(cohort:).select(:lead_provider_id)).order(:name)
+    end
+
+    def cohort
+      @cohort ||= Cohort.find_by(start_year: 2023)
+    end
   end
 end

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -19,7 +19,7 @@
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Using a training provider (full induction programme)</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"></td>
+      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"><%= @pilot_stats.fip_total %></td>
     </tr>
     <% @pilot_stats.partnership_totals.each do |provider| %>
       <tr class="govuk-table__row">

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -1,3 +1,60 @@
-<h1>Admin page</h1>
+<h1 class="govuk-heading-xl">Overview</h1>
 
-<p>Not sure if we'll need it yet but here's a admin overview page</p>
+<table class="govuk-table" style="width: auto;">
+  <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for 2023 to 2024</caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Training programme</th>
+      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Schools</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Delivering their training using DfE materials</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">2</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Designing their own programme</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Using a training provider (full induction programme)</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular">115</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Ambition</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">28</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Best Practice Network</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Education Development Trust</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">21</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">National Institute of Teaching</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Teach First</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">UCL Institute of Education</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric">15</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Not expecting any early career teachers</th>
+      <td class="govuk-table__cell  govuk-table__cell--numeric">60</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Total</th>
+      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">177</td>
+    </tr>
+
+  </tfoot>
+</table>

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -11,50 +11,31 @@
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Delivering their training using DfE materials</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">2</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.cip_total %></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Designing their own programme</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.diy_total %></td>
     </tr>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Using a training provider (full induction programme)</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular">115</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"></td>
     </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Ambition</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">28</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Best Practice Network</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Education Development Trust</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">21</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">National Institute of Teaching</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">0</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">Teach First</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5">UCL Institute of Education</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric">15</td>
-    </tr>
+    <% @pilot_stats.partnership_totals.each do |provider| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5"><%= provider[:name] %></th>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><%= provider[:total] %></td>
+      </tr>
+    <% end %>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Not expecting any early career teachers</th>
-      <td class="govuk-table__cell  govuk-table__cell--numeric">60</td>
+      <td class="govuk-table__cell  govuk-table__cell--numeric"><%= @pilot_stats.no_ects_total %></td>
     </tr>
   </tbody>
   <tfoot>
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header">Total</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">177</td>
+      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= @pilot_stats.total %></td>
     </tr>
-
   </tfoot>
 </table>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,6 +1,6 @@
 <% content_for :nav_bar do %>
   <%= render PrimaryNavComponent.new(wide: true) do |component| %>
-    <%= component.nav_item(path: "/admin", selected: false) do %>
+    <%= component.nav_item(path: "/admin", selected: current_page?('/admin')) do %>
       Overview
     <% end %>
     <%= component.nav_item(path: "/admin/schools") do %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,8 @@
 <% content_for :nav_bar do %>
-  <%= render PrimaryNavComponent.new do |component| %>
+  <%= render PrimaryNavComponent.new(wide: true) do |component| %>
+    <%= component.nav_item(path: "/admin", selected: false) do %>
+      Overview
+    <% end %>
     <%= component.nav_item(path: "/admin/schools") do %>
       Schools
     <% end %>


### PR DESCRIPTION
This adds an Overview page to the admin navigation, which contains some basic stats about the numbers of schools who have registered for the upcoming academic year.

## Screenshot

<img width="1367" alt="Screenshot 2023-06-23 at 16 37 32" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/9755e7fa-ecc2-4975-b320-0cf8fb7331aa">
