### PR TITLE
Put ZenDesk widget behind a feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,9 @@ class FeatureFlag
   end
 
   # Long-lived settings that are often environment-specific
-  PERMANENT_SETTINGS = %i[].freeze
+  PERMANENT_SETTINGS = %i[
+    zendesk_widget
+  ].freeze
 
   # Short-lived feature flags
   TEMPORARY_FEATURE_FLAGS = %i[

--- a/app/views/layouts/_width_container.html.erb
+++ b/app/views/layouts/_width_container.html.erb
@@ -42,8 +42,10 @@
   </div>
 <% end %>
 
-<% if current_user.present? && !Rails.env.test? %>
-  <!-- Start of teachercpdhelp Zendesk Widget script -->
-  <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3544292a-5b38-4f45-bd16-98efeaa11ae9"> </script>
-  <!-- End of teachercpdhelp Zendesk Widget script -->
+<% if FeatureFlag.active?(:zendesk_widget) %>
+  <% if current_user.present? && !Rails.env.test? %>
+    <!-- Start of teachercpdhelp Zendesk Widget script -->
+    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=3544292a-5b38-4f45-bd16-98efeaa11ae9"> </script>
+    <!-- End of teachercpdhelp Zendesk Widget script -->
+  <% end %>
 <% end %>


### PR DESCRIPTION
### Context

Usually we have no need for a feature flag as our support works by email. However, on a couple of occasions we've run into problems where our email address has stopped working (or the forwarding from O365 to ZenDesk has broken) and that leaves us unable to support our users.

During the last major incident we added a ZenDesk widget that appears on the page when a user is logged in. This was reverted after the incident was closed, and then re-reverted to add it back during the second incident.

Now, instead of re-re-reverting we'll hide it behind a flag, so it can easily be enabled using the Rails console should the need arise.
