### PR TITLE
Allow deploy-staging to fail for the moment

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -83,6 +83,7 @@ jobs:
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
+        continue-on-error: true # temporary while we get staging working
         with:
           environment: staging
           docker-image: ${{ needs.docker.outputs.image }}


### PR DESCRIPTION
### Context

We need to iron out the AZURE_CREDENTIALS and currently it's blocking any deploys.
