### PR TITLE
Autostrip whitespace on email/name columns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,8 @@ gem "sprockets-rails", require: "sprockets/railtie"
 # Code Highlighter
 gem "rouge"
 
+gem "auto_strip_attributes", "~> 2.6"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     ar-uuid (0.2.3)
       activerecord
     ast (2.4.2)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     aws-eventstream (1.2.0)
     aws-partitions (1.791.0)
     aws-sdk-core (3.178.0)
@@ -637,6 +639,7 @@ DEPENDENCIES
   activerecord-explain-analyze
   activerecord-session_store (~> 2.0)
   ar-uuid (~> 0.2.3)
+  auto_strip_attributes (~> 2.6)
   aws-sdk-s3
   axe-core-rspec
   bootsnap (~> 1.16)

--- a/app/models/additional_school_email.rb
+++ b/app/models/additional_school_email.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class AdditionalSchoolEmail < ApplicationRecord
+  extend AutoStripAttributes
+
   belongs_to :school
   validates :email_address, uniqueness: { scope: :school }
+
+  auto_strip_attributes :email_address, nullify: false
 end

--- a/app/models/data_stage/school.rb
+++ b/app/models/data_stage/school.rb
@@ -3,6 +3,7 @@
 module DataStage
   class School < ApplicationRecord
     include GiasHelpers
+    extend AutoStripAttributes
 
     self.table_name = "data_stage_schools"
 
@@ -17,6 +18,9 @@ module DataStage
     has_one :counterpart, class_name: "::School",
                           foreign_key: :urn,
                           primary_key: :urn
+
+    auto_strip_attributes :primary_contact_email, nullify: false
+    auto_strip_attributes :secondary_contact_email, nullify: false
 
     scope :schools_to_add, -> { currently_open.left_joins(:counterpart).where(counterpart: { urn: nil }) }
 

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 class Network < ApplicationRecord
+  extend AutoStripAttributes
+
   has_many :schools
+
+  auto_strip_attributes :secondary_contact_email, nullify: false
 end

--- a/app/models/participant_identity.rb
+++ b/app/models/participant_identity.rb
@@ -3,6 +3,8 @@
 class ParticipantIdentity < ApplicationRecord
   has_paper_trail
 
+  extend AutoStripAttributes
+
   belongs_to :user, touch: true
   has_many :participant_profiles
   has_many :npq_participant_profiles, class_name: "ParticipantProfile::NPQ"
@@ -11,6 +13,8 @@ class ParticipantIdentity < ApplicationRecord
 
   validates :email, presence: true, uniqueness: true, notify_email: true
   validates :external_identifier, uniqueness: true
+
+  auto_strip_attributes :email, nullify: false
 
   enum origin: {
     ecf: "ecf",

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -5,6 +5,7 @@ class School < ApplicationRecord
 
   extend FriendlyId
   include GiasHelpers
+  extend AutoStripAttributes
 
   friendly_id :slug_candidates
 
@@ -49,6 +50,9 @@ class School < ApplicationRecord
   has_many :active_ecf_participants, through: :active_ecf_participant_profiles, source: :user
 
   has_many :additional_school_emails
+
+  auto_strip_attributes :secondary_contact_email, nullify: false
+  auto_strip_attributes :primary_contact_email, nullify: false
 
   scope :with_local_authority, lambda { |local_authority|
     joins(%i[school_local_authorities local_authorities])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   has_paper_trail
 
+  extend AutoStripAttributes
+
   devise :registerable, :trackable, :passwordless_authenticatable
 
   has_many :participant_identities
@@ -36,7 +38,9 @@ class User < ApplicationRecord
   has_many :npq_application_eligibility_imports, class_name: "NPQApplications::EligibilityImport"
   has_many :npq_application_exports, class_name: "NPQApplications::Export"
 
-  before_validation :strip_whitespace
+  auto_strip_attributes :full_name, nullify: false, squish: true
+  auto_strip_attributes :email, nullify: false
+
   after_update :sync_email_with_identity
 
   validates :full_name, presence: true
@@ -221,10 +225,5 @@ private
     if saved_change_to_email? && participant_identities.count == 1
       participant_identities.original.first&.update!(email:)
     end
-  end
-
-  def strip_whitespace
-    full_name&.squish!
-    email&.squish!
   end
 end

--- a/spec/factories/additional_school_emails.rb
+++ b/spec/factories/additional_school_emails.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :additional_school_email do
+    school
+    email_address { Faker::Internet.email }
+  end
+end

--- a/spec/models/additional_school_email_spec.rb
+++ b/spec/models/additional_school_email_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe AdditionalSchoolEmail, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:school) }
   end
+
+  describe "whitespace stripping" do
+    let(:additional_school_email) { build(:additional_school_email, email_address: " \tgordo@example.com \n ") }
+
+    it "strips whitespace from :email_address" do
+      additional_school_email.valid?
+      expect(additional_school_email.email_address).to eq "gordo@example.com"
+    end
+  end
 end

--- a/spec/models/data_stage/school_spec.rb
+++ b/spec/models/data_stage/school_spec.rb
@@ -72,4 +72,14 @@ RSpec.describe DataStage::School, type: :model do
       end
     end
   end
+
+  describe "whitespace stripping" do
+    let(:school) { create(:staged_school, primary_contact_email: " \tgordo@example.com \n ", secondary_contact_email: " \ttracy@example.com \n ") }
+
+    it "strips whitespace from emails" do
+      school.valid?
+      expect(school.primary_contact_email).to eq "gordo@example.com"
+      expect(school.secondary_contact_email).to eq "tracy@example.com"
+    end
+  end
 end

--- a/spec/models/network_spec.rb
+++ b/spec/models/network_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe Network, type: :model do
 
     it { is_expected.to have_many(:schools) }
   end
+
+  describe "whitespace stripping" do
+    let(:network) { create(:network, secondary_contact_email: " \tgordo@example.com \n ") }
+
+    it "strips whitespace from emails" do
+      network.valid?
+      expect(network.secondary_contact_email).to eq "gordo@example.com"
+    end
+  end
 end

--- a/spec/models/participant_identity_spec.rb
+++ b/spec/models/participant_identity_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe ParticipantIdentity, type: :model do
     end
   end
 
+  describe "whitespace stripping" do
+    let(:participant_identity) { create(:participant_identity, email: " \tgordo@example.com \n ") }
+
+    it "strips whitespace from emails" do
+      participant_identity.valid?
+      expect(participant_identity.email).to eq "gordo@example.com"
+    end
+  end
+
   describe "scopes" do
     describe "#email_matches" do
       it "adds a wildcarded condition on email" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe School, type: :model do
     end
   end
 
+  describe "whitespace stripping" do
+    let(:school) { create(:school, primary_contact_email: " \tgordo@example.com \n ", secondary_contact_email: " \ttracy@example.com \n ") }
+
+    it "strips whitespace from emails" do
+      school.valid?
+      expect(school.primary_contact_email).to eq "gordo@example.com"
+      expect(school.secondary_contact_email).to eq "tracy@example.com"
+    end
+  end
+
   describe "associations" do
     it { is_expected.to have_many(:partnerships) }
     it { is_expected.to have_many(:lead_providers).through(:partnerships) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "before_validation" do
+  describe "whitespace stripping" do
     let(:user) { build(:user, full_name: "\t  Gordon \tBanks \n", email: " \tgordo@example.com \n ") }
 
     it "strips whitespace from :full_name" do


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CST-1727

### Changes proposed in this pull request

- Adds auto_strip_attributes gem
- Adds squish on save to email/name columns on: 
  - additional_school_emails
  - data_stage_schools
  - networks
  - participant_identities
  - schools
  - users
