### PR TITLE
Allow filtering NPQ outcomes by created_at

### DIFF
--- a/app/controllers/api/v1/provider_outcomes_controller.rb
+++ b/app/controllers/api/v1/provider_outcomes_controller.rb
@@ -20,7 +20,14 @@ module Api
       def query_scope
         ParticipantOutcomesQuery.new(
           cpd_lead_provider:,
+          params: npq_participant_outcome_params,
         ).scope
+      end
+
+      def npq_participant_outcome_params
+        params
+          .with_defaults({ filter: { created_since: "" } })
+          .permit(filter: %i[created_since])
       end
 
       def cpd_lead_provider

--- a/app/services/api/v1/participant_outcomes_query.rb
+++ b/app/services/api/v1/participant_outcomes_query.rb
@@ -3,31 +3,44 @@
 module Api
   module V1
     class ParticipantOutcomesQuery
-      attr_reader :cpd_lead_provider, :participant_external_id
+      attr_reader :cpd_lead_provider, :participant_external_id, :params
 
-      def initialize(cpd_lead_provider:, participant_external_id: nil)
+      def initialize(cpd_lead_provider:, participant_external_id: nil, params: {})
         @cpd_lead_provider = cpd_lead_provider
         @participant_external_id = participant_external_id
+        @params = params
       end
 
       def scope
-        if participant_external_id.nil?
-          return ParticipantOutcome::NPQ
+        scope = ParticipantOutcome::NPQ
             .includes(participant_declaration: [participant_profile: [:participant_identity]])
             .joins(:participant_declaration)
             .order(:created_at)
             .merge(declarations_scope)
-        end
 
-        ParticipantOutcome::NPQ
-          .includes(participant_declaration: [participant_profile: [:participant_identity]])
-          .joins(participant_declaration: { participant_profile: :participant_identity })
-          .order(:created_at)
-          .merge(declarations_scope)
-          .merge(participant_scope)
+        scope = filter_by_participant(scope) if participant_external_id.present?
+        scope = filter_by_created_since(scope) if created_since.present?
+        scope
       end
 
     private
+
+      def filter
+        params[:filter] ||= {}
+      end
+
+      def created_since_filter
+        filter[:created_since]
+      end
+
+      def filter_by_created_since(scope)
+        scope.where(created_at: created_since..)
+      end
+
+      def filter_by_participant(scope)
+        scope.joins(participant_declaration: { participant_profile: :participant_identity })
+          .merge(participant_scope)
+      end
 
       def declarations_scope
         ParticipantDeclaration.for_lead_provider(cpd_lead_provider)
@@ -35,6 +48,18 @@ module Api
 
       def participant_scope
         ParticipantIdentity.where(user_id: participant_external_id)
+      end
+
+      def created_since
+        return if created_since_filter.blank?
+
+        Time.iso8601(created_since_filter)
+      rescue ArgumentError
+        begin
+          Time.iso8601(URI.decode_www_form_component(created_since_filter))
+        rescue ArgumentError
+          raise Api::Errors::InvalidDatetimeError, I18n.t(:invalid_created_since_filter)
+        end
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
   invalid_declaration_date: "Enter a valid RCF3339 '#/declaration_date'."
   invalid_completion_date: "The '#/completion_date' value must be in the following format: 'yyyy-mm-dd'"
   invalid_updated_since_filter: "The filter '#/updated_since' must be a valid RCF3339 date"
+  invalid_created_since_filter: "The filter '#/created_since' must be a valid RCF3339 date"
   future_date: "The '#/%{attribute}' value cannot be a future date. Check the date and try again."
   future_date_outcomes: "The attribute '#/%{attribute}' cannot contain a future date. Resubmit the outcome update with a valid date."
   mismatch_declaration_type_for_schedule: "The property '#/declaration_type' does not exist for this schedule."

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 13th July 2023
+
+Providers may now filter outcomes by created_since date. For example:
+
+* GET /api/v1/participants/npq/outcomes?filter[created_since]=2023-04-17T23:11:18Z
+
+The change applies to all API versions.
+
 ## 12th July 2023
 
 DfE has changed functionality around the endpoint `PUT /api/v1/participants/npq/{id}/defer`

--- a/spec/docs/v1/participant_outcomes_spec.rb
+++ b/spec/docs/v1/participant_outcomes_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe "API", type: :request, swagger_doc: "v1/api_spec.json" do
       tags "Participants Outcomes"
       security [bearerAuth: []]
 
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/NPQOutcomeFilter",
+                },
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine participant outcomes to return.",
+                example: CGI.unescape({ filter: { created_since: "2020-11-13T11:21:55Z" } }.to_param)
+
       parameter name: :page,
                 in: :query,
                 schema: {

--- a/spec/docs/v2/participant_outcomes_spec.rb
+++ b/spec/docs/v2/participant_outcomes_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe "API", type: :request, swagger_doc: "v2/api_spec.json" do
       tags "Participants Outcomes"
       security [bearerAuth: []]
 
+      parameter name: :filter,
+                in: :query,
+                schema: {
+                  "$ref": "#/components/schemas/NPQOutcomeFilter",
+                },
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine participant outcomes to return.",
+                example: CGI.unescape({ filter: { created_since: "2020-11-13T11:21:55Z" } }.to_param)
+
       parameter name: :page,
                 in: :query,
                 schema: {

--- a/spec/docs/v3/npq_participant_outcomes_spec.rb
+++ b/spec/docs/v3/npq_participant_outcomes_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
       parameter name: :filter,
                 in: :query,
                 schema: {
-                  "$ref": "#/components/schemas/ListFilter",
+                  "$ref": "#/components/schemas/NPQOutcomeFilter",
                 },
                 style: :deepObject,
                 explode: true,
                 required: false,
                 description: "Refine participant outcomes to return.",
-                example: CGI.unescape({ filter: { cohort: 2022, created_since: "2020-11-13T11:21:55Z" } }.to_param)
+                example: CGI.unescape({ filter: { created_since: "2020-11-13T11:21:55Z" } }.to_param)
 
       parameter name: :page,
                 in: :query,

--- a/spec/requests/api/v1/provider_outcomes_spec.rb
+++ b/spec/requests/api/v1/provider_outcomes_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "participant outcomes endpoint spec", type: :request do
 
           expect(parsed_response).to eq(expected_response)
         end
+
+        context "when filtering by created_since" do
+          before { travel_to(2.weeks.ago) { create(:participant_outcome, participant_declaration: declaration) } }
+
+          it "returns outcomes created since the given date" do
+            created_since = 5.days.ago.iso8601
+            get "/api/v1/participants/npq/outcomes", params: { filter: { created_since: } }
+            expect(response.status).to eq 200
+            expect(parsed_response).to eq(expected_response)
+          end
+        end
       end
 
       it "can return paginated data" do

--- a/spec/requests/api/v2/provider_outcomes_spec.rb
+++ b/spec/requests/api/v2/provider_outcomes_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "provider outcomes endpoint spec", type: :request do
 
           expect(parsed_response).to eq(expected_response)
         end
+
+        context "when filtering by created_since" do
+          before { travel_to(2.weeks.ago) { create(:participant_outcome, participant_declaration: declaration) } }
+
+          it "returns outcomes created since the given date" do
+            created_since = 5.days.ago.iso8601
+            get "/api/v2/participants/npq/outcomes", params: { filter: { created_since: } }
+            expect(response.status).to eq 200
+            expect(parsed_response).to eq(expected_response)
+          end
+        end
       end
 
       it "can return paginated data" do

--- a/spec/requests/api/v3/provider_outcomes_spec.rb
+++ b/spec/requests/api/v3/provider_outcomes_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "participant outcomes endpoint spec", type: :request do
 
           expect(parsed_response).to eq(expected_response)
         end
+
+        context "when filtering by created_since" do
+          before { travel_to(2.weeks.ago) { create(:participant_outcome, participant_declaration: declaration) } }
+
+          it "returns outcomes created since the given date" do
+            created_since = 5.days.ago.iso8601
+            get "/api/v3/participants/npq/outcomes", params: { filter: { created_since: } }
+            expect(response.status).to eq 200
+            expect(parsed_response).to eq(expected_response)
+          end
+        end
       end
 
       it "can return paginated data" do

--- a/spec/services/api/v1/participant_outcomes_query_spec.rb
+++ b/spec/services/api/v1/participant_outcomes_query_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe Api::V1::ParticipantOutcomesQuery do
   let(:provider_declaration) { create_declaration }
-  let!(:provider_outcomes) { create_outcomes(provider_declaration) }
+  let!(:provider_outcomes) { create_outcomes(provider_declaration, date: 3.days.ago) }
   let(:other_provider_declaration) { create_declaration }
-  let!(:other_provider_outcomes) { create_outcomes(other_provider_declaration) }
+  let!(:other_provider_outcomes) { create_outcomes(other_provider_declaration, date: 2.days.ago) }
 
   describe "#scope" do
     context "for lead provider only" do
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::ParticipantOutcomesQuery do
 
       it "returns outcomes across multiple declarations" do
         other_provider_declaration.update!(cpd_lead_provider: provider_declaration.cpd_lead_provider)
-        expect(index.scope.to_a).to eq(provider_outcomes.append(other_provider_outcomes).flatten)
+        expect(index.scope.to_a).to eq(provider_outcomes + other_provider_outcomes)
       end
     end
 
@@ -36,7 +36,48 @@ RSpec.describe Api::V1::ParticipantOutcomesQuery do
 
       it "does not return outcomes for other participants" do
         provider_declaration.update!(participant_profile: other_provider_declaration.participant_profile)
-        expect(index.scope.to_a).to eq([])
+        expect(index.scope.to_a).to be_empty
+      end
+    end
+
+    context "when created_since filter is supplied" do
+      let!(:early_provider_outcomes) { create_outcomes(provider_declaration, date: 3.weeks.ago) }
+
+      subject!(:index) do
+        described_class.new(
+          cpd_lead_provider: provider_declaration.cpd_lead_provider,
+          params: { filter: { created_since: } },
+        )
+      end
+
+      context "when created_since is earlier than all outcomes" do
+        let(:created_since) { (3.weeks + 1.day).ago.iso8601 }
+
+        it { expect(index.scope.to_a).to eq(early_provider_outcomes + provider_outcomes) }
+      end
+
+      context "when created_since is later than some outcomes" do
+        let(:created_since) { 2.weeks.ago.iso8601 }
+
+        it { expect(index.scope.to_a).to eq(provider_outcomes) }
+      end
+
+      context "when created_since is later than all outcomes" do
+        let(:created_since) { 1.day.from_now.iso8601 }
+
+        it { expect(index.scope.to_a).to be_empty }
+      end
+
+      context "when the created_since is a URL encoded iso8601 date" do
+        let(:created_since) { CGI.escape(2.weeks.ago.iso8601) }
+
+        it { expect(index.scope.to_a).to eq(provider_outcomes) }
+      end
+
+      context "when created_since is not a valid date" do
+        let(:created_since) { "yesterday" }
+
+        it { expect { index.scope }.to raise_error(Api::Errors::InvalidDatetimeError, "The filter '#/created_since' must be a valid RCF3339 date") }
       end
     end
   end
@@ -51,11 +92,13 @@ private
            cpd_lead_provider: provider)
   end
 
-  def create_outcomes(declaration)
-    [
-      create(:participant_outcome, :failed, participant_declaration: declaration),
-      create(:participant_outcome, :passed, participant_declaration: declaration),
-      create(:participant_outcome, :voided, participant_declaration: declaration),
-    ]
+  def create_outcomes(declaration, date: Time.zone.now)
+    travel_to(date) do
+      [
+        create(:participant_outcome, :failed, participant_declaration: declaration),
+        create(:participant_outcome, :passed, participant_declaration: declaration),
+        create(:participant_outcome, :voided, participant_declaration: declaration),
+      ]
+    end
   end
 end

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -896,6 +896,18 @@
         ],
         "parameters": [
           {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NPQOutcomeFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine participant outcomes to return.",
+            "example": "filter[created_since]=2020-11-13T11:21:55Z"
+          },
+          {
             "name": "page",
             "in": "query",
             "schema": {
@@ -5250,6 +5262,17 @@
             "description": "Return only records for the given cohort",
             "type": "string",
             "example": "2022"
+          }
+        }
+      },
+      "NPQOutcomeFilter": {
+        "description": "Filter NPQ outcomes to return more specific results",
+        "type": "object",
+        "properties": {
+          "created_since": {
+            "description": "Return only records that have been created since this date and time (ISO 8601 date format)",
+            "type": "string",
+            "example": "2021-05-13T11:21:55Z"
           }
         }
       },

--- a/swagger/v1/component_schemas/NPQOutcomeFilter.yml
+++ b/swagger/v1/component_schemas/NPQOutcomeFilter.yml
@@ -1,0 +1,7 @@
+description: "Filter NPQ outcomes to return more specific results"
+type: object
+properties:
+  created_since:
+    description: "Return only records that have been created since this date and time (ISO 8601 date format)"
+    type: string
+    example: "2021-05-13T11:21:55Z"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -948,6 +948,18 @@
         ],
         "parameters": [
           {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NPQOutcomeFilter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine participant outcomes to return.",
+            "example": "filter[created_since]=2020-11-13T11:21:55Z"
+          },
+          {
             "name": "page",
             "in": "query",
             "schema": {
@@ -5253,6 +5265,17 @@
             "description": "Return only records for the given cohort",
             "type": "string",
             "example": "2022"
+          }
+        }
+      },
+      "NPQOutcomeFilter": {
+        "description": "Filter NPQ outcomes to return more specific results",
+        "type": "object",
+        "properties": {
+          "created_since": {
+            "description": "Return only records that have been created since this date and time (ISO 8601 date format)",
+            "type": "string",
+            "example": "2021-05-13T11:21:55Z"
           }
         }
       },

--- a/swagger/v2/component_schemas/NPQOutcomeFilter.yml
+++ b/swagger/v2/component_schemas/NPQOutcomeFilter.yml
@@ -1,0 +1,7 @@
+description: "Filter NPQ outcomes to return more specific results"
+type: object
+properties:
+  created_since:
+    description: "Return only records that have been created since this date and time (ISO 8601 date format)"
+    type: string
+    example: "2021-05-13T11:21:55Z"

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -1001,7 +1001,7 @@
             "explode": true,
             "required": false,
             "description": "Refine participant outcomes to return.",
-            "example": "filter[cohort]=2022&filter[created_since]=2020-11-13T11:21:55Z"
+            "example": "filter[created_since]=2020-11-13T11:21:55Z"
           },
           {
             "name": "page",

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -995,7 +995,7 @@
             "name": "filter",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListFilter"
+              "$ref": "#/components/schemas/NPQOutcomeFilter"
             },
             "style": "deepObject",
             "explode": true,
@@ -6923,6 +6923,17 @@
             "description": "Return only records for the given cohort",
             "type": "string",
             "example": "2022"
+          }
+        }
+      },
+      "NPQOutcomeFilter": {
+        "description": "Filter NPQ outcomes to return more specific results",
+        "type": "object",
+        "properties": {
+          "created_since": {
+            "description": "Return only records that have been created since this date and time (ISO 8601 date format)",
+            "type": "string",
+            "example": "2021-05-13T11:21:55Z"
           }
         }
       },

--- a/swagger/v3/component_schemas/NPQOutcomeFilter.yml
+++ b/swagger/v3/component_schemas/NPQOutcomeFilter.yml
@@ -1,0 +1,7 @@
+description: "Filter NPQ outcomes to return more specific results"
+type: object
+properties:
+  created_since:
+    description: "Return only records that have been created since this date and time (ISO 8601 date format)"
+    type: string
+    example: "2021-05-13T11:21:55Z"


### PR DESCRIPTION
[Jira-2145](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2145)

### Context

We want to allow providers to filter NPQ outcomes by the `created_at` date.

### Changes proposed in this pull request

- Allow filtering NPW outcomes by `created_at`

Update query to support filtering by `created_since` and permit filter parameters in controller.

### Guidance to review

