### PR TITLE
Add config for staging env in AKS

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -44,7 +44,7 @@ runs:
       id: apply-terraform
       shell: bash
       run: |
-        make ci ${{ inputs.environment }}_aks terraform-apply
+        make ci ${{ inputs.environment }} terraform-apply
         cd terraform/aks && echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
       env:
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}

--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.5.3
+        terraform_version: 1.5.4
         terraform_wrapper: false
 
     - uses: DFE-Digital/github-actions/set-arm-environment-variables@master

--- a/.github/workflows/aks_destroy_review.yml
+++ b/.github/workflows/aks_destroy_review.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.5.3
+          terraform_version: 1.5.4
           terraform_wrapper: false
 
       - name: Set environment variables

--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,7 @@ group :development, :test do
   gem "erb_lint", ">= 0.1.1", require: false
 end
 
-group :development, :deployed_development, :test, :sandbox, :review do
+group :development, :deployed_development, :test, :staging, :sandbox, :review do
   gem "factory_bot_rails", "~> 6.2.0"
   gem "faker"
   gem "timecop"

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ development:
 	$(eval DEPLOY_ENV=development)
 	$(eval include global_config/development_aks.sh)
 
-.PHONY: staging_aks
-staging_aks: aks
+.PHONY: staging
+staging: aks
 	$(eval DEPLOY_ENV=staging)
 	$(eval include global_config/staging_aks.sh)
 
@@ -23,8 +23,8 @@ staging_aks: aks
 sandbox:
 	$(eval DEPLOY_ENV=sandbox)
 
-.PHONY: review_aks
-review_aks: aks ## Specify review AKS environment
+.PHONY: review
+review: aks ## Specify review AKS environment
 	# PULL_REQUEST_NUMBER is set by the GitHub action
 	$(if $(PULL_REQUEST_NUMBER), , $(error Missing environment variable "PULL_REQUEST_NUMBER"))
 	$(eval include global_config/review_aks.sh)

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ development:
 	$(eval DEPLOY_ENV=development)
 	$(eval include global_config/development_aks.sh)
 
-.PHONY: staging
-staging:
+.PHONY: staging_aks
+staging_aks: aks
 	$(eval DEPLOY_ENV=staging)
+	$(eval include global_config/staging_aks.sh)
 
 .PHONY: sandbox
 sandbox:

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -25,7 +25,7 @@ class Users::SessionsController < Devise::SessionsController
   ].freeze
 
   skip_before_action :check_privacy_policy_accepted
-  before_action :mock_login, only: :create, if: -> { Rails.env.in?(%w[development deployed_development review sandbox]) }
+  before_action :mock_login, only: :create, if: -> { Rails.env.in?(%w[development deployed_development review staging sandbox]) }
   before_action :redirect_to_dashboard, only: %i[sign_in_with_token redirect_from_magic_link]
   before_action :ensure_login_token_valid, only: %i[sign_in_with_token redirect_from_magic_link]
 

--- a/app/middlewares/time_traveler.rb
+++ b/app/middlewares/time_traveler.rb
@@ -6,7 +6,7 @@ class TimeTraveler
   end
 
   def call(env)
-    return @app.call(env) unless env.key?("HTTP_X_WITH_SERVER_DATE") && %w[development deployed_development sandbox review test].include?(Rails.env)
+    return @app.call(env) unless env.key?("HTTP_X_WITH_SERVER_DATE") && %w[development deployed_development staging sandbox review test].include?(Rails.env)
 
     Timecop.travel(Time.zone.parse(env["HTTP_X_WITH_SERVER_DATE"])) do
       @app.call(env)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -155,4 +155,6 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   config.cip_resource_bucket = "https://paas-s3-broker-prod-lon-ac28a7a5-2bc2-4d3b-8d16-a88eaef65526.s3.amazonaws.com"
+
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/check") } } }
 end

--- a/config/seed_quantities.yml
+++ b/config/seed_quantities.yml
@@ -72,3 +72,6 @@ review:
 
 deployed_development:
   <<: *default
+
+staging:
+  <<: *default

--- a/db/new_seeds/base/add_api_tokens.rb
+++ b/db/new_seeds/base/add_api_tokens.rb
@@ -2,7 +2,7 @@
 
 # finally for the smoke tests to work we need to set up some tokens
 
-if Rails.env.deployed_development? || Rails.env.review?
+if Rails.env.in?(%w[deployed_development review staging])
   EngageAndLearnApiToken.find_or_create_by!(hashed_token: "dfce9a34c6f982e8adb4b903f8b6064682e6ad1f7858c41ed8a0a7468abc8896")
   NPQRegistrationApiToken.find_or_create_by!(hashed_token: "1dae3836ed90df4b796eff1f4a4713247ac5bc8a00352ea46eee621d74cd4fcf")
   DataStudioApiToken.find_or_create_by!(hashed_token: "c7123fb0e2aecb17e1089e01849d71665983e200e891fe726341a08f176c1d64")

--- a/db/new_seeds/base/add_environment_specific_data.rb
+++ b/db/new_seeds/base/add_environment_specific_data.rb
@@ -2,7 +2,7 @@
 
 # The following section creates some records that Delivery Partners can use to
 # familiarise themselves with the school user interface.
-if Rails.env.in?(%w[development deployed_development review])
+if Rails.env.in?(%w[development deployed_development staging review])
   delivery_partner_credentials = {
     "Ambition Institute" => "ambition-institute-sit-%d@example.com",
     "Best Practice Network" => "best-practice-network-sit-%d@example.com",

--- a/db/new_seeds/base/add_feature_flags.rb
+++ b/db/new_seeds/base/add_feature_flags.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if Rails.env.development? || Rails.env.deployed_development? || Rails.env.review?
+if Rails.env.in?(%w[development deployed_development review staging])
   Rails.logger.info("activating permanent feature flags")
 
   FeatureFlag::PERMANENT_SETTINGS.each do |feature|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,13 +7,13 @@ if ENV["LEGACY_SEEDS"] == "true"
   load Rails.root.join(*seed_path, "initial_seed.rb").to_s
   load Rails.root.join(*seed_path, "schedules.rb").to_s
 
-  if %w[development deployed_development test sandbox review].include?(Rails.env)
+  if Rails.env.in?(%w[development deployed_development test sandbox staging review])
     %w[test_data dummy_structures appropriate_bodies].each do |seed|
       load Rails.root.join(*seed_path, "#{seed}.rb").to_s
     end
   end
 
-  if Rails.env.development? || Rails.env.deployed_development? || Rails.env.review?
+  if Rails.env.in?(%w[development deployed_development staging review])
     FeatureFlag::PERMANENT_SETTINGS.each do |feature|
       FeatureFlag.activate(feature)
     end

--- a/global_config/staging_aks.sh
+++ b/global_config/staging_aks.sh
@@ -1,0 +1,7 @@
+AZURE_RESOURCE_PREFIX=s189t01
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
+CONFIG=staging_aks
+CONFIG_SHORT=st
+DEPLOY_ENV=staging_aks
+ENV_TAG=Test
+PLATFORM=aks

--- a/lib/tasks/safe_reset.rake
+++ b/lib/tasks/safe_reset.rake
@@ -3,7 +3,7 @@
 namespace :db do
   desc "Remove all database content, then seed it. Only for dev environments."
   task safe_reset: :environment do
-    if Rails.env.in?(%w[development deployed_development sandbox review])
+    if Rails.env.in?(%w[development deployed_development staging sandbox review])
       connection = ActiveRecord::Base.connection
       tables = connection
                    .execute("SELECT * FROM pg_catalog.pg_tables;")

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.5.3"
+  required_version = "1.5.4"
 
   backend "azurerm" {}
 

--- a/terraform/aks/workspace_variables/README.md
+++ b/terraform/aks/workspace_variables/README.md
@@ -1,0 +1,30 @@
+# Backend tfvars naming convention
+
+```
+s189t01cpdecftfstatestsa
+╞═════╡╞════╡╞═════╡╞╡╞╡
+│      │     │      │  └─── type of resouce
+│      │     │      │         sa      = storage account
+│      │     │      └────── environment:
+│      │     │                dv      = development
+│      │     │                rv      = review
+│      │     │                st      = staging
+│      │     │                sb      = sandbox
+│      │     │                pd      = production
+│      │     └───────────── contents
+│      │                      tfstate = terraform state file
+│      └─────────────────── programme/app
+│                             cpd     = continuing professional development
+│                             ecf     = early careers framework
+│                             npq     = national professional qualifications
+│                             eal     = engage and learn
+│                             i       = information
+└────────────────────────── subscription
+                              d01     = development (used for devops testing)
+                              t01     = test (used for testing, review apps, staging)
+                              p01     = production (used for sandbox, prod)
+```
+
+This string can be 24 characters long max so we can't afford to use
+the three letter names for some envs that other teams use (like sbx
+for sandbox).

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -1,7 +1,7 @@
 {
   "app_environment": "staging",
   "cluster": "test",
-  "deploy_azure_backing_services": false,
+  "deploy_azure_backing_services": true,
   "enable_monitoring": false,
   "namespace": "cpd-development",
   "db_sslmode": "prefer"

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -1,0 +1,8 @@
+{
+  "app_environment": "staging",
+  "cluster": "test",
+  "deploy_azure_backing_services": false,
+  "enable_monitoring": false,
+  "namespace": "cpd-development",
+  "db_sslmode": "prefer"
+}

--- a/terraform/aks/workspace_variables/staging_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/staging_aks.tfvars.json
@@ -3,6 +3,5 @@
   "cluster": "test",
   "deploy_azure_backing_services": true,
   "enable_monitoring": false,
-  "namespace": "cpd-development",
-  "db_sslmode": "prefer"
+  "namespace": "cpd-development"
 }

--- a/terraform/aks/workspace_variables/staging_aks_backend.tfvars
+++ b/terraform/aks/workspace_variables/staging_aks_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s189t01-cpdecf-st-rg"
+storage_account_name = "s189t01cpdecftfstatestsa"
+container_name       = "cpdecf-tfstate"
+key                  = "terraform.tfstate"


### PR DESCRIPTION
### Context

Staging is an environment we'll deploy to before production/sandbox. It will be used to ensure existing databases can be migrated before attempting in prod/sandbox.

### Changes proposed in this pull request

- Add configuration for staging env in AKS
- Add README with breakdown of naming conventions
