### PR TITLE
Display CIP materials on the participant dashboard

### DIFF
--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -13,6 +13,18 @@
     <% row.action(text: "Change", href: change_programme_schools_cohort_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "induction programme choice") %>
   <% end %>
 
+  <% if school_cohort.core_induction_programme? %>
+    <% list.row do |row| %>
+      <% row.key(text: "Materials supplier") %>
+      <% row.value(text: school_cohort.default_induction_programme&.core_induction_programme&.name) %>
+      <% if school_cohort.default_induction_programme&.core_induction_programme.blank? %>
+        <% row.action(text: "Choose", href: info_schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
+      <% else %>
+        <% row.action(text: "Change", href: schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <% if school_cohort.appropriate_body.present? %>
     <% list.row do |row| %>
       <% row.key(text: "Appropriate body") %>
@@ -46,16 +58,6 @@
         <% row.value(text: school_cohort_delivery_partner_name(school_cohort)) %>
       <% end %>
       <% row.action(text: :none) %>
-    <% end %>
-  <% elsif school_cohort.core_induction_programme? %>
-    <% list.row do |row| %>
-      <% row.key(text: "Materials supplier") %>
-      <% row.value(text: school_cohort.default_induction_programme&.core_induction_programme&.name) %>
-      <% if school_cohort.default_induction_programme&.core_induction_programme.blank? %>
-        <% row.action(text: "Choose", href: info_schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
-      <% else %>
-        <% row.action(text: "Change", href: schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
-      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -111,7 +111,7 @@
         </div>
       <% end %>
 
-      <% if !@induction_record.enrolled_in_cip? %>
+      <% if @induction_record.enrolled_in_fip? %>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
           <dt class="govuk-summary-list__key">
             Lead provider

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -100,25 +100,39 @@
         </div>
       <% end %>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Lead provider
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @induction_record.lead_provider_name %>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
+      <% if @induction_record.enrolled_in_cip? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Programme
+          </dt>
+          <dd class="govuk-summary-list__value">
+            DfE accredited materials
+          </dd>
+          <dd class="govuk-summary-list__actions"></dd>
+        </div>
+      <% end %>
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Delivery partner
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @induction_record.delivery_partner_name %>
-        </dd>
-        <dd class="govuk-summary-list__actions"></dd>
-      </div>
+      <% if !@induction_record.enrolled_in_cip? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Lead provider
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= @induction_record.lead_provider_name %>
+          </dd>
+          <dd class="govuk-summary-list__actions"></dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Delivery partner
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= @induction_record.delivery_partner_name %>
+          </dd>
+          <dd class="govuk-summary-list__actions"></dd>
+        </div>
+      <% end %>
 
       <% if can_appropriate_body_be_changed? %>
         <div class="govuk-summary-list__row">

--- a/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_cip_participants_spec.rb
@@ -187,6 +187,9 @@ RSpec.describe "Manage CIP participants", js: true, with_feature_flags: { eligib
       when_i_click_on_the_participants_name "CFI Mentor"
       then_i_am_taken_to_view_details_page
       then_i_can_view_participant_with_status(:request_for_details_delivered)
+      and_i_see_the_cip_programme
+      and_i_dont_see_the_lead_provider
+      and_i_dont_see_the_delivery_partner
     end
   end
 

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1095,6 +1095,18 @@ module ManageTrainingSteps
     expect(page).to have_summary_row("Appropriate body", appropriate_body.name)
   end
 
+  def and_i_see_the_cip_programme
+    expect(page).to have_summary_row("Programme", "DfE accredited materials")
+  end
+
+  def and_i_dont_see_the_lead_provider
+    expect(page).to_not have_content("Lead provider")
+  end
+
+  def and_i_dont_see_the_delivery_partner
+    expect(page).to_not have_content("Delivery partner")
+  end
+
   # Set_steps
 
   def set_participant_data


### PR DESCRIPTION
* Lead provider and delivery partner hidden for CIP

### Context

- Ticket: CST-1673, CST-1674

### Changes proposed in this pull request

* When CIP:
  * Added **Programme** detail line to the participant dashboard
  * Removed **Lead provider** and **Delivery partner** detail lines
  * **Material supplier** detail line moved above the **appropriate body** one