### PR TITLE
Change "To be confirmed" to be more specific

### DIFF
--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -63,7 +63,7 @@ private
     elsif school_cohort.default_induction_programme&.delivery_partner_to_be_confirmed?
       previous_lead_provider(school_cohort)&.name
     else
-      "To be confirmed"
+      "Your lead provider needs to confirm this with us"
     end
   end
 
@@ -71,7 +71,7 @@ private
     if school_cohort.delivery_partner.present?
       school_cohort.delivery_partner.name
     else
-      "To be confirmed"
+      "Your lead provider needs to confirm this with us"
     end
   end
 

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -203,11 +203,11 @@ module ChooseProgrammeSteps
   end
 
   def and_i_see_training_provider_to_be_confirmed
-    expect(page).to have_summary_row("Lead provider", "To be confirmed")
+    expect(page).to have_summary_row("Lead provider", "Your lead provider needs to confirm this with us")
   end
 
   def and_i_see_delivery_partner_to_be_confirmed
-    expect(page).to have_summary_row("Delivery partner", "To be confirmed")
+    expect(page).to have_summary_row("Delivery partner", "Your lead provider needs to confirm this with us")
   end
 
   def and_i_see_delivery_partner_to_be_the_previous_one

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -997,7 +997,7 @@ module ManageTrainingSteps
     expect(page).to have_text("Assign mentor")
   end
 
-  def then_i_can_view_the_fip_induction_dashboard_without_partnership_details(displayed_value: "To be confirmed")
+  def then_i_can_view_the_fip_induction_dashboard_without_partnership_details(displayed_value: "Your lead provider needs to confirm this with us")
     expect(page).to have_selector("h1", text: "Manage your training")
     expect(page).to have_summary_row("Delivery partner", displayed_value)
   end


### PR DESCRIPTION
Some users got in touch with support asking how they could confirm lead provider and delivery partner.

The text "To be confirmed"  did not make clear that this had to be confirmed by the lead provider. We’ve changed this to "Your lead provider needs to confirm this with us".

## Screenshots

### Before

<img width="778" alt="Screenshot 2023-07-06 at 11 06 23" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/211c7254-2761-454d-8be8-1dde008e30ef">

### After

<img width="810" alt="Screenshot 2023-07-06 at 11 04 46" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/4ed8f668-2f92-48ce-9296-46d9cd3de8e0">

