### PR TITLE
Update content on pages asking if schools expect any ECTs or not

### DIFF
--- a/app/views/nominations/choose_how_to_continue/new.html.erb
+++ b/app/views/nominations/choose_how_to_continue/new.html.erb
@@ -1,10 +1,9 @@
-<% title = "Do you expect any new ECTs or mentors to join your school this academic year?" %>
-<% content_for :title, title %>
+<% title = "Will any ECTs start their induction at your school in the #{@how_to_continue_form.cohort.description} academic year?" %><% content_for :title, title %>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-xl"><%= @how_to_continue_form.school.name %></span>
+        <span class="govuk-caption-l"><%= @how_to_continue_form.school.name %></span>
 
         <%= form_for @how_to_continue_form, url: choose_how_to_continue_path(token: @how_to_continue_form.token) do |f| %>
             <%= f.govuk_error_summary %>
@@ -13,14 +12,9 @@
                 @how_to_continue_form.choices,
                 :id,
                 :name,
-                legend: { text: title, size: "xl", tag: "h1" },
-                ) do %>
-
-                <p class="govuk-body">
-                  These are early career teachers or mentors who are starting their induction
-                  or mentor training from <%= @how_to_continue_form.academic_year_start_date.to_date.to_fs(:govuk) %>
-                </p>
-                <% end %>
+                legend: { text: title, size: "l", tag: "h1" },
+                hint: { text: "This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet." }
+                )  %>
 
             <%= f.hidden_field :token %>
             <%= f.govuk_submit "Continue" %>

--- a/app/views/nominations/choose_how_to_continue/new.html.erb
+++ b/app/views/nominations/choose_how_to_continue/new.html.erb
@@ -3,21 +3,21 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <%= form_for @how_to_continue_form, url: choose_how_to_continue_path(token: @how_to_continue_form.token) do |f| %>
-            <%= f.govuk_error_summary %>
-            <span class="govuk-caption-l"><%= @how_to_continue_form.school.name %></span>
-            <%= f.govuk_collection_radio_buttons(
-                :how_to_continue,
-                @how_to_continue_form.choices,
-                :id,
-                :name,
-                legend: { text: title, size: "l", tag: "h1" },
-                hint: { text: "This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet." }
-                )  %>
+      <%= form_for @how_to_continue_form, url: choose_how_to_continue_path(token: @how_to_continue_form.token) do |f| %>
+        <%= f.govuk_error_summary %>
+        <span class="govuk-caption-l"><%= @how_to_continue_form.school.name %></span>
+        <%= f.govuk_collection_radio_buttons(
+          :how_to_continue,
+          @how_to_continue_form.choices,
+          :id,
+          :name,
+          legend: { text: title, size: "l", tag: "h1" },
+          hint: { text: "This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet." }
+        ) %>
 
-            <%= f.hidden_field :token %>
-            <%= f.govuk_submit "Continue" %>
-        <% end %>
+        <%= f.hidden_field :token %>
+        <%= f.govuk_submit "Continue" %>
+      <% end %>
 
     </div>
 </div>

--- a/app/views/nominations/choose_how_to_continue/new.html.erb
+++ b/app/views/nominations/choose_how_to_continue/new.html.erb
@@ -3,10 +3,9 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <span class="govuk-caption-l"><%= @how_to_continue_form.school.name %></span>
-
         <%= form_for @how_to_continue_form, url: choose_how_to_continue_path(token: @how_to_continue_form.token) do |f| %>
             <%= f.govuk_error_summary %>
+            <span class="govuk-caption-l"><%= @how_to_continue_form.school.name %></span>
             <%= f.govuk_collection_radio_buttons(
                 :how_to_continue,
                 @how_to_continue_form.choices,

--- a/app/views/schools/cohort_setup/expect_any_ects.html.erb
+++ b/app/views/schools/cohort_setup/expect_any_ects.html.erb
@@ -1,4 +1,4 @@
-<% title = "Will any ECTs start their induction at your school in the 2023 to 2024 academic year?" %>
+<% title = "Will any ECTs start their induction at your school in the #{@wizard.cohort.description} academic year?" %>
 
 <% content_for :title, title %>
 

--- a/app/views/schools/cohort_setup/expect_any_ects.html.erb
+++ b/app/views/schools/cohort_setup/expect_any_ects.html.erb
@@ -16,9 +16,11 @@
                 simple_yes_no_options,
                 :id,
                 :name,
-                legend: { text: title, tag: 'h1', size: 'xl' }) do %>
-                <p class="govuk-body govuk-!-margin-top-4">This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet.</p>
-            <% end %>
+                legend: { text: title, tag: 'h1', size: 'l' },
+                hint: {
+                  text: "This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet."
+                }
+              )  %>
 
             <%= f.govuk_submit "Continue" %>
         <% end %>

--- a/app/views/schools/cohort_setup/expect_any_ects.html.erb
+++ b/app/views/schools/cohort_setup/expect_any_ects.html.erb
@@ -6,11 +6,11 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-xl"><%= @wizard.school.name %></span>
 
         <%= form_with model: @wizard.form, url: url_for(action: :update), scope: @wizard.to_key, method: :put do |f| %>
             <%= f.govuk_error_summary %>
 
+            <span class="govuk-caption-xl"><%= @wizard.school.name %></span>
             <%= f.govuk_collection_radio_buttons(
                 :expect_any_ects,
                 simple_yes_no_options,

--- a/app/views/schools/cohort_setup/expect_any_ects.html.erb
+++ b/app/views/schools/cohort_setup/expect_any_ects.html.erb
@@ -1,4 +1,4 @@
-<% title = "Does your school expect any new ECTs in the new academic year?" %>
+<% title = "Will any ECTs start their induction at your school in the 2023 to 2024 academic year?" %>
 
 <% content_for :title, title %>
 
@@ -17,9 +17,7 @@
                 :id,
                 :name,
                 legend: { text: title, tag: 'h1', size: 'xl' }) do %>
-                <p class="govuk-body govuk-!-margin-top-4">ECTs are teachers who have finished their initial teacher training.</p>
-                <p class="govuk-body">Do not include ECTs who started training before
-                    <%= @wizard.cohort.academic_year_start_date.to_date.to_fs(:govuk) %>.</p>
+                <p class="govuk-body govuk-!-margin-top-4">This means teachers who have completed their initial teacher training, but have not started their 2-year induction yet.</p>
             <% end %>
 
             <%= f.govuk_submit "Continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,7 +149,7 @@ en:
     mentor:
       blank: "Choose one"
     how_to_continue:
-      blank: "Tell us whether you expect to have any early career teachers this year"
+      blank: "Select an answer"
     schools:
       blank: "The details you entered do not match any schools"
     programme_choice:
@@ -360,6 +360,10 @@ en:
               blank: "Enter an email address for your teacher"
             core_induction_programme_id:
               blank: "Select the materials you want to use"
+        schools/cohorts/wizard_steps/expect_any_ects_step:
+          attributes:
+            expect_any_ects:
+              inclusion: Select an answer
         schools/add_participants/wizard_steps/participant_type_step:
           attributes:
             participant_type:

--- a/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
+++ b/spec/features/nominations/nominate_induction_tutor_journey_spec.rb
@@ -6,6 +6,8 @@ require_relative "./nominate_induction_tutor_steps"
 RSpec.feature "ECT nominate SIT journey", type: :feature, js: true do
   include NominateInductionTutorSteps
 
+  let(:academic_year_text) { Cohort.current.description }
+
   scenario "Valid nomination link was sent" do
     given_a_valid_nomination_email_has_been_created
     when_i_click_the_link_to_nominate_a_sit

--- a/spec/features/nominations/nominate_induction_tutor_steps.rb
+++ b/spec/features/nominations/nominate_induction_tutor_steps.rb
@@ -61,7 +61,7 @@ module NominateInductionTutorSteps
   end
 
   def then_i_should_be_on_the_choose_how_to_continue_page
-    expect(page).to have_selector("h1", text: "Will any ECTs start their induction at your school in the 2023 to 2024 academic year?")
+    expect(page).to have_selector("h1", text: "Will any ECTs start their induction at your school in the #{academic_year_text} academic year?")
     expect(page).to have_field("Yes", visible: :all)
     expect(page).to have_field("No", visible: :all)
     expect(page).to have_field("We do not know", visible: :all)

--- a/spec/features/nominations/nominate_induction_tutor_steps.rb
+++ b/spec/features/nominations/nominate_induction_tutor_steps.rb
@@ -61,7 +61,7 @@ module NominateInductionTutorSteps
   end
 
   def then_i_should_be_on_the_choose_how_to_continue_page
-    expect(page).to have_selector("h1", text: "Do you expect any new ECTs or mentors to join your school this academic year?")
+    expect(page).to have_selector("h1", text: "Will any ECTs start their induction at your school in the 2023 to 2024 academic year?")
     expect(page).to have_field("Yes", visible: :all)
     expect(page).to have_field("No", visible: :all)
     expect(page).to have_field("We do not know", visible: :all)

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -52,7 +52,7 @@ module ChooseProgrammeSteps
 
   def then_i_am_taken_to_ects_expected_in_next_academic_year_page
     expect(page).to have_content(@school.name)
-    expect(page).to have_content("Does your school expect any new ECTs in the new academic year?")
+    expect(page).to have_content("Will any ECTs start their induction at your school in the 2023 to 2024 academic year?")
   end
 
   def then_i_am_taken_to_the_submitted_page

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -52,7 +52,7 @@ module ChooseProgrammeSteps
 
   def then_i_am_taken_to_ects_expected_in_next_academic_year_page
     expect(page).to have_content(@school.name)
-    expect(page).to have_content("Will any ECTs start their induction at your school in the 2023 to 2024 academic year?")
+    expect(page).to have_content("Will any ECTs start their induction at your school in the 2022 to 2023 academic year?")
   end
 
   def then_i_am_taken_to_the_submitted_page

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -52,7 +52,7 @@ module ChooseProgrammeSteps
 
   def then_i_am_taken_to_ects_expected_in_next_academic_year_page
     expect(page).to have_content(@school.name)
-    expect(page).to have_content("Will any ECTs start their induction at your school in the 2022 to 2023 academic year?")
+    expect(page).to have_content("Will any ECTs start their induction at your school in the #{Cohort.next.description} academic year?")
   end
 
   def then_i_am_taken_to_the_submitted_page

--- a/spec/forms/nominate_how_to_continue_form_spec.rb
+++ b/spec/forms/nominate_how_to_continue_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe NominateHowToContinueForm, type: :model do
   describe "validations" do
-    it { is_expected.to validate_presence_of(:how_to_continue).with_message("Tell us whether you expect to have any early career teachers this year") }
+    it { is_expected.to validate_presence_of(:how_to_continue).with_message("Select an answer") }
   end
 
   describe "#choices" do


### PR DESCRIPTION
See Jira ticket for context: https://dfedigital.atlassian.net/browse/CST-1738?atlOrigin=eyJpIjoiYWRhZmJjY2NlNTk1NDdjMjhkZDE3NDQ5MjEyOTc1ZWIiLCJwIjoiaiJ9

Can a developer confirm these content changes do not impact any tests please? I've removed a wizard that was pulling in the academic year.

This updates the content of the 2 screens asking schools if they expecting any early career teachers in the upcoming year. Previously we’ve had feedback from school users that they’re confused by the reference to ‘ECTs who started training before September 2023’ – they were conflating ITT with ECF-based training.

We’ve also:

* made the question and guidance on the 2 screens consistent
* dropped the question font size down from extra-large to large (following the [heading guidance](https://design-system.service.gov.uk/styles/typography/#headings))
* made the guidance text be hint text, so that it is read out by screen users when in forms mode

## Screenshots

| | Before | After
|---|-----|-----|
| School induction tutor view | <img width="1026" alt="Screenshot 2023-07-12 at 12 36 14" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/a09a712d-4ba2-4548-a025-5c56c4d69969"> | <img width="996" alt="Screenshot 2023-07-12 at 12 36 00" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/0507fadb-67c1-47e3-8517-595b5b1a3d06"> |
| No school induction tutor view (using link sent to GIAS contact) | <img width="980" alt="Screenshot 2023-07-12 at 15 30 56" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/d4253aeb-f054-4328-bf0f-6b85f3dcb73c"> | <img width="989" alt="Screenshot 2023-07-12 at 15 30 36" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/dd7a2afd-d612-4e3b-b789-063250c2c1d1"> |

### Error message

<img width="1026" alt="Screenshot 2023-07-12 at 15 51 16" src="https://github.com/DFE-Digital/early-careers-framework/assets/30665/cb342c3f-3eb6-42f0-96db-2ece303517ae">



