### PR TITLE
[CPDLP-2293] Fix appropriate bodies service duplicates

### DIFF
--- a/app/controllers/appropriate_bodies/participants_controller.rb
+++ b/app/controllers/appropriate_bodies/participants_controller.rb
@@ -3,7 +3,7 @@
 module AppropriateBodies
   class ParticipantsController < BaseController
     def index
-      collection = InductionRecord.includes(:participant_profile).where(appropriate_body:)
+      collection = InductionRecordsQuery.new(appropriate_body:).induction_records
 
       @filter = ParticipantsFilter.new(collection:, params: filter_params)
 

--- a/app/services/appropriate_bodies/induction_records_query.rb
+++ b/app/services/appropriate_bodies/induction_records_query.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module AppropriateBodies
+  class InductionRecordsQuery
+    attr_reader :appropriate_body
+
+    def initialize(appropriate_body:)
+      @appropriate_body = appropriate_body
+    end
+
+    def induction_records
+      join = InductionRecord
+        .select("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id")
+        .joins(:participant_profile, :appropriate_body, induction_programme: :partnership)
+        .where(
+          induction_programme: {
+            partnerships: {
+              challenged_at: nil,
+              challenge_reason: nil,
+              pending: false,
+            },
+          },
+        )
+
+      InductionRecord.distinct
+        .joins("JOIN (#{join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
+        .where(appropriate_body:)
+    end
+
+  private
+
+    def latest_induction_record_order
+      <<~SQL
+        PARTITION BY induction_records.participant_profile_id ORDER BY
+          CASE
+            WHEN induction_records.end_date IS NULL
+              THEN 1
+            ELSE 2
+          END,
+          induction_records.start_date DESC,
+          induction_records.created_at DESC
+      SQL
+    end
+  end
+end

--- a/app/services/appropriate_bodies/induction_records_query.rb
+++ b/app/services/appropriate_bodies/induction_records_query.rb
@@ -10,35 +10,20 @@ module AppropriateBodies
 
     def induction_records
       join = InductionRecord
-        .select("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id")
-        .joins(:participant_profile, :appropriate_body, induction_programme: :partnership)
-        .where(
-          induction_programme: {
-            partnerships: {
-              challenged_at: nil,
-              challenge_reason: nil,
-              pending: false,
-            },
-          },
-        )
+        .select(Arel.sql("DISTINCT FIRST_VALUE(induction_records.id) OVER (#{latest_induction_record_order}) AS latest_id"))
+        .joins(:participant_profile)
+        .where(appropriate_body:)
 
       InductionRecord.distinct
         .joins("JOIN (#{join.to_sql}) AS latest_induction_records ON latest_induction_records.latest_id = induction_records.id")
-        .where(appropriate_body:)
     end
 
   private
 
     def latest_induction_record_order
       <<~SQL
-        PARTITION BY induction_records.participant_profile_id ORDER BY
-          CASE
-            WHEN induction_records.end_date IS NULL
-              THEN 1
-            ELSE 2
-          END,
-          induction_records.start_date DESC,
-          induction_records.created_at DESC
+        PARTITION BY induction_records.participant_profile_id, induction_records.appropriate_body_id
+          ORDER BY induction_records.created_at DESC
       SQL
     end
   end

--- a/spec/features/appropriate_bodies/participants_spec.rb
+++ b/spec/features/appropriate_bodies/participants_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Appropriate body users participants", type: :feature do
     )
   end
   let(:induction_programme) { create(:induction_programme, partnership:, school_cohort:) }
-  let!(:induction_record) { create :induction_record, participant_profile:, appropriate_body:, induction_programme:, training_status: "withdrawn" }
+  let!(:induction_record) { create(:induction_record, participant_profile:, appropriate_body:, induction_programme:, training_status: "withdrawn") }
 
   let!(:prev_cohort_year) { create(:cohort, start_year: 2020) }
 
@@ -114,6 +114,18 @@ RSpec.feature "Appropriate body users participants", type: :feature do
     end
   end
 
+  context "when there are newer induction records for a different appropriate body" do
+    let!(:latest_induction_record) { create(:induction_record, participant_profile:, induction_programme:, training_status: "deferred") }
+
+    scenario "Visit participants page" do
+      then_i_see("Participants")
+      and_i_see_participant_details
+      and_i_do_not_see_newer_induction_record_details
+    end
+  end
+
+private
+
   def given_i_am_logged_in_as_a_appropriate_body_user
     sign_in_as(appropriate_body_user)
   end
@@ -162,5 +174,9 @@ RSpec.feature "Appropriate body users participants", type: :feature do
     data = CSV.parse(page.body).transpose
     expect(data[0]).to eq(["full_name", participant_profile.user.full_name])
     expect(data[1]).to eq(["email_address", participant_profile.user.email])
+  end
+
+  def and_i_do_not_see_newer_induction_record_details
+    expect(page).not_to have_content(latest_induction_record.training_status)
   end
 end

--- a/spec/services/appropriate_bodies/induction_records_query_spec.rb
+++ b/spec/services/appropriate_bodies/induction_records_query_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AppropriateBodies::InductionRecordsQuery do
+  let(:appropriate_body_user) { create(:user, :appropriate_body) }
+  let(:appropriate_body) { appropriate_body_user.appropriate_bodies.first }
+  let(:participant_profile) { create(:ect_participant_profile) }
+  let(:partnership) do
+    create(
+      :partnership,
+      challenged_at: nil,
+      challenge_reason: nil,
+      pending: false,
+    )
+  end
+  let(:induction_programme) { create(:induction_programme, partnership:) }
+  let!(:induction_record) { create(:induction_record, participant_profile:, appropriate_body:, induction_programme:) }
+  let!(:another_induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
+
+  subject { described_class.new(appropriate_body:) }
+
+  describe "#induction_records" do
+    it "returns latest induction record for appropriate body" do
+      expect(subject.induction_records).to match_array([induction_record])
+    end
+  end
+end

--- a/spec/services/appropriate_bodies/induction_records_query_spec.rb
+++ b/spec/services/appropriate_bodies/induction_records_query_spec.rb
@@ -24,5 +24,21 @@ RSpec.describe AppropriateBodies::InductionRecordsQuery do
     it "returns latest induction record for appropriate body" do
       expect(subject.induction_records).to match_array([induction_record])
     end
+
+    context "when there are more induction records for the same appropriate body" do
+      let!(:latest_induction_record) { create(:induction_record, participant_profile:, appropriate_body:, induction_programme:) }
+
+      it "returns latest induction record for appropriate body" do
+        expect(subject.induction_records).to match_array([latest_induction_record])
+      end
+    end
+
+    context "when there are newer induction records for a different appropriate body" do
+      let!(:latest_induction_record) { create(:induction_record, participant_profile:, induction_programme:, training_status: "deferred") }
+
+      it "returns correct induction record for appropriate body" do
+        expect(subject.induction_records).to match_array([induction_record])
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2293](https://dfedigital.atlassian.net/browse/CPDLP-2293)

As an AB I need the latest data about any ECF training/s a participant registered for their induction with me is doing.

### Changes proposed in this pull request

The AB service ‘picks’ the most accurate/timely record for a given participant for a given training.

### Guidance to review



[CPDLP-2293]: https://dfedigital.atlassian.net/browse/CPDLP-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ