### PR TITLE
[CST-1206] Treat school based roles as one role to avoid seeing options at sign in

### DIFF
--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -83,9 +83,9 @@ private
   end
 
   def teacher_role?
-    # in order to show the correct page we need to use the presence of teacher_profile
-    # because a withdrawn participant will not have any roles
-    user.teacher_profile.present?
+    # in order to show the correct page we need to participant profiles
+    # because a withdrawn participant will not have any roles in user_roles
+    user.participant_profiles.ecf.any?
   end
 
   def role_values

--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -10,7 +10,6 @@ class ChooseRoleForm
     "admin" => "DfE admin",
     "finance" => "DfE Finance",
     "induction_coordinator" => "Induction tutor",
-    "induction_coordinator_and_mentor" => "Induction tutor and mentor",
     "teacher" => "Teacher",
   }.freeze
 
@@ -20,7 +19,7 @@ class ChooseRoleForm
   validates :role, inclusion: { in: :role_values }
 
   def role_options
-    USER_ROLES.slice(*user.user_roles)
+    USER_ROLES.slice(*sanitized_user_roles)
   end
 
   def redirect_path(helpers:)
@@ -35,8 +34,6 @@ class ChooseRoleForm
       helpers.delivery_partners_path
     when "appropriate_body"
       helpers.appropriate_bodies_path
-    when "induction_coordinator_and_mentor"
-      helpers.induction_coordinator_mentor_path(user)
     when "induction_coordinator"
       helpers.induction_coordinator_dashboard_path(user)
     when "teacher"
@@ -47,20 +44,43 @@ class ChooseRoleForm
   end
 
   def only_one_role
-    return false unless user.user_roles.count == 1
+    return false unless sanitized_user_roles.count == 1
 
-    self.role = user.user_roles.first
+    self.role = sanitized_user_roles.first
     true
   end
 
   def has_no_role
-    return false unless user.user_roles.count.zero?
+    return false unless sanitized_user_roles.empty?
 
     self.role = "no_role"
     true
   end
 
 private
+
+  def sanitized_user_roles
+    roles = user_roles.reject { |role| role.in? %w[induction_coordinator induction_coordinator_and_mentor teacher] }
+
+    if sit_role?
+      roles << "induction_coordinator"
+    elsif teacher_role?
+      roles << "teacher"
+    end
+    roles
+  end
+
+  def user_roles
+    @user_roles ||= user.user_roles
+  end
+
+  def sit_role?
+    user_roles.any?(/induction_coordinator*/)
+  end
+
+  def teacher_role?
+    user_roles.include? "teacher"
+  end
 
   def role_values
     role_options.keys << "change_role"

--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -83,7 +83,9 @@ private
   end
 
   def teacher_role?
-    user_roles.any? { |r| r.in? %w[early_career_teacher mentor] }
+    # in order to show the correct page we need to use the presence of teacher_profile
+    # because a withdrawn participant will not have any roles
+    user.teacher_profile.present?
   end
 
   def role_values

--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -60,12 +60,13 @@ class ChooseRoleForm
 private
 
   def rejected_roles
-    %w[induction_coordinator early_career_teacher mentor npq_applicant npq_participant lead_provider].freeze
+    %w[induction_coordinator early_career_teacher mentor npq_applicant npq_participant teacher lead_provider].freeze
   end
 
   def sanitized_user_roles
     roles = user_roles.reject { |role| rejected_roles.include?(role) }
 
+    # choose either a SIT role or a teacher role to prevent school users from seeing this
     if sit_role?
       roles << "induction_coordinator"
     elsif teacher_role?
@@ -83,9 +84,7 @@ private
   end
 
   def teacher_role?
-    # in order to show the correct page we need to participant profiles
-    # because a withdrawn participant will not have any roles in user_roles
-    user.participant_profiles.ecf.any?
+    user_roles.include?("teacher")
   end
 
   def role_values

--- a/app/forms/choose_role_form.rb
+++ b/app/forms/choose_role_form.rb
@@ -59,8 +59,12 @@ class ChooseRoleForm
 
 private
 
+  def rejected_roles
+    %w[induction_coordinator early_career_teacher mentor npq_applicant npq_participant lead_provider].freeze
+  end
+
   def sanitized_user_roles
-    roles = user_roles.reject { |role| role.in? %w[induction_coordinator induction_coordinator_and_mentor teacher] }
+    roles = user_roles.reject { |role| rejected_roles.include?(role) }
 
     if sit_role?
       roles << "induction_coordinator"
@@ -75,11 +79,11 @@ private
   end
 
   def sit_role?
-    user_roles.any?(/induction_coordinator*/)
+    user_roles.include?("induction_coordinator")
   end
 
   def teacher_role?
-    user_roles.include? "teacher"
+    user_roles.any? { |r| r.in? %w[early_career_teacher mentor] }
   end
 
   def role_values

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,6 +166,7 @@ class User < ApplicationRecord
       ("early_career_teacher" if early_career_teacher?),
       ("npq_participant" if npq?),
       ("npq_applicant" if npq_applications.any? && !npq?),
+      ("teacher" if teacher?), # presence of teacher profile, could include orphaned de-duped users
     ].compact
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -157,12 +157,15 @@ class User < ApplicationRecord
   def user_roles
     @user_roles ||= [
       ("appropriate_body" if appropriate_body?),
+      ("lead_provider" if lead_provider?),
       ("delivery_partner" if delivery_partner?),
       ("admin" if admin?),
       ("finance" if finance?),
       ("induction_coordinator" if induction_coordinator?),
-      ("induction_coordinator_and_mentor" if induction_coordinator_and_mentor?),
-      ("teacher" if teacher?),
+      ("mentor" if mentor?),
+      ("early_career_teacher" if early_career_teacher?),
+      ("npq_participant" if npq?),
+      ("npq_applicant" if npq_applications.any? && !npq?),
     ].compact
   end
 

--- a/spec/forms/choose_role_form_spec.rb
+++ b/spec/forms/choose_role_form_spec.rb
@@ -240,23 +240,22 @@ RSpec.describe ChooseRoleForm, type: :model do
     describe "induction_coordinator and mentor roles" do
       let(:user) { create(:user, :induction_coordinator, :mentor) }
 
-      it { is_expected.to validate_inclusion_of(:role).in_array(%w[induction_coordinator_and_mentor]) }
+      it { is_expected.to validate_inclusion_of(:role).in_array(%w[induction_coordinator]) }
 
       it "only_one_role should be false" do
-        expect(form.only_one_role).to be false
+        expect(form.only_one_role).to be true
       end
 
       it "has correct role_options" do
         expect(form.role_options).to have_key("induction_coordinator")
-        expect(form.role_options).to have_key("induction_coordinator_and_mentor")
       end
 
       describe "param with induction_coordinator_and_mentor role" do
-        let(:form_role) { "induction_coordinator_and_mentor" }
+        let(:form_role) { "induction_coordinator" }
         let(:helpers) do
           Struct.new(:induction_coordinator_mentor_path) {
-            def induction_coordinator_mentor_path(_user)
-              "/induction_coordinator_and_mentor"
+            def induction_coordinator_dashboard_path(_user)
+              "/induction_coordinator"
             end
           }.new
         end
@@ -266,7 +265,7 @@ RSpec.describe ChooseRoleForm, type: :model do
         end
 
         it "returns correct redirect_path" do
-          expect(form.redirect_path(helpers:)).to be helpers.induction_coordinator_mentor_path(user)
+          expect(form.redirect_path(helpers:)).to be helpers.induction_coordinator_dashboard_path(user)
         end
       end
 
@@ -298,14 +297,14 @@ RSpec.describe ChooseRoleForm, type: :model do
     describe "teacher, induction_coordinator and delivery_partner roles" do
       let(:user) { create(:user, :teacher, :induction_coordinator, :delivery_partner) }
 
-      it { is_expected.to validate_inclusion_of(:role).in_array(%w[teacher induction_coordinator delivery_partner]) }
+      it { is_expected.to validate_inclusion_of(:role).in_array(%w[induction_coordinator delivery_partner]) }
 
       it "only_one_role should be false" do
         expect(form.only_one_role).to be false
       end
 
       it "has correct role_options" do
-        expect(form.role_options).to have_key("teacher")
+        expect(form.role_options).not_to have_key("teacher")
         expect(form.role_options).to have_key("induction_coordinator")
         expect(form.role_options).to have_key("delivery_partner")
       end

--- a/spec/forms/choose_role_form_spec.rb
+++ b/spec/forms/choose_role_form_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe ChooseRoleForm, type: :model do
     end
 
     describe "teacher role" do
-      let(:user) { create(:user, :teacher) }
+      let(:user) { create(:user, :early_career_teacher) }
 
       it { is_expected.to validate_inclusion_of(:role).in_array(%w[teacher]) }
 
@@ -232,6 +232,40 @@ RSpec.describe ChooseRoleForm, type: :model do
           expect(form.valid?).to be false
           expect(form.errors[:role]).to include "Choose a role"
         end
+      end
+    end
+  end
+
+  describe "NPQ roles" do
+    describe "NPQ applicant" do
+      let(:user) { create(:seed_npq_application, :valid).user }
+
+      it "has no role" do
+        expect(form.has_no_role).to be true
+      end
+
+      it "only_one_role should be false" do
+        expect(form.only_one_role).to be false
+      end
+
+      it "has correct role_options" do
+        expect(form.role_options).to be_empty
+      end
+    end
+
+    describe "NPQ participant" do
+      let(:user) { create(:user, :npq) }
+
+      it "has no role" do
+        expect(form.has_no_role).to be true
+      end
+
+      it "only_one_role should be false" do
+        expect(form.only_one_role).to be false
+      end
+
+      it "has correct role_options" do
+        expect(form.role_options).to be_empty
       end
     end
   end
@@ -295,7 +329,7 @@ RSpec.describe ChooseRoleForm, type: :model do
     end
 
     describe "teacher, induction_coordinator and delivery_partner roles" do
-      let(:user) { create(:user, :teacher, :induction_coordinator, :delivery_partner) }
+      let(:user) { create(:user, :mentor, :induction_coordinator, :delivery_partner) }
 
       it { is_expected.to validate_inclusion_of(:role).in_array(%w[induction_coordinator delivery_partner]) }
 

--- a/spec/forms/choose_role_form_spec.rb
+++ b/spec/forms/choose_role_form_spec.rb
@@ -256,16 +256,16 @@ RSpec.describe ChooseRoleForm, type: :model do
     describe "NPQ participant" do
       let(:user) { create(:user, :npq) }
 
-      it "has no role" do
-        expect(form.has_no_role).to be true
+      it "has a role" do
+        expect(form.has_no_role).to be false
       end
 
-      it "only_one_role should be false" do
-        expect(form.only_one_role).to be false
+      it "only_one_role should be true" do
+        expect(form.only_one_role).to be true
       end
 
       it "has correct role_options" do
-        expect(form.role_options).to be_empty
+        expect(form.role_options).to have_key("teacher")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -405,6 +405,10 @@ RSpec.describe User, type: :model do
       expect(create(:user, :delivery_partner).user_roles).to eq(%w[delivery_partner])
     end
 
+    it "returns lead_prpvider role" do
+      expect(create(:user, :lead_provider).user_roles).to eq(%w[lead_provider])
+    end
+
     it "returns appropriate_body role" do
       expect(create(:user, :appropriate_body).user_roles).to eq(%w[appropriate_body])
     end
@@ -421,20 +425,32 @@ RSpec.describe User, type: :model do
       expect(build(:user, :induction_coordinator).user_roles).to eq(%w[induction_coordinator])
     end
 
-    it "returns teacher role" do
-      expect(build(:user, :teacher).user_roles).to eq(%w[teacher])
+    it "returns early career teacher role" do
+      expect(create(:user, :early_career_teacher).user_roles).to match_array(%w[early_career_teacher])
     end
 
-    it "returns induction_coordinator_and_mentor role" do
-      expect(create(:user, :mentor, :induction_coordinator).user_roles.sort).to eq(%w[induction_coordinator_and_mentor induction_coordinator teacher].sort)
+    it "returns mentor role" do
+      expect(create(:user, :mentor).user_roles).to eq(%w[mentor])
     end
 
-    it "returns induction_coordinator and delivery_partner role" do
-      expect(create(:user, :induction_coordinator, :delivery_partner).user_roles.sort).to eq(%w[delivery_partner induction_coordinator].sort)
+    it "returns npq_participant role" do
+      expect(create(:user, :npq).user_roles).to eq(%w[npq_participant])
     end
 
-    it "returns teacher, induction_coordinator and delivery_partner role" do
-      expect(create(:user, :teacher, :induction_coordinator, :delivery_partner).user_roles.sort).to eq(%w[delivery_partner induction_coordinator teacher].sort)
+    it "returns npq_applicant role" do
+      expect(create(:seed_npq_application, :valid).user.user_roles).to eq(%w[npq_applicant])
+    end
+
+    it "returns induction_coordinator and mentor roles" do
+      expect(create(:user, :mentor, :induction_coordinator).user_roles).to match_array(%w[induction_coordinator mentor])
+    end
+
+    it "returns induction_coordinator and delivery_partner roles" do
+      expect(create(:user, :induction_coordinator, :delivery_partner).user_roles).to match_array(%w[delivery_partner induction_coordinator])
+    end
+
+    it "returns mentor, induction_coordinator and delivery_partner roles" do
+      expect(create(:user, :mentor, :induction_coordinator, :delivery_partner).user_roles).to match_array(%w[delivery_partner induction_coordinator mentor])
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe User, type: :model do
       expect(create(:user, :delivery_partner).user_roles).to eq(%w[delivery_partner])
     end
 
-    it "returns lead_prpvider role" do
+    it "returns lead_provider role" do
       expect(create(:user, :lead_provider).user_roles).to eq(%w[lead_provider])
     end
 
@@ -426,15 +426,15 @@ RSpec.describe User, type: :model do
     end
 
     it "returns early career teacher role" do
-      expect(create(:user, :early_career_teacher).user_roles).to match_array(%w[early_career_teacher])
+      expect(create(:user, :early_career_teacher).user_roles).to match_array(%w[early_career_teacher teacher])
     end
 
     it "returns mentor role" do
-      expect(create(:user, :mentor).user_roles).to eq(%w[mentor])
+      expect(create(:user, :mentor).user_roles).to eq(%w[mentor teacher])
     end
 
     it "returns npq_participant role" do
-      expect(create(:user, :npq).user_roles).to eq(%w[npq_participant])
+      expect(create(:user, :npq).user_roles).to eq(%w[npq_participant teacher])
     end
 
     it "returns npq_applicant role" do
@@ -442,7 +442,7 @@ RSpec.describe User, type: :model do
     end
 
     it "returns induction_coordinator and mentor roles" do
-      expect(create(:user, :mentor, :induction_coordinator).user_roles).to match_array(%w[induction_coordinator mentor])
+      expect(create(:user, :mentor, :induction_coordinator).user_roles).to match_array(%w[induction_coordinator mentor teacher])
     end
 
     it "returns induction_coordinator and delivery_partner roles" do
@@ -450,7 +450,7 @@ RSpec.describe User, type: :model do
     end
 
     it "returns mentor, induction_coordinator and delivery_partner roles" do
-      expect(create(:user, :mentor, :induction_coordinator, :delivery_partner).user_roles).to match_array(%w[delivery_partner induction_coordinator mentor])
+      expect(create(:user, :mentor, :induction_coordinator, :delivery_partner).user_roles).to match_array(%w[delivery_partner induction_coordinator mentor teacher])
     end
   end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -235,14 +235,28 @@ RSpec.describe "Users::Sessions", type: :request do
 
     context "when user is an induction coordinator and a non-validated mentor" do
       let(:user) { create(:user, :induction_coordinator) }
+      let(:school) { user.schools.first }
       let(:teacher_profile) { create :teacher_profile, user: }
       let!(:participant_profile) { create :mentor_participant_profile, teacher_profile: }
       let!(:cohort) { participant_profile.cohort }
 
       it "redirects to correct dashboard" do
         post "/users/sign_in_with_token", params: { login_token: user.login_token }
-        # Choose teacher role
-        post "/choose-role", params: { choose_role_form: { role: "teacher" } }
+        # it will treat multiple school roles as one role
+        follow_redirect!
+        expect(response).to redirect_to(schools_choose_programme_path(school_id: school.slug, cohort_id: cohort.start_year))
+      end
+    end
+
+    context "when user is a non-validated mentor" do
+      let(:user) { create(:user) }
+      let(:teacher_profile) { create :teacher_profile, user: }
+      let!(:participant_profile) { create :mentor_participant_profile, teacher_profile: }
+      let!(:cohort) { participant_profile.cohort }
+
+      it "redirects to correct dashboard" do
+        post "/users/sign_in_with_token", params: { login_token: user.login_token }
+        follow_redirect!
         expect(response).to redirect_to(participants_validation_path)
       end
     end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1206)

School users (SITs) can be confused by the options presented to them if they have more than 1 type of profile e.g. SIT/mentor or SIT who's also doing a NPQ

This PR tries to ensure school users ie. SITs, are never presented with these options in general.

### Changes proposed in this pull request
Treat "school" roles more logically:
- A SIT with a mentor profile will be treated as a single role SIT
- A SIT with a `TeacherProfile` will be treated as a single role SIT

### Guidance to review

