### PR TITLE
[CPDLP-2317] Update NPQ outcomes table in the finance application to show details of an successful/unsuccessful request to the TRA

### DIFF
--- a/app/components/finance/npq/participant_outcomes/table.html.erb
+++ b/app/components/finance/npq/participant_outcomes/table.html.erb
@@ -1,23 +1,25 @@
 <%=
   govuk_table do |table|
-    table.with_caption(size: 's', text: "Declaration Outcomes", classes: "govuk-heading-s")
+    table.with_caption(size: 's', text: caption_text, classes: "govuk-heading-s")
 
     table.with_head do |head|
       head.with_row do |row|
-        row.with_cell(header: true, text: 'Outcome')
-        row.with_cell(header: true, text: 'Completion date')
-        row.with_cell(header: true, text: 'Changed at')
-        row.with_cell(header: true, text: 'Sent to TRA', numeric: true)
+        row.with_cell(header: true, text: t("finance.npq.participant_outcomes.outcome"))
+        row.with_cell(header: true, text: t("finance.npq.participant_outcomes.completion_date"))
+        row.with_cell(header: true, text: t("finance.npq.participant_outcomes.submitted"))
+        row.with_cell(header: true, text: t("finance.npq.participant_outcomes.attempted"))
+        row.with_cell(header: true, text: t("finance.npq.participant_outcomes.recorded"))
       end
     end
 
     table.with_body do |body|
       outcomes.each do |outcome|
         body.with_row do |row|
-          row.with_cell(text: outcome.state)
+          row.with_cell(text: state(outcome))
           row.with_cell(text: completion_date(outcome))
           row.with_cell(text: changed_date(outcome))
-          row.with_cell(text: sent_to_tra(outcome), numeric: true)
+          row.with_cell(text: sent_to_tra_at(outcome))
+          row.with_cell(text: sent_to_tra_tag(outcome.qualified_teachers_api_request_successful))
         end
       end
     end

--- a/app/components/finance/npq/participant_outcomes/table.rb
+++ b/app/components/finance/npq/participant_outcomes/table.rb
@@ -6,8 +6,6 @@ module Finance
       class Table < BaseComponent
         attr_reader :participant_declaration
 
-        delegate :outcomes, to: :participant_declaration
-
         def initialize(participant_declaration:)
           @participant_declaration = participant_declaration
         end
@@ -16,16 +14,62 @@ module Finance
           participant_declaration.participant_profile.npq? && outcomes.present?
         end
 
+        def state(outcome)
+          outcome.state&.capitalize
+        end
+
         def completion_date(outcome)
           outcome.completion_date.to_fs(:govuk)
         end
 
         def changed_date(outcome)
-          outcome.created_at.to_fs(:govuk)
+          outcome.created_at.to_date.to_fs(:govuk)
         end
 
-        def sent_to_tra(outcome)
-          outcome.sent_to_qualified_teachers_api_at&.to_fs(:govuk)
+        def sent_to_tra_at(outcome)
+          return "<strong class='govuk-tag govuk-tag--yellow'>#{t('finance.npq.participant_outcomes.na')}</strong>".html_safe if outcome.sent_to_qualified_teachers_api_at.blank?
+
+          outcome.sent_to_qualified_teachers_api_at.to_date.to_fs(:govuk)
+        end
+
+        def sent_to_tra_tag(bool)
+          if bool.nil?
+            "<strong class='govuk-tag govuk-tag--yellow'>#{t('finance.npq.participant_outcomes.na')}</strong>"
+          elsif bool
+            "<strong class='govuk-tag govuk-tag--green'>#{t('finance.npq.participant_outcomes.yes')}</strong>"
+          else
+            "<strong class='govuk-tag govuk-tag--red'>#{t('finance.npq.participant_outcomes.no')}</strong>"
+          end.html_safe
+        end
+
+        def caption_text
+          titles = [t("finance.npq.participant_outcomes.declaration_outcomes")]
+
+          latest_outcome = outcomes.first
+
+          return titles.join if latest_outcome.blank?
+
+          if latest_outcome.passed_and_not_sent?
+            titles << t("finance.npq.participant_outcomes.passed")
+          elsif latest_outcome.failed_and_not_sent?
+            titles << t("finance.npq.participant_outcomes.failed")
+          elsif latest_outcome.passed_and_recorded?
+            titles << t("finance.npq.participant_outcomes.passed_and_recorded")
+          elsif latest_outcome.failed_and_recorded?
+            titles << t("finance.npq.participant_outcomes.failed_and_recorded")
+          elsif latest_outcome.passed_and_not_recorded?
+            titles << t("finance.npq.participant_outcomes.passed_and_not_recorded")
+          elsif latest_outcome.failed_and_not_recorded?
+            titles << t("finance.npq.participant_outcomes.failed_and_not_recorded")
+          end
+
+          titles.join(": ")
+        end
+
+      private
+
+        def outcomes
+          @outcomes ||= participant_declaration&.outcomes&.order(created_at: :desc)
         end
       end
     end

--- a/app/components/finance/npq/participant_outcomes/table.rb
+++ b/app/components/finance/npq/participant_outcomes/table.rb
@@ -27,43 +27,44 @@ module Finance
         end
 
         def sent_to_tra_at(outcome)
-          return "<strong class='govuk-tag govuk-tag--yellow'>#{t('finance.npq.participant_outcomes.na')}</strong>".html_safe if outcome.sent_to_qualified_teachers_api_at.blank?
+          return t("finance.npq.participant_outcomes.na") if outcome.sent_to_qualified_teachers_api_at.blank?
 
           outcome.sent_to_qualified_teachers_api_at.to_date.to_fs(:govuk)
         end
 
         def sent_to_tra_tag(bool)
           if bool.nil?
-            "<strong class='govuk-tag govuk-tag--yellow'>#{t('finance.npq.participant_outcomes.na')}</strong>"
+            tag.strong(t("finance.npq.participant_outcomes.na"), class: "govuk-tag govuk-tag--yellow")
           elsif bool
-            "<strong class='govuk-tag govuk-tag--green'>#{t('finance.npq.participant_outcomes.yes')}</strong>"
+            tag.strong(t("finance.npq.participant_outcomes.yes"), class: "govuk-tag govuk-tag--green")
           else
-            "<strong class='govuk-tag govuk-tag--red'>#{t('finance.npq.participant_outcomes.no')}</strong>"
-          end.html_safe
+            tag.strong(t("finance.npq.participant_outcomes.no"), class: "govuk-tag govuk-tag--red")
+          end
         end
 
         def caption_text
-          titles = [t("finance.npq.participant_outcomes.declaration_outcomes")]
-
+          title = t("finance.npq.participant_outcomes.declaration_outcomes")
           latest_outcome = outcomes.first
 
-          return titles.join if latest_outcome.blank?
+          return title if latest_outcome.blank?
 
-          if latest_outcome.passed_and_not_sent?
-            titles << t("finance.npq.participant_outcomes.passed")
-          elsif latest_outcome.failed_and_not_sent?
-            titles << t("finance.npq.participant_outcomes.failed")
-          elsif latest_outcome.passed_and_recorded?
-            titles << t("finance.npq.participant_outcomes.passed_and_recorded")
-          elsif latest_outcome.failed_and_recorded?
-            titles << t("finance.npq.participant_outcomes.failed_and_recorded")
-          elsif latest_outcome.passed_and_not_recorded?
-            titles << t("finance.npq.participant_outcomes.passed_and_not_recorded")
-          elsif latest_outcome.failed_and_not_recorded?
-            titles << t("finance.npq.participant_outcomes.failed_and_not_recorded")
-          end
+          outcome_description = if latest_outcome.passed_but_not_sent?
+                                  t("finance.npq.participant_outcomes.passed")
+                                elsif latest_outcome.failed_but_not_sent?
+                                  t("finance.npq.participant_outcomes.failed")
+                                elsif latest_outcome.passed_and_recorded?
+                                  t("finance.npq.participant_outcomes.passed_and_recorded")
+                                elsif latest_outcome.failed_and_recorded?
+                                  t("finance.npq.participant_outcomes.failed_and_recorded")
+                                elsif latest_outcome.passed_but_not_recorded?
+                                  t("finance.npq.participant_outcomes.passed_but_not_recorded")
+                                elsif latest_outcome.failed_but_not_recorded?
+                                  t("finance.npq.participant_outcomes.failed_but_not_recorded")
+                                else
+                                  latest_outcome.state.capitalize
+                                end
 
-          titles.join(": ")
+          "#{title}: #{outcome_description}"
         end
 
       private

--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -75,11 +75,11 @@ class ParticipantOutcome::NPQ < ApplicationRecord
     failed?
   end
 
-  def passed_and_not_sent?
+  def passed_but_not_sent?
     has_passed? && sent_to_qualified_teachers_api_at.nil?
   end
 
-  def failed_and_not_sent?
+  def failed_but_not_sent?
     has_failed? && sent_to_qualified_teachers_api_at.nil?
   end
 
@@ -91,11 +91,11 @@ class ParticipantOutcome::NPQ < ApplicationRecord
     has_failed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful
   end
 
-  def passed_and_not_recorded?
+  def passed_but_not_recorded?
     has_passed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful == false
   end
 
-  def failed_and_not_recorded?
+  def failed_but_not_recorded?
     has_failed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful == false
   end
 

--- a/app/models/participant_outcome/npq.rb
+++ b/app/models/participant_outcome/npq.rb
@@ -69,6 +69,36 @@ class ParticipantOutcome::NPQ < ApplicationRecord
     passed?
   end
 
+  def has_failed?
+    return nil if voided?
+
+    failed?
+  end
+
+  def passed_and_not_sent?
+    has_passed? && sent_to_qualified_teachers_api_at.nil?
+  end
+
+  def failed_and_not_sent?
+    has_failed? && sent_to_qualified_teachers_api_at.nil?
+  end
+
+  def passed_and_recorded?
+    has_passed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful
+  end
+
+  def failed_and_recorded?
+    has_failed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful
+  end
+
+  def passed_and_not_recorded?
+    has_passed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful == false
+  end
+
+  def failed_and_not_recorded?
+    has_failed? && sent_to_qualified_teachers_api_at.present? && qualified_teachers_api_request_successful == false
+  end
+
 private
 
   def push_outcome_to_big_query

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,10 +695,24 @@ en:
           retained_3: Retained 3
           retained_4: Retained 4
           completed: Completed
-          extended: Extended
-
     npq:
       payment_breakdown: NPQ Payment Breakdown
+      participant_outcomes:
+        outcome: "Outcome"
+        completion_date: "Completion date"
+        submitted: "Submitted by provider"
+        attempted: "Attempted to send to TRA API"
+        recorded: "Recorded by TRA API"
+        "yes": "YES"
+        "no": "NO. CONTACT THE DIGITAL SERVICE TEAM"
+        na: "N/A"
+        declaration_outcomes: "Declaration Outcomes"
+        passed: "Passed"
+        failed: "Failed"
+        passed_and_recorded: "Passed and recorded"
+        failed_and_recorded: "Failed and recorded"
+        passed_and_not_recorded: "Passed and not recorded"
+        failed_and_not_recorded: "Failed and not recorded"
     service_fee:
       caption: Service fee
     output_payment:
@@ -711,7 +725,6 @@ en:
       per_participant: Clawback per participant
     targeted_delivery_funding:
       caption: Targeted delivery funding
-
     banding_tracker:
       providers:
         show:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,6 +695,7 @@ en:
           retained_3: Retained 3
           retained_4: Retained 4
           completed: Completed
+          extended: Extended
     npq:
       payment_breakdown: NPQ Payment Breakdown
       participant_outcomes:
@@ -711,8 +712,8 @@ en:
         failed: "Failed"
         passed_and_recorded: "Passed and recorded"
         failed_and_recorded: "Failed and recorded"
-        passed_and_not_recorded: "Passed and not recorded"
-        failed_and_not_recorded: "Failed and not recorded"
+        passed_but_not_recorded: "Passed but not recorded"
+        failed_but_not_recorded: "Failed but not recorded"
     service_fee:
       caption: Service fee
     output_payment:

--- a/spec/components/finance/npq/participant_outcomes/table_spec.rb
+++ b/spec/components/finance/npq/participant_outcomes/table_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Finance::NPQ::ParticipantOutcomes::Table, type: :component do
         is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
         is_expected.to have_table_text(tra_datetime.to_date.to_fs(:govuk), col: 4)
         is_expected.to have_table_text("NO. CONTACT THE DIGITAL SERVICE TEAM", col: 5)
-        is_expected.to have_table_caption("Declaration Outcomes: Passed and not recorded")
+        is_expected.to have_table_caption("Declaration Outcomes: Passed but not recorded")
       end
     end
   end

--- a/spec/components/finance/npq/participant_outcomes/table_spec.rb
+++ b/spec/components/finance/npq/participant_outcomes/table_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe Finance::NPQ::ParticipantOutcomes::Table, type: :component do
 
     it "renders correctly" do
       is_expected.to have_table_row_count(1)
-      is_expected.to have_table_text("failed", col: 1)
+      is_expected.to have_table_text("Failed", col: 1)
       is_expected.to have_table_text(participant_outcome.completion_date.to_fs(:govuk), col: 2)
-      is_expected.to have_table_text(participant_outcome.created_at.to_fs(:govuk), col: 3)
-      is_expected.to have_table_text("", col: 4)
+      is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
+      is_expected.to have_table_text("N/A", col: 4)
+      is_expected.to have_table_text("N/A", col: 5)
+      is_expected.to have_table_caption("Declaration Outcomes: Failed")
     end
   end
 
@@ -27,10 +29,12 @@ RSpec.describe Finance::NPQ::ParticipantOutcomes::Table, type: :component do
 
     it "renders correctly" do
       is_expected.to have_table_row_count(1)
-      is_expected.to have_table_text("voided", col: 1)
+      is_expected.to have_table_text("Voided", col: 1)
       is_expected.to have_table_text(participant_outcome.completion_date.to_fs(:govuk), col: 2)
-      is_expected.to have_table_text(participant_outcome.created_at.to_fs(:govuk), col: 3)
-      is_expected.to have_table_text("", col: 4)
+      is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
+      is_expected.to have_table_text("N/A", col: 4)
+      is_expected.to have_table_text("N/A", col: 5)
+      is_expected.to have_table_caption("Declaration Outcomes")
     end
   end
 
@@ -40,10 +44,12 @@ RSpec.describe Finance::NPQ::ParticipantOutcomes::Table, type: :component do
 
       it "renders correctly" do
         is_expected.to have_table_row_count(1)
-        is_expected.to have_table_text("passed", col: 1)
+        is_expected.to have_table_text("Passed", col: 1)
         is_expected.to have_table_text(participant_outcome.completion_date.to_fs(:govuk), col: 2)
-        is_expected.to have_table_text(participant_outcome.created_at.to_fs(:govuk), col: 3)
-        is_expected.to have_table_text("", col: 4)
+        is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
+        is_expected.to have_table_text("N/A", col: 4)
+        is_expected.to have_table_text("N/A", col: 5)
+        is_expected.to have_table_caption("Declaration Outcomes: Passed")
       end
     end
 
@@ -53,10 +59,42 @@ RSpec.describe Finance::NPQ::ParticipantOutcomes::Table, type: :component do
 
       it "renders correctly" do
         is_expected.to have_table_row_count(1)
-        is_expected.to have_table_text("passed", col: 1)
+        is_expected.to have_table_text("Passed", col: 1)
         is_expected.to have_table_text(participant_outcome.completion_date.to_fs(:govuk), col: 2)
-        is_expected.to have_table_text(participant_outcome.created_at.to_fs(:govuk), col: 3)
-        is_expected.to have_table_text(tra_datetime.to_fs(:govuk), col: 4)
+        is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
+        is_expected.to have_table_text(tra_datetime.to_date.to_fs(:govuk), col: 4)
+        is_expected.to have_table_text("N/A", col: 5)
+        is_expected.to have_table_caption("Declaration Outcomes")
+      end
+    end
+
+    context "successfully sent to TRA" do
+      let(:tra_datetime) { Time.zone.now }
+      let!(:participant_outcome) { create :participant_outcome, :passed, participant_declaration:, sent_to_qualified_teachers_api_at: tra_datetime, qualified_teachers_api_request_successful: true }
+
+      it "renders correctly" do
+        is_expected.to have_table_row_count(1)
+        is_expected.to have_table_text("Passed", col: 1)
+        is_expected.to have_table_text(participant_outcome.completion_date.to_fs(:govuk), col: 2)
+        is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
+        is_expected.to have_table_text(tra_datetime.to_date.to_fs(:govuk), col: 4)
+        is_expected.to have_table_text("YES", col: 5)
+        is_expected.to have_table_caption("Declaration Outcomes: Passed and recorded")
+      end
+    end
+
+    context "unsuccessfully sent to TRA" do
+      let(:tra_datetime) { Time.zone.now }
+      let!(:participant_outcome) { create :participant_outcome, :passed, participant_declaration:, sent_to_qualified_teachers_api_at: tra_datetime, qualified_teachers_api_request_successful: false }
+
+      it "renders correctly" do
+        is_expected.to have_table_row_count(1)
+        is_expected.to have_table_text("Passed", col: 1)
+        is_expected.to have_table_text(participant_outcome.completion_date.to_fs(:govuk), col: 2)
+        is_expected.to have_table_text(participant_outcome.created_at.to_date.to_fs(:govuk), col: 3)
+        is_expected.to have_table_text(tra_datetime.to_date.to_fs(:govuk), col: 4)
+        is_expected.to have_table_text("NO. CONTACT THE DIGITAL SERVICE TEAM", col: 5)
+        is_expected.to have_table_caption("Declaration Outcomes: Passed and not recorded")
       end
     end
   end
@@ -67,5 +105,9 @@ RSpec.describe Finance::NPQ::ParticipantOutcomes::Table, type: :component do
 
   def have_table_row_count(count)
     have_css(".govuk-table__body > .govuk-table__row", count:)
+  end
+
+  def have_table_caption(txt)
+    have_css(".govuk-table__caption", text: txt)
   end
 end

--- a/spec/features/finance/npq/participant_outcomes_spec.rb
+++ b/spec/features/finance/npq/participant_outcomes_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Search participant data - participant outcomes", type: :feature do
   describe "NPQ user" do
     let(:participant_declaration) { create(:npq_participant_declaration) }
-    let(:participant_outcome) { create :participant_outcome, :passed, participant_declaration: }
+    let(:participant_outcome) { create(:participant_outcome, :passed, participant_declaration:, sent_to_qualified_teachers_api_at: Time.zone.now, qualified_teachers_api_request_successful: true) }
     let(:user) { participant_declaration.user }
 
     scenario "passed outcome exists" do
@@ -13,8 +13,8 @@ RSpec.feature "Search participant data - participant outcomes", type: :feature d
       and_an_user_with_declarations_and_outcomes
       when_i_visit_the_search_participant_data_page
       then_i_see("ParticipantProfile::NPQ")
-      and_i_see("Declaration Outcomes")
-      and_i_see("passed")
+      and_i_see("Declaration Outcomes: Passed and recorded")
+      and_i_see("Passed")
     end
   end
 

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -249,37 +249,37 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
     end
   end
 
-  describe "#passed_and_not_sent?" do
-    it "returns true if passed and not sent" do
+  describe "#passed_but_not_sent?" do
+    it "returns true if passed but not sent" do
       outcome = described_class.new(state: "passed", sent_to_qualified_teachers_api_at: nil)
-      expect(outcome.passed_and_not_sent?).to eql(true)
+      expect(outcome.passed_but_not_sent?).to eql(true)
     end
 
     it "returns false if passed and sent" do
       outcome = described_class.new(state: "passed", sent_to_qualified_teachers_api_at: Time.zone.now)
-      expect(outcome.passed_and_not_sent?).to eql(false)
+      expect(outcome.passed_but_not_sent?).to eql(false)
     end
 
     it "returns false if failed" do
-      outcome = described_class.new(state: "failed")
-      expect(outcome.passed_and_not_sent?).to eql(false)
+      outcome = described_class.new(state: "failed", sent_to_qualified_teachers_api_at: nil)
+      expect(outcome.passed_but_not_sent?).to eql(false)
     end
   end
 
-  describe "#failed_and_not_sent?" do
-    it "returns true if failed and not sent" do
+  describe "#failed_but_not_sent?" do
+    it "returns true if failed but not sent" do
       outcome = described_class.new(state: "failed", sent_to_qualified_teachers_api_at: nil)
-      expect(outcome.failed_and_not_sent?).to eql(true)
+      expect(outcome.failed_but_not_sent?).to eql(true)
     end
 
     it "returns false if failed and sent" do
       outcome = described_class.new(state: "failed", sent_to_qualified_teachers_api_at: Time.zone.now)
-      expect(outcome.failed_and_not_sent?).to eql(false)
+      expect(outcome.failed_but_not_sent?).to eql(false)
     end
 
     it "returns false if passed" do
-      outcome = described_class.new(state: "passed")
-      expect(outcome.failed_and_not_sent?).to eql(false)
+      outcome = described_class.new(state: "passed", sent_to_qualified_teachers_api_at: nil)
+      expect(outcome.failed_but_not_sent?).to eql(false)
     end
   end
 
@@ -293,9 +293,27 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
       expect(outcome.passed_and_recorded?).to eql(true)
     end
 
-    it "returns false if passed and not recorded" do
+    it "returns false if passed but not recorded" do
       outcome = described_class.new(
         state: "passed",
+        sent_to_qualified_teachers_api_at: nil,
+        qualified_teachers_api_request_successful: nil,
+      )
+      expect(outcome.passed_and_recorded?).to eql(false)
+    end
+
+    it "returns false if failed and recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.passed_and_recorded?).to eql(false)
+    end
+
+    it "returns false if failed but not recorded" do
+      outcome = described_class.new(
+        state: "failed",
         sent_to_qualified_teachers_api_at: nil,
         qualified_teachers_api_request_successful: nil,
       )
@@ -313,24 +331,13 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
       expect(outcome.failed_and_recorded?).to eql(true)
     end
 
-    it "returns false if failed and not recorded" do
+    it "returns false if failed but not recorded" do
       outcome = described_class.new(
         state: "failed",
         sent_to_qualified_teachers_api_at: nil,
         qualified_teachers_api_request_successful: nil,
       )
       expect(outcome.failed_and_recorded?).to eql(false)
-    end
-  end
-
-  describe "#passed_and_not_recorded?" do
-    it "returns true if passed and not recorded" do
-      outcome = described_class.new(
-        state: "passed",
-        sent_to_qualified_teachers_api_at: Time.zone.now,
-        qualified_teachers_api_request_successful: false,
-      )
-      expect(outcome.passed_and_not_recorded?).to eql(true)
     end
 
     it "returns false if passed and recorded" do
@@ -339,18 +346,36 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
         sent_to_qualified_teachers_api_at: Time.zone.now,
         qualified_teachers_api_request_successful: true,
       )
-      expect(outcome.passed_and_not_recorded?).to eql(false)
+      expect(outcome.failed_and_recorded?).to eql(false)
+    end
+
+    it "returns false if passed but not recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: nil,
+        qualified_teachers_api_request_successful: nil,
+      )
+      expect(outcome.failed_and_recorded?).to eql(false)
     end
   end
 
-  describe "#failed_and_not_recorded?" do
-    it "returns true if failed and not recorded" do
+  describe "#passed_but_not_recorded?" do
+    it "returns true if passed but not recorded" do
       outcome = described_class.new(
-        state: "failed",
+        state: "passed",
         sent_to_qualified_teachers_api_at: Time.zone.now,
         qualified_teachers_api_request_successful: false,
       )
-      expect(outcome.failed_and_not_recorded?).to eql(true)
+      expect(outcome.passed_but_not_recorded?).to eql(true)
+    end
+
+    it "returns false if passed and recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.passed_but_not_recorded?).to eql(false)
     end
 
     it "returns false if failed and recorded" do
@@ -359,7 +384,54 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
         sent_to_qualified_teachers_api_at: Time.zone.now,
         qualified_teachers_api_request_successful: true,
       )
-      expect(outcome.failed_and_not_recorded?).to eql(false)
+      expect(outcome.passed_but_not_recorded?).to eql(false)
+    end
+
+    it "returns false if failed but not recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: nil,
+        qualified_teachers_api_request_successful: nil,
+      )
+      expect(outcome.passed_but_not_recorded?).to eql(false)
+    end
+  end
+
+  describe "#failed_but_not_recorded?" do
+    it "returns true if failed but not recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: false,
+      )
+      expect(outcome.failed_but_not_recorded?).to eql(true)
+    end
+
+    it "returns false if failed and recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.failed_but_not_recorded?).to eql(false)
+    end
+
+    it "returns false if passed and recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.failed_but_not_recorded?).to eql(false)
+    end
+
+    it "returns false if passed but not recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: nil,
+        qualified_teachers_api_request_successful: nil,
+      )
+      expect(outcome.failed_but_not_recorded?).to eql(false)
     end
   end
 end

--- a/spec/models/participant_outcome/npq_spec.rb
+++ b/spec/models/participant_outcome/npq_spec.rb
@@ -231,4 +231,135 @@ RSpec.describe ParticipantOutcome::NPQ, type: :model do
       end
     end
   end
+
+  describe "#has_failed?" do
+    it "returns true if failed" do
+      outcome = described_class.new(state: "failed")
+      expect(outcome.has_failed?).to eql(true)
+    end
+
+    it "returns false if passed" do
+      outcome = described_class.new(state: "passed")
+      expect(outcome.has_failed?).to eql(false)
+    end
+
+    it "returns nil if voided" do
+      outcome = described_class.new(state: "voided")
+      expect(outcome.has_failed?).to eql(nil)
+    end
+  end
+
+  describe "#passed_and_not_sent?" do
+    it "returns true if passed and not sent" do
+      outcome = described_class.new(state: "passed", sent_to_qualified_teachers_api_at: nil)
+      expect(outcome.passed_and_not_sent?).to eql(true)
+    end
+
+    it "returns false if passed and sent" do
+      outcome = described_class.new(state: "passed", sent_to_qualified_teachers_api_at: Time.zone.now)
+      expect(outcome.passed_and_not_sent?).to eql(false)
+    end
+
+    it "returns false if failed" do
+      outcome = described_class.new(state: "failed")
+      expect(outcome.passed_and_not_sent?).to eql(false)
+    end
+  end
+
+  describe "#failed_and_not_sent?" do
+    it "returns true if failed and not sent" do
+      outcome = described_class.new(state: "failed", sent_to_qualified_teachers_api_at: nil)
+      expect(outcome.failed_and_not_sent?).to eql(true)
+    end
+
+    it "returns false if failed and sent" do
+      outcome = described_class.new(state: "failed", sent_to_qualified_teachers_api_at: Time.zone.now)
+      expect(outcome.failed_and_not_sent?).to eql(false)
+    end
+
+    it "returns false if passed" do
+      outcome = described_class.new(state: "passed")
+      expect(outcome.failed_and_not_sent?).to eql(false)
+    end
+  end
+
+  describe "#passed_and_recorded?" do
+    it "returns true if passed and recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.passed_and_recorded?).to eql(true)
+    end
+
+    it "returns false if passed and not recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: nil,
+        qualified_teachers_api_request_successful: nil,
+      )
+      expect(outcome.passed_and_recorded?).to eql(false)
+    end
+  end
+
+  describe "#failed_and_recorded?" do
+    it "returns true if failed and recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.failed_and_recorded?).to eql(true)
+    end
+
+    it "returns false if failed and not recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: nil,
+        qualified_teachers_api_request_successful: nil,
+      )
+      expect(outcome.failed_and_recorded?).to eql(false)
+    end
+  end
+
+  describe "#passed_and_not_recorded?" do
+    it "returns true if passed and not recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: false,
+      )
+      expect(outcome.passed_and_not_recorded?).to eql(true)
+    end
+
+    it "returns false if passed and recorded" do
+      outcome = described_class.new(
+        state: "passed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.passed_and_not_recorded?).to eql(false)
+    end
+  end
+
+  describe "#failed_and_not_recorded?" do
+    it "returns true if failed and not recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: false,
+      )
+      expect(outcome.failed_and_not_recorded?).to eql(true)
+    end
+
+    it "returns false if failed and recorded" do
+      outcome = described_class.new(
+        state: "failed",
+        sent_to_qualified_teachers_api_at: Time.zone.now,
+        qualified_teachers_api_request_successful: true,
+      )
+      expect(outcome.failed_and_not_recorded?).to eql(false)
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2317](https://dfedigital.atlassian.net/browse/CPDLP-2317)

### Changes proposed in this pull request

Update NPQ outcomes table in the finance application view to show details of an successful/unsuccessful request to the TRA.


[CPDLP-2317]: https://dfedigital.atlassian.net/browse/CPDLP-2317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ