### PR TITLE
[CPDLP-2327] Add extended declarations to API spec with release note for sandbox

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -6,8 +6,26 @@ weight: 8
 # Release notes
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
-  
-## 10 August 2023
+
+## 17 August 2023
+
+Lead providers can now submit 'extended declarations' for ECTs that are on extended schedules in the sandbox environment. Providers may not submit extended declarations for mentors.
+
+Qualifying ECTs will have had their induction extended as a result of having not yet met the Teachers' standards, and need additional support to meet the standards. These ECTs must be placed onto one of the available ['extended schedules'](/api-reference/ecf/schedules-and-milestone-dates.html#extended-schedules) for ECF.
+
+Providers may submit an extended declaration (subject to meeting the engagement criteria) for each extended term until the ECT has completed their induction, up to a maximum of three extensions. On completing induction, the provider should submit a completion declaration for the final term.
+
+For further details about how and when to use these declaration types, providers should refer to the ECF payment guidance issued by their contract manager.
+
+Providers may submit extended declarations using the following values in the `declaration_type` field on the [participant declaration request body](/api-reference/reference-v3.html#schema-participantdeclarationrequest):
+
+- extended-1
+- extended-2
+- extended-3
+
+Providers will be notified ahead of this functionality becoming available in the production environment.
+
+## 10th August 2023
 
 Lead providers can now ‘resume’ NPQ and ECF participants they've previously withdrawn.
 
@@ -171,7 +189,7 @@ To enable the scenario where a participant needs to be registered as a mentor af
 
 The `training_record_id` value will be unique to each registration that a participant has for ECF-based training, as either an ECT or mentor.
 
-Induction tutors have not yet been able to register participants as mentors if they were already registered as ECTs. Given the likely scenario that ECTs will go on to become mentors, the `training_record_id` attribute will soon allow the service to recognise and differentiate registrations. Note, DfE does not expect induction tutors to begin registering ECTs as mentors until June. 
+Induction tutors have not yet been able to register participants as mentors if they were already registered as ECTs. Given the likely scenario that ECTs will go on to become mentors, the `training_record_id` attribute will soon allow the service to recognise and differentiate registrations. Note, DfE does not expect induction tutors to begin registering ECTs as mentors until June.
 
 For the moment, we have added examples to provider sandbox environments:
 
@@ -368,7 +386,7 @@ A teacher from a country outside the UK uses the DfE’s digital service to regi
 
 The API will now return a 422 error message to highlight invalid ECF or NPQ `course_identifier` entries.
 
-Invalid entries include: 
+Invalid entries include:
 
 * spelling errors
 * unrecognised values not included in the schema, or a value included in the schema but not associated with the participant
@@ -489,7 +507,7 @@ Add `employer` as possible option for NPQ `funding_choice`.
 
 ## 19 October 2021
 
-With this release we've: 
+With this release we've:
 
 * added ability to withdraw an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/withdraw`
 * added the new endpoint to withdraw an NPQ participant from a given course. `PUT /api/v1/participants/npq/{id}/withdraw`

--- a/swagger/v1/api_spec.json
+++ b/swagger/v1/api_spec.json
@@ -1910,6 +1910,9 @@
           },
           {
             "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+          },
+          {
+            "$ref": "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
           }
         ]
       },
@@ -2050,6 +2053,58 @@
               "completed"
             ],
             "example": "completed"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_identifier": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
+            "enum": [
+              "ecf-induction",
+              "ecf-mentor"
+            ],
+            "example": "ecf-induction"
+          },
+          "evidence_held": {
+            "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
+            "type": "string",
+            "enum": [
+              "training-event-attended",
+              "self-study-material-completed",
+              "other"
+            ]
+          }
+        }
+      },
+      "ECFParticipantDeclarationExtendedAttributesRequest": {
+        "description": "An ECF extended participant declaration",
+        "type": "object",
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_identifier",
+          "evidence_held"
+        ],
+        "properties": {
+          "participant_id": {
+            "description": "The unique ID of the participant",
+            "type": "string",
+            "example": "3452b1a6-cbaa-422f-9ca9-40afa28583a2"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "type": "string",
+            "enum": [
+              "extended-1",
+              "extended-2",
+              "extended-3"
+            ],
+            "example": "extended-1"
           },
           "declaration_date": {
             "description": "The event declaration date",
@@ -5060,11 +5115,14 @@
             "type": "string",
             "enum": [
               "started",
-              "completed",
               "retained-1",
               "retained-2",
               "retained-3",
-              "retained-4"
+              "retained-4",
+              "completed",
+              "extended-1",
+              "extended-2",
+              "extended-3"
             ],
             "example": "started"
           },
@@ -5169,7 +5227,10 @@
               "retained-2",
               "retained-3",
               "retained-4",
-              "completed"
+              "completed",
+              "extended-1",
+              "extended-2",
+              "extended-3"
             ],
             "example": "started"
           },

--- a/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v1/component_schemas/ParticipantDeclarationAttributes.yml
@@ -20,11 +20,14 @@ properties:
     type: string
     enum:
       - started
-      - completed
       - retained-1
       - retained-2
       - retained-3
       - retained-4
+      - completed
+      - extended-1
+      - extended-2
+      - extended-3
     example: started
   declaration_date:
     description: "The event declaration date"

--- a/swagger/v2/api_spec.json
+++ b/swagger/v2/api_spec.json
@@ -1766,6 +1766,9 @@
           },
           {
             "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+          },
+          {
+            "$ref": "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
           }
         ]
       },
@@ -1906,6 +1909,58 @@
               "completed"
             ],
             "example": "completed"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_identifier": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
+            "enum": [
+              "ecf-induction",
+              "ecf-mentor"
+            ],
+            "example": "ecf-induction"
+          },
+          "evidence_held": {
+            "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
+            "type": "string",
+            "enum": [
+              "training-event-attended",
+              "self-study-material-completed",
+              "other"
+            ]
+          }
+        }
+      },
+      "ECFParticipantDeclarationExtendedAttributesRequest": {
+        "description": "An ECF extended participant declaration",
+        "type": "object",
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_identifier",
+          "evidence_held"
+        ],
+        "properties": {
+          "participant_id": {
+            "description": "The unique ID of the participant",
+            "type": "string",
+            "example": "3452b1a6-cbaa-422f-9ca9-40afa28583a2"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "type": "string",
+            "enum": [
+              "extended-1",
+              "extended-2",
+              "extended-3"
+            ],
+            "example": "extended-1"
           },
           "declaration_date": {
             "description": "The event declaration date",
@@ -5091,11 +5146,14 @@
             "type": "string",
             "enum": [
               "started",
-              "completed",
               "retained-1",
               "retained-2",
               "retained-3",
-              "retained-4"
+              "retained-4",
+              "completed",
+              "extended-1",
+              "extended-2",
+              "extended-3"
             ],
             "example": "started"
           },
@@ -5184,7 +5242,10 @@
               "retained-2",
               "retained-3",
               "retained-4",
-              "completed"
+              "completed",
+              "extended-1",
+              "extended-2",
+              "extended-3"
             ],
             "example": "started"
           },

--- a/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v2/component_schemas/ParticipantDeclarationAttributes.yml
@@ -18,11 +18,14 @@ properties:
     type: string
     enum:
       - started
-      - completed
       - retained-1
       - retained-2
       - retained-3
       - retained-4
+      - completed
+      - extended-1
+      - extended-2
+      - extended-3
     example: started
   declaration_date:
     description: "The event declaration date"

--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -3380,11 +3380,14 @@
             "type": "string",
             "enum": [
               "started",
-              "completed",
               "retained-1",
               "retained-2",
               "retained-3",
-              "retained-4"
+              "retained-4",
+              "completed",
+              "extended-1",
+              "extended-2",
+              "extended-3"
             ],
             "example": "started"
           },
@@ -3514,6 +3517,58 @@
               "completed"
             ],
             "example": "completed"
+          },
+          "declaration_date": {
+            "description": "The event declaration date",
+            "type": "string",
+            "format": "date-time",
+            "example": "2021-05-31T02:21:32.000Z"
+          },
+          "course_identifier": {
+            "description": "The type of course the participant is enrolled in",
+            "type": "string",
+            "enum": [
+              "ecf-induction",
+              "ecf-mentor"
+            ],
+            "example": "ecf-induction"
+          },
+          "evidence_held": {
+            "description": "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period",
+            "type": "string",
+            "enum": [
+              "training-event-attended",
+              "self-study-material-completed",
+              "other"
+            ]
+          }
+        }
+      },
+      "ECFParticipantDeclarationExtendedAttributesRequest": {
+        "description": "An ECF extended participant declaration",
+        "type": "object",
+        "required": [
+          "participant_id",
+          "declaration_type",
+          "declaration_date",
+          "course_identifier",
+          "evidence_held"
+        ],
+        "properties": {
+          "participant_id": {
+            "description": "The unique ID of the participant",
+            "type": "string",
+            "example": "3452b1a6-cbaa-422f-9ca9-40afa28583a2"
+          },
+          "declaration_type": {
+            "description": "The event declaration type",
+            "type": "string",
+            "enum": [
+              "extended-1",
+              "extended-2",
+              "extended-3"
+            ],
+            "example": "extended-1"
           },
           "declaration_date": {
             "description": "The event declaration date",
@@ -6689,6 +6744,9 @@
                 "$ref": "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
               },
               {
+                "$ref": "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
+              },
+              {
                 "$ref": "#/components/schemas/NPQParticipantDeclarationStartedAttributesRequest"
               },
               {
@@ -6762,11 +6820,14 @@
             "type": "string",
             "enum": [
               "started",
-              "completed",
               "retained-1",
               "retained-2",
               "retained-3",
-              "retained-4"
+              "retained-4",
+              "completed",
+              "extended-1",
+              "extended-2",
+              "extended-3"
             ],
             "example": "started"
           },

--- a/swagger/v3/component_schemas/ECFParticipantDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/ECFParticipantDeclarationAttributes.yml
@@ -19,11 +19,14 @@ properties:
     type: string
     enum:
       - started
-      - completed
       - retained-1
       - retained-2
       - retained-3
       - retained-4
+      - completed
+      - extended-1
+      - extended-2
+      - extended-3
     example: started
   declaration_date:
     description: "The event declaration date"

--- a/swagger/v3/component_schemas/ECFParticipantDeclarationExtendedAttributesRequest copy.yml
+++ b/swagger/v3/component_schemas/ECFParticipantDeclarationExtendedAttributesRequest copy.yml
@@ -1,0 +1,41 @@
+description: "An ECF extended participant declaration"
+type: object
+required:
+  - participant_id
+  - declaration_type
+  - declaration_date
+  - course_identifier
+  - evidence_held
+properties:
+  participant_id:
+    description: The unique ID of the participant
+    type: string
+    example: 3452b1a6-cbaa-422f-9ca9-40afa28583a2
+  declaration_type:
+    description: The event declaration type
+    type: string
+    enum:
+      - extended-1
+      - extended-2
+      - extended-3
+    example: extended-1
+  declaration_date:
+    description: The event declaration date
+    type: string
+    format: date-time
+    example: "2021-05-31T02:21:32.000Z"
+  course_identifier:
+    description: The type of course the participant is enrolled in
+    type: string
+    enum:
+      - ecf-induction
+      - ecf-mentor
+    example: ecf-induction
+  evidence_held:
+    description: "The type of evidence that the lead provider holds on their platform to demonstrate that the participant has met the retention criteria for the current milestone period"
+    type: string
+    enum:
+      - training-event-attended
+      - self-study-material-completed
+      - other
+    example: training-event-attended

--- a/swagger/v3/component_schemas/ParticipantDeclarationAttributes.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationAttributes.yml
@@ -18,11 +18,14 @@ properties:
     type: string
     enum:
       - started
-      - completed
       - retained-1
       - retained-2
       - retained-3
       - retained-4
+      - completed
+      - extended-1
+      - extended-2
+      - extended-3
     example: started
   declaration_date:
     description: "The event declaration date"

--- a/swagger/v3/component_schemas/ParticipantDeclarationDataRequest.yml
+++ b/swagger/v3/component_schemas/ParticipantDeclarationDataRequest.yml
@@ -10,6 +10,7 @@ properties:
       - $ref: "#/components/schemas/ECFParticipantDeclarationStartedAttributesRequest"
       - $ref: "#/components/schemas/ECFParticipantDeclarationRetainedAttributesRequest"
       - $ref: "#/components/schemas/ECFParticipantDeclarationCompletedAttributesRequest"
+      - $ref: "#/components/schemas/ECFParticipantDeclarationExtendedAttributesRequest"
       - $ref: "#/components/schemas/NPQParticipantDeclarationStartedAttributesRequest"
       - $ref: "#/components/schemas/NPQParticipantDeclarationRetainedAttributesRequest"
       - $ref: "#/components/schemas/NPQParticipantDeclarationCompletedAttributesRequest"


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2327](https://dfedigital.atlassian.net/browse/CPDLP-2327)

Following changes from https://github.com/DFE-Digital/early-careers-framework/pull/3780, we need to add the new extended declarations types to API spec and a release note for sandbox.

### Changes proposed in this pull request

Add extended declarations to API spec with release note for sandbox

[CPDLP-2327]: https://dfedigital.atlassian.net/browse/CPDLP-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Guidance to review

https://ecf-review-pr-3809.london.cloudapps.digital/api-reference