### PR TITLE
CST-1682: do not change start date of IRs when placing participants i…

### DIFF
--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -70,7 +70,7 @@ module Induction
       return true if in_target_cohort?(induction_record)
 
       ActiveRecord::Base.transaction do
-        induction_record.update!(induction_programme:, start_date:, schedule:)
+        induction_record.update!(induction_programme:, schedule:)
         participant_profile.update!(school_cohort: target_school_cohort, schedule:)
       rescue ActiveRecord::RecordInvalid
         errors.add(:induction_record, induction_record.errors.full_messages.first) if induction_record.errors.any?
@@ -156,10 +156,6 @@ module Induction
 
     def source_cohort
       @source_cohort ||= Cohort.find_by(start_year: source_cohort_start_year)
-    end
-
-    def start_date
-      @start_date ||= target_cohort.academic_year_start_date
     end
 
     def target_cohort

--- a/spec/services/induction/amend_participant_cohort_spec.rb
+++ b/spec/services/induction/amend_participant_cohort_spec.rb
@@ -191,13 +191,13 @@ RSpec.describe Induction::AmendParticipantCohort do
 
         context "when the cohort change cannot be persisted" do
           before do
-            allow(form).to receive(:start_date)
+            allow(form).to receive(:schedule)
           end
 
           it "returns false and set errors" do
             expect(form.save).to be_falsey
             expect(form.errors.first.attribute).to eq(:induction_record)
-            expect(form.errors.first.message).to eq("Start date can't be blank")
+            expect(form.errors.first.message).to eq("Schedule must exist")
           end
         end
 
@@ -213,7 +213,6 @@ RSpec.describe Induction::AmendParticipantCohort do
             induction_record = participant_profile.reload.induction_records.latest
 
             expect(induction_record.induction_programme).to eq(target_school_cohort.default_induction_programme)
-            expect(induction_record.start_date).to eq(target_cohort.academic_year_start_date)
             expect(induction_record.schedule).to eq(Finance::Schedule::ECF.default_for(cohort: target_cohort))
             expect(participant_profile.school_cohort).to eq(target_school_cohort)
             expect(participant_profile.schedule).to eq(Finance::Schedule::ECF.default_for(cohort: target_cohort))


### PR DESCRIPTION
…n their permanent cohort

### Context
The tool created to amend a participant's cohort initially needed to modify the start date of the induction record created after SITs registered participants in a wrong cohort.

After all the cohortless stuff and the new way to setup temporary and permanent cohorts based on DQT reporting induction start dates, we don't need to change the start date of any IR.

[Ticket](https://dfedigital.atlassian.net/browse/CST-1681)

### Changes proposed in this pull request
Keep updating latest induction record schedule and induction_programme to sit it in the permanent cohort.
Do not update the start_date though.

