### PR TITLE
[CST-1731] - Prevent error in Notify callback when association object is now nil

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -15,6 +15,8 @@ class Email < ApplicationRecord
 
   def create_association_with(*objects, as: nil)
     objects.each do |object|
+      next if object.blank?
+
       Association.create!(
         email: self,
         object:,

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Email, type: :model do
+  subject(:email) { described_class.create! }
+
+  describe "associations" do
+    it { is_expected.to have_many(:associations) }
+  end
+
+  describe "#create_association_with" do
+    let(:school) { create(:seed_school, urn: "123123", name: "Imaginary High School") }
+
+    it "adds an Association record" do
+      expect {
+        email.create_association_with(school, as: :school)
+      }.to change { Email::Association.count }.by(1)
+    end
+
+    context "when the object is nil" do
+      let(:school) { nil }
+
+      it "does not raise an error" do
+        expect {
+          email.create_association_with(school)
+        }.not_to raise_error
+      end
+
+      it "does not create an Association record" do
+        expect {
+          email.create_association_with(school)
+        }.not_to change { Email::Association.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1731)

### Changes proposed in this pull request
Prevent error being raised when the association object is `nil`. This could happen if a school changed their SIT between the mail being queued and receiving the Notify callback and the Email was associated with the `SchoolInductionCoordinatorProfile` for example.

### Guidance to review

