### PR TITLE
Always build the branch unless it's dependabot

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -26,7 +26,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'review-app')
+    if: github.actor != 'dependabot[bot]'
 
     outputs:
       image: ${{ steps.build-docker-image.outputs.image }}


### PR DESCRIPTION
The pipeline isn't currently running the docker build step on `main`. We always want it to run **unless the branch was created by dependabot**. Now the if statement checks the `github.actor`.

The if statement logic was lifted and amended from [this documentation page](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#common-dependabot-automations).
