### PR TITLE
Increase the login magic links lifetime to 24 hours

### DIFF
--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -35,7 +35,7 @@ module Devise
               **UTMService.email(:sign_in),
             )
 
-            UserMailer.with(email: email.downcase, full_name: user.full_name, url:, token_expiry: token_expiry.localtime.to_fs(:time)).sign_in_email.deliver_later(queue: "priority_mailers")
+            UserMailer.with(email: email.downcase, full_name: user.full_name, url:, token_expiry: token_expiry.localtime.to_fs(:govuk)).sign_in_email.deliver_later(queue: "priority_mailers")
             raise LoginIncompleteError
           else
             raise EmailNotFoundError

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -6,6 +6,8 @@ require_relative "../../../app/mailers/user_mailer"
 module Devise
   module Strategies
     class PasswordlessAuthenticatable < Authenticatable
+      TOKEN_LIFETIME = 24.hours
+
       class Error < StandardError; end
 
       class EmailNotFoundError < Error; end
@@ -22,7 +24,7 @@ module Devise
 
           user = Identity.find_user_by(email:)
 
-          token_expiry = 24.hours.from_now
+          token_expiry = TOKEN_LIFETIME.from_now
           result = user&.update(
             login_token: SecureRandom.hex(10),
             login_token_valid_until: token_expiry,

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -22,7 +22,7 @@ module Devise
 
           user = Identity.find_user_by(email:)
 
-          token_expiry = 12.hours.from_now
+          token_expiry = 24.hours.from_now
           result = user&.update(
             login_token: SecureRandom.hex(10),
             login_token_valid_until: token_expiry,

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Users::Sessions", type: :request do
 
   describe "POST /users/sign_in" do
     let(:login_url_regex) { /http:\/\/www\.example\.com\/users\/confirm_sign_in\?login_token=.*/ }
-    let(:token_expiry_regex) { /\d\d:\d\d/ }
+    let(:token_expiry_regex) { /^\d{1,2}\s\w+\s\d{4},\s+\d{1,2}:\d{2}\s(PM|AM)+$/ }
 
     before do
       allow(UserMailer).to receive(:with).and_call_original


### PR DESCRIPTION
### Context

- Ticket: CST-1779, CST-1790

We want to increase the expiration time of the login magic links to 24 hours and update the sign in email to display both the date and the time the link expires.

### Changes proposed in this pull request
- Update the token expiry in the `Devise::Strategies::PasswordlessAuthenticatable` to 24h
- Update the format of the `token_expiry` that is passed to the sign in mailer

### Guidance to review
1. Trigger the sign in email
2. Confirm the email says `This link will expire at 28 July 2023, 12:04 PM.`