### PR TITLE
Replace flash notice with flash success

### DIFF
--- a/app/controllers/admin/administrators/administrators_controller.rb
+++ b/app/controllers/admin/administrators/administrators_controller.rb
@@ -58,7 +58,8 @@ module Admin
 
       def update
         if @administrator.update(permitted_attributes(@administrator))
-          redirect_to :admin_administrators, notice: "Changes saved successfully"
+          set_success_message(content: "Changes saved successfully", title: "Success")
+          redirect_to :admin_administrators
         else
           render :edit
         end

--- a/app/controllers/admin/induction_coordinators_controller.rb
+++ b/app/controllers/admin/induction_coordinators_controller.rb
@@ -14,7 +14,8 @@ module Admin
 
     def update
       if @induction_coordinator.update(permitted_attributes(@induction_coordinator))
-        redirect_to :admin_induction_coordinators, notice: "Changes saved successfully"
+        set_success_message(content: "Changes saved successfully", title: "Success")
+        redirect_to :admin_induction_coordinators
       else
         render :edit
       end

--- a/app/controllers/admin/suppliers/lead_provider_users_controller.rb
+++ b/app/controllers/admin/suppliers/lead_provider_users_controller.rb
@@ -10,7 +10,8 @@ module Admin
 
       def update
         if @lead_provider_user.update(permitted_attributes(@lead_provider_user))
-          redirect_to :admin_supplier_users, notice: "Changes saved successfully"
+          set_success_message(content: "Changes saved successfully", title: "Success")
+          redirect_to :admin_supplier_users
         else
           render :edit
         end

--- a/spec/requests/admin/administrators/administrators_spec.rb
+++ b/spec/requests/admin/administrators/administrators_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Admin::Administrators::Administrators", type: :request do
 
       expect(admin.reload.email).to eq email
       expect(response).to redirect_to(:admin_administrators)
-      expect(flash[:notice]).to eq "Changes saved successfully"
+      expect(flash[:success][:content]).to eq "Changes saved successfully"
     end
 
     context "when the user params are invalid" do

--- a/spec/requests/admin/induction_coordinators_spec.rb
+++ b/spec/requests/admin/induction_coordinators_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Admin::InductionCoodinators", type: :request do
 
       expect(induction_coordinator.reload.email).to eq email
       expect(response).to redirect_to(:admin_induction_coordinators)
-      expect(flash[:notice]).to eq "Changes saved successfully"
+      expect(flash[:success][:content]).to eq "Changes saved successfully"
     end
 
     context "when the user params are invalid" do

--- a/spec/requests/admin/lead_providers/lead_provider_users_spec.rb
+++ b/spec/requests/admin/lead_providers/lead_provider_users_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Admin::LeadProviders::LeadProviderUsers", type: :request do
 
       expect(lead_provider_user.reload.email).to eq email
       expect(response).to redirect_to(:admin_supplier_users)
-      expect(flash[:notice]).to eq "Changes saved successfully"
+      expect(flash[:success][:content]).to eq "Changes saved successfully"
     end
 
     context "when the user params are invalid" do


### PR DESCRIPTION
### Changes proposed in this pull request

We encountered a bug when updating admin profiles because the success message was set inconsistently. We used two approaches, adding the `:notice` param onto `redirect_to`, and setting the flash manually via `set_success_message`.

We use `set_success_message` in more places and it's a bit more flexible, so this change switches the remaining notice variants over.
