### PR TITLE
CST-1681: restrict changes to induction records of participants not y…

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -7,6 +7,14 @@ class Schools::ParticipantsController < Schools::BaseController
   before_action :set_participant, except: %i[index email_used]
   before_action :build_mentor_form, only: :edit_mentor
   before_action :set_mentors_added, only: %i[index show]
+  before_action :authorize_induction_record, only: %i[edit_name
+                                                      update_name
+                                                      edit_email
+                                                      update_email
+                                                      edit_mentor
+                                                      update_mentor]
+  before_action :authorize_ab_changes, only: %i[add_appropriate_body
+                                                appropriate_body_confirmation]
 
   helper_method :can_appropriate_body_be_changed?, :participant_has_appropriate_body?
 
@@ -97,6 +105,14 @@ class Schools::ParticipantsController < Schools::BaseController
   end
 
 private
+
+  def authorize_ab_changes
+    authorize @induction_record, :edit_appropriate_body?
+  end
+
+  def authorize_induction_record
+    authorize @induction_record
+  end
 
   def set_mentors_added
     @mentors_added = @school.school_mentors.any?

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -105,6 +105,10 @@ class InductionRecord < ApplicationRecord
   # core_induction_programme_name
   delegate :core_induction_programme_name, to: :induction_programme
 
+  def current?
+    active? || transferring_out? || claimed_by_another_school?
+  end
+
   # delivery_partner_name. This will return nil if the partnership is challenged
   delegate :delivery_partner_name, to: :induction_programme
 

--- a/app/policies/induction_record_policy.rb
+++ b/app/policies/induction_record_policy.rb
@@ -9,6 +9,30 @@ class InductionRecordPolicy < ApplicationPolicy
     admin?
   end
 
+  def edit_appropriate_body?
+    return true if admin?
+
+    school_induction_coordinator? && (record.current? || record.transferring_in?)
+  end
+
+  def edit_email?
+    return true if admin?
+
+    school_induction_coordinator? && (record.current? || record.transferring_in?)
+  end
+
+  def edit_mentor?
+    return true if admin?
+
+    school_induction_coordinator? && (record.current? || record.transferring_in?)
+  end
+
+  def edit_name?
+    return true if admin?
+
+    school_induction_coordinator? && record.current?
+  end
+
   def validate?
     admin?
   end
@@ -16,6 +40,11 @@ class InductionRecordPolicy < ApplicationPolicy
   def change_preferred_email?
     super_user_only
   end
+
+  alias_method :update_appropriate_body?, :edit_appropriate_body?
+  alias_method :update_email?, :edit_email?
+  alias_method :update_mentor?, :edit_mentor?
+  alias_method :update_name?, :edit_name?
 
   alias_method :edit_preferred_email?, :change_preferred_email?
   alias_method :update_preferred_email?, :change_preferred_email?
@@ -30,5 +59,11 @@ class InductionRecordPolicy < ApplicationPolicy
 
       scope.where(induction_programme_id: InductionProgramme.joins(:school_cohort).where(school_cohort: { school: user.schools }).select(:id))
     end
+  end
+
+private
+
+  def school_induction_coordinator?
+    user.school_ids.include?(record.school_id)
   end
 end

--- a/app/services/dashboard/participants.rb
+++ b/app/services/dashboard/participants.rb
@@ -81,10 +81,9 @@ module Dashboard
         induction_record.participant_no_qts?
     end
 
-    def orphan_and_deferred_or_transferred_ects(ects)
-      @deferred_or_transferred_ects, @orphan_ects = ects.partition(&:deferred_or_transferred?).map do |ects_subset|
-        dashboard_participants(ects_subset)
-      end
+    def orphan_and_deferred_or_transferred_ects(induction_records)
+      @deferred_or_transferred_ects, @orphan_ects = induction_records.partition(&:deferred_or_transferred?)
+                                                                     .map { |subset| dashboard_participants(subset) }
     end
 
     def orphan_mentors

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -19,7 +19,8 @@
           <%= @profile.full_name %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% if @profile.policy_class.new(current_user, @profile).edit_name? %>
+          <% if @profile.policy_class.new(current_user, @profile).edit_name? &&
+                policy(@induction_record).edit_name? %>
             <%= govuk_link_to school_participant_edit_name_path(participant_id: @profile) do %>
               Change <span class="govuk-visually-hidden">name</span>
             <% end %>
@@ -53,7 +54,8 @@
           <%= @induction_record.preferred_identity&.email || @profile.participant_identity&.email %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% if @profile.policy_class.new(current_user, @profile).edit_email? %>
+          <% if @profile.policy_class.new(current_user, @profile).edit_email? &&
+                policy(@induction_record).edit_email? %>
             <%= govuk_link_to school_participant_edit_email_path(participant_id: @profile) do %>
               Change <span class="govuk-visually-hidden">email address</span>
             <% end %>
@@ -75,7 +77,8 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% if @mentors_added %>
-              <% if @profile.policy_class.new(current_user, @profile).update_mentor? %>
+              <% if @profile.policy_class.new(current_user, @profile).update_mentor? &&
+                    policy(@induction_record).edit_mentor? %>
                 <%= govuk_link_to school_participant_edit_mentor_path(participant_id: @profile.id) do %>
                   Change <span class="govuk-visually-hidden">mentor</span>
                 <% end %>
@@ -126,7 +129,9 @@
             <%= @induction_record.appropriate_body_name %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <% if @profile.ect? && @profile.policy_class.new(current_user, @profile).add_appropriate_body? %>
+            <% if @profile.ect? &&
+                  @profile.policy_class.new(current_user, @profile).add_appropriate_body? &&
+                  policy(@induction_record).edit_appropriate_body? %>
               <%= govuk_link_to(participant_has_appropriate_body? ? "Change" : "Add",
                                 { action: :add_appropriate_body, participant_id: @profile }) %>
             <% end %>
@@ -149,7 +154,7 @@
               <% row.action(text: "Change",
                             visually_hidden_text: "mentor",
                             href: school_participant_edit_mentor_path(participant_id: ect.participant_profile_id,
-                                                                       from_mentor: @profile.id)) %>
+                                                                      from_mentor: @profile.id)) %>
             <% end %>
           <% end %>
         <% end %>

--- a/spec/policies/induction_record_policy_spec.rb
+++ b/spec/policies/induction_record_policy_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe InductionRecordPolicy, type: :policy do
   subject { described_class.new(user, induction_record) }
 
   let(:user) { scenario.user }
-  let(:induction_record) { create(:induction_record) }
+  let(:induction_record) { build(:induction_record) }
 
   context "being a super user admin" do
     let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build.with_super_user }
@@ -14,9 +14,94 @@ RSpec.describe InductionRecordPolicy, type: :policy do
     it { is_expected.to permit_actions(%i[edit_preferred_email update_preferred_email]) }
   end
 
-  context "not being a super user admin" do
+  context "being an admin" do
     let(:scenario) { NewSeeds::Scenarios::Users::AdminUser.new.build }
 
-    it { is_expected.to forbid_actions(%i[edit_preferred_email update_preferred_email]) }
+    it {
+      is_expected.to permit_actions(%i[edit_appropriate_body
+                                       edit_email
+                                       edit_mentor
+                                       edit_name
+                                       update_appropriate_body
+                                       update_email
+                                       update_mentor
+                                       update_name])
+    }
+
+    it {
+      is_expected.to forbid_actions(%i[edit_preferred_email
+                                       update_preferred_email])
+    }
+  end
+
+  context "being a school induction tutor" do
+    let(:cohort) { Cohort.current || create(:cohort, :current) }
+    let(:programme_type) { :full_induction_programme }
+    let(:scenario) do
+      NewSeeds::Scenarios::Schools::School.new
+                                          .build
+                                          .with_an_induction_tutor
+                                          .with_school_cohort_and_programme(cohort:, programme_type:)
+    end
+    let(:induction_programme) { scenario.induction_programme }
+    let(:user) { scenario.induction_tutor }
+
+    context "current induction record" do
+      let(:induction_record) { build(:induction_record, induction_programme:) }
+
+      it {
+        is_expected.to permit_actions(%i[edit_appropriate_body
+                                         edit_email
+                                         edit_mentor
+                                         edit_name
+                                         update_appropriate_body
+                                         update_email
+                                         update_mentor
+                                         update_name])
+      }
+    end
+
+    context "transferring in induction record" do
+      let(:induction_record) { build(:induction_record, :school_transfer, induction_programme:, start_date: Date.tomorrow) }
+
+      it {
+        is_expected.to permit_actions(%i[edit_appropriate_body
+                                         edit_email
+                                         edit_mentor
+                                         update_appropriate_body
+                                         update_email
+                                         update_mentor])
+      }
+    end
+
+    context "other induction records" do
+      let(:induction_record) { build(:induction_record, induction_programme:, induction_status: :changed) }
+
+      it {
+        is_expected.to forbid_actions(%i[edit_appropriate_body
+                                         edit_email
+                                         edit_mentor
+                                         edit_name
+                                         update_appropriate_body
+                                         update_email
+                                         update_mentor
+                                         update_name])
+      }
+    end
+  end
+
+  context "any other user" do
+    let(:scenario) { NewSeeds::Scenarios::Users::FinanceUser.new.build }
+
+    it {
+      is_expected.to forbid_actions(%i[edit_appropriate_body
+                                       edit_email
+                                       edit_mentor
+                                       edit_name
+                                       update_appropriate_body
+                                       update_email
+                                       update_mentor
+                                       update_name])
+    }
   end
 end


### PR DESCRIPTION
…et/anymore in a school

### Context
When a participant is no longer at a school, the SIT might still see them as “no longer training…” but should not be allowed to change their details: name, school email, mentor or AB.

Currently the service allow this to happen.
Not only it feels wrong but also, it is one of the causes we have a category of oddly-shaped induction records.

[Ticket](https://dfedigital.atlassian.net/browse/CST-1681)

### Changes proposed in this pull request
Add authorisation restrictions to the links to change data from a participant that have left the school or  not yet in it (transferring in).

### Guidance to review
In the participant view of the dashboard check that the SIT:
- can only see the "Change" link next to the name of the participant if the ECT/Mentor is already/still in the school.
- can only see the "Change" link next to the email of the participant if the ECT/Mentor is in the school or is being transferred in.
- can only see the "Change" link next to the mentor of the participant if the ECT/Mentor is in the school or is being transferred in.
- can only see the "Change" link next to the appropriate body of the participant if the ECT/Mentor is in the school or is being transferred in.