### PR TITLE
[Bug-fix] Fix missed module name change

### DIFF
--- a/app/controllers/concerns/journey_wizard/controller.rb
+++ b/app/controllers/concerns/journey_wizard/controller.rb
@@ -33,7 +33,7 @@ module JourneyWizard
       else
         wizard.validate_state!
       end
-    rescue Wizard::Form::AlreadyInitialised, Wizard::Form::InvalidStep
+    rescue JourneyWizard::Form::AlreadyInitialised, JourneyWizard::Form::InvalidStep
       remove_session_data
       redirect_to abort_path
     end


### PR DESCRIPTION
### Context

Error spotted by admin user and in Sentry.  As a protection against jumping around in the wizards we perform some checks at initialisation and raise errors if we spot something wrong. These are rescued in the controller and the wizard data is reset and the journey starts over. However a refactor that renamed the module missed the exception class names rescued so that when an initialisation error happens we're not catching the correct error (in fact it generates a different error trying to rescue a class that doesn't exist).

### Changes proposed in this pull request
Fix the module name in the rescue clause
