### PR TITLE
Update deprecated cypress config

### DIFF
--- a/config/initializers/cypress_on_rails.rb
+++ b/config/initializers/cypress_on_rails.rb
@@ -2,7 +2,7 @@
 
 if defined?(CypressOnRails)
   CypressOnRails.configure do |c|
-    c.cypress_folder = File.expand_path("#{__dir__}/../../spec/cypress")
+    c.install_folder = File.expand_path("#{__dir__}/../../spec/cypress")
     # WARNING!! CypressOnRails can execute arbitrary ruby code
     # please use with extra caution if enabling on hosted servers or starting your local server on 0.0.0.0
     c.use_middleware = Rails.env.test?


### PR DESCRIPTION
### Context

- Ticket: N/A

We get warning messages about the deprecated cypress config `cypress_folder`. 

### Changes proposed in this pull request
- Replace `cypress_folder` with `install_folder`

### Guidance to review

