### PR TITLE
[CST-1654] Add the launch comms tasks

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -633,7 +633,7 @@ class SchoolMailer < ApplicationMailer
         name: sit_user.full_name,
         nomination_link:,
       },
-    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(sit_user)
+    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(school, sit_user)
   end
 
   def launch_ask_gias_contact_to_report_school_training_details

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -633,7 +633,7 @@ class SchoolMailer < ApplicationMailer
         name: sit_user.full_name,
         nomination_link:,
       },
-    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(school, sit_user)
+    ).tag(:launch_ask_sit_to_report_school_training_details).associate_with(sit_user.school, sit_user)
   end
 
   def launch_ask_gias_contact_to_report_school_training_details

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -125,16 +125,22 @@ namespace :comms do
       end
 
       if Email.tagged_with(:launch_ask_gias_contact_to_report_school_training_details).associated_with(school).any?
-        logger.info "The school's primary GIAS has been already contacted"
+        logger.info "The school's GIAS contact has been already contacted"
         next
       end
 
-      logger.info "Sending launch to the school's primary GIAS contact"
-      nomination_token = create_nomination_token(school, school.primary_contact_email)
+      gias_contact_email = school.primary_contact_email || school.secondary_contact_email
+      unless gias_contact_email
+        logger.error "No GIAS contacts found for this school"
+        next
+      end
+
+      logger.info "Sending launch email to the school's GIAS contact"
+      nomination_token = create_nomination_token(school, gias_contact_email)
       SchoolMailer
         .with(
           school:,
-          gias_contact_email: school.primary_contact_email,
+          gias_contact_email:,
           nomination_link: get_gias_nomination_url(token: nomination_token),
         )
         .launch_ask_gias_contact_to_report_school_training_details

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -72,6 +72,75 @@ namespace :comms do
       end
     end
   end
+
+  desc "Send launch comms to SITs"
+  task :send_sit_launch_comms, [:path_to_csv] => :environment do |_task, args|
+    logger = Logger.new($stdout)
+
+    rows = CSV.read(args.path_to_csv, headers: true)
+
+    rows.each do |school|
+      logger.info "Processing school with URN: #{school['urn']}"
+
+      school = School.find_by_urn(school["urn"])
+
+      if school.school_cohorts.for_year(2023).first&.induction_programme_choice
+        logger.info "School has reported the training programme"
+        next
+      end
+
+      school.induction_coordinators.each do |sit_user|
+        if Email.tagged_with(:launch_ask_sit_to_report_school_training_details).associated_with(sit_user).any?
+          logger.info "The SIT has been already contacted"
+          next
+        end
+
+        logger.info "Sending launch email to the school's SIT with user id: #{sit_user.id}"
+        nomination_token = create_nomination_token(school, sit_user.email)
+        SchoolMailer
+          .with(
+            sit_user:,
+            nomination_link: get_sit_nomination_url(token: nomination_token),
+          )
+          .launch_ask_sit_to_report_school_training_details
+          .deliver_later
+      end
+    end
+  end
+
+  desc "Send launch comms to GIAS contacts"
+  task :send_gias_launch_comms, [:path_to_csv] => :environment do |_task, args|
+    logger = Logger.new($stdout)
+
+    rows = CSV.read(args.path_to_csv, headers: true)
+
+    rows.each do |school|
+      logger.info "Processing school with URN: #{school['urn']}"
+
+      school = School.find_by_urn(school["urn"])
+
+      if school.induction_coordinators.any?
+        logger.info "The GIAS contact has already nominated a SIT"
+        next
+      end
+
+      if Email.tagged_with(:launch_ask_gias_contact_to_report_school_training_details).associated_with(school).any?
+        logger.info "The school's primary GIAS has been already contacted"
+        next
+      end
+
+      logger.info "Sending launch to the school's primary GIAS contact"
+      nomination_token = create_nomination_token(school, school.primary_contact_email)
+      SchoolMailer
+        .with(
+          school:,
+          gias_contact_email: school.primary_contact_email,
+          nomination_link: get_gias_nomination_url(token: nomination_token),
+        )
+        .launch_ask_gias_contact_to_report_school_training_details
+        .deliver_later
+    end
+  end
 end
 
 def get_sit_nomination_url(token:)


### PR DESCRIPTION
### Context

- Ticket: CST-1654

The launch comms have been scheduled to be sent to schools with SITs and to schools without SITs individually and in batches.

The average batch is 5,000 schools.

### Changes proposed in this pull request
- Add a rake tasks for each launch comms

### Guidance to review

