### PR TITLE
SITs becoming mentors - remove separate journey

### DIFF
--- a/app/controllers/schools/add_participants/base_controller.rb
+++ b/app/controllers/schools/add_participants/base_controller.rb
@@ -64,7 +64,7 @@ module Schools
                                      submitted_params:)
         end
         @form = @wizard.form
-      rescue BaseWizard::AlreadyInitialised => e
+      rescue BaseWizard::AlreadyInitialised
         Rails.logger.error("AddParticipants::BaseController: already initialised")
         remove_session_data
         redirect_to abort_path

--- a/app/controllers/schools/add_participants/base_controller.rb
+++ b/app/controllers/schools/add_participants/base_controller.rb
@@ -65,6 +65,7 @@ module Schools
         end
         @form = @wizard.form
       rescue BaseWizard::AlreadyInitialised, BaseWizard::InvalidStep
+        Rails.logger.error("AddParticipants::BaseController: Invalid step \"#{step_name}\"")
         remove_session_data
         redirect_to abort_path
       end

--- a/app/controllers/schools/add_participants/base_controller.rb
+++ b/app/controllers/schools/add_participants/base_controller.rb
@@ -64,7 +64,11 @@ module Schools
                                      submitted_params:)
         end
         @form = @wizard.form
-      rescue BaseWizard::AlreadyInitialised, BaseWizard::InvalidStep
+      rescue BaseWizard::AlreadyInitialised => e
+        Rails.logger.error("AddParticipants::BaseController: already initialised")
+        remove_session_data
+        redirect_to abort_path
+      rescue BaseWizard::InvalidStep
         Rails.logger.error("AddParticipants::BaseController: Invalid step \"#{step_name}\"")
         remove_session_data
         redirect_to abort_path

--- a/app/controllers/schools/add_participants/transfer_controller.rb
+++ b/app/controllers/schools/add_participants/transfer_controller.rb
@@ -21,7 +21,9 @@ module Schools
       def needs_after_transfer_sign_in?
         if @wizard.after_transfer_sign_in_needed
           sign_in(@wizard.current_user, scope: :user)
-          PrivacyPolicy.current.accept!(@wizard.current_user)
+          if PrivacyPolicy.acceptance_required?(@wizard.current_user)
+            PrivacyPolicy.current.accept!(@wizard.current_user)
+          end
         end
       end
 

--- a/app/controllers/schools/add_participants/transfer_controller.rb
+++ b/app/controllers/schools/add_participants/transfer_controller.rb
@@ -20,7 +20,11 @@ module Schools
 
       def needs_after_transfer_sign_in?
         if @wizard.after_transfer_sign_in_needed
-          sign_in(@wizard.current_user, scope: :user)
+          if true_user.admin?
+            impersonate_user(@wizard.current_user)
+          else
+            sign_in(@wizard.current_user, scope: :user)
+          end
           ensure_policy_acceptance
         end
       end

--- a/app/controllers/schools/add_participants/transfer_controller.rb
+++ b/app/controllers/schools/add_participants/transfer_controller.rb
@@ -6,7 +6,24 @@ module Schools
       before_action :initialize_wizard
       before_action :data_check
 
+      def update
+        if @form.valid?
+          @wizard.save!
+          check_needs_after_transfer_sign_in
+          redirect_to @wizard.next_step_path
+        else
+          render @wizard.current_step
+        end
+      end
+
     private
+
+      def check_needs_after_transfer_sign_in
+        if @wizard.after_transfer_sign_in_needed
+          sign_in(@wizard.current_user, scope: :user)
+          PrivacyPolicy.current.accept!(@wizard.current_user)
+        end
+      end
 
       def data_check
         if has_already_completed? || !who_stage_complete?

--- a/app/controllers/schools/add_participants/transfer_controller.rb
+++ b/app/controllers/schools/add_participants/transfer_controller.rb
@@ -9,7 +9,7 @@ module Schools
       def update
         if @form.valid?
           @wizard.save!
-          needs_after_transfer_sign_in?
+          needs_user_dedup_sign_in?
           redirect_to @wizard.next_step_path
         else
           render @wizard.current_step
@@ -18,8 +18,8 @@ module Schools
 
     private
 
-      def needs_after_transfer_sign_in?
-        if @wizard.after_transfer_sign_in_needed
+      def needs_user_dedup_sign_in?
+        if @wizard.after_user_dedup_sign_in_needed
           if true_user.admin?
             impersonate_user(@wizard.current_user)
           else
@@ -30,8 +30,9 @@ module Schools
       end
 
       def ensure_policy_acceptance
-        if PrivacyPolicy.current.acceptance_required?(@wizard.current_user)
-          PrivacyPolicy.current.accept!(@wizard.current_user)
+        policy = PrivacyPolicy.current
+        if policy.acceptance_required?(@wizard.current_user)
+          policy.accept!(@wizard.current_user)
         end
       end
 

--- a/app/controllers/schools/add_participants/transfer_controller.rb
+++ b/app/controllers/schools/add_participants/transfer_controller.rb
@@ -9,7 +9,7 @@ module Schools
       def update
         if @form.valid?
           @wizard.save!
-          check_needs_after_transfer_sign_in
+          needs_after_transfer_sign_in?
           redirect_to @wizard.next_step_path
         else
           render @wizard.current_step
@@ -18,7 +18,7 @@ module Schools
 
     private
 
-      def check_needs_after_transfer_sign_in
+      def needs_after_transfer_sign_in?
         if @wizard.after_transfer_sign_in_needed
           sign_in(@wizard.current_user, scope: :user)
           PrivacyPolicy.current.accept!(@wizard.current_user)

--- a/app/controllers/schools/add_participants/transfer_controller.rb
+++ b/app/controllers/schools/add_participants/transfer_controller.rb
@@ -21,9 +21,13 @@ module Schools
       def needs_after_transfer_sign_in?
         if @wizard.after_transfer_sign_in_needed
           sign_in(@wizard.current_user, scope: :user)
-          if PrivacyPolicy.acceptance_required?(@wizard.current_user)
-            PrivacyPolicy.current.accept!(@wizard.current_user)
-          end
+          ensure_policy_acceptance
+        end
+      end
+
+      def ensure_policy_acceptance
+        if PrivacyPolicy.current.acceptance_required?(@wizard.current_user)
+          PrivacyPolicy.current.accept!(@wizard.current_user)
         end
       end
 

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -97,6 +97,10 @@ module Schools
         "#{start_term.capitalize} #{start_term == 'spring' ? Time.zone.now.year + 1 : Time.zone.now.year}"
       end
 
+      def sit_added_as_mentor?
+        participant_create_args[:email] == current_user.email
+      end
+
     private
 
       def add_participant!

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -40,6 +40,9 @@ module Schools
           else
             show_path_for(step: :email)
           end
+        elsif form.next_step == :abort
+          reset_form
+          abort_path
         else
           show_path_for(step: form.next_step)
         end
@@ -129,8 +132,10 @@ module Schools
       end
 
       def find_existing_mentor_by_trn
-        profile = ECFParticipantValidationData.find_by(trn:)&.participant_profile
-        profile if profile.mentor?
+        teacher_profile = TeacherProfile.find_by(trn:)
+        return if teacher_profile.nil?
+
+        teacher_profile.ecf_profiles.mentors.first
       end
 
       def sit_adding_themself_as_existing_mentor?

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -11,6 +11,7 @@ module Schools
           start_date
           start_term
           cannot_add_registration_not_yet_open
+          cannot_add_yourself_as_ect
           need_training_setup
           choose_mentor
           confirm_appropriate_body

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -10,6 +10,7 @@ module Schools
           start_date
           start_term
           cannot_add_registration_not_yet_open
+          cannot_add_yourself_as_ect
           need_training_setup
           choose_mentor
           confirm_appropriate_body

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -6,12 +6,10 @@ module Schools
       def self.steps
         %i[
           email
-          yourself
           email_already_taken
           start_date
           start_term
           cannot_add_registration_not_yet_open
-          cannot_add_yourself_as_ect
           need_training_setup
           choose_mentor
           confirm_appropriate_body
@@ -40,9 +38,6 @@ module Schools
           else
             show_path_for(step: :email)
           end
-        elsif form.next_step == :abort
-          reset_form
-          abort_path
         else
           show_path_for(step: form.next_step)
         end

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -6,6 +6,7 @@ module Schools
       def self.steps
         %i[
           email
+          yourself
           email_already_taken
           start_date
           start_term

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -112,8 +112,6 @@ module Schools
                                                     preferred_email: email)
                     elsif ect_participant?
                       EarlyCareerTeachers::Create.call(**participant_create_args)
-                    elsif sit_adding_themself_as_existing_mentor?
-                      transfer_existing_mentor_profile_to_sit
                     else
                       Mentors::Create.call(**participant_create_args.except(:induction_start_date, :mentor_profile_id))
                     end
@@ -124,22 +122,6 @@ module Schools
         send_added_and_validated_email(profile) if profile && profile.ecf_participant_validation_data.present? && !sit_mentor?
 
         profile
-      end
-
-      def transfer_existing_mentor_profile_to_sit
-        existing_profile = find_existing_mentor_by_trn
-        Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
-      end
-
-      def find_existing_mentor_by_trn
-        teacher_profile = TeacherProfile.find_by(trn:)
-        return if teacher_profile.nil?
-
-        teacher_profile.ecf_profiles.mentors.first
-      end
-
-      def sit_adding_themself_as_existing_mentor?
-        adding_yourself_as_mentor? && find_existing_mentor_by_trn.present?
       end
 
       def store_validation_result!(profile)

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -11,6 +11,7 @@ module Schools
           start_term
           cannot_add_registration_not_yet_open
           cannot_add_yourself_as_ect
+          yourself
           need_training_setup
           choose_mentor
           confirm_appropriate_body

--- a/app/forms/schools/add_participants/add_wizard.rb
+++ b/app/forms/schools/add_participants/add_wizard.rb
@@ -125,20 +125,7 @@ module Schools
 
       def transfer_existing_mentor_profile_to_sit
         existing_profile = find_existing_mentor_by_trn
-        user = existing_profile.user
-        Identity::Transfer.call(from_user: user, to_user: current_user)
-        user.destroy!
-        existing_profile.reload
-
-        ParticipantProfileState.create!(participant_profile: existing_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
-        if school_cohort.default_induction_programme.present?
-          Induction::Enrol.call(participant_profile: existing_profile,
-                                induction_programme: school_cohort.default_induction_programme,
-                                start_date:)
-        end
-        Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile: existing_profile)
-
-        existing_profile
+        Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
       end
 
       def find_existing_mentor_by_trn

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -169,10 +169,11 @@ module Schools
         data_store.email == current_user.email
       end
 
-      def adding_yourself_as_mentor?
+      def sit_adding_themself_as_mentor?
         using_sit_email? && participant_type == "mentor"
       end
-      alias_method :sit_mentor?, :adding_yourself_as_mentor?
+
+      alias_method :sit_mentor?, :sit_adding_themself_as_mentor?
 
       def find_existing_mentor_by_trn
         teacher_profile = TeacherProfile.find_by(trn:)
@@ -182,7 +183,7 @@ module Schools
       end
 
       def sit_adding_themself_as_existing_mentor?
-        adding_yourself_as_mentor? && find_existing_mentor_by_trn.present?
+        sit_adding_themself_as_mentor? && find_existing_mentor_by_trn.present?
       end
 
       def adding_yourself_as_ect?

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -169,6 +169,10 @@ module Schools
         participant_type == "mentor" && current_user.email == data_store.email
       end
 
+      def adding_yourself_as_ect?
+        participant_type == "ect" && current_user.email == data_store.email
+      end
+
       def email_used_in_the_same_school?
         if email_in_use?
           participant_profile = @email_owner.teacher_profile&.ecf_profiles&.first

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -578,10 +578,6 @@ module Schools
       def adding_ect_as_mentor?
         participant_type == "mentor" && !@email_owner&.teacher_profile&.participant_profiles&.mentors&.exists?
       end
-
-      def sit_added_as_mentor?
-        false
-      end
     end
   end
 end

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -166,7 +166,7 @@ module Schools
       end
 
       def adding_yourself_as_mentor?
-        current_user.email == data_store.email
+        participant_type == "mentor" && current_user.email == data_store.email
       end
 
       def email_used_in_the_same_school?

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -165,12 +165,16 @@ module Schools
         @email_owner != existing_user
       end
 
+      def using_sit_email?
+        data_store.email == current_user.email
+      end
+
       def adding_yourself_as_mentor?
-        participant_type == "mentor" && current_user.email == data_store.email
+        using_sit_email? && participant_type == "mentor"
       end
 
       def adding_yourself_as_ect?
-        participant_type == "ect" && current_user.email == data_store.email
+        using_sit_email? && participant_type == "ect"
       end
 
       def email_used_in_the_same_school?

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -17,7 +17,7 @@ module Schools
 
       delegate :return_point, :changing_answer?, :transfer?, :participant_type, :trn, :confirmed_trn, :date_of_birth,
                :induction_start_date, :nino, :ect_participant?, :mentor_id, :continue_current_programme?, :participant_profile,
-               :sit_mentor?, :mentor_participant?, :appropriate_body_confirmed?, :appropriate_body_id, :known_by_another_name?,
+               :mentor_participant?, :appropriate_body_confirmed?, :appropriate_body_id, :known_by_another_name?,
                :same_provider?, :was_withdrawn_participant?, :complete?, :start_date, :start_term, :last_visited_step,
                :ect_mentor?,
                to: :data_store
@@ -172,6 +172,7 @@ module Schools
       def adding_yourself_as_mentor?
         using_sit_email? && participant_type == "mentor"
       end
+      alias_method :sit_mentor?, :adding_yourself_as_mentor?
 
       def adding_yourself_as_ect?
         using_sit_email? && participant_type == "ect"
@@ -415,6 +416,14 @@ module Schools
 
       def formatted_trn
         TeacherReferenceNumber.new(trn).formatted_trn
+      end
+
+      def full_name_or_you
+        if sit_mentor?
+          "you"
+        else
+          full_name
+        end
       end
 
       def full_name_or_yourself

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -165,6 +165,10 @@ module Schools
         @email_owner != existing_user
       end
 
+      def adding_yourself_as_mentor?
+        current_user.email == data_store.email
+      end
+
       def email_used_in_the_same_school?
         if email_in_use?
           participant_profile = @email_owner.teacher_profile&.ecf_profiles&.first

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -174,6 +174,17 @@ module Schools
       end
       alias_method :sit_mentor?, :adding_yourself_as_mentor?
 
+      def find_existing_mentor_by_trn
+        teacher_profile = TeacherProfile.find_by(trn:)
+        return if teacher_profile.nil?
+
+        teacher_profile.ecf_profiles.mentors.first
+      end
+
+      def sit_adding_themself_as_existing_mentor?
+        adding_yourself_as_mentor? && find_existing_mentor_by_trn.present?
+      end
+
       def adding_yourself_as_ect?
         using_sit_email? && participant_type == "ect"
       end

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -578,6 +578,10 @@ module Schools
       def adding_ect_as_mentor?
         participant_type == "mentor" && !@email_owner&.teacher_profile&.participant_profiles&.mentors&.exists?
       end
+
+      def sit_added_as_mentor?
+        false
+      end
     end
   end
 end

--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -99,6 +99,14 @@ module Schools
         full_name.present? && trn.present? && date_of_birth.present?
       end
 
+      def after_transfer_sign_in_needed
+        data_store.get(:after_transfer_sign_in_needed)
+      end
+
+      def current_user
+        data_store.get(:current_user)
+      end
+
     private
 
       def transfer_participant!
@@ -147,6 +155,8 @@ module Schools
       def transfer_sit_to_mentor_profile
         existing_profile = find_existing_mentor_by_trn
         profile = Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
+        data_store.set(:current_user, profile.user)
+        data_store.set(:after_transfer_sign_in_needed, true)
         profile.induction_records.latest
       end
 

--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -159,9 +159,9 @@ module Schools
       def transfer_sit_to_mentor_profile
         existing_profile = find_existing_mentor_by_trn
         profile = Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
-        data_store.set(:current_user, profile.user)
         data_store.set(:after_transfer_sign_in_needed, true)
         data_store.set(:sit_added_as_mentor, true)
+        data_store.set(:current_user, profile.user)
         profile.induction_records.latest
       end
 

--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -107,6 +107,10 @@ module Schools
         data_store.get(:current_user)
       end
 
+      def sit_added_as_mentor?
+        data_store.get(:sit_added_as_mentor)
+      end
+
     private
 
       def transfer_participant!
@@ -157,6 +161,7 @@ module Schools
         profile = Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
         data_store.set(:current_user, profile.user)
         data_store.set(:after_transfer_sign_in_needed, true)
+        data_store.set(:sit_added_as_mentor, true)
         profile.induction_records.latest
       end
 

--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -99,8 +99,8 @@ module Schools
         full_name.present? && trn.present? && date_of_birth.present?
       end
 
-      def after_transfer_sign_in_needed
-        data_store.get(:after_transfer_sign_in_needed)
+      def after_user_dedup_sign_in_needed
+        data_store.get(:after_user_dedup_sign_in_needed)
       end
 
       def current_user
@@ -159,7 +159,7 @@ module Schools
       def transfer_sit_to_mentor_profile
         existing_profile = find_existing_mentor_by_trn
         profile = Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
-        data_store.set(:after_transfer_sign_in_needed, true)
+        data_store.set(:after_user_dedup_sign_in_needed, true)
         data_store.set(:sit_added_as_mentor, true)
         data_store.set(:current_user, profile.user)
         profile.induction_records.latest

--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -110,7 +110,7 @@ module Schools
                                elsif !needs_to_confirm_programme? || chose_to_join_school_programme?
                                  transfer_fip_participant_to_schools_programme(profile)
                                elsif sit_adding_themself_as_existing_mentor?
-                                 transfer_existing_mentor_profile_to_sit
+                                 transfer_sit_to_mentor_profile
                                else
                                  transfer_fip_participant_and_continue_existing_programme(profile)
                                end
@@ -144,7 +144,7 @@ module Schools
         )
       end
 
-      def transfer_existing_mentor_profile_to_sit
+      def transfer_sit_to_mentor_profile
         existing_profile = find_existing_mentor_by_trn
         profile = Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
         profile.induction_records.latest

--- a/app/forms/schools/add_participants/transfer_wizard.rb
+++ b/app/forms/schools/add_participants/transfer_wizard.rb
@@ -9,6 +9,7 @@ module Schools
           join_school_programme
           cannot_add_manual_transfer
           email
+          yourself
           email_already_taken
           joining_date
           choose_mentor
@@ -108,6 +109,8 @@ module Schools
                                  transfer_fip_participant_to_schools_programme(profile)
                                elsif !needs_to_confirm_programme? || chose_to_join_school_programme?
                                  transfer_fip_participant_to_schools_programme(profile)
+                               elsif sit_adding_themself_as_existing_mentor?
+                                 transfer_existing_mentor_profile_to_sit
                                else
                                  transfer_fip_participant_and_continue_existing_programme(profile)
                                end
@@ -139,6 +142,12 @@ module Schools
           end_date: start_date,
           mentor_profile:,
         )
+      end
+
+      def transfer_existing_mentor_profile_to_sit
+        existing_profile = find_existing_mentor_by_trn
+        profile = Mentors::TransferExistingMentorToSit.call(sit_user: current_user, mentor_profile: existing_profile, school_cohort:, start_date:)
+        profile.induction_records.latest
       end
 
       # This methods assumes that all transfers are requested by the incoming school for now. There

--- a/app/forms/schools/add_participants/who_to_add_wizard.rb
+++ b/app/forms/schools/add_participants/who_to_add_wizard.rb
@@ -35,10 +35,6 @@ module Schools
         save_progress!
       end
 
-      def sit_can_become_a_mentor?
-        !current_user.mentor?
-      end
-
       def registration_open_for_participant_cohort?
         desired_cohort = cohort_to_place_participant
 

--- a/app/forms/schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step.rb
@@ -3,7 +3,28 @@
 module Schools
   module AddParticipants
     module WizardSteps
-      class CannotAddYourselfAsECTStep < CannotAddStep
+      class CannotAddYourselfAsECTStep < ::WizardStep
+        attr_accessor :participant_type
+
+        validates :participant_type, inclusion: { in: %w[mentor return] }
+
+        def self.permitted_params
+          %i[
+            participant_type
+          ]
+        end
+
+        def next_step
+          if switch_to_mentor?
+            :yourself
+          else
+            :abort
+          end
+        end
+
+        def switch_to_mentor?
+          participant_type == "mentor"
+        end
       end
     end
   end

--- a/app/forms/schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Schools
+  module AddParticipants
+    module WizardSteps
+      class CannotAddYourselfAsECTStep < CannotAddStep
+      end
+    end
+  end
+end

--- a/app/forms/schools/add_participants/wizard_steps/email_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/email_step.rb
@@ -17,6 +17,8 @@ module Schools
         def next_step
           if wizard.email_in_use?
             :email_already_taken
+          elsif wizard.adding_yourself_as_mentor?
+            :yourself
           elsif wizard.transfer?
             if wizard.needs_to_choose_a_mentor?
               :choose_mentor

--- a/app/forms/schools/add_participants/wizard_steps/email_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/email_step.rb
@@ -17,7 +17,7 @@ module Schools
         def next_step
           if wizard.email_in_use?
             :email_already_taken
-          elsif wizard.adding_yourself_as_mentor?
+          elsif wizard.sit_adding_themself_as_mentor?
             :yourself
           elsif wizard.adding_yourself_as_ect?
             :cannot_add_yourself_as_ect

--- a/app/forms/schools/add_participants/wizard_steps/email_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/email_step.rb
@@ -19,6 +19,8 @@ module Schools
             :email_already_taken
           elsif wizard.adding_yourself_as_mentor?
             :yourself
+          elsif wizard.adding_yourself_as_ect?
+            :cannot_add_yourself_as_ect
           elsif wizard.transfer?
             if wizard.needs_to_choose_a_mentor?
               :choose_mentor

--- a/app/forms/schools/add_participants/wizard_steps/yourself_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/yourself_step.rb
@@ -21,12 +21,12 @@ module Schools
             else
               :check_answers
             end
-            elsif wizard.needs_to_confirm_start_term?
-              :start_term
-            elsif wizard.needs_to_choose_a_mentor?
-              :choose_mentor
-            elsif wizard.needs_to_confirm_appropriate_body?
-              :confirm_appropriate_body
+          elsif wizard.needs_to_confirm_start_term?
+            :start_term
+          elsif wizard.needs_to_choose_a_mentor?
+            :choose_mentor
+          elsif wizard.needs_to_confirm_appropriate_body?
+            :confirm_appropriate_body
           else
             :check_answers
           end

--- a/app/forms/schools/add_participants/wizard_steps/yourself_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/yourself_step.rb
@@ -13,11 +13,27 @@ module Schools
         end
 
         def next_step
-          :trn
+          if wizard.transfer?
+            if wizard.needs_to_choose_a_mentor?
+              :choose_mentor
+            elsif wizard.needs_to_confirm_programme?
+              :continue_current_programme
+            else
+              :check_answers
+            end
+            elsif wizard.needs_to_confirm_start_term?
+              :start_term
+            elsif wizard.needs_to_choose_a_mentor?
+              :choose_mentor
+            elsif wizard.needs_to_confirm_appropriate_body?
+              :confirm_appropriate_body
+          else
+            :check_answers
+          end
         end
 
         def before_save
-          @participant_type = "self"
+          @participant_type = "mentor"
         end
       end
     end

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -6,14 +6,18 @@ module Mentors
 
     def call
       ActiveRecord::Base.transaction do
+        Induction::TransferToSchoolsProgramme.call(
+          participant_profile: mentor_profile,
+          induction_programme: school_cohort.default_induction_programme,
+          start_date:,
+        )
+
         mentor_user = mentor_profile.user
-        Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme, start_date:)
-        Mentors::AddToSchool.call(mentor_profile:, school: school_cohort.school)
         if mentor_user != sit_user
           Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
           sit_user.reload.destroy!
-          mentor_profile.reload
         end
+        mentor_profile.reload
       end
     end
 

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -7,11 +7,13 @@ module Mentors
     def call
       ActiveRecord::Base.transaction do
         mentor_user = mentor_profile.user
-        Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
         Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme, start_date:)
         Mentors::AddToSchool.call(mentor_profile:, school: school_cohort.school)
-        sit_user.reload.destroy!
-        mentor_profile.reload
+        if mentor_user != sit_user
+          Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
+          sit_user.reload.destroy!
+          mentor_profile.reload
+        end
       end
     end
 

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -7,18 +7,8 @@ module Mentors
     def call
       mentor_user = mentor_profile.user
       Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
-      sit_user.destroy!
+      # sit_user.destroy!
       mentor_profile.reload
-
-      # ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
-      # if school_cohort.default_induction_programme.present?
-      #   Induction::Enrol.call(participant_profile: mentor_profile,
-      #                         induction_programme: school_cohort.default_induction_programme,
-      #                         start_date:)
-      # end
-      # Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile:)
-
-      mentor_profile
     end
 
   private

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -5,13 +5,14 @@ module Mentors
     include SchoolCohortDelegator
 
     def call
-      mentor_user = mentor_profile.user
-      Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
-      Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme, start_date:)
-      Mentors::AddToSchool.call(mentor_profile:, school: school_cohort.school)
-      mentor_profile.reload
-      # TODO: handle SIT user destroy
-      # sit_user.destroy!
+      ActiveRecord::Base.transaction do
+        mentor_user = mentor_profile.user
+        Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
+        Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme, start_date:)
+        Mentors::AddToSchool.call(mentor_profile:, school: school_cohort.school)
+        sit_user.reload.destroy!
+        mentor_profile.reload
+      end
     end
 
   private

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -6,8 +6,8 @@ module Mentors
 
     def call
       mentor_user = mentor_profile.user
-      Identity::Transfer.call(from_user: mentor_user, to_user: sit_user)
-      mentor_user.destroy!
+      Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
+      sit_user.destroy!
       mentor_profile.reload
 
       ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -10,13 +10,13 @@ module Mentors
       sit_user.destroy!
       mentor_profile.reload
 
-      ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
-      if school_cohort.default_induction_programme.present?
-        Induction::Enrol.call(participant_profile: mentor_profile,
-                              induction_programme: school_cohort.default_induction_programme,
-                              start_date:)
-      end
-      Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile:)
+      # ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+      # if school_cohort.default_induction_programme.present?
+      #   Induction::Enrol.call(participant_profile: mentor_profile,
+      #                         induction_programme: school_cohort.default_induction_programme,
+      #                         start_date:)
+      # end
+      # Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile:)
 
       mentor_profile
     end

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Mentors
+  class TransferExistingMentorToSit < BaseService
+    include SchoolCohortDelegator
+
+    def call
+      mentor_user = mentor_profile.user
+      Identity::Transfer.call(from_user: mentor_user, to_user: sit_user)
+      mentor_user.destroy!
+      mentor_profile.reload
+
+      ParticipantProfileState.create!(participant_profile: mentor_profile, cpd_lead_provider: school_cohort&.default_induction_programme&.lead_provider&.cpd_lead_provider)
+      if school_cohort.default_induction_programme.present?
+        Induction::Enrol.call(participant_profile: mentor_profile,
+                              induction_programme: school_cohort.default_induction_programme,
+                              start_date:)
+      end
+      Mentors::AddToSchool.call(school: school_cohort.school, mentor_profile:)
+
+      mentor_profile
+    end
+
+    private
+
+    attr_reader :sit_user, :mentor_profile, :school_cohort, :start_date
+
+    def initialize(sit_user:, mentor_profile:, school_cohort:, start_date:)
+      @sit_user = sit_user
+      @mentor_profile = mentor_profile
+      @school_cohort = school_cohort
+      @start_date = start_date
+    end
+  end
+end

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -8,7 +8,7 @@ module Mentors
       mentor_user = mentor_profile.user
       Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
       Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme, start_date:)
-      Mentors::AddToSchool.call(mentor_profile: mentor_profile, school: school_cohort.school)
+      Mentors::AddToSchool.call(mentor_profile:, school: school_cohort.school)
       mentor_profile.reload
       # TODO: handle SIT user destroy
       # sit_user.destroy!

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -7,8 +7,11 @@ module Mentors
     def call
       mentor_user = mentor_profile.user
       Identity::Transfer.call(from_user: sit_user, to_user: mentor_user)
-      # sit_user.destroy!
+      Induction::Enrol.call(participant_profile: mentor_profile, induction_programme: school_cohort.default_induction_programme, start_date:)
+      Mentors::AddToSchool.call(mentor_profile: mentor_profile, school: school_cohort.school)
       mentor_profile.reload
+      # TODO: handle SIT user destroy
+      # sit_user.destroy!
     end
 
   private

--- a/app/services/mentors/transfer_existing_mentor_to_sit.rb
+++ b/app/services/mentors/transfer_existing_mentor_to_sit.rb
@@ -21,7 +21,7 @@ module Mentors
       mentor_profile
     end
 
-    private
+  private
 
     attr_reader :sit_user, :mentor_profile, :school_cohort, :start_date
 

--- a/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
+++ b/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
@@ -5,10 +5,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <span class="govuk-caption-xl"><%= @school.name %></span>
-    <h1 class="govuk-heading-xl"><%= title %></h1>
+    <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <p class="govuk-body">If you are trying to add yourself as a mentor, follow the link below.</p>
-    <%= govuk_link_to "Add yourself as a mentor", schools_who_to_add_start_path(@school), no_visited_state: true %>
+      <span class="govuk-caption-xl"><%= @school.name %></span>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
+
+      <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "What would you like to do?", size: 'm' } do %>
+        <%= f.govuk_radio_button :participant_type, :mentor, label: { text: "Add myself as a mentor instead" }, link_errors: true %>
+        <%= f.govuk_radio_button :participant_type, :return, label: { text: "Cancel and return to the list of ECTs and mentors" } %>
+      <% end %>
+
+      <%= f.govuk_submit "Continue" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
+++ b/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
@@ -1,0 +1,15 @@
+<% title = "TEMPORARY PAGE: You cannot add yourself as ECT" %>
+<% content_for :title, title %>
+
+<% content_for :before_content, govuk_back_link( text: "Back", href: wizard_back_link_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-xl"><%= @school.name %></span>
+    <h1 class="govuk-heading-xl"><%= title %></h1>
+
+    <p class="govuk-body">TEMPORARY PAGE: can't add yourself as ECT</p>
+
+    <%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
+  </div>
+</div>

--- a/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
+++ b/app/views/schools/add_participants/cannot_add_yourself_as_ect.html.erb
@@ -1,4 +1,4 @@
-<% title = "TEMPORARY PAGE: You cannot add yourself as ECT" %>
+<% title = "You cannot add yourself as an ECT" %>
 <% content_for :title, title %>
 
 <% content_for :before_content, govuk_back_link( text: "Back", href: wizard_back_link_path) %>
@@ -8,8 +8,7 @@
     <span class="govuk-caption-xl"><%= @school.name %></span>
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
-    <p class="govuk-body">TEMPORARY PAGE: can't add yourself as ECT</p>
-
-    <%= govuk_link_to "Return to your ECTs and mentors", @wizard.dashboard_path, no_visited_state: true %>
+    <p class="govuk-body">If you are trying to add yourself as a mentor, follow the link below.</p>
+    <%= govuk_link_to "Add yourself as a mentor", schools_who_to_add_start_path(@school), no_visited_state: true %>
   </div>
 </div>

--- a/app/views/schools/add_participants/complete.html.erb
+++ b/app/views/schools/add_participants/complete.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @wizard.participant_profile.post_transitional? %>
       <%= render partial: 'schools/add_participants/eligibility_confirmation/post_transitional', locals: { profile: @wizard.participant_profile } %>
-    <% elsif @wizard.sit_mentor? %>
+    <% elsif @wizard.sit_added_as_mentor? %>
       <%= govuk_panel title_text: "You’ve been added as a mentor", text: nil, classes: "govuk-!-margin-bottom-7" %>
     <% elsif exempt_from_induction?(@wizard.participant_profile) %>
       <%= render partial: 'schools/add_participants/eligibility_confirmation/exempt_from_induction', locals: { profile: @wizard.participant_profile } %>

--- a/app/views/schools/add_participants/participant_type.html.erb
+++ b/app/views/schools/add_participants/participant_type.html.erb
@@ -5,6 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    <span class="govuk-caption-xl"><%= @school.name %></span>
 
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
@@ -13,16 +14,8 @@
         <p class="govuk-body govuk-!-margin-top-4">
           This could be a new teacher or a teacher transferring from another school where they’ve started ECF-based training or mentoring.
         </p>
-        <% if @wizard.sit_can_become_a_mentor? %>
-          <p class="govuk-body">
-            You can also add yourself as a mentor.
-          </p>
-        <% end %>
         <%= f.govuk_radio_button :participant_type, :ect, label: { text: "ECT" }, link_errors: true %>
         <%= f.govuk_radio_button :participant_type, :mentor, label: { text: "Mentor" } %>
-        <% if @wizard.sit_can_become_a_mentor? %>
-          <%= f.govuk_radio_button :participant_type, :self, label: { text: "Yourself as a mentor" } %>
-        <% end %>
       <% end %>
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/add_participants/participant_type.html.erb
+++ b/app/views/schools/add_participants/participant_type.html.erb
@@ -9,7 +9,6 @@
 
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
-      <span class="govuk-caption-xl"><%= @school.name %></span>
       <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "Who do you want to add?", tag: 'h1', size: 'xl' } do %>
         <p class="govuk-body govuk-!-margin-top-4">
           This could be a new teacher or a teacher transferring from another school where they’ve started ECF-based training or mentoring.

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -1,4 +1,10 @@
-<% title = "When will #{@wizard.full_name} start their #{@wizard.ect_participant? ? 'induction' : 'mentor training'}?" %>
+<%
+    title = if @wizard.sit_mentor?
+              "When will you start mentor training?"
+            else
+              "When will #{@wizard.full_name} start their #{@wizard.ect_participant? ? 'induction' : 'mentor training'}?"
+            end
+%>
 
 <% content_for :title, title %>
 
@@ -15,7 +21,7 @@
         :name,
         legend: { text: title, tag: 'h1', size: 'xl' },
         caption: { text: @school.name, size: "xl" },
-        hint: { text: "This is when #{@wizard.full_name} will start their #{@wizard.ect_participant? ? 'induction and begin ECF-based training' : 'ECF-based mentor training'} at your school." }) %>
+        hint: { text: "This is when #{@wizard.full_name_or_you} will start #{@wizard.sit_mentor? ? 'your' : 'their'} #{@wizard.ect_participant? ? 'induction and begin ECF-based training' : 'ECF-based mentor training'} at your school." }) %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/app/views/schools/add_participants/start_term.html.erb
+++ b/app/views/schools/add_participants/start_term.html.erb
@@ -1,9 +1,11 @@
 <%
-    title = if @wizard.sit_mentor?
-              "When will you start mentor training?"
-            else
-              "When will #{@wizard.full_name} start their #{@wizard.ect_participant? ? 'induction' : 'mentor training'}?"
-            end
+    if @wizard.sit_mentor?
+      title = "When will you start mentor training?"
+      hint = "This is when you’ll start ECF-based mentor training"
+    else
+      title = "When will #{@wizard.full_name} start their #{@wizard.ect_participant? ? 'induction' : 'mentor training'}?"
+      hint = "This is when #{@wizard.full_name} will start their #{@wizard.ect_participant? ? 'induction and begin ECF-based training' : 'ECF-based mentor training'} at your school."
+    end
 %>
 
 <% content_for :title, title %>
@@ -21,7 +23,7 @@
         :name,
         legend: { text: title, tag: 'h1', size: 'xl' },
         caption: { text: @school.name, size: "xl" },
-        hint: { text: "This is when #{@wizard.full_name_or_you} will start #{@wizard.sit_mentor? ? 'your' : 'their'} #{@wizard.ect_participant? ? 'induction and begin ECF-based training' : 'ECF-based mentor training'} at your school." }) %>
+        hint: { text: hint }) %>
 
       <%= f.govuk_submit "Continue" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,7 +408,7 @@ en:
         schools/add_participants/wizard_steps/start_term_step:
           attributes:
             start_term:
-              inclusion: "Select the start term for this participant"
+              inclusion: "Select the start you will start mentor training"
         schools/add_participants/wizard_steps/joining_date_step:
           attributes:
             start_date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,10 @@ en:
           attributes:
             mentor_id:
               blank: "Choose a mentor"
+        schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step:
+          attributes:
+            participant_type:
+              inclusion: "Select whether to add yourself as a mentor or cancel"
         schools/transferring_participant_form:
           attributes:
             full_name:

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "SIT adding themself as ECT", js: true do
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add
-    then_i_am_taken_to_sit_added_as_mentor_page
+    then_i_am_taken_to_yourself_as_mentor_confirmation_page
 
     when_i_click_on_view_ects_and_mentors
     then_i_see_the_sit_name

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../training_dashboard/manage_training_steps"
 
-RSpec.describe "SIT adding ECT", js: true do
+RSpec.describe "SIT adding themself as ECT", js: true do
   include ManageTrainingSteps
 
   before do
@@ -17,7 +17,7 @@ RSpec.describe "SIT adding ECT", js: true do
     set_dqt_validation_result
   end
 
-  scenario "Induction tutor tries to add themself as ECT" do
+  scenario "SIT aborts process as it can't add themself as ECT" do
     when_i_navigate_to_participants_dashboard
     when_i_click_to_add_a_new_ect_or_mentor
     then_i_should_be_on_the_who_to_add_page
@@ -45,5 +45,56 @@ RSpec.describe "SIT adding ECT", js: true do
     when_i_add_sits_email
     when_i_click_on_continue
     then_i_am_taken_to_you_cant_add_yourself_as_ect_page
+
+    when_i_choose_to_cancel
+    and_i_click_on_continue
+    then_i_am_taken_to_manage_your_training_page
+  end
+
+  scenario "SIT chooses to add themself as Mentor instead" do
+    when_i_navigate_to_participants_dashboard
+    when_i_click_to_add_a_new_ect_or_mentor
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "ECT"
+    when_i_click_on_continue
+
+    then_i_am_taken_to_the_what_we_need_from_you_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_name_page
+
+    when_i_add_ect_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_sits_email
+    when_i_click_on_continue
+    then_i_am_taken_to_you_cant_add_yourself_as_ect_page
+
+    when_i_choose_to_add_myself_as_mentor
+    and_i_click_on_continue
+    then_i_am_taken_to_add_yourself_as_mentor_confirmation_page
+
+    when_i_click_on_confirm
+    then_i_am_taken_to_sit_mentor_start_training_page
+
+    when_i_choose_summer_term_2023
+    and_i_click_on_continue
+    then_i_am_taken_to_check_answers_page
+
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_sit_added_as_mentor_page
+
+    when_i_click_on_view_ects_and_mentors
+    then_i_see_the_sit_name
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe "SIT adding ECT", js: true do
 
     when_i_select_to_add_a "ECT"
     when_i_click_on_continue
+
     then_i_am_taken_to_the_what_we_need_from_you_page
 
     when_i_click_on_continue

--- a/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_ect_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../training_dashboard/manage_training_steps"
+
+RSpec.describe "SIT adding ECT", js: true do
+  include ManageTrainingSteps
+
+  before do
+    given_there_is_a_school_that_has_chosen_cip
+    set_participant_data
+    given_there_is_a_school_that_has_chosen_fip_and_partnered
+    and_i_am_signed_in_as_an_induction_coordinator
+    and_i_click_on(Cohort.current.description)
+    then_i_am_taken_to_fip_induction_dashboard
+
+    set_dqt_validation_result
+  end
+
+  scenario "Induction tutor tries to add themself as ECT" do
+    when_i_navigate_to_participants_dashboard
+    when_i_click_to_add_a_new_ect_or_mentor
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "ECT"
+    when_i_click_on_continue
+    then_i_am_taken_to_the_what_we_need_from_you_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_name_page
+
+    when_i_add_ect_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_sits_email
+    when_i_click_on_continue
+    then_i_am_taken_to_you_cant_add_yourself_as_ect_page
+  end
+end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_fip_induction_dashboard
 
     @mentor = create(:mentor)
+    @mentor.user.teacher_profile.update!(trn: @participant_data[:trn])
+
     ECFParticipantValidationData.create!(
       participant_profile: @mentor,
       trn: @participant_data[:trn],
@@ -46,17 +48,25 @@ RSpec.describe "SIT adding mentor", js: true do
 
     when_i_add_a_date_of_birth
     when_i_click_on_continue
+    expect(page).to have_text("Will #{@participant_data[:full_name]} only mentor ECTs at your school?")
+
+    when_i_choose_yes
+    and_i_click_on_confirm
+    expect(page).to have_text("When is #{@participant_data[:full_name]} moving to your school?")
+
+    when_i_add_a_start_date
+    when_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
 
     when_i_add_sits_email
-    when_i_click_on_continue
+    and_i_click_on_continue
     then_i_am_taken_to_are_you_sure_page
 
     when_i_click_on_confirm
-    then_i_am_taken_to_sit_mentor_start_training_page
+    then_i_am_taken_to_continue_current_training_page
 
-    when_i_choose_summer_term_2023
-    when_i_click_on_continue
+    when_i_choose_yes
+    and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "SIT adding mentor", js: true do
     and_i_click_on(Cohort.current.description)
     then_i_am_taken_to_fip_induction_dashboard
 
+    create(:participant_identity, user: @induction_coordinator_profile.user)
+
     @mentor = create(:mentor)
     @mentor.user.teacher_profile.update!(trn: @participant_data[:trn])
 
@@ -26,8 +28,9 @@ RSpec.describe "SIT adding mentor", js: true do
     set_dqt_validation_result
   end
 
-  scenario "Induction tutor adds themself as mentor using their own email address" do
+  scenario "Induction tutor adds themself as mentor using their own email address and TRN belonging to an existing mentor profile" do
     when_i_navigate_to_participants_dashboard
+
     when_i_click_to_add_a_new_ect_or_mentor
     then_i_should_be_on_the_who_to_add_page
 
@@ -73,6 +76,9 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_sit_mentor_added_confirmation_page
 
     click_on "View your ECTs and mentors"
-    then_i_see_the_sit_name
+    expect(page).to have_text(@mentor.user.full_name)
+
+    click_on "Back"
+    expect(page).to have_summary_row("Induction tutor", @mentor.user.full_name)
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -6,19 +6,80 @@ require_relative "../../training_dashboard/manage_training_steps"
 RSpec.describe "SIT adding mentor", js: true do
   include ManageTrainingSteps
 
-  before do
+  scenario "Induction tutor adds themself as mentor using their own email address and TRN belonging to an existing mentor profile" do
+    given_there_is_a_school_that_has_chosen_cip
+    set_participant_data
+    given_there_is_a_school_that_has_chosen_fip_and_partnered
+    and_i_am_signed_in_as_an_induction_coordinator
+    and_i_click_on(Cohort.current.description)
+    then_i_am_taken_to_fip_induction_dashboard
+    set_dqt_validation_result
+
+    when_i_navigate_to_participants_dashboard
+    when_i_click_to_add_a_new_ect_or_mentor
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "Mentor"
+    and_i_click_on_continue
+    then_i_am_taken_to_the_what_we_need_from_mentor_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_mentor_full_name_page
+
+    when_i_add_mentor_name
+    and_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    and_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    and_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_sits_email
+    and_i_click_on_continue
+    then_i_am_taken_to_are_you_sure_page
+
+    when_i_click_on_confirm
+    then_i_am_taken_to_sit_mentor_start_training_page
+
+    when_i_choose_summer_term_2023
+    and_i_click_on_continue
+    then_i_am_taken_to_check_answers_page
+
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_sit_mentor_added_confirmation_page
+
+    when_i_click_on "View your ECTs and mentors"
+    then_i_see_the_sit_name
+  end
+
+  scenario "Induction tutor adds themself as mentor using their own email address when email already present" do
     given_there_is_a_school_that_has_chosen_cip
     set_participant_data
     given_there_is_a_school_that_has_chosen_fip_and_partnered
     given_there_is_a_mentor_with_the_same_trn
-    and_i_am_signed_in_as_an_induction_coordinator
+    # @mentor.user.update!(email: @participant_data[:email])
+
+    # and_i_am_signed_in_as_an_induction_coordinator
+    ms = create(:school)
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [ms, @school], user: create(:user, full_name: @participant_data[:full_name], email: @participant_data[:email]))
+    create(:participant_identity, user: @induction_coordinator_profile.user)
+    privacy_policy = create(:privacy_policy)
+    privacy_policy.accept!(@induction_coordinator_profile.user)
+    sign_in_as @induction_coordinator_profile.user
+
+    # Support::SchoolInductionTutors::Replace.call(school_urn: ms.urn, email: @participant_data[:email], full_name: @participant_data[:full_name])
+
+    and_i_click_on(@school.name)
     and_i_click_on(Cohort.current.description)
     then_i_am_taken_to_fip_induction_dashboard
 
     set_dqt_validation_result
-  end
 
-  scenario "Induction tutor adds themself as mentor using their own email address and TRN belonging to an existing mentor profile" do
+    #
     when_i_navigate_to_participants_dashboard
 
     when_i_click_to_add_a_new_ect_or_mentor
@@ -40,35 +101,24 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_add_date_of_birth_page
 
     when_i_add_a_date_of_birth
-    when_i_click_on_continue
-    then_i_am_taken_to_only_mentor_ects_at_your_school_page
-
-    when_i_choose_yes
-    and_i_click_on_confirm
-    then_i_am_taken_to_when_is_participant_moving_to_school_page
-
-    when_i_add_a_start_date
-    when_i_click_on_continue
+    and_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
 
-    when_i_add_sits_email
+    when_i_add_ect_or_mentor_email
     and_i_click_on_continue
-    then_i_am_taken_to_are_you_sure_page
+    then_i_am_taken_to_add_yourself_as_mentor_confirmation_page
 
     when_i_click_on_confirm
-    then_i_am_taken_to_continue_current_training_page
+    then_i_am_taken_to_sit_mentor_start_training_page
 
-    when_i_choose_yes
+    when_i_choose_summer_term_2023
     and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add
-    then_i_am_taken_to_sit_mentor_added_confirmation_page
+    then_i_am_taken_to_mentor_confirmation_page
 
     click_on "View your ECTs and mentors"
-    then_i_see_the_existing_mentor_name
-
-    click_on "Back"
-    then_i_see_induction_tutor_name
+    expect(page).to have_content(@participant_data[:full_name])
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "SIT adding mentor", js: true do
 
     when_i_select_to_add_a "Mentor"
     when_i_click_on_continue
-    then_i_am_taken_to_the_what_we_need_from_you_page
+    then_i_am_taken_to_the_what_we_need_from_mentor_page
 
     when_i_click_on_continue
     then_i_am_taken_to_add_mentor_full_name_page

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_are_you_sure_page
 
     when_i_click_on_confirm
-    then_i_am_taken_to_mentor_start_training_page
+    then_i_am_taken_to_sit_mentor_start_training_page
 
     when_i_choose_summer_term_2023
     when_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add
-    then_i_am_taken_to_mentor_added_confirmation_page
+    then_i_am_taken_to_sit_mentor_added_confirmation_page
 
     click_on "View your ECTs and mentors"
     then_i_see_the_sit_name

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -10,20 +10,10 @@ RSpec.describe "SIT adding mentor", js: true do
     given_there_is_a_school_that_has_chosen_cip
     set_participant_data
     given_there_is_a_school_that_has_chosen_fip_and_partnered
+    given_there_is_a_mentor_with_the_same_trn
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_click_on(Cohort.current.description)
     then_i_am_taken_to_fip_induction_dashboard
-
-    create(:participant_identity, user: @induction_coordinator_profile.user)
-
-    @mentor = create(:mentor)
-    @mentor.user.teacher_profile.update!(trn: @participant_data[:trn])
-
-    ECFParticipantValidationData.create!(
-      participant_profile: @mentor,
-      trn: @participant_data[:trn],
-      date_of_birth: @participant_data[:date_of_birth],
-    )
 
     set_dqt_validation_result
   end
@@ -51,11 +41,11 @@ RSpec.describe "SIT adding mentor", js: true do
 
     when_i_add_a_date_of_birth
     when_i_click_on_continue
-    expect(page).to have_text("Will #{@participant_data[:full_name]} only mentor ECTs at your school?")
+    then_i_am_taken_to_only_mentor_ects_at_your_school_page
 
     when_i_choose_yes
     and_i_click_on_confirm
-    expect(page).to have_text("When is #{@participant_data[:full_name]} moving to your school?")
+    then_i_am_taken_to_when_is_participant_moving_to_school_page
 
     when_i_add_a_start_date
     when_i_click_on_continue
@@ -76,9 +66,9 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_sit_mentor_added_confirmation_page
 
     click_on "View your ECTs and mentors"
-    expect(page).to have_text(@mentor.user.full_name)
+    then_i_see_the_existing_mentor_name
 
     click_on "Back"
-    expect(page).to have_summary_row("Induction tutor", @mentor.user.full_name)
+    then_i_see_induction_tutor_name
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -6,14 +6,17 @@ require_relative "../../training_dashboard/manage_training_steps"
 RSpec.describe "SIT adding mentor", js: true do
   include ManageTrainingSteps
 
-  scenario "Induction tutor adds themself as mentor using their own email address and TRN belonging to an existing mentor profile" do
+  before do
     given_there_is_a_school_that_has_chosen_cip
-    set_participant_data
     given_there_is_a_school_that_has_chosen_fip_and_partnered
-    and_i_am_signed_in_as_an_induction_coordinator
+    set_participant_data
+    set_dqt_validation_result
+  end
+
+  scenario "Induction tutor adds themself as mentor using their own email address" do
+    when_i_am_signed_in_as_an_induction_coordinator
     and_i_click_on(Cohort.current.description)
     then_i_am_taken_to_fip_induction_dashboard
-    set_dqt_validation_result
 
     when_i_navigate_to_participants_dashboard
     when_i_click_to_add_a_new_ect_or_mentor
@@ -56,51 +59,41 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_see_the_sit_name
   end
 
-  scenario "Induction tutor adds themself as mentor using their own email address when email already present" do
-    given_there_is_a_school_that_has_chosen_cip
-    set_participant_data
-    given_there_is_a_school_that_has_chosen_fip_and_partnered
-    given_there_is_a_mentor_with_the_same_trn
-    # @mentor.user.update!(email: @participant_data[:email])
+  scenario "Induction tutor adds themself as mentor using their own email address when email and TRN belongs to an existing mentor" do
+    given_there_is_a_sit_and_mentor_in_another_school
 
-    # and_i_am_signed_in_as_an_induction_coordinator
-    ms = create(:school)
-    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [ms, @school], user: create(:user, full_name: @participant_data[:full_name], email: @participant_data[:email]))
-    create(:participant_identity, user: @induction_coordinator_profile.user)
-    privacy_policy = create(:privacy_policy)
-    privacy_policy.accept!(@induction_coordinator_profile.user)
-    sign_in_as @induction_coordinator_profile.user
-
-    # Support::SchoolInductionTutors::Replace.call(school_urn: ms.urn, email: @participant_data[:email], full_name: @participant_data[:full_name])
-
-    and_i_click_on(@school.name)
+    when_i_sign_in_as_sit
     and_i_click_on(Cohort.current.description)
     then_i_am_taken_to_fip_induction_dashboard
 
-    set_dqt_validation_result
-
-    #
     when_i_navigate_to_participants_dashboard
-
-    when_i_click_to_add_a_new_ect_or_mentor
+    and_i_click_to_add_a_new_ect_or_mentor
     then_i_should_be_on_the_who_to_add_page
 
     when_i_select_to_add_a "Mentor"
-    when_i_click_on_continue
+    and_i_click_on_continue
     then_i_am_taken_to_the_what_we_need_from_mentor_page
 
     when_i_click_on_continue
     then_i_am_taken_to_add_mentor_full_name_page
 
     when_i_add_mentor_name
-    when_i_click_on_continue
+    and_i_click_on_continue
     then_i_am_taken_to_add_teachers_trn_page
 
     when_i_add_the_trn
-    when_i_click_on_continue
+    and_i_click_on_continue
     then_i_am_taken_to_add_date_of_birth_page
 
     when_i_add_a_date_of_birth
+    and_i_click_on_continue
+    then_i_am_taken_to_only_mentor_ects_at_your_school_page
+
+    when_i_choose_yes
+    and_i_click_on_confirm
+    then_i_am_taken_to_when_is_participant_moving_to_school_page
+
+    when_i_add_a_start_date
     and_i_click_on_continue
     then_i_am_taken_to_add_ect_or_mentor_email_page
 
@@ -109,16 +102,16 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_add_yourself_as_mentor_confirmation_page
 
     when_i_click_on_confirm
-    then_i_am_taken_to_sit_mentor_start_training_page
+    then_i_should_be_taken_to_the_teachers_current_programme_page
 
-    when_i_choose_summer_term_2023
+    when_i_choose_yes
     and_i_click_on_continue
     then_i_am_taken_to_check_answers_page
 
     when_i_click_confirm_and_add
-    then_i_am_taken_to_mentor_confirmation_page
+    then_i_am_taken_to_yourself_as_mentor_confirmation_page
 
-    click_on "View your ECTs and mentors"
-    expect(page).to have_content(@participant_data[:full_name])
+    when_i_click_on "View your ECTs and mentors"
+    then_i_see_the_mentor_name
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe "SIT adding mentor", js: true do
     ECFParticipantValidationData.create!(
       participant_profile: @mentor,
       trn: @participant_data[:trn],
-      date_of_birth: @participant_data[:date_of_birth])
+      date_of_birth: @participant_data[:date_of_birth],
+    )
 
     set_dqt_validation_result
   end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "SIT adding mentor", js: true do
   before do
     given_there_is_a_school_that_has_chosen_cip
     set_participant_data
-    # and_i_have_added_an_ect_with_email(@participant_data[:email])
     given_there_is_a_school_that_has_chosen_fip_and_partnered
     and_i_am_signed_in_as_an_induction_coordinator
     and_i_click_on(Cohort.current.description)
@@ -64,6 +63,6 @@ RSpec.describe "SIT adding mentor", js: true do
     then_i_am_taken_to_mentor_added_confirmation_page
 
     click_on "View your ECTs and mentors"
-    then_i_see_the_mentor_name
+    then_i_see_the_sit_name
   end
 end

--- a/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
+++ b/spec/features/schools/participants/add_participants/sit_add_mentor_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../training_dashboard/manage_training_steps"
+
+RSpec.describe "SIT adding mentor", js: true do
+  include ManageTrainingSteps
+
+  before do
+    given_there_is_a_school_that_has_chosen_cip
+    set_participant_data
+    # and_i_have_added_an_ect_with_email(@participant_data[:email])
+    given_there_is_a_school_that_has_chosen_fip_and_partnered
+    and_i_am_signed_in_as_an_induction_coordinator
+    and_i_click_on(Cohort.current.description)
+    then_i_am_taken_to_fip_induction_dashboard
+
+    @mentor = create(:mentor)
+    ECFParticipantValidationData.create!(
+      participant_profile: @mentor,
+      trn: @participant_data[:trn],
+      date_of_birth: @participant_data[:date_of_birth])
+
+    set_dqt_validation_result
+  end
+
+  scenario "Induction tutor adds themself as mentor using their own email address" do
+    when_i_navigate_to_participants_dashboard
+    when_i_click_to_add_a_new_ect_or_mentor
+    then_i_should_be_on_the_who_to_add_page
+
+    when_i_select_to_add_a "Mentor"
+    when_i_click_on_continue
+    then_i_am_taken_to_the_what_we_need_from_you_page
+
+    when_i_click_on_continue
+    then_i_am_taken_to_add_mentor_full_name_page
+
+    when_i_add_mentor_name
+    when_i_click_on_continue
+    then_i_am_taken_to_add_teachers_trn_page
+
+    when_i_add_the_trn
+    when_i_click_on_continue
+    then_i_am_taken_to_add_date_of_birth_page
+
+    when_i_add_a_date_of_birth
+    when_i_click_on_continue
+    then_i_am_taken_to_add_ect_or_mentor_email_page
+
+    when_i_add_sits_email
+    when_i_click_on_continue
+    then_i_am_taken_to_are_you_sure_page
+
+    when_i_click_on_confirm
+    then_i_am_taken_to_mentor_start_training_page
+
+    when_i_choose_summer_term_2023
+    when_i_click_on_continue
+    then_i_am_taken_to_check_answers_page
+
+    when_i_click_confirm_and_add
+    then_i_am_taken_to_mentor_added_confirmation_page
+
+    click_on "View your ECTs and mentors"
+    then_i_see_the_mentor_name
+  end
+end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -826,6 +826,10 @@ module ManageTrainingSteps
     expect(page).to have_text("#{@participant_data[:full_name]} has been added as a mentor")
   end
 
+  def then_i_am_taken_to_sit_mentor_added_confirmation_page
+    expect(page).to have_text("You’ve been added as a mentor")
+  end
+
   def then_i_see_the_mentor_name
     expect(page).to have_text(@participant_data[:full_name])
   end
@@ -1155,6 +1159,10 @@ module ManageTrainingSteps
     expect(page).to have_selector("h1", text: "When will #{@participant_data[:full_name]} start their mentor training?")
   end
 
+  def then_i_am_taken_to_sit_mentor_start_training_page
+    expect(page).to have_selector("h1", text: "When will you start mentor training?")
+  end
+
   def then_i_am_taken_to_the_cannot_add_page_same_school
     expect(page).to have_selector("h1", text: "You cannot add Sally Teacher")
     expect(page).to have_text("Our records show this person is already registered on an ECF-based training programme at your school")
@@ -1222,7 +1230,7 @@ module ManageTrainingSteps
   end
 
   def then_i_am_taken_to_you_cant_add_yourself_as_ect_page
-    expect(page).to have_content("You cannot add yourself as ECT")
+    expect(page).to have_content("You cannot add yourself as an ECT")
   end
 
   def and_i_see_the_cip_programme

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -408,7 +408,7 @@ module ManageTrainingSteps
   end
 
   def then_i_see_induction_tutor_name
-    expect(page).to have_summary_row("Induction tutor", @mentor.user.full_name)
+    expect(page).to have_summary_row("Induction tutor", @induction_coordinator_profile.user.full_name)
   end
 
   def then_i_should_be_on_the_who_to_add_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -700,6 +700,10 @@ module ManageTrainingSteps
     fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: @participant_data[:email]
   end
 
+  def when_i_add_sits_email
+    fill_in "What’s #{@participant_data[:full_name]}’s email address?", with: @induction_coordinator_profile.user.email
+  end
+
   def when_i_add_ect_or_mentor_nino_for(name)
     fill_in "What’s #{name}’s National Insurance number?", with: @participant_data[:nino]
   end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -881,6 +881,10 @@ module ManageTrainingSteps
     expect(page).to have_text("What we need to know about this ECT")
   end
 
+  def then_i_am_taken_to_the_what_we_need_from_mentor_page
+    expect(page).to have_text("What we need to know about this mentor")
+  end
+
   def then_i_am_taken_to_manage_mentors_and_ects_page
     expect(page).to have_selector("h1", text: "Manage mentors and ECTs")
     expect(page).to have_text("Add ECT or mentor")

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -17,6 +17,21 @@ module ManageTrainingSteps
     @induction_programme.update!(partnership: @partnership)
   end
 
+  def given_there_is_a_sit_and_mentor_in_another_school
+    @induction_coordinator_profile = create(:induction_coordinator_profile, schools: [@school], user: create(:user, full_name: @participant_data[:full_name], email: @participant_data[:email]))
+    create(:participant_identity, user: @induction_coordinator_profile.user)
+    privacy_policy = create(:privacy_policy)
+    privacy_policy.accept!(@induction_coordinator_profile.user)
+
+    @mentor = create(:mentor, user: @induction_coordinator_profile.user)
+    @mentor.user.teacher_profile.update!(trn: @participant_data[:trn])
+    ECFParticipantValidationData.create!(
+      participant_profile: @mentor,
+      trn: @participant_data[:trn],
+      date_of_birth: @participant_data[:date_of_birth],
+    )
+  end
+
   def given_there_is_a_school_that_has_chosen_fip
     @cohort = Cohort.current || create(:cohort, :current)
     @school = create(:school, name: "Fip School")
@@ -194,6 +209,8 @@ module ManageTrainingSteps
     set_participant_data
     set_updated_participant_data
   end
+
+  alias_method :when_i_am_signed_in_as_an_induction_coordinator, :and_i_am_signed_in_as_an_induction_coordinator
 
   def and_i_have_added_an_ect
     user = create(:user, full_name: "Sally Teacher", email: "sally-teacher@example.com")
@@ -684,6 +701,7 @@ module ManageTrainingSteps
     click_on "Add ECT or mentor"
   end
   alias_method :when_i_click_to_add_a_new_participant, :when_i_click_to_add_a_new_ect_or_mentor
+  alias_method :and_i_click_to_add_a_new_ect_or_mentor, :when_i_click_to_add_a_new_ect_or_mentor
 
   def when_i_select_to_add_a(participant_type)
     choose(participant_type, allow_label_click: true)
@@ -708,6 +726,8 @@ module ManageTrainingSteps
   def when_i_sign_back_in
     sign_in_as @induction_coordinator_profile.user
   end
+
+  alias_method :when_i_sign_in_as_sit, :when_i_sign_back_in
 
   def when_i_click_on_change_name
     click_on("Change name", visible: false)

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1217,6 +1217,10 @@ module ManageTrainingSteps
     expect(page).to have_summary_row("Appropriate body", appropriate_body.name)
   end
 
+  def then_i_am_taken_to_you_cant_add_yourself_as_ect_page
+    expect(page).to have_content("You cannot add yourself as ECT")
+  end
+
   def and_i_see_the_cip_programme
     expect(page).to have_summary_row("Programme", "DfE accredited materials")
   end

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -607,6 +607,14 @@ module ManageTrainingSteps
     click_on("Back")
   end
 
+  def when_i_choose_to_cancel
+    choose "Cancel and return to the list of ECTs and mentors"
+  end
+
+  def when_i_choose_to_add_myself_as_mentor
+    choose "Add myself as a mentor instead"
+  end
+
   def when_i_click_on_confirm
     click_on("Confirm")
   end
@@ -616,6 +624,10 @@ module ManageTrainingSteps
   def when_i_filter_by(option)
     when_i_select(option)
     click_on("Apply")
+  end
+
+  def when_i_click_on_view_ects_and_mentors
+    click_on "View your ECTs and mentors"
   end
 
   def when_i_submit_an_empty_form
@@ -907,6 +919,18 @@ module ManageTrainingSteps
 
   def then_i_see_the_sit_name
     expect(page).to have_text(@induction_coordinator_profile.user.full_name)
+  end
+
+  def then_i_am_taken_to_manage_your_training_page
+    expect(page).to have_selector("h1", text: "Manage your training")
+  end
+
+  def then_i_am_taken_to_add_yourself_as_mentor_confirmation_page
+    expect(page).to have_text("Are you sure you want to add yourself as a mentor?")
+  end
+
+  def then_i_am_taken_to_sit_added_as_mentor_page
+    expect(page).to have_text("#{@induction_coordinator_profile.user.full_name} has been added as a mentor")
   end
 
   def then_i_am_taken_to_roles_page

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -864,6 +864,10 @@ module ManageTrainingSteps
   end
   alias_method :and_i_see_the_participants_sorted_by_induction_start_date, :then_i_see_the_participants_sorted_by_induction_start_date
 
+  def then_i_see_the_sit_name
+    expect(page).to have_text(@induction_coordinator_profile.user.full_name)
+  end
+
   def then_i_am_taken_to_roles_page
     expect(page).to have_selector("h1", text: "Check what each person needs to do in the early career teacher training programme")
     expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -877,6 +877,10 @@ module ManageTrainingSteps
     expect(page).to have_text("An induction tutor should only assign themself as a mentor in exceptional circumstances")
   end
 
+  def then_i_am_taken_to_the_what_we_need_from_you_page
+    expect(page).to have_text("What we need to know about this ECT")
+  end
+
   def then_i_am_taken_to_manage_mentors_and_ects_page
     expect(page).to have_selector("h1", text: "Manage mentors and ECTs")
     expect(page).to have_text("Add ECT or mentor")

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -572,6 +572,10 @@ module ManageTrainingSteps
     choose "Summer term 2023"
   end
 
+  def when_i_choose_yes
+    choose("Yes")
+  end
+
   def when_i_click_on_back
     click_on("Back")
   end
@@ -579,6 +583,8 @@ module ManageTrainingSteps
   def when_i_click_on_confirm
     click_on("Confirm")
   end
+
+  alias_method :and_i_click_on_confirm, :when_i_click_on_confirm
 
   def when_i_filter_by(option)
     when_i_select(option)
@@ -824,6 +830,10 @@ module ManageTrainingSteps
 
   def then_i_am_taken_to_mentor_added_confirmation_page
     expect(page).to have_text("#{@participant_data[:full_name]} has been added as a mentor")
+  end
+
+  def then_i_am_taken_to_continue_current_training_page
+    expect(page).to have_text("Will #{@induction_coordinator_profile.user.full_name} continue with their current training programme?")
   end
 
   def then_i_am_taken_to_sit_mentor_added_confirmation_page

--- a/spec/forms/schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/cannot_add_yourself_as_ect_step_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Schools::AddParticipants::WizardSteps::CannotAddYourselfAsECTStep, type: :model do
+  let(:wizard) { instance_double(Schools::AddParticipants::AddWizard) }
+  subject(:step) { described_class.new(wizard:) }
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:participant_type).in_array(%w[mentor return]) }
+  end
+
+  describe ".permitted_params" do
+    it "returns permitted parameters" do
+      expect(described_class.permitted_params).to eql %i[participant_type]
+    end
+  end
+
+  describe "#next_step" do
+    context "when the SIT chooses to add themselves as a mentor" do
+      it "returns :yourself" do
+        step.participant_type = "mentor"
+        expect(step.next_step).to eql :yourself
+      end
+    end
+
+    context "when the SIT chooses to cancel" do
+      it "returns :abort" do
+        step.participant_type = "return"
+        expect(step.next_step).to eql :abort
+      end
+    end
+  end
+end

--- a/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
@@ -24,12 +24,14 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
     let(:ect_participant) { false }
     let(:confirm_start_term) { false }
     let(:confirm_appropriate_body) { false }
+    let(:adding_yourself_as_mentor) { false }
 
     before do
       allow(wizard).to receive(:email_in_use?).and_return(email_taken)
       allow(wizard).to receive(:transfer?).and_return(transfer)
       allow(wizard).to receive(:needs_to_choose_a_mentor?).and_return(choose_mentor)
       allow(wizard).to receive(:ect_participant?).and_return(ect_participant)
+      allow(wizard).to receive(:adding_yourself_as_mentor?).and_return(adding_yourself_as_mentor)
     end
 
     context "when the email is already in use" do
@@ -102,6 +104,14 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
 
         it "returns :confirm_appropriate_body" do
           expect(step.next_step).to eql :confirm_appropriate_body
+        end
+      end
+
+      context "when SIT is adding themself as mentor" do
+        let(:adding_yourself_as_mentor) { true }
+
+        it "returns :yourself" do
+          expect(step.next_step).to eql :yourself
         end
       end
     end

--- a/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
     let(:confirm_start_term) { false }
     let(:confirm_appropriate_body) { false }
     let(:adding_yourself_as_mentor) { false }
+    let(:adding_yourself_as_ect) { false }
 
     before do
       allow(wizard).to receive(:email_in_use?).and_return(email_taken)
@@ -32,6 +33,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
       allow(wizard).to receive(:needs_to_choose_a_mentor?).and_return(choose_mentor)
       allow(wizard).to receive(:ect_participant?).and_return(ect_participant)
       allow(wizard).to receive(:adding_yourself_as_mentor?).and_return(adding_yourself_as_mentor)
+      allow(wizard).to receive(:adding_yourself_as_ect?).and_return(adding_yourself_as_ect)
     end
 
     context "when the email is already in use" do
@@ -112,6 +114,14 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
 
         it "returns :yourself" do
           expect(step.next_step).to eql :yourself
+        end
+      end
+
+      context "when SIT is adding themself as ECT" do
+        let(:adding_yourself_as_ect) { true }
+
+        it "returns :cannot_add_yourself_as_ect" do
+          expect(step.next_step).to eql :cannot_add_yourself_as_ect
         end
       end
     end

--- a/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
+++ b/spec/forms/schools/add_participants/wizard_steps/email_step_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
     let(:ect_participant) { false }
     let(:confirm_start_term) { false }
     let(:confirm_appropriate_body) { false }
-    let(:adding_yourself_as_mentor) { false }
+    let(:sit_adding_themself_as_mentor) { false }
     let(:adding_yourself_as_ect) { false }
 
     before do
@@ -32,7 +32,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
       allow(wizard).to receive(:transfer?).and_return(transfer)
       allow(wizard).to receive(:needs_to_choose_a_mentor?).and_return(choose_mentor)
       allow(wizard).to receive(:ect_participant?).and_return(ect_participant)
-      allow(wizard).to receive(:adding_yourself_as_mentor?).and_return(adding_yourself_as_mentor)
+      allow(wizard).to receive(:sit_adding_themself_as_mentor?).and_return(sit_adding_themself_as_mentor)
       allow(wizard).to receive(:adding_yourself_as_ect?).and_return(adding_yourself_as_ect)
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Schools::AddParticipants::WizardSteps::EmailStep, type: :model do
       end
 
       context "when SIT is adding themself as mentor" do
-        let(:adding_yourself_as_mentor) { true }
+        let(:sit_adding_themself_as_mentor) { true }
 
         it "returns :yourself" do
           expect(step.next_step).to eql :yourself


### PR DESCRIPTION
### Context

SITs becoming mentors - remove separate journey

- Ticket: CST-1799

### Changes proposed in this pull request

- SITs becoming mentors - add speedbump page (CST-1796)
- SITs can't accidentally add themselves as ECTs page (CST-1807)
- Remove "Add yourself as a mentor" option from add participant wizard (CST-1808)
- SITs becoming mentors - dedupe when registered at a previous school with a different email address (CST-1797)


![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/15299755-d554-41bc-b306-5976d180362d)

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/71b783dc-73a5-4bc0-bc99-f9c1ca0dc7b3)

![image](https://github.com/DFE-Digital/early-careers-framework/assets/333931/534b11c5-4b4b-4548-b3f0-57a4fee9437c)
