### PR TITLE
Add `CONIFRM_PRODUCTION` to ci to allow deploying to prod in aks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ arm-deployment: set-azure-account set-azure-template-tag set-azure-resource-grou
 ci:	## Run in automation environment
 	$(eval SP_AUTH=true)
 	$(eval AUTO_APPROVE=-auto-approve)
+	$(eval CONFIRM_PRODUCTION=true)
 
 .PHONY: terraform-init
 terraform-init:


### PR DESCRIPTION
### Context
We call ci in the github action when deploying, however when deploying to prod we need to confirm production flag set

- Ticket: n/a

### Changes proposed in this pull request
Set the `CONFIRM_PRODUCTION` flag in ci to allow deploying to prod

### Guidance to review

