### PR TITLE
Add concurrency group and enable cancel-in-progress

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -1,4 +1,9 @@
 name: "Deploy"
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Add [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) so that we can automatically cancel runs when one part fails.


We've tested this by force pushing and it appears to work, the first run was correctly cancelled.

![image](https://github.com/DFE-Digital/early-careers-framework/assets/128088/a70382b3-5fc5-418e-9aac-8eaa2141f097)
