### PR TITLE
Remove continue-on-error from prod deploy on AKS

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -140,7 +140,6 @@ jobs:
 
       - uses: ./.github/actions/deploy-environment-to-aks
         id: deploy
-        continue-on-error: true # temporary until we've got prod fully configured
         with:
           environment: production
           docker-image: ${{ needs.deploy_staging.outputs.docker-image }}


### PR DESCRIPTION
### Context

We should no longer need it now that production is fully configured.
