### PR TITLE
Add participant declaration & profile requires back to get around top-level constant lookup rule

### DIFF
--- a/app/models/participant_declaration.rb
+++ b/app/models/participant_declaration.rb
@@ -178,3 +178,6 @@ private
     declaration_states.build(state:)
   end
 end
+
+require "participant_declaration/ecf"
+require "participant_declaration/npq"

--- a/app/models/participant_profile.rb
+++ b/app/models/participant_profile.rb
@@ -167,3 +167,6 @@ class ParticipantProfile < ApplicationRecord
     decision || validation_decisions.build(validation_step: name)
   end
 end
+
+require "participant_profile/npq"
+require "participant_profile/ecf"

--- a/app/models/participant_profile/ecf.rb
+++ b/app/models/participant_profile/ecf.rb
@@ -137,3 +137,6 @@ private
     induction_record&.update!(mentor_profile:) if saved_change_to_mentor_profile_id?
   end
 end
+
+require "participant_profile/ect"
+require "participant_profile/mentor"


### PR DESCRIPTION
### Context

`NameError: Rails couldn't find a valid model for ParticipantDeclaration::NPQ association. `

We're getting some exceptions like the above one in dev due to how Ruby loads classes and constants... (top-level constant lookup rule).. there's more context in the website below:

https://blog.jetbrains.com/ruby/2017/03/why-you-should-not-use-a-class-as-a-namespace-in-rails-applications/

https://ukgovernmentdfe.slack.com/archives/G01F7SE8TLY/p1689329822799979

### Changes proposed in this pull request

This is only a workaround.. in reality we should rename the modules to be in the plural to be more "Rails" way and prevent issues when ruby is loading classes & constants. But there's a high risk of doing that.

`class ParticipantProfile::ECT < ParticipantProfile::ECF`
to
`class ParticipantProfiles::ECT < ParticipantProfiles::ECF`

`class ParticipantProfile::ECF < ParticipantProfile`
to
`class ParticipantProfiles::ECF < ParticipantProfile`

`class ParticipantDeclaration::ECF < ParticipantDeclaration`
to 
`class ParticipantDeclarations::ECF < ParticipantDeclaration`


