### PR TITLE
Remove the development env from AKS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,6 @@ aks:  ## Sets environment variables for aks deployment
 	$(eval REGION=UK South)
 	$(eval KEY_VAULT_PURGE_PROTECTION=false)
 
-.PHONY: development
-development: test-cluster
-	$(eval include global_config/development_aks.sh)
-
 .PHONY: review
 review: aks test-cluster ## Specify review AKS environment
 	# PULL_REQUEST_NUMBER is set by the GitHub action

--- a/global_config/development_aks.sh
+++ b/global_config/development_aks.sh
@@ -1,7 +1,0 @@
-AZURE_RESOURCE_PREFIX=s189t01
-AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
-CONFIG=development_aks
-CONFIG_SHORT=dv
-DEPLOY_ENV=${CONFIG}
-ENV_TAG=Test
-PLATFORM=aks

--- a/terraform/aks/workspace_variables/development_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/development_aks.tfvars.json
@@ -1,3 +1,0 @@
-{
-  "cluster": "test"
-}

--- a/terraform/aks/workspace_variables/development_aks_backend.tfvars
+++ b/terraform/aks/workspace_variables/development_aks_backend.tfvars
@@ -1,4 +1,0 @@
-resource_group_name  = "s189t01-cpdecf-dv-rg"
-storage_account_name = "s189t01cpdecftfstatedvsa"
-container_name       = "cpdecf-tfstate"
-key                  = "terraform.tfstate"


### PR DESCRIPTION
We aren't using development any more because we want a 1:1 mapping between AKS environments and Rails environments. We use development for local dev, so having a `deployed_development` is a unnecessary complication. Staging is the new development.
