### PR TITLE
Fix the What each person does page

### DIFF
--- a/app/views/pages/what_each_person_does.html.erb
+++ b/app/views/pages/what_each_person_does.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "shared/roles.html.erb" %>
+<%= render partial: "shared/roles" %>

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe "Static pages", type: :request do
       expect(response).to render_template("pages/year_2020_core_materials_info")
     end
   end
+
+  describe "GET /pages/what-each-person-does" do
+    it "renders the correct template" do
+      get "/pages/what-each-person-does"
+
+      expect(response).to render_template("shared/_roles")
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: N/A

The "What each person does" page tries to render the `shared/roles` partial and fails with 500 error.

### Changes proposed in this pull request
- Update the partial name
- Add spec

### Guidance to review
Visit the `/pages/what-each-person-does`

