### PR TITLE
Add notification banner for SITs about their completed participants

### DIFF
--- a/app/helpers/schools/dashboard_helper.rb
+++ b/app/helpers/schools/dashboard_helper.rb
@@ -21,5 +21,9 @@ module Schools
     def mentor_count(school_cohorts)
       school_cohorts.sum { |sc| sc.current_induction_records.mentors.count }
     end
+
+    def participants_count(school_cohorts)
+      school_cohorts.sum { |sc| sc.current_induction_records.count }
+    end
   end
 end

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -3,6 +3,15 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: schools_dashboard_path) %>
 
 <div class="govuk-grid-row">
+  <% if participants_count(@school.school_cohorts) > 0 %>
+    <div class="govuk-width-container">
+      <%= render GovukComponent::NotificationBannerComponent.new(title_text: 'Important', classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-5', html_attributes: { data: { test: "notification-banner"} }) do |banner| %>
+        <p class="govuk-notification-banner__heading">Do not remove ECTs or mentors who have completed their induction and training.</p>
+        <p class="govuk-notification-banner__heading">Your appropriate body and provider will confirm this with us soon, and we’ll update their records.</p>
+      <% end %>
+    </div>
+  <% end %>
+
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl">Manage mentors and ECTs</h1>

--- a/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
+++ b/spec/features/schools/participant_dashboard/manage_fip_partnered_participants_spec.rb
@@ -9,6 +9,28 @@ RSpec.describe "Manage FIP partnered participants with no change of circumstance
   context "inactive change of circumstances flag" do
     it_behaves_like "manage fip participants example"
   end
+
+  context "Completed participants banner" do
+    context "when school has participants" do
+      scenario "the banner is displayed" do
+        given_there_is_a_school_that_has_chosen_fip_and_partnered
+        and_i_have_added_a_contacted_for_info_mentor
+        and_i_have_added_an_eligible_ect_with_mentor
+        and_i_am_signed_in_as_an_induction_coordinator
+        and_i_click("Manage mentors and ECTs")
+        then_i_see_the_complete_participants_banner
+      end
+    end
+
+    context "when school has no participants" do
+      scenario "The banner is not displayed" do
+        given_there_is_a_school_that_has_chosen_fip_and_partnered
+        and_i_am_signed_in_as_an_induction_coordinator
+        and_i_click("Manage mentors and ECTs")
+        then_i_do_not_see_the_complete_participants_banner
+      end
+    end
+  end
 end
 
 RSpec.describe "Manage FIP partnered participants with change of circumstances", js: true, with_feature_flags: { eligibility_notifications: "active" } do

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1079,6 +1079,14 @@ module ManageTrainingSteps
     then_i_see_the_tab_for_the_cohort(2022)
   end
 
+  def then_i_see_the_complete_participants_banner
+    expect(page).to have_text("Do not remove ECTs or mentors who have completed their induction and training.")
+  end
+
+  def then_i_do_not_see_the_complete_participants_banner
+    expect(page).not_to have_text("Do not remove ECTs or mentors who have completed their induction and training.")
+  end
+
   def then_i_am_on_the_what_we_need_to_know_page
     expect(page).to have_text("Tell us if any new ECTs will start training at your school in the 2022 to 2023 academic year")
   end


### PR DESCRIPTION
### Context

- Ticket: CST-1801

We want to display a banner to the `Manage mentors and ECTs` screen to reassure SITs in schools with participants that they do not need to withdraw, transfer or request deletion for their completed participants.


### Changes proposed in this pull request
- Use the Notification banner component to display the banner
- Add helper method to count all the school's active participants

### Guidance to review
Schools with participants:
1. Visit the `Manage your training` page of a school
2. Click to `Manage mentors and ECTs` button
3. The banner should be displayed at the top of the page

Schools with no participants:
1. Visit the `Manage your training` page of a school
2. Click to `Manage mentors and ECTs` button
3. The banner should not be displayed

| Before | After |
|--------|--------|
| ![image](https://github.com/DFE-Digital/early-careers-framework/assets/951947/155a3ea0-9a7f-48e4-93c4-00bd9d23182d) | ![image](https://github.com/DFE-Digital/early-careers-framework/assets/951947/2424dd56-faa0-4d8a-a0a7-891dc5b6b168)|