### PR TITLE
Redirect to admin overview path when signing in

### DIFF
--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -28,7 +28,7 @@ class ChooseRoleForm
     when "change_role"
       helpers.contact_support_choose_role_path
     when "admin"
-      helpers.admin_schools_path
+      helpers.admin_path
     when "finance"
       helpers.finance_landing_page_path
     when "delivery_partner"

--- a/spec/forms/choose_role_form_spec.rb
+++ b/spec/forms/choose_role_form_spec.rb
@@ -94,14 +94,14 @@ RSpec.describe ChooseRoleForm, type: :model do
 
       describe "param with admin role" do
         let(:form_role) { "admin" }
-        let(:helpers) { Struct.new(:admin_schools_path).new("/admins") }
+        let(:helpers) { Struct.new(:admin_path).new("/admin") }
 
         it "should be valid" do
           expect(form.valid?).to be true
         end
 
         it "returns correct redirect_path" do
-          expect(form.redirect_path(helpers:)).to be helpers.admin_schools_path
+          expect(form.redirect_path(helpers:)).to be helpers.admin_path
         end
       end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe "Users::Sessions", type: :request do
       it "redirects to correct dashboard" do
         post "/users/sign_in_with_token", params: { login_token: user.login_token }
         follow_redirect!
-        expect(response).to redirect_to(admin_schools_path)
+        expect(response).to redirect_to(admin_path)
       end
     end
 

--- a/spec/support/features/pages/admin_support/admin_support_portal.rb
+++ b/spec/support/features/pages/admin_support/admin_support_portal.rb
@@ -4,8 +4,8 @@ require_relative "../base_page"
 
 module Pages
   class AdminSupportPortal < ::Pages::BasePage
-    set_url "/admin/schools"
-    set_primary_heading "Schools"
+    set_url "/admin"
+    set_primary_heading "Overview"
 
     def view_participant_list
       click_on "Participants"


### PR DESCRIPTION
When signing in as an admin, it now makes sense to start on the Overview page.