### PR TITLE
Improve the environment specific phase banners

### DIFF
--- a/app/helpers/phase_banner_helper.rb
+++ b/app/helpers/phase_banner_helper.rb
@@ -10,6 +10,7 @@ module PhaseBannerHelper
   def phase_banner_tag_colour(env = Rails.env)
     {
       "development" => "red",
+      "deployed_development" => "grey",
       "review" => "purple",
       "staging" => "turquoise",
       "sandbox" => "yellow",

--- a/app/helpers/phase_banner_helper.rb
+++ b/app/helpers/phase_banner_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PhaseBannerHelper
+  def phase_banner_tag_text(env = Rails.env)
+    return "Beta" if env == "production"
+
+    env
+  end
+
+  def phase_banner_tag_colour(env = Rails.env)
+    {
+      "development" => "red",
+      "review" => "purple",
+      "staging" => "turquoise",
+      "sandbox" => "yellow",
+    }.fetch(env, nil)
+  end
+end

--- a/app/views/layouts/_phase_banner.erb
+++ b/app/views/layouts/_phase_banner.erb
@@ -1,22 +1,9 @@
 <%= tag.div(class: class_names("govuk-width-container", "govuk-width-container__wide" => wide_container_view?)) do %>
-  <div class="govuk-phase-banner app-phase-banner--no-border govuk-!-display-none-print">
-    <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag">
-        <% if Rails.env.production?  %>
-          Beta
-        <% elsif Rails.env.staging? %>
-          Staging
-        <% elsif Rails.env.sandbox? %>
-          Sandbox
-        <% else %>
-          Development
-        <% end %>
-      </strong>
-      <span class="govuk-phase-banner__text">
-        This is a new service – your
-        <%= govuk_link_to "feedback", feedback_form_url, target: "_blank", rel: "noopener noreferrer" %>
-        will help us to improve it.
-      </span>
-    </p>
-  </div>
+  <%= govuk_phase_banner(
+    tag: { text: phase_banner_tag_text, colour: phase_banner_tag_colour },
+    text: Rails.env) do %>
+      This is a new service – your
+      <%= govuk_link_to "feedback", feedback_form_url, target: "_blank", rel: "noopener noreferrer" %>
+      will help us to improve it.
+  <% end %>
 <% end %>

--- a/spec/helpers/phase_banner_helper_spec.rb
+++ b/spec/helpers/phase_banner_helper_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PhaseBannerHelper, type: :helper do
+  describe "#phase_banner_tag_text" do
+    context "when production" do
+      it "returns 'Beta'" do
+        expect(phase_banner_tag_text("production")).to eql("Beta")
+      end
+    end
+
+    context "other environments" do
+      %w[development staging review sandbox an_unknown_environment].each do |other_env|
+        let(:other_env) { other_env }
+
+        it "for #{other_env} it returns #{other_env}" do
+          expect(phase_banner_tag_text(other_env)).to eql(other_env)
+        end
+      end
+    end
+  end
+
+  describe "#phase_banner_tag_colour" do
+    context "when production" do
+      it "returns nil (for the default white on blue)" do
+        expect(phase_banner_tag_colour("production")).to be_nil
+      end
+    end
+
+    context "other environments" do
+      {
+        "development" => "red",
+        "review" => "purple",
+        "staging" => "turquoise",
+        "sandbox" => "yellow",
+        "an_unknown_environment" => nil,
+      }.each do |other_env, expected_colour|
+        let(:other_env) { other_env }
+
+        it "for #{other_env} it returns #{expected_colour || 'nil'}" do
+          expect(phase_banner_tag_colour(other_env)).to eql(expected_colour)
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/phase_banner_helper_spec.rb
+++ b/spec/helpers/phase_banner_helper_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe PhaseBannerHelper, type: :helper do
     context "other environments" do
       {
         "development" => "red",
+        "deployed_development" => "grey",
         "review" => "purple",
         "staging" => "turquoise",
         "sandbox" => "yellow",


### PR DESCRIPTION
### Context

Now they will have a colour per environment and tests cover the env-specific text

### Previews

| Environment | Preview |
| ------------ | ------- |
| Development | ![Screenshot from 2023-07-28 11-05-39](https://github.com/DFE-Digital/early-careers-framework/assets/128088/51a95c42-5689-4146-98c8-2108899ab967) |
| Review | ![image](https://github.com/DFE-Digital/early-careers-framework/assets/128088/6265f7ce-7077-4b28-93f5-cf7b59dedfcc) |
| Staging | ![Screenshot from 2023-07-28 11-05-16](https://github.com/DFE-Digital/early-careers-framework/assets/128088/52fe797f-099b-473a-bace-ac789bb83d33) |
| Sandbox 🏖️ | ![Screenshot from 2023-07-28 11-04-52](https://github.com/DFE-Digital/early-careers-framework/assets/128088/26b71682-c752-4b86-97a3-6faf4a8ad95b) |
| Production | ![Screenshot from 2023-07-28 11-05-58](https://github.com/DFE-Digital/early-careers-framework/assets/128088/f6baa3c9-89b5-46cf-8e58-3834df609f63) |