### PR TITLE
[SPIKE] How might we safely remove service fees from all NPQ statements

### DIFF
--- a/app/components/finance/npq/payment_overviews/course.html.erb
+++ b/app/components/finance/npq/payment_overviews/course.html.erb
@@ -63,7 +63,7 @@
         <% end %>
       <% end %>
 
-      <% if statement.service_fee_enabled %>
+      <% unless calculator.monthly_service_fees.zero? %>
         <tr class="gov-table__row">
           <td scope="row" class="govuk-table__cell govuk-body-s"><strong><%= t("finance.service_fee.caption") %></strong></td>
           <td scope="row" class="govuk-table__cell govuk-body-s"><%= calculator.recruitment_target %></td>

--- a/app/components/finance/npq/payment_overviews/course.html.erb
+++ b/app/components/finance/npq/payment_overviews/course.html.erb
@@ -63,12 +63,14 @@
         <% end %>
       <% end %>
 
-      <tr class="gov-table__row">
-        <td scope="row" class="govuk-table__cell govuk-body-s"><strong><%= t("finance.service_fee.caption") %></strong></td>
-        <td scope="row" class="govuk-table__cell govuk-body-s"><%= calculator.recruitment_target %></td>
-        <td scope="row" class="govuk-table__cell govuk-body-s govuk-!-text-align-right"><%= number_to_pounds calculator.service_fees_per_participant %></td>
-        <td scope="row" class="govuk-table__cell govuk-body-s govuk-!-text-align-right"><%= number_to_pounds calculator.monthly_service_fees %></td>
-      </tr>
+      <% if statement.service_fee_enabled %>
+        <tr class="gov-table__row">
+          <td scope="row" class="govuk-table__cell govuk-body-s"><strong><%= t("finance.service_fee.caption") %></strong></td>
+          <td scope="row" class="govuk-table__cell govuk-body-s"><%= calculator.recruitment_target %></td>
+          <td scope="row" class="govuk-table__cell govuk-body-s govuk-!-text-align-right"><%= number_to_pounds calculator.service_fees_per_participant %></td>
+          <td scope="row" class="govuk-table__cell govuk-body-s govuk-!-text-align-right"><%= number_to_pounds calculator.monthly_service_fees %></td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 

--- a/app/services/finance/npq/course_statement_calculator.rb
+++ b/app/services/finance/npq/course_statement_calculator.rb
@@ -107,6 +107,8 @@ module Finance
       end
 
       def monthly_service_fees
+        return 0.0 unless statement.service_fee_enabled
+
         contract.monthly_service_fee || calculated_service_fee
       end
 

--- a/app/services/finance/npq/course_statement_calculator.rb
+++ b/app/services/finance/npq/course_statement_calculator.rb
@@ -107,9 +107,9 @@ module Finance
       end
 
       def monthly_service_fees
-        return 0.0 unless statement.service_fee_enabled
+        return calculated_service_fee if contract.monthly_service_fee.nil?
 
-        contract.monthly_service_fee || calculated_service_fee
+        contract.monthly_service_fee
       end
 
       def course_total

--- a/app/services/finance/npq/statement_calculator.rb
+++ b/app/services/finance/npq/statement_calculator.rb
@@ -31,8 +31,6 @@ module Finance
       end
 
       def total_service_fees
-        return 0.0 unless statement.service_fee_enabled
-
         contracts.sum do |contract|
           CourseStatementCalculator.new(statement:, contract:).monthly_service_fees
         end

--- a/app/services/finance/npq/statement_calculator.rb
+++ b/app/services/finance/npq/statement_calculator.rb
@@ -31,6 +31,8 @@ module Finance
       end
 
       def total_service_fees
+        return 0.0 unless statement.service_fee_enabled
+
         contracts.sum do |contract|
           CourseStatementCalculator.new(statement:, contract:).monthly_service_fees
         end
@@ -53,10 +55,14 @@ module Finance
       end
 
       def overall_vat
+        return 0.0 unless statement.show_total_with_vat
+
         total_payment * vat_rate
       end
 
       def vat
+        return 0.0 unless statement.show_total_with_vat
+
         total_payment * (npq_lead_provider.vat_chargeable ? 0.2 : 0.0)
       end
 

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -33,17 +33,19 @@
           <span><%= number_to_pounds(-@calculator.total_clawbacks) %></span>
         </p>
 
-        <% if @statement.service_fee_enabled %>
+        <% unless @calculator.total_service_fees.zero? %>
           <p class="govuk-body-s govuk-!-margin-bottom-2">
             <%= t("finance.service_fee.caption") %>
             <span><%= number_to_pounds(@calculator.total_service_fees) %></span>
           </p>
         <% end %>
 
-        <p class="govuk-body-s govuk-!-margin-bottom-2">
-          <%= t("finance.vat") %>
-          <span><%= number_to_pounds(@calculator.vat) %></span>
-        </p>
+        <% if @statement.show_total_with_vat %>
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            <%= t("finance.vat") %>
+            <span><%= number_to_pounds(@calculator.vat) %></span>
+          </p>
+        <% end %>
       </div>
 
       <ul class="first govuk-list govuk-!-margin-bottom-0">

--- a/app/views/finance/npq/statements/show.html.erb
+++ b/app/views/finance/npq/statements/show.html.erb
@@ -11,6 +11,9 @@
 
     <div class="app-application__panel__summary">
       <div class="govuk-!-margin-right-4">
+        <% unless @statement.show_total_with_vat %>
+          <span class="govuk-caption-m">Net VAT</span>
+        <% end %>
         <h4 class="govuk-heading-l govuk-!-margin-bottom-2"><%= t("finance.total") %> <%= number_to_pounds(@calculator.total_with_vat) %></h4>
 
         <p class="govuk-body-s govuk-!-margin-bottom-2">
@@ -30,10 +33,12 @@
           <span><%= number_to_pounds(-@calculator.total_clawbacks) %></span>
         </p>
 
-        <p class="govuk-body-s govuk-!-margin-bottom-2">
-          <%= t("finance.service_fee.caption") %>
-          <span><%= number_to_pounds(@calculator.total_service_fees) %></span>
-        </p>
+        <% if @statement.service_fee_enabled %>
+          <p class="govuk-body-s govuk-!-margin-bottom-2">
+            <%= t("finance.service_fee.caption") %>
+            <span><%= number_to_pounds(@calculator.total_service_fees) %></span>
+          </p>
+        <% end %>
 
         <p class="govuk-body-s govuk-!-margin-bottom-2">
           <%= t("finance.vat") %>

--- a/db/migrate/20230727145328_add_service_fee_enabled_to_statements.rb
+++ b/db/migrate/20230727145328_add_service_fee_enabled_to_statements.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddServiceFeeEnabledToStatements < ActiveRecord::Migration[7.0]
-  def change
-    add_column :statements, :service_fee_enabled, :boolean, default: true
-  end
-end

--- a/db/migrate/20230727145328_add_service_fee_enabled_to_statements.rb
+++ b/db/migrate/20230727145328_add_service_fee_enabled_to_statements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddServiceFeeEnabledToStatements < ActiveRecord::Migration[7.0]
+  def change
+    add_column :statements, :service_fee_enabled, :boolean, default: true
+  end
+end

--- a/db/migrate/20230727151545_add_show_total_with_vat_to_statements.rb
+++ b/db/migrate/20230727151545_add_show_total_with_vat_to_statements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddShowTotalWithVatToStatements < ActiveRecord::Migration[7.0]
+  def change
+    add_column :statements, :show_total_with_vat, :boolean, default: false
+  end
+end

--- a/db/migrate/20230801094247_change_column_monthly_service_fee_for_npq_contracts.rb
+++ b/db/migrate/20230801094247_change_column_monthly_service_fee_for_npq_contracts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeColumnMonthlyServiceFeeForNPQContracts < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :npq_contracts, :monthly_service_fee, from: nil, to: 0.0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_151545) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_01_094247) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -601,7 +601,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_151545) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "cohort_id", null: false
-    t.decimal "monthly_service_fee"
+    t.decimal "monthly_service_fee", default: "0.0"
     t.decimal "targeted_delivery_funding_per_participant", default: "100.0"
     t.index ["cohort_id"], name: "index_npq_contracts_on_cohort_id"
     t.index ["npq_lead_provider_id"], name: "index_npq_contracts_on_npq_lead_provider_id"
@@ -1022,7 +1022,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_151545) do
     t.boolean "output_fee", default: true
     t.string "contract_version", default: "0.0.1"
     t.decimal "reconcile_amount", default: "0.0", null: false
-    t.boolean "service_fee_enabled", default: true
     t.boolean "show_total_with_vat", default: false
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_214306) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_151545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -665,7 +665,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_214306) do
     t.boolean "pupil_premium_uplift"
     t.uuid "delivery_partner_id"
     t.uuid "mentor_user_id"
-    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY (ARRAY[('submitted'::character varying)::text, ('eligible'::character varying)::text, ('payable'::character varying)::text, ('paid'::character varying)::text]))"
+    t.index ["cpd_lead_provider_id", "participant_profile_id", "declaration_type", "course_identifier", "state"], name: "unique_declaration_index", unique: true, where: "((state)::text = ANY ((ARRAY['submitted'::character varying, 'eligible'::character varying, 'payable'::character varying, 'paid'::character varying])::text[]))"
     t.index ["cpd_lead_provider_id"], name: "index_participant_declarations_on_cpd_lead_provider_id"
     t.index ["declaration_type"], name: "index_participant_declarations_on_declaration_type"
     t.index ["delivery_partner_id"], name: "index_participant_declarations_on_delivery_partner_id"
@@ -1022,6 +1022,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_214306) do
     t.boolean "output_fee", default: true
     t.string "contract_version", default: "0.0.1"
     t.decimal "reconcile_amount", default: "0.0", null: false
+    t.boolean "service_fee_enabled", default: true
+    t.boolean "show_total_with_vat", default: false
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"
   end


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2251

### Changes proposed in this pull request

* Option 1: ~~New column `service_fee_enabled` added to model `Finance::Statement`~~
  * ~~Default `true`~~
  * ~~When false, service_fee will always return 0.0 and the statement view will hide service fees~~
* Option 2: Use existing `npq_contracts.monthly_service_fee` column
  * If set to `0.0` we hide service fee row from each course block
  * If total service fee is zero, we hide the total
  * If column set to `nil`, there's a "calculated" value (existing behaviour)
  * QUESTION: we have some with `0.0`, going forward the zero service fees will be hidden, is this ok?
* New column `show_total_with_vat` added to model `Finance::Statement`
  * Default `false`
  * When true, the total will include vat
  * Adding a new column to show/hide vat from view I would consider code debt.
  * Recommend we either:
    * decide to remove VAT for all statements
    * or add both incl VAT and excl VAT totals.

### Guidance to review

