### PR TITLE
[CST-1763] Add new chaser emails for SITs

### DIFF
--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -40,6 +40,24 @@ class SchoolMailer < ApplicationMailer
   LAUNCH_ASK_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "f4dfee2a-2cc3-4d32-97f9-8adca41343bf"
   COHORTLESS_PILOT_2023_SURVEY_TEMPLATE = "5f6dc6bf-62c5-4cf1-8cc8-1440453f4a2d"
   REMIND_SIT_TO_ADD_PARTICIPANTS_TEMPLATE = "19b5a258-e615-4371-9e55-f9cc58187448"
+  REMIND_SIT_TO_ASSIGN_MENTORS_TO_ECTS_TEMPLATE = "ae0b1c48-de11-4231-b394-0288bb779987"
+
+  def remind_sit_to_assign_mentors_to_ects_email
+    induction_coordinator = params[:induction_coordinator]
+    email_address = induction_coordinator.user.email
+    name = induction_coordinator.user.full_name
+
+    template_mail(
+      REMIND_SIT_TO_ASSIGN_MENTORS_TO_ECTS_TEMPLATE,
+      to: email_address,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name:,
+        email_address:,
+      },
+    ).tag(:remind_sits_to_assign_mentors_to_ects).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+  end
 
   def remind_sit_to_add_ects_and_mentors_email
     induction_coordinator = params[:induction_coordinator]

--- a/app/mailers/school_mailer.rb
+++ b/app/mailers/school_mailer.rb
@@ -39,6 +39,24 @@ class SchoolMailer < ApplicationMailer
   LAUNCH_ASK_SIT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "1f796f27-9ba4-4705-a7c9-57462bd1e0b7"
   LAUNCH_ASK_GIAS_CONTACT_TO_REPORT_SCHOOL_TRAINING_DETAILS_TEMPLATE = "f4dfee2a-2cc3-4d32-97f9-8adca41343bf"
   COHORTLESS_PILOT_2023_SURVEY_TEMPLATE = "5f6dc6bf-62c5-4cf1-8cc8-1440453f4a2d"
+  REMIND_SIT_TO_ADD_PARTICIPANTS_TEMPLATE = "19b5a258-e615-4371-9e55-f9cc58187448"
+
+  def remind_sit_to_add_ects_and_mentors_email
+    induction_coordinator = params[:induction_coordinator]
+    email_address = induction_coordinator.user.email
+    name = induction_coordinator.user.full_name
+
+    template_mail(
+      REMIND_SIT_TO_ADD_PARTICIPANTS_TEMPLATE,
+      to: email_address,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        name:,
+        email_address:,
+      },
+    ).tag(:remind_sits_to_add_ects_and_mentors).associate_with(induction_coordinator, as: :induction_coordinator_profile)
+  end
 
   def cohortless_pilot_2023_survey_email
     sit_user = params[:sit_user]

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -3,6 +3,19 @@
 require "rails_helper"
 
 RSpec.describe SchoolMailer, type: :mailer do
+  describe "#remind_sit_to_assign_mentors_to_ects_email" do
+    let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+
+    let(:email) do
+      SchoolMailer.with(induction_coordinator:).remind_sit_to_assign_mentors_to_ects_email.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(email.from).to eq(["mail@example.com"])
+      expect(email.to).to eq [induction_coordinator.user.email]
+    end
+  end
+
   describe "#remind_sit_to_add_ects_and_mentors_email" do
     let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
 

--- a/spec/mailers/school_mailer_spec.rb
+++ b/spec/mailers/school_mailer_spec.rb
@@ -3,6 +3,19 @@
 require "rails_helper"
 
 RSpec.describe SchoolMailer, type: :mailer do
+  describe "#remind_sit_to_add_ects_and_mentors_email" do
+    let(:induction_coordinator) { create(:seed_induction_coordinator_profile, :with_user) }
+
+    let(:email) do
+      SchoolMailer.with(induction_coordinator:).remind_sit_to_add_ects_and_mentors_email.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(email.from).to eq(["mail@example.com"])
+      expect(email.to).to eq [induction_coordinator.user.email]
+    end
+  end
+
   describe "#cohortless_pilot_2023_survey_email" do
     let(:sit_user) { create(:seed_induction_coordinator_profile, :with_user).user }
 


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1763)

### Changes proposed in this pull request
Adds new mailer for chaser email to SIT to remind them to add participants
Adds new mailer for chaser to SIT to remind them to assign mentors to ECTs

### Guidance to review
![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/b5bbeed0-9098-4277-84c1-eaf5063ea5a2)

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/3a0d354b-f629-4ded-ae62-432bac8b122b)

