### PR TITLE
Update unfunded mentor information

### DIFF
--- a/docs/source/ecf/guidance.html.md
+++ b/docs/source/ecf/guidance.html.md
@@ -485,7 +485,7 @@ A single mentor can be assigned to multiple ECTs, including ECTs who are trainin
 
 ‘Unfunded mentors’ are mentors who are registered with other providers.
 
-A participant will have the same participant_id throughout the API. 
+A participant will have the same `participant_id` throughout the API. 
 
 If a participant is a mentor and linked to an ECT, then the mentor_id that appears on the response for their ECT will be the mentor’s participant_id. 
 

--- a/docs/source/ecf/guidance.html.md
+++ b/docs/source/ecf/guidance.html.md
@@ -489,7 +489,7 @@ A participant will have the same `participant_id` throughout the API.
 
 If a participant is a mentor and linked to an ECT, then the `mentor_id` that appears on the response for their ECT will be the mentor’s `participant_id`. 
 
-If the mentor is an unfunded mentor, then the identifier will be their participant_id.
+If the mentor is an unfunded mentor, then the identifier will be their `participant_id`.
 
 ```
  GET /api/v3/unfunded-mentors/ecf

--- a/docs/source/ecf/guidance.html.md
+++ b/docs/source/ecf/guidance.html.md
@@ -487,7 +487,7 @@ A single mentor can be assigned to multiple ECTs, including ECTs who are trainin
 
 A participant will have the same `participant_id` throughout the API. 
 
-If a participant is a mentor and linked to an ECT, then the mentor_id that appears on the response for their ECT will be the mentor’s participant_id. 
+If a participant is a mentor and linked to an ECT, then the `mentor_id` that appears on the response for their ECT will be the mentor’s `participant_id`. 
 
 If the mentor is an unfunded mentor, then the identifier will be their participant_id.
 

--- a/docs/source/ecf/guidance.html.md
+++ b/docs/source/ecf/guidance.html.md
@@ -485,7 +485,11 @@ A single mentor can be assigned to multiple ECTs, including ECTs who are trainin
 
 ‘Unfunded mentors’ are mentors who are registered with other providers.
 
-Providers can view the names and email addresses of ‘unfunded mentors’ assigned to ECTs, and give these mentors appropriate access to learning platforms.
+A participant will have the same participant_id throughout the API. 
+
+If a participant is a mentor and linked to an ECT, then the mentor_id that appears on the response for their ECT will be the mentor’s participant_id. 
+
+If the mentor is an unfunded mentor, then the identifier will be their participant_id.
 
 ```
  GET /api/v3/unfunded-mentors/ecf
@@ -519,11 +523,9 @@ For more detailed information see the specifications for this [view all unfunded
 
 <div class="govuk-inset-text">The following endpoint is only available for systems integrated with API v3 onwards. It will not return data for API v1 or v2.</div>
 
-If providers do **not** see any details for mentors when using the endpoint `GET /api/v3/participants/ecf` they can check to see whether they are an ‘unfunded mentor’.
+If providers do not see any details for mentors when using the endpoint `GET /api/v3/participants/ecf` they can check to see whether they are an ‘unfunded mentor’.
 
-‘Unfunded mentors’ are mentors who are registered with other providers.
-
-Providers can view the names and email addresses of ‘unfunded mentors’ assigned to ECTs, and give these mentors appropriate access to learning platforms.
+Using the unfunded mentors endpoints, providers can view the names and email addresses of ‘unfunded mentors’ assigned to ECTs, and give these mentors appropriate access to learning platforms.
 
 ```
  GET /api/v3/unfunded-mentors/ecf/{id}


### PR DESCRIPTION
Replaced: 

Providers can view the names and email addresses of ‘unfunded mentors’ assigned to ECTs, and give these mentors appropriate access to learning platforms.

With:

A participant will have the same participant_id throughout the API. 

If a participant is a mentor and linked to an ECT, then the mentor_id that appears on the response for their ECT will be the mentor’s participant_id. 

If the mentor is an unfunded mentor, then the identifier will be their participant_id.

And...

Added: 

Using the unfunded mentors endpoints, 

At the start of the following par: 

Providers can view the names and email addresses of ‘unfunded mentors’ assigned to ECTs, and give these mentors appropriate access to learning platforms.

### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2324

### Changes proposed in this pull request

### Guidance to review

