### PR TITLE
[CST-1780] Fix admin transferring participants to schools without programmes

### DIFF
--- a/app/forms/admin/school_transfer_form.rb
+++ b/app/forms/admin/school_transfer_form.rb
@@ -177,7 +177,7 @@ private
   end
 
   def no_programmes_to_transfer_into_or_continue?
-    latest_induction_record.blank? && (new_school_cohort.blank? || new_school_programmes.where(training_programme: %w[core_induction_programme full_induction_programme]).empty?)
+    new_school_cohort.blank? || new_school_programmes.where(training_programme: %w[core_induction_programme full_induction_programme]).empty?
   end
 
   def make_programme_description(induction_programme)

--- a/spec/forms/admin/school_transfer_form_spec.rb
+++ b/spec/forms/admin/school_transfer_form_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
 
   let(:school_in) { create(:school) }
 
+  describe "#cannot_transfer_to_new_school?" do
+    context "when new school doesn't have any programmes in participant's cohort" do
+      it "returns true" do
+        expect(form.cannot_transfer_to_new_school?).to be true
+      end
+    end
+  end
+
   describe "#perform_transfer!" do
     let(:partnership_in) {}
     let(:school_cohort_in) do


### PR DESCRIPTION
### Context

- Ticket: CST-1780

The transfer in admin console is creating a default partnership when a school hasn't got a cohort set up, when the expected behaviour is to prevent the transfer.

### Changes proposed in this pull request
- Update the condition in the `Admin::SchoolTransferForm#no_programmes_to_transfer_into_or_continue?` to only check if the new school has a cohort with a programme the participant can transfer into

### Guidance to review
1. Start transferring a participant in the admin console from school A to school B, where school B doesn’t have a training programme set up for the participant’s cohort
2. You should be redirected to the "cannot transfer" page


