### PR TITLE
Add deploy env to AKS step

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -1,0 +1,60 @@
+name: Deploy environment to AKS
+description: Deploys an application environment to AKS
+
+inputs:
+  environment:
+    description: The name of the environment
+    required: true
+  docker-image:
+    description: The Docker image to deploy
+    required: true
+  azure-credentials:
+    description: JSON object containing a key for the service principal authorised on the Azure subscription
+    required: true
+  pull-request-number:
+    description: The pull request number which triggered this deploy. If set, this will automatically seed the database.
+    required: false
+  smoke-test-credentials-required:
+    description: Whether to run the smoke test with support credentials
+    required: false
+    default: "true"
+
+outputs:
+  url:
+    description: The base URL for the deployed environment
+    value: ${{ steps.apply-terraform.outputs.url }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.5.3
+        terraform_wrapper: false
+
+    - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      with:
+        azure-credentials: ${{ inputs.azure-credentials }}
+
+    - name: Apply Terraform
+      id: apply-terraform
+      shell: bash
+      run: |
+        make ci ${{ inputs.environment }}_aks terraform-apply
+        cd terraform/aks && echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
+      env:
+        TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}
+        DOCKER_IMAGE: ${{ inputs.docker-image }}
+        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
+
+    - uses: Azure/login@v1
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Seed database
+      if: ${{ inputs.pull-request-number != '' }}
+      shell: bash
+      run: |
+        az aks get-credentials --resource-group s189t01-tsc-ts-rg --name s189t01-tsc-test-aks
+        kubectl exec -n cpd-development deployment/cpd-ecf-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && /usr/local/bin/bundle exec rails db:safe_reset"

--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -1,0 +1,55 @@
+name: Prepare application environment
+description: Performs setup steps common to jobs that need to run the application
+inputs:
+  skip-ruby:
+    description: Allows skipping Ruby setup for jobs where it isn't required
+    required: false
+    default: "false"
+  skip-node:
+    description: Allows skipping Node.js setup for jobs where it isn't required
+    required: false
+    default: "false"
+  node-version:
+    description: The version of Node.js to install
+    required: false
+    default: "18.17"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby
+      if: ${{ inputs.skip-ruby == 'false' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Set up Node
+      if: ${{ inputs.skip-node == 'false' }}
+      uses: actions/setup-node@v2.5.0
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install yarn
+      if: ${{ inputs.skip-node == 'false' }}
+      run: npm install yarn -g
+      shell: bash
+
+    - name: Yarn cache
+      if: ${{ inputs.skip-node == 'false' }}
+      id: yarn-cache
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Set up yarn cache
+      if: ${{ inputs.skip-node == 'false' }}
+      uses: actions/cache@v2.1.7
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install node.js dependencies
+      if: ${{ inputs.skip-node == 'false' }}
+      run: yarn install
+      shell: bash

--- a/.github/workflows/aks_deploy_review.yml
+++ b/.github/workflows/aks_deploy_review.yml
@@ -42,6 +42,7 @@ jobs:
   deploy_review:
     name: Deploy to review environment
     concurrency: deploy_review_${{ github.event.pull_request.number }}
+    if: contains(github.event.pull_request.labels.*.name, 'review-app')
     needs: [docker]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/aks_deploy_review.yml
+++ b/.github/workflows/aks_deploy_review.yml
@@ -1,0 +1,58 @@
+name: "Deploy review"
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy environment"
+        required: true
+        default: review_aks
+        type: environment
+        options:
+          - review_aks
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - opened
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    outputs:
+      image: ${{ steps.build-docker-image.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/early-careers-framework
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_review:
+    name: Deploy to review environment
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    needs: [docker]
+    runs-on: ubuntu-latest
+    environment:
+      name: review
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          environment: review
+          docker-image: ${{ needs.docker.outputs.image }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          pull-request-number: ${{ github.event.pull_request.number }}

--- a/terraform/aks/outputs.tf
+++ b/terraform/aks/outputs.tf
@@ -1,0 +1,3 @@
+output "url" {
+  value = module.web_application.url
+}


### PR DESCRIPTION
This change adds automatic review app deployment to AKS. There is a generic action, `deploy-environment-to-aks` that will deploy any docker image to any environment, and a new workflow, `aks_deploy_review` that builds a docker image for the current PR and calls the action.

We will be able to deploy other environments using the same process.