### PR TITLE
Only send Big Query updates if table exists for environment

### DIFF
--- a/app/jobs/npq/stream_big_query_enrollment_job.rb
+++ b/app/jobs/npq/stream_big_query_enrollment_job.rb
@@ -7,7 +7,9 @@ module NPQ
     def perform(npq_application_id:)
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_registration", skip_lookup: true
-      table = dataset.table "enrollments_#{Rails.env.downcase}", skip_lookup: true
+      table = dataset.table "enrollments_#{Rails.env.downcase}"
+      return if table.nil?
+
       npq_application = NPQApplication.includes(:cohort).find(npq_application_id)
 
       rows = [

--- a/app/jobs/npq/stream_big_query_profile_job.rb
+++ b/app/jobs/npq/stream_big_query_profile_job.rb
@@ -7,7 +7,10 @@ module NPQ
     def perform(profile_id:)
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_registration", skip_lookup: true
-      table = dataset.table "profiles_#{Rails.env.downcase}", skip_lookup: true
+      table = dataset.table "profiles_#{Rails.env.downcase}"
+
+      return if table.nil?
+
       profile = ParticipantProfile::NPQ
         .includes(:npq_application, :schedule, :npq_course, :participant_identity)
         .find(profile_id)

--- a/app/jobs/participant_outcomes/stream_api_requests_to_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_api_requests_to_big_query_job.rb
@@ -5,6 +5,8 @@ module ParticipantOutcomes
     queue_as :big_query
 
     def perform(participant_outcome_api_request_id:)
+      return if table.nil?
+
       api_request = ParticipantOutcomeApiRequest.find(participant_outcome_api_request_id)
 
       rows = [
@@ -28,7 +30,7 @@ module ParticipantOutcomes
     def table
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_participant_outcomes", skip_lookup: true
-      dataset.table "npq_participant_outcome_api_requests_#{Rails.env.downcase}", skip_lookup: true
+      dataset.table "npq_participant_outcome_api_requests_#{Rails.env.downcase}"
     end
   end
 end

--- a/app/jobs/participant_outcomes/stream_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_big_query_job.rb
@@ -7,9 +7,10 @@ module ParticipantOutcomes
     def perform(participant_outcome_id:)
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_participant_outcomes", skip_lookup: true
-      table = dataset.table "npq_participant_outcomes_#{Rails.env.downcase}", skip_lookup: true
-      outcome = ParticipantOutcome::NPQ.find(participant_outcome_id)
+      table = dataset.table "npq_participant_outcomes_#{Rails.env.downcase}"
+      return if table.nil?
 
+      outcome = ParticipantOutcome::NPQ.find(participant_outcome_id)
       rows = [
         {
           participant_outcome_id: outcome.id,

--- a/app/jobs/participant_outcomes/stream_big_query_job.rb
+++ b/app/jobs/participant_outcomes/stream_big_query_job.rb
@@ -8,6 +8,7 @@ module ParticipantOutcomes
       bigquery = Google::Cloud::Bigquery.new
       dataset = bigquery.dataset "npq_participant_outcomes", skip_lookup: true
       table = dataset.table "npq_participant_outcomes_#{Rails.env.downcase}"
+
       return if table.nil?
 
       outcome = ParticipantOutcome::NPQ.find(participant_outcome_id)

--- a/spec/jobs/npq/stream_big_query_profile_job_spec.rb
+++ b/spec/jobs/npq/stream_big_query_profile_job_spec.rb
@@ -32,5 +32,16 @@ RSpec.describe NPQ::StreamBigQueryProfileJob, :with_default_schedules do
         updated_at: profile.updated_at,
       }.stringify_keys], ignore_unknown: true)
     end
+
+    context "where the BigQuery table does not exist" do
+      before do
+        allow(dataset).to receive(:table).and_return(nil)
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(profile_id: profile.id)
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end

--- a/spec/jobs/participant_outcomes/stream_api_requests_to_big_query_job_spec.rb
+++ b/spec/jobs/participant_outcomes/stream_api_requests_to_big_query_job_spec.rb
@@ -38,5 +38,16 @@ RSpec.describe ParticipantOutcomes::StreamApiRequestsToBigQueryJob, :with_defaul
         described_class.perform_now(participant_outcome_api_request_id: api_request.id)
       }.to have_enqueued_job(described_class).on_queue("big_query")
     end
+
+    context "where the BigQuery table does not exist" do
+      before do
+        allow(dataset).to receive(:table).and_return(nil)
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(participant_outcome_api_request_id: api_request.id)
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end

--- a/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
+++ b/spec/jobs/participant_outcomes/stream_big_query_job_spec.rb
@@ -39,5 +39,16 @@ RSpec.describe ParticipantOutcomes::StreamBigQueryJob, :with_default_schedules d
         described_class.perform_now(participant_outcome_id: outcome.id)
       }.to have_enqueued_job(described_class).on_queue("big_query")
     end
+
+    context "where the BigQuery table does not exist" do
+      before do
+        allow(dataset).to receive(:table).and_return(nil)
+      end
+
+      it "doesn't attempt to stream" do
+        described_class.perform_now(participant_outcome_id: outcome.id)
+        expect(table).not_to have_received(:insert)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

We are attempting to send outcomes to BQ in other environments where no table or dataset are setup, as we only have tables in sandbox and production. This is causing large logs of errors in dev as the cron job runs every ten minutes.


- Ticket: n/a

### Changes proposed in this pull request
- Allow table lookup when setting BQ table
- Only stream BQ updates if the BQ table exists

### Guidance to review
I've checked manually in sandbox and dev if this will work and results were good
