### PR TITLE
Never create successor induction records with inconsistent dates

### DIFF
--- a/app/services/induction/change_induction_record.rb
+++ b/app/services/induction/change_induction_record.rb
@@ -8,8 +8,10 @@ class Induction::ChangeInductionRecord < BaseService
       if induction_record.start_date > time_now
         induction_record.update!(changes)
       else
+        new_record_end_date = [time_now, induction_record.end_date].max if induction_record.end_date
         default_attrs = {
           start_date: time_now,
+          end_date: new_record_end_date,
           school_transfer: false,
         }
         new_record = induction_record.dup


### PR DESCRIPTION
### Context
  Induction::ChangeInductionRecord sometimes creates successor induction records where start_date > end_date

- Ticket: 

### Changes proposed in this pull request
   Match end_date to start_date when the previous induction record has a end_date in the past.

 
### Guidance to review

