### PR TITLE
[CST-1802] Move un-partnered participants to new partnership programme when reported

### DIFF
--- a/app/services/induction/change_partnership.rb
+++ b/app/services/induction/change_partnership.rb
@@ -2,20 +2,21 @@
 
 class Induction::ChangePartnership < BaseService
   def call
-    default_induction_programme = school_cohort.default_induction_programme
+    ActiveRecord::Base.transaction do
+      default_induction_programme = school_cohort.default_induction_programme
 
-    if default_induction_programme.present? &&
-        default_induction_programme.full_induction_programme?
+      if default_induction_programme.present? &&
+          default_induction_programme.full_induction_programme?
 
-      if default_induction_programme.partnership.blank?
-        # there is no partnership, we presume there was none when the school chose FIP
-        # so we can just update the programme
-        default_induction_programme.update!(partnership:)
+        if default_induction_programme.partnership.blank?
+          # there is no partnership, we presume there was none when the school chose FIP
+          # so we can just update the programme
+          default_induction_programme.update!(partnership:)
+          move_unpartnered_participants
 
-      elsif default_induction_programme.partnership != partnership &&
-          default_induction_programme.partnership.challenged?
+        elsif default_induction_programme.partnership != partnership &&
+            default_induction_programme.partnership.challenged?
 
-        ActiveRecord::Base.transaction do
           # existing FIP partnership replaced so create a new programme and migrate
           # all the participants to the new one
           programme = InductionProgramme.create!(school_cohort:,
@@ -26,10 +27,12 @@ class Induction::ChangePartnership < BaseService
                                                             to_programme: programme)
 
           school_cohort.update!(default_induction_programme: programme)
+          move_unpartnered_participants
         end
+      else
+        Induction::SetCohortInductionProgramme.call(school_cohort:, programme_choice: "full_induction_programme")
+        move_unpartnered_participants
       end
-    else
-      Induction::SetCohortInductionProgramme.call(school_cohort:, programme_choice: "full_induction_programme")
     end
   end
 
@@ -40,5 +43,21 @@ private
   def initialize(school_cohort:, partnership:)
     @school_cohort = school_cohort
     @partnership = partnership
+  end
+
+  def move_unpartnered_participants
+    unpartnered_fip_programmes.each do |programme|
+      Induction::MigrateParticipantsToNewProgramme.call(from_programme: programme,
+                                                        to_programme: school_cohort.default_induction_programme)
+    end
+  end
+
+  def unpartnered_fip_programmes
+    school_cohort
+      .induction_programmes
+      .full_induction_programme
+      .joins(:active_induction_records)
+      .left_joins(:partnership)
+      .where("partnerships.id IS NULL OR partnerships.challenged_at IS NOT NULL")
   end
 end

--- a/spec/services/induction/change_partnership_spec.rb
+++ b/spec/services/induction/change_partnership_spec.rb
@@ -142,5 +142,40 @@ RSpec.describe Induction::ChangePartnership do
         expect(school_cohort.default_induction_programme).to eq induction_programme
       end
     end
+
+    context "when there are challenged relationships present" do
+      let(:relationship) { create(:partnership, :challenged, relationship: true, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider:) }
+      let(:ect_profile_2) { create(:ect_participant_profile, school_cohort:) }
+      let(:induction_programme_2) { create(:induction_programme, :fip, school_cohort:, partnership: relationship) }
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme_2, participant_profile: ect_profile_2, start_date: 2.weeks.ago) }
+
+      it "moves the participants to the new programme" do
+        service.call(school_cohort:, partnership: new_partnership)
+        expect(school_cohort.default_induction_programme.participant_profiles).to include(ect_profile_2)
+      end
+    end
+
+    context "when there are CIP programmes present" do
+      let(:ect_profile_2) { create(:ect_participant_profile, school_cohort:) }
+      let(:induction_programme_2) { create(:induction_programme, :cip, school_cohort:) }
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme_2, participant_profile: ect_profile_2, start_date: 2.weeks.ago) }
+
+      it "does not move the participants to the new programme" do
+        service.call(school_cohort:, partnership: new_partnership)
+        expect(school_cohort.default_induction_programme.participant_profiles).not_to include(ect_profile_2)
+      end
+    end
+
+    context "when there are FIP relationships present" do
+      let(:relationship) { create(:partnership, relationship: true, school: school_cohort.school, cohort: school_cohort.cohort, lead_provider:) }
+      let(:ect_profile_2) { create(:ect_participant_profile, school_cohort:) }
+      let(:induction_programme_2) { create(:induction_programme, :fip, school_cohort:, partnership: relationship) }
+      let!(:induction_record) { create(:induction_record, induction_programme: induction_programme_2, participant_profile: ect_profile_2, start_date: 2.weeks.ago) }
+
+      it "does not move the participants to the new programme" do
+        service.call(school_cohort:, partnership: new_partnership)
+        expect(school_cohort.default_induction_programme.participant_profiles).not_to include(ect_profile_2)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1802)

When a new partnership is reported, we want to move any participants in FIP programmes with relationships that have been challenged to the new default programme.

### Changes proposed in this pull request

### Guidance to review

