### PR TITLE
Add `CONFIRM_PRODUCTION` check to deploy action

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -47,6 +47,7 @@ runs:
         make ci ${{ inputs.environment }} terraform-apply
         cd terraform/aks && echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
       env:
+        CONFIRM_PRODUCTION: ${{ vars.CONFIRM_PRODUCTION || "0" }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}


### PR DESCRIPTION
### Context

The var is set in the GitHub environment settings for production. It'll default to "0" for the non-production environments.
