### PR TITLE
[CST-1732] Ask schools to report their next year programme when there is no last year partnership

### DIFF
--- a/app/forms/schools/cohorts/setup_wizard.rb
+++ b/app/forms/schools/cohorts/setup_wizard.rb
@@ -50,6 +50,10 @@ module Schools
         previous_school_cohort&.fip?
       end
 
+      def previous_partnership_exists?
+        previous_lead_provider && previous_delivery_partner
+      end
+
       def provider_relationship_is_valid?
         return false unless previous_lead_provider && previous_delivery_partner
 

--- a/app/forms/schools/cohorts/wizard_steps/expect_any_ects_step.rb
+++ b/app/forms/schools/cohorts/wizard_steps/expect_any_ects_step.rb
@@ -27,6 +27,7 @@ module Schools
         def next_step
           return :no_expected_ects unless expect_any_ects?
           return :how_will_you_run_training unless wizard.previously_fip?
+          return :what_changes unless wizard.previous_partnership_exists?
           return :keep_providers if wizard.provider_relationship_is_valid?
 
           :providers_relationship_has_changed

--- a/spec/features/schools/choose_programme/choose_programme_spec.rb
+++ b/spec/features/schools/choose_programme/choose_programme_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature "Schools should be able to choose their programme", type: :feature
 
       when_i_choose_ects_expected
       and_i_click_continue
-      then_i_am_taken_to_the_lp_dp_relationship_has_changed_page
+      then_i_am_taken_to_what_changes_page
     end
 
     scenario "A school chooses to keep the same FIP programme in the new cohort" do

--- a/spec/forms/schools/cohorts/setup_wizard_spec.rb
+++ b/spec/forms/schools/cohorts/setup_wizard_spec.rb
@@ -197,4 +197,24 @@ RSpec.describe Schools::Cohorts::SetupWizard, type: :model do
       include_context "sending the pilot survey"
     end
   end
+
+  describe "#previous_partnership_exists?" do
+    context "when the previous cohort has an active partnership with a lead provider and a delivery partnern" do
+      it "returns true" do
+        allow(wizard).to receive(:previous_delivery_partner).and_return(true)
+        allow(wizard).to receive(:previous_lead_provider).and_return(true)
+
+        expect(wizard.previous_partnership_exists?).to be true
+      end
+    end
+
+    context "when the previous cohort does not have an active partnership" do
+      it "returns false" do
+        allow(wizard).to receive(:previous_delivery_partner).and_return(false)
+        allow(wizard).to receive(:previous_lead_provider).and_return(false)
+
+        expect(wizard.previous_partnership_exists?).to be false
+      end
+    end
+  end
 end

--- a/spec/forms/schools/cohorts/wizard_steps/expect_any_ects_step_spec.rb
+++ b/spec/forms/schools/cohorts/wizard_steps/expect_any_ects_step_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::Cohorts::WizardSteps::ExpectAnyEctsStep, type: :model do
+  let(:wizard) { instance_double(Schools::Cohorts::SetupWizard) }
+  subject(:step) { described_class.new(wizard:) }
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:expect_any_ects).in_array(%w[yes no]) }
+  end
+
+  describe ".permitted_params" do
+    it "returns the permitted params for the step" do
+      expect(described_class.permitted_params).to eql %i[expect_any_ects]
+    end
+  end
+
+  describe "#expected?" do
+    it "returns true" do
+      expect(step.expected?).to be true
+    end
+  end
+
+  describe "#expect_any_ects?" do
+    context "when ects are expected" do
+      it "returns true" do
+        step.expect_any_ects = "yes"
+        expect(step).to be_expect_any_ects
+      end
+    end
+
+    context "when no ects are expected" do
+      it "returns false" do
+        step.expect_any_ects = nil
+        expect(step).not_to be_expect_any_ects
+
+        step.expect_any_ects = "no"
+        expect(step).not_to be_expect_any_ects
+      end
+    end
+  end
+
+  describe "#complete?" do
+    context "when ects are expected" do
+      it "returns false" do
+        step.expect_any_ects = "yes"
+        expect(step.complete?).to be false
+      end
+    end
+
+    context "when no ects are expected" do
+      it "returns true" do
+        step.expect_any_ects = nil
+        expect(step.complete?).to be true
+
+        step.expect_any_ects = "no"
+        expect(step.complete?).to be true
+      end
+    end
+  end
+
+  describe "#next_step" do
+    context "when no ects are expected" do
+      it "returns :no_expected_ects" do
+        step.expect_any_ects = "no"
+        expect(step.next_step).to eq :no_expected_ects
+      end
+    end
+
+    context "when ects are expected" do
+      before do
+        step.expect_any_ects = "yes"
+      end
+
+      context "when not previously fip" do
+        before do
+          allow(wizard).to receive(:previously_fip?).and_return(false)
+        end
+
+        it "returns :how_will_you_run_training" do
+          expect(step.next_step).to eq :how_will_you_run_training
+        end
+      end
+
+      context "when previously fip" do
+        before do
+          allow(wizard).to receive(:previously_fip?).and_return(true)
+        end
+
+        context "when the LP and DP have a partnership in the new cohort" do
+          before do
+            allow(wizard).to receive(:provider_relationship_is_valid?).and_return(true)
+          end
+
+          it "returns :keep_providers" do
+            expect(step.next_step).to eq :keep_providers
+          end
+        end
+
+        context "when the LP and DP do not have a partnership in the new cohort" do
+          before do
+            allow(wizard).to receive(:provider_relationship_is_valid?).and_return(false)
+          end
+
+          it "returns :providers_relationship_has_changed" do
+            expect(step.next_step).to eq :providers_relationship_has_changed
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/forms/schools/cohorts/wizard_steps/expect_any_ects_step_spec.rb
+++ b/spec/forms/schools/cohorts/wizard_steps/expect_any_ects_step_spec.rb
@@ -86,26 +86,41 @@ RSpec.describe Schools::Cohorts::WizardSteps::ExpectAnyEctsStep, type: :model do
           allow(wizard).to receive(:previously_fip?).and_return(true)
         end
 
-        context "when the LP and DP have a partnership in the new cohort" do
+        context "when there is no partnership in previous cohort" do
           before do
-            allow(wizard).to receive(:provider_relationship_is_valid?).and_return(true)
+            allow(wizard).to receive(:previous_partnership_exists?).and_return(false)
           end
 
-          it "returns :keep_providers" do
-            expect(step.next_step).to eq :keep_providers
+          it "returns :what_changes" do
+            expect(step.next_step).to eq :what_changes
           end
         end
 
-        context "when the LP and DP do not have a partnership in the new cohort" do
+        context "when there is a partnership in previous cohort" do
           before do
-            allow(wizard).to receive(:provider_relationship_is_valid?).and_return(false)
+            allow(wizard).to receive(:previous_partnership_exists?).and_return(true)
           end
 
-          it "returns :providers_relationship_has_changed" do
-            expect(step.next_step).to eq :providers_relationship_has_changed
+          context "when the LP and DP have a partnership in the new cohort" do
+            before do
+              allow(wizard).to receive(:provider_relationship_is_valid?).and_return(true)
+            end
+
+            it "returns :keep_providers" do
+              expect(step.next_step).to eq :keep_providers
+            end
+          end
+
+          context "when the LP and DP do not have a partnership in the new cohort" do
+            before do
+              allow(wizard).to receive(:provider_relationship_is_valid?).and_return(false)
+            end
+
+            it "returns :providers_relationship_has_changed" do
+              expect(step.next_step).to eq :providers_relationship_has_changed
+            end
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
### Context

- Ticket: CST-1732

School that don't have a partnership recorded for last year and trying to report their next year training programme are being told the relationship between their Lead Provider and Delivery Partner has changed. The journey should ask the schools to report what changes instead.

### Changes proposed in this pull request
- Add missing specs
- Update the wizard to redirect SITs to the `what-changes` page when their school has no partnership recorded for last year

### Guidance to review

