### PR TITLE
CST-1710: stop sending emails to capita when a capita school chooses a different training provider for 2023

### DIFF
--- a/app/controllers/schools/cohort_setup_controller.rb
+++ b/app/controllers/schools/cohort_setup_controller.rb
@@ -90,15 +90,6 @@ module Schools
       session.delete(wizard_session_key)
     end
 
-    def save_programme_change
-      set_cohort_induction_programme!(@setup_school_cohort_form.programme_choice)
-      if previous_school_cohort.full_induction_programme?
-        send_fip_programme_changed_email!
-      end
-
-      redirect_to action: :what_changes_submitted
-    end
-
     def wizard_class
       Schools::Cohorts::SetupWizard
     end

--- a/app/forms/schools/cohorts/setup_wizard/success.rb
+++ b/app/forms/schools/cohorts/setup_wizard/success.rb
@@ -63,13 +63,15 @@ module Schools
             return Rails.logger.warn(msg)
           end
 
-          previous_partnership.lead_provider.users.each do |lead_provider_user|
-            LeadProviderMailer.with(
-              partnership: previous_partnership,
-              user: lead_provider_user,
-              cohort_year: school_cohort.academic_year,
-              what_changes_choice: what_changes,
-            ).programme_changed_email.deliver_later
+          if previous_partnership.lead_provider.providing_training?(cohort)
+            previous_partnership.lead_provider.users.each do |lead_provider_user|
+              LeadProviderMailer.with(
+                partnership: previous_partnership,
+                user: lead_provider_user,
+                cohort_year: school_cohort.academic_year,
+                what_changes_choice: what_changes,
+              ).programme_changed_email.deliver_later
+            end
           end
         end
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -36,4 +36,8 @@ class LeadProvider < ApplicationRecord
   def next_output_fee_statement(cohort)
     statements.next_output_fee_statements.where(cohort:).first
   end
+
+  def providing_training?(cohort)
+    provider_relationships.exists?(cohort:)
+  end
 end

--- a/spec/forms/schools/cohorts/setup_wizard_spec.rb
+++ b/spec/forms/schools/cohorts/setup_wizard_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
-  let(:cohort) { Cohort.current || create(:cohort, :current) }
+  let(:cohort) { Cohort.active_registration_cohort }
+  let(:previous_cohort) { Cohort.find_or_create_by!(start_year: cohort.start_year - 1) }
   let(:current_step) { :what_we_need }
   let(:data_store) { instance_double(FormData::CohortSetupStore) }
   let(:school) { create(:seed_school, :with_induction_coordinator) }
@@ -11,7 +12,15 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
   let(:submitted_params) { {} }
   let(:start_year) { cohort.start_year }
 
-  subject(:wizard) { described_class.new(current_step:, data_store:, current_user: sit_user, default_step_name:, cohort:, school:, submitted_params:) }
+  subject(:wizard) do
+    described_class.new(current_step:,
+                        data_store:,
+                        current_user: sit_user,
+                        default_step_name:,
+                        cohort:,
+                        school:,
+                        submitted_params:)
+  end
 
   before do
     allow(data_store).to receive(:store).and_return({ something: "is here" })
@@ -21,6 +30,8 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
     allow(data_store).to receive(:bulk_get).and_return({})
     allow(data_store).to receive(:clean)
     allow(data_store).to receive(:cohort_start_year).and_return(start_year)
+    allow(data_store).to receive(:appropriate_body_id).and_return(3)
+    allow(data_store).to receive(:appropriate_body_appointed?).and_return(true)
   end
 
   shared_context "sending the pilot survey" do
@@ -30,11 +41,11 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
       }.not_to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
     end
 
-    context "when the school is in the pilot", with_feature_flag: { cohortless_dashboard: "active" }, travel_to: Date.new(2023, 7, 1) do
+    context "when the school is in the pilot", with_feature_flags: { cohortless_dashboard: "active" }, travel_to: Date.new(2023, 7, 1) do
       it "sends the pilot survey" do
         expect {
           wizard.success
-        }.not_to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
+        }.to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
       end
     end
   end
@@ -52,8 +63,15 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
 
     context "when the SIT does not expect any ECTs" do
       it "does not send the pilot survey" do
-        expect(wizard).to receive(:set_cohort_induction_programme!).with(:no_early_career_teachers, opt_out_of_updates: true)
-
+        expect(Induction::SetCohortInductionProgramme)
+          .to receive(:call).with(programme_choice: :no_early_career_teachers,
+                                  school_cohort:,
+                                  opt_out_of_updates: true,
+                                  delivery_partner_to_be_confirmed: false)
+        expect(Induction::SetSchoolCohortAppropriateBody)
+          .to receive(:call).with(school_cohort:,
+                                  appropriate_body_id: 3,
+                                  appropriate_body_appointed: true)
         expect {
           wizard.success
         }.not_to have_enqueued_mail(SchoolMailer, :cohortless_pilot_2023_survey_email)
@@ -66,13 +84,39 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
 
       before do
         expect(wizard).to receive(:active_partnership?).and_return(true)
-        expect(wizard).to receive(:save_appropriate_body).once
+        expect(Induction::SetSchoolCohortAppropriateBody)
+          .to receive(:call).with(school_cohort:,
+                                  appropriate_body_id: 3,
+                                  appropriate_body_appointed: true)
       end
 
       include_context "sending the pilot survey"
     end
 
     context "when the SIT chooses to keep providers" do
+      let(:expect_any_ects) { true }
+      let(:keep_providers) { true }
+
+      before do
+        allow(wizard).to receive(:active_partnership?).and_return(false)
+        NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: previous_cohort, school:)
+                                               .build
+                                               .with_programme
+        expect(Induction::SetCohortInductionProgramme)
+          .to receive(:call).with(programme_choice: :full_induction_programme,
+                                  school_cohort:,
+                                  opt_out_of_updates: false,
+                                  delivery_partner_to_be_confirmed: false)
+        expect(Induction::SetSchoolCohortAppropriateBody)
+          .to receive(:call).with(school_cohort:,
+                                  appropriate_body_id: 3,
+                                  appropriate_body_appointed: true)
+      end
+
+      include_context "sending the pilot survey"
+    end
+
+    context "when the SIT chooses to change something" do
       let(:expect_any_ects) { true }
       let(:what_changes) { "change_lead_provider" }
 
@@ -89,8 +133,65 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
       let(:what_changes) { "change_lead_provider" }
 
       before do
-        expect(wizard).to receive(:set_cohort_induction_programme!).with(:full_induction_programme)
-        expect(wizard).to receive(:previously_fip?).and_return(false)
+        expect(Induction::SetCohortInductionProgramme)
+          .to receive(:call).with(programme_choice: :full_induction_programme,
+                                  school_cohort:,
+                                  opt_out_of_updates: false,
+                                  delivery_partner_to_be_confirmed: false)
+        expect(Induction::SetSchoolCohortAppropriateBody)
+          .to receive(:call).with(school_cohort:,
+                                  appropriate_body_id: 3,
+                                  appropriate_body_appointed: true)
+      end
+
+      context "when the previous programme was not fip" do
+        before do
+          allow(wizard).to receive(:previously_fip?).and_return(false)
+        end
+
+        it "do not notify any provider" do
+          expect {
+            wizard.success
+          }.not_to have_enqueued_mail(LeadProviderMailer, :programme_changed_email)
+        end
+      end
+
+      context "when the previous provider do not provides training this year" do
+        before do
+          allow(wizard).to receive(:previously_fip?).and_return(true)
+          NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: previous_cohort, school:)
+                                                 .build
+                                                 .with_programme
+        end
+
+        it "do not notify any provider" do
+          expect {
+            wizard.success
+          }.not_to have_enqueued_mail(LeadProviderMailer, :programme_changed_email)
+        end
+      end
+
+      context "when the previous provider still provides training this year" do
+        let(:old_school_cohort) do
+          NewSeeds::Scenarios::SchoolCohorts::Fip.new(cohort: previous_cohort, school:)
+                                                 .build
+                                                 .with_programme
+                                                 .school_cohort
+        end
+        let(:lead_provider) { old_school_cohort.default_induction_programme.lead_provider }
+        let(:delivery_partner) { old_school_cohort.default_induction_programme.delivery_partner }
+
+        before do
+          allow(wizard).to receive(:previously_fip?).and_return(true)
+          ProviderRelationship.create!(lead_provider:, delivery_partner:, cohort:)
+          lead_provider.users.create!(email: "any@example.com", full_name: "Any surname")
+        end
+
+        it "notify the old provider" do
+          expect {
+            wizard.success
+          }.to have_enqueued_mail(LeadProviderMailer, :programme_changed_email)
+        end
       end
 
       include_context "sending the pilot survey"

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -88,5 +88,26 @@ RSpec.describe LeadProvider, type: :model do
         expect(lead_provider.active_ecf_participant_profiles).not_to include participant_profile
       end
     end
+
+    describe "#providing_training?" do
+      let(:cohort) { Cohort.current || create(:cohort, :current) }
+      let(:lead_provider) { create(:lead_provider) }
+
+      context "when the lead provider has no relationships with any delivery_partner on the cohort" do
+        it "return false" do
+          expect(lead_provider.providing_training?(cohort)).to be_falsey
+        end
+      end
+
+      context "when the lead provider has at least one relationship with a delivery_partner on the cohort" do
+        before do
+          create(:provider_relationship, lead_provider:, cohort:)
+        end
+
+        it "return false" do
+          expect(lead_provider.providing_training?(cohort)).to be_truthy
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- [Ticket: ](https://dfedigital.atlassian.net/browse/CST-1710)

### Changes proposed in this pull request
 Do not notify school programme changes to providers not training in the related cohort.

### Guidance to review

