### PR TITLE
Add missing database extensions to Azure

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -28,5 +28,5 @@ module "postgres" {
 
   use_azure               = var.deploy_azure_backing_services
   azure_enable_monitoring = var.enable_monitoring
-  azure_extensions        = ["citext", "pg_stat_statements", "pgcrypto", "plpgsql"]
+  azure_extensions        = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
 }


### PR DESCRIPTION
### Context

We matched the prod schema, but didn't add the new extensions to Azure
- Ticket: n/a

### Changes proposed in this pull request
Add `fuzzystrmatch` and `uuid-ossp` to Azure extensions

