### PR TITLE
[CPDLP-1928] Ensure NPQ users cannot defer an NPQ participant that has no declarations

### DIFF
--- a/app/services/defer_participant.rb
+++ b/app/services/defer_participant.rb
@@ -25,6 +25,7 @@ class DeferParticipant
             }
   validate :not_already_deferred
   validate :not_already_withdrawn
+  validate :do_not_defer_if_without_declarations
 
   def call
     ActiveRecord::Base.transaction do
@@ -59,6 +60,15 @@ class DeferParticipant
   end
 
 private
+
+  def do_not_defer_if_without_declarations
+    return unless participant_profile&.npq?
+    return unless participant_profile.npq_application.accepted?
+
+    if participant_profile.participant_declarations.empty?
+      errors.add(:participant_profile, I18n.t(:invalid_deferral_no_declarations))
+    end
+  end
 
   def not_already_deferred
     return unless participant_profile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
   invalid_withdrawal: The participant is already withdrawn
   invalid_resume: Cannot resume a withdrawn participant
   invalid_deferral: The participant is already deferred
+  invalid_deferral_no_declarations: You cannot defer an NPQ participant that has no declarations
   invalid_event: "The property '#/declaration_type' must be a valid declaration type"
   invalid_course: "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again."
   invalid_evidence_type: "Enter an available '#/evidence_held' type for this participant's event and course."
@@ -468,6 +469,7 @@ en:
           attributes:
             training_status:
               inclusion: Choose a valid training status
+              invalid_deferral_no_declarations: You cannot defer an NPQ participant that has no declarations
             reason:
               inclusion: Choose a valid reason for training status
         finance/npq/change_lead_provider_form:

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 12th July 2023
+
+DfE has changed functionality around the endpoint `PUT /api/v1/participants/npq/{id}/defer`
+
+Providers may not defer an NPQ participant unless the participant has at least a `started` declaration and which has not been voided. This is in line with the NPQ withdrawal endpoint and contractual requirements. The change applies to all versions of the API.
+
+If a provider wishes to defer a participant without a started declaration then they should contact the DfE which can undo the application.
+
 ## 7th July 2023
 
 Providers can now see the name of the lead provider which submitted a given declaration. Providers can find more detail on the new attribute `lead_provider_name` in the [v3 specification](/api-reference/reference-v3.html#schema-participantdeclarationresponse).

--- a/spec/forms/finance/npq/change_training_status_form_spec.rb
+++ b/spec/forms/finance/npq/change_training_status_form_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe Finance::NPQ::ChangeTrainingStatusForm, type: :model do
   describe "NPQ" do
     let(:user) { create(:participant_identity, :secondary).user }
     let(:participant_profile) { create(:npq_participant_profile, user:, training_status: "active") }
-    let(:params) { { participant_profile:, training_status: "deferred", reason: "bereavement" } }
+    let(:params) { { participant_profile:, training_status: "withdrawn", reason: "insufficient-capacity-to-undertake-programme" } }
 
     it { is_expected.to validate_inclusion_of(:training_status).in_array(ParticipantProfile.training_statuses.values) }
-    it { is_expected.to validate_inclusion_of(:reason).in_array(ParticipantProfile::DEFERRAL_REASONS) }
+    it { is_expected.to validate_inclusion_of(:reason).in_array(ParticipantProfile::NPQ::WITHDRAW_REASONS) }
 
     describe ".save" do
       context "valid params" do
         it "should change training status" do
           expect(form.save).to be true
-          expect(participant_profile.reload.training_status).to eql("deferred")
+          expect(participant_profile.reload.training_status).to eql("withdrawn")
         end
       end
 
@@ -25,6 +25,30 @@ RSpec.describe Finance::NPQ::ChangeTrainingStatusForm, type: :model do
         it "should not change training status" do
           expect(form.save).to be false
           expect(participant_profile.reload.training_status).to eql("active")
+        end
+      end
+
+      context "defer" do
+        let(:params) { { participant_profile:, training_status: "deferred", reason: "bereavement" } }
+
+        describe "without declarations" do
+          it "is invalid returning an error message" do
+            expect(participant_profile.participant_declarations).to be_empty
+            expect(form.save).to be false
+            expect(form.errors.messages_for(:training_status)).to include("You cannot defer an NPQ participant that has no declarations")
+          end
+        end
+
+        describe "with a declaration" do
+          before do
+            create(:npq_participant_declaration, participant_profile:, cpd_lead_provider: participant_profile.npq_application.npq_lead_provider.cpd_lead_provider)
+          end
+
+          it "should be valid" do
+            expect(participant_profile.participant_declarations).to_not be_empty
+            expect(form.save).to be true
+            expect(participant_profile.reload.training_status).to eql("deferred")
+          end
         end
       end
     end

--- a/spec/services/defer_participant_spec.rb
+++ b/spec/services/defer_participant_spec.rb
@@ -240,6 +240,25 @@ RSpec.describe DeferParticipant do
           expect(service.errors.messages_for(:participant_id)).to include("Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.")
         end
       end
+
+      describe "without declarations" do
+        it "is invalid returning an error message" do
+          expect(participant_profile.participant_declarations).to be_empty
+          is_expected.to be_invalid
+          expect(service.errors.messages_for(:participant_profile)).to include("You cannot defer an NPQ participant that has no declarations")
+        end
+      end
+
+      describe "with a declaration" do
+        before do
+          create(:npq_participant_declaration, participant_profile:, cpd_lead_provider:)
+        end
+
+        it "should be valid" do
+          is_expected.to be_valid
+          expect(service.errors).to be_blank
+        end
+      end
     end
 
     describe ".call" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-1928

### Changes proposed in this pull request

* Added validation to `DeferParticipant` service.
* Added validation to `Finance::NPQ::ChangeTrainingStatusForm`
* Updated release notes.

### Guidance to review

