### PR TITLE
[CPDLP-2325] Add seed data for ECF extended schedules

### DIFF
--- a/db/data/schedules/schedules.csv
+++ b/db/data/schedules/schedules.csv
@@ -237,6 +237,78 @@ npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 3 - Parti
 npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
 npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
 npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 3 - Participant Completion,completed,01/01/2024,,01/01/2024
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 1 - Participant Start,started,01/06/2023,31/12/2023,30/11/2023
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,31/03/2024,30/04/2024
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,31/07/2024,31/08/2024
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 4 - Retention Point 3,retained-3,01/08/2024,31/12/2024,31/01/2025
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 5 - Retention Point 4,retained-4,01/01/2025,31/03/2025,30/04/2025
+ecf_standard,ecf-standard-september,ECF Standard September,2023,Output 6 - Participant Completion,completed,01/04/2025,31/07/2025,31/08/2025
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 1 - Participant Start,started,01/01/2024,31/03/2024,30/04/2024
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,31/07/2024,31/08/2024
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 3 - Retention Point 2,retained-2,01/08/2024,31/12/2024,31/01/2025
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 4 - Retention Point 3,retained-3,01/01/2025,31/03/2025,30/04/2025
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 5 - Retention Point 4,retained-4,01/04/2025,31/07/2025,31/08/2025
+ecf_standard,ecf-standard-january,ECF Standard January,2023,Output 6 - Participant Completion,completed,01/08/2025,31/12/2025,31/01/2026
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 1 - Participant Start,started,01/04/2024,31/07/2024,31/08/2024
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 2 - Retention Point 1,retained-1,01/08/2024,31/12/2024,31/01/2025
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 3 - Retention Point 2,retained-2,01/01/2025,31/03/2025,30/04/2025
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 4 - Retention Point 3,retained-3,01/04/2025,31/07/2025,31/08/2025
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 5 - Retention Point 4,retained-4,01/08/2025,31/12/2025,31/01/2026
+ecf_standard,ecf-standard-april,ECF Standard April,2023,Output 6 - Participant Completion,completed,01/01/2026,31/03/2026,30/04/2026
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
+ecf_reduced,ecf-reduced-september,ECF Reduced September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
+ecf_reduced,ecf-reduced-january,ECF Reduced January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
+ecf_reduced,ecf-reduced-april,ECF Reduced April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 1 - Participant Start,started,01/09/2023,,01/09/2023
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 2 - Retention Point 1,retained-1,01/09/2023,,01/09/2023
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 3 - Retention Point 2,retained-2,01/09/2023,,01/09/2023
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 4 - Retention Point 3,retained-3,01/09/2023,,01/09/2023
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 5 - Retention Point 4,retained-4,01/09/2023,,01/09/2023
+ecf_replacement,ecf-replacement-september,ECF Replacement September,2023,Output 6 - Participant Completion,completed,01/09/2023,,01/09/2023
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 3 - Retention Point 2,retained-2,01/01/2024,,01/01/2024
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 4 - Retention Point 3,retained-3,01/01/2024,,01/01/2024
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 5 - Retention Point 4,retained-4,01/01/2024,,01/01/2024
+ecf_replacement,ecf-replacement-january,ECF Replacement January,2023,Output 6 - Participant Completion,completed,01/01/2024,,01/01/2024
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 1 - Participant Start,started,01/04/2024,,01/04/2024
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 2 - Retention Point 1,retained-1,01/04/2024,,01/04/2024
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 3 - Retention Point 2,retained-2,01/04/2024,,01/04/2024
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 4 - Retention Point 3,retained-3,01/04/2024,,01/04/2024
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 5 - Retention Point 4,retained-4,01/04/2024,,01/04/2024
+ecf_replacement,ecf-replacement-april,ECF Replacement April,2023,Output 6 - Participant Completion,completed,01/04/2024,,01/04/2024
 ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 7 - Extended Point 1,extended-1,01/09/2021,,01/09/2021
 ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 8 - Extended Point 2,extended-2,01/09/2021,,01/09/2021
 ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 9 - Extended Point 3,extended-3,01/09/2021,,01/09/2021

--- a/db/data/schedules/schedules.csv
+++ b/db/data/schedules/schedules.csv
@@ -237,3 +237,30 @@ npq_specialist,npq-specialist-autumn,NPQ Specialist Autumn,2023,Output 3 - Parti
 npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 1 - Participant Start,started,01/01/2024,,01/01/2024
 npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 2 - Retention Point 1,retained-1,01/01/2024,,01/01/2024
 npq_specialist,npq-specialist-spring,NPQ Specialist Spring,2023,Output 3 - Participant Completion,completed,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 7 - Extended Point 1,extended-1,01/09/2021,,01/09/2021
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 8 - Extended Point 2,extended-2,01/09/2021,,01/09/2021
+ecf_extended,ecf-extended-september,ECF Extended September,2021,Output 9 - Extended Point 3,extended-3,01/09/2021,,01/09/2021
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 7 - Extended Point 1,extended-1,01/01/2022,,01/01/2022
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 8 - Extended Point 2,extended-2,01/01/2022,,01/01/2022
+ecf_extended,ecf-extended-january,ECF Extended January,2021,Output 9 - Extended Point 3,extended-3,01/01/2022,,01/01/2022
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 7 - Extended Point 1,extended-1,01/04/2022,,01/04/2022
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 8 - Extended Point 2,extended-2,01/04/2022,,01/04/2022
+ecf_extended,ecf-extended-april,ECF Extended April,2021,Output 9 - Extended Point 3,extended-3,01/04/2022,,01/04/2022
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 7 - Extended Point 1,extended-1,01/09/2022,,01/09/2022
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 8 - Extended Point 2,extended-2,01/09/2022,,01/09/2022
+ecf_extended,ecf-extended-september,ECF Extended September,2022,Output 9 - Extended Point 3,extended-3,01/09/2022,,01/09/2022
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 7 - Extended Point 1,extended-1,01/01/2023,,01/01/2023
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 8 - Extended Point 2,extended-2,01/01/2023,,01/01/2023
+ecf_extended,ecf-extended-january,ECF Extended January,2022,Output 9 - Extended Point 3,extended-3,01/01/2023,,01/01/2023
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 7 - Extended Point 1,extended-1,01/04/2023,,01/04/2023
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 8 - Extended Point 2,extended-2,01/04/2023,,01/04/2023
+ecf_extended,ecf-extended-april,ECF Extended April,2022,Output 9 - Extended Point 3,extended-3,01/04/2023,,01/04/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 7 - Extended Point 1,extended-1,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 8 - Extended Point 2,extended-2,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-september,ECF Extended September,2023,Output 9 - Extended Point 3,extended-3,01/09/2023,,01/09/2023
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 7 - Extended Point 1,extended-1,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 8 - Extended Point 2,extended-2,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-january,ECF Extended January,2023,Output 9 - Extended Point 3,extended-3,01/01/2024,,01/01/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 7 - Extended Point 1,extended-1,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 8 - Extended Point 2,extended-2,01/04/2024,,01/04/2024
+ecf_extended,ecf-extended-april,ECF Extended April,2023,Output 9 - Extended Point 3,extended-3,01/04/2024,,01/04/2024

--- a/spec/models/finance/schedule/ecf_spec.rb
+++ b/spec/models/finance/schedule/ecf_spec.rb
@@ -32,39 +32,41 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
     end
   end
 
-  context "for 2021 cohort" do
-    let(:cohort) { Cohort.find_by(start_year: 2021) }
+  Cohort.where.not(start_year: 2020).find_each do |cohort|
+    context "for #{cohort.start_year} cohort" do
+      let(:cohort) { Cohort.find_by(start_year: cohort.start_year) }
 
-    it "seeds ecf schedules and milestones" do
-      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-standard-april")
+      it "seeds ecf schedules and milestones" do
+        schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-standard-april")
 
-      expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(6)
+        expect(schedule).to be_present
+        expect(schedule.milestones.count).to eql(6)
 
-      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-reduced-april")
+        schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-reduced-april")
 
-      expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(6)
+        expect(schedule).to be_present
+        expect(schedule.milestones.count).to eql(6)
 
-      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-april")
+        schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-april")
 
-      expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(9)
+        expect(schedule).to be_present
+        expect(schedule.milestones.count).to eql(9)
 
-      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-replacement-april")
+        schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-replacement-april")
 
-      expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(6)
+        expect(schedule).to be_present
+        expect(schedule.milestones.count).to eql(6)
 
-      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-january")
+        schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-january")
 
-      expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(9)
+        expect(schedule).to be_present
+        expect(schedule.milestones.count).to eql(9)
 
-      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-september")
+        schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-september")
 
-      expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(9)
+        expect(schedule).to be_present
+        expect(schedule.milestones.count).to eql(9)
+      end
     end
   end
 end

--- a/spec/models/finance/schedule/ecf_spec.rb
+++ b/spec/models/finance/schedule/ecf_spec.rb
@@ -49,12 +49,22 @@ RSpec.describe Finance::Schedule::ECF, type: :model do
       schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-april")
 
       expect(schedule).to be_present
-      expect(schedule.milestones.count).to eql(6)
+      expect(schedule.milestones.count).to eql(9)
 
       schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-replacement-april")
 
       expect(schedule).to be_present
       expect(schedule.milestones.count).to eql(6)
+
+      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-january")
+
+      expect(schedule).to be_present
+      expect(schedule.milestones.count).to eql(9)
+
+      schedule = described_class.find_by(cohort:, schedule_identifier: "ecf-extended-september")
+
+      expect(schedule).to be_present
+      expect(schedule.milestones.count).to eql(9)
     end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2325](https://dfedigital.atlassian.net/browse/CPDLP-2325)

### Changes proposed in this pull request

Add new milestone seed data for ECF extended schedules.

### Guidance to review

go to review app url /finance/schedules to check whether the new milestones have been added to the ecf-extended schedules.



[CPDLP-2325]: https://dfedigital.atlassian.net/browse/CPDLP-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ