### PR TITLE
[CST-1740] Fix content in the what-changes page

### DIFF
--- a/app/forms/schools/cohorts/wizard_steps/what_changes_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/what_changes_step.rb
@@ -14,7 +14,7 @@ module Schools
 
         def choices
           [
-            OpenStruct.new(id: :change_lead_provider,               name: "Form new partnership with a lead provider and delivery partner"),
+            OpenStruct.new(id: :change_lead_provider,               name: "Form a new partnership"),
             OpenStruct.new(id: :change_to_core_induction_programme, name: "Deliver your own programme using DfE-accredited materials"),
             OpenStruct.new(id: :change_to_design_our_own,           name: "Design and deliver your own programme based on the Early Career Framework (ECF)"),
           ]

--- a/spec/features/schools/choose_programme/choose_programme_steps.rb
+++ b/spec/features/schools/choose_programme/choose_programme_steps.rb
@@ -313,7 +313,7 @@ module ChooseProgrammeSteps
   end
 
   def when_i_choose_to_form_a_new_partnership
-    choose("Form new partnership with a lead provider and delivery partner")
+    choose("Form a new partnership")
   end
 
   def when_i_choose_to_change_delivery_partner


### PR DESCRIPTION
### Context

- Ticket: CST-1740

The first radio button in the `what-changes` page should be `Form a new partnership`.

### Changes proposed in this pull request
- Update the label

### Guidance to review

| Before | After |
|--------|--------|
|![image](https://github.com/DFE-Digital/early-careers-framework/assets/951947/339839f2-de85-4424-9d32-e3e8071b3062)|![image](https://github.com/DFE-Digital/early-careers-framework/assets/951947/0e9e45c3-290b-4f52-8d4b-ec92d895021f)|