### PR TITLE
Add service/rake task to export delivery partners

### DIFF
--- a/app/services/admin/delivery_partners/exporter.rb
+++ b/app/services/admin/delivery_partners/exporter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Admin
+  module DeliveryPartners
+    class Exporter
+      COLUMN_HEADINGS = [
+        "Full name",
+        "Email",
+        "Delivery Partner ID",
+        "Delivery Partner Name",
+      ].freeze
+
+      def csv
+        CSV.generate do |csv|
+          csv << COLUMN_HEADINGS
+          delivery_partner_profiles.each { |dpp| csv << row(dpp) }
+        end
+      end
+
+    private
+
+      def row(delivery_partner_profile)
+        [
+          delivery_partner_profile.user.full_name,
+          delivery_partner_profile.user.email,
+          delivery_partner_profile.delivery_partner.id,
+          delivery_partner_profile.delivery_partner.name,
+        ]
+      end
+
+      def delivery_partner_profiles
+        @delivery_partner_profiles ||= DeliveryPartnerProfile
+          .includes(:user, :delivery_partner)
+          .order("users.full_name")
+      end
+    end
+  end
+end

--- a/lib/tasks/delivery_partners.rake
+++ b/lib/tasks/delivery_partners.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :delivery_partners do
+  desc "Exports all delivery partners in CSV format (to a file if specified)"
+  task :export, %i[path_to_csv] => :environment do |_task, args|
+    exporter = Admin::DeliveryPartners::Exporter.new
+    csv_data = exporter.csv
+    csv_path = args[:path_to_csv]
+
+    if csv_path.present?
+      File.write(csv_path, csv_data)
+    else
+      puts csv_data
+    end
+  end
+end

--- a/spec/services/admin/delivery_partners/exporter_spec.rb
+++ b/spec/services/admin/delivery_partners/exporter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Admin::DeliveryPartners::Exporter do
+  let(:instance) { described_class.new }
+
+  describe "#csv" do
+    subject { instance.csv }
+
+    it "returns a CSV of all delivery partners ordered by user full_name" do
+      user1 = create(:user, full_name: "Ben Smith")
+      user2 = create(:user, full_name: "Andrew Jones")
+
+      delivery_partner_profile1 = create(:delivery_partner_profile, user: user1)
+      delivery_partner_profile2 = create(:delivery_partner_profile, user: user1)
+      delivery_partner_profile3 = create(:delivery_partner_profile, user: user2)
+
+      delivery_partner1 = delivery_partner_profile1.delivery_partner
+      delivery_partner2 = delivery_partner_profile2.delivery_partner
+      delivery_partner3 = delivery_partner_profile3.delivery_partner
+
+      is_expected.to eq(
+        <<~CSV,
+          Full name,Email,Delivery Partner ID,Delivery Partner Name
+          #{user2.full_name},#{user2.email},#{delivery_partner3.id},#{delivery_partner3.name}
+          #{user1.full_name},#{user1.email},#{delivery_partner1.id},#{delivery_partner1.name}
+          #{user1.full_name},#{user1.email},#{delivery_partner2.id},#{delivery_partner2.name}
+        CSV
+      )
+    end
+  end
+end


### PR DESCRIPTION
[Jira-2334](https://dfedigital.atlassian.net/browse/CPDLP-2334)

### Context

We want to be able to export delivery partners easily and periodically; adding a service to perform this action and a rake task so that it can be ran in production. We may want to expose the functionality via the admin interface in the future.

### Changes proposed in this pull request

- Add service/rake task to export delivery partners

### Guidance to review

Output to a CSV file:

```
bundle exec rake 'delivery_partners:export[./out.csv]'
```

Output to the console:

```
bundle exec rake delivery_partners:export
```