### PR TITLE
Check if accidental column exists before removing

### DIFF
--- a/db/migrate/20230705152210_remove_accidental_columns_from_versions.rb
+++ b/db/migrate/20230705152210_remove_accidental_columns_from_versions.rb
@@ -3,7 +3,7 @@
 class RemoveAccidentalColumnsFromVersions < ActiveRecord::Migration[6.1]
   def change
     StrongMigrations.disable_check(:remove_column)
-    remove_column :versions, "{:null=>false}", :string
+    remove_column :versions, "{:null=>false}", :string, if_exists: true
     StrongMigrations.enable_check(:remove_column)
   end
 end


### PR DESCRIPTION
### Context
This migration is failing in envs the column does not exist in. Add exists true to ensure migration passes if column doesn't exist

- Ticket: n/a

### Changes proposed in this pull request

Check if column exists before running remove column migration

### Guidance to review

