### PR TITLE
[CPDLP-2351] Enable lead providers to 'unwithdraw' an ECF or NPQ participant via the API

### DIFF
--- a/app/services/resume_participant.rb
+++ b/app/services/resume_participant.rb
@@ -17,7 +17,6 @@ class ResumeParticipant
   validates :cpd_lead_provider,
             induction_record: true
   validate :not_already_active
-  validate :not_already_withdrawn
 
   def call
     ActiveRecord::Base.transaction do
@@ -57,12 +56,6 @@ private
     return unless participant_profile
 
     errors.add(:participant_profile, I18n.t(:already_active)) if participant_profile.active_for?(cpd_lead_provider:)
-  end
-
-  def not_already_withdrawn
-    return unless participant_profile
-
-    errors.add(:participant_profile, I18n.t(:invalid_withdrawal)) if participant_profile.withdrawn_for?(cpd_lead_provider:)
   end
 
   def relevant_induction_record

--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -7,6 +7,14 @@ weight: 8
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## 10th August 2023
+
+Lead providers can now ‘resume’ participants NPQ and ECF that they have previously withdrawn.
+
+Lead providers should use the relevant [ecf](/api-reference/reference-v3.html#api-v3-participants-ecf-id-resume-put) or [npq](/api-reference/reference-v3.html#api-v3-participants-npq-id-resume-put) resume endpoints to change a given participant’s training_status from withdrawn to active.
+
+The DfE will monitor levels of withdrawn participants that have been resumed.
+
 ## 31st July 2023
 
 Lead Providers can now change the cohort of an ECF participant, providing that:

--- a/spec/support/shared_examples/participant_actions_resume_support.rb
+++ b/spec/support/shared_examples/participant_actions_resume_support.rb
@@ -17,11 +17,11 @@ RSpec.shared_examples "JSON Participant Resume endpoint" do |serialiser_type|
     expect(response).not_to be_successful
   end
 
-  it "returns an error when the participant is already withdrawn" do
+  it "changes the training status of a withdrawn participant to active" do
     put withdrawal_url, params: withdrawal_params
     put(url, params:)
 
-    expect(response).not_to be_successful
+    expect(response).to be_successful
   end
 end
 


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2351

### Changes proposed in this pull request

* Removed validation that prevents participants from changing from `withdrawn` to `active`
* Updated tests
* Release notes updated

### Guidance to review

