### PR TITLE
[CST-1750] Add services to fetch and populate the induction start date

### DIFF
--- a/app/forms/participants/participant_validation_form.rb
+++ b/app/forms/participants/participant_validation_form.rb
@@ -170,7 +170,7 @@ module Participants
     end
 
     def change_participant_cohort_and_induction_start_date!
-      Participants::SyncDqtInductionStartDate.call(dqt_response[:induction_start_date], participant_profile) if dqt_response.present?
+      Participants::SyncDQTInductionStartDate.call(dqt_response[:induction_start_date], participant_profile) if dqt_response.present?
     end
 
     def store_analytics!

--- a/app/forms/schools/add_participants/base_wizard.rb
+++ b/app/forms/schools/add_participants/base_wizard.rb
@@ -358,7 +358,7 @@ module Schools
       def dqt_record_check(force_recheck: false)
         @dqt_record_check = nil if force_recheck
 
-        @dqt_record_check ||= DqtRecordCheck.call(
+        @dqt_record_check ||= DQTRecordCheck.call(
           full_name:,
           trn: formatted_trn,
           date_of_birth:,

--- a/app/models/sync_dqt_induction_start_date_error.rb
+++ b/app/models/sync_dqt_induction_start_date_error.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SyncDqtInductionStartDateError < ApplicationRecord
+class SyncDQTInductionStartDateError < ApplicationRecord
   belongs_to :participant_profile
 
   validates :participant_profile, presence: true

--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DqtRecordPresenter < SimpleDelegator
+class DQTRecordPresenter < SimpleDelegator
   def name
     dqt_record["name"]
   end

--- a/app/services/dqt/get_induction_record.rb
+++ b/app/services/dqt/get_induction_record.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class DQT::GetInductionRecord < ::BaseService
+  def call
+    dqt_record&.dig("induction")
+  end
+
+private
+
+  attr_reader :trn
+
+  def initialize(trn:)
+    @trn = trn
+  end
+
+  def dqt_record
+    @dqt_record ||= client.get_record(trn:)
+  end
+
+  def client
+    @client ||= FullDQT::V3::Client.new
+  end
+end

--- a/app/services/dqt_record_check.rb
+++ b/app/services/dqt_record_check.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DqtRecordCheck < ::BaseService
+class DQTRecordCheck < ::BaseService
   TITLES = %w[mr mrs miss ms dr prof rev].freeze
 
   CheckResult = Struct.new(
@@ -48,7 +48,7 @@ private
     @trn = "0000001" if trn.blank?
 
     padded_trn = TeacherReferenceNumber.new(trn).formatted_trn
-    dqt_record = DqtRecordPresenter.new(dqt_record(padded_trn, nino))
+    dqt_record = DQTRecordPresenter.new(dqt_record(padded_trn, nino))
 
     return check_failure(:no_match_found) if dqt_record.blank?
     return check_failure(:found_but_not_active) unless dqt_record.active?
@@ -171,6 +171,6 @@ private
         "status" => "In Progress",
       })
     end
-    DqtRecordPresenter.new(record)
+    DQTRecordPresenter.new(record)
   end
 end

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -51,7 +51,7 @@ private
   end
 
   def matching_record
-    result = DqtRecordCheck.call(trn:, nino:, full_name:, date_of_birth:, check_first_name_only: check_first_name_only?)
+    result = DQTRecordCheck.call(trn:, nino:, full_name:, date_of_birth:, check_first_name_only: check_first_name_only?)
     result.dqt_record if result.total_matched >= 3
   end
 end

--- a/app/services/participants/set_start_date_from_dqt.rb
+++ b/app/services/participants/set_start_date_from_dqt.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Participants::SetStartDateFromDQT < ::BaseService
+  def call
+    return unless participant_profile.ect?
+    return if trn.blank?
+
+    induction = DQT::GetInductionRecord.call(trn:)
+    return unless induction.present?
+
+    start_date = induction["startDate"]
+
+    participant_profile.update!(induction_start_date: start_date)
+  end
+
+private
+
+  attr_reader :participant_profile
+
+  def initialize(participant_profile:)
+    @participant_profile = participant_profile
+  end
+
+  def trn
+    @trn ||= participant_profile&.teacher_profile&.trn
+  end
+end

--- a/app/services/participants/set_start_date_from_dqt.rb
+++ b/app/services/participants/set_start_date_from_dqt.rb
@@ -6,7 +6,7 @@ class Participants::SetStartDateFromDQT < ::BaseService
     return if trn.blank?
 
     induction = DQT::GetInductionRecord.call(trn:)
-    return unless induction.present?
+    return if induction.blank?
 
     start_date = induction["startDate"]
 

--- a/app/services/participants/sync_dqt_induction_start_date.rb
+++ b/app/services/participants/sync_dqt_induction_start_date.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Participants
-  class SyncDqtInductionStartDate < BaseService
+  class SyncDQTInductionStartDate < BaseService
     FIRST_2021_ACADEMIC_DATE = Date.new(2021, 9, 1)
     FIRST_2023_REGISTRATION_DATE = Cohort.find_by(start_year: 2023)&.registration_start_date || Date.new(2023, 6, 1)
 
@@ -35,7 +35,7 @@ module Participants
     end
 
     def clear_participant_sync_errors
-      SyncDqtInductionStartDateError.where(participant_profile:).destroy_all
+      SyncDQTInductionStartDateError.where(participant_profile:).destroy_all
     end
 
     def pre_2021_dqt_induction_start_date?
@@ -48,7 +48,7 @@ module Participants
 
     def save_errors(*messages)
       messages.each do |message|
-        SyncDqtInductionStartDateError.find_or_create_by!(participant_profile:, message:)
+        SyncDQTInductionStartDateError.find_or_create_by!(participant_profile:, message:)
       end
 
       false

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -25,4 +25,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "ECF"
   inflect.acronym "STI"
   inflect.acronym "BPN"
+  inflect.acronym "DQT"
 end

--- a/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
+++ b/spec/features/schools/participants/add_participants/add_ect_with_appropriate_body_spec.rb
@@ -124,8 +124,8 @@ private
   end
 
   def and_i_fill_in_all_info
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response,
         true,
         true,
@@ -146,7 +146,7 @@ private
   end
 
   def valid_dqt_response
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => "George ECT",
       "trn" => "5234457",
       "state_name" => "Active",

--- a/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
+++ b/spec/features/schools/participants/add_participants/reporting_participants_with_trn_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
   end
 
   before do
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(participant_data),
         true,
         true,
@@ -195,7 +195,7 @@ RSpec.describe "Reporting participants with a known TRN", type: :feature, js: tr
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
       "trn" => participant_data[:trn],
       "state_name" => "Active",

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/allow_withdrawn_participant_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
   end
 
   def set_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@participant_data),
         true,
         true,
@@ -246,7 +246,7 @@ RSpec.describe "transferring a withdrawn participant", type: :feature, js: true 
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
       "trn" => participant_data[:trn],
       "state_name" => "Active",

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_different_partner_spec.rb
@@ -356,8 +356,8 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
   end
 
   def set_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@participant_data),
         true,
         true,
@@ -369,7 +369,7 @@ RSpec.describe "Transferring ECT is with a different lead provider", type: :feat
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
       "trn" => participant_data[:trn],
       "state_name" => "Active",

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/ect_no_change_spec.rb
@@ -364,8 +364,8 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   end
 
   def set_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@participant_data),
         true,
         true,
@@ -377,7 +377,7 @@ RSpec.describe "ECT has matching lead provider and delivery partner", type: :fea
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
       "trn" => participant_data[:trn],
       "state_name" => "Active",

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_different_partner_spec.rb
@@ -334,8 +334,8 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   end
 
   def set_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@participant_data),
         true,
         true,
@@ -347,7 +347,7 @@ RSpec.describe "Transferring a mentor with a different provider", type: :feature
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
       "trn" => participant_data[:trn],
       "state_name" => "Active",

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/mentor_no_change_spec.rb
@@ -230,8 +230,8 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
   end
 
   def set_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@participant_data),
         true,
         true,
@@ -243,7 +243,7 @@ RSpec.describe "Transferring a mentor weith matching lead provider and delivery 
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
       "trn" => participant_data[:trn],
       "state_name" => "Active",

--- a/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
+++ b/spec/features/schools/participants/transferring_participants/fip_to_fip/unhappy_path_cannot_validate_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe "transferring participants", type: :feature, js: true do
       end
 
       def set_dqt_validation_result
-        allow(DqtRecordCheck).to receive(:call).and_return(
-          DqtRecordCheck::CheckResult.new(
+        allow(DQTRecordCheck).to receive(:call).and_return(
+          DQTRecordCheck::CheckResult.new(
             nil,
             false,
             false,
@@ -208,7 +208,7 @@ RSpec.describe "transferring participants", type: :feature, js: true do
       end
 
       def valid_dqt_response(participant_data)
-        DqtRecordPresenter.new({
+        DQTRecordPresenter.new({
           "name" => participant_data[:full_name],
           "trn" => participant_data[:trn],
           "state_name" => "Active",

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -1173,8 +1173,8 @@ module ManageTrainingSteps
   end
 
   def set_sit_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@sit_data),
         true,
         true,
@@ -1186,7 +1186,7 @@ module ManageTrainingSteps
   end
 
   def valid_dqt_response(participant_data)
-    DqtRecordPresenter.new({
+    DQTRecordPresenter.new({
       "name" => participant_data[:full_name],
                              "trn" => participant_data[:trn],
                              "state_name" => "Active",
@@ -1207,8 +1207,8 @@ module ManageTrainingSteps
   end
 
   def set_dqt_blank_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         nil,
         true,
         true,
@@ -1220,8 +1220,8 @@ module ManageTrainingSteps
   end
 
   def set_dqt_validation_result
-    allow(DqtRecordCheck).to receive(:call).and_return(
-      DqtRecordCheck::CheckResult.new(
+    allow(DQTRecordCheck).to receive(:call).and_return(
+      DQTRecordCheck::CheckResult.new(
         valid_dqt_response(@participant_data),
         true,
         true,
@@ -1233,9 +1233,9 @@ module ManageTrainingSteps
   end
 
   def set_dqt_validation_with_nino
-    allow(DqtRecordCheck).to receive(:call) do |args|
+    allow(DQTRecordCheck).to receive(:call) do |args|
       if args[:nino] == @participant_data[:nino]
-        DqtRecordCheck::CheckResult.new(
+        DQTRecordCheck::CheckResult.new(
           valid_dqt_response(@participant_data),
           true,
           true,
@@ -1244,7 +1244,7 @@ module ManageTrainingSteps
           4,
         )
       else
-        DqtRecordCheck::CheckResult.new(
+        DQTRecordCheck::CheckResult.new(
           nil,
           true,
           true,

--- a/spec/services/dqt/get_induction_record_spec.rb
+++ b/spec/services/dqt/get_induction_record_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe DQT::GetInductionRecord do
+  describe "#call" do
+    let(:trn) { "1000864" }
+    let(:valid_record) do
+      {
+        "trn" => "1000864",
+        "firstName" => "Peter",
+        "middleName"=>"",
+        "lastName" => "Bonetti",
+        "dateOfBirth"=> Date.new(1987, 3, 1),
+        "nationalInsuranceNumber" => "QQ123456Q",
+        "email" => nil,
+        "qts" => { "awarded" => 2.years.ago.to_date },
+        "eyts" => nil,
+        "induction" => { "startDate" => 18.months.ago.to_date,
+                         "endDate" => nil,
+                         "status" => "InProgress",
+                         "periods"=>[{ "startDate" => 18.months.ago.to_date,
+                                      "endDate" => nil,
+                                      "terms" => nil,
+                                      "appropriateBody" => { "name" => "The Most Fantasic AB Ltd" } }] },
+      }
+    end
+
+    subject(:service) { described_class }
+
+    it "returns the induction section of the participants DQT record" do
+      expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(valid_record)
+
+      result = service.call(trn:)
+
+      expect(result).to eq valid_record["induction"]
+    end
+
+    context "when the record is not found" do
+      it "returns nil" do
+        expect_any_instance_of(FullDQT::V3::Client).to receive(:get_record).with(trn:).once.and_return(nil)
+
+        result = service.call(trn:)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/dqt_record_check_spec.rb
+++ b/spec/services/dqt_record_check_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DqtRecordCheck do
+RSpec.describe DQTRecordCheck do
   shared_context "build fake DQT response" do
     before do
       allow_any_instance_of(FullDQT::V1::Client).to(receive(:get_record).and_return(fake_api_response || default_api_response))
@@ -25,7 +25,7 @@ RSpec.describe DqtRecordCheck do
   end
   let(:fake_api_response) { nil }
 
-  subject { DqtRecordCheck.new(**kwargs) }
+  subject { DQTRecordCheck.new(**kwargs) }
 
   context "when trn and national insurance number are blank" do
     let(:trn) { "" }
@@ -206,7 +206,7 @@ RSpec.describe DqtRecordCheck do
       end
 
       before do
-        allow_any_instance_of(DqtRecordCheck).to receive(:check_record).and_call_original
+        allow_any_instance_of(DQTRecordCheck).to receive(:check_record).and_call_original
       end
 
       it "sets trn to 0000001 and calls check_record again" do

--- a/spec/services/participants/set_start_date_from_dqt_spec.rb
+++ b/spec/services/participants/set_start_date_from_dqt_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Participants::SetStartDateFromDQT do
+  describe "#call" do
+    let(:trn) { "1000864" }
+    let(:teacher_profile) { create(:teacher_profile, trn:) }
+    let(:participant_profile) { create(:ect_participant_profile, teacher_profile:) }
+    let(:start_date) { 18.months.ago.to_date }
+    let(:valid_record) do
+      {
+        "startDate" => start_date,
+        "endDate" => nil,
+        "status" => "InProgress",
+        "periods"=>[{ "startDate" => start_date,
+                      "endDate" => nil,
+                      "terms" => nil,
+                      "appropriateBody" => { "name" => "The Most Fantasic AB Ltd" } }],
+      }
+    end
+
+    subject(:service) { described_class }
+
+    it "sets the induction_start_date using the induction start date from DQT" do
+      expect(DQT::GetInductionRecord).to receive(:call).with(trn:).once.and_return(valid_record)
+
+      service.call(participant_profile:)
+
+      expect(participant_profile.reload.induction_start_date).to eq start_date
+    end
+
+    context "when the DQT record is not found" do
+      it "does not update the induction start date" do
+        expect(DQT::GetInductionRecord).to receive(:call).with(trn:).once.and_return(nil)
+
+        service.call(participant_profile:)
+
+        expect(participant_profile.reload.induction_start_date).to be_nil
+      end
+    end
+
+    context "when the participant is not an ECT" do
+      let(:participant_profile) { create(:mentor_participant_profile, teacher_profile:) }
+
+      it "does not look up the DQT record" do
+        expect(DQT::GetInductionRecord).not_to receive(:call)
+        service.call(participant_profile:)
+      end
+
+      it "does not update the induction start date" do
+        service.call(participant_profile:)
+        expect(participant_profile.reload.induction_start_date).to be_nil
+      end
+    end
+
+    context "when there is no TRN on the teacher_profile" do
+      let(:trn) { nil }
+
+      it "does not look up the DQT record" do
+        expect(DQT::GetInductionRecord).not_to receive(:call)
+        service.call(participant_profile:)
+      end
+
+      it "does not update the induction start date" do
+        service.call(participant_profile:)
+        expect(participant_profile.reload.induction_start_date).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/participants/sync_dqt_induction_start_date_spec.rb
+++ b/spec/services/participants/sync_dqt_induction_start_date_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { cohortless_dashboard: "active" } do
+RSpec.describe Participants::SyncDQTInductionStartDate, with_feature_flags: { cohortless_dashboard: "active" } do
   let(:dqt_induction_start_date) {}
   let(:participant_induction_start_date) {}
   let(:participant_created_at) { described_class::FIRST_2023_REGISTRATION_DATE + 1.hour }
@@ -28,7 +28,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
     it "does not change the participant" do
       expect { subject }.to not_change(participant_profile, :updated_at)
                               .and not_change(participant_profile, :induction_start_date)
-                                     .and not_change(SyncDqtInductionStartDateError, :count)
+                                     .and not_change(SyncDQTInductionStartDateError, :count)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
     it "does not change the participant" do
       expect { subject }.to not_change(participant_profile, :updated_at)
                               .and not_change(participant_profile, :induction_start_date)
-                                     .and not_change(SyncDqtInductionStartDateError, :count)
+                                     .and not_change(SyncDQTInductionStartDateError, :count)
     end
   end
 
@@ -61,7 +61,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
       it "update the participant's induction start date" do
         expect { subject }.to change(participant_profile, :updated_at)
                                 .and change(participant_profile, :induction_start_date)
-                                       .and not_change(SyncDqtInductionStartDateError, :count)
+                                       .and not_change(SyncDQTInductionStartDateError, :count)
 
         expect(participant_profile.induction_start_date).to eq(dqt_induction_start_date)
       end
@@ -73,7 +73,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
       it "update the participant's induction start date" do
         expect { subject }.to change(participant_profile, :updated_at)
                                 .and change(participant_profile, :induction_start_date)
-                                       .and not_change(SyncDqtInductionStartDateError, :count)
+                                       .and not_change(SyncDQTInductionStartDateError, :count)
 
         expect(participant_profile.induction_start_date).to eq(dqt_induction_start_date)
       end
@@ -90,7 +90,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
       it "update only the participant's induction start date" do
         expect { subject }.to change(participant_profile, :updated_at)
                                 .and change(participant_profile, :induction_start_date)
-                                       .and not_change(SyncDqtInductionStartDateError, :count)
+                                       .and not_change(SyncDQTInductionStartDateError, :count)
 
         expect(participant_profile.induction_start_date).to eq(dqt_induction_start_date)
       end
@@ -102,7 +102,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
       it "update the participant's induction start date" do
         expect { subject }.to change(participant_profile, :updated_at)
                                 .and change(participant_profile, :induction_start_date)
-                                       .and not_change(SyncDqtInductionStartDateError, :count)
+                                       .and not_change(SyncDQTInductionStartDateError, :count)
 
         expect(participant_profile.induction_start_date).to eq(dqt_induction_start_date)
       end
@@ -116,7 +116,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
       it "does not change the participant but persist the error" do
         expect { subject }.to not_change(participant_profile, :updated_at)
                                 .and not_change(participant_profile, :induction_start_date)
-                                       .and change(SyncDqtInductionStartDateError, :count).by(1)
+                                       .and change(SyncDQTInductionStartDateError, :count).by(1)
       end
     end
 
@@ -128,7 +128,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
         expect { subject }.to change(participant_profile, :induction_start_date)
                                 .to(dqt_induction_start_date)
                                 .and not_change { participant_profile.induction_records.latest.cohort }
-                                       .and not_change(SyncDqtInductionStartDateError, :count)
+                                       .and not_change(SyncDQTInductionStartDateError, :count)
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
                                 .to(dqt_induction_start_date)
                                 .and change { participant_profile.induction_records.latest.cohort.start_year }
                                        .to(Cohort.current.start_year)
-                                       .and not_change(SyncDqtInductionStartDateError, :count)
+                                       .and not_change(SyncDQTInductionStartDateError, :count)
       end
     end
 
@@ -160,14 +160,14 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
         expect { subject }.to not_change(participant_profile, :induction_start_date)
                                 .and not_change { participant_profile.induction_records.latest.cohort.start_year }
 
-        expect(SyncDqtInductionStartDateError.find_by(participant_profile:).message)
+        expect(SyncDQTInductionStartDateError.find_by(participant_profile:).message)
           .to include("Target school cohort starting on #{Cohort.current.start_year} not setup")
       end
     end
 
     context "when an error is already present from a previous job" do
       let(:dqt_induction_start_date) { Date.new(Cohort.current.start_year, 10, 2) }
-      let!(:error) { SyncDqtInductionStartDateError.create!(participant_profile:, message: "test message") }
+      let!(:error) { SyncDQTInductionStartDateError.create!(participant_profile:, message: "test message") }
 
       context "when the participant is successfully processed" do
         let(:participant_cohort_start_year) { Cohort.current.start_year }
@@ -176,7 +176,7 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
           expect { subject }.to change(participant_profile, :induction_start_date)
                                   .to(dqt_induction_start_date)
 
-          expect(SyncDqtInductionStartDateError.where(participant_profile:)).not_to exist
+          expect(SyncDQTInductionStartDateError.where(participant_profile:)).not_to exist
         end
       end
 
@@ -187,8 +187,8 @@ RSpec.describe Participants::SyncDqtInductionStartDate, with_feature_flags: { co
           expect { subject }.to not_change(participant_profile, :induction_start_date)
                                   .and not_change { participant_profile.induction_records.latest.cohort.start_year }
 
-          expect(SyncDqtInductionStartDateError.where(participant_profile:, message: "test message")).not_to exist
-          expect(SyncDqtInductionStartDateError.where(participant_profile:)).to exist
+          expect(SyncDQTInductionStartDateError.where(participant_profile:, message: "test message")).not_to exist
+          expect(SyncDQTInductionStartDateError.where(participant_profile:)).to exist
         end
       end
     end

--- a/spec/support/features/steps/changes_of_circumstance_steps.rb
+++ b/spec/support/features/steps/changes_of_circumstance_steps.rb
@@ -72,8 +72,8 @@ module Steps
                                            .choose_to_add_an_ect_or_mentor
         participant_start_date = Date.new(2021, 9, 1)
 
-        allow(DqtRecordCheck).to receive(:call).and_return(
-          DqtRecordCheck::CheckResult.new(
+        allow(DQTRecordCheck).to receive(:call).and_return(
+          DQTRecordCheck::CheckResult.new(
             {
               "name" => participant_name,
               "trn" => participant_trn,


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1750)

These services are to aid backfilling induction start dates for 2021 and 2022 participants form their DQT records.  The backfilling which will be scripted as a 1 time job and isn't in this PR.
Also added DQT to the inflections list which meant renaming of some classes from `Dqt` to `DQT` naming.

### Changes proposed in this pull request

New service to return the induction section of a participants record
New service to set the induction start date on a profile
Use uppercase DQT in names.

### Guidance to review
