### PR TITLE
Move important date definitions to Cohort entity

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -46,7 +46,7 @@ module Admin
     end
 
     def cohort
-      @cohort ||= Cohort.find_by(start_year: 2023)
+      @cohort ||= Cohort.current
     end
   end
 end

--- a/app/controllers/admin/schools/cohorts_controller.rb
+++ b/app/controllers/admin/schools/cohorts_controller.rb
@@ -11,8 +11,7 @@ module Admin
           .joins(:school)
           .where(school: @school)
 
-        # We do not display the 2020 cohort, because it is non-standard
-        @cohorts = Cohort.where.not(start_year: 2020).where(start_year: ..Cohort.active_registration_cohort.start_year).order(start_year: :asc)
+        @cohorts = Cohort.current_national_rollout_year.order(start_year: :asc)
       end
 
     private

--- a/app/controllers/concerns/api_filter.rb
+++ b/app/controllers/concerns/api_filter.rb
@@ -45,6 +45,6 @@ private
   def with_cohorts
     return Cohort.find_by(start_year: filter[:cohort]) if filter[:cohort].present?
 
-    Cohort.where("start_year > 2020")
+    Cohort.national_rollout_year
   end
 end

--- a/app/forms/appropriate_body_selection_form.rb
+++ b/app/forms/appropriate_body_selection_form.rb
@@ -6,7 +6,7 @@ class AppropriateBodySelectionForm
   include ActiveModel::Serialization
 
   TYPES = [
-    OpenStruct.new(id: "local_authority", name: "Local authority", disable_from_year: 2023),
+    OpenStruct.new(id: "local_authority", name: "Local authority", disable_from_year: Cohort::LAST_LOCAL_AUTHORITY_AB_YEAR),
     OpenStruct.new(id: "national", name: "National organisation", disable_from_year: nil),
     OpenStruct.new(id: "teaching_school_hub", name: "Teaching school hub", disable_from_year: nil),
   ].freeze

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -235,7 +235,7 @@ module Schools
       def needs_to_confirm_start_term?
         # are we in the next registration period (or pre-registration period) and the participant does not have
         # an induction start date
-        (mentor_participant? || induction_start_date.blank?) && !Cohort.within_automatic_assignment_period?
+        (mentor_participant? || induction_start_date.blank?) && !Cohort.within_ecf_automatic_assignment_period?
       end
 
       ## appropriate bodies
@@ -375,7 +375,7 @@ module Schools
           Cohort.containing_date(induction_start_date).tap do |cohort|
             return Cohort.current if cohort.blank? || cohort.npq_plus_one_or_earlier?
           end
-        elsif Cohort.within_automatic_assignment_period?
+        elsif Cohort.within_ecf_automatic_assignment_period?
           # true from 1/9 to end of automatic assignment period
           Cohort.current
         elsif start_term == "summer"

--- a/app/forms/schools/add_participants/who_to_add_wizard.rb
+++ b/app/forms/schools/add_participants/who_to_add_wizard.rb
@@ -44,7 +44,7 @@ module Schools
 
         return true if desired_cohort.start_year <= Cohort.current.start_year
 
-        if Cohort.within_next_registration_period? && desired_cohort == Cohort.next
+        if Cohort.within_next_ecf_registration_period? && desired_cohort == Cohort.next
           FeatureFlag.active?(:cohortless_dashboard, for: school)
         else
           false

--- a/app/forms/schools/add_participants/wizard_steps/start_date_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/start_date_step.rb
@@ -32,7 +32,7 @@ module Schools
           # This could be dynamic based on Cohort.registration_start_date but the ask on the ticket is for
           # a temporary stop to prevent registrations
           if FeatureFlag.active? :prevent_2023_ect_registrations
-            wizard.ect_participant? && start_date >= Date.new(2023, 9, 1)
+            wizard.ect_participant? && start_date >= Cohort::COHORTLESS_RELEASE_DATE
           else
             false
           end
@@ -45,7 +45,7 @@ module Schools
             begin
               @start_date = Date.parse (1..3).map { |n| start_date[n] }.join("/")
 
-              unless start_date.between?(Date.new(2021, 9, 1), Date.current + 1.year)
+              unless Cohort.valid_national_rollout_date?(start_date)
                 errors.add(:start_date, :invalid)
               end
             rescue Date::Error

--- a/app/forms/schools/add_participants/wizard_steps/start_term_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/start_term_step.rb
@@ -47,14 +47,14 @@ module Schools
       private
 
         def start_term_in_registration_scope?
-          return true if Cohort.within_next_registration_period? && FeatureFlag.active?(:cohortless_dashboard, for: wizard.school)
+          return true if Cohort.within_next_ecf_registration_period? && FeatureFlag.active?(:cohortless_dashboard, for: wizard.school)
           return true if cannot_automatically_determine_cohort? && start_term == "summer"
 
           false
         end
 
         def cannot_automatically_determine_cohort?
-          !Cohort.within_automatic_assignment_period?
+          !Cohort.within_ecf_automatic_assignment_period?
         end
       end
     end

--- a/app/forms/schools/cohorts/setup_wizard/success.rb
+++ b/app/forms/schools/cohorts/setup_wizard/success.rb
@@ -98,7 +98,7 @@ module Schools
         end
 
         def should_send_the_pilot_survey?
-          cohort.start_year == 2023 && FeatureFlag.active?(:cohortless_dashboard, for: school) &&
+          cohort.start_year == Cohort::COHORTLESS_RELEASE_YEAR && FeatureFlag.active?(:cohortless_dashboard, for: school) &&
             expect_any_ects? && current_user.induction_coordinator?
         end
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
   end
 
   def participant_start_path(user)
-    return participants_no_access_path unless post_2020_ecf_participant?(user)
+    return participants_no_access_path unless ecf_national_rollout_participant?(user)
 
     participants_validation_path
   end
@@ -84,8 +84,8 @@ module ApplicationHelper
 
 private
 
-  def post_2020_ecf_participant?(user)
-    user.teacher_profile.ecf_profiles.where.not(cohort: Cohort.find_by(start_year: 2020)).any?
+  def ecf_national_rollout_participant?(user)
+    user.teacher_profile.ecf_profiles.where(cohort: Cohort.national_rollout_year).any?
   end
 
   def school_dashboard_with_tab_path(school)

--- a/app/models/school_cohort.rb
+++ b/app/models/school_cohort.rb
@@ -56,7 +56,7 @@ class SchoolCohort < ApplicationRecord
   def self.dashboard_for_school(school:, latest_year:)
     joins(:cohort)
       .where(school:)
-      .merge(Cohort.between_2021_and(latest_year))
+      .merge(Cohort.in_national_roll_out(latest_year))
       .order(start_year: :desc)
       .limit(3)
   end

--- a/app/services/api/v1/ecf/participants_query.rb
+++ b/app/services/api/v1/ecf/participants_query.rb
@@ -64,7 +64,7 @@ module Api
         def with_cohorts
           return Cohort.where(start_year: filter[:cohort].split(",")) if filter[:cohort].present?
 
-          Cohort.where("start_year > 2020")
+          Cohort.national_rollout_year
         end
 
         def updated_since

--- a/app/services/api/v3/delivery_partners_query.rb
+++ b/app/services/api/v3/delivery_partners_query.rb
@@ -30,7 +30,7 @@ module Api
       def with_cohorts
         return Cohort.where(start_year: filter[:cohort].split(",")) if filter[:cohort].present?
 
-        Cohort.where("start_year > 2020")
+        Cohort.national_rollout_year
       end
     end
   end

--- a/app/services/api/v3/ecf/participants_query.rb
+++ b/app/services/api/v3/ecf/participants_query.rb
@@ -71,7 +71,7 @@ module Api
         def with_cohorts
           return Cohort.where(start_year: filter[:cohort].split(",")) if filter[:cohort].present?
 
-          Cohort.where("start_year > 2020")
+          Cohort.national_rollout_year
         end
 
         def updated_since

--- a/app/services/api/v3/ecf/partnerships_query.rb
+++ b/app/services/api/v3/ecf/partnerships_query.rb
@@ -55,7 +55,7 @@ module Api
         def with_cohorts
           return Cohort.where(start_year: filter[:cohort].split(",")) if filter[:cohort].present?
 
-          Cohort.where("start_year > 2020")
+          Cohort.national_rollout_year
         end
       end
     end

--- a/app/services/api/v3/finance/statements_query.rb
+++ b/app/services/api/v3/finance/statements_query.rb
@@ -40,7 +40,7 @@ module Api
         def with_cohorts
           return Cohort.where(start_year: filter[:cohort].split(",")) if filter[:cohort].present?
 
-          Cohort.where("start_year > 2020")
+          Cohort.national_rollout_year
         end
 
         def statement_class

--- a/app/services/api/v3/npq_applications_query.rb
+++ b/app/services/api/v3/npq_applications_query.rb
@@ -89,7 +89,7 @@ module Api
         cohorts = if cohort_filter.present?
                     Cohort.where(start_year: cohort_filter.split(","))
                   else
-                    Cohort.where("start_year > 2020")
+                    Cohort.national_rollout_year
                   end
 
         scope.where(cohort: cohorts)

--- a/app/services/induction/amend_participant_cohort.rb
+++ b/app/services/induction/amend_participant_cohort.rb
@@ -14,26 +14,24 @@ module Induction
       end
     end
 
-    ECF_FIRST_YEAR = 2020
-
     attr_accessor :participant_profile, :source_cohort_start_year, :target_cohort_start_year
 
     validates :source_cohort_start_year,
               numericality: {
                 only_integer: true,
-                greater_than_or_equal_to: ECF_FIRST_YEAR,
+                greater_than_or_equal_to: Cohort::EARLY_ROLLOUT_LAST_YEAR,
                 less_than_or_equal_to: Date.current.year,
                 message: :invalid,
-                start: ECF_FIRST_YEAR,
+                start: Cohort::EARLY_ROLLOUT_LAST_YEAR,
                 end: Date.current.year,
               }
     validates :target_cohort_start_year,
               numericality: {
                 only_integer: true,
-                greater_than_or_equal_to: ECF_FIRST_YEAR,
+                greater_than_or_equal_to: Cohort::EARLY_ROLLOUT_LAST_YEAR,
                 less_than_or_equal_to: Date.current.year,
                 message: :invalid,
-                start: ECF_FIRST_YEAR,
+                start: Cohort::EARLY_ROLLOUT_LAST_YEAR,
                 end: Date.current.year,
               }
     validates :target_cohort,

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -42,8 +42,7 @@ private
     return true if validation_data.induction_completion_date.present?
     return false if validation_data.induction_start_date.nil?
 
-    # this should always be a check against 2021 not Cohort.current.start_year
-    validation_data.induction_start_date < ActiveSupport::TimeZone["London"].local(2021, 9, 1)
+    validation_data.induction_start_date < Cohort::NATIONAL_ROLLOUT_START_DATE
   end
 
   def check_first_name_only?

--- a/app/views/admin/participants/change_cohort/edit.html.erb
+++ b/app/views/admin/participants/change_cohort/edit.html.erb
@@ -7,7 +7,7 @@
 
       <%= f.govuk_collection_select(
         :target_cohort_start_year,
-        Cohort.where(start_year: 2021..Cohort.active_registration_cohort.start_year),
+        Cohort.current_national_rollout_year,
         :start_year,
         :start_year,
         label: { text: "Change #{@participant_profile.user.full_name}'s cohort", tag: "h1", size: "l" },

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -8,7 +8,7 @@
     <span class="govuk-caption-l"><%= @ecf_lead_provider.name %></span>
     <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 
-    <%= render Finance::Statements::ECFStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
+    <%= render Finance::Statements::ECFStatementSelector.new(current_statement: @statement, cohorts: Cohort.national_rollout_year) %>
   </div>
 </div>
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -7,7 +7,7 @@
     <span class="govuk-caption-l"><%= @statement.cpd_lead_provider.name %></span>
     <h2 class="govuk-heading-l"><%= @statement.name %></h2>
 
-    <%= render Finance::Statements::NPQStatementSelector.new(current_statement: @statement, cohorts: Cohort.where(start_year: 2021..)) %>
+    <%= render Finance::Statements::NPQStatementSelector.new(current_statement: @statement, cohorts: Cohort.national_rollout_year) %>
 
     <div class="app-application__panel__summary">
       <div class="govuk-!-margin-right-4">

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -101,9 +101,9 @@ end %>
   <li>A confirmation email will also be sent to schools:</li>
 </ul>
 
-<%= render GovukComponent::InsetTextComponent.new(text: 'Hello,<br/>
+<%= render GovukComponent::InsetTextComponent.new(text: "Hello,<br/>
     <br/>
-    <code>&lt;Delivery partner name&gt;</code>, with <code>&lt;Lead provider name&gt;</code>, has confirmed they will be delivering an induction programme to early career teachers at <code>&lt;School name&gt;</code>, starting in 2021.<br/>
+    <code>&lt;Delivery partner name&gt;</code>, with <code>&lt;Lead provider name&gt;</code>, has confirmed they will be delivering an induction programme to early career teachers at <code>&lt;School name&gt;</code>, starting in #{Cohort::NATIONAL_ROLLOUT_FIRST_YEAR}.<br/>
 
     <h3>If this is a mistake</h3>
 
@@ -111,7 +111,7 @@ end %>
     <br/>
     <code>&lt;URL&gt;</code><br/>
     <br/>
-    This link will expire in 14 days'.html_safe)
+    This link will expire in 14 days".html_safe)
 %>
 
 

--- a/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
+++ b/app/views/schools/add_participants/eligibility_confirmation/_previous_induction.html.erb
@@ -1,7 +1,7 @@
 <p class="govuk-body"><%= profile.user.full_name %> is not eligible for the early career teacher training programme</p>
 
 <h2 class="govuk-heading-m">Why?</h2>
-<p class="govuk-body">Our records show they started or completed their statutory induction before 1 September 2021. Teachers are only eligible for the new 2-year funded training if they started their induction after that date.</p>
+<p class="govuk-body">Our records show they started or completed their statutory induction before <%= Cohort::NATIONAL_ROLLOUT_START_DATE.strftime("%d %B %Y") %>. Teachers are only eligible for the new 2-year funded training if they started their induction after that date.</p>
 
 <h2 class="govuk-heading-m">What to do if that start date is incorrect</h2>
 <p class="govuk-body">Contact your appropriate body and ask them to update the TRA records with the correct date. This should be the date their induction training formally began, which may be different to their contract start date.</p>

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Changing participant details from check answers", type: :feature
     and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
 
     # FIXME: only before 2023 cohort?
-    and_i_add_start_term_to_the_school_add_participant_wizard @participant_data[:start_term] if Cohort.within_next_registration_period?
+    and_i_add_start_term_to_the_school_add_participant_wizard @participant_data[:start_term] if Cohort.within_next_ecf_registration_period?
 
     and_i_choose_mentor_later_on_the_school_add_participant_wizard
     then_i_am_taken_to_check_details_page
@@ -73,7 +73,7 @@ RSpec.describe "Changing participant details from check answers", type: :feature
     and_i_add_email_address_to_the_school_add_participant_wizard "Sally Teacher", @participant_data[:email]
 
     # FIXME: only before 2023 cohort?
-    and_i_add_start_term_to_the_school_add_participant_wizard @participant_data[:start_term] if Cohort.within_next_registration_period?
+    and_i_add_start_term_to_the_school_add_participant_wizard @participant_data[:start_term] if Cohort.within_next_ecf_registration_period?
 
     then_i_am_taken_to_add_mentor_page
     then_the_page_should_be_accessible

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe Cohort, type: :model do
       end
     end
 
-    describe ".between_2021_and" do
+    describe ".in_national_roll_out" do
       it "generates a BETWEEN clause with 2021 and the given year" do
         expected = %(WHERE "cohorts"."start_year" BETWEEN 2021 AND 2030)
-        expect(Cohort.between_2021_and(2030).to_sql).to include(expected)
+        expect(Cohort.in_national_roll_out(2030).to_sql).to include(expected)
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe Cohort, type: :model do
     context "when the current time is after the registration start date for then next cohort" do
       it "returns true" do
         Timecop.freeze(Date.new(2023, 7, 1)) do
-          expect(Cohort).to be_within_next_registration_period
+          expect(Cohort).to be_within_next_ecf_registration_period
         end
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe Cohort, type: :model do
     context "when the active_registration_cohort and the current cohort are the same" do
       it "returns false" do
         Timecop.freeze(Date.new(2023, 9, 1)) do
-          expect(Cohort).not_to be_within_next_registration_period
+          expect(Cohort).not_to be_within_next_ecf_registration_period
         end
       end
     end
@@ -149,11 +149,11 @@ RSpec.describe Cohort, type: :model do
     end
   end
 
-  describe ".active_registration_cohort" do
+  describe ".active_ecf_registration_cohort" do
     describe "when the current date matches the registration start date" do
       it "returns the cohort with start_year the current year" do
         Timecop.freeze(Cohort.find_by(start_year: 2022).registration_start_date) do
-          expect(Cohort.active_registration_cohort.start_year).to eq 2022
+          expect(Cohort.active_ecf_registration_cohort.start_year).to eq 2022
         end
       end
     end

--- a/spec/models/district_sparsity_spec.rb
+++ b/spec/models/district_sparsity_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DistrictSparsity, type: :model do
 
   describe ":latest" do
     let!(:current_sparsity) { create(:district_sparsity) }
-    let!(:previous_sparsity) { create(:district_sparsity, start_year: 2019, end_year: 2020) }
+    let!(:previous_sparsity) { create(:district_sparsity, start_year: 3033, end_year: 3033) }
 
     it "includes current sparsity" do
       expect(DistrictSparsity.latest).to include(current_sparsity)

--- a/spec/requests/admin/schools/cohorts_spec.rb
+++ b/spec/requests/admin/schools/cohorts_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Admin::Schools::Cohorts", type: :request do
       get "/admin/schools/#{school.id}/cohorts"
       expect(response).to render_template("admin/schools/cohorts/index")
       expect(assigns(:school_cohorts)).to match_array school.school_cohorts
-      Cohort.where.not(start_year: 2020).each do |cohort|
+      Cohort.national_rollout_year.each do |cohort|
         expect(response.body).to include cohort.start_year.to_s
       end
     end


### PR DESCRIPTION
### Context

Dates are currently added directly to service and controllers without any description of the significance they hold.

### Changes proposed in this pull request

- move key date definitions to the cohort entity as constants to be reused
- rename certain cohort identification methods to include ECF

### Guidance to review

