### PR TITLE
Fix undefined method bug when application profile is empty

### DIFF
--- a/app/models/npq_application.rb
+++ b/app/models/npq_application.rb
@@ -111,7 +111,7 @@ class NPQApplication < ApplicationRecord
   end
 
   def declared_as_billable?
-    profile.participant_declarations.billable.count.positive?
+    profile.present? && profile.participant_declarations.billable.count.positive?
   end
 
 private

--- a/spec/models/npq_application_spec.rb
+++ b/spec/models/npq_application_spec.rb
@@ -390,6 +390,14 @@ RSpec.describe NPQApplication, type: :model do
   end
 
   describe "#declared_as_billable" do
+    context "when application does not have a profile" do
+      subject(:npq_application) { create(:npq_application) }
+
+      it "is false" do
+        expect(npq_application.declared_as_billable?).to eq(false)
+      end
+    end
+
     %w[submitted voided ineligible awaiting_clawback clawed_back].each do |state|
       context "when declaration state is #{state}" do
         let(:participant_declaration) { create(:npq_participant_declaration, state:) }


### PR DESCRIPTION
### Context

For some applications, profile is empty resulting in `NoMethodError` exception.

