### PR TITLE
Set required chromedriver version to 114 and disable build check

### DIFF
--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -8,7 +8,7 @@ require "site_prism"
 require "site_prism/all_there" # Optional but needed to perform more complex matching
 
 Capybara.register_driver :chrome_headless do |app|
-  args = %w[disable-dev-shm-usage no-sandbox window-size=1400,1400]
+  args = %w[disable-build-check disable-dev-shm-usage no-sandbox window-size=1400,1400]
   args << "headless" unless ENV["NOT_HEADLESS"]
 
   Capybara::Selenium::Driver.new(
@@ -17,6 +17,10 @@ Capybara.register_driver :chrome_headless do |app|
     options: Selenium::WebDriver::Options.chrome(args:),
   )
 end
+
+# This is required as per https://github.com/titusfortner/webdrivers/issues/247
+# and can be removed when selenium 4.11 is released
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 Capybara.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
 Capybara.javascript_driver = :chrome_headless


### PR DESCRIPTION
### Context

We are getting failures in the specs: https://github.com/DFE-Digital/early-careers-framework/actions/runs/5660570693/job/15336566031
Having a look at this issue https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1648154088

The recommendation is to pin the required version to a known version and and disable build check

### Changes proposed in this pull request
- Pin Chromedriver version to 114
- Disable build check in Selenium 

### Guidance to review
Hopefully this solves the issue