### PR TITLE
Fix validation in the admin school transfer form

### DIFF
--- a/app/forms/admin/school_transfer_form.rb
+++ b/app/forms/admin/school_transfer_form.rb
@@ -195,7 +195,7 @@ private
   end
 
   def moving_to_new_school
-    errors.add(:new_school_urn, :same_school, urn: new_school_urn) if participant_profile.school == new_school
+    errors.add(:new_school_urn, :same_school, urn: new_school_urn) if latest_induction_record&.school == new_school
   end
 
   def new_school_programmes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,7 +269,7 @@ en:
             new_school_urn:
               blank: "Enter the URN of the school the participant will transfer to"
               invalid: "Cannot find a school with the URN ‘%{urn}’"
-              same_school: "Enter the URN of the school the participant is joining"
+              same_school: "The participant is already associated to this school. Enter a different school URN"
             transfer_choice:
               blank: "Select which programme the participant will join"
             start_date:

--- a/spec/forms/admin/school_transfer_form_spec.rb
+++ b/spec/forms/admin/school_transfer_form_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Admin::SchoolTransferForm, type: :model do
       end
 
       it "checks the urn provided is from a new school" do
-        form.new_school_urn = participant_profile.school.urn
+        form.new_school_urn = participant_profile.latest_induction_record.school.urn
         expect(form.valid?(:select_school)).to be false
       end
 


### PR DESCRIPTION
### Context

- Ticket: CST-1856

The validation is retrieving the participant's current school and checks if it's not the same with the one moving into. Problem is that it's not retrieving the participant's school from their induction record.

### Changes proposed in this pull request
- Update the validation to use the participant's latest induction record to retrieve their current school

### Guidance to review

