### PR TITLE
Academic Year Spike

### DIFF
--- a/app/forms/nominate_how_to_continue_form.rb
+++ b/app/forms/nominate_how_to_continue_form.rb
@@ -6,7 +6,7 @@ class NominateHowToContinueForm
 
   attr_accessor :how_to_continue, :token, :school, :cohort
 
-  delegate :academic_year_start_date, to: :cohort
+  delegate :academic_year, to: :cohort
 
   def attributes
     { how_to_continue: nil }

--- a/app/forms/schools/cohorts/setup_wizard/success.rb
+++ b/app/forms/schools/cohorts/setup_wizard/success.rb
@@ -68,7 +68,7 @@ module Schools
               LeadProviderMailer.with(
                 partnership: previous_partnership,
                 user: lead_provider_user,
-                cohort_year: school_cohort.academic_year,
+                cohort_year: school_cohort.academic_year.id,
                 what_changes_choice: what_changes,
               ).programme_changed_email.deliver_later
             end

--- a/app/mailers/lead_provider_mailer.rb
+++ b/app/mailers/lead_provider_mailer.rb
@@ -42,7 +42,7 @@ class LeadProviderMailer < ApplicationMailer
         school_urn: partnership.school.urn,
         delivery_partner_name: partnership.delivery_partner.name,
         lead_provider_name:,
-        cohort_year: partnership.cohort.academic_year,
+        cohort_year: partnership.cohort.academic_year.id,
         reason:,
       },
     ).tag(:partnership_challenged).associate_with(partnership)

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+class AcademicYear < ApplicationRecord
+  after_initialize :set_defaults
+
+  IDENTIFIER_FORMAT = /\A\d{4}\/\d{2}\z/
+
+  # e.g. "2021/22"
+  validates :id,
+            format: { with: IDENTIFIER_FORMAT, message: "must be in the format dddd/dd" },
+            uniqueness: true
+  alias_attribute :label, :id
+
+  # e.g. "2020/21"
+  validates :previous_id,
+            format: { with: IDENTIFIER_FORMAT, message: "must be in the format dddd/dd" },
+            allow_blank: true,
+            uniqueness: true
+
+  validates :start_date, presence: true
+  validates :start_year, uniqueness: true, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 9999 }
+  validates :end_year, uniqueness: true, presence: true, numericality: { only_integer: true, less_than_or_equal_to: 9999 }
+
+  validate :validate_configuration
+
+  belongs_to :previous, class_name: "AcademicYear", optional: true
+  has_one :next, class_name: "AcademicYear", foreign_key: :previous_id
+  belongs_to :cohort, optional: true
+
+  scope :starts_before_date, ->(date) { where(start_date: ...date) }
+  scope :starts_after_date, ->(date) { where(start_date: date..) }
+  scope :containing_date, ->(date) { left_outer_joins(:next).where(start_date: ..date).where("nexts_academic_years.start_date > ? OR nexts_academic_years IS NULL", date) }
+  scope :for_date, ->(date) { containing_date(date).order(start_year: :desc) }
+
+  scope :ecf_early_rollout_years, -> { where(ecf_early_rollout_year: true) }
+  scope :ecf_national_rollout_years, -> { where(ecf_early_rollout_year: false) }
+
+  class << self
+    def last_ecf_early_rollout_year
+      ecf_early_rollout_years.order(start_year: :desc).first
+    end
+
+    def first_ecf_national_rollout_year
+      ecf_national_rollout_years.order(start_year: :asc).first
+    end
+
+    def now
+      AcademicYear.containing_date(Time.zone.today).first
+    end
+
+    def id_from_year(year)
+      sprintf("#{year}/%02d", ((year + 1) % 100))
+    end
+  end
+
+  # e.g. "2021 to 2022"
+  def description
+    @description ||= "#{start_year} to #{end_year}"
+  end
+
+  # e.g. "2021"
+  def display_name
+    @display_name ||= start_year.to_s
+  end
+
+  delegate :ecf_registration_start_date, to: :cohort
+  def ecf_registration_end_date
+    @ecf_registration_end_date ||= self.next.cohort.registration_start_date - 1.day if self.next.present?
+  end
+
+  delegate :npq_registration_start_date, to: :cohort
+  def npq_registration_end_date
+    @npq_registration_end_date ||= self.next.cohort.npq_registration_start_date - 1.day if self.next.present?
+  end
+
+  def end_date
+    @end_date ||= self.next.start_date - 1.day if self.next.present?
+  end
+
+  def is_ecf_early_rollout_year?
+    ecf_early_rollout_year == true
+  end
+
+  def is_ecf_national_rollout_year?
+    ecf_early_rollout_year == false
+  end
+
+private
+
+  def set_defaults
+    self.start_year ||= current_period.start_year
+    self.end_year ||= current_period.end_year
+
+    self.start_date ||= Date.new(start_year, 9, 1)
+
+    self.cohort_id ||= Cohort.find_by(start_year:)&.id
+    self.previous_id ||= AcademicYear.find_by(id: AcademicYear.id_from_year(start_year - 1))&.id
+  end
+
+  def validate_configuration
+    return unless id.match(IDENTIFIER_FORMAT)
+
+    errors.add(:id, "<#{id}> must represent two consecutive years not #{current_period.years} years") if current_period.years != 2
+
+    errors.add(:start_date, "<#{start_date}> must have the year <#{start_year}>") if start_date.year != start_year
+
+    errors.add(:cohort_id, "<#{cohort_id}> must be for the cohort with the same start_year not #{cohort.start_year} years") if cohort_id.present? && cohort.start_year != start_year
+
+    if previous_id.present?
+      return unless previous_id.match(IDENTIFIER_FORMAT)
+
+      errors.add(:previous_id, "<#{previous_id}> must represent two consecutive years not #{previous_period.years} years") if previous_period.years != 2
+      errors.add(:previous_id, "<#{previous_id}> must have the end year <#{start_year}>") if previous_period.end_year != start_year
+    end
+  end
+
+  def current_period
+    @current_period ||= CalendarDetails.new(id)
+  end
+
+  def previous_period
+    @previous_period ||= CalendarDetails.new(previous_id)
+  end
+
+  CalendarDetails = Struct.new(
+    :start_year,
+    :end_year,
+    :years,
+  ) do
+    def initialize(id)
+      start_year, end_year = id.split("/").map(&:to_i)
+      end_year ||= 0
+      end_year = 100 if end_year.zero?
+      end_year = start_year - (start_year % 100) + end_year
+      years = (end_year - start_year) + 1
+
+      self[:start_year] = start_year
+      self[:end_year] = end_year
+      self[:years] = years
+    end
+  end
+end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -11,15 +11,22 @@ class Cohort < ApplicationRecord
   has_many :schedules, class_name: "Finance::Schedule"
   has_many :statements
 
+  has_one :academic_year
+
   scope :between_years, ->(lower, upper) { where(start_year: lower..upper) }
   scope :between_2021_and, ->(upper) { between_years(2021, upper) }
   scope :ordered_by_start_year, -> { order(start_year: :asc) }
 
   # Class Methods
 
-  def self.active_registration_cohort
-    where(registration_start_date: ..Date.current).order(start_year: :desc).first
+  def self.active_ecf_registration_cohort
+    where(ecf_registration_start_date: ..Date.current).order(start_year: :desc).first
   end
+
+  def self.active_registration_cohort
+    active_ecf_registration_cohort
+  end
+  alias_attribute :ecf_registration_start_date, :registration_start_date
 
   def self.active_npq_registration_cohort
     where(npq_registration_start_date: ..Date.current).order(start_year: :desc).first.presence || current
@@ -55,11 +62,6 @@ class Cohort < ApplicationRecord
   private_class_method :starting_within
 
   # Instance Methods
-
-  # e.g. "2021/22"
-  def academic_year
-    sprintf("#{start_year}/%02d", ((start_year + 1) % 100))
-  end
 
   # e.g. "2021 to 2022"
   def description

--- a/app/models/partnership.rb
+++ b/app/models/partnership.rb
@@ -70,7 +70,7 @@ class Partnership < ApplicationRecord
 private
 
   def cohort_challenge_deadline
-    cohort.academic_year_start_date + CHALLENGE_PERIOD_SINCE_ACADEMIC_YEAR_START
+    cohort.academic_year.start_date + CHALLENGE_PERIOD_SINCE_ACADEMIC_YEAR_START
   end
 
   def update_analytics

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -10,7 +10,7 @@ module Induction
       end
 
       def active?(participant_profile)
-        participant_profile&.active_record? && participant_profile.training_status_active?
+        participant_profile&.active_record? && participant_profile&.training_status_active?
       end
     end
 

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -10,7 +10,7 @@ module Induction
       end
 
       def active?(participant_profile)
-        participant_profile&.active_record? && participant_profile&.training_status_active?
+        participant_profile&.active_record? && participant_profile.training_status_active?
       end
     end
 

--- a/app/services/participants/history_builder.rb
+++ b/app/services/participants/history_builder.rb
@@ -236,7 +236,7 @@ private
     schedule = Finance::Schedule.find_by(id: schedule_id)
     return schedule_id if schedule.nil?
 
-    "#{schedule.name} (#{schedule.schedule_identifier}) #{schedule.cohort.academic_year}"
+    "#{schedule.name} (#{schedule.schedule_identifier}) #{schedule.cohort.academic_year.id}"
   end
 
   def get_appropriate_body_label(appropriate_body_id)
@@ -268,7 +268,7 @@ private
       induction_programme.lead_provider&.name,
       induction_programme.delivery_partner&.name,
       induction_programme.core_induction_programme&.name,
-      "(#{induction_programme.cohort&.academic_year})",
+      "(#{induction_programme.cohort&.academic_year&.id})",
     ].filter(&:present?).join(" ")
   end
 end

--- a/app/services/partnerships/report.rb
+++ b/app/services/partnerships/report.rb
@@ -86,7 +86,7 @@ module Partnerships
     end
 
     def early_academic_year_challenge_deadline
-      cohort.academic_year_start_date + EARLY_ACADEMIC_YEAR_CHALLENGE_WINDOW
+      cohort.academic_year.start_date + EARLY_ACADEMIC_YEAR_CHALLENGE_WINDOW
     end
 
     def default_challenge_deadline

--- a/app/views/admin/schools/cohorts/change_programme/show.html.erb
+++ b/app/views/admin/schools/cohorts/change_programme/show.html.erb
@@ -12,7 +12,7 @@
             @induction_choice_form.programme_choices(i18n_scope: "admin.induction_choice_form.options"),
             :id,
             :name,
-            legend: { text: "Change induction programme for #{@school.name} #{@induction_choice_form.cohort.academic_year}", size: "l", tag: "h1" },
+            legend: { text: "Change induction programme for #{@school.name} #{@induction_choice_form.cohort.academic_year.id}", size: "l", tag: "h1" },
           ) %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/admin/schools/cohorts/change_training_materials/show.html.erb
+++ b/app/views/admin/schools/cohorts/change_training_materials/show.html.erb
@@ -6,7 +6,7 @@
                                            CoreInductionProgramme.all,
                                            :id,
                                            :name,
-                                           legend: { text: "Change course for #{@school.name} #{@cohort.academic_year}", tag: "h1", size: "xl" } %>
+                                           legend: { text: "Change course for #{@school.name} #{@cohort.academic_year.id}", tag: "h1", size: "xl" } %>
       <%= f.govuk_submit "Continue" %>
     <% end %>
   </div>

--- a/app/views/admin/test_data/cip_schools/index.html.erb
+++ b/app/views/admin/test_data/cip_schools/index.html.erb
@@ -1,7 +1,7 @@
 <% title = "Test Data" %>
 <% content_for :title, title %>
 
-<span class="govuk-caption-xl">Schools that have chosen CIP for <%= Cohort.current.academic_year %></span>
+<span class="govuk-caption-xl">Schools that have chosen CIP for <%= Cohort.current.academic_year.id %></span>
 <h1 class="govuk-heading-xl"><%= title %></h1>
 
 <%= render partial: "admin/test_data/nav" %>
@@ -30,7 +30,7 @@
           <td class="govuk-table__cell nhsuk-table__cell">
             <span class="nhsuk-table-responsive__heading">Materials</span>
             <% programme = school.school_cohorts.where(cohort: Cohort.current).first.default_induction_programme %>
-            <%= "#{programme&.core_induction_programme&.name.presence || "-"}" %> 
+            <%= "#{programme&.core_induction_programme&.name.presence || "-"}" %>
           </td>
           <td class="govuk-table__cell nhsuk-table__cell">
             <span class="nhsuk-table-responsive__heading">Induction tutor</span>

--- a/app/views/admin/test_data/fip_schools/index.html.erb
+++ b/app/views/admin/test_data/fip_schools/index.html.erb
@@ -1,7 +1,7 @@
 <% title = "Test Data" %>
 <% content_for :title, title %>
 
-<span class="govuk-caption-xl">Schools that have chosen FIP for <%= Cohort.current.academic_year %></span>
+<span class="govuk-caption-xl">Schools that have chosen FIP for <%= Cohort.current.academic_year.id %></span>
 <h1 class="govuk-heading-xl"><%= title %></h1>
 
 <%= render partial: "admin/test_data/nav" %>
@@ -30,7 +30,7 @@
           <td class="govuk-table__cell nhsuk-table__cell">
             <span class="nhsuk-table-responsive__heading">Provider</span>
             <% programme = school.school_cohorts.where(cohort: Cohort.current).first.default_induction_programme %>
-            <%= "#{programme&.lead_provider_name} / #{programme&.delivery_partner_name}" %> 
+            <%= "#{programme&.lead_provider_name} / #{programme&.delivery_partner_name}" %>
           </td>
           <td class="govuk-table__cell nhsuk-table__cell">
             <span class="nhsuk-table-responsive__heading">Induction tutor</span>

--- a/app/views/nominations/choose_how_to_continue/new.html.erb
+++ b/app/views/nominations/choose_how_to_continue/new.html.erb
@@ -2,7 +2,6 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <%= form_for @how_to_continue_form, url: choose_how_to_continue_path(token: @how_to_continue_form.token) do |f| %>
         <%= f.govuk_error_summary %>
         <span class="govuk-caption-l"><%= @how_to_continue_form.school.name %></span>
@@ -18,6 +17,5 @@
         <%= f.hidden_field :token %>
         <%= f.govuk_submit "Continue" %>
       <% end %>
-
     </div>
 </div>

--- a/db/migrate/20230628122110_create_academic_years.rb
+++ b/db/migrate/20230628122110_create_academic_years.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateAcademicYears < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    create_table :academic_years, id: :string do |t|
+      t.column :previous_id, :string, limit: 7, null: true
+      t.column :start_year, :int
+      t.column :end_year, :int
+      t.column :start_date, :datetime
+
+      t.column :ecf_early_rollout_year, :boolean, default: false
+
+      t.references :cohort, foreign_key: true, index: true, null: true, type: :uuid
+
+      t.index :id, unique: true
+      t.index :start_year, unique: true
+      t.index :end_year, unique: true
+      t.index :start_date, unique: true
+      t.index :previous_id, unique: true
+
+      t.timestamps
+    end
+
+    add_foreign_key :academic_years, :academic_years, column: :previous_id, validate: false
+
+    validate_foreign_key :academic_years, :academic_years
+  end
+end

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -31,8 +31,10 @@ FactoryBot.define do
       start_year { generate(:base_year) }
     end
 
-    initialize_with do
-      Cohort.find_by(start_year:) || new(**attributes)
+    after(:create) do |cohort|
+      if cohort.academic_year.blank?
+        AcademicYear.create! id: AcademicYear.id_from_year(cohort.start_year), start_year: cohort.start_year, start_date: cohort.academic_year_start_date
+      end
     end
   end
 end

--- a/spec/factories/seeds/academic_year_factory.rb
+++ b/spec/factories/seeds/academic_year_factory.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:seed_academic_year, class: "AcademicYear") do
+    sequence(:start_year) { Faker::Number.unique.between(from: 2050, to: 9999) }
+
+    start_date { Date.new(start_year, 9, 1) }
+
+    initialize_with do
+      AcademicYear.find_by(start_year:) || new(**attributes)
+    end
+
+    trait(:with_cohort) { association :cohort, :seed_cohort, start_year:, academic_year_start_date: start_date }
+
+    trait(:valid) do
+      :with_cohort
+    end
+
+    after(:build) { |academic_year| Rails.logger.debug("seeded academic year #{academic_year.id}") }
+  end
+end

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -12,14 +12,12 @@ FactoryBot.define do
       Cohort.find_by(start_year:) || new(**attributes)
     end
 
+    trait(:with_academic_year) do
+      FactoryBot.create :seed_academic_year, start_year:, start_date: academic_year_start_date
+    end
+
     trait(:valid) {}
 
     after(:build) { |cohort| Rails.logger.debug("seeded cohort #{cohort.start_year}") }
-
-    after(:create) do |cohort|
-      if cohort.academic_year.blank?
-        AcademicYear.create! id: AcademicYear.id_from_year(cohort.start_year), start_year: cohort.start_year, start_date: cohort.academic_year_start_date
-      end
-    end
   end
 end

--- a/spec/factories/seeds/cohort_factory.rb
+++ b/spec/factories/seeds/cohort_factory.rb
@@ -15,5 +15,11 @@ FactoryBot.define do
     trait(:valid) {}
 
     after(:build) { |cohort| Rails.logger.debug("seeded cohort #{cohort.start_year}") }
+
+    after(:create) do |cohort|
+      if cohort.academic_year.blank?
+        AcademicYear.create! id: AcademicYear.id_from_year(cohort.start_year), start_year: cohort.start_year, start_date: cohort.academic_year_start_date
+      end
+    end
   end
 end

--- a/spec/features/finance/schedules_spec.rb
+++ b/spec/features/finance/schedules_spec.rb
@@ -3,14 +3,13 @@
 require "rails_helper"
 
 RSpec.feature "Finance users payment breakdowns", type: :feature do
-  let(:schedule) { create(:ecf_schedule) }
+  let!(:schedule) { create(:ecf_schedule) }
 
+  # TODO: this should be a request and a component test, not a capybara test
   scenario "viewing a schedule" do
     given_i_am_logged_in_as_a_finance_user
-    and_there_is_a_schedule
     when_i_click("View payment schedules")
     then_i_see("Schedules")
-    and_see_table_with_schedule
 
     within page.first("table tbody tr", text: /#{schedule.schedule_identifier}/) do
       when_i_click(schedule.schedule_identifier)
@@ -20,18 +19,8 @@ RSpec.feature "Finance users payment breakdowns", type: :feature do
     and_see_table_of_milestones_for_schedule
   end
 
-  def and_there_is_a_schedule
-    schedule
-  end
-
   def then_i_see(string)
     expect(page).to have_content(string)
-  end
-
-  def and_see_table_with_schedule
-    within(first("table")) do
-      expect(page).to have_content(schedule.schedule_identifier)
-    end
   end
 
   def and_see_table_of_milestones_for_schedule

--- a/spec/models/academic_years_spec.rb
+++ b/spec/models/academic_years_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AcademicYear, type: :model do
+  before do
+    AcademicYear.delete_all
+  end
+
+  describe "#create!" do
+    describe "when @id is not in the correct numerical format" do
+      it "will not create an academic year" do
+        expect { AcademicYear.create! id: "24/25" }.to raise_error ActiveRecord::RecordInvalid,
+                                                                   "Validation failed: Id must be in the format dddd/dd"
+      end
+    end
+
+    describe "when @id format is totally wrong" do
+      it "will not create an academic year" do
+        expect { AcademicYear.create! id: "AJX0006-23423-23523-LP" }.to raise_error ActiveRecord::RecordInvalid,
+                                                                                    "Validation failed: Id must be in the format dddd/dd"
+      end
+    end
+
+    describe "when @id spans more than two consecutive years" do
+      it "will not create an academic year" do
+        expect { AcademicYear.create! id: "5055/57" }.to raise_error ActiveRecord::RecordInvalid,
+                                                                     "Validation failed: Id <5055/57> must represent two consecutive years not 3 years"
+      end
+    end
+
+    describe "when @id spans two consecutive centuries" do
+      it "will not create an academic year" do
+        expect { AcademicYear.create! id: "5099/00" }.to_not raise_error
+      end
+    end
+
+    describe "when academic year already exists in the database" do
+      let(:label) { "4444/45" }
+      let!(:existing_academic_year) { AcademicYear.create! id: label }
+
+      it "will not create an academic year that already exists" do
+        expect { AcademicYear.create! id: label }.to raise_error ActiveRecord::RecordInvalid,
+                                                                 "Validation failed: Id has already been taken, Start year has already been taken, End year has already been taken"
+      end
+    end
+
+    describe "when @start_date does not have the same year as the @id" do
+      it "will not create an academic year" do
+        expect { AcademicYear.create! id: "2222/23", start_date: Date.new(2223, 9, 1) }.to raise_error ActiveRecord::RecordInvalid,
+                                                                                                       "Validation failed: Start date <2223-09-01 00:00:00 UTC> must have the year <2222>"
+      end
+    end
+
+    describe "when @start_date was not provided" do
+      subject(:created_academic_year) { AcademicYear.create! id: "2220/21" }
+
+      it "will create an academic year" do
+        expect { subject }.to_not raise_error
+      end
+
+      it "@start_date will default to 1st September" do
+        is_expected.to have_attributes(start_date: Date.new(2220, 9, 1))
+      end
+    end
+
+    describe "when :previous academic year already exists" do
+      let!(:previous_academic_year) { AcademicYear.create! id: "2219/20" }
+      subject(:created_academic_year) { AcademicYear.create! id: "2220/21" }
+
+      it "will create an academic year" do
+        expect { subject }.to_not raise_error
+      end
+
+      it "@previous_id will be set to the existing academic year" do
+        is_expected.to have_attributes(previous_id: "2219/20")
+      end
+    end
+  end
+
+  describe "@end_date" do
+    let!(:current_academic_year) { AcademicYear.create! id: "8887/88", start_date: Date.new(8887, 9, 1) }
+
+    describe "when a next academic year has been configured" do
+      let!(:next_academic_year) { AcademicYear.create! id: "8888/89", start_date: Date.new(8888, 8, 31) }
+
+      it "returns 1 day before the start date of the next academic year" do
+        expect(current_academic_year.next).to eq next_academic_year
+        expect(current_academic_year.end_date).to eq next_academic_year.start_date - 1.day
+      end
+    end
+
+    describe "when there is no next academic year" do
+      it "returns nil" do
+        expect(current_academic_year.end_date).to eq nil
+      end
+    end
+  end
+
+  describe "#label" do
+    let(:academic_year) { AcademicYear.create! id: "6062/63" }
+
+    it "displays the label that should be used to identify the academic year in the format dddd/dd" do
+      expect(academic_year.label).to eq "6062/63"
+    end
+  end
+
+  describe "#description" do
+    let(:academic_year) { AcademicYear.create! id: "1034/35" }
+
+    it "displays a description of the time period covered by the academic year in the format ' to '" do
+      expect(academic_year.description).to eq "1034 to 1035"
+    end
+  end
+
+  describe "#start_year" do
+    let(:academic_year) { AcademicYear.create! id: "3024/25" }
+
+    it "returns the start year as a integer" do
+      expect(academic_year.start_year).to eq 3024
+    end
+  end
+
+  describe "#display_name" do
+    let(:academic_year) { AcademicYear.create! id: "7083/84" }
+
+    it "returns the display name as a string representing the start year" do
+      expect(academic_year.display_name).to eq "7083"
+    end
+  end
+
+  describe "#previous" do
+    let(:current_academic_year) { AcademicYear.create! id: "3031/32" }
+
+    describe "when a previous academic year has been configured" do
+      let!(:previous_academic_year) { AcademicYear.create! id: "3030/31" }
+
+      it "returns the previous academic year" do
+        expect(current_academic_year.previous).to eq previous_academic_year
+      end
+    end
+
+    describe "when a previous academic year has not been configured" do
+      let!(:previous_academic_year) { nil }
+
+      it "returns nil" do
+        expect(current_academic_year.previous).to eq nil
+      end
+    end
+  end
+
+  describe "#next" do
+    let!(:current_academic_year) { AcademicYear.create! id: "3030/31" }
+
+    describe "when a next academic year has been configured" do
+      let!(:next_academic_year) { AcademicYear.create! id: "3031/32" }
+
+      it "returns the next academic year" do
+        expect(current_academic_year.next).to eq next_academic_year
+      end
+
+      it "returns the day before the next academic years start_date" do
+        expect(current_academic_year.end_date).to eq next_academic_year.start_date - 1.day
+      end
+    end
+
+    describe "when a next academic year has not been configured" do
+      it "returns nil" do
+        expect(current_academic_year.next).to eq nil
+      end
+
+      it "returns no end_date" do
+        expect(current_academic_year.end_date).to eq nil
+      end
+    end
+  end
+
+  describe "#cohort" do
+    let(:current_academic_year) { AcademicYear.create! id: "3030/31" }
+
+    describe "when a cohort exists that matches the start year" do
+      let!(:current_cohort) { Cohort.create! start_year: 3030 }
+
+      it "returns the the cohort with the correct start_year" do
+        expect(current_academic_year.cohort).to eq current_cohort
+      end
+    end
+
+    describe "when a cohort does not exist that matches the start year" do
+      let!(:current_cohort) { FactoryBot.create :seed_cohort, start_year: 3031 }
+
+      it "returns nil" do
+        expect(current_academic_year.cohort).to eq nil
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:first_academic_year) { AcademicYear.create! id: "7041/42", start_date: Date.new(7041, 9, 1), ecf_early_rollout_year: true }
+    let!(:second_academic_year) { AcademicYear.create! id: "7042/43", start_date: Date.new(7042, 9, 1) }
+    let!(:third_academic_year) { AcademicYear.create! id: "7043/44", start_date: Date.new(7043, 9, 1) }
+
+    context "#all" do
+      subject(:results) { AcademicYear.all }
+
+      it { is_expected.to include first_academic_year, second_academic_year, third_academic_year }
+    end
+
+    context "#starts_before_date" do
+      subject(:results) { AcademicYear.starts_before_date(Date.new(7043, 8, 1)) }
+
+      it { is_expected.to include first_academic_year, second_academic_year }
+      it { is_expected.to_not include third_academic_year }
+    end
+
+    context "#starts_after_date" do
+      subject(:results) { AcademicYear.starts_after_date(Date.new(7041, 10, 10)) }
+
+      it { is_expected.to_not include first_academic_year }
+      it { is_expected.to include second_academic_year, third_academic_year }
+    end
+
+    context "#containing_date" do
+      subject(:results) { AcademicYear.containing_date(Date.new(7042, 10, 10)) }
+
+      it { is_expected.to include second_academic_year }
+      it { is_expected.to_not include first_academic_year, third_academic_year }
+    end
+
+    context "#ecf_early_rollout_years" do
+      subject(:results) { AcademicYear.ecf_early_rollout_years }
+
+      it { is_expected.to include first_academic_year }
+      it { is_expected.to_not include second_academic_year, third_academic_year }
+    end
+
+    context "#ecf_national_rollout_years" do
+      subject(:results) { AcademicYear.ecf_national_rollout_years }
+
+      it { is_expected.to include second_academic_year, third_academic_year }
+      it { is_expected.to_not include first_academic_year }
+    end
+
+    context "#first_ecf_national_rollout_year" do
+      subject(:results) { AcademicYear.first_ecf_national_rollout_year }
+
+      it { is_expected.to eq second_academic_year }
+    end
+  end
+
+  describe "AcademicYear.now" do
+    describe "when the correct academic year exists" do
+      let!(:current_academic_year) { AcademicYear.create! id: "4044/45" }
+
+      it "returns the academic year which contains the date provided by Time.zone.today" do
+        travel_to(Date.new(4044, 10, 10)) do
+          expect(AcademicYear.now).to eq current_academic_year
+        end
+      end
+    end
+
+    describe "when the current academic year does not exist" do
+      it "returns nil" do
+        travel_to(200.years.from_now) do
+          expect(AcademicYear.now).to eq nil
+        end
+      end
+    end
+  end
+end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -121,9 +121,9 @@ RSpec.describe Cohort, type: :model do
     end
   end
 
-  describe "#academic_year" do
+  describe "#academic_year.id" do
     it "displays the years covered by the academic year" do
-      expect(Cohort.find_by(start_year: 2021).academic_year).to eq("2021/22")
+      expect(Cohort.find_by(start_year: 2021).academic_year.id).to eq("2021/22")
     end
   end
 

--- a/spec/seeds/seed_factories/academic_year_factory_spec.rb
+++ b/spec/seeds/seed_factories/academic_year_factory_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "./shared_factory_examples"
+
+RSpec.describe("seed_academic_year") do
+  it_behaves_like("a seed factory") do
+    let(:factory_name) { :seed_academic_year }
+    let(:factory_class) { AcademicYear }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,10 +109,16 @@ RSpec.configure do |config|
   config.bisect_runner = :shell
 
   config.before(:suite) do
-    # create cohorts since 2020 with default schedule
+    # create early rollout cohorts
+    cohort = Cohort.find_by(start_year: 2020) || FactoryBot.create(:seed_cohort, start_year: 2020)
+    AcademicYear.create!(id: AcademicYear.id_from_year(cohort.start_year), start_date: cohort.academic_year_start_date, ecf_early_rollout_year: true) if cohort.academic_year.blank?
+
+    # create national rollout cohorts with default schedules
     end_year = Date.current.month < 9 ? Date.current.year : Date.current.year + 1
-    (2020..end_year).each do |start_year|
-      cohort = Cohort.find_by(start_year:) || FactoryBot.create(:cohort, start_year:)
+    (2021..end_year).each do |start_year|
+      cohort = Cohort.find_by(start_year:) || FactoryBot.create(:seed_cohort, start_year:)
+      AcademicYear.create!(id: AcademicYear.id_from_year(cohort.start_year), start_date: cohort.academic_year_start_date) if cohort.academic_year.blank?
+
       Finance::Schedule::ECF.default_for(cohort:) || FactoryBot.create(:ecf_schedule, cohort:)
 
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,13 +111,13 @@ RSpec.configure do |config|
   config.before(:suite) do
     # create early rollout cohorts
     cohort = Cohort.find_by(start_year: 2020) || FactoryBot.create(:seed_cohort, start_year: 2020)
-    AcademicYear.create!(id: AcademicYear.id_from_year(cohort.start_year), start_date: cohort.academic_year_start_date, ecf_early_rollout_year: true) if cohort.academic_year.blank?
+    AcademicYear.find_by(start_year: cohort.start_year) || FactoryBot.create(:seed_academic_year, start_year: cohort.start_year, start_date: cohort.academic_year_start_date, ecf_early_rollout_year: true) if cohort.academic_year.blank?
 
     # create national rollout cohorts with default schedules
     end_year = Date.current.month < 9 ? Date.current.year : Date.current.year + 1
     (2021..end_year).each do |start_year|
       cohort = Cohort.find_by(start_year:) || FactoryBot.create(:seed_cohort, start_year:)
-      AcademicYear.create!(id: AcademicYear.id_from_year(cohort.start_year), start_date: cohort.academic_year_start_date) if cohort.academic_year.blank?
+      AcademicYear.find_by(start_year:) || FactoryBot.create(:seed_academic_year, start_year:, start_date: cohort.academic_year_start_date) if cohort.academic_year.blank?
 
       Finance::Schedule::ECF.default_for(cohort:) || FactoryBot.create(:ecf_schedule, cohort:)
 


### PR DESCRIPTION
### Context

Investigating a new alternative to Cohort, the Academic Year

### Changes proposed in this pull request

- use the name AcademicYear
- create an id that is in the format dddd/dd e.g. 2022/23 to make data reading easier
- automatically associate new academic years with previous academic years and existing cohorts to chain them
- use only start_dates so the end_date is controlled by the next academic year
- use validation to enforce uniqueness
- use attributes to associate academic years with the early rollout and national rollout of ECF
- delegate to the appropriate cohort so that its easy to assign the right academic year to entities