### PR TITLE
Add table for participants to Admin overview page

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -22,6 +22,9 @@ module Admin
         no_ects_total: choices.fetch("no_early_career_teachers", 0),
         total: choices.values.sum,
         partnership_totals:,
+        ect_count: participants_registered.ects.count,
+        mentors_count: participants_registered.mentors.count,
+        total_participants: participants_registered.count,
       })
     end
 
@@ -39,6 +42,10 @@ module Admin
 
     def providers
       LeadProvider.where(id: ProviderRelationship.where(cohort:).select(:lead_provider_id)).order(:name)
+    end
+
+    def participants_registered
+      @participants_registered ||= ParticipantProfile::ECF.joins(schedule: :cohort).where(schedule: { cohort: })
     end
 
     def valid_choices

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -14,31 +14,31 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Delivering their training using DfE materials</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.cip_total %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(@pilot_stats.cip_total) %></td>
         </tr>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Designing their own programme</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.diy_total %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(@pilot_stats.diy_total) %></td>
         </tr>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Using a training provider (full induction programme)</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"><%= @pilot_stats.fip_total %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"><%= number_with_delimiter(@pilot_stats.fip_total) %></td>
         </tr>
         <% @pilot_stats.partnership_totals.each do |provider| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5"><%= provider[:name] %></th>
-            <td class="govuk-table__cell govuk-table__cell--numeric"><%= provider[:total] %></td>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(provider[:total]) %></td>
           </tr>
         <% end %>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Not expecting any early career teachers</th>
-          <td class="govuk-table__cell  govuk-table__cell--numeric"><%= @pilot_stats.no_ects_total %></td>
+          <td class="govuk-table__cell  govuk-table__cell--numeric"><%= number_with_delimiter(@pilot_stats.no_ects_total) %></td>
         </tr>
       </tbody>
       <tfoot>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">Total</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= @pilot_stats.total %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%=  number_with_delimiter(@pilot_stats.total) %></td>
         </tr>
       </tfoot>
     </table>
@@ -55,17 +55,17 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Early career teachers</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(100) %></td>
         </tr>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Mentors</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric">50</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(500) %></td>
         </tr>
       </tbody>
       <tfoot>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">Total</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">150</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= number_with_delimiter(1500) %></td>
         </tr>
       </tfoot>
     </table>

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -55,17 +55,17 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Early career teachers</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(100) %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(@pilot_stats.ect_count) %></td>
         </tr>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Mentors</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(500) %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter(@pilot_stats.mentors_count) %></td>
         </tr>
       </tbody>
       <tfoot>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">Total</th>
-          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= number_with_delimiter(1500) %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= number_with_delimiter(@pilot_stats.total_participants) %></td>
         </tr>
       </tfoot>
     </table>

--- a/app/views/admin/home/show.html.erb
+++ b/app/views/admin/home/show.html.erb
@@ -1,41 +1,74 @@
-<h1 class="govuk-heading-xl">Overview</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<table class="govuk-table" style="width: auto;">
-  <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for 2023 to 2024</caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Training programme</th>
-      <th scope="col" class="govuk-table__header govuk-table__header--numeric">Schools</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Delivering their training using DfE materials</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.cip_total %></td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Designing their own programme</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.diy_total %></td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Using a training provider (full induction programme)</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"><%= @pilot_stats.fip_total %></td>
-    </tr>
-    <% @pilot_stats.partnership_totals.each do |provider| %>
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5"><%= provider[:name] %></th>
-        <td class="govuk-table__cell govuk-table__cell--numeric"><%= provider[:total] %></td>
-      </tr>
-    <% end %>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Not expecting any early career teachers</th>
-      <td class="govuk-table__cell  govuk-table__cell--numeric"><%= @pilot_stats.no_ects_total %></td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Total</th>
-      <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= @pilot_stats.total %></td>
-    </tr>
-  </tfoot>
-</table>
+    <h1 class="govuk-heading-xl">Overview</h1>
+
+    <table class="govuk-table govuk-!-margin-bottom-9">
+      <caption class="govuk-table__caption govuk-table__caption--m">Schools registered for 2023 to 2024</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Training programme</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Schools</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Delivering their training using DfE materials</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.cip_total %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Designing their own programme</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><%= @pilot_stats.diy_total %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Using a training provider (full induction programme)</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-regular"><%= @pilot_stats.fip_total %></td>
+        </tr>
+        <% @pilot_stats.partnership_totals.each do |provider| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header govuk-!-font-weight-regular govuk-!-padding-left-5"><%= provider[:name] %></th>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= provider[:total] %></td>
+          </tr>
+        <% end %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Not expecting any early career teachers</th>
+          <td class="govuk-table__cell  govuk-table__cell--numeric"><%= @pilot_stats.no_ects_total %></td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Total</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold"><%= @pilot_stats.total %></td>
+        </tr>
+      </tfoot>
+    </table>
+
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Participants registered for 2023 to 2024</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Participant type</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Registered</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Early career teachers</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-font-weight-regular">Mentors</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric">50</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Total</th>
+          <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-font-weight-bold">150</td>
+        </tr>
+      </tfoot>
+    </table>
+
+  </div>
+</div>


### PR DESCRIPTION
This adds a second table to the Admin overview page, which gives the numbers of participants registered for the 2023-2024 academic year, broken down by participant type (early career teachers and mentors).

- Ticket: [Add the numbers of ECTs and mentors registered for 2023-2024 to the admin overview page](https://dfedigital.atlassian.net/jira/software/projects/CST/boards/119?selectedIssue=CST-1713)

## Screenshots

![admin-overview-page](https://github.com/DFE-Digital/early-careers-framework/assets/30665/f40f9e1f-c6f4-4cf7-9083-21eaab603714)

