### PR TITLE
Add contidional validation to npq application eligibility status

### DIFF
--- a/app/controllers/admin/npq/applications/eligible_for_funding_controller.rb
+++ b/app/controllers/admin/npq/applications/eligible_for_funding_controller.rb
@@ -23,7 +23,7 @@ module Admin
           set_eligibility_status(eligible_for_funding_params["eligible_for_funding"])
           name = @npq_application.participant_identity.user.full_name
 
-          if @npq_application.save
+          if @npq_application.save(context: :admin)
 
             flash[:success] = {
               title: "#{name} updated",

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 class NPQApplication < ApplicationRecord
+  VALID_FUNDING_ELIGIBILITY_STATUS_CODES = %w[
+    funded
+    no_institution
+    ineligible_establishment_type
+    ineligible_institution_type
+    previously_funded
+    not_new_headteacher_requesting_ehco
+    school_outside_catchment
+    early_years_outside_catchment
+    not_on_early_years_register
+    early_years_invalid_npq
+    marked_funded_by_policy
+    marked_ineligible_by_policy
+  ].freeze
+
   has_paper_trail only: %i[user_id npq_lead_provider_id npq_course_id created_at updated_at lead_provider_approval_status]
 
   self.ignored_columns = %w[user_id]
@@ -53,6 +68,7 @@ class NPQApplication < ApplicationRecord
   scope :created_at_range, ->(start_date, end_date) { where(created_at: start_date..end_date) }
 
   validates :eligible_for_funding_before_type_cast, inclusion: { in: [true, false, "true", "false"] }
+  validate  :validate_funding_eligiblity_status_code_change, on: :admin
 
   delegate :start_year, to: :cohort, prefix: true, allow_nil: true
 
@@ -94,6 +110,12 @@ class NPQApplication < ApplicationRecord
     ParticipantDeclaration::NPQ&.find_by_participant_profile_id(ParticipantProfile&.find_by_participant_identity_id(participant_identity_id)&.id)
   end
 
+  def declared_as_payable?
+    profile.participant_declarations.any? do |declaration|
+      %w[eligible payable paid].include? declaration.state
+    end
+  end
+
 private
 
   def previously_funded?
@@ -113,6 +135,12 @@ private
   def push_enrollment_to_big_query
     if (saved_changes.keys & %w[cohort_id id lead_provider_approval_status]).present?
       NPQ::StreamBigQueryEnrollmentJob.perform_later(npq_application_id: id)
+    end
+  end
+
+  def validate_funding_eligiblity_status_code_change
+    if declared_as_payable? && eligible_for_funding == false
+      errors.add(:funding_eligiblity_status_code)
     end
   end
 end

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -111,9 +111,7 @@ class NPQApplication < ApplicationRecord
   end
 
   def declared_as_payable?
-    profile.participant_declarations.any? do |declaration|
-      %w[eligible payable paid].include? declaration.state
-    end
+    profile.participant_declarations.paid_payable_or_eligible.count.positive?
   end
 
 private

--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -110,8 +110,8 @@ class NPQApplication < ApplicationRecord
     ParticipantDeclaration::NPQ&.find_by_participant_profile_id(ParticipantProfile&.find_by_participant_identity_id(participant_identity_id)&.id)
   end
 
-  def declared_as_payable?
-    profile.participant_declarations.paid_payable_or_eligible.count.positive?
+  def declared_as_billable?
+    profile.participant_declarations.billable.count.positive?
   end
 
 private
@@ -137,8 +137,8 @@ private
   end
 
   def validate_funding_eligiblity_status_code_change
-    if declared_as_payable? && eligible_for_funding == false
-      errors.add(:funding_eligiblity_status_code)
+    if declared_as_billable? && eligible_for_funding == false
+      errors.add(:base, :billable_declaration_exists)
     end
   end
 end

--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -61,7 +61,6 @@ class ParticipantDeclaration < ApplicationRecord
   scope :mentor, -> { where(participant_profile_id: ParticipantProfile::Mentor.select(:id)) }
   scope :npq, -> { where(participant_profile_id: ParticipantProfile::NPQ.select(:id)) }
 
-  scope :paid_payable_or_eligible, -> { where(state: %w[eligible payable paid]) }
   scope :changeable, -> { where(state: %w[eligible submitted]) }
   scope :unique_id, -> { select(:user_id).distinct }
 
@@ -105,6 +104,7 @@ class ParticipantDeclaration < ApplicationRecord
   scope :paid_uplift_for_lead_provider, ->(lead_provider) { paid_for_lead_provider(lead_provider).uplift }
 
   scope :billable, -> { where(state: %w[eligible payable paid]) }
+  scope :paid_payable_or_eligible, -> { billable }
   scope :billable_or_changeable, -> { billable.or(changeable) }
 
   before_create :build_initial_declaration_state

--- a/app/services/admin/npq_applications/eligibility_import/application_updater.rb
+++ b/app/services/admin/npq_applications/eligibility_import/application_updater.rb
@@ -4,21 +4,6 @@ module Admin
   module NPQApplications
     module EligibilityImport
       class ApplicationUpdater
-        VALID_FUNDING_ELIGIBILITY_STATUS_CODES = %w[
-          funded
-          no_institution
-          ineligible_establishment_type
-          ineligible_institution_type
-          previously_funded
-          not_new_headteacher_requesting_ehco
-          school_outside_catchment
-          early_years_outside_catchment
-          not_on_early_years_register
-          early_years_invalid_npq
-          marked_funded_by_policy
-          marked_ineligible_by_policy
-        ].freeze
-
         attr_reader :application_updates, :user, :update_errors, :updated_records, :eligibility_import
 
         def initialize(application_updates:, user:, eligibility_import:)
@@ -36,7 +21,7 @@ module Admin
       private
 
         def valid_status_code?(application_update)
-          VALID_FUNDING_ELIGIBILITY_STATUS_CODES.include?(application_update.funding_eligiblity_status_code)
+          NPQApplication::VALID_FUNDING_ELIGIBILITY_STATUS_CODES.include?(application_update.funding_eligiblity_status_code)
         end
 
         def build_error_message(csv_row:, message:)

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -34,13 +34,20 @@
       row.value(text: @npq_application.lead_provider_approval_status)
     end
 
-    sl.row do |row|
-      row.key(text: "Eligible for funding")
-      row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
-      row.action(
-        text: 'edit',
-        href: edit_admin_npq_applications_eligible_for_funding_path(@npq_application)
-      ) if @npq_application.declared_as_payable? && !@npq_application.eligible_for_funding
+    if (@npq_application.declared_as_payable? && @npq_application.eligible_for_funding)
+      sl.row do |row|
+        row.key(text: "Eligible for funding")
+        row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
+      end
+    else
+      sl.row do |row|
+        row.key(text: "Eligible for funding")
+        row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
+        row.action(
+          text: 'edit',
+          href: edit_admin_npq_applications_eligible_for_funding_path(@npq_application)
+        )
+      end
     end
 
     sl.row do |row|

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -34,7 +34,7 @@
       row.value(text: @npq_application.lead_provider_approval_status)
     end
 
-    if (@npq_application.declared_as_payable? && @npq_application.eligible_for_funding)
+    if (@npq_application.declared_as_billable? && @npq_application.eligible_for_funding)
       sl.row do |row|
         row.key(text: "Eligible for funding")
         row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -45,7 +45,8 @@
         row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
         row.action(
           text: 'edit',
-          href: edit_admin_npq_applications_eligible_for_funding_path(@npq_application)
+          href: edit_admin_npq_applications_eligible_for_funding_path(@npq_application),
+          visually_hidden_text: "NPQ application"
         )
       end
     end

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -40,7 +40,7 @@
       row.action(
         text: 'edit',
         href: edit_admin_npq_applications_eligible_for_funding_path(@npq_application)
-      )
+      ) if @npq_application.declared_as_payable? && !@npq_application.eligible_for_funding
     end
 
     sl.row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,8 @@ en:
               blank: "enter your expected number of teachers"
         npq_application:
           attributes:
+            base:
+              billable_declaration_exists: "Eligibility can not be changed because billable declaration exists"
             lead_provider_approval_status:
               has_another_accepted_application: The participant already has an accepted application for this course
               has_already_been_accepted: This NPQ application has already been accepted

--- a/spec/requests/admin/npq/applications/edge_case_controller_spec.rb
+++ b/spec/requests/admin/npq/applications/edge_case_controller_spec.rb
@@ -6,16 +6,25 @@ RSpec.describe "Admin::NPQ::Applications::EdgeCasesController", type: :request d
   before do
     # Applications that wont show up
     create(:npq_application,
+           :funded,
+           :accepted,
+           :with_started_declaration,
            works_in_school: true,
            works_in_childcare: false,
            funding_eligiblity_status_code: "no_institution")
     create(:npq_application,
+           :funded,
+           :accepted,
+           :with_started_declaration,
            works_in_school: false,
            works_in_childcare: true,
            funding_eligiblity_status_code: "funded")
 
     # Applications that will show up
     create(:npq_application,
+           :funded,
+           :accepted,
+           :with_started_declaration,
            works_in_school: false,
            works_in_childcare: false,
            employment_type: "local_authority_supply_teacher",
@@ -23,12 +32,18 @@ RSpec.describe "Admin::NPQ::Applications::EdgeCasesController", type: :request d
            employer_name: "University of Newcastle upon Tyne",
            funding_eligiblity_status_code: "no_institution")
     create(:npq_application,
+           :funded,
+           :accepted,
+           :with_started_declaration,
            works_in_school: false,
            works_in_childcare: false,
            employment_role: "Music Teacher",
            employer_name: "St Joseph's Specialist Trust",
            funding_eligiblity_status_code: "marked_ineligible_by_policy")
     create(:npq_application,
+           :funded,
+           :accepted,
+           :with_started_declaration,
            works_in_school: false,
            works_in_childcare: false,
            employment_type: "hospital_school",
@@ -36,6 +51,9 @@ RSpec.describe "Admin::NPQ::Applications::EdgeCasesController", type: :request d
            employer_name: "Salford council",
            funding_eligiblity_status_code: "awaiting_more_information")
     create(:npq_application,
+           :funded,
+           :accepted,
+           :with_started_declaration,
            works_in_school: false,
            works_in_childcare: false,
            employment_type: "local_authority_supply_teacher",

--- a/spec/requests/admin/npq/applications/eligible_for_funding_controller_spec.rb
+++ b/spec/requests/admin/npq/applications/eligible_for_funding_controller_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe "Admin::NPQ::Applications::EligibleForFundingController", type: :
            employment_type: "local_authority_supply_teacher",
            employment_role: "Programme Leader",
            employer_name: "University of Newcastle upon Tyne",
-           funding_eligiblity_status_code: "no_institution"
-          )
+           funding_eligiblity_status_code: "no_institution")
   end
 
   let(:admin_user) { create :user, :admin }
@@ -45,7 +44,7 @@ RSpec.describe "Admin::NPQ::Applications::EligibleForFundingController", type: :
     let(:application_id) { application.id }
 
     before do
-      application.profile.participant_declarations.each { |d| d.update!(state: 'submitted') }
+      application.profile.participant_declarations.each { |d| d.update!(state: "submitted") }
     end
 
     it "renders the show template for the application", :aggregate_failures do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1224

### Changes proposed in this pull request

To prevent financial mismatch, disable ability for admin to turn `eligible` application to `ineligible` when there are declarations that are payble against application.

### Guidance to review

