### PR TITLE
Remove continue-on-error from staging deploy step

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -83,7 +83,6 @@ jobs:
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
-        continue-on-error: true # temporary while we get staging working
         with:
           environment: staging
           docker-image: ${{ needs.docker.outputs.image }}


### PR DESCRIPTION
### Context

Now staging deploys are working properly we no longer need this. Add it back later if necessary. 
