### PR TITLE
Show the correct academic year in confirmation pages when changing lead provider or delivery partner

### DIFF
--- a/app/views/schools/cohort_setup/_change_delivery_partner_submitted.html.erb
+++ b/app/views/schools/cohort_setup/_change_delivery_partner_submitted.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m">What happens next</h2>
 <p class="govuk-body">We’ll let <%= @wizard.previous_delivery_partner&.name %> know that your school wants to make a change for ECTs and
-  mentors starting in the 2022 to 2023 academic year.</p>
+  mentors starting in the <%= @cohort.description %> academic year.</p>
 <p class="govuk-body">They may contact you to confirm this.</p>
 
 <h2 class="govuk-heading-m">What to do next</h2>

--- a/app/views/schools/cohort_setup/_change_lead_provider_submitted.html.erb
+++ b/app/views/schools/cohort_setup/_change_lead_provider_submitted.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">What happens next</h2>
 <p class="govuk-body">We’ll let <%= @wizard.previous_lead_provider&.name %> and <%= @wizard.previous_delivery_partner&.name %> know that your school wants
   to make a change for ECTs and
-  mentors starting in the 2022 to 2023 academic year.</p>
+  mentors starting in the <%= @cohort.description %> academic year.</p>
 <p class="govuk-body">They may contact you to confirm this.</p>
 
 <h2 class="govuk-heading-m">What to do next</h2>


### PR DESCRIPTION
### Context

- Ticket: CST-1724

### Changes proposed in this pull request

Hardcoded academic year replaced by `cohort.description`


