### PR TITLE
Allow filtering NPQ/ECF participants by training_status

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -13,6 +13,7 @@ module Api
     rescue_from ActiveRecord::RecordInvalid, with: :invalid_transition
     rescue_from Api::Errors::InvalidTransitionError, with: :invalid_transition
     rescue_from Api::Errors::InvalidDatetimeError, with: :invalid_updated_since_response
+    rescue_from Api::Errors::InvalidTrainingStatusError, with: :invalid_training_status_response
     rescue_from Pagy::VariableError, with: :invalid_pagination_response
 
     def append_info_to_payload(payload)
@@ -53,6 +54,10 @@ module Api
     end
 
     def invalid_updated_since_response(exception)
+      render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
+    end
+
+    def invalid_training_status_response(exception)
       render json: { errors: Api::ParamErrorFactory.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
     end
 

--- a/app/controllers/api/errors/invalid_training_status_error.rb
+++ b/app/controllers/api/errors/invalid_training_status_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Api
+  module Errors
+    class InvalidTrainingStatusError < StandardError; end
+  end
+end

--- a/app/controllers/api/v3/ecf/participants_controller.rb
+++ b/app/controllers/api/v3/ecf/participants_controller.rb
@@ -45,8 +45,8 @@ module Api
 
         def ecf_participant_params
           params
-            .with_defaults({ sort: "", filter: { cohort: "", updated_since: "" } })
-            .permit(:id, :sort, filter: %i[cohort updated_since])
+            .with_defaults({ sort: "", filter: { cohort: "", updated_since: "", training_status: "" } })
+            .permit(:id, :sort, filter: %i[cohort updated_since training_status])
         end
 
         def ecf_participant_query

--- a/app/controllers/api/v3/npq_participants_controller.rb
+++ b/app/controllers/api/v3/npq_participants_controller.rb
@@ -24,8 +24,8 @@ module Api
 
       def npq_participant_params
         params
-          .with_defaults({ sort: "", filter: { updated_since: "" } })
-          .permit(:id, :sort, filter: %i[updated_since])
+          .with_defaults({ sort: "", filter: { updated_since: "", training_status: "" } })
+          .permit(:id, :sort, filter: %i[updated_since training_status])
       end
 
       def serializer_class

--- a/app/services/api/v3/concerns/filter_training_status.rb
+++ b/app/services/api/v3/concerns/filter_training_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Api::V3::Concerns::FilterTrainingStatus
+  extend ActiveSupport::Concern
+
+protected
+
+  def filter
+    params[:filter] ||= {}
+  end
+
+  def training_status_filter
+    filter[:training_status].to_s
+  end
+
+  def training_status
+    return if training_status_filter.blank?
+
+    unless training_status_filter.in?(valid_training_status)
+      raise Api::Errors::InvalidTrainingStatusError, I18n.t(:invalid_training_status, valid_training_status:)
+    end
+
+    training_status_filter
+  end
+
+  def valid_training_status
+    ParticipantProfile.training_statuses.keys
+  end
+end

--- a/app/services/api/v3/npq_participants_query.rb
+++ b/app/services/api/v3/npq_participants_query.rb
@@ -4,6 +4,7 @@ module Api
   module V3
     class NPQParticipantsQuery
       include Concerns::FilterUpdatedSince
+      include Concerns::FilterTrainingStatus
 
       attr_reader :npq_lead_provider, :params
 
@@ -15,6 +16,7 @@ module Api
       def participants
         scope = npq_lead_provider.npq_participants.includes(:teacher_profile, npq_profiles: [:npq_course, :participant_profile_states, :participant_identity, { schedule: [:cohort], npq_application: [npq_lead_provider: :cpd_lead_provider] }])
         scope = scope.where("users.updated_at > ?", updated_since) if updated_since_filter.present?
+        scope = scope.where(npq_profiles: { training_status: }) if training_status.present?
         scope = scope.order("npq_profiles.created_at ASC") if params[:sort].blank?
         scope.distinct
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
   invalid_completion_date: "The '#/completion_date' value must be in the following format: 'yyyy-mm-dd'"
   invalid_updated_since_filter: "The filter '#/updated_since' must be a valid RCF3339 date"
   invalid_created_since_filter: "The filter '#/created_since' must be a valid RCF3339 date"
+  invalid_training_status: "The filter '#/training_status' must be %{valid_training_status}"
   future_date: "The '#/%{attribute}' value cannot be a future date. Check the date and try again."
   future_date_outcomes: "The attribute '#/%{attribute}' cannot contain a future date. Resubmit the outcome update with a valid date."
   mismatch_declaration_type_for_schedule: "The property '#/declaration_type' does not exist for this schedule."

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -15,6 +15,13 @@ Providers may now filter outcomes by created_since date. For example:
 
 The change applies to all API versions.
 
+Providers can now filter ECF and NPQ participants by training_status, for example: 
+
+* GET /api/v3/participants/ecf?filter[training_status]=deferred
+* GET /api/v3/participants/npq?filter[training_status]=active
+
+The filter is optional and only applies to v3 of the API. More detail is available in the [NPQ](/api-reference/reference-v3.html#api-v3-participants-npq-get) and [ECF](/api-reference/reference-v3.html#api-v3-participants-ecf-get) specifications.
+
 ## 12th July 2023
 
 DfE has changed functionality around the endpoint `PUT /api/v1/participants/npq/{id}/defer`

--- a/spec/docs/v3/ecf_participants_spec.rb
+++ b/spec/docs/v3/ecf_participants_spec.rb
@@ -25,13 +25,13 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
       parameter name: :filter,
                 in: :query,
                 schema: {
-                  "$ref": "#/components/schemas/ListFilter",
+                  "$ref": "#/components/schemas/ECFParticipantFilter",
                 },
                 style: :deepObject,
                 explode: true,
                 required: false,
                 description: "Refine ECF participants to return.",
-                example: CGI.unescape({ filter: { cohort: 2022, updated_since: "2020-11-13T11:21:55Z" } }.to_param)
+                example: CGI.unescape({ filter: { cohort: 2022, updated_since: "2020-11-13T11:21:55Z", training_status: :active } }.to_param)
 
       parameter name: :page,
                 in: :query,

--- a/spec/docs/v3/npq_participants_spec.rb
+++ b/spec/docs/v3/npq_participants_spec.rb
@@ -23,13 +23,13 @@ describe "API", type: :request, swagger_doc: "v3/api_spec.json" do
       parameter name: :filter,
                 in: :query,
                 schema: {
-                  "$ref": "#/components/schemas/ListFilter",
+                  "$ref": "#/components/schemas/NPQParticipantFilter",
                 },
                 style: :deepObject,
                 explode: true,
                 required: false,
                 description: "Refine NPQ participants to return.",
-                example: CGI.unescape({ filter: { updated_since: "2020-11-13T11:21:55Z" } }.to_param)
+                example: CGI.unescape({ filter: { updated_since: "2020-11-13T11:21:55Z", training_status: :active } }.to_param)
 
       parameter name: :page,
                 in: :query,

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -147,6 +147,20 @@ RSpec.describe "API ECF Participants", type: :request do
           expect(parsed_response["data"].size).to eq(withdrawn_ect_records.count)
         end
 
+        it "returns an error when the training_status is not valid" do
+          get "/api/v3/participants/ecf", params: { filter: { training_status: :invalid } }
+
+          expect(response).to be_bad_request
+          expect(parsed_response).to eql(HashWithIndifferentAccess.new({
+            "errors": [
+              {
+                "title": "Bad request",
+                "detail": %(The filter '#/training_status' must be ["active", "deferred", "withdrawn"]),
+              },
+            ],
+          }))
+        end
+
         context "when updated_since parameter is supplied" do
           it "returns users changed since the updated_since parameter" do
             get "/api/v3/participants/ecf", params: { filter: { updated_since: 1.day.ago.iso8601 } }

--- a/spec/requests/api/v3/ecf/participants_spec.rb
+++ b/spec/requests/api/v3/ecf/participants_spec.rb
@@ -138,6 +138,15 @@ RSpec.describe "API ECF Participants", type: :request do
           expect(parsed_response["data"].last["id"]).to eq ParticipantProfile.order(created_at: :asc).last.user.id
         end
 
+        it "returns matching users when filtering by training_status" do
+          induction_programme = school_cohort.default_induction_programme
+          withdrawn_ect_records = create_list(:induction_record, 2, induction_programme:, training_status: :withdrawn)
+
+          get "/api/v3/participants/ecf", params: { filter: { training_status: :withdrawn } }
+
+          expect(parsed_response["data"].size).to eq(withdrawn_ect_records.count)
+        end
+
         context "when updated_since parameter is supplied" do
           it "returns users changed since the updated_since parameter" do
             get "/api/v3/participants/ecf", params: { filter: { updated_since: 1.day.ago.iso8601 } }

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -70,8 +70,20 @@ RSpec.describe "NPQ Participants API", type: :request do
         context "filtering" do
           before do
             travel_to 10.days.ago do
-              create_list(:npq_application, 3, :accepted, npq_lead_provider:, school_urn: "123456", npq_course:)
+              create_list(:npq_application, 3,
+                          :accepted,
+                          npq_lead_provider:,
+                          school_urn: "123456",
+                          npq_course:).each do |application|
+                application.profile.update!(training_status: :withdrawn)
+              end
             end
+          end
+
+          it "returns correctly when filtering by training_status" do
+            get "/api/v3/participants/npq", params: { filter: { training_status: :withdrawn } }
+
+            expect(parsed_response["data"].size).to eq(3)
           end
 
           it "returns content updated after specified timestamp" do

--- a/spec/requests/api/v3/npq_participants_spec.rb
+++ b/spec/requests/api/v3/npq_participants_spec.rb
@@ -80,10 +80,24 @@ RSpec.describe "NPQ Participants API", type: :request do
             end
           end
 
-          it "returns correctly when filtering by training_status" do
+          it "returns matching users when filtering by training_status" do
             get "/api/v3/participants/npq", params: { filter: { training_status: :withdrawn } }
 
             expect(parsed_response["data"].size).to eq(3)
+          end
+
+          it "returns an error when the training_status is not valid" do
+            get "/api/v3/participants/npq", params: { filter: { training_status: :invalid } }
+
+            expect(response).to be_bad_request
+            expect(parsed_response).to eql(HashWithIndifferentAccess.new({
+              "errors": [
+                {
+                  "title": "Bad request",
+                  "detail": %(The filter '#/training_status' must be ["active", "deferred", "withdrawn"]),
+                },
+              ],
+            }))
           end
 
           it "returns content updated after specified timestamp" do

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -1174,7 +1174,7 @@
             "explode": true,
             "required": false,
             "description": "Refine NPQ participants to return.",
-            "example": "filter[updated_since]=2020-11-13T11:21:55Z&training_status=active"
+            "example": "filter[updated_since]=2020-11-13T11:21:55Z&filter[training_status]=active"
           },
           {
             "name": "page",
@@ -2091,7 +2091,7 @@
             "explode": true,
             "required": false,
             "description": "Refine ECF participants to return.",
-            "example": "filter[cohort]=2022&filter[updated_since]=2020-11-13T11:21:55Z&training_status=active"
+            "example": "filter[cohort]=2022&filter[updated_since]=2020-11-13T11:21:55Z&filter[training_status]=active"
           },
           {
             "name": "page",

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -1168,13 +1168,13 @@
             "name": "filter",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListFilter"
+              "$ref": "#/components/schemas/NPQParticipantFilter"
             },
             "style": "deepObject",
             "explode": true,
             "required": false,
             "description": "Refine NPQ participants to return.",
-            "example": "filter[updated_since]=2020-11-13T11:21:55Z"
+            "example": "filter[updated_since]=2020-11-13T11:21:55Z&training_status=active"
           },
           {
             "name": "page",
@@ -2085,13 +2085,13 @@
             "name": "filter",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/ListFilter"
+              "$ref": "#/components/schemas/ECFParticipantFilter"
             },
             "style": "deepObject",
             "explode": true,
             "required": false,
             "description": "Refine ECF participants to return.",
-            "example": "filter[cohort]=2022&filter[updated_since]=2020-11-13T11:21:55Z"
+            "example": "filter[cohort]=2022&filter[updated_since]=2020-11-13T11:21:55Z&training_status=active"
           },
           {
             "name": "page",
@@ -6910,7 +6910,7 @@
           }
         }
       },
-      "ParticipantListFilter": {
+      "ECFParticipantFilter": {
         "description": "Filter a list of records to return more specific results",
         "type": "object",
         "properties": {
@@ -6923,6 +6923,27 @@
             "description": "Return only records for the given cohort",
             "type": "string",
             "example": "2022"
+          },
+          "training_status": {
+            "description": "Return only records that have this training status",
+            "type": "string",
+            "example": "active"
+          }
+        }
+      },
+      "NPQParticipantFilter": {
+        "description": "Filter a list of records to return more specific results",
+        "type": "object",
+        "properties": {
+          "updated_since": {
+            "description": "Return only records that have been updated since this date and time (ISO 8601 date format)",
+            "type": "string",
+            "example": "2021-05-13T11:21:55Z"
+          },
+          "training_status": {
+            "description": "Return only records that have this training status",
+            "type": "string",
+            "example": "active"
           }
         }
       },

--- a/swagger/v3/component_schemas/ECFParticipantFilter.yml
+++ b/swagger/v3/component_schemas/ECFParticipantFilter.yml
@@ -1,0 +1,15 @@
+description: "Filter a list of records to return more specific results"
+type: object
+properties:
+  updated_since:
+    description: "Return only records that have been updated since this date and time (ISO 8601 date format)"
+    type: :string
+    example: "2021-05-13T11:21:55Z"
+  cohort:
+    description: "Return only records for the given cohort"
+    type: :string
+    example: "2022"
+  training_status:
+    description: "Return only records that have this training status"
+    type: :string
+    example: "active"

--- a/swagger/v3/component_schemas/NPQParticipantFilter.yml
+++ b/swagger/v3/component_schemas/NPQParticipantFilter.yml
@@ -5,7 +5,7 @@ properties:
     description: "Return only records that have been updated since this date and time (ISO 8601 date format)"
     type: :string
     example: "2021-05-13T11:21:55Z"
-  cohort:
-    description: "Return only records for the given cohort"
+  training_status:
+    description: "Return only records that have this training status"
     type: :string
-    example: "2022"
+    example: "active"


### PR DESCRIPTION
[Jira-2298](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2298)

### Context

We want to allow filtering of NPQ and ECF participants by `training_status` in the v3 API.

### Changes proposed in this pull request

- Allow filtering NPQ/ECF participants by training_status

Add concern to support `training_status` filtering. Update query models to filter when present and accept `training_status` param in controller.

Update documentation with new filter usage.

### Guidance to review

