### PR TITLE
Add job to update the induction start dates from DQT for 2021/22 ECTs

### DIFF
--- a/app/jobs/set_participant_start_date_job.rb
+++ b/app/jobs/set_participant_start_date_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This is a one off job to update all of the induction start dates from DQT for
+# all of the 2021/2022 ECTs that do not currently have them.
+# It runs in batches of 200 as we have a 300 lookup per minute limit on the API
+# There are approx 57600 participants in this state currently
+class SetParticipantStartDateJob < ApplicationJob
+  def perform
+    ParticipantProfile::ECT
+      .joins(schedule: :cohort)
+      .eligible_status
+      .where(cohort: { start_year: [2021, 2022] })
+      .where(induction_start_date: nil)
+      .order(:created_at)
+      .limit(200)
+      .each do |participant_profile|
+        ActiveRecord::Base.no_touching do
+          Participants::SetStartDateFromDQT.call(participant_profile:)
+        end
+      end
+  rescue StandardError => e
+    Rails.logger.error("SetParticipantStartDateJob: #{e.message}")
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -33,3 +33,7 @@ send_outcomes_to_qualified_teachers_api:
   cron: "*/10 * * * *"
   class: "ParticipantOutcomes::BatchSendLatestOutcomesJob"
   queue: participant_outcomes
+set_participant_start_date_job:
+  cron: "*/2 0-8 * * *"
+  class: "SetParticipantStartDateJob"
+  queue: default


### PR DESCRIPTION
### Context

- Ticket: Follow on from #3819 to actually call the services and update the participants that are missing those dates.
- There are approx 58,000 ECTs in total from 2021 and 2022 when we didn't store the date.
- The job will run every 2 minutes from midnight to 8am.  This should do most if not all of these and keep within our 300 per minute quota.
- This job can then probably be removed.


