### PR TITLE
Change the review env's log level to warn

### DIFF
--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -3,6 +3,6 @@
 require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
-  config.log_level = :info
+  config.log_level = :warn
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/check") } } }
 end


### PR DESCRIPTION
### Context

Creating the review apps generates _lots_ of log messages when the call-off contracts and statements are seeded.
