### PR TITLE
Allow to resend failed comms

### DIFF
--- a/lib/tasks/comms.rake
+++ b/lib/tasks/comms.rake
@@ -32,7 +32,7 @@ namespace :comms do
         end
 
         school.induction_coordinators.each do |sit_user|
-          if Email.tagged_with(:pilot_chase_sit_to_report_school_training_details).associated_with(sit_user).any?
+          if Email.tagged_with(:pilot_chase_sit_to_report_school_training_details).associated_with(sit_user).where.not(status: Email::FAILED_STATUSES).any?
             logger.info "The user has been already contacted"
             next
           end
@@ -54,7 +54,7 @@ namespace :comms do
           next
         end
 
-        if Email.tagged_with(:pilot_chase_gias_contact_to_report_school_training_details).associated_with(school).any?
+        if Email.tagged_with(:pilot_chase_gias_contact_to_report_school_training_details).associated_with(school).where.not(status: Email::FAILED_STATUSES).any?
           logger.info "The school's primary GIAS has been already contacted"
           next
         end
@@ -124,7 +124,7 @@ namespace :comms do
         next
       end
 
-      if Email.tagged_with(:launch_ask_gias_contact_to_report_school_training_details).associated_with(school).any?
+      if Email.tagged_with(:launch_ask_gias_contact_to_report_school_training_details).associated_with(school).where.not(status: Email::FAILED_STATUSES).any?
         logger.info "The school's GIAS contact has been already contacted"
         next
       end


### PR DESCRIPTION
### Context

- Ticket: N/A

This PR will allow us to resend comms that fail.

Some of the reasons we would need to do that are:
- We hit Rate Limit on the Notify service which will return "failed" status
- Notify was temp unable to send an email

### Changes proposed in this pull request
- Skip only schools that the emails are pending or delivered

### Guidance to review

