### PR TITLE
Increase number of schools shown per page

### DIFF
--- a/app/controllers/schools/dashboard_controller.rb
+++ b/app/controllers/schools/dashboard_controller.rb
@@ -12,7 +12,7 @@ class Schools::DashboardController < Schools::BaseController
                       .schools
                       .order(:name),
                            page: params[:page],
-                           items: 10)
+                           items: 20)
   end
 
   def show


### PR DESCRIPTION
A participant in user research had 37 schools listed across 4 pages.

Having more schools per page would make it faster for them to locate a specific school.