### PR TITLE
Add back requires to allow data locally to be loaded as expected

### DIFF
--- a/app/models/finance/schedule.rb
+++ b/app/models/finance/schedule.rb
@@ -10,3 +10,6 @@ module Finance
     validates :schedule_identifier, presence: true
   end
 end
+
+require "finance/schedule/ecf"
+require "finance/schedule/npq"

--- a/app/models/finance/schedule/ecf.rb
+++ b/app/models/finance/schedule/ecf.rb
@@ -11,3 +11,5 @@ class Finance::Schedule::ECF < Finance::Schedule
     find_by(cohort:, schedule_identifier: "ecf-standard-september")
   end
 end
+
+require "finance/schedule/mentor"

--- a/app/models/finance/schedule/npq.rb
+++ b/app/models/finance/schedule/npq.rb
@@ -2,3 +2,7 @@
 
 class Finance::Schedule::NPQ < Finance::Schedule
 end
+
+require "finance/schedule/npq_leadership"
+require "finance/schedule/npq_specialist"
+require "finance/schedule/npq_support"

--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -74,3 +74,6 @@ class Finance::Statement < ApplicationRecord
       .where("payment_date < ?", payment_date)
   end
 end
+
+require "finance/statement/ecf"
+require "finance/statement/npq"

--- a/app/models/finance/statement/ecf.rb
+++ b/app/models/finance/statement/ecf.rb
@@ -32,3 +32,6 @@ class Finance::Statement::ECF < Finance::Statement
       .where("payment_date < ?", payment_date)
   end
 end
+
+require "finance/statement/ecf/payable"
+require "finance/statement/ecf/paid"

--- a/app/models/finance/statement/npq.rb
+++ b/app/models/finance/statement/npq.rb
@@ -24,3 +24,5 @@ class Finance::Statement::NPQ < Finance::Statement
     cohort.start_year >= 2022
   end
 end
+require "finance/statement/npq/payable"
+require "finance/statement/npq/paid"


### PR DESCRIPTION
### Context
Without those requires development environments do not load the different ECF/NPQ records causing confusion. 

- Ticket: n/a
those were removed from https://github.com/DFE-Digital/early-careers-framework/pull/3590/commits/3e760ceb74c4fe794742e791fbc68263680f744b

### Changes proposed in this pull request
Add back requires to statements and schedules to allow records to be loaded in development 

### Guidance to review
Did I miss anyhting?
