### PR TITLE
Change the `cpd_lead_provider_id` index format back to default

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -654,7 +654,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_05_152210) do
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
     t.uuid "mentor_user_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying])::text[]))"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"


### PR DESCRIPTION
### Context

This line flip flops depending on who runs the migration. For most of the team, this is the version that's output by running `rails db:migrate` on a clean repo.
