### PR TITLE
Export correct delivery partner in assurance report

### DIFF
--- a/app/services/finance/ecf/assurance_report/query.rb
+++ b/app/services/finance/ecf/assurance_report/query.rb
@@ -79,7 +79,7 @@ module Finance
             JOIN schedules sch ON sch.id = latest_induction_record.schedule_id
             JOIN schools sc ON sc.id = latest_induction_record.school_id
             LEFT OUTER JOIN ecf_participant_eligibilities epe ON epe.participant_profile_id = pp.id
-            JOIN delivery_partners dp ON dp.id = latest_induction_record.delivery_partner_id
+            JOIN delivery_partners dp ON dp.id = COALESCE(pd.delivery_partner_id, latest_induction_record.delivery_partner_id)
             WHERE pd.type = 'ParticipantDeclaration::ECF' AND #{where_values}
             ORDER BY u.full_name ASC
           EOSQL

--- a/spec/services/finance/ecf/assurance_report/query_spec.rb
+++ b/spec/services/finance/ecf/assurance_report/query_spec.rb
@@ -4,92 +4,89 @@ require "rails_helper"
 
 RSpec.describe Finance::ECF::AssuranceReport::Query do
   let(:cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
-  let(:statement)         { create(:ecf_statement, cpd_lead_provider:) }
+  let(:statement) { create(:ecf_statement, cpd_lead_provider:) }
 
-  let(:uplifts)                   { [] }
-  let(:participant_profile)       { create(:ect, :eligible_for_funding, uplifts:, lead_provider: cpd_lead_provider.lead_provider) }
-  let(:participant_identity)      { participant_profile.participant_identity }
-  let!(:participant_declaration)  { travel_to(statement.deadline_date) { create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:) } }
+  let(:uplifts) { [] }
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:participant_profile) { create(:ect, :eligible_for_funding, uplifts:, lead_provider: cpd_lead_provider.lead_provider) }
+  let(:participant_identity) { participant_profile.participant_identity }
+  let!(:participant_declaration) { travel_to(statement.deadline_date) { create(:ect_participant_declaration, participant_profile:, cpd_lead_provider:, delivery_partner:) } }
 
-  let(:other_statement)                { create(:ecf_statement, cpd_lead_provider:, deadline_date: statement.deadline_date + 1.day) }
+  let(:other_statement) { create(:ecf_statement, cpd_lead_provider:, deadline_date: statement.deadline_date + 1.day) }
   let!(:other_participant_declaration) { travel_to(other_statement.deadline_date) { create(:ect_participant_declaration, cpd_lead_provider:) } }
 
-  let(:other_cpd_lead_provider)                          { create(:cpd_lead_provider, :with_lead_provider) }
-  let(:other_cpd_lead_provider_statement)                { create(:ecf_statement, cpd_lead_provider:, deadline_date: statement.deadline_date + 1.day) }
+  let(:other_cpd_lead_provider) { create(:cpd_lead_provider, :with_lead_provider) }
+  let(:other_cpd_lead_provider_statement) { create(:ecf_statement, cpd_lead_provider:, deadline_date: statement.deadline_date + 1.day) }
   let!(:other_cpd_lead_provider_participant_declaration) { travel_to(other_cpd_lead_provider_statement.deadline_date) { create(:ect_participant_declaration, cpd_lead_provider:) } }
 
-  subject(:query) { described_class.new(statement) }
+  let(:query) { described_class.new(statement) }
 
   let(:assurance_report) { query.participant_declarations.first }
+  let(:induction_record) { participant_profile.induction_records.latest }
 
   describe "#participant_declarations" do
-    it "includes the declaration" do
-      expect(query.participant_declarations).to eq([participant_declaration])
-    end
+    subject { query.participant_declarations }
 
-    it "surfaces the preferred external identifier" do
-      participant_declarations = query.participant_declarations
-      expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id)
-    end
+    it { is_expected.to contain_exactly(participant_declaration) }
+    it { expect(assurance_report.participant_id).to eq(participant_identity.user_id) }
 
     context "with multiple participant identities" do
-      let(:induction_record) { participant_profile.induction_records.latest }
-      let(:new_participant_identity) { ParticipantIdentity.find_by!(email: "second_email@example.com") }
       before do
         Induction::ChangePreferredEmail.call(induction_record:, preferred_email: "second_email@example.com")
         # We ideally should not update the existing participant identity on a profile when a new one is added
         # however, some of the data has this incorrect shape, so we should account for it.
-        participant_profile.update!(participant_identity: new_participant_identity)
+        participant_profile.update!(participant_identity: ParticipantIdentity.find_by!(email: "second_email@example.com"))
       end
 
-      it "includes the declaration" do
-        expect(query.participant_declarations).to eq([participant_declaration])
-      end
+      it { is_expected.to contain_exactly(participant_declaration) }
+      it { expect(assurance_report.participant_id).to eq(participant_identity.user_id) }
+    end
+  end
 
-      it "surfaces the preferred external identifier" do
-        participant_declarations = query.participant_declarations
-        expect(participant_declarations.first.participant_id).to eq(participant_identity.user_id)
-      end
+  describe "#delivery_partner_name" do
+    subject { assurance_report.delivery_partner_name }
+
+    it { is_expected.to eq(participant_declaration.delivery_partner.name) }
+    it { is_expected.not_to eq(induction_record.delivery_partner.name) }
+
+    context "when the declaration does not have a delivery partner" do
+      let(:delivery_partner) { nil }
+
+      it { is_expected.to eq(induction_record.delivery_partner.name) }
     end
   end
 
   describe "#sparsity_and_pp" do
+    subject { assurance_report }
+
     context "with no uplifts" do
-      it "is false" do
-        expect(assurance_report).not_to be_sparsity_uplift
-        expect(assurance_report).not_to be_pupil_premium_uplift
-        expect(assurance_report).not_to be_sparsity_and_pp
-      end
+      it { is_expected.not_to be_sparsity_uplift }
+      it { is_expected.not_to be_pupil_premium_uplift }
+      it { is_expected.not_to be_sparsity_and_pp }
     end
 
     context "with sparsity_uplift" do
       let(:uplifts) { [:sparsity_uplift] }
 
-      it "is false", :aggregate_failures do
-        expect(assurance_report).to     be_sparsity_uplift
-        expect(assurance_report).not_to be_pupil_premium_uplift
-        expect(assurance_report).not_to be_sparsity_and_pp
-      end
+      it { is_expected.to be_sparsity_uplift }
+      it { is_expected.not_to be_pupil_premium_uplift }
+      it { is_expected.not_to be_sparsity_and_pp }
     end
 
     context "with pupil_premium_uplift" do
       let(:uplifts) { [:pupil_premium_uplift] }
 
-      it "is false", :aggregate_failures do
-        expect(assurance_report).not_to be_sparsity_uplift
-        expect(assurance_report).to     be_pupil_premium_uplift
-        expect(assurance_report).not_to be_sparsity_and_pp
-      end
+      it { is_expected.not_to be_sparsity_uplift }
+      it { is_expected.to be_pupil_premium_uplift }
+      it { is_expected.not_to be_sparsity_and_pp }
     end
 
     context "with sparsity_uplift and pupil_premium_uplift" do
       let(:uplifts) { %i[pupil_premium_and_sparsity_uplift] }
 
-      it "is true", :aggregate_failures do
-        expect(assurance_report).to be_pupil_premium_uplift
-        expect(assurance_report).to be_sparsity_uplift
-        expect(assurance_report).to be_sparsity_and_pp
-      end
+      it { is_expected.to be_sparsity_uplift }
+      it { is_expected.to be_pupil_premium_uplift }
+      it { is_expected.to be_sparsity_and_pp }
     end
   end
 end


### PR DESCRIPTION
[Jira-2169](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2169)

### Context

The assurance report query currently takes the delivery partner from the latest induction record. This may not be correct in all scenarios and is inconsistent with how we select the delivery partner in other areas of the application.

Instead, we want to use the delivery partner associated with the declaration and only fallback to the latest induction record if it is not set (which it may not be on some historical records).

### Changes proposed in this pull request

- Export correct delivery partner in assurance report

### Guidance to review

Also has a general tidy-up to the query specs.

