### PR TITLE
Sanitize the privacy policy

### DIFF
--- a/app/views/privacy_policies/show.html.erb
+++ b/app/views/privacy_policies/show.html.erb
@@ -9,7 +9,7 @@
             <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
         <% end %>
 
-        <%= h(@policy.html) %>
+        <%= sanitize(@policy.html) %>
 
         <% if @policy.acceptance_required?(current_user) %>
             <%= form_tag({action: :update}, method: :put) do %>


### PR DESCRIPTION
### Context

The privacy policy is displaying with HTML tags, the output needs to be sanitized. I introduced this on Friday while fixing the Brakeman warnings 🤦
