### PR TITLE
Change the GIAS nomination link in the launch comms

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -607,7 +607,7 @@ class SchoolMailer < ApplicationMailer
   def pilot_chase_gias_contact_to_report_school_training_details
     school = params[:school]
     gias_contact_email = params[:gias_contact_email]
-    nomination_link = params[:nomination_link]
+    opt_in_out_link = params[:nomination_link]
 
     template_mail(
       PILOT_CHASE_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE,
@@ -615,7 +615,7 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        nomination_link:,
+        opt_in_out_link:,
       },
     ).tag(:pilot_chase_gias_contact_to_report_school_training_details).associate_with(school)
   end
@@ -639,7 +639,7 @@ class SchoolMailer < ApplicationMailer
   def launch_ask_gias_contact_to_report_school_training_details
     school = params[:school]
     gias_contact_email = params[:gias_contact_email]
-    nomination_link = params[:nomination_link]
+    opt_in_out_link = params[:opt_in_out_link]
 
     template_mail(
       LAUNCH_ASK_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE,
@@ -647,7 +647,7 @@ class SchoolMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
-        nomination_link:,
+        opt_in_out_link:,
       },
     ).tag(:launch_ask_gias_contact_to_report_school_training_details).associate_with(school)
   end

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -162,7 +162,7 @@ def get_gias_nomination_url(token:)
     .application
     .routes
     .url_helpers
-    .start_nomination_nominate_induction_coordinator_url(token:, host: Rails.application.config.domain)
+    .choose_how_to_continue_url(token:, host: Rails.application.config.domain)
 end
 
 def create_nomination_token(school, email_address)

--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -65,7 +65,7 @@ namespace :comms do
           .with(
             school:,
             gias_contact_email: school.primary_contact_email,
-            nomination_link: get_gias_nomination_url(token: nomination_token),
+            opt_in_out_link: get_opt_in_out_url(token: nomination_token),
           )
           .pilot_chase_gias_contact_to_report_school_training_details
           .deliver_later
@@ -141,7 +141,7 @@ namespace :comms do
         .with(
           school:,
           gias_contact_email:,
-          nomination_link: get_gias_nomination_url(token: nomination_token),
+          opt_in_out_link: get_opt_in_out_url(token: nomination_token),
         )
         .launch_ask_gias_contact_to_report_school_training_details
         .deliver_later
@@ -157,7 +157,7 @@ def get_sit_nomination_url(token:)
     .start_nominate_induction_coordinator_url(token:, host: Rails.application.config.domain)
 end
 
-def get_gias_nomination_url(token:)
+def get_opt_in_out_url(token:)
   Rails
     .application
     .routes

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -281,13 +281,13 @@ RSpec.describe SchoolMailer, type: :mailer do
   describe "#pilot_chase_gias_contact_to_report_school_training_details" do
     let(:school) { create(:school) }
     let(:gias_contact_email) { school.primary_contact_email }
-    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
+    let(:opt_in_out_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:pilot_chase_gias_contact_to_report_school_training_details) do
       SchoolMailer.with(
         school:,
         gias_contact_email:,
-        nomination_link:,
+        opt_in_out_link:,
       ).pilot_chase_gias_contact_to_report_school_training_details.deliver_now
     end
 
@@ -325,13 +325,13 @@ RSpec.describe SchoolMailer, type: :mailer do
   describe "#launch_ask_gias_contact_to_report_school_training_details" do
     let(:school) { create(:school) }
     let(:gias_contact_email) { school.primary_contact_email }
-    let(:nomination_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
+    let(:opt_in_out_link) { "https://ecf-dev.london.cloudapps/nominations/start?token=123" }
 
     let(:launch_ask_gias_contact_to_report_school_training_details) do
       SchoolMailer.with(
         school:,
         gias_contact_email:,
-        nomination_link:,
+        opt_in_out_link:,
       ).launch_ask_gias_contact_to_report_school_training_details.deliver_now
     end
 


### PR DESCRIPTION
The GIAS contact should is now sent to the `Choose how to continue` page, where they can opt out, without having to nominate an SIT.
