### PR TITLE
Make prod deploy continue-on-error

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -140,6 +140,7 @@ jobs:
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
+        continue-on-error: true # temporary until we've got prod fully configured
         with:
           environment: production
           docker-image: ${{ needs.deploy_staging.outputs.docker-image }}


### PR DESCRIPTION
### Context

This will keep the builds green while we finalise how our production env looks.
