### PR TITLE
[CST-1851] Set induction completion date and induction status

### DIFF
--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -103,6 +103,10 @@ class InductionRecord < ApplicationRecord
     update!(induction_status: :changed, end_date: date_of_change)
   end
 
+  def completing!(date_of_change = Time.zone.now)
+    update!(induction_status: :completed, end_date: date_of_change)
+  end
+
   def claimed_by_another_school?
     leaving_induction_status? && !school_transfer && end_date.future?
   end

--- a/app/models/induction_record.rb
+++ b/app/models/induction_record.rb
@@ -103,10 +103,6 @@ class InductionRecord < ApplicationRecord
     update!(induction_status: :changed, end_date: date_of_change)
   end
 
-  def completing!(date_of_change = Time.zone.now)
-    update!(induction_status: :completed, end_date: date_of_change)
-  end
-
   def claimed_by_another_school?
     leaving_induction_status? && !school_transfer && end_date.future?
   end

--- a/app/services/determine_training_record_state.rb
+++ b/app/services/determine_training_record_state.rb
@@ -172,7 +172,11 @@ class DetermineTrainingRecordState < BaseService
   def call
     result = ActiveRecord::Base.connection.execute(query)
 
-    Record.new(**result.first)
+    # Adding the guard condition as this sometimes raises an error
+    # when there are no results returned. This may just be a dev data setup
+    # problem that occurs when you set a participant as "completed" but it
+    # doesn't happen to every participant marked as completed.
+    Record.new(**result.first) unless result.count.zero?
   end
 
   def all

--- a/app/services/induction/complete.rb
+++ b/app/services/induction/complete.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Induction::Complete < BaseService
+  def call
+    ActiveRecord::Base.transaction do
+      participant_profile.update!(induction_completion_date: completion_date)
+
+      Induction::ChangeInductionRecord.call(induction_record: latest_induction_record,
+                                            changes: { induction_status: :completed })
+    end
+  end
+
+private
+
+  attr_reader :participant_profile, :completion_date
+
+  def initialize(participant_profile:, completion_date:)
+    @participant_profile = participant_profile
+    @completion_date = completion_date
+  end
+
+  def latest_induction_record
+    @latest_induction_record ||= Induction::FindBy.call(participant_profile:)
+  end
+end

--- a/app/services/induction/complete.rb
+++ b/app/services/induction/complete.rb
@@ -6,7 +6,7 @@ class Induction::Complete < BaseService
       participant_profile.update!(induction_completion_date: completion_date)
 
       Induction::ChangeInductionRecord.call(induction_record: latest_induction_record,
-                                            changes: { induction_status: :completed })
+                                            changes: { induction_status: :completed, mentor_profile: nil })
     end
   end
 

--- a/db/new_seeds/scenarios/participants/ects/ect.rb
+++ b/db/new_seeds/scenarios/participants/ects/ect.rb
@@ -34,6 +34,12 @@ module NewSeeds
             self
           end
 
+          # NOTE: run me after adding an induction record
+          def that_has_completed(completion_date: 1.week.ago)
+            Induction::Complete.call(participant_profile:, completion_date:)
+            self
+          end
+
           def add_induction_record(induction_programme:, mentor_profile: nil, start_date: 6.months.ago, end_date: nil,
                                    induction_status: "active", training_status: "active", preferred_identity: nil,
                                    appropriate_body: nil, school_transfer: false)

--- a/spec/services/induction/complete_spec.rb
+++ b/spec/services/induction/complete_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Induction::Complete do
     let(:school_cohort) { create :school_cohort }
     let(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
     let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
-    let!(:induction_record) { Induction::Enrol.call(induction_programme:, participant_profile:, start_date: 6.months.ago) }
+    let(:mentor_profile) { create(:mentor_participant_profile, school_cohort:) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme:, participant_profile:, start_date: 6.months.ago, mentor_profile:) }
     let(:completion_date) { 2.weeks.ago.to_date }
 
     subject(:service) { described_class }
@@ -26,6 +27,13 @@ RSpec.describe Induction::Complete do
       service.call(participant_profile:, completion_date:)
 
       expect(induction_record.reload.end_date).to be_within(2.seconds).of Time.zone.now
+    end
+
+    it "removes the mentor_profile from the induction record" do
+      service.call(participant_profile:, completion_date:)
+
+      expect(induction_record.reload.mentor_profile).to eq mentor_profile
+      expect(participant_profile.latest_induction_record.mentor_profile).to be_nil
     end
 
     context "when the latest induction record already has an end date" do

--- a/spec/services/induction/complete_spec.rb
+++ b/spec/services/induction/complete_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Induction::Complete do
+  describe "#call" do
+    let(:school_cohort) { create :school_cohort }
+    let(:induction_programme) { create(:induction_programme, :fip, school_cohort:) }
+    let(:participant_profile) { create(:ect_participant_profile, school_cohort:) }
+    let!(:induction_record) { Induction::Enrol.call(induction_programme:, participant_profile:, start_date: 6.months.ago) }
+    let(:completion_date) { 2.weeks.ago.to_date }
+
+    subject(:service) { described_class }
+
+    it "sets the completion date on the profile" do
+      service.call(participant_profile:, completion_date:)
+
+      expect(participant_profile.induction_completion_date).to eq completion_date
+    end
+
+    it "sets the induction induction_status to completed on the latest induction record" do
+      service.call(participant_profile:, completion_date:)
+
+      expect(participant_profile.latest_induction_record).to be_completed_induction_status
+    end
+
+    it "sets the induction record end_date on the previous induction record" do
+      service.call(participant_profile:, completion_date:)
+
+      expect(induction_record.reload.end_date).to be_within(2.seconds).of Time.zone.now
+    end
+
+    context "when the latest induction record already has an end date" do
+      before do
+        induction_record.leaving!(1.week.ago)
+      end
+
+      it "does not update the end_date" do
+        expect {
+          service.call(participant_profile:, completion_date:)
+        }.not_to change { induction_record.end_date }
+      end
+    end
+
+    context "when the latest induction record has a future start date" do
+      before do
+        induction_record.update!(start_date: 1.week.from_now)
+      end
+
+      it "updates the induction status" do
+        service.call(participant_profile:, completion_date:)
+        expect(induction_record.reload).to be_completed_induction_status
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1851)

Set the `induction_completion_date` and add a new induction record with the `completed` induction status.

### Changes proposed in this pull request
Adds a service to mark a participant as completed and set the completion date.
The actual induction completion date will be retrieved in a subsequent PR

### Guidance to review
