### PR TITLE
Upgrade to latest version of GOV.UK frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,6 @@ group :test do
   gem "shoulda-matchers", "~> 5.3"
   gem "simplecov"
   gem "site_prism", "~> 3.7"
-  gem "webdrivers", "~> 5.3"
   gem "webmock", "~> 3.18"
   gem "with_model"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ gem "mail-notify", "~> 1.1"
 # do not rely on host's timezone data, which can be inconsistent
 gem "tzinfo-data"
 
-gem "govuk-components", "~> 3.3"
-gem "govuk_design_system_formbuilder", "~> 3.3"
+gem "govuk-components", "~> 4.1.0"
+gem "govuk_design_system_formbuilder", "~> 4.1.1"
 gem "view_component", require: "view_component/engine"
 
 # Fetching from APIs
@@ -68,7 +68,7 @@ gem "savon", "~> 2.14"
 gem "strong_migrations", "~> 1.6"
 
 # Pagination
-gem "pagy", "~> 5.10", ">= 5.10.1"
+gem "pagy", "~> 6", ">= 6"
 
 # Json Schema for api validation
 gem "json-schema", ">= 2.8.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,20 +242,20 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-components (3.3.0)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
-      pagy (~> 5.10.1)
-      view_component (~> 2.74.1)
-    govuk_design_system_formbuilder (3.3.0)
+    govuk-components (4.1.0)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (~> 6.0)
+      view_component (~> 3.3.0)
+    govuk_design_system_formbuilder (4.1.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
+      html-attributes-utils (~> 1)
     gyoku (1.4.0)
       builder (>= 2.1.2)
       rexml (~> 3.0)
     hashdiff (1.0.1)
-    html-attributes-utils (0.9.2)
+    html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     httpclient (2.8.3)
     httpi (3.0.1)
@@ -338,8 +338,7 @@ GEM
       commonmarker (~> 0.17)
     orm_adapter (0.5.0)
     os (1.1.4)
-    pagy (5.10.1)
-      activesupport
+    pagy (6.0.4)
     paper_trail (12.3.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
@@ -592,8 +591,8 @@ GEM
     uber (0.1.0)
     unaccent (0.4.0)
     unicode-display_width (2.4.2)
-    view_component (2.74.1)
-      activesupport (>= 5.0.0, < 8.0)
+    view_component (3.3.0)
+      activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
     virtus (2.0.0)
@@ -661,8 +660,8 @@ DEPENDENCIES
   google-apis-drive_v3
   google-cloud-bigquery
   googleauth
-  govuk-components (~> 3.3)
-  govuk_design_system_formbuilder (~> 3.3)
+  govuk-components (~> 4.1.0)
+  govuk_design_system_formbuilder (~> 4.1.1)
   httpclient (~> 2.8, >= 2.8.3)
   jsbundling-rails
   json-diff (~> 0.4.1)
@@ -681,7 +680,7 @@ DEPENDENCIES
   net-smtp
   nokogiri
   openapi3_parser (~> 0.9.2)
-  pagy (~> 5.10, >= 5.10.1)
+  pagy (~> 6, >= 6)
   paper_trail
   parallel_tests
   pg (~> 1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,7 +513,7 @@ GEM
     scss_lint-govuk (0.2.0)
       scss_lint
     secure_headers (6.5.0)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -610,10 +610,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -723,7 +719,6 @@ DEPENDENCIES
   view_component
   wdm (~> 0.1)
   web-console (~> 4.2.0)
-  webdrivers (~> 5.3)
   webmock (~> 3.18)
   with_model
 

--- a/app/assets/stylesheets/search_box.scss
+++ b/app/assets/stylesheets/search_box.scss
@@ -18,24 +18,16 @@
   @include govuk-media-query($from: tablet) {
     &__form {
       display: flex;
+      gap: govuk-spacing(3);
       align-items: flex-end;
     }
 
     &__input {
       flex-grow: 1;
-
-      .govuk-form-group {
-        margin-bottom: 0;
-      }
-
-      &:nth-of-type(n+2) {
-        margin-left: govuk-spacing(3);
-      }
     }
 
     &__button {
       flex-grow: 0;
-      margin-left: govuk-spacing(3);
       transform: translateY(-2px);
     }
   }

--- a/app/components/admin/npq/participants/details.html.erb
+++ b/app/components/admin/npq/participants/details.html.erb
@@ -3,67 +3,67 @@
 </h2>
 
 <%= govuk_summary_list do |sl|
-  sl.row do |row|
-    row.key(text: "Participant name")
-    row.value(text: user_full_name)
+  sl.with_row do |row|
+    row.with_key(text: "Participant name")
+    row.with_value(text: user_full_name)
     unless npq_application.user.get_an_identity_id.present?
-    row.action(text: "Change",
+    row.with_action(text: "Change",
       href: edit_admin_participant_npq_change_full_name_path(profile),visually_hidden_text: "participant name")
   end
   end
 
-  sl.row do |row|
-    row.key(text: "Participant email")
-    row.value(text: user_email)
+  sl.with_row do |row|
+    row.with_key(text: "Participant email")
+    row.with_value(text: user_email)
     unless npq_application.user.get_an_identity_id.present?
-    row.action(text: "Change", href: edit_admin_participant_npq_change_email_path(profile), visually_hidden_text: "participant email address")
+    row.with_action(text: "Change", href: edit_admin_participant_npq_change_email_path(profile), visually_hidden_text: "participant email address")
   end
   end
 
   if profile_pending?
-    sl.row do |row|
-      row.key(text: "National Insurance number")
-      row.value(text: npq_application_nino)
+    sl.with_row do |row|
+      row.with_key(text: "National Insurance number")
+      row.with_value(text: npq_application_nino)
     end
 
-    sl.row do |row|
-      row.key(text: "Date of birth")
-      row.value(text: npq_application_date_of_birth.to_formatted_s(:govuk))
+    sl.with_row do |row|
+      row.with_key(text: "Date of birth")
+      row.with_value(text: npq_application_date_of_birth.to_formatted_s(:govuk))
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Teacher reference number")
-    row.value(text: npq_application_teacher_reference_number)
+  sl.with_row do |row|
+    row.with_key(text: "Teacher reference number")
+    row.with_value(text: npq_application_teacher_reference_number)
   end
 
-  sl.row do |row|
-    row.key(text: "School name")
-    row.value(text: school_name)
+  sl.with_row do |row|
+    row.with_key(text: "School name")
+    row.with_value(text: school_name)
   end
 
-  sl.row do |row|
-    row.key(text: "School URN")
-    row.value(text: school_urn)
+  sl.with_row do |row|
+    row.with_key(text: "School URN")
+    row.with_value(text: school_urn)
   end
 
-  sl.row do |row|
-    row.key(text: "Participant type")
-    row.value(text: t(:npq, scope: "schools.participants.type"))
+  sl.with_row do |row|
+    row.with_key(text: "Participant type")
+    row.with_value(text: t(:npq, scope: "schools.participants.type"))
   end
 
-  sl.row do |row|
-    row.key(text: "Provider")
-    row.value(text: npq_application.npq_lead_provider_name)
+  sl.with_row do |row|
+    row.with_key(text: "Provider")
+    row.with_value(text: npq_application.npq_lead_provider_name)
   end
 
-  sl.row do |row|
-    row.key(text: "NPQ course")
-    row.value(text: npq_application.npq_course_name)
+  sl.with_row do |row|
+    row.with_key(text: "NPQ course")
+    row.with_value(text: npq_application.npq_course_name)
   end
 
-  sl.row do |row|
-    row.key(text: "Last updated")
-    row.value(text: last_updated)
+  sl.with_row do |row|
+    row.with_key(text: "Last updated")
+    row.with_value(text: last_updated)
   end
 end %>

--- a/app/components/admin/participants/identities.html.erb
+++ b/app/components/admin/participants/identities.html.erb
@@ -6,24 +6,24 @@
   <h3><%= "Identity #{i} (#{identity_transferred_label(identity)})" %></h3>
 
   <%= govuk_summary_list do |summary_list| %>
-    <% summary_list.row do |row| %>
-      <% row.key(text: "User ID / Participant ID" ) %>
-      <% row.value(text: tag.code(identity.user_id) ) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: "User ID / Participant ID" ) %>
+      <% row.with_value(text: tag.code(identity.user_id) ) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key(text: "External ID" ) %>
-      <% row.value(text: tag.code(identity.external_identifier) ) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: "External ID" ) %>
+      <% row.with_value(text: tag.code(identity.external_identifier) ) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key(text: "Email" ) %>
-      <% row.value(text: identity.email ) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: "Email" ) %>
+      <% row.with_value(text: identity.email ) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key(text: "Origin" ) %>
-      <% row.value(text: identity.origin ) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key(text: "Origin" ) %>
+      <% row.with_value(text: identity.origin ) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/admin/schools/cohorts/cohort.html.erb
+++ b/app/components/admin/schools/cohorts/cohort.html.erb
@@ -7,13 +7,13 @@
     <% ci.summary_list_rows do %>
       <%=
         render(GovukComponent::SummaryListComponent::RowComponent.new) do |row|
-          row.key(text: "Lead provider")
-          row.value(text: partnership.lead_provider.name)
+          row.with_key(text: "Lead provider")
+          row.with_value(text: partnership.lead_provider.name)
         end
 
         render(GovukComponent::SummaryListComponent::RowComponent.new) do |row|
-          row.key(text: "Delivery partner")
-          row.value(text: partnership.delivery_partner.name)
+          row.with_key(text: "Delivery partner")
+          row.with_value(text: partnership.delivery_partner.name)
         end
       %>
     <% end %>
@@ -29,19 +29,19 @@
     <% relationships.each do |relationship| %>
       <%=
         govuk_summary_list do |sl|
-          sl.row do |row|
-            row.key(text: "Lead provider")
-            row.value(text: relationship.lead_provider.name)
+          sl.with_row do |row|
+            row.with_key(text: "Lead provider")
+            row.with_value(text: relationship.lead_provider.name)
           end
 
-          sl.row do |row|
-            row.key(text: "Delivery partner")
-            row.value(text: relationship.delivery_partner.name)
+          sl.with_row do |row|
+            row.with_key(text: "Delivery partner")
+            row.with_value(text: relationship.delivery_partner.name)
           end
 
-          sl.row do |row|
-            row.key(text: "Participants")
-            row.value do
+          sl.with_row do |row|
+            row.with_key(text: "Participants")
+            row.with_value do
               helpers.html_list(
                 relationship
                   .induction_programmes

--- a/app/components/finance/additional_adjustments/table.html.erb
+++ b/app/components/finance/additional_adjustments/table.html.erb
@@ -6,20 +6,20 @@
       <% row.with_cell(header: true, text: "Payment type") %>
       <% row.with_cell(header: true, text: "Payments", numeric: true) %>
     <% end %>
+  <% end %>
 
-    <% table.with_body do |body| %>
-      <% adjustments.each do |adjustment| %>
-        <% body.with_row do |row| %>
-          <% row.with_cell(text: adjustment.payment_type) %>
-          <% row.with_cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
-        <% end %>
+  <% table.with_body do |body| %>
+    <% adjustments.each do |adjustment| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: adjustment.payment_type) %>
+        <% row.with_cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
       <% end %>
+    <% end %>
 
-      <% if adjustments.empty? %>
-        <% body.with_row do |row| %>
-          <% row.with_cell(text: "") %>
-          <% row.with_cell(text: number_to_pounds(0), numeric: true) %>
-        <% end %>
+    <% if adjustments.empty? %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: "") %>
+        <% row.with_cell(text: number_to_pounds(0), numeric: true) %>
       <% end %>
     <% end %>
   <% end %>
@@ -43,7 +43,7 @@
 
   <div class="govuk-grid-column-one-half govuk-!-text-align-right govuk-heading-s">
     Total
-    <br/>
+    <br />
     <%= number_to_pounds(total_amount) %>
   </div>
 </div>

--- a/app/components/finance/additional_adjustments/table.html.erb
+++ b/app/components/finance/additional_adjustments/table.html.erb
@@ -1,24 +1,24 @@
 <%= govuk_table do |table| %>
   <% table.caption(size: "s", text: "Additional adjustments") %>
 
-  <% table.head do |head| %>
-    <% head.row do |row| %>
-      <% row.cell(header: true, text: "Payment type") %>
-      <% row.cell(header: true, text: "Payments", numeric: true) %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(header: true, text: "Payment type") %>
+      <% row.with_cell(header: true, text: "Payments", numeric: true) %>
     <% end %>
 
     <% table.body do |body| %>
       <% adjustments.each do |adjustment| %>
-        <% body.row do |row| %>
-          <% row.cell(text: adjustment.payment_type) %>
-          <% row.cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: adjustment.payment_type) %>
+          <% row.with_cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
         <% end %>
       <% end %>
 
       <% if adjustments.empty? %>
-        <% body.row do |row| %>
-          <% row.cell(text: "") %>
-          <% row.cell(text: number_to_pounds(0), numeric: true) %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: "") %>
+          <% row.with_cell(text: number_to_pounds(0), numeric: true) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/finance/additional_adjustments/table.html.erb
+++ b/app/components/finance/additional_adjustments/table.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_table do |table| %>
-  <% table.caption(size: "s", text: "Additional adjustments") %>
+  <% table.with_caption(size: "s", text: "Additional adjustments") %>
 
   <% table.with_head do |head| %>
     <% head.with_row do |row| %>
@@ -7,7 +7,7 @@
       <% row.with_cell(header: true, text: "Payments", numeric: true) %>
     <% end %>
 
-    <% table.body do |body| %>
+    <% table.with_body do |body| %>
       <% adjustments.each do |adjustment| %>
         <% body.with_row do |row| %>
           <% row.with_cell(text: adjustment.payment_type) %>

--- a/app/components/primary_nav_component.rb
+++ b/app/components/primary_nav_component.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PrimaryNavComponent < ViewComponent::Base
-  include ViewComponent::SlotableV2
   attr_reader :wide
 
   renders_many :nav_items, "NavItemComponent"

--- a/app/components/school_recruited_transition_component.html.erb
+++ b/app/components/school_recruited_transition_component.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_notification_banner(title_text: "Important") do |banner| %>
-  <% banner.heading(text: "#{delivery_partner.name}, with #{lead_provider.name}, has confirmed your school.") %>
+  <% banner.with_heading(text: "#{delivery_partner.name}, with #{lead_provider.name}, has confirmed your school.") %>
   <p>This means they will be delivering an induction programme to your early career teachers, starting in
     <%= cohort.start_year %>.</p>
   <p>If this is a

--- a/app/components/status_tags/appropriate_body_participant_status_tag.rb
+++ b/app/components/status_tags/appropriate_body_participant_status_tag.rb
@@ -9,21 +9,21 @@ module StatusTags
     end
 
     def label
-      t :label, scope: translation_scope
+      I18n.t :label, scope: translation_scope
     end
 
     def id
-      t :id, scope: translation_scope
+      I18n.t :id, scope: translation_scope
     end
 
     def description
-      Array.wrap(t(:description, scope: translation_scope, contact_us: render(MailToSupportComponent.new("contact us")))).map(&:html_safe)
+      Array.wrap(I18n.t(:description, scope: translation_scope, contact_us: render(MailToSupportComponent.new("contact us")))).map(&:html_safe)
     rescue I18n::MissingTranslationData
       []
     end
 
     def colour
-      t :colour, scope: translation_scope
+      I18n.t :colour, scope: translation_scope
     end
 
   private

--- a/app/components/status_tags/delivery_partner_participant_status_tag.rb
+++ b/app/components/status_tags/delivery_partner_participant_status_tag.rb
@@ -9,11 +9,11 @@ module StatusTags
     end
 
     def label
-      t :label, scope: translation_scope
+      I18n.t :label, scope: translation_scope
     end
 
     def id
-      t :id, scope: translation_scope
+      I18n.t :id, scope: translation_scope
     end
 
     def description
@@ -23,7 +23,7 @@ module StatusTags
     end
 
     def colour
-      t :colour, scope: translation_scope
+      I18n.t :colour, scope: translation_scope
     end
 
   private

--- a/app/components/subnav_component.rb
+++ b/app/components/subnav_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SubnavComponent < BaseComponent
-  include ViewComponent::SlotableV2
-
   renders_many :nav_items, "NavItemComponent"
 
   class NavItemComponent < BaseComponent

--- a/app/helpers/finance/ecf/duplicates_helper.rb
+++ b/app/helpers/finance/ecf/duplicates_helper.rb
@@ -12,46 +12,46 @@ module Finance
       end
 
       def header_row_for(row)
-        row.cell(header: true, text: "Profile type")
-        row.cell(header: true, text: "Participant ID")
-        row.cell(header: true, text: "Profile ID")
-        row.cell(header: true, text: "TRN")
-        row.cell(header: true, text: "Cohort")
-        row.cell(header: true, text: "Schedule")
-        row.cell(header: true, text: "Induction status")
-        row.cell(header: true, text: "Training status")
-        row.cell(header: true, text: "Lead Provider")
-        row.cell(header: true, text: "School")
-        row.cell(header: true, text: "Starts on")
-        row.cell(header: true, text: "Ends on")
-        row.cell(header: true, text: "Declaration count")
+        row.with_cell(header: true, text: "Profile type")
+        row.with_cell(header: true, text: "Participant ID")
+        row.with_cell(header: true, text: "Profile ID")
+        row.with_cell(header: true, text: "TRN")
+        row.with_cell(header: true, text: "Cohort")
+        row.with_cell(header: true, text: "Schedule")
+        row.with_cell(header: true, text: "Induction status")
+        row.with_cell(header: true, text: "Training status")
+        row.with_cell(header: true, text: "Lead Provider")
+        row.with_cell(header: true, text: "School")
+        row.with_cell(header: true, text: "Starts on")
+        row.with_cell(header: true, text: "Ends on")
+        row.with_cell(header: true, text: "Declaration count")
       end
 
       def row_for(row, participant_profile)
-        row.cell { tag_for(participant_profile) }
-        row.cell do
+        row.with_cell { tag_for(participant_profile) }
+        row.with_cell do
           participant_profile.participant_id
         end
-        row.cell(text: participant_profile.id)
-        row.cell(text: participant_profile.teacher_profile_trn.to_s)
-        row.cell(text: participant_profile.cohort)
-        row.cell(text: participant_profile.schedule_identifier)
-        row.cell(text: participant_profile.induction_status)
-        row.cell(text: participant_profile.training_status)
-        row.cell(text: participant_profile.provider_name)
-        row.cell(text: participant_profile.school_name)
-        row.cell(text: participant_profile.start_date.to_fs(:govuk))
-        row.cell(text: participant_profile.end_date&.to_fs(:govuk))
-        row.cell(text: participant_profile.declaration_count)
+        row.with_cell(text: participant_profile.id)
+        row.with_cell(text: participant_profile.teacher_profile_trn.to_s)
+        row.with_cell(text: participant_profile.cohort)
+        row.with_cell(text: participant_profile.schedule_identifier)
+        row.with_cell(text: participant_profile.induction_status)
+        row.with_cell(text: participant_profile.training_status)
+        row.with_cell(text: participant_profile.provider_name)
+        row.with_cell(text: participant_profile.school_name)
+        row.with_cell(text: participant_profile.start_date.to_fs(:govuk))
+        row.with_cell(text: participant_profile.end_date&.to_fs(:govuk))
+        row.with_cell(text: participant_profile.declaration_count)
       end
 
       def comparative_table_row_for(primary_profile:, duplicate_profile:, header:, row:, method:)
         primary_value = primary_profile.public_send(method)
         duplicate_value = duplicate_profile.public_send(method)
         classes = primary_value == duplicate_value ? [] : ["govuk-tag--red"]
-        row.cell(header: true, text: header)
-        row.cell(text: primary_value, classes:)
-        row.cell(text: duplicate_value, classes:)
+        row.with_cell(header: true, text: header)
+        row.with_cell(text: primary_value, classes:)
+        row.with_cell(text: duplicate_value, classes:)
       end
     end
   end

--- a/app/helpers/finance_helper.rb
+++ b/app/helpers/finance_helper.rb
@@ -16,13 +16,13 @@ module FinanceHelper
 
   def change_induction_record_training_status_button(induction_record, participant_profile, row)
     if latest_induction_record_for_provider?(induction_record, participant_profile)
-      row.action(
+      row.with_action(
         text: "Change",
         visually_hidden_text: "training status",
         href: new_finance_participant_profile_ecf_induction_records_path(participant_profile.id, induction_record.id),
       )
     else
-      row.action(text: :none)
+      row.with_action(text: :none)
     end
   end
 

--- a/app/views/admin/appropriate_bodies/_heading.html.erb
+++ b/app/views/admin/appropriate_bodies/_heading.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-l">Appropriate bodies</h1>
 
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_appropriate_bodies_users_path) do %>
+  <%= component.with_nav_item(path: admin_appropriate_bodies_users_path) do %>
     All users
   <% end %>
 <% end %>

--- a/app/views/admin/delivery_partners/_heading.html.erb
+++ b/app/views/admin/delivery_partners/_heading.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-l">Delivery partners</h1>
 
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_delivery_partners_users_path) do %>
+  <%= component.with_nav_item(path: admin_delivery_partners_users_path) do %>
     All users
   <% end %>
 <% end %>

--- a/app/views/admin/npq/applications/_application_details.html.erb
+++ b/app/views/admin/npq/applications/_application_details.html.erb
@@ -1,78 +1,78 @@
 <h2 class="govuk-heading-m">Application details</h2>
 <%=
   govuk_summary_list do |sl|
-    sl.row do |row|
-      row.key(text: 'Application ID')
-      row.value(text: application.id || govuk_tag(text: "Missing", colour: "red"))
+    sl.with_row do |row|
+      row.with_key(text: 'Application ID')
+      row.with_value(text: application.id || govuk_tag(text: "Missing", colour: "red"))
     end
 
-    sl.row do |row|
-      row.key(text: 'User ID')
-      row.value(text: application.user.id || govuk_tag(text: "Missing", colour: "red"))
+    sl.with_row do |row|
+      row.with_key(text: 'User ID')
+      row.with_value(text: application.user.id || govuk_tag(text: "Missing", colour: "red"))
     end
 
-    sl.row do |row|
-      row.key(text: 'GAI ID')
-      row.value(text: application.user.get_an_identity_id || '-')
+    sl.with_row do |row|
+      row.with_key(text: 'GAI ID')
+      row.with_value(text: application.user.get_an_identity_id || '-')
     end
 
-    sl.row do |row|
-      row.key(text: 'External ID')
-      row.value(text: application.participant_identity.external_identifier || '-')
+    sl.with_row do |row|
+      row.with_key(text: 'External ID')
+      row.with_value(text: application.participant_identity.external_identifier || '-')
     end
 
-    sl.row do |row|
-      row.key(text: 'Proflie ID')
+    sl.with_row do |row|
+      row.with_key(text: 'Proflie ID')
       if application.profile.present?
-        row.value(text: application.profile_id)
+        row.with_value(text: application.profile_id)
       else
-        row.value(text: '-')
+        row.with_value(text: '-')
       end
     end
 
-    sl.row do |row|
-      row.key(text: 'Email')
-      row.value(text: application.user.email)
+    sl.with_row do |row|
+      row.with_key(text: 'Email')
+      row.with_value(text: application.user.email)
       unless application.user.get_an_identity_id.present?
-        row.action(
+        row.with_action(
           href: edit_admin_npq_applications_change_email_path(application),
         )
       end
     end
 
-    sl.row do |row|
-      row.key(text: 'Preferred name')
-      row.value(text: application.user.full_name)
+    sl.with_row do |row|
+      row.with_key(text: 'Preferred name')
+      row.with_value(text: application.user.full_name)
       unless application.user.get_an_identity_id.present?
-        row.action(
+        row.with_action(
           href: edit_admin_npq_applications_change_name_path(application),
         )
       end
     end
 
-    sl.row do |row|
-      row.key(text: 'TRN')
-      row.value(text: application.teacher_reference_number || '-')
+    sl.with_row do |row|
+      row.with_key(text: 'TRN')
+      row.with_value(text: application.teacher_reference_number || '-')
     end
 
-    sl.row do |row|
-      row.key(text: 'TRN validated')
-      row.value { boolean_red_green_tag(application.teacher_reference_number_verified) }
+    sl.with_row do |row|
+      row.with_key(text: 'TRN validated')
+      row.with_value { boolean_red_green_tag(application.teacher_reference_number_verified) }
     end
 
-    sl.row do |row|
-      row.key(text: 'Course')
-      row.value(text: application.npq_course.name)
+    sl.with_row do |row|
+      row.with_key(text: 'Course')
+      row.with_value(text: application.npq_course.name)
     end
 
-    sl.row do |row|
-      row.key(text: 'Lead provider')
-      row.value(text: application.npq_lead_provider.name)
+    sl.with_row do |row|
+      row.with_key(text: 'Lead provider')
+      row.with_value(text: application.npq_lead_provider.name)
     end
 
-    sl.row do |row|
-      row.key(text: 'Lead provider approval status')
-      row.value(text: application.lead_provider_approval_status)
+    sl.with_row do |row|
+      row.with_key(text: 'Lead provider approval status')
+      row.with_value(text: application.lead_provider_approval_status)
     end
   end
 %>

--- a/app/views/admin/npq/applications/_employment_details.html.erb
+++ b/app/views/admin/npq/applications/_employment_details.html.erb
@@ -1,52 +1,52 @@
 <h2 class="govuk-heading-m">Employment details</h2>
 <%=
   govuk_summary_list do |sl|
-    sl.row do |row|
-      row.key(text: 'School URN')
-      row.value(text: application.school_urn || '-')
+    sl.with_row do |row|
+      row.with_key(text: 'School URN')
+      row.with_value(text: application.school_urn || '-')
       if application.school.present?
-        row.action(text: "View School", href: admin_school_path(application.school))
+        row.with_action(text: "View School", href: admin_school_path(application.school))
       end
     end
 
-    sl.row do |row|
-      row.key(text: 'School UKPRN')
-      row.value(text: application.school_ukprn || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'School UKPRN')
+      row.with_value(text: application.school_ukprn || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'Private Childcare Provider URN')
-      row.value(text: application.private_childcare_provider_urn || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Private Childcare Provider URN')
+      row.with_value(text: application.private_childcare_provider_urn || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'Headteacher status')
-      row.value(text: application.headteacher_status || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Headteacher status')
+      row.with_value(text: application.headteacher_status || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'Employer name')
-      row.value(text: application.employer_name || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Employer name')
+      row.with_value(text: application.employer_name || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'Employment role')
-      row.value(text: application.employment_role || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Employment role')
+      row.with_value(text: application.employment_role || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'ITT Lead mentor')
-      row.value { boolean_red_green_tag(application.lead_mentor?) }
+    sl.with_row do |row|
+      row.with_key(text: 'ITT Lead mentor')
+      row.with_value { boolean_red_green_tag(application.lead_mentor?) }
     end
 
-    sl.row do |row|
-      row.key(text: 'ITT provider')
-      row.value(text: application.itt_provider || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'ITT provider')
+      row.with_value(text: application.itt_provider || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'Country')
-      row.value(text: application.teacher_catchment_country || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Country')
+      row.with_value(text: application.teacher_catchment_country || "-")
     end
 
 

--- a/app/views/admin/npq/applications/_funding_eligibility.html.erb
+++ b/app/views/admin/npq/applications/_funding_eligibility.html.erb
@@ -1,70 +1,70 @@
 <h2 class="govuk-heading-m">Funding eligibility</h2>
 <%=
   govuk_summary_list do |sl|
-    sl.row do |row|
-      row.key(text: 'Funding eligibility')
-      row.value(text: boolean_red_green_tag(application.eligible_for_funding))
+    sl.with_row do |row|
+      row.with_key(text: 'Funding eligibility')
+      row.with_value(text: boolean_red_green_tag(application.eligible_for_funding))
     end
 
-    sl.row do |row|
-      row.key(text: 'Funding eligibility status code')
-      row.value(text: application.funding_eligiblity_status_code || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Funding eligibility status code')
+      row.with_value(text: application.funding_eligiblity_status_code || "-")
     end
 
-    sl.row do |row|
-      row.key(text: 'Primary establishment')
-      row.value{ boolean_red_green_tag(application.primary_establishment) }
-      row.action
+    sl.with_row do |row|
+      row.with_key(text: 'Primary establishment')
+      row.with_value{ boolean_red_green_tag(application.primary_establishment) }
+      row.with_action
     end
 
-    sl.row do |row|
-      row.key(text: 'Number of pupils')
-      row.value(text: application.number_of_pupils.to_i)
-      row.action
+    sl.with_row do |row|
+      row.with_key(text: 'Number of pupils')
+      row.with_value(text: application.number_of_pupils.to_i)
+      row.with_action
     end
 
-    sl.row do |row|
-      row.key(text: 'Targeted support funding primary plus eligibility')
-      row.value{ boolean_red_green_tag(application.tsf_primary_plus_eligibility) }
-      row.action
+    sl.with_row do |row|
+      row.with_key(text: 'Targeted support funding primary plus eligibility')
+      row.with_value{ boolean_red_green_tag(application.tsf_primary_plus_eligibility) }
+      row.with_action
     end
 
-    sl.row do |row|
-      row.key(text: "Targeted delivery funding eligibility")
-      row.value { boolean_red_green_tag(application.targeted_delivery_funding_eligibility) }
+    sl.with_row do |row|
+      row.with_key(text: "Targeted delivery funding eligibility")
+      row.with_value { boolean_red_green_tag(application.targeted_delivery_funding_eligibility) }
     end
 
-    sl.row do |row|
-      row.key(text: 'Funding choice')
-      row.value(text: application.funding_choice&.capitalize || "-")
+    sl.with_row do |row|
+      row.with_key(text: 'Funding choice')
+      row.with_value(text: application.funding_choice&.capitalize || "-")
     end
 
-    sl.row do |row|
-      row.key(text: "Schedule Cohort")
+    sl.with_row do |row|
+      row.with_key(text: "Schedule Cohort")
       if application.cohort.present?
-        row.value(text: application.cohort.try(:start_year).to_s)
+        row.with_value(text: application.cohort.try(:start_year).to_s)
       else
-        row.value(text: "-" )
+        row.with_value(text: "-" )
       end
     end
 
-    sl.row do |row|
-      row.key(text: 'Schedule identifier')
+    sl.with_row do |row|
+      row.with_key(text: 'Schedule identifier')
       if application.profile.present?
-        row.value(text: application.profile.schedule.schedule_identifier)
+        row.with_value(text: application.profile.schedule.schedule_identifier)
       else
-        row.value(text: '-')
+        row.with_value(text: '-')
       end
     end
 
-    sl.row do |row|
-      row.key(text: "Created at")
-      row.value { l application.created_at, format: :admin }
+    sl.with_row do |row|
+      row.with_key(text: "Created at")
+      row.with_value { l application.created_at, format: :admin }
     end
 
-    sl.row do |row|
-      row.key(text: "Updated at")
-      row.value { l application.updated_at, format: :admin }
+    sl.with_row do |row|
+      row.with_key(text: "Updated at")
+      row.with_value { l application.updated_at, format: :admin }
     end
   end
 %>

--- a/app/views/admin/npq/applications/_layout.html.erb
+++ b/app/views/admin/npq/applications/_layout.html.erb
@@ -1,16 +1,16 @@
 <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_npq_applications_applications_path) do %>
+  <%= component.with_nav_item(path: admin_npq_applications_applications_path) do %>
     <%= t(".applications") %>
   <% end %>
-  <%= component.nav_item(path: admin_npq_applications_edge_cases_path) do %>
+  <%= component.with_nav_item(path: admin_npq_applications_edge_cases_path) do %>
     <%= t(".edge_cases") %>
   <% end %>
-  <%= component.nav_item(path: admin_npq_applications_eligibility_imports_path) do %>
+  <%= component.with_nav_item(path: admin_npq_applications_eligibility_imports_path) do %>
     <%= t(".eligibility_imports") %>
   <% end %>
-  <%= component.nav_item(path: admin_npq_applications_exports_path) do %>
+  <%= component.with_nav_item(path: admin_npq_applications_exports_path) do %>
     <%= t(".exports") %>
   <% end %>
 <% end %>

--- a/app/views/admin/npq/applications/_teacher_profile_details.html.erb
+++ b/app/views/admin/npq/applications/_teacher_profile_details.html.erb
@@ -1,9 +1,9 @@
 <h2 class="govuk-heading-m">Teacher Profile details</h2>
 <%=
   govuk_summary_list do |sl|
-    sl.row do |row|
-      row.key(text: 'Teacher profile TRN')
-      row.value(text: teacher_profile&.trn || '-')
+    sl.with_row do |row|
+      row.with_key(text: 'Teacher profile TRN')
+      row.with_value(text: teacher_profile&.trn || '-')
     end
   end
 %>

--- a/app/views/admin/npq/applications/edge_cases/index.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/index.html.erb
@@ -1,6 +1,6 @@
 <%= render "admin/npq/applications/layout", locals = { page: "applications" } %>
 
-<%= render SearchBoxWithDateRange.new( 
+<%= render SearchBoxWithDateRange.new(
   query: params[:query],
   title: "Enter the Applicant’s ID, Name, Email, Employer's Name, TRN or Application Id",
   filters: [
@@ -40,28 +40,28 @@
 
 <%=
   govuk_table do |table|
-    table.head do |head|
-      head.row do |row|
-        row.cell(header: true, text: "Name")
-        row.cell(header: true, text: "Eligible for funding")
-        row.cell(header: true, text: "Funding eligibility status code")
-        row.cell(header: true, text: "Employment type")
-        row.cell(header: true, text: "Employer name")
-        row.cell(header: true, text: "Role")
-        row.cell(header: true, text: "Registration submitted date")
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(header: true, text: "Name")
+        row.with_cell(header: true, text: "Eligible for funding")
+        row.with_cell(header: true, text: "Funding eligibility status code")
+        row.with_cell(header: true, text: "Employment type")
+        row.with_cell(header: true, text: "Employer name")
+        row.with_cell(header: true, text: "Role")
+        row.with_cell(header: true, text: "Registration submitted date")
       end
-    end 
+    end
 
-    table.body do |body|
+    table.with_body do |body|
       @npq_applications.each do |application|
-        body.row do |row|
-          row.cell(text: govuk_link_to(application.user.full_name, admin_npq_applications_edge_case_path(application)), classes: 'applicant-name')
-          row.cell(text: boolean_red_green_tag(application.eligible_for_funding))
-          row.cell(text: application.funding_eligiblity_status_code&.humanize&.downcase)
-          row.cell(text: application.employment_type&.humanize || '-')
-          row.cell(text: application.employer_name || '-')
-          row.cell(text: application.employment_role&.humanize&.downcase || '-')
-          row.cell(text: application.created_at.to_fs(:govuk_short))
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(application.user.full_name, admin_npq_applications_edge_case_path(application)), classes: 'applicant-name')
+          row.with_cell(text: boolean_red_green_tag(application.eligible_for_funding))
+          row.with_cell(text: application.funding_eligiblity_status_code&.humanize&.downcase)
+          row.with_cell(text: application.employment_type&.humanize || '-')
+          row.with_cell(text: application.employer_name || '-')
+          row.with_cell(text: application.employment_role&.humanize&.downcase || '-')
+          row.with_cell(text: application.created_at.to_fs(:govuk_short))
         end
       end
     end

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -4,60 +4,60 @@
 
 <%=
   govuk_summary_list do |sl|
-    sl.row do |row|
-      row.key(text: "Participant ID")
-      row.value(text: @npq_application.profile_id)
+    sl.with_row do |row|
+      row.with_key(text: "Participant ID")
+      row.with_value(text: @npq_application.profile_id)
     end
 
-    sl.row do |row|
-      row.key(text: "Application ID")
-      row.value(text: @npq_application.id)
+    sl.with_row do |row|
+      row.with_key(text: "Application ID")
+      row.with_value(text: @npq_application.id)
     end
 
-    sl.row do |row|
-      row.key(text: "Email")
-      row.value(text: @npq_application.user.email)
+    sl.with_row do |row|
+      row.with_key(text: "Email")
+      row.with_value(text: @npq_application.user.email)
     end
 
-    sl.row do |row|
-      row.key(text: "NPQ course name")
-      row.value(text: @npq_application.npq_course_name)
+    sl.with_row do |row|
+      row.with_key(text: "NPQ course name")
+      row.with_value(text: @npq_application.npq_course_name)
     end
 
-    sl.row do |row|
-      row.key(text: "Lead provider")
-      row.value(text: @npq_application.npq_lead_provider.name)
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: @npq_application.npq_lead_provider.name)
     end
 
-    sl.row do |row|
-      row.key(text: "Lead provider approval status")
-      row.value(text: @npq_application.lead_provider_approval_status)
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider approval status")
+      row.with_value(text: @npq_application.lead_provider_approval_status)
     end
 
-    sl.row do |row|
-      row.key(text: "Employment type")
-      row.value(text: @npq_application.employment_type&.humanize || "-")
+    sl.with_row do |row|
+      row.with_key(text: "Employment type")
+      row.with_value(text: @npq_application.employment_type&.humanize || "-")
     end
 
-    sl.row do |row|
-      row.key(text: "Employment name")
-      row.value(text: @npq_application.employer_name&.humanize || "-")
+    sl.with_row do |row|
+      row.with_key(text: "Employment name")
+      row.with_value(text: @npq_application.employer_name&.humanize || "-")
     end
 
-    sl.row do |row|
-      row.key(text: "Employment role")
-      row.value(text: @npq_application.employment_role&.humanize || "-")
+    sl.with_row do |row|
+      row.with_key(text: "Employment role")
+      row.with_value(text: @npq_application.employment_role&.humanize || "-")
     end
 
-    sl.row do |row|
-      row.key(text: "Application submitted date")
-      row.value(text: @npq_application.created_at.to_fs(:govuk_short))
+    sl.with_row do |row|
+      row.with_key(text: "Application submitted date")
+      row.with_value(text: @npq_application.created_at.to_fs(:govuk_short))
     end
 
-    sl.row do |row|
-      row.key(text: "Last updated date")
-      row.value(text: @npq_application.updated_at.to_fs(:govuk_short))
-      row.action(
+    sl.with_row do |row|
+      row.with_key(text: "Last updated date")
+      row.with_value(text: @npq_application.updated_at.to_fs(:govuk_short))
+      row.with_action(
         text: 'View change log',
         href:  admin_npq_applications_application_change_logs_path(@npq_application),
       ) if @npq_application.change_logs.any?
@@ -70,15 +70,15 @@
 <%=
   govuk_summary_list do |sl|
     if (@npq_application.declared_as_billable? && @npq_application.eligible_for_funding)
-      sl.row do |row|
-        row.key(text: "Eligible for funding")
-        row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
+      sl.with_row do |row|
+        row.with_key(text: "Eligible for funding")
+        row.with_value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
       end
     else
-      sl.row do |row|
-        row.key(text: "Eligible for funding")
-        row.value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
-        row.action(
+      sl.with_row do |row|
+        row.with_key(text: "Eligible for funding")
+        row.with_value(text: boolean_red_green_tag(@npq_application.eligible_for_funding))
+        row.with_action(
           text: 'Edit',
           href: edit_admin_npq_applications_eligible_for_funding_path(@npq_application),
           visually_hidden_text: "NPQ application"
@@ -86,23 +86,23 @@
       end
     end
 
-    sl.row do |row|
-      row.key(text: "Funding eligibility status code")
+    sl.with_row do |row|
+      row.with_key(text: "Funding eligibility status code")
       if @npq_application.eligible_for_funding?
-        row.value(text: @npq_application.funding_eligiblity_status_code&.humanize)
+        row.with_value(text: @npq_application.funding_eligiblity_status_code&.humanize)
       else
-        row.value(text: @npq_application.funding_eligiblity_status_code&.humanize)
-        row.action(
+        row.with_value(text: @npq_application.funding_eligiblity_status_code&.humanize)
+        row.with_action(
           text: 'Edit',
           href: edit_admin_npq_applications_eligibility_status_path(@npq_application)
         )
       end
     end
-    sl.row do |row|
-      row.key(text: "Notes")
+    sl.with_row do |row|
+      row.with_key(text: "Notes")
 
       notes_present = @npq_application.notes.present?
-      row.value do
+      row.with_value do
         if notes_present
           simple_format(@npq_application.notes, class: "govuk-body")
         else
@@ -112,7 +112,7 @@
 
       user = @npq_application.user
 
-      row.action(
+      row.with_action(
         text: notes_present ? "Change notes" : "Add notes",
         href: edit_admin_npq_applications_note_path(@npq_application),
         visually_hidden_text: notes_present ? "on #{user.full_name}'s profile" : "to #{user.full_name}'s profile",

--- a/app/views/admin/npq/applications/edge_cases/show.html.erb
+++ b/app/views/admin/npq/applications/edge_cases/show.html.erb
@@ -98,6 +98,32 @@
         )
       end
     end
+
+    sl.with_row do |row|
+      row.with_key(text: "Employment type")
+      row.with_value(text: @npq_application.employment_type&.humanize || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Employment name")
+      row.with_value(text: @npq_application.employer_name&.humanize || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Employment role")
+      row.with_value(text: @npq_application.employment_role&.humanize || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Created at")
+      row.with_value(text: @npq_application.created_at.to_fs(:govuk_short))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Updated at")
+      row.with_value(text: @npq_application.updated_at.to_fs(:govuk_short))
+    end
+
     sl.with_row do |row|
       row.with_key(text: "Notes")
 

--- a/app/views/admin/npq/applications/show.html.erb
+++ b/app/views/admin/npq/applications/show.html.erb
@@ -8,7 +8,7 @@
 <h1 class="govuk-heading-l"><%= title ||= t(".title") %></h1>
 
 <%= govuk_tabs(title: t(".tabs")) do |c| %>
-  <%= c.tab(label: t(".details")) do %>
+  <%= c.with_tab(label: t(".details")) do %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <%= render "application_details", application: @application %>

--- a/app/views/admin/participants/_cohorts.html.erb
+++ b/app/views/admin/participants/_cohorts.html.erb
@@ -3,14 +3,14 @@
 <% end %>
 
 <%= govuk_summary_list do |sl|
-  sl.row do |row|
-    row.key(text: "Cohort (via induction record)")
-    row.value(text: latest_induction_record&.cohort&.start_year)
+  sl.with_row do |row|
+    row.with_key(text: "Cohort (via induction record)")
+    row.with_value(text: latest_induction_record&.cohort&.start_year)
   end
 
-  sl.row do |row|
-    row.key(text: "Cohort (via schedule)")
-    row.value(text: latest_induction_record&.schedule&.cohort&.start_year)
+  sl.with_row do |row|
+    row.with_key(text: "Cohort (via schedule)")
+    row.with_value(text: latest_induction_record&.schedule&.cohort&.start_year)
   end
 end %>
 

--- a/app/views/admin/participants/_declarations_history.erb
+++ b/app/views/admin/participants/_declarations_history.erb
@@ -5,59 +5,59 @@
 
   <%=
     govuk_summary_list do |sl|
-      sl.row do |row|
-        row.key(text: "Declaration type")
-        row.value(text: participant_declaration.declaration_type)
+      sl.with_row do |row|
+        row.with_key(text: "Declaration type")
+        row.with_value(text: participant_declaration.declaration_type)
       end
 
-      sl.row do |row|
-        row.key(text: "Declaration date")
-        row.value(text: participant_declaration.declaration_date.to_formatted_s(:govuk))
+      sl.with_row do |row|
+        row.with_key(text: "Declaration date")
+        row.with_value(text: participant_declaration.declaration_date.to_formatted_s(:govuk))
       end
 
-      sl.row do |row|
-        row.key(text: "Course identifier")
-        row.value(text: participant_declaration.course_identifier)
+      sl.with_row do |row|
+        row.with_key(text: "Course identifier")
+        row.with_value(text: participant_declaration.course_identifier)
       end
 
-      sl.row do |row|
-        row.key(text: "Evidence held")
-        row.value(text: participant_declaration.evidence_held)
+      sl.with_row do |row|
+        row.with_key(text: "Evidence held")
+        row.with_value(text: participant_declaration.evidence_held)
       end
 
-      sl.row do |row|
-        row.key(text: "Type")
-        row.value(text: participant_declaration.type)
+      sl.with_row do |row|
+        row.with_key(text: "Type")
+        row.with_value(text: participant_declaration.type)
       end
 
-      sl.row do |row|
-        row.key(text: "CPD Lead Provider")
-        row.value(text: participant_declaration.cpd_lead_provider&.name)
+      sl.with_row do |row|
+        row.with_key(text: "CPD Lead Provider")
+        row.with_value(text: participant_declaration.cpd_lead_provider&.name)
       end
 
-      sl.row do |row|
-        row.key(text: "Delivery parner")
-        row.value(text: participant_declaration.delivery_partner&.name)
+      sl.with_row do |row|
+        row.with_key(text: "Delivery parner")
+        row.with_value(text: participant_declaration.delivery_partner&.name)
       end
 
-      sl.row do |row|
-        row.key(text: "State")
-        row.value(text: participant_declaration.state)
+      sl.with_row do |row|
+        row.with_key(text: "State")
+        row.with_value(text: participant_declaration.state)
       end
 
-      sl.row do |row|
-        row.key(text: "Superseded by")
-        row.value(text: participant_declaration.superseded_by_id)
+      sl.with_row do |row|
+        row.with_key(text: "Superseded by")
+        row.with_value(text: participant_declaration.superseded_by_id)
       end
 
-      sl.row do |row|
-        row.key(text: "Sparcity uplift")
-        row.value(text: participant_declaration.sparsity_uplift)
+      sl.with_row do |row|
+        row.with_key(text: "Sparcity uplift")
+        row.with_value(text: participant_declaration.sparsity_uplift)
       end
 
-      sl.row do |row|
-        row.key(text: "Pupil premium uplift")
-        row.value(text: participant_declaration.pupil_premium_uplift)
+      sl.with_row do |row|
+        row.with_key(text: "Pupil premium uplift")
+        row.with_value(text: participant_declaration.pupil_premium_uplift)
       end
     end
   %>

--- a/app/views/admin/participants/_nav.html.erb
+++ b/app/views/admin/participants/_nav.html.erb
@@ -1,37 +1,37 @@
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_participant_details_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_details_path(@participant_profile)) do %>
     Details
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_school_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_school_path(@participant_profile)) do %>
     Training
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_statuses_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_statuses_path(@participant_profile)) do %>
     Statuses
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_induction_records_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_induction_records_path(@participant_profile)) do %>
     Induction records
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_cohorts_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_cohorts_path(@participant_profile)) do %>
     Cohorts
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_declaration_history_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_declaration_history_path(@participant_profile)) do %>
     Declaration history
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_validation_data_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_validation_data_path(@participant_profile)) do %>
     Validation data
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_identities_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_identities_path(@participant_profile)) do %>
     Identities
   <% end %>
 
-  <%= component.nav_item(path: admin_participant_change_log_path(@participant_profile)) do %>
+  <%= component.with_nav_item(path: admin_participant_change_log_path(@participant_profile)) do %>
     Change log
   <% end %>
 <% end %>

--- a/app/views/admin/participants/change_relationship/confirm_new_relationship.html.erb
+++ b/app/views/admin/participants/change_relationship/confirm_new_relationship.html.erb
@@ -14,13 +14,13 @@
 
             <%= govuk_warning_text(text: "Has this been authorised by the Policy Engagement Team?") %>
             <%= govuk_summary_list do |summary_list| %>
-              <% summary_list.row do |row| %>
-                <% row.key { "Lead provider" } %>
-                <% row.value { @wizard.selected_lead_provider_name } %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key { "Lead provider" } %>
+                <% row.with_value { @wizard.selected_lead_provider_name } %>
               <% end %>
-              <% summary_list.row do |row| %>
-                <% row.key { "Delivery partner" } %>
-                <% row.value { @wizard.selected_delivery_partner_name } %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key { "Delivery partner" } %>
+                <% row.with_value { @wizard.selected_delivery_partner_name } %>
               <% end %>
             <% end %>
 

--- a/app/views/admin/participants/change_relationship/confirm_selected_partnership.html.erb
+++ b/app/views/admin/participants/change_relationship/confirm_selected_partnership.html.erb
@@ -14,13 +14,13 @@
 
             <%= govuk_warning_text(text: "Has this been authorised by the Policy Engagement Team?") %>
             <%= govuk_summary_list do |summary_list| %>
-              <% summary_list.row do |row| %>
-                <% row.key { "Lead provider" } %>
-                <% row.value { @wizard.selected_lead_provider_name } %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key { "Lead provider" } %>
+                <% row.with_value { @wizard.selected_lead_provider_name } %>
               <% end %>
-              <% summary_list.row do |row| %>
-                <% row.key { "Delivery partner" } %>
-                <% row.value { @wizard.selected_delivery_partner_name } %>
+              <% summary_list.with_row do |row| %>
+                <% row.with_key { "Delivery partner" } %>
+                <% row.with_value { @wizard.selected_delivery_partner_name } %>
               <% end %>
             <% end %>
 

--- a/app/views/admin/participants/change_relationship/relationship_already_exists.html.erb
+++ b/app/views/admin/participants/change_relationship/relationship_already_exists.html.erb
@@ -9,13 +9,13 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.row do |row| %>
-        <% row.key { "Lead provider" } %>
-        <% row.value { @wizard.selected_lead_provider_name } %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Lead provider" } %>
+        <% row.with_value { @wizard.selected_lead_provider_name } %>
       <% end %>
-      <% summary_list.row do |row| %>
-        <% row.key { "Delivery partner" } %>
-        <% row.value { @wizard.selected_delivery_partner_name } %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Delivery partner" } %>
+        <% row.with_value { @wizard.selected_delivery_partner_name } %>
       <% end %>
     <% end %>
 

--- a/app/views/admin/participants/cohorts/show.html.erb
+++ b/app/views/admin/participants/cohorts/show.html.erb
@@ -12,14 +12,14 @@
 <% end %>
 
 <%= govuk_summary_list do |sl|
-  sl.row do |row|
-    row.key(text: "Cohort (via induction record)")
-    row.value(text: @participant_presenter.start_year)
+  sl.with_row do |row|
+    row.with_key(text: "Cohort (via induction record)")
+    row.with_value(text: @participant_presenter.start_year)
   end
 
-  sl.row do |row|
-    row.key(text: "Cohort (via schedule)")
-    row.value(text: @participant_presenter&.relevant_induction_record&.schedule&.cohort&.start_year)
+  sl.with_row do |row|
+    row.with_key(text: "Cohort (via schedule)")
+    row.with_value(text: @participant_presenter&.relevant_induction_record&.schedule&.cohort&.start_year)
   end
 end %>
 

--- a/app/views/admin/participants/declaration_history/show.html.erb
+++ b/app/views/admin/participants/declaration_history/show.html.erb
@@ -19,59 +19,59 @@
 
     <%=
       govuk_summary_list do |sl|
-        sl.row do |row|
-          row.key(text: "Declaration type")
-          row.value(text: participant_declaration.declaration_type)
+        sl.with_row do |row|
+          row.with_key(text: "Declaration type")
+          row.with_value(text: participant_declaration.declaration_type)
         end
 
-        sl.row do |row|
-          row.key(text: "Declaration date")
-          row.value(text: participant_declaration.declaration_date.to_formatted_s(:govuk))
+        sl.with_row do |row|
+          row.with_key(text: "Declaration date")
+          row.with_value(text: participant_declaration.declaration_date.to_formatted_s(:govuk))
         end
 
-        sl.row do |row|
-          row.key(text: "Course identifier")
-          row.value(text: participant_declaration.course_identifier)
+        sl.with_row do |row|
+          row.with_key(text: "Course identifier")
+          row.with_value(text: participant_declaration.course_identifier)
         end
 
-        sl.row do |row|
-          row.key(text: "Evidence held")
-          row.value(text: participant_declaration.evidence_held)
+        sl.with_row do |row|
+          row.with_key(text: "Evidence held")
+          row.with_value(text: participant_declaration.evidence_held)
         end
 
-        sl.row do |row|
-          row.key(text: "Type")
-          row.value(text: participant_declaration.type)
+        sl.with_row do |row|
+          row.with_key(text: "Type")
+          row.with_value(text: participant_declaration.type)
         end
 
-        sl.row do |row|
-          row.key(text: "CPD Lead Provider")
-          row.value(text: participant_declaration.cpd_lead_provider&.name)
+        sl.with_row do |row|
+          row.with_key(text: "CPD Lead Provider")
+          row.with_value(text: participant_declaration.cpd_lead_provider&.name)
         end
 
-        sl.row do |row|
-          row.key(text: "Delivery parner")
-          row.value(text: participant_declaration.delivery_partner&.name)
+        sl.with_row do |row|
+          row.with_key(text: "Delivery parner")
+          row.with_value(text: participant_declaration.delivery_partner&.name)
         end
 
-        sl.row do |row|
-          row.key(text: "State")
-          row.value(text: participant_declaration.state)
+        sl.with_row do |row|
+          row.with_key(text: "State")
+          row.with_value(text: participant_declaration.state)
         end
 
-        sl.row do |row|
-          row.key(text: "Superseded by")
-          row.value(text: participant_declaration.superseded_by_id)
+        sl.with_row do |row|
+          row.with_key(text: "Superseded by")
+          row.with_value(text: participant_declaration.superseded_by_id)
         end
 
-        sl.row do |row|
-          row.key(text: "Sparcity uplift")
-          row.value(text: participant_declaration.sparsity_uplift)
+        sl.with_row do |row|
+          row.with_key(text: "Sparcity uplift")
+          row.with_value(text: participant_declaration.sparsity_uplift)
         end
 
-        sl.row do |row|
-          row.key(text: "Pupil premium uplift")
-          row.value(text: participant_declaration.pupil_premium_uplift)
+        sl.with_row do |row|
+          row.with_key(text: "Pupil premium uplift")
+          row.with_value(text: participant_declaration.pupil_premium_uplift)
         end
       end
     %>

--- a/app/views/admin/participants/details/_show_ecf.html.erb
+++ b/app/views/admin/participants/details/_show_ecf.html.erb
@@ -1,20 +1,20 @@
 <%= govuk_summary_list do |sl|
-  sl.row do |row|
-    row.key(text: "Full name")
-    row.value(text: @participant_presenter.full_name)
+  sl.with_row do |row|
+    row.with_key(text: "Full name")
+    row.with_value(text: @participant_presenter.full_name)
     unless @participant_profile.user.get_an_identity_id.present?
-      row.action(
+      row.with_action(
         href: edit_admin_participant_change_name_path(@participant_profile),
         visually_hidden_text: "name"
       )
     end
   end
 
-  sl.row do |row|
-    row.key(text: "User email address")
-    row.value(text: @participant_presenter.email)
+  sl.with_row do |row|
+    row.with_key(text: "User email address")
+    row.with_value(text: @participant_presenter.email)
     unless @participant_profile.user.get_an_identity_id.present?
-      row.action(
+      row.with_action(
         href: edit_admin_participant_change_email_path(@participant_profile),
         visually_hidden_text: "email"
       )
@@ -22,34 +22,34 @@
   end
 
   if policy(:super_user).show?
-    sl.row do |row|
-      row.key(text: "Participant identity")
-      row.value(text: @participant_presenter.participant_identity.email)
+    sl.with_row do |row|
+      row.with_key(text: "Participant identity")
+      row.with_value(text: @participant_presenter.participant_identity.email)
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Date of birth")
-    row.value(text: @participant_presenter&.ecf_participant_validation_data&.date_of_birth&.to_fs(:govuk))
+  sl.with_row do |row|
+    row.with_key(text: "Date of birth")
+    row.with_value(text: @participant_presenter&.ecf_participant_validation_data&.date_of_birth&.to_fs(:govuk))
   end
 
   if @participant_presenter.enrolled_in_fip?
-    sl.row do |row|
-      row.key(text: "Lead provider")
-      row.value(text: @participant_presenter.lead_provider_name)
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: @participant_presenter.lead_provider_name)
       if policy(:super_user).show?
-        row.action(
+        row.with_action(
           href: start_admin_change_relationship_participant_path(@participant_profile),
           visually_hidden_text: "lead provider"
         )
       end
     end
 
-    sl.row do |row|
-      row.key(text: "Delivery partner")
-      row.value(text: @participant_presenter.delivery_partner_name)
+    sl.with_row do |row|
+      row.with_key(text: "Delivery partner")
+      row.with_value(text: @participant_presenter.delivery_partner_name)
       if policy(:super_user).show?
-        row.action(
+        row.with_action(
           href: start_admin_change_relationship_participant_path(@participant_profile),
           visually_hidden_text: "delivery partner"
         )
@@ -57,42 +57,42 @@
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Training record state")
-    row.value(text: render(StatusTags::AdminParticipantStatusTag.new(participant_profile: @participant_profile, school: @participant_presenter.school)))
+  sl.with_row do |row|
+    row.with_key(text: "Training record state")
+    row.with_value(text: render(StatusTags::AdminParticipantStatusTag.new(participant_profile: @participant_profile, school: @participant_presenter.school)))
   end
 
   if @participant_presenter.teacher_profile
-    sl.row do |row|
-      row.key(text: "TRN")
-      row.value(text: @participant_presenter.teacher_profile.trn)
+    sl.with_row do |row|
+      row.with_key(text: "TRN")
+      row.with_value(text: @participant_presenter.teacher_profile.trn)
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Profile ID")
-    row.value(text: tag.code(@participant_presenter.id))
+  sl.with_row do |row|
+    row.with_key(text: "Profile ID")
+    row.with_value(text: tag.code(@participant_presenter.id))
   end
 
-  sl.row do |row|
-    row.key(text: "User ID")
-    row.value(text: tag.code(@participant_presenter.user_id))
+  sl.with_row do |row|
+    row.with_key(text: "User ID")
+    row.with_value(text: tag.code(@participant_presenter.user_id))
   end
 
-  sl.row do |row|
-    row.key(text: "External ID")
-    row.value(text: tag.code(@participant_presenter.participant_identity.external_identifier))
+  sl.with_row do |row|
+    row.with_key(text: "External ID")
+    row.with_value(text: tag.code(@participant_presenter.participant_identity.external_identifier))
   end
 
-  sl.row do |row|
-    row.key(text: "Associated email addresses")
-    row.value(text: html_list(all_emails_associated_with_a_user(@participant_profile.user)))
+  sl.with_row do |row|
+    row.with_key(text: "Associated email addresses")
+    row.with_value(text: html_list(all_emails_associated_with_a_user(@participant_profile.user)))
   end
 
-  sl.row do |row|
-    row.key(text: "Notes")
+  sl.with_row do |row|
+    row.with_key(text: "Notes")
 
-    row.value do
+    row.with_value do
       if @participant_presenter.notes?
         simple_format(@participant_presenter.notes, class: "govuk-body")
       else
@@ -102,7 +102,7 @@
 
     notes_present = @participant_presenter.notes.present?
 
-    row.action(
+    row.with_action(
       text: notes_present ? "Change notes" : "Add notes",
       href: edit_admin_note_path(@participant_profile),
       visually_hidden_text: notes_present ? "on #{@participant_presenter.full_name}'s profile" : "to #{@participant_presenter.full_name}'s profile",

--- a/app/views/admin/participants/induction_records/show.html.erb
+++ b/app/views/admin/participants/induction_records/show.html.erb
@@ -15,14 +15,14 @@
 
     <%=
       govuk_summary_list do |sl|
-        sl.row do |row|
-          row.key(text: "Cohort")
-          row.value(text: induction_record.cohort.start_year)
+        sl.with_row do |row|
+          row.with_key(text: "Cohort")
+          row.with_value(text: induction_record.cohort.start_year)
         end
 
-        sl.row do |row|
-          row.key(text: "School name")
-          row.value do
+        sl.with_row do |row|
+          row.with_key(text: "School name")
+          row.with_value do
             govuk_link_to(
               induction_record.school_name,
               admin_school_path(induction_record.school.friendly_id)
@@ -30,99 +30,99 @@
           end
         end
 
-        sl.row do |row|
-          row.key(text: "School URN")
-          row.value(text: induction_record.school_urn)
+        sl.with_row do |row|
+          row.with_key(text: "School URN")
+          row.with_value(text: induction_record.school_urn)
         end
 
-        sl.row do |row|
-          row.key(text: "School record state")
-          row.value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
+        sl.with_row do |row|
+          row.with_key(text: "School record state")
+          row.with_value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
         end
 
-        sl.row do |row|
-          row.key(text: "Preferred email")
-          row.value(text: induction_record.participant_email)
+        sl.with_row do |row|
+          row.with_key(text: "Preferred email")
+          row.with_value(text: induction_record.participant_email)
           if policy(induction_record).edit_preferred_email?
-            row.action(
+            row.with_action(
               href: edit_preferred_email_admin_participant_induction_records_path(@participant_profile, induction_record),
               visually_hidden_text: "preferred email"
             )
           end
         end
 
-        sl.row do |row|
-          row.key(text: "Training programme")
-          row.value(text: induction_programme_friendly_name(induction_record.training_programme))
+        sl.with_row do |row|
+          row.with_key(text: "Training programme")
+          row.with_value(text: induction_programme_friendly_name(induction_record.training_programme))
         end
 
-        sl.row do |row|
-          row.key(text: "Lead provider")
-          row.value(text: induction_record.lead_provider_name || "No lead provider")
+        sl.with_row do |row|
+          row.with_key(text: "Lead provider")
+          row.with_value(text: induction_record.lead_provider_name || "No lead provider")
         end
 
-        sl.row do |row|
-          row.key(text: "Delivery partner")
-          row.value(text: induction_record.delivery_partner_name || "No delivery partner")
+        sl.with_row do |row|
+          row.with_key(text: "Delivery partner")
+          row.with_value(text: induction_record.delivery_partner_name || "No delivery partner")
         end
 
         if induction_record.delivery_partner.present?
-          sl.row do |row|
-            row.key(text: "Delivery partner record state")
-            row.value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
+          sl.with_row do |row|
+            row.with_key(text: "Delivery partner record state")
+            row.with_value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
           end
         end
 
-        sl.row do |row|
-          row.key(text: "School transfer")
-          row.value(text: induction_record.school_transfer)
+        sl.with_row do |row|
+          row.with_key(text: "School transfer")
+          row.with_value(text: induction_record.school_transfer)
         end
 
-        sl.row do |row|
-          row.key(text: "Induction status")
-          row.value(text: induction_record.induction_status)
+        sl.with_row do |row|
+          row.with_key(text: "Induction status")
+          row.with_value(text: induction_record.induction_status)
         end
 
-        sl.row do |row|
-          row.key(text: "Training status")
-          row.value(text: induction_record.training_status)
+        sl.with_row do |row|
+          row.with_key(text: "Training status")
+          row.with_value(text: induction_record.training_status)
         end
 
-        sl.row do |row|
-          row.key(text: "Mentor")
-          row.value(text: induction_record.mentor_full_name)
+        sl.with_row do |row|
+          row.with_key(text: "Mentor")
+          row.with_value(text: induction_record.mentor_full_name)
         end
 
-        sl.row do |row|
-          row.key(text: "Schedule")
-          row.value(text: induction_record.schedule_identifier)
+        sl.with_row do |row|
+          row.with_key(text: "Schedule")
+          row.with_value(text: induction_record.schedule_identifier)
         end
 
-        sl.row do |row|
-          row.key(text: "Appropriate body")
-          row.value(text: induction_record.appropriate_body_name)
+        sl.with_row do |row|
+          row.with_key(text: "Appropriate body")
+          row.with_value(text: induction_record.appropriate_body_name)
         end
 
         if induction_record.appropriate_body.present?
-          sl.row do |row|
-            row.key(text: "Appropriate body record state")
-            row.value(text: render(StatusTags::AppropriateBodyParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
+          sl.with_row do |row|
+            row.with_key(text: "Appropriate body record state")
+            row.with_value(text: render(StatusTags::AppropriateBodyParticipantStatusTag.new(participant_profile: induction_record.participant_profile, induction_record: induction_record)))
           end
         end
 
-        sl.row do |row|
-          row.key(text: "Creation date")
-          row.value(text: induction_record.created_at&.to_fs(:govuk))
+        sl.with_row do |row|
+          row.with_key(text: "Creation date")
+          row.with_value(text: induction_record.created_at&.to_fs(:govuk))
         end
 
-        sl.row do |row|
-          row.key(text: "Start date")
-          row.value(text: induction_record.start_date.to_formatted_s(:govuk))
+        sl.with_row do |row|
+          row.with_key(text: "Start date")
+          row.with_value(text: induction_record.start_date.to_formatted_s(:govuk))
         end
 
-        sl.row do |row|
-          row.key(text: "End date")
-          row.value(text: induction_record.end_date&.to_fs(:govuk))
+        sl.with_row do |row|
+          row.with_key(text: "End date")
+          row.with_value(text: induction_record.end_date&.to_fs(:govuk))
         end
       end
     %>

--- a/app/views/admin/participants/school/show.html.erb
+++ b/app/views/admin/participants/school/show.html.erb
@@ -13,9 +13,9 @@
   <p>No school details for <%= @participant_presenter.full_name %>.</p>
 <% else %>
   <%= govuk_summary_list(actions: true) do |sl|
-    sl.row do |row|
-      row.key(text: "School name")
-      row.value do
+    sl.with_row do |row|
+      row.with_key(text: "School name")
+      row.with_value do
         govuk_link_to(
           @participant_presenter.school_name,
           admin_school_path(@participant_presenter.school_friendly_id)
@@ -23,15 +23,15 @@
       end
     end
 
-    sl.row do |row|
-      row.key(text: "School URN")
-      row.value(text: @participant_presenter.school_urn)
+    sl.with_row do |row|
+      row.with_key(text: "School URN")
+      row.with_value(text: @participant_presenter.school_urn)
     end
 
     if @participant_profile.ect?
-      sl.row do |row|
-        row.key(text: "Mentor")
-        row.value(
+      sl.with_row do |row|
+        row.with_key(text: "Mentor")
+        row.with_value(
           text: if @participant_presenter.has_mentor?
                   govuk_link_to(
                     @participant_presenter.mentor_full_name,
@@ -44,30 +44,30 @@
       end
     end
 
-    sl.row do |row|
-      row.key(text: "School record state")
-      row.value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, school: @participant_presenter.school)))
+    sl.with_row do |row|
+      row.with_key(text: "School record state")
+      row.with_value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, school: @participant_presenter.school)))
     end
 
-    sl.row do |row|
-      row.key(text: "Lead provider")
-      row.value(text: @participant_presenter.school_lead_provider_name)
+    sl.with_row do |row|
+      row.with_key(text: "Lead provider")
+      row.with_value(text: @participant_presenter.school_lead_provider_name)
     end
 
-    sl.row do |row|
-      row.key(text: "Delivery partner")
-      row.value(text: @participant_presenter.school_delivery_partner_name)
+    sl.with_row do |row|
+      row.with_key(text: "Delivery partner")
+      row.with_value(text: @participant_presenter.school_delivery_partner_name)
     end
 
-    sl.row do |row|
-      row.key(text: "Appropriate body")
-      row.value(text: @participant_presenter.appropriate_body_name)
+    sl.with_row do |row|
+      row.with_key(text: "Appropriate body")
+      row.with_value(text: @participant_presenter.appropriate_body_name)
     end
 
     if @participant_presenter.mentor?
-      sl.row do |row|
-        row.key(text: "Mentoring")
-        row.value do
+      sl.with_row do |row|
+        row.with_key(text: "Mentoring")
+        row.with_value do
           if @participant_presenter.mentees_by_school.any?
             html_list(
               @participant_presenter.mentees_by_school.map do |school, mentees|

--- a/app/views/admin/participants/school_transfer/check_answers.html.erb
+++ b/app/views/admin/participants/school_transfer/check_answers.html.erb
@@ -9,46 +9,46 @@
     <h1 class="govuk-heading-xl"><%= title %></h1>
 
     <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.row do |row| %>
-        <% row.key { "Current school" } %>
-        <% row.value { @school_transfer_form.current_school.name } %>
-        <% row.action(text: :none) %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Current school" } %>
+        <% row.with_value { @school_transfer_form.current_school.name } %>
+        <% row.with_action(text: :none) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Current programme" } %>
-        <% row.value { @school_transfer_form.current_programme_description } %>
-        <% row.action(text: :none) %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Current programme" } %>
+        <% row.with_value { @school_transfer_form.current_programme_description } %>
+        <% row.with_action(text: :none) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Transfer to" } %>
-        <% row.value { @school_transfer_form.new_school.name } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Transfer to" } %>
+        <% row.with_value { @school_transfer_form.new_school.name } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "destination school",
                       href: url_for({ action: :select_school})) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Training choice" } %>
-        <% row.value { @school_transfer_form.transfer_choice_description } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Training choice" } %>
+        <% row.with_value { @school_transfer_form.transfer_choice_description } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "programme to join",
                       href: url_for({ action: :transfer_options})) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Start date" } %>
-        <% row.value { @school_transfer_form.start_date.to_date.to_fs(:govuk) } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Start date" } %>
+        <% row.with_value { @school_transfer_form.start_date.to_date.to_fs(:govuk) } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "start date at new school",
                       href: url_for({ action: :start_date})) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Email" } %>
-        <% row.value { @school_transfer_form.email } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Email" } %>
+        <% row.with_value { @school_transfer_form.email } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "email address",
                       href: url_for({ action: :email})) %>
       <% end %>

--- a/app/views/admin/participants/statuses/show.html.erb
+++ b/app/views/admin/participants/statuses/show.html.erb
@@ -14,9 +14,9 @@
   <p>No school details for <%= @participant_presenter.full_name %>.</p>
 <% else %>
   <%= govuk_summary_list(actions: true) do |sl|
-    sl.row do |row|
-      row.key(text: "Name")
-      row.value do
+    sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value do
         govuk_link_to(
           @participant_presenter.school_name,
           admin_school_path(@participant_presenter.school_friendly_id)
@@ -24,9 +24,9 @@
       end
     end
 
-    sl.row do |row|
-      row.key(text: "Training record status")
-      row.value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, school: @participant_presenter.school)))
+    sl.with_row do |row|
+      row.with_key(text: "Training record status")
+      row.with_value(text: render(StatusTags::SchoolParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, school: @participant_presenter.school)))
     end
   end %>
 <% end %>
@@ -36,14 +36,14 @@
   <p>No lead provider details for <%= @participant_presenter.full_name %>.</p>
 <% else %>
   <%= govuk_summary_list(actions: true) do |sl|
-    sl.row do |row|
-      row.key(text: "Name")
-      row.value(text: @participant_presenter.lead_provider_name)
+    sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: @participant_presenter.lead_provider_name)
     end
 
-    sl.row do |row|
-      row.key(text: "Training record state")
-      row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
+    sl.with_row do |row|
+      row.with_key(text: "Training record state")
+      row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
     end
   end %>
 <% end %>
@@ -53,14 +53,14 @@
   <p>No delivery partner details for <%= @participant_presenter.full_name %>.</p>
 <% else %>
   <%= govuk_summary_list(actions: true) do |sl|
-    sl.row do |row|
-      row.key(text: "Name")
-      row.value(text: @participant_presenter.delivery_partner_name)
+    sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: @participant_presenter.delivery_partner_name)
     end
 
-    sl.row do |row|
-      row.key(text: "Training record state")
-      row.value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, delivery_partner: @participant_presenter.school_cohort&.delivery_partner)))
+    sl.with_row do |row|
+      row.with_key(text: "Training record state")
+      row.with_value(text: render(StatusTags::DeliveryPartnerParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, delivery_partner: @participant_presenter.school_cohort&.delivery_partner)))
     end
   end %>
 <% end %>
@@ -70,70 +70,70 @@
   <p>No appropriate body details for <%= @participant_presenter.full_name %>.</p>
 <% else %>
   <%= govuk_summary_list(actions: true) do |sl|
-    sl.row do |row|
-      row.key(text: "Name")
-      row.value(text: @participant_presenter.appropriate_body_name)
+    sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: @participant_presenter.appropriate_body_name)
     end
 
-    sl.row do |row|
-      row.key(text: "Training record state")
-      row.value(text: render(StatusTags::AppropriateBodyParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, appropriate_body: @participant_presenter.school_cohort&.appropriate_body)))
+    sl.with_row do |row|
+      row.with_key(text: "Training record state")
+      row.with_value(text: render(StatusTags::AppropriateBodyParticipantStatusTag.new(participant_profile: @participant_presenter.participant_profile, appropriate_body: @participant_presenter.school_cohort&.appropriate_body)))
     end
   end %>
 <% end %>
 
 <h2 class="govuk-heading-m">Training record states</h2>
 <%= govuk_summary_list(actions: true) do |sl|
-  sl.row do |row|
-    row.key(text: "Validation status")
-    row.value(text: govuk_tag(text: states.validation_state.humanize, colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "Validation status")
+    row.with_value(text: govuk_tag(text: states.validation_state.humanize, colour: "grey"))
   end
 
-  sl.row do |row|
-    row.key(text: "Training eligibility status")
-    row.value(text: govuk_tag(text: states.training_eligibility_state.humanize, colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "Training eligibility status")
+    row.with_value(text: govuk_tag(text: states.training_eligibility_state.humanize, colour: "grey"))
   end
 
-  sl.row do |row|
-    row.key(text: "FIP funding eligibility status")
-    row.value(text: govuk_tag(text: states.fip_funding_eligibility_state.humanize, colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "FIP funding eligibility status")
+    row.with_value(text: govuk_tag(text: states.fip_funding_eligibility_state.humanize, colour: "grey"))
   end
 
-  sl.row do |row|
-    row.key(text: "Mentoring status")
-    row.value(text: govuk_tag(text: states.mentoring_state.humanize, colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "Mentoring status")
+    row.with_value(text: govuk_tag(text: states.mentoring_state.humanize, colour: "grey"))
   end
 
-  sl.row do |row|
-    row.key(text: "Training status")
-    row.value(text: govuk_tag(text: states.training_state.humanize, colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "Training status")
+    row.with_value(text: govuk_tag(text: states.training_state.humanize, colour: "grey"))
   end
 end %>
 
 <h3 class="govuk-heading-m">Relevant induction record statuses</h3>
 <%= govuk_summary_list(actions: true) do |sl|
-  sl.row do |row|
-    row.key(text: "induction status")
-    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status || "No Induction Record Found", colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "induction status")
+    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.induction_status || "No Induction Record Found", colour: "grey"))
   end
 
-  sl.row do |row|
-    row.key(text: "training status")
-    row.value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
+  sl.with_row do |row|
+    row.with_key(text: "training status")
+    row.with_value(text: govuk_tag(text: @participant_presenter.relevant_induction_record&.training_status || "No Induction Record Found", colour: "grey"))
   end
 end %>
 
 <h3 class="govuk-heading-m">Participant profile statuses</h3>
 <%= govuk_summary_list(actions: true) do |sl|
-  sl.row do |row|
-    row.key(text: "status")
-    row.value(text: govuk_tag(text: @participant_presenter.participant_profile.status, colour: "grey") +
+  sl.with_row do |row|
+    row.with_key(text: "status")
+    row.with_value(text: govuk_tag(text: @participant_presenter.participant_profile.status, colour: "grey") +
       "<p class=\"govuk-body-s\">A historical status used if the induction_records induction_status is not set. Note: a status of Withdrawn indicates a 'soft delete' of this record.</p>".html_safe)
   end
 
-  sl.row do |row|
-    row.key(text: "training status")
-    row.value(text: govuk_tag(text: @participant_presenter.participant_profile.training_status, colour: "grey") +
+  sl.with_row do |row|
+    row.with_key(text: "training status")
+    row.with_value(text: govuk_tag(text: @participant_presenter.participant_profile.training_status, colour: "grey") +
       "<p class=\"govuk-body-s\">A historical status used if the induction_records training_status is not set.</p>".html_safe)
   end
 end %>

--- a/app/views/admin/participants/validation_data/show.html.erb
+++ b/app/views/admin/participants/validation_data/show.html.erb
@@ -11,54 +11,54 @@
 <% states = DetermineTrainingRecordState.call(participant_profile: @participant_profile) %>
 
 <%= govuk_summary_list(actions: true) do |sl|
-  sl.row do |row|
-    row.key(text: "Full name")
-    row.value(text: @participant_presenter.validation_data.full_name)
+  sl.with_row do |row|
+    row.with_key(text: "Full name")
+    row.with_value(text: @participant_presenter.validation_data.full_name)
 
     if can_be_updated
-      row.action(
+      row.with_action(
         href: full_name_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
         visually_hidden_text: "name used for validation"
       )
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Teacher Reference Number (TRN)")
-    row.value(text: @participant_presenter.validation_data.trn)
+  sl.with_row do |row|
+    row.with_key(text: "Teacher Reference Number (TRN)")
+    row.with_value(text: @participant_presenter.validation_data.trn)
     if can_be_updated
-      row.action(
+      row.with_action(
         href: trn_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
         visually_hidden_text: "teacher reference number"
       )
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Date of birth")
-    row.value(text: @participant_presenter.validation_data.date_of_birth&.to_fs(:govuk))
+  sl.with_row do |row|
+    row.with_key(text: "Date of birth")
+    row.with_value(text: @participant_presenter.validation_data.date_of_birth&.to_fs(:govuk))
     if can_be_updated
-      row.action(
+      row.with_action(
         href: date_of_birth_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
         visually_hidden_text: "date of birth"
       )
     end
   end
 
-  sl.row do |row|
-    row.key(text: "National Insurance Number")
-    row.value(text: @participant_presenter.validation_data.nino)
+  sl.with_row do |row|
+    row.with_key(text: "National Insurance Number")
+    row.with_value(text: @participant_presenter.validation_data.nino)
     if can_be_updated
-      row.action(
+      row.with_action(
         href: nino_admin_participant_validation_data_path(@participant_presenter.validation_data.participant_profile),
         visually_hidden_text: "National Insurance number"
       )
     end
   end
 
-  sl.row do |row|
-    row.key(text: "Validation state")
-    row.value(text: states.validation_state)
+  sl.with_row do |row|
+    row.with_key(text: "Validation state")
+    row.with_value(text: states.validation_state)
   end
 end %>
 
@@ -66,53 +66,53 @@ end %>
   <% if @participant_presenter.eligibility_data.present? %>
     <h3 class="govuk-heading-m">Eligibility data</h3>
     <%= govuk_summary_list(actions: true) do |sl|
-      sl.row do |row|
-        row.key(text: "Primary reason")
-        row.value(text: @participant_presenter.eligibility_data.reason)
+      sl.with_row do |row|
+        row.with_key(text: "Primary reason")
+        row.with_value(text: @participant_presenter.eligibility_data.reason)
       end
 
-      sl.row do |row|
-        row.key(text: "Active Flags")
-        row.value(text: @participant_presenter.eligibility_data.active_flags)
+      sl.with_row do |row|
+        row.with_key(text: "Active Flags")
+        row.with_value(text: @participant_presenter.eligibility_data.active_flags)
       end
 
       if @participant_presenter.eligibility_data.mentor?
-        sl.row do |row|
-          row.key(text: "Previous participation (ERO)")
-          row.value(text: @participant_presenter.eligibility_data.previous_participation)
+        sl.with_row do |row|
+          row.with_key(text: "Previous participation (ERO)")
+          row.with_value(text: @participant_presenter.eligibility_data.previous_participation)
         end
 
-        sl.row do |row|
-          row.key(text: "Secondary mentor profile")
-          row.value(text: @participant_presenter.eligibility_data.duplicate_profile)
+        sl.with_row do |row|
+          row.with_key(text: "Secondary mentor profile")
+          row.with_value(text: @participant_presenter.eligibility_data.duplicate_profile)
         end
       end
 
       if @participant_presenter.eligibility_data.ect?
-        sl.row do |row|
-          row.key(text: "Previous induction (NQT+1)")
-          row.value(text: @participant_presenter.eligibility_data.previous_induction)
+        sl.with_row do |row|
+          row.with_key(text: "Previous induction (NQT+1)")
+          row.with_value(text: @participant_presenter.eligibility_data.previous_induction)
         end
 
-        sl.row do |row|
-          row.key(text: "Qualified teacher status (QTS)")
-          row.value(text: @participant_presenter.eligibility_data.qts)
+        sl.with_row do |row|
+          row.with_key(text: "Qualified teacher status (QTS)")
+          row.with_value(text: @participant_presenter.eligibility_data.qts)
         end
 
-        sl.row do |row|
-          row.key(text: "Exempt from induction")
-          row.value(text: @participant_presenter.eligibility_data.exempt_from_induction)
+        sl.with_row do |row|
+          row.with_key(text: "Exempt from induction")
+          row.with_value(text: @participant_presenter.eligibility_data.exempt_from_induction)
         end
 
-        sl.row do |row|
-          row.key(text: "Induction is registered with TRA")
-          row.value(text: @participant_presenter.eligibility_data.registered_induction)
+        sl.with_row do |row|
+          row.with_key(text: "Induction is registered with TRA")
+          row.with_value(text: @participant_presenter.eligibility_data.registered_induction)
         end
       end
 
-      sl.row do |row|
-        row.key(text: "Teacher profile has different TRN")
-        row.value(text: @participant_presenter.eligibility_data.different_trn)
+      sl.with_row do |row|
+        row.with_key(text: "Teacher profile has different TRN")
+        row.with_value(text: @participant_presenter.eligibility_data.different_trn)
       end
     end %>
 

--- a/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/confirm.html.erb
@@ -7,19 +7,19 @@
     <%= govuk_warning_text(text: "Has this been authorised by the Policy Engagement Team?") %>
 
     <%= govuk_summary_list do |sl|
-      sl.row do |row|
-        row.key(text: "Cohort")
-        row.value(text: @challenge_partnership_form.partnership.cohort.start_year)
+      sl.with_row do |row|
+        row.with_key(text: "Cohort")
+        row.with_value(text: @challenge_partnership_form.partnership.cohort.start_year)
       end
 
-      sl.row do |row|
-        row.key(text: "Lead Provider")
-        row.value(text: @challenge_partnership_form.partnership.lead_provider.name)
+      sl.with_row do |row|
+        row.with_key(text: "Lead Provider")
+        row.with_value(text: @challenge_partnership_form.partnership.lead_provider.name)
       end
 
-      sl.row do |row|
-        row.key(text: "Delivery partner")
-        row.value(text: @challenge_partnership_form.partnership.delivery_partner.name)
+      sl.with_row do |row|
+        row.with_key(text: "Delivery partner")
+        row.with_value(text: @challenge_partnership_form.partnership.delivery_partner.name)
       end
     end %>
     <%= form_for @challenge_partnership_form, url: admin_school_partnership_challenge_partnership_path do |f| %>

--- a/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
+++ b/app/views/admin/schools/cohorts/challenge_partnership/new.html.erb
@@ -7,19 +7,19 @@
     </h1>
 
     <%= govuk_summary_list do |sl|
-      sl.row do |row|
-        row.key(text: "Cohort")
-        row.value(text: @challenge_partnership_form.partnership.cohort.start_year)
+      sl.with_row do |row|
+        row.with_key(text: "Cohort")
+        row.with_value(text: @challenge_partnership_form.partnership.cohort.start_year)
       end
 
-      sl.row do |row|
-        row.key(text: "Lead Provider")
-        row.value(text: @challenge_partnership_form.partnership.lead_provider.name)
+      sl.with_row do |row|
+        row.with_key(text: "Lead Provider")
+        row.with_value(text: @challenge_partnership_form.partnership.lead_provider.name)
       end
 
-      sl.row do |row|
-        row.key(text: "Delivery partner")
-        row.value(text: @challenge_partnership_form.partnership.delivery_partner.name)
+      sl.with_row do |row|
+        row.with_key(text: "Delivery partner")
+        row.with_value(text: @challenge_partnership_form.partnership.delivery_partner.name)
       end
     end %>
 

--- a/app/views/admin/schools/shared/_navigation.html.erb
+++ b/app/views/admin/schools/shared/_navigation.html.erb
@@ -1,11 +1,11 @@
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_school_path(@school)) do %>
+  <%= component.with_nav_item(path: admin_school_path(@school)) do %>
     Overview
   <% end %>
-  <%= component.nav_item(path: admin_school_participants_path(@school)) do %>
+  <%= component.with_nav_item(path: admin_school_participants_path(@school)) do %>
     Participants
   <% end %>
-  <%= component.nav_item(path: admin_school_cohorts_path(@school)) do %>
+  <%= component.with_nav_item(path: admin_school_cohorts_path(@school)) do %>
     Cohorts
   <% end %>
 <% end %>

--- a/app/views/admin/schools/show.html.erb
+++ b/app/views/admin/schools/show.html.erb
@@ -14,11 +14,11 @@
 
 <%=
   govuk_summary_list do |sl|
-    sl.row do |row|
-      row.key(text: "URN")
-      row.value(text: @school.urn)
+    sl.with_row do |row|
+      row.with_key(text: "URN")
+      row.with_value(text: @school.urn)
       if @school.urn.present?
-        row.action(
+        row.with_action(
           text: "Open in GIAS",
           href: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{@school.urn}",
           html_attributes: { rel: "noreferrer noopener", target: "_blank" },
@@ -26,29 +26,29 @@
       end
     end
 
-    sl.row do |row|
-      row.key(text: "Induction tutor")
-      row.value do
+    sl.with_row do |row|
+      row.with_key(text: "Induction tutor")
+      row.with_value do
         if @induction_coordinator.present?
           safe_join([@induction_coordinator.full_name, tag.br, govuk_mail_to(@induction_coordinator.email, @induction_coordinator.email)])
         end
       end
 
       if @induction_coordinator.present?
-        row.action(text: "Change", visually_hidden_text: "induction tutor", href: admin_school_replace_or_update_induction_tutor_path(@school))
+        row.with_action(text: "Change", visually_hidden_text: "induction tutor", href: admin_school_replace_or_update_induction_tutor_path(@school))
       else
-        row.action(text: "Add", visually_hidden_text: "induction tutor", href: new_admin_school_induction_coordinator_path(@school))
+        row.with_action(text: "Add", visually_hidden_text: "induction tutor", href: new_admin_school_induction_coordinator_path(@school))
       end
     end
 
-    sl.row do |row|
-      row.key(text: "Local authority")
-      row.value(text: @school.local_authority&.name)
+    sl.with_row do |row|
+      row.with_key(text: "Local authority")
+      row.with_value(text: @school.local_authority&.name)
     end
 
-    sl.row do |row|
-      row.key(text: "Address")
-      row.value(
+    sl.with_row do |row|
+      row.with_key(text: "Address")
+      row.with_value(
         text: format_address(
           @school.address_line1,
           @school.address_line2,

--- a/app/views/admin/suppliers/suppliers/_layout.html.erb
+++ b/app/views/admin/suppliers/suppliers/_layout.html.erb
@@ -1,10 +1,10 @@
 <h1 class="govuk-heading-l">Suppliers</h1>
 
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_suppliers_path) do %>
+  <%= component.with_nav_item(path: admin_suppliers_path) do %>
     All suppliers
   <% end %>
-  <%= component.nav_item(path: admin_supplier_users_path) do %>
+  <%= component.with_nav_item(path: admin_supplier_users_path) do %>
     All users
   <% end %>
 <% end %>

--- a/app/views/admin/test_data/_nav.html.erb
+++ b/app/views/admin/test_data/_nav.html.erb
@@ -3,19 +3,19 @@
 <% end %>
 
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: admin_test_data_fip_schools_path) do %>
+  <%= component.with_nav_item(path: admin_test_data_fip_schools_path) do %>
     FIP Schools
   <% end %>
 
-  <%= component.nav_item(path: admin_test_data_cip_schools_path) do %>
+  <%= component.with_nav_item(path: admin_test_data_cip_schools_path) do %>
     CIP Schools
   <% end %>
 
-  <%= component.nav_item(path: admin_test_data_unclaimed_schools_path) do %>
+  <%= component.with_nav_item(path: admin_test_data_unclaimed_schools_path) do %>
     Unclaimed schools
   <% end %>
 
-  <%= component.nav_item(path: admin_test_data_yet_to_choose_schools_path) do %>
+  <%= component.with_nav_item(path: admin_test_data_yet_to_choose_schools_path) do %>
     Yet to choose a programme
   <% end %>
 

--- a/app/views/dashboard/_navigation.html.erb
+++ b/app/views/dashboard/_navigation.html.erb
@@ -1,10 +1,10 @@
 <% content_for :nav_bar do %>
   <%= render PrimaryNavComponent.new do |component| %>
-    <%= component.nav_item(path: dashboard_path) do %>
+    <%= component.with_nav_item(path: dashboard_path) do %>
       Overview
     <% end %>
 
-    <%= component.nav_item(path: lead_providers_your_schools_path(cohort: Cohort.current)) do %>
+    <%= component.with_nav_item(path: lead_providers_your_schools_path(cohort: Cohort.current)) do %>
       Schools
     <% end %>
   <% end %>

--- a/app/views/finance/adjustments/edit.html.erb
+++ b/app/views/finance/adjustments/edit.html.erb
@@ -50,13 +50,13 @@
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
       <br />
       <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
         providing are correct.</p>
       <br />
 
       <%= f.govuk_submit "Confirm and continue" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/finance/adjustments/edit.html.erb
+++ b/app/views/finance/adjustments/edit.html.erb
@@ -5,6 +5,8 @@
     <%= form_for @adjustment, url: finance_statement_adjustment_path(@statement, @adjustment.id), method: :put, as: :finance_adjustment do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.hidden_field(:form_step) %>
+      <%= f.hidden_field(:payment_type) %>
+      <%= f.hidden_field(:amount) %>
 
       <% case @adjustment.form_step %>
       <% when "step1" %>
@@ -54,8 +56,6 @@
         providing are correct.</p>
       <br />
 
-      <%= f.hidden_field(:payment_type) %>
-      <%= f.hidden_field(:amount) %>
       <%= f.govuk_submit "Confirm and continue" %>
     <% end %>
   </div>

--- a/app/views/finance/adjustments/edit.html.erb
+++ b/app/views/finance/adjustments/edit.html.erb
@@ -28,19 +28,19 @@
         <h1 class="govuk-heading-xl">Check your answers</h1>
 
         <%= govuk_table do |table| %>
-          <% table.head do |head| %>
-            <% table.body do |body| %>
-              <% body.row do |row| %>
-                <% row.cell(header: true, text: "Payment type") %>
-                <% row.cell(text: @adjustment.payment_type) %>
-                <% row.cell(numeric: true) do %>
+          <% table.with_head do |head| %>
+            <% table.with_body do |body| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(header: true, text: "Payment type") %>
+                <% row.with_cell(text: @adjustment.payment_type) %>
+                <% row.with_cell(numeric: true) do %>
                   <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, @adjustment.id, form_step: "step1") %>
                 <% end %>
               <% end %>
-              <% body.row do |row| %>
-                <% row.cell(header: true, text: "Payments") %>
-                <% row.cell(text: number_to_pounds(@adjustment.amount)) %>
-                <% row.cell(numeric: true) do %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(header: true, text: "Payments") %>
+                <% row.with_cell(text: number_to_pounds(@adjustment.amount)) %>
+                <% row.with_cell(numeric: true) do %>
                   <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, @adjustment.id, form_step: "step2") %>
                 <% end %>
               <% end %>

--- a/app/views/finance/adjustments/edit.html.erb
+++ b/app/views/finance/adjustments/edit.html.erb
@@ -9,18 +9,18 @@
       <% case @adjustment.form_step %>
       <% when "step1" %>
         <%= f.govuk_text_field(
-          :payment_type,
-          caption: { text: "Change or remove an adjustment", size: "xl"},
-          label: { text: "What is the name of the adjustment", tag: "h1", size: "xl" },
-          hint: { text: "Describe what the adjustment is for. For example 'IT consultant fee'" }
-        ) %>
+                :payment_type,
+                caption: { text: "Change or remove an adjustment", size: "xl" },
+                label: { text: "What is the name of the adjustment", tag: "h1", size: "xl" },
+                hint: { text: "Describe what the adjustment is for. For example 'IT consultant fee'" }
+            ) %>
         <%= f.govuk_submit "Continue" %>
       <% when "step2" %>
         <%= f.govuk_text_field(
-          :amount,
-          caption: { text: "Change or remove an adjustment", size: "xl"},
-          label: { text: "How much is the payment?", tag: "h1", size: "xl" }
-        ) %>
+                :amount,
+                caption: { text: "Change or remove an adjustment", size: "xl" },
+                label: { text: "How much is the payment?", tag: "h1", size: "xl" }
+            ) %>
         <%= f.hidden_field(:payment_type) %>
         <%= f.govuk_submit "Continue" %>
       <% when "confirm" %>
@@ -29,32 +29,34 @@
 
         <%= govuk_table do |table| %>
           <% table.with_head do |head| %>
-            <% table.with_body do |body| %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(header: true, text: "Payment type") %>
-                <% row.with_cell(text: @adjustment.payment_type) %>
-                <% row.with_cell(numeric: true) do %>
-                  <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, @adjustment.id, form_step: "step1") %>
-                <% end %>
+          <% end %>
+
+          <% table.with_body do |body| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(header: true, text: "Payment type") %>
+              <% row.with_cell(text: @adjustment.payment_type) %>
+              <% row.with_cell(numeric: true) do %>
+                <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, @adjustment.id, form_step: "step1") %>
               <% end %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(header: true, text: "Payments") %>
-                <% row.with_cell(text: number_to_pounds(@adjustment.amount)) %>
-                <% row.with_cell(numeric: true) do %>
-                  <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, @adjustment.id, form_step: "step2") %>
-                <% end %>
+            <% end %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(header: true, text: "Payments") %>
+              <% row.with_cell(text: number_to_pounds(@adjustment.amount)) %>
+              <% row.with_cell(numeric: true) do %>
+                <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, @adjustment.id, form_step: "step2") %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
-        <br/>
-        <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
-        <br/>
-
-        <%= f.hidden_field(:payment_type) %>
-        <%= f.hidden_field(:amount) %>
-        <%= f.govuk_submit "Confirm and continue" %>
       <% end %>
+      <br />
+      <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
+        providing are correct.</p>
+      <br />
+
+      <%= f.hidden_field(:payment_type) %>
+      <%= f.hidden_field(:amount) %>
+      <%= f.govuk_submit "Confirm and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/finance/adjustments/edit.html.erb
+++ b/app/views/finance/adjustments/edit.html.erb
@@ -50,12 +50,12 @@
             <% end %>
           <% end %>
         <% end %>
-      <br />
-      <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
-        providing are correct.</p>
-      <br />
+        <br />
+        <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
+          providing are correct.</p>
+        <br />
 
-      <%= f.govuk_submit "Confirm and continue" %>
+        <%= f.govuk_submit "Confirm and continue" %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/finance/adjustments/index.html.erb
+++ b/app/views/finance/adjustments/index.html.erb
@@ -19,17 +19,17 @@
             <% row.with_cell(header: true, text: "Payments", numeric: true) %>
             <% row.with_cell(header: true, text: "", numeric: true) %>
           <% end %>
+        <% end %>
 
-          <% table.with_body do |body| %>
-            <% @adjustments.each do |adjustment| %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(text: adjustment.payment_type) %>
-                <% row.with_cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
-                <% row.with_cell(numeric: true) do %>
-                  <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, adjustment, form_step: "confirm") %>
-                  &nbsp;&nbsp;|&nbsp;&nbsp;
-                  <%= govuk_link_to "Remove", delete_finance_statement_adjustment_path(@statement, adjustment) %>
-                <% end %>
+        <% table.with_body do |body| %>
+          <% @adjustments.each do |adjustment| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: adjustment.payment_type) %>
+              <% row.with_cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
+              <% row.with_cell(numeric: true) do %>
+                <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, adjustment, form_step: "confirm") %>
+                &nbsp;&nbsp;|&nbsp;&nbsp;
+                <%= govuk_link_to "Remove", delete_finance_statement_adjustment_path(@statement, adjustment) %>
               <% end %>
             <% end %>
           <% end %>
@@ -37,7 +37,7 @@
       <% end %>
 
       <% if params[:added_new].present? %>
-        <br/>
+        <br />
         <%= f.govuk_radio_buttons_fieldset :add_another, legend: { text: "Do you need to add another adjustment", tag: 'h1', size: 'm' } do %>
           <%= f.govuk_radio_button :add_another, "yes", label: { text: "Yes" }, link_errors: true %>
           <%= f.govuk_radio_button :add_another, "no", label: { text: "No" } %>

--- a/app/views/finance/adjustments/index.html.erb
+++ b/app/views/finance/adjustments/index.html.erb
@@ -13,19 +13,19 @@
       <% end %>
 
       <%= govuk_table do |table| %>
-        <% table.head do |head| %>
-          <% head.row do |row| %>
-            <% row.cell(header: true, text: "Payment type") %>
-            <% row.cell(header: true, text: "Payments", numeric: true) %>
-            <% row.cell(header: true, text: "", numeric: true) %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(header: true, text: "Payment type") %>
+            <% row.with_cell(header: true, text: "Payments", numeric: true) %>
+            <% row.with_cell(header: true, text: "", numeric: true) %>
           <% end %>
 
-          <% table.body do |body| %>
+          <% table.with_body do |body| %>
             <% @adjustments.each do |adjustment| %>
-              <% body.row do |row| %>
-                <% row.cell(text: adjustment.payment_type) %>
-                <% row.cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
-                <% row.cell(numeric: true) do %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: adjustment.payment_type) %>
+                <% row.with_cell(text: number_to_pounds(adjustment.amount), numeric: true) %>
+                <% row.with_cell(numeric: true) do %>
                   <%= govuk_link_to "Change", edit_finance_statement_adjustment_path(@statement, adjustment, form_step: "confirm") %>
                   &nbsp;&nbsp;|&nbsp;&nbsp;
                   <%= govuk_link_to "Remove", delete_finance_statement_adjustment_path(@statement, adjustment) %>

--- a/app/views/finance/adjustments/new.html.erb
+++ b/app/views/finance/adjustments/new.html.erb
@@ -9,18 +9,18 @@
       <% case @adjustment.form_step %>
       <% when "step1" %>
         <%= f.govuk_text_field(
-          :payment_type,
-          caption: { text: "Add adjustment", size: "xl"},
-          label: { text: "What is the name of the adjustment", tag: "h1", size: "xl" },
-          hint: { text: "Describe what the adjustment is for. For example 'IT consultant fee'" }
-        ) %>
+                :payment_type,
+                caption: { text: "Add adjustment", size: "xl" },
+                label: { text: "What is the name of the adjustment", tag: "h1", size: "xl" },
+                hint: { text: "Describe what the adjustment is for. For example 'IT consultant fee'" }
+            ) %>
         <%= f.govuk_submit "Continue" %>
       <% when "step2" %>
         <%= f.govuk_text_field(
-          :amount,
-          caption: { text: "Add adjustment", size: "xl"},
-          label: { text: "How much is the payment?", tag: "h1", size: "xl" }
-        ) %>
+                :amount,
+                caption: { text: "Add adjustment", size: "xl" },
+                label: { text: "How much is the payment?", tag: "h1", size: "xl" }
+            ) %>
         <%= f.hidden_field(:payment_type) %>
         <%= f.govuk_submit "Continue" %>
       <% when "confirm" %>
@@ -29,32 +29,33 @@
 
         <%= govuk_table do |table| %>
           <% table.with_head do |head| %>
-            <% table.with_body do |body| %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(header: true, text: "Payment type") %>
-                <% row.with_cell(text: @adjustment.payment_type) %>
-                <% row.with_cell(numeric: true) do %>
-                  <%= govuk_link_to "Change", new_finance_statement_adjustment_path(@statement, form_step: "step1") %>
-                <% end %>
+          <% end %>
+          <% table.with_body do |body| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(header: true, text: "Payment type") %>
+              <% row.with_cell(text: @adjustment.payment_type) %>
+              <% row.with_cell(numeric: true) do %>
+                <%= govuk_link_to "Change", new_finance_statement_adjustment_path(@statement, form_step: "step1") %>
               <% end %>
-              <% body.with_row do |row| %>
-                <% row.with_cell(header: true, text: "Payments") %>
-                <% row.with_cell(text: number_to_pounds(@adjustment.amount)) %>
-                <% row.with_cell(numeric: true) do %>
-                  <%= govuk_link_to "Change", new_finance_statement_adjustment_path(@statement, form_step: "step2") %>
-                <% end %>
+            <% end %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(header: true, text: "Payments") %>
+              <% row.with_cell(text: number_to_pounds(@adjustment.amount)) %>
+              <% row.with_cell(numeric: true) do %>
+                <%= govuk_link_to "Change", new_finance_statement_adjustment_path(@statement, form_step: "step2") %>
               <% end %>
             <% end %>
           <% end %>
         <% end %>
-        <br/>
-        <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
-        <br/>
-
-        <%= f.hidden_field(:payment_type) %>
-        <%= f.hidden_field(:amount) %>
-        <%= f.govuk_submit "Confirm and continue" %>
       <% end %>
+      <br />
+      <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
+        providing are correct.</p>
+      <br />
+
+      <%= f.hidden_field(:payment_type) %>
+      <%= f.hidden_field(:amount) %>
+      <%= f.govuk_submit "Confirm and continue" %>
     <% end %>
   </div>
 </div>

--- a/app/views/finance/adjustments/new.html.erb
+++ b/app/views/finance/adjustments/new.html.erb
@@ -49,13 +49,13 @@
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
-      <br />
-      <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
-        providing are correct.</p>
-      <br />
+        <br />
+        <p class="govuk-body">By continuing you are confirming that, to the best of your knowledge, the details you are
+          providing are correct.</p>
+        <br />
 
-      <%= f.govuk_submit "Confirm and continue" %>
+        <%= f.govuk_submit "Confirm and continue" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/finance/adjustments/new.html.erb
+++ b/app/views/finance/adjustments/new.html.erb
@@ -28,19 +28,19 @@
         <h1 class="govuk-heading-xl">Check your answers</h1>
 
         <%= govuk_table do |table| %>
-          <% table.head do |head| %>
-            <% table.body do |body| %>
-              <% body.row do |row| %>
-                <% row.cell(header: true, text: "Payment type") %>
-                <% row.cell(text: @adjustment.payment_type) %>
-                <% row.cell(numeric: true) do %>
+          <% table.with_head do |head| %>
+            <% table.with_body do |body| %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(header: true, text: "Payment type") %>
+                <% row.with_cell(text: @adjustment.payment_type) %>
+                <% row.with_cell(numeric: true) do %>
                   <%= govuk_link_to "Change", new_finance_statement_adjustment_path(@statement, form_step: "step1") %>
                 <% end %>
               <% end %>
-              <% body.row do |row| %>
-                <% row.cell(header: true, text: "Payments") %>
-                <% row.cell(text: number_to_pounds(@adjustment.amount)) %>
-                <% row.cell(numeric: true) do %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(header: true, text: "Payments") %>
+                <% row.with_cell(text: number_to_pounds(@adjustment.amount)) %>
+                <% row.with_cell(numeric: true) do %>
                   <%= govuk_link_to "Change", new_finance_statement_adjustment_path(@statement, form_step: "step2") %>
                 <% end %>
               <% end %>

--- a/app/views/finance/adjustments/new.html.erb
+++ b/app/views/finance/adjustments/new.html.erb
@@ -5,6 +5,8 @@
     <%= form_for @adjustment, url: finance_statement_adjustments_path(@statement), as: :finance_adjustment do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.hidden_field(:form_step) %>
+      <%= f.hidden_field(:payment_type) %>
+      <%= f.hidden_field(:amount) %>
 
       <% case @adjustment.form_step %>
       <% when "step1" %>
@@ -53,8 +55,6 @@
         providing are correct.</p>
       <br />
 
-      <%= f.hidden_field(:payment_type) %>
-      <%= f.hidden_field(:amount) %>
       <%= f.govuk_submit "Confirm and continue" %>
     <% end %>
   </div>

--- a/app/views/finance/ecf/duplicates/compare/_details.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_details.html.erb
@@ -1,44 +1,44 @@
 <%= govuk_table do |table|
-  table.head(classes: ["govuk-body-s"]) do |head|
-    table.body(classes: ["govuk-body-s"]) do |body|
-      body.row do |row|
-        row.cell(header: true, text: "Record type")
-        row.cell { |row| govuk_tag(text: "primary", colour: "green") }
-        row.cell { |row| govuk_tag(text: "duplicate", colour: "grey") }
+  table.with_head(classes: ["govuk-body-s"]) do |head|
+    table.with_body(classes: ["govuk-body-s"]) do |body|
+      body.with_row do |row|
+        row.with_cell(header: true, text: "Record type")
+        row.with_cell { |_| tag_for(primary_profile)}
+        row.with_cell { |_| tag_for(duplicate_profile)}
       end
-      body.row { |row| comparative_table_row_for(row: row, header: "Profile type", method: :profile_type, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "User ID", method: :user_id, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "External identifier", method: :external_identifier, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Profile ID", method: :id, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "TRN", method: :teacher_profile_trn, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Teacher Profile ID", method: :teacher_profile_id, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Cohort", method: :cohort, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Schedule", method: :schedule_identifier, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Induction status", method: :induction_status, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Training status", method: :training_status, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "Lead Provider", method: :provider_name, primary_profile:, duplicate_profile:) }
-      body.row { |row| comparative_table_row_for(row: row, header: "School", method: :school_name, primary_profile:, duplicate_profile:) }
-      body.row do |row|
-        row.cell(header: true, text: "Starts on")
-        row.cell(text: primary_profile.start_date&.to_fs(:govuk))
-        row.cell(text: duplicate_profile.start_date&.to_fs(:govuk))
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Profile type", method: :profile_type, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "User ID", method: :user_id, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "External identifier", method: :external_identifier, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Profile ID", method: :id, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "TRN", method: :teacher_profile_trn, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Teacher Profile ID", method: :teacher_profile_id, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Cohort", method: :cohort, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Schedule", method: :schedule_identifier, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Induction status", method: :induction_status, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Training status", method: :training_status, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Lead Provider", method: :provider_name, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "School", method: :school_name, primary_profile:, duplicate_profile:) }
+      body.with_row do |row|
+        row.with_cell(header: true, text: "Starts on")
+        row.with_cell(text: primary_profile.start_date&.to_fs(:govuk))
+        row.with_cell(text: duplicate_profile.start_date&.to_fs(:govuk))
       end
-      body.row do |row|
-        row.cell(header: true, text: "Ends on")
-        row.cell(text: primary_profile.end_date&.to_fs(:govuk))
-        row.cell(text: duplicate_profile.end_date&.to_fs(:govuk))
+      body.with_row do |row|
+        row.with_cell(header: true, text: "Ends on")
+        row.with_cell(text: primary_profile.end_date&.to_fs(:govuk))
+        row.with_cell(text: duplicate_profile.end_date&.to_fs(:govuk))
       end
-      body.row do |row|
-        row.cell(header: true, text: "Created at")
-        row.cell(text: primary_profile.created_at&.to_fs(:govuk))
-        row.cell(text: duplicate_profile.created_at&.to_fs(:govuk))
+      body.with_row do |row|
+        row.with_cell(header: true, text: "Created at")
+        row.with_cell(text: primary_profile.created_at&.to_fs(:govuk))
+        row.with_cell(text: duplicate_profile.created_at&.to_fs(:govuk))
       end
-      body.row do |row|
-        row.cell(header: true, text: "Updated at")
-        row.cell(text: primary_profile.updated_at&.to_fs(:govuk))
-        row.cell(text: duplicate_profile.updated_at&.to_fs(:govuk))
+      body.with_row do |row|
+        row.with_cell(header: true, text: "Updated at")
+        row.with_cell(text: primary_profile.updated_at&.to_fs(:govuk))
+        row.with_cell(text: duplicate_profile.updated_at&.to_fs(:govuk))
       end
-      body.row { |row| comparative_table_row_for(row: row, header: "Declaration count", method: :declaration_count, primary_profile:, duplicate_profile:) }
+      body.with_row { |row| comparative_table_row_for(row: row, header: "Declaration count", method: :declaration_count, primary_profile:, duplicate_profile:) }
     end
   end
 end %>
@@ -47,4 +47,4 @@ end %>
   c.tab(label: "Induction records") { render 'finance/ecf/duplicates/compare/induction_records', primary_profile:, duplicate_profile: }
   c.tab(label: "Declarations") { render 'finance/ecf/duplicates/compare/declarations', primary_profile:, duplicate_profile: }
   c.tab(label: "Deduplicate") { render 'finance/ecf/duplicates/compare/deduplicate', primary_profile:, duplicate_profile: }
-end%>
+end %>

--- a/app/views/finance/ecf/duplicates/compare/_details.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_details.html.erb
@@ -1,49 +1,50 @@
 <%= govuk_table do |table|
   table.with_head(classes: ["govuk-body-s"]) do |head|
-    table.with_body(classes: ["govuk-body-s"]) do |body|
-      body.with_row do |row|
-        row.with_cell(header: true, text: "Record type")
-        row.with_cell { |_| tag_for(primary_profile)}
-        row.with_cell { |_| tag_for(duplicate_profile)}
-      end
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Profile type", method: :profile_type, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "User ID", method: :user_id, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "External identifier", method: :external_identifier, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Profile ID", method: :id, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "TRN", method: :teacher_profile_trn, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Teacher Profile ID", method: :teacher_profile_id, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Cohort", method: :cohort, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Schedule", method: :schedule_identifier, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Induction status", method: :induction_status, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Training status", method: :training_status, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Lead Provider", method: :provider_name, primary_profile:, duplicate_profile:) }
-      body.with_row { |row| comparative_table_row_for(row: row, header: "School", method: :school_name, primary_profile:, duplicate_profile:) }
-      body.with_row do |row|
-        row.with_cell(header: true, text: "Starts on")
-        row.with_cell(text: primary_profile.start_date&.to_fs(:govuk))
-        row.with_cell(text: duplicate_profile.start_date&.to_fs(:govuk))
-      end
-      body.with_row do |row|
-        row.with_cell(header: true, text: "Ends on")
-        row.with_cell(text: primary_profile.end_date&.to_fs(:govuk))
-        row.with_cell(text: duplicate_profile.end_date&.to_fs(:govuk))
-      end
-      body.with_row do |row|
-        row.with_cell(header: true, text: "Created at")
-        row.with_cell(text: primary_profile.created_at&.to_fs(:govuk))
-        row.with_cell(text: duplicate_profile.created_at&.to_fs(:govuk))
-      end
-      body.with_row do |row|
-        row.with_cell(header: true, text: "Updated at")
-        row.with_cell(text: primary_profile.updated_at&.to_fs(:govuk))
-        row.with_cell(text: duplicate_profile.updated_at&.to_fs(:govuk))
-      end
-      body.with_row { |row| comparative_table_row_for(row: row, header: "Declaration count", method: :declaration_count, primary_profile:, duplicate_profile:) }
+  end
+
+  table.with_body(classes: ["govuk-body-s"]) do |body|
+    body.with_row do |row|
+      row.with_cell(header: true, text: "Record type")
+      row.with_cell { |_| tag_for(primary_profile) }
+      row.with_cell { |_| tag_for(duplicate_profile) }
     end
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Profile type", method: :profile_type, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "User ID", method: :user_id, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "External identifier", method: :external_identifier, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Profile ID", method: :id, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "TRN", method: :teacher_profile_trn, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Teacher Profile ID", method: :teacher_profile_id, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Cohort", method: :cohort, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Schedule", method: :schedule_identifier, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Induction status", method: :induction_status, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Training status", method: :training_status, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Lead Provider", method: :provider_name, primary_profile:, duplicate_profile:) }
+    body.with_row { |row| comparative_table_row_for(row: row, header: "School", method: :school_name, primary_profile:, duplicate_profile:) }
+    body.with_row do |row|
+      row.with_cell(header: true, text: "Starts on")
+      row.with_cell(text: primary_profile.start_date&.to_fs(:govuk))
+      row.with_cell(text: duplicate_profile.start_date&.to_fs(:govuk))
+    end
+    body.with_row do |row|
+      row.with_cell(header: true, text: "Ends on")
+      row.with_cell(text: primary_profile.end_date&.to_fs(:govuk))
+      row.with_cell(text: duplicate_profile.end_date&.to_fs(:govuk))
+    end
+    body.with_row do |row|
+      row.with_cell(header: true, text: "Created at")
+      row.with_cell(text: primary_profile.created_at&.to_fs(:govuk))
+      row.with_cell(text: duplicate_profile.created_at&.to_fs(:govuk))
+    end
+    body.with_row do |row|
+      row.with_cell(header: true, text: "Updated at")
+      row.with_cell(text: primary_profile.updated_at&.to_fs(:govuk))
+      row.with_cell(text: duplicate_profile.updated_at&.to_fs(:govuk))
+    end
+    body.with_row { |row| comparative_table_row_for(row: row, header: "Declaration count", method: :declaration_count, primary_profile:, duplicate_profile:) }
   end
 end %>
 
-<%=  govuk_tabs(title: "Induction records and declarations") do |c|
+<%= govuk_tabs(title: "Induction records and declarations") do |c|
   c.with_tab(label: "Induction records") { render 'finance/ecf/duplicates/compare/induction_records', primary_profile:, duplicate_profile: }
   c.with_tab(label: "Declarations") { render 'finance/ecf/duplicates/compare/declarations', primary_profile:, duplicate_profile: }
   c.with_tab(label: "Deduplicate") { render 'finance/ecf/duplicates/compare/deduplicate', primary_profile:, duplicate_profile: }

--- a/app/views/finance/ecf/duplicates/compare/_details.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_details.html.erb
@@ -44,7 +44,7 @@
 end %>
 
 <%=  govuk_tabs(title: "Induction records and declarations") do |c|
-  c.tab(label: "Induction records") { render 'finance/ecf/duplicates/compare/induction_records', primary_profile:, duplicate_profile: }
-  c.tab(label: "Declarations") { render 'finance/ecf/duplicates/compare/declarations', primary_profile:, duplicate_profile: }
-  c.tab(label: "Deduplicate") { render 'finance/ecf/duplicates/compare/deduplicate', primary_profile:, duplicate_profile: }
+  c.with_tab(label: "Induction records") { render 'finance/ecf/duplicates/compare/induction_records', primary_profile:, duplicate_profile: }
+  c.with_tab(label: "Declarations") { render 'finance/ecf/duplicates/compare/declarations', primary_profile:, duplicate_profile: }
+  c.with_tab(label: "Deduplicate") { render 'finance/ecf/duplicates/compare/deduplicate', primary_profile:, duplicate_profile: }
 end %>

--- a/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_induction_record_summary_list.html.erb
@@ -1,42 +1,42 @@
 <%= govuk_summary_list do |summary_list|
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "ID" }
-    row.value  { induction_record.id }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "ID" }
+    row.with_value  { induction_record.id }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Lead provider" }
-    row.value  { induction_record.lead_provider&.name }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Lead provider" }
+    row.with_value  { induction_record.lead_provider&.name }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Cohort" }
-    row.value { induction_record.cohort.display_name }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Cohort" }
+    row.with_value { induction_record.cohort.display_name }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Schedule" }
-    row.value { induction_record.schedule.schedule_identifier }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Schedule" }
+    row.with_value { induction_record.schedule.schedule_identifier }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Starts on" }
-    row.value { induction_record.start_date.to_fs(:govuk) }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Starts on" }
+    row.with_value { induction_record.start_date.to_fs(:govuk) }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key    { "Ends on" }
-    row.value  { induction_record.end_date&.to_fs(:govuk) }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key    { "Ends on" }
+    row.with_value  { induction_record.end_date&.to_fs(:govuk) }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key    { "Preferred email" }
-    row.value  { induction_record.preferred_identity&.email }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key    { "Preferred email" }
+    row.with_value  { induction_record.preferred_identity&.email }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key    { "Induction status" }
-    row.value  { induction_record.induction_status }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key    { "Induction status" }
+    row.with_value  { induction_record.induction_status }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key    { "Training status" }
-    row.value  { induction_record.training_status }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key    { "Training status" }
+    row.with_value  { induction_record.training_status }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key    { "Induction Programme Type" }
-    row.value  { induction_record.induction_programme.training_programme }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key    { "Induction Programme Type" }
+    row.with_value  { induction_record.induction_programme.training_programme }
   end
 end %>

--- a/app/views/finance/ecf/duplicates/compare/_participant_declaration_summary_list.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_participant_declaration_summary_list.html.erb
@@ -1,46 +1,46 @@
 <%= govuk_summary_list do |summary_list|
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "ID" }
-    row.value  { participant_declaration.id }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "ID" }
+    row.with_value  { participant_declaration.id }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Type" }
-    row.value  { participant_declaration.declaration_type }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Type" }
+    row.with_value  { participant_declaration.declaration_type }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "State" }
-    row.value  { participant_declaration.state }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "State" }
+    row.with_value  { participant_declaration.state }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Lead provider" }
-    row.value  { participant_declaration.cpd_lead_provider.name }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Lead provider" }
+    row.with_value  { participant_declaration.cpd_lead_provider.name }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Declaration date" }
-    row.value { participant_declaration.declaration_date.to_fs(:govuk) }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Declaration date" }
+    row.with_value { participant_declaration.declaration_date.to_fs(:govuk) }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Course" }
-    row.value { participant_declaration.course_identifier }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Course" }
+    row.with_value { participant_declaration.course_identifier }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Sparsity uplift" }
-    row.value { participant_declaration.sparsity_uplift.to_s }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Sparsity uplift" }
+    row.with_value { participant_declaration.sparsity_uplift.to_s }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Pupil premium uplift" }
-    row.value { participant_declaration.pupil_premium_uplift.to_s }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Pupil premium uplift" }
+    row.with_value { participant_declaration.pupil_premium_uplift.to_s }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Delivery Partner" }
-    row.value { participant_declaration.delivery_partner&.name }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Delivery Partner" }
+    row.with_value { participant_declaration.delivery_partner&.name }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Updated at" }
-    row.value { participant_declaration.updated_at.to_fs(:govuk) }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Updated at" }
+    row.with_value { participant_declaration.updated_at.to_fs(:govuk) }
   end
-  summary_list.row(classes: "govuk-body-s") do |row|
-    row.key { "Created at" }
-    row.value { participant_declaration.created_at.to_fs(:govuk) }
+  summary_list.with_row(classes: "govuk-body-s") do |row|
+    row.with_key { "Created at" }
+    row.with_value { participant_declaration.created_at.to_fs(:govuk) }
   end
 end %>

--- a/app/views/finance/ecf/duplicates/edit.html.erb
+++ b/app/views/finance/ecf/duplicates/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content,  govuk_breadcrumbs(breadcrumbs: @breadcrumbs) %>
+<% content_for :before_content, govuk_breadcrumbs(breadcrumbs: @breadcrumbs) %>
 
 <span class="govuk-caption-l"><%= @participant_profile.profile_type %></span>
 <h1 class="govuk-heading-xl">Delete duplicate profiles for <%= @participant_profile.user.full_name %></h1>
@@ -15,18 +15,18 @@
           row.with_cell(header: true, text: "Declaration count")
           row.with_cell(header: true, text: "Actions")
         end
+      end
 
-        table.with_body do |body|
-          @participant_profile.duplicate_participant_profiles.each do |participant_profile|
-            body.with_row do |row|
-              row.with_cell(text: participant_profile.id)
-              row.with_cell(text: participant_profile.induction_status)
-              row.with_cell(text: participant_profile.training_status)
-              row.with_cell(text: participant_profile.provider_name)
-              row.with_cell(text: participant_profile.declaration_count)
-              row.with_cell do
-                govuk_link_to "compare", finance_ecf_duplicate_profile_compare_path(participant_profile, @participant_profile)
-              end
+      table.with_body do |body|
+        @participant_profile.duplicate_participant_profiles.each do |participant_profile|
+          body.with_row do |row|
+            row.with_cell(text: participant_profile.id)
+            row.with_cell(text: participant_profile.induction_status)
+            row.with_cell(text: participant_profile.training_status)
+            row.with_cell(text: participant_profile.provider_name)
+            row.with_cell(text: participant_profile.declaration_count)
+            row.with_cell do
+              govuk_link_to "compare", finance_ecf_duplicate_profile_compare_path(participant_profile, @participant_profile)
             end
           end
         end

--- a/app/views/finance/ecf/duplicates/edit.html.erb
+++ b/app/views/finance/ecf/duplicates/edit.html.erb
@@ -6,25 +6,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_table do |table|
-      table.head do |head|
-        head.row do |row|
-          row.cell(header: true, text: "Profile ID")
-          row.cell(header: true, text: "Induction status")
-          row.cell(header: true, text: "Training status")
-          row.cell(header: true, text: "Provider")
-          row.cell(header: true, text: "Declaration count")
-          row.cell(header: true, text: "Actions")
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: "Profile ID")
+          row.with_cell(header: true, text: "Induction status")
+          row.with_cell(header: true, text: "Training status")
+          row.with_cell(header: true, text: "Provider")
+          row.with_cell(header: true, text: "Declaration count")
+          row.with_cell(header: true, text: "Actions")
         end
 
-        table.body do |body|
+        table.with_body do |body|
           @participant_profile.duplicate_participant_profiles.each do |participant_profile|
-            body.row do |row|
-              row.cell(text: participant_profile.id)
-              row.cell(text: participant_profile.induction_status)
-              row.cell(text: participant_profile.training_status)
-              row.cell(text: participant_profile.provider_name)
-              row.cell(text: participant_profile.declaration_count)
-              row.cell do
+            body.with_row do |row|
+              row.with_cell(text: participant_profile.id)
+              row.with_cell(text: participant_profile.induction_status)
+              row.with_cell(text: participant_profile.training_status)
+              row.with_cell(text: participant_profile.provider_name)
+              row.with_cell(text: participant_profile.declaration_count)
+              row.with_cell do
                 govuk_link_to "compare", finance_ecf_duplicate_profile_compare_path(participant_profile, @participant_profile)
               end
             end

--- a/app/views/finance/ecf/duplicates/index.html.erb
+++ b/app/views/finance/ecf/duplicates/index.html.erb
@@ -23,23 +23,23 @@
           row.with_cell(header: true, text: "Declaration count")
           row.with_cell(header: true, text: "Actions")
         end
+      end
 
-        table.with_body(classes: ["govuk-body-s"]) do |body|
-          @participant_profiles.each do |participant_profile|
-            body.with_row do |row|
-              row.with_cell(text: participant_profile.profile_type)
-              row.with_cell(text: participant_profile.external_identifier)
-              row.with_cell(text: participant_profile.id)
-              row.with_cell(text: participant_profile.cohort)
-              row.with_cell(text: participant_profile.schedule_identifier)
-              row.with_cell(text: participant_profile.induction_status)
-              row.with_cell(text: participant_profile.training_status)
-              row.with_cell(text: participant_profile.provider_name)
-              row.with_cell(text: participant_profile.duplicate_profile_count - 1)
-              row.with_cell(text: participant_profile.declaration_count)
-              row.with_cell do
-                govuk_link_to "View duplicates", finance_ecf_duplicate_path(participant_profile), { class: govuk_link_classes }
-              end
+      table.with_body(classes: ["govuk-body-s"]) do |body|
+        @participant_profiles.each do |participant_profile|
+          body.with_row do |row|
+            row.with_cell(text: participant_profile.profile_type)
+            row.with_cell(text: participant_profile.external_identifier)
+            row.with_cell(text: participant_profile.id)
+            row.with_cell(text: participant_profile.cohort)
+            row.with_cell(text: participant_profile.schedule_identifier)
+            row.with_cell(text: participant_profile.induction_status)
+            row.with_cell(text: participant_profile.training_status)
+            row.with_cell(text: participant_profile.provider_name)
+            row.with_cell(text: participant_profile.duplicate_profile_count - 1)
+            row.with_cell(text: participant_profile.declaration_count)
+            row.with_cell do
+              govuk_link_to "View duplicates", finance_ecf_duplicate_path(participant_profile), { class: govuk_link_classes }
             end
           end
         end

--- a/app/views/finance/ecf/duplicates/index.html.erb
+++ b/app/views/finance/ecf/duplicates/index.html.erb
@@ -9,35 +9,35 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_table do |table|
-      table.head(classes: ["govuk-body-s"]) do |head|
-        head.row do |row|
-          row.cell(header: true, text: "Profile type")
-          row.cell(header: true, text: "External identifier")
-          row.cell(header: true, text: "Profile ID")
-          row.cell(header: true, text: "Cohort")
-          row.cell(header: true, text: "Schedule")
-          row.cell(header: true, text: "Induction status")
-          row.cell(header: true, text: "Training status")
-          row.cell(header: true, text: "Provider")
-          row.cell(header: true, text: "Duplicate count")
-          row.cell(header: true, text: "Declaration count")
-          row.cell(header: true, text: "Actions")
+      table.with_head(classes: ["govuk-body-s"]) do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: "Profile type")
+          row.with_cell(header: true, text: "External identifier")
+          row.with_cell(header: true, text: "Profile ID")
+          row.with_cell(header: true, text: "Cohort")
+          row.with_cell(header: true, text: "Schedule")
+          row.with_cell(header: true, text: "Induction status")
+          row.with_cell(header: true, text: "Training status")
+          row.with_cell(header: true, text: "Provider")
+          row.with_cell(header: true, text: "Duplicate count")
+          row.with_cell(header: true, text: "Declaration count")
+          row.with_cell(header: true, text: "Actions")
         end
 
-        table.body(classes: ["govuk-body-s"]) do |body|
+        table.with_body(classes: ["govuk-body-s"]) do |body|
           @participant_profiles.each do |participant_profile|
-            body.row do |row|
-              row.cell(text: participant_profile.profile_type)
-              row.cell(text: participant_profile.external_identifier)
-              row.cell(text: participant_profile.id)
-              row.cell(text: participant_profile.cohort)
-              row.cell(text: participant_profile.schedule_identifier)
-              row.cell(text: participant_profile.induction_status)
-              row.cell(text: participant_profile.training_status)
-              row.cell(text: participant_profile.provider_name)
-              row.cell(text: participant_profile.duplicate_profile_count - 1)
-              row.cell(text: participant_profile.declaration_count)
-              row.cell do
+            body.with_row do |row|
+              row.with_cell(text: participant_profile.profile_type)
+              row.with_cell(text: participant_profile.external_identifier)
+              row.with_cell(text: participant_profile.id)
+              row.with_cell(text: participant_profile.cohort)
+              row.with_cell(text: participant_profile.schedule_identifier)
+              row.with_cell(text: participant_profile.induction_status)
+              row.with_cell(text: participant_profile.training_status)
+              row.with_cell(text: participant_profile.provider_name)
+              row.with_cell(text: participant_profile.duplicate_profile_count - 1)
+              row.with_cell(text: participant_profile.declaration_count)
+              row.with_cell do
                 govuk_link_to "View duplicates", finance_ecf_duplicate_path(participant_profile), { class: govuk_link_classes }
               end
             end

--- a/app/views/finance/ecf/duplicates/show.html.erb
+++ b/app/views/finance/ecf/duplicates/show.html.erb
@@ -6,57 +6,57 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_table do |table|
-      table.head(classes: ["govuk-body-s"]) do |head|
-        head.row do |row|
-          row.cell(header: true, text: "Profile type")
-          row.cell(header: true, text: "User ID")
-          row.cell(header: true, text: "External identifier")
-          row.cell(header: true, text: "Profile ID")
-          row.cell(header: true, text: "Cohort")
-          row.cell(header: true, text: "Schedule")
-          row.cell(header: true, text: "Induction status")
-          row.cell(header: true, text: "Training status")
-          row.cell(header: true, text: "Lead Provider")
-          row.cell(header: true, text: "School")
-          row.cell(header: true, text: "Starts on")
-          row.cell(header: true, text: "Ends on")
-          row.cell(header: true, text: "Declaration count")
-          row.cell(header: true, text: "Actions")
+      table.with_head(classes: ["govuk-body-s"]) do |head|
+        head.with_row do |row|
+          row.with_cell(header: true, text: "Profile type")
+          row.with_cell(header: true, text: "User ID")
+          row.with_cell(header: true, text: "External identifier")
+          row.with_cell(header: true, text: "Profile ID")
+          row.with_cell(header: true, text: "Cohort")
+          row.with_cell(header: true, text: "Schedule")
+          row.with_cell(header: true, text: "Induction status")
+          row.with_cell(header: true, text: "Training status")
+          row.with_cell(header: true, text: "Lead Provider")
+          row.with_cell(header: true, text: "School")
+          row.with_cell(header: true, text: "Starts on")
+          row.with_cell(header: true, text: "Ends on")
+          row.with_cell(header: true, text: "Declaration count")
+          row.with_cell(header: true, text: "Actions")
         end
 
-        table.body(classes: ["govuk-body-s"]) do |body|
-          body.row do |row|
-            row.cell { tag_for(@participant_profile) }
-            row.cell(text: @participant_profile.user_id)
-            row.cell(text: @participant_profile.external_identifier)
-            row.cell(text: @participant_profile.id)
-            row.cell(text: @participant_profile.cohort)
-            row.cell(text: @participant_profile.schedule_identifier)
-            row.cell(text: @participant_profile.induction_status)
-            row.cell(text: @participant_profile.training_status)
-            row.cell(text: @participant_profile.provider_name)
-            row.cell(text: @participant_profile.school_name)
-            row.cell(text: @participant_profile.start_date.to_date.to_fs(:govuk))
-            row.cell(text: @participant_profile.end_date&.to_date&.to_fs(:govuk))
-            row.cell(text: @participant_profile.declaration_count)
-            row.cell {}
+        table.with_body(classes: ["govuk-body-s"]) do |body|
+          body.with_row do |row|
+            row.with_cell { tag_for(@participant_profile) }
+            row.with_cell(text: @participant_profile.user_id)
+            row.with_cell(text: @participant_profile.external_identifier)
+            row.with_cell(text: @participant_profile.id)
+            row.with_cell(text: @participant_profile.cohort)
+            row.with_cell(text: @participant_profile.schedule_identifier)
+            row.with_cell(text: @participant_profile.induction_status)
+            row.with_cell(text: @participant_profile.training_status)
+            row.with_cell(text: @participant_profile.provider_name)
+            row.with_cell(text: @participant_profile.school_name)
+            row.with_cell(text: @participant_profile.start_date.to_date.to_fs(:govuk))
+            row.with_cell(text: @participant_profile.end_date&.to_date&.to_fs(:govuk))
+            row.with_cell(text: @participant_profile.declaration_count)
+            row.with_cell {}
           end
           @participant_profile.duplicate_participant_profiles.each do |participant_profile|
-            body.row do |row|
-              row.cell { tag_for(participant_profile) }
-              row.cell(text: participant_profile.user_id)
-              row.cell(text: participant_profile.external_identifier)
-              row.cell(text: participant_profile.id)
-              row.cell(text: participant_profile.cohort)
-              row.cell(text: participant_profile.schedule_identifier)
-              row.cell(text: participant_profile.induction_status)
-              row.cell(text: participant_profile.training_status)
-              row.cell(text: participant_profile.provider_name)
-              row.cell(text: participant_profile.school_name)
-              row.cell(text: participant_profile.start_date&.to_date&.to_fs(:govuk))
-              row.cell(text: participant_profile.end_date&.to_date&.to_fs(:govuk))
-              row.cell(text: participant_profile.declaration_count)
-              row.cell do
+            body.with_row do |row|
+              row.with_cell { tag_for(participant_profile) }
+              row.with_cell(text: participant_profile.user_id)
+              row.with_cell(text: participant_profile.external_identifier)
+              row.with_cell(text: participant_profile.id)
+              row.with_cell(text: participant_profile.cohort)
+              row.with_cell(text: participant_profile.schedule_identifier)
+              row.with_cell(text: participant_profile.induction_status)
+              row.with_cell(text: participant_profile.training_status)
+              row.with_cell(text: participant_profile.provider_name)
+              row.with_cell(text: participant_profile.school_name)
+              row.with_cell(text: participant_profile.start_date&.to_date&.to_fs(:govuk))
+              row.with_cell(text: participant_profile.end_date&.to_date&.to_fs(:govuk))
+              row.with_cell(text: participant_profile.declaration_count)
+              row.with_cell do
                 govuk_link_to "View details", finance_ecf_duplicate_compare_path(participant_profile, @participant_profile)
               end
             end

--- a/app/views/finance/ecf/duplicates/show.html.erb
+++ b/app/views/finance/ecf/duplicates/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :before_content,  govuk_breadcrumbs(breadcrumbs: @breadcrumbs) %>
+<% content_for :before_content, govuk_breadcrumbs(breadcrumbs: @breadcrumbs) %>
 
 <span class="govuk-caption-l"><%= @participant_profile.profile_type.titleize %></span>
 <h1 class="govuk-heading-l"><%= @participant_profile.user.full_name %></h1>
@@ -23,42 +23,42 @@
           row.with_cell(header: true, text: "Declaration count")
           row.with_cell(header: true, text: "Actions")
         end
+      end
 
-        table.with_body(classes: ["govuk-body-s"]) do |body|
+      table.with_body(classes: ["govuk-body-s"]) do |body|
+        body.with_row do |row|
+          row.with_cell { tag_for(@participant_profile) }
+          row.with_cell(text: @participant_profile.user_id)
+          row.with_cell(text: @participant_profile.external_identifier)
+          row.with_cell(text: @participant_profile.id)
+          row.with_cell(text: @participant_profile.cohort)
+          row.with_cell(text: @participant_profile.schedule_identifier)
+          row.with_cell(text: @participant_profile.induction_status)
+          row.with_cell(text: @participant_profile.training_status)
+          row.with_cell(text: @participant_profile.provider_name)
+          row.with_cell(text: @participant_profile.school_name)
+          row.with_cell(text: @participant_profile.start_date.to_date.to_fs(:govuk))
+          row.with_cell(text: @participant_profile.end_date&.to_date&.to_fs(:govuk))
+          row.with_cell(text: @participant_profile.declaration_count)
+          row.with_cell {}
+        end
+        @participant_profile.duplicate_participant_profiles.each do |participant_profile|
           body.with_row do |row|
-            row.with_cell { tag_for(@participant_profile) }
-            row.with_cell(text: @participant_profile.user_id)
-            row.with_cell(text: @participant_profile.external_identifier)
-            row.with_cell(text: @participant_profile.id)
-            row.with_cell(text: @participant_profile.cohort)
-            row.with_cell(text: @participant_profile.schedule_identifier)
-            row.with_cell(text: @participant_profile.induction_status)
-            row.with_cell(text: @participant_profile.training_status)
-            row.with_cell(text: @participant_profile.provider_name)
-            row.with_cell(text: @participant_profile.school_name)
-            row.with_cell(text: @participant_profile.start_date.to_date.to_fs(:govuk))
-            row.with_cell(text: @participant_profile.end_date&.to_date&.to_fs(:govuk))
-            row.with_cell(text: @participant_profile.declaration_count)
-            row.with_cell {}
-          end
-          @participant_profile.duplicate_participant_profiles.each do |participant_profile|
-            body.with_row do |row|
-              row.with_cell { tag_for(participant_profile) }
-              row.with_cell(text: participant_profile.user_id)
-              row.with_cell(text: participant_profile.external_identifier)
-              row.with_cell(text: participant_profile.id)
-              row.with_cell(text: participant_profile.cohort)
-              row.with_cell(text: participant_profile.schedule_identifier)
-              row.with_cell(text: participant_profile.induction_status)
-              row.with_cell(text: participant_profile.training_status)
-              row.with_cell(text: participant_profile.provider_name)
-              row.with_cell(text: participant_profile.school_name)
-              row.with_cell(text: participant_profile.start_date&.to_date&.to_fs(:govuk))
-              row.with_cell(text: participant_profile.end_date&.to_date&.to_fs(:govuk))
-              row.with_cell(text: participant_profile.declaration_count)
-              row.with_cell do
-                govuk_link_to "View details", finance_ecf_duplicate_compare_path(participant_profile, @participant_profile)
-              end
+            row.with_cell { tag_for(participant_profile) }
+            row.with_cell(text: participant_profile.user_id)
+            row.with_cell(text: participant_profile.external_identifier)
+            row.with_cell(text: participant_profile.id)
+            row.with_cell(text: participant_profile.cohort)
+            row.with_cell(text: participant_profile.schedule_identifier)
+            row.with_cell(text: participant_profile.induction_status)
+            row.with_cell(text: participant_profile.training_status)
+            row.with_cell(text: participant_profile.provider_name)
+            row.with_cell(text: participant_profile.school_name)
+            row.with_cell(text: participant_profile.start_date&.to_date&.to_fs(:govuk))
+            row.with_cell(text: participant_profile.end_date&.to_date&.to_fs(:govuk))
+            row.with_cell(text: participant_profile.declaration_count)
+            row.with_cell do
+              govuk_link_to "View details", finance_ecf_duplicate_compare_path(participant_profile, @participant_profile)
             end
           end
         end

--- a/app/views/finance/ecf/participant_declarations/voided/show.html.erb
+++ b/app/views/finance/ecf/participant_declarations/voided/show.html.erb
@@ -10,22 +10,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_table do |table| %>
-      <% table.head do |head| %>
-        <% head.row do |row| %>
-          <% row.cell(header: true, text: "Declaration ID") %>
-          <% row.cell(header: true, text: "Participant ID") %>
-          <% row.cell(header: true, text: "Type") %>
-          <% row.cell(header: true, text: "Course") %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(header: true, text: "Declaration ID") %>
+          <% row.with_cell(header: true, text: "Participant ID") %>
+          <% row.with_cell(header: true, text: "Type") %>
+          <% row.with_cell(header: true, text: "Course") %>
         <% end %>
       <% end %>
 
-      <% table.body do |body| %>
+      <% table.with_body do |body| %>
         <% @voided_declarations.each do |declaration| %>
-          <% body.row do |row| %>
-            <% row.cell(text: declaration.id) %>
-            <% row.cell(text: declaration.user.id) %>
-            <% row.cell(text: declaration.declaration_type) %>
-            <% row.cell(text: declaration.course_identifier) %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: declaration.id) %>
+            <% row.with_cell(text: declaration.user.id) %>
+            <% row.with_cell(text: declaration.declaration_type) %>
+            <% row.with_cell(text: declaration.course_identifier) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -123,7 +123,7 @@
   <div class="govuk-grid-column-full">
     <div class="finance-panel finance-panel__output-payments">
       <%= govuk_table classes: ["output-payments"] do |table| %>
-        <% table.caption(size: 'm', text: "Output payments") %>
+        <% table.with_caption(size: 'm', text: "Output payments") %>
 
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
@@ -174,7 +174,7 @@
 
     <div class="finance-panel finance-panel__uplifts govuk-!-margin-top-5 govuk-!-margin-bottom-5">
       <%= govuk_table do |table| %>
-        <% table.caption(size: "m", text: "Uplift fees") %>
+        <% table.with_caption(size: "m", text: "Uplift fees") %>
 
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
@@ -198,7 +198,7 @@
       <h2 class="govuk-heading-m">Adjustments</h2>
 
       <%= govuk_table do |table| %>
-        <% table.caption(size: "s", text: "Clawbacks") %>
+        <% table.with_caption(size: "s", text: "Clawbacks") %>
 
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -125,38 +125,38 @@
       <%= govuk_table classes: ["output-payments"] do |table| %>
         <% table.caption(size: 'm', text: "Output payments") %>
 
-        <% table.head do |head| %>
-          <% head.row do |row| %>
-            <% row.cell(header: true, text: "Outputs") %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(header: true, text: "Outputs") %>
 
             <% @calculator.band_letters.each do |letter| %>
-              <% row.cell(header: true, text: "Band #{letter.upcase}", numeric: true) %>
+              <% row.with_cell(header: true, text: "Band #{letter.upcase}", numeric: true) %>
             <% end %>
 
-            <% row.cell(header: true, text: "Payments", numeric: true) %>
+            <% row.with_cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
 
-          <% table.body do |body| %>
+          <% table.with_body do |body| %>
             <% @calculator.event_types_for_display.each do |event_type| %>
 
-              <% body.row do |row| %>
-                <% row.cell(text: t(".#{event_type}"), header: true) %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: t(".#{event_type}"), header: true) %>
 
                 <% @calculator.band_letters.each do |letter| %>
-                  <% row.cell(text: @calculator.public_send("#{event_type}_band_#{letter}_additions"), numeric: true) %>
+                  <% row.with_cell(text: @calculator.public_send("#{event_type}_band_#{letter}_additions"), numeric: true) %>
                 <% end %>
 
-                <% row.cell(text: "") %>
+                <% row.with_cell(text: "") %>
               <% end %>
 
-              <% body.row do |row| %>
-                <% row.cell(text: "Fee per participant") %>
+              <% body.with_row do |row| %>
+                <% row.with_cell(text: "Fee per participant") %>
 
                 <% @calculator.band_letters.each do |letter| %>
-                  <% row.cell(text: number_to_pounds(@calculator.public_send("#{event_type}_band_#{letter}_fee_per_declaration")), numeric: true) %>
+                  <% row.with_cell(text: number_to_pounds(@calculator.public_send("#{event_type}_band_#{letter}_fee_per_declaration")), numeric: true) %>
                 <% end %>
 
-                <% row.cell(text: number_to_pounds(@calculator.public_send("additions_for_#{event_type}")), numeric: true) %>
+                <% row.with_cell(text: number_to_pounds(@calculator.public_send("additions_for_#{event_type}")), numeric: true) %>
               <% end %>
             <% end %>
           <% end %>
@@ -176,18 +176,18 @@
       <%= govuk_table do |table| %>
         <% table.caption(size: "m", text: "Uplift fees") %>
 
-        <% table.head do |head| %>
-          <% head.row do |row| %>
-            <% row.cell(header: true, text: "Number of participants") %>
-            <% row.cell(header: true, text: "Fee per participant", numeric: true) %>
-            <% row.cell(header: true, text: "Payments", numeric: true) %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(header: true, text: "Number of participants") %>
+            <% row.with_cell(header: true, text: "Fee per participant", numeric: true) %>
+            <% row.with_cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
 
-          <% table.body do |body| %>
-            <% body.row do |row| %>
-              <% row.cell(text: @calculator.uplift_additions_count) %>
-              <% row.cell(text: number_to_pounds(@calculator.uplift_fee_per_declaration), numeric: true) %>
-              <% row.cell(text: number_to_pounds(@calculator.uplift_additions_count * @calculator.uplift_fee_per_declaration), numeric: true) %>
+          <% table.with_body do |body| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: @calculator.uplift_additions_count) %>
+              <% row.with_cell(text: number_to_pounds(@calculator.uplift_fee_per_declaration), numeric: true) %>
+              <% row.with_cell(text: number_to_pounds(@calculator.uplift_additions_count * @calculator.uplift_fee_per_declaration), numeric: true) %>
             <% end %>
           <% end %>
         <% end %>
@@ -200,20 +200,20 @@
       <%= govuk_table do |table| %>
         <% table.caption(size: "s", text: "Clawbacks") %>
 
-        <% table.head do |head| %>
-          <% head.row do |row| %>
-            <% row.cell(header: true, text: "Payment type") %>
-            <% row.cell(header: true, text: "Number of participants") %>
-            <% row.cell(header: true, text: "Fee per participant", numeric: true) %>
-            <% row.cell(header: true, text: "Payments", numeric: true) %>
+        <% table.with_head do |head| %>
+          <% head.with_row do |row| %>
+            <% row.with_cell(header: true, text: "Payment type") %>
+            <% row.with_cell(header: true, text: "Number of participants") %>
+            <% row.with_cell(header: true, text: "Fee per participant", numeric: true) %>
+            <% row.with_cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
 
-          <% table.body do |body| %>
-            <% body.row do |row| %>
-              <% row.cell(text: "Uplift clawbacks") %>
-              <% row.cell(text: @calculator.uplift_deductions_count) %>
-              <% row.cell(text: number_to_pounds(-@calculator.uplift_fee_per_declaration), numeric: true) %>
-              <% row.cell(text: number_to_pounds(@calculator.uplift_clawback_deductions), numeric: true) %>
+          <% table.with_body do |body| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: "Uplift clawbacks") %>
+              <% row.with_cell(text: @calculator.uplift_deductions_count) %>
+              <% row.with_cell(text: number_to_pounds(-@calculator.uplift_fee_per_declaration), numeric: true) %>
+              <% row.with_cell(text: number_to_pounds(@calculator.uplift_clawback_deductions), numeric: true) %>
             <% end %>
 
             <% @calculator.send(:output_calculator).banding_breakdown.each do |hash| %>
@@ -223,13 +223,13 @@
               <% relevant_hash.each do |name, count| %>
                 <% next if count.zero? %>
 
-                <% body.row do |row| %>
+                <% body.with_row do |row| %>
                   <% fee = @calculator.fee_for_declaration(band_letter: hash[:band], type: name) %>
 
-                  <% row.cell(text: "Clawback for #{name.to_s.humanize} (Band: #{hash[:band].to_s.upcase})") %>
-                  <% row.cell(text: count) %>
-                  <% row.cell(text: number_to_pounds(-fee)) %>
-                  <% row.cell(text: number_to_pounds(-count * fee), numeric: true) %>
+                  <% row.with_cell(text: "Clawback for #{name.to_s.humanize} (Band: #{hash[:band].to_s.upcase})") %>
+                  <% row.with_cell(text: count) %>
+                  <% row.with_cell(text: number_to_pounds(-fee)) %>
+                  <% row.with_cell(text: number_to_pounds(-count * fee), numeric: true) %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/finance/ecf/statements/show.html.erb
+++ b/app/views/finance/ecf/statements/show.html.erb
@@ -135,29 +135,29 @@
 
             <% row.with_cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
+        <% end %>
 
-          <% table.with_body do |body| %>
-            <% @calculator.event_types_for_display.each do |event_type| %>
+        <% table.with_body do |body| %>
+          <% @calculator.event_types_for_display.each do |event_type| %>
 
-              <% body.with_row do |row| %>
-                <% row.with_cell(text: t(".#{event_type}"), header: true) %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: t(".#{event_type}"), header: true) %>
 
-                <% @calculator.band_letters.each do |letter| %>
-                  <% row.with_cell(text: @calculator.public_send("#{event_type}_band_#{letter}_additions"), numeric: true) %>
-                <% end %>
-
-                <% row.with_cell(text: "") %>
+              <% @calculator.band_letters.each do |letter| %>
+                <% row.with_cell(text: @calculator.public_send("#{event_type}_band_#{letter}_additions"), numeric: true) %>
               <% end %>
 
-              <% body.with_row do |row| %>
-                <% row.with_cell(text: "Fee per participant") %>
+              <% row.with_cell(text: "") %>
+            <% end %>
 
-                <% @calculator.band_letters.each do |letter| %>
-                  <% row.with_cell(text: number_to_pounds(@calculator.public_send("#{event_type}_band_#{letter}_fee_per_declaration")), numeric: true) %>
-                <% end %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: "Fee per participant") %>
 
-                <% row.with_cell(text: number_to_pounds(@calculator.public_send("additions_for_#{event_type}")), numeric: true) %>
+              <% @calculator.band_letters.each do |letter| %>
+                <% row.with_cell(text: number_to_pounds(@calculator.public_send("#{event_type}_band_#{letter}_fee_per_declaration")), numeric: true) %>
               <% end %>
+
+              <% row.with_cell(text: number_to_pounds(@calculator.public_send("additions_for_#{event_type}")), numeric: true) %>
             <% end %>
           <% end %>
         <% end %>
@@ -182,13 +182,13 @@
             <% row.with_cell(header: true, text: "Fee per participant", numeric: true) %>
             <% row.with_cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
+        <% end %>
 
-          <% table.with_body do |body| %>
-            <% body.with_row do |row| %>
-              <% row.with_cell(text: @calculator.uplift_additions_count) %>
-              <% row.with_cell(text: number_to_pounds(@calculator.uplift_fee_per_declaration), numeric: true) %>
-              <% row.with_cell(text: number_to_pounds(@calculator.uplift_additions_count * @calculator.uplift_fee_per_declaration), numeric: true) %>
-            <% end %>
+        <% table.with_body do |body| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: @calculator.uplift_additions_count) %>
+            <% row.with_cell(text: number_to_pounds(@calculator.uplift_fee_per_declaration), numeric: true) %>
+            <% row.with_cell(text: number_to_pounds(@calculator.uplift_additions_count * @calculator.uplift_fee_per_declaration), numeric: true) %>
           <% end %>
         <% end %>
       <% end %>
@@ -207,30 +207,30 @@
             <% row.with_cell(header: true, text: "Fee per participant", numeric: true) %>
             <% row.with_cell(header: true, text: "Payments", numeric: true) %>
           <% end %>
+        <% end %>
 
-          <% table.with_body do |body| %>
-            <% body.with_row do |row| %>
-              <% row.with_cell(text: "Uplift clawbacks") %>
-              <% row.with_cell(text: @calculator.uplift_deductions_count) %>
-              <% row.with_cell(text: number_to_pounds(-@calculator.uplift_fee_per_declaration), numeric: true) %>
-              <% row.with_cell(text: number_to_pounds(@calculator.uplift_clawback_deductions), numeric: true) %>
-            <% end %>
+        <% table.with_body do |body| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: "Uplift clawbacks") %>
+            <% row.with_cell(text: @calculator.uplift_deductions_count) %>
+            <% row.with_cell(text: number_to_pounds(-@calculator.uplift_fee_per_declaration), numeric: true) %>
+            <% row.with_cell(text: number_to_pounds(@calculator.uplift_clawback_deductions), numeric: true) %>
+          <% end %>
 
-            <% @calculator.send(:output_calculator).banding_breakdown.each do |hash| %>
-              <% relevant_hash = hash.select { |k,v| k.match?(/_subtractions/) } %>
-              <% relevant_hash = relevant_hash.transform_keys { |k| k.to_s.gsub("_subtractions", "").to_sym } %>
+          <% @calculator.send(:output_calculator).banding_breakdown.each do |hash| %>
+            <% relevant_hash = hash.select { |k, v| k.match?(/_subtractions/) } %>
+            <% relevant_hash = relevant_hash.transform_keys { |k| k.to_s.gsub("_subtractions", "").to_sym } %>
 
-              <% relevant_hash.each do |name, count| %>
-                <% next if count.zero? %>
+            <% relevant_hash.each do |name, count| %>
+              <% next if count.zero? %>
 
-                <% body.with_row do |row| %>
-                  <% fee = @calculator.fee_for_declaration(band_letter: hash[:band], type: name) %>
+              <% body.with_row do |row| %>
+                <% fee = @calculator.fee_for_declaration(band_letter: hash[:band], type: name) %>
 
-                  <% row.with_cell(text: "Clawback for #{name.to_s.humanize} (Band: #{hash[:band].to_s.upcase})") %>
-                  <% row.with_cell(text: count) %>
-                  <% row.with_cell(text: number_to_pounds(-fee)) %>
-                  <% row.with_cell(text: number_to_pounds(-count * fee), numeric: true) %>
-                <% end %>
+                <% row.with_cell(text: "Clawback for #{name.to_s.humanize} (Band: #{hash[:band].to_s.upcase})") %>
+                <% row.with_cell(text: count) %>
+                <% row.with_cell(text: number_to_pounds(-fee)) %>
+                <% row.with_cell(text: number_to_pounds(-count * fee), numeric: true) %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/finance/npq/participant_declarations/voided/show.html.erb
+++ b/app/views/finance/npq/participant_declarations/voided/show.html.erb
@@ -10,22 +10,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= govuk_table do |table| %>
-      <% table.head do |head| %>
-        <% head.row do |row| %>
-          <% row.cell(header: true, text: "Declaration ID") %>
-          <% row.cell(header: true, text: "Participant ID") %>
-          <% row.cell(header: true, text: "Type") %>
-          <% row.cell(header: true, text: "Course") %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(header: true, text: "Declaration ID") %>
+          <% row.with_cell(header: true, text: "Participant ID") %>
+          <% row.with_cell(header: true, text: "Type") %>
+          <% row.with_cell(header: true, text: "Course") %>
         <% end %>
       <% end %>
 
-      <% table.body do |body| %>
+      <% table.with_body do |body| %>
         <% @voided_declarations.each do |declaration| %>
-          <% body.row do |row| %>
-            <% row.cell(text: declaration.id) %>
-            <% row.cell(text: declaration.user.id) %>
-            <% row.cell(text: declaration.declaration_type) %>
-            <% row.cell(text: declaration.course_identifier) %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: declaration.id) %>
+            <% row.with_cell(text: declaration.user.id) %>
+            <% row.with_cell(text: declaration.declaration_type) %>
+            <% row.with_cell(text: declaration.course_identifier) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/finance/participants/_declaration.html.erb
+++ b/app/views/finance/participants/_declaration.html.erb
@@ -1,47 +1,47 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "Declaration ID" } %>
-    <% row.value { declaration.id } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Declaration ID" } %>
+    <% row.with_value { declaration.id } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Declaration type" } %>
-    <% row.value { declaration.declaration_type } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Declaration type" } %>
+    <% row.with_value { declaration.declaration_type } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Declaration date" } %>
-    <% row.value { declaration.declaration_date.to_fs(:govuk) } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Declaration date" } %>
+    <% row.with_value { declaration.declaration_date.to_fs(:govuk) } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Course identifier" } %>
-    <% row.value { declaration.course_identifier } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Course identifier" } %>
+    <% row.with_value { declaration.course_identifier } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Evidence held" } %>
-    <% row.value { declaration.evidence_held } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Evidence held" } %>
+    <% row.with_value { declaration.evidence_held } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead provider" } %>
-    <% row.value { declaration.cpd_lead_provider.name } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead provider" } %>
+    <% row.with_value { declaration.cpd_lead_provider.name } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "State" } %>
-    <% row.value { declaration.state } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "State" } %>
+    <% row.with_value { declaration.state } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Created at" } %>
-    <% row.value { declaration.created_at.to_fs(:govuk) } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Created at" } %>
+    <% row.with_value { declaration.created_at.to_fs(:govuk) } %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Updated at" } %>
-    <% row.value { declaration.updated_at.to_fs(:govuk) } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Updated at" } %>
+    <% row.with_value { declaration.updated_at.to_fs(:govuk) } %>
   <% end %>
 <% end %>
 

--- a/app/views/finance/participants/_ecf_profile.html.erb
+++ b/app/views/finance/participants/_ecf_profile.html.erb
@@ -1,62 +1,62 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "User ID / Participant ID" } %>
-    <% row.value { @user.id } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "User ID / Participant ID" } %>
+    <% row.with_value { @user.id } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Profile ID" } %>
-    <% row.value { pp.id } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Profile ID" } %>
+    <% row.with_value { pp.id } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Eligible for funding" } %>
-    <% row.value { pp.fundable?.to_s.upcase } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Eligible for funding" } %>
+    <% row.with_value { pp.fundable?.to_s.upcase } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead provider" } %>
-    <% row.value { pp&.school_cohort&.school&.active_partnerships[0]&.lead_provider&.name } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead provider" } %>
+    <% row.with_value { pp&.school_cohort&.school&.active_partnerships[0]&.lead_provider&.name } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "School URN" } %>
-    <% row.value { pp&.school_cohort&.school&.urn } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "School URN" } %>
+    <% row.with_value { pp&.school_cohort&.school&.urn } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Status" } %>
-    <% row.value { pp.status } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Status" } %>
+    <% row.with_value { pp.status } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Schedule identifier" } %>
-    <% row.value { pp.schedule&.schedule_identifier } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Schedule identifier" } %>
+    <% row.with_value { pp.schedule&.schedule_identifier } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Schedule cohort" } %>
-    <% row.value { pp.schedule&.cohort&.start_year&.to_s } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Schedule cohort" } %>
+    <% row.with_value { pp.schedule&.cohort&.start_year&.to_s } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Created at" } %>
-    <% row.value { pp.created_at.to_fs(:govuk) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Created at" } %>
+    <% row.with_value { pp.created_at.to_fs(:govuk) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Updated at" } %>
-    <% row.value { pp.updated_at.to_fs(:govuk) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Updated at" } %>
+    <% row.with_value { pp.updated_at.to_fs(:govuk) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 <% end %>
 
@@ -66,63 +66,63 @@
   <h5>Induction record: <%= ir.id %></h5>
 
   <%= govuk_summary_list do |summary_list| %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Training programme" } %>
-      <% row.value { ir.induction_programme.training_programme.humanize } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Training programme" } %>
+      <% row.with_value { ir.induction_programme.training_programme.humanize } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "School URN" } %>
-      <% row.value { ir.induction_programme.school_cohort.school.urn } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "School URN" } %>
+      <% row.with_value { ir.induction_programme.school_cohort.school.urn } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "Lead provider" } %>
-      <% row.value { ir.induction_programme.partnership&.lead_provider&.name } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Lead provider" } %>
+      <% row.with_value { ir.induction_programme.partnership&.lead_provider&.name } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "Induction status" } %>
-      <% row.value { ir.induction_status } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Induction status" } %>
+      <% row.with_value { ir.induction_status } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "Training status" } %>
-      <% row.value { ir.training_status } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Training status" } %>
+      <% row.with_value { ir.training_status } %>
       <%= change_induction_record_training_status_button(ir, pp, row) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "Start date" } %>
-      <% row.value { ir.start_date&.to_fs(:govuk) } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Start date" } %>
+      <% row.with_value { ir.start_date&.to_fs(:govuk) } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "End date" } %>
-      <% row.value { ir.end_date&.to_fs(:govuk) } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "End date" } %>
+      <% row.with_value { ir.end_date&.to_fs(:govuk) } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "Schedule" } %>
-      <% row.value { ir.schedule.schedule_identifier } %>
-      <% row.action(text: :none) %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Schedule" } %>
+      <% row.with_value { ir.schedule.schedule_identifier } %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
     <% if latest_induction_record_for_provider?(ir, pp) %>
-      <% summary_list.row do |row| %>
-        <% row.key { "Lead Provider API V3" } %>
-        <% row.value do %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Lead Provider API V3" } %>
+        <% row.with_value do %>
           <%= govuk_details(summary_text: "See this participant as it appears over the Lead Provider API") do %>
             <%= induction_record_participant_api_response(ir, pp) %>
           <% end %>
         <% end %>
-        <% row.action(text: :none) %>
+        <% row.with_action(text: :none) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/finance/participants/_npq_application.html.erb
+++ b/app/views/finance/participants/_npq_application.html.erb
@@ -1,23 +1,23 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "Application ID" } %>
-    <% row.value { govuk_link_to application.id, finance_participant_path(application.id) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Application ID" } %>
+    <% row.with_value { govuk_link_to application.id, finance_participant_path(application.id) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead Provider" } %>
-    <% row.value { application.npq_lead_provider.name } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead Provider" } %>
+    <% row.with_value { application.npq_lead_provider.name } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead Provider approval status" } %>
-    <% row.value { application.lead_provider_approval_status } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead Provider approval status" } %>
+    <% row.with_value { application.lead_provider_approval_status } %>
     <% if application.lead_provider_approval_status == "pending" %>
-      <% row.action(text: :none) %>
+      <% row.with_action(text: :none) %>
     <% else %>
-      <% row.action(
+      <% row.with_action(
         text: "Change to pending",
         visually_hidden_text: "",
         href: new_finance_npq_application_change_lead_provider_approval_status_path(application))
@@ -25,49 +25,49 @@
     <% end %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "NPQ course" } %>
-    <% row.value { application.npq_course.name } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "NPQ course" } %>
+    <% row.with_value { application.npq_course.name } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "School URN" } %>
-    <% row.value { application.school_urn } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "School URN" } %>
+    <% row.with_value { application.school_urn } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "School UKPRN" } %>
-    <% row.value { application.school_ukprn } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "School UKPRN" } %>
+    <% row.with_value { application.school_ukprn } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Targeted support funding eligibility" } %>
-    <% row.value { bool_to_tag(application.targeted_delivery_funding_eligibility) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Targeted support funding eligibility" } %>
+    <% row.with_value { bool_to_tag(application.targeted_delivery_funding_eligibility) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Created at" } %>
-    <% row.value { application.created_at.to_fs(:govuk) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Created at" } %>
+    <% row.with_value { application.created_at.to_fs(:govuk) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Updated at" } %>
-    <% row.value { application.updated_at.to_fs(:govuk) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Updated at" } %>
+    <% row.with_value { application.updated_at.to_fs(:govuk) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead Provider API V3" } %>
-    <% row.value do %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead Provider API V3" } %>
+    <% row.with_value do %>
       <%= govuk_details(summary_text: "See this application as it appears over the Lead Provider API") do %>
         <%= npq_application_api_response(application) %>
       <% end %>
     <% end %>
-    <% row.action(text: :none) %>
+    <% row.with_action(text: :none) %>
   <% end %>
 <% end %>

--- a/app/views/finance/participants/_npq_profile.html.erb
+++ b/app/views/finance/participants/_npq_profile.html.erb
@@ -1,96 +1,96 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "User ID / Participant ID" } %>
-    <% row.value { @user.id } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "User ID / Participant ID" } %>
+    <% row.with_value { @user.id } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Profile ID" } %>
-    <% row.value { pp.id } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Profile ID" } %>
+    <% row.with_value { pp.id } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Eligible for funding" } %>
-    <% row.value { pp.fundable?.to_s.upcase } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Eligible for funding" } %>
+    <% row.with_value { pp.fundable?.to_s.upcase } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "NPQ course" } %>
-    <% row.value { pp.npq_course&.name } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "NPQ course" } %>
+    <% row.with_value { pp.npq_course&.name } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead provider" } %>
-    <% row.value { pp.npq_application&.npq_lead_provider&.name } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead provider" } %>
+    <% row.with_value { pp.npq_application&.npq_lead_provider&.name } %>
     <% if Finance::NPQ::ChangeLeadProviderForm.new(participant_profile: pp).change_lead_provider? %>
-      <% row.action(
+      <% row.with_action(
         text: "Change",
         visually_hidden_text: "lead provider",
         href: new_finance_participant_profile_npq_change_lead_provider_path(pp))
       %>
     <% else %>
-      <% row.action(text: :none) %>
+      <% row.with_action(text: :none) %>
     <% end %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "School URN" } %>
-    <% row.value { pp.npq_application&.school_urn } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "School URN" } %>
+    <% row.with_value { pp.npq_application&.school_urn } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Status" } %>
-    <% row.value { pp.status } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Status" } %>
+    <% row.with_value { pp.status } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Training status" } %>
-    <% row.value { pp.state } %>
-    <% row.action(
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Training status" } %>
+    <% row.with_value { pp.state } %>
+    <% row.with_action(
       text: "Change",
       visually_hidden_text: "training status",
       href: new_finance_participant_profile_npq_change_training_status_path(pp))
     %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Schedule identifier" } %>
-    <% row.value { pp.schedule&.schedule_identifier } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Schedule identifier" } %>
+    <% row.with_value { pp.schedule&.schedule_identifier } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Schedule cohort" } %>
-    <% row.value { pp.schedule&.cohort&.start_year&.to_s } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Schedule cohort" } %>
+    <% row.with_value { pp.schedule&.cohort&.start_year&.to_s } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Created at" } %>
-    <% row.value { pp.created_at.to_fs(:govuk) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Created at" } %>
+    <% row.with_value { pp.created_at.to_fs(:govuk) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Updated at" } %>
-    <% row.value { pp.updated_at.to_fs(:govuk) } %>
-    <% row.action(text: :none) %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Updated at" } %>
+    <% row.with_value { pp.updated_at.to_fs(:govuk) } %>
+    <% row.with_action(text: :none) %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Lead Provider API V3" } %>
-    <% row.value do %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Lead Provider API V3" } %>
+    <% row.with_value do %>
       <%= govuk_details(summary_text: "See this participant as it appears over the Lead Provider API") do %>
         <%= npq_participant_api_response(pp) %>
       <% end %>
     <% end %>
-    <% row.action(text: :none) %>
+    <% row.with_action(text: :none) %>
   <% end %>
 <% end %>
 

--- a/app/views/finance/participants/show.html.erb
+++ b/app/views/finance/participants/show.html.erb
@@ -8,19 +8,19 @@
   <h3><%= "Identity #{i + 1}" %></h3>
 
   <%= govuk_summary_list do |summary_list| %>
-    <% summary_list.row do |row| %>
-      <% row.key { "User ID / Participant ID" } %>
-      <% row.value { govuk_link_to identity.user_id, finance_participant_path(identity.user_id) } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "User ID / Participant ID" } %>
+      <% row.with_value { govuk_link_to identity.user_id, finance_participant_path(identity.user_id) } %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "External ID" } %>
-      <% row.value { govuk_link_to identity.external_identifier, finance_participant_path(identity.external_identifier) } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "External ID" } %>
+      <% row.with_value { govuk_link_to identity.external_identifier, finance_participant_path(identity.external_identifier) } %>
     <% end %>
 
-    <% summary_list.row do |row| %>
-      <% row.key { "Full name" } %>
-      <% row.value { identity.user&.full_name } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Full name" } %>
+      <% row.with_value { identity.user&.full_name } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/layouts/_application.html.erb
+++ b/app/views/layouts/_application.html.erb
@@ -72,7 +72,7 @@
 
     <%= govuk_header(service_name:, container_classes: ("govuk-width-container__wide" if wide_container_view?)) do |header|
       if user_signed_in?
-        header.navigation_item(text: "Sign out", href: destroy_user_session_path)
+        header.with_navigation_item(text: "Sign out", href: destroy_user_session_path)
       end
     end %>
 

--- a/app/views/layouts/_width_container.html.erb
+++ b/app/views/layouts/_width_container.html.erb
@@ -16,7 +16,7 @@
                 success: true,
                 html_attributes: { data: { test: "notification-banner" } }
               ) do |banner| %>
-            <% banner.heading(text: msg[:heading]) %>
+            <% banner.with_heading(text: msg[:heading]) %>
             <% msg[:content] %>
           <% end %>
         <% elsif type == "notice" %>
@@ -24,7 +24,7 @@
                 title_text: msg[:title],
                 html_attributes: { data: { test: "notification-banner" } }
               ) do |banner| %>
-            <% banner.heading(text: msg[:heading]) %>
+            <% banner.with_heading(text: msg[:heading]) %>
             <% msg[:content] %>
           <% end %>
         <% else %>

--- a/app/views/layouts/_width_container_wide.html.erb
+++ b/app/views/layouts/_width_container_wide.html.erb
@@ -18,7 +18,7 @@
                 success: true,
                 html_attributes: { data: { test: "notification-banner" } }
               ) do |banner| %>
-            <% banner.heading(text: msg[:heading]) %>
+            <% banner.with_heading(text: msg[:heading]) %>
             <% sanitize(msg[:content]) %>
           <% end %>
         <% elsif type == "notice" %>
@@ -26,7 +26,7 @@
                 title_text: msg[:title],
                 html_attributes: { data: { test: "notification-banner" } }
               ) do |banner| %>
-            <% banner.heading(text: msg[:heading]) %>
+            <% banner.with_heading(text: msg[:heading]) %>
             <% msg[:content] %>
           <% end %>
         <% else %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,31 +1,31 @@
 <% content_for :nav_bar do %>
   <%= render PrimaryNavComponent.new(wide: true) do |component| %>
-    <%= component.nav_item(path: "/admin", selected: current_page?('/admin')) do %>
+    <%= component.with_nav_item(path: "/admin", selected: current_page?('/admin')) do %>
       Overview
     <% end %>
-    <%= component.nav_item(path: "/admin/schools") do %>
+    <%= component.with_nav_item(path: "/admin/schools") do %>
       Schools
     <% end %>
-    <%= component.nav_item(path: "/admin/participants") do %>
+    <%= component.with_nav_item(path: "/admin/participants") do %>
       Participants
     <% end %>
-    <%= component.nav_item(path: "/admin/suppliers") do %>
+    <%= component.with_nav_item(path: "/admin/suppliers") do %>
       Suppliers
     <% end %>
-    <%= component.nav_item(path: "/admin/administrators") do %>
+    <%= component.with_nav_item(path: "/admin/administrators") do %>
       Admin users
     <% end %>
-    <%= component.nav_item(path: admin_npq_applications_edge_cases_path, selected: on_admin_npq_application_page?) do %>
+    <%= component.with_nav_item(path: admin_npq_applications_edge_cases_path, selected: on_admin_npq_application_page?) do %>
       NPQ
     <% end %>
-    <%= component.nav_item(path: admin_delivery_partners_users_path) do %>
+    <%= component.with_nav_item(path: admin_delivery_partners_users_path) do %>
       Delivery partners
     <% end %>
-    <%= component.nav_item(path: admin_appropriate_bodies_users_path) do %>
+    <%= component.with_nav_item(path: admin_appropriate_bodies_users_path) do %>
       Appropriate bodies
     <% end %>
     <% if policy(:super_user).show? %>
-      <%= component.nav_item(path: admin_super_user_path) do %>
+      <%= component.with_nav_item(path: admin_super_user_path) do %>
         Super users
       <% end %>
     <% end %>

--- a/app/views/layouts/basic.html.erb
+++ b/app/views/layouts/basic.html.erb
@@ -15,7 +15,7 @@
               success: true,
               html_attributes: { data: { test: "notification-banner" } }
             ) do |banner| %>
-          <% banner.heading(text: msg[:heading]) %>
+          <% banner.with_heading(text: msg[:heading]) %>
           <% msg[:content] %>
         <% end %>
       <% else %>

--- a/app/views/layouts/school_cohort.html.erb
+++ b/app/views/layouts/school_cohort.html.erb
@@ -2,7 +2,7 @@
   <%= render SchoolRecruitedTransitionComponent.new(school_cohort: @school_cohort) if @school_cohort %>
     <% if current_user&.induction_coordinator_and_mentor? && !current_user&.mentor_profile&.completed_validation_wizard? %>
       <%= render GovukComponent::NotificationBannerComponent.new(title_text: "Important", html_attributes: { data: { test: "add-mentor-information-banner" } }) do |banner|
-        banner.heading(
+        banner.with_heading(
           text: "You need to add information about yourself as a mentor.",
           link_text: "Update now",
           link_href: participants_validation_path,

--- a/app/views/lead_providers/content/partnership_guide.html.erb
+++ b/app/views/lead_providers/content/partnership_guide.html.erb
@@ -66,29 +66,29 @@
 <p class="govuk-body-m">When you have confirmed partnerships, the schools will be sent a confirmation email. This includes a link to report if they have been confirmed incorrectly.</p>
 
 <%= render GovukComponent::SummaryListComponent.new(actions: false) do |component|
-  component.row do |row|
-    row.key { "Recruited by other provider" }
-    row.value { "Another training provider has confirmed this school" }
+  component.with_row do |row|
+    row.with_key { "Recruited by other provider" }
+    row.with_value { "Another training provider has confirmed this school" }
   end
-  component.row do |row|
-    row.key { "URN is not valid" }
-    row.value { "The unique reference number (URN) does not match this school" }
+  component.with_row do |row|
+    row.with_key { "URN is not valid" }
+    row.with_value { "The unique reference number (URN) does not match this school" }
   end
-  component.row do |row|
-    row.key { "Your school - already confirmed" }
-    row.value { "You have already confirmed this school and it’s on your list" }
+  component.with_row do |row|
+    row.with_key { "Your school - already confirmed" }
+    row.with_value { "You have already confirmed this school and it’s on your list" }
   end
-  component.row do |row|
-    row.key { "School not eligible for inductions" }
-    row.value { "School is not an eligible establishment type and/or isn’t in England and/or isn’t open as per our GIAS snapshot" }
+  component.with_row do |row|
+    row.with_key { "School not eligible for inductions" }
+    row.with_value { "School is not an eligible establishment type and/or isn’t in England and/or isn’t open as per our GIAS snapshot" }
   end
-  component.row do |row|
-    row.key { "School not eligible for funding" }
-    row.value { "This school is not eligible to receive funding from the DfE. (Other independent special schools, Welsh establishments, British schools overseas etc.)<br/><br/>They can only use the accredited materials (core induction programme).".html_safe }
+  component.with_row do |row|
+    row.with_key { "School not eligible for funding" }
+    row.with_value { "This school is not eligible to receive funding from the DfE. (Other independent special schools, Welsh establishments, British schools overseas etc.)<br/><br/>They can only use the accredited materials (core induction programme).".html_safe }
   end
-    component.row do |row|
-    row.key { "School programme not yet confirmed" }
-    row.value { "The school induction tutor has not yet logged into the service to confirm if they will deliver training using a DfE-funded training provider this year and/or will continue with their current provider".html_safe }
+  component.with_row do |row|
+    row.with_key { "School programme not yet confirmed" }
+    row.with_value { "The school induction tutor has not yet logged into the service to confirm if they will deliver training using a DfE-funded training provider this year and/or will continue with their current provider".html_safe }
   end
 end %>
 

--- a/app/views/lead_providers/partnerships/show.html.erb
+++ b/app/views/lead_providers/partnerships/show.html.erb
@@ -5,10 +5,10 @@
 }) %>
 <% content_for :nav_bar do %>
   <%= render PrimaryNavComponent.new do |component| %>
-    <%= component.nav_item(path: dashboard_path) do %>
+    <%= component.with_nav_item(path: dashboard_path) do %>
       Overview
     <% end %>
-    <%= component.nav_item(path: lead_providers_your_schools_path, selected: true) do %>
+    <%= component.with_nav_item(path: lead_providers_your_schools_path, selected: true) do %>
       Schools
     <% end %>
   <% end %>

--- a/app/views/lead_providers/report_schools/base/start.html.erb
+++ b/app/views/lead_providers/report_schools/base/start.html.erb
@@ -2,10 +2,10 @@
   <div class="govuk-grid-column-two-thirds">
     <% content_for :nav_bar do %>
       <%= render PrimaryNavComponent.new do |component| %>
-        <%= component.nav_item(path: dashboard_path) do %>
+        <%= component.with_nav_item(path: dashboard_path) do %>
           Overview
         <% end %>
-        <%= component.nav_item(path: lead_providers_report_schools_start_path) do %>
+        <%= component.with_nav_item(path: lead_providers_report_schools_start_path) do %>
           Schools
         <% end %>
       <% end %>

--- a/app/views/lead_providers/your_schools/index.html.erb
+++ b/app/views/lead_providers/your_schools/index.html.erb
@@ -2,10 +2,10 @@
 
 <% content_for :nav_bar do %>
   <%= render PrimaryNavComponent.new do |component| %>
-    <%= component.nav_item(path: dashboard_path) do %>
+    <%= component.with_nav_item(path: dashboard_path) do %>
       Overview
     <% end %>
-    <%= component.nav_item(path: lead_providers_your_schools_path) do %>
+    <%= component.with_nav_item(path: lead_providers_your_schools_path) do %>
       Schools
     <% end %>
   <% end %>
@@ -22,7 +22,7 @@
 <% if @cohorts.length > 1 %>
   <%= render SubnavComponent.new do |component| %>
     <% @cohorts.each do |cohort| %>
-      <%= component.nav_item(path: lead_providers_your_schools_path(cohort: cohort)) do %>
+      <%= component.with_nav_item(path: lead_providers_your_schools_path(cohort: cohort)) do %>
         <%= cohort.start_year %> cohort
       <% end %>
     <% end %>

--- a/app/views/pages/core_materials_info.html.erb
+++ b/app/views/pages/core_materials_info.html.erb
@@ -34,7 +34,7 @@
 <p><%= govuk_link_to "See an example of an Ambition topic", "https://www.early-career-framework.education.gov.uk/ambition/ambition-institute/self-directed-study-materials/1-behaviour/2-routines/" %></p>
 
 <%= govuk_accordion do |accordion| %>
-  <%= accordion.section heading_text: "Module 1: behaviour" do %>
+  <%= accordion.with_section heading_text: "Module 1: behaviour" do %>
     <p>Teachers will cover:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>how to establish an effective learning environment</li>
@@ -43,7 +43,7 @@
     </ul>
   <% end %>
 
-  <%= accordion.section heading_text: "Module 2: instruction" do %>
+  <%= accordion.with_section heading_text: "Module 2: instruction" do %>
     <p>Teachers will cover:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the link between effective instruction and pupil learning</li>
@@ -52,7 +52,7 @@
     </ul>
   <% end %>
 
-  <%= accordion.section heading_text: "Module 3: subject" do %>
+  <%= accordion.with_section heading_text: "Module 3: subject" do %>
     <p>Teachers will cover:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the curriculum</li>
@@ -81,47 +81,47 @@
                      "https://www.early-career-framework.education.gov.uk/edt/edt-early-career-framework/self-directed-study-materials/establishing-a-positive-climate-for-learning/1-3-learning-about-classroom-routines/" %>
 
 <%= govuk_accordion do |accordion| %>
-  <% accordion.section heading_text: "Module 1: establishing a positive climate for learning" do %>
+  <% accordion.with_section heading_text: "Module 1: establishing a positive climate for learning" do %>
     <p>Teachers will learn about teaching your pupils how to behave in the classroom, setting clear expectations and reinforcing these with consistent routines.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 2: how pupils learn - memory and cognition" do %>
+  <% accordion.with_section heading_text: "Module 2: how pupils learn - memory and cognition" do %>
     <p>Teachers will gain an understanding of how the brain works, and how they can then design more effective learning for their pupils.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 3: developing effective classroom practice - teaching and adapting" do %>
+  <% accordion.with_section heading_text: "Module 3: developing effective classroom practice - teaching and adapting" do %>
     <p>Teachers will focus on the fundamental techniques they can use to become a more effective teacher.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 4: the importance of subject and curriculum knowledge" do %>
+  <% accordion.with_section heading_text: "Module 4: the importance of subject and curriculum knowledge" do %>
     <p>Teachers will learn practical ways to develop their subject and curriculum knowledge.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 5: assessment, feedback and questioning" do %>
+  <% accordion.with_section heading_text: "Module 5: assessment, feedback and questioning" do %>
     <p>Teachers will work on developing effective assessment and feedback practices.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 6: a people profession" do %>
+  <% accordion.with_section heading_text: "Module 6: a people profession" do %>
     <p>Teachers will focus on developing strong professional relationships to build the best outcomes for their pupils.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 7: embedding a positive climate for learning" do %>
+  <% accordion.with_section heading_text: "Module 7: embedding a positive climate for learning" do %>
     <p>Teachers will look at what motivates pupils so they can develop a really purposeful learning environment.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 8: how pupils learn - memory and cognition" do %>
+  <% accordion.with_section heading_text: "Module 8: how pupils learn - memory and cognition" do %>
     <p>Teachers will consider how they can make new learning stick over time so pupils remember what they’ve been taught.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 9: enhancing classroom practice - grouping and tailoring" do %>
+  <% accordion.with_section heading_text: "Module 9: enhancing classroom practice - grouping and tailoring" do %>
     <p>Teachers will enhance their teaching effectiveness by learning advanced group and pair working skills.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 10: revisiting the importance of subject and curriculum knowledge" do %>
+  <% accordion.with_section heading_text: "Module 10: revisiting the importance of subject and curriculum knowledge" do %>
     <p>Teachers will focus on how they can use their in-depth understanding of the subjects they teach to strengthen their pupils’ knowledge.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 11: deepening assessment, feedback and questioning" do %>
+  <% accordion.with_section heading_text: "Module 11: deepening assessment, feedback and questioning" do %>
     <p>Teachers will build on their existing knowledge to develop further practical ways to hone their assessment, feedback and questioning techniques.</p>
   <% end %>
 <% end %>
@@ -146,27 +146,27 @@
                      "https://www.early-career-framework.education.gov.uk/teachfirst/teach-first/self-directed-study-material/1-how-can-you-create-an-effective-learning-environment/1-establishing-effective-routines-51-minutes/" %></p>
 
 <%= govuk_accordion do |accordion| %>
-  <% accordion.section heading_text: "Module 1: how to create an effective learning environment" do %>
+  <% accordion.with_section heading_text: "Module 1: how to create an effective learning environment" do %>
     <p>Teachers will explore what effective learning environments look like and strategies they can use to achieve them.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 2: how do pupils learn?" do %>
+  <% accordion.with_section heading_text: "Module 2: how do pupils learn?" do %>
     <p>Teachers will explore the findings and evidence gathered during studies of how pupils learn, and the related implications for teaching.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 3: what makes classroom practice effective?" do %>
+  <% accordion.with_section heading_text: "Module 3: what makes classroom practice effective?" do %>
     <p>Teachers will hear an education expert talking about the features of effective classroom practice and why they are so important. They’ll then explore the features in detail and have time to plan them into their sequences of lessons.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 4: how to use assessment and feedback to greatest effect" do %>
+  <% accordion.with_section heading_text: "Module 4: how to use assessment and feedback to greatest effect" do %>
     <p>Teachers will hear from education experts about why assessment should be at the heart of their teaching. They’ll also explore ways to give purposeful feedback to their pupils and what they can learn from summative data sets.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 5: how to support all pupils to succeed" do %>
+  <% accordion.with_section heading_text: "Module 5: how to support all pupils to succeed" do %>
     <p>Teachers will hear a variety of educational specialists talk about ways to support all pupils to succeed across the curriculum, and why this is important.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 6: how to design a coherent curriculum" do %>
+  <% accordion.with_section heading_text: "Module 6: how to design a coherent curriculum" do %>
     <p>Teachers will learn how to design a carefully sequenced and coherent scheme of work and how this will improve learning for their pupils.</p>
   <% end %>
 <% end %>
@@ -190,35 +190,35 @@
                      "https://www.early-career-framework.education.gov.uk/ucl/ucl/2-understanding-teachers-as-role-models/4-making-productive-use-of-assessment/5-planning-effective-and-manageable-marking-and-feedback/" %></p>
 
 <%= govuk_accordion do |accordion| %>
-  <% accordion.section heading_text: "Module 1: enabling pupil learning" do %>
+  <% accordion.with_section heading_text: "Module 1: enabling pupil learning" do %>
     <p>Teachers will focus on how they set up their classroom as a learning environment. They’ll be able to reflect on the different ways they can influence their environment, and learn practical strategies that keep pupils safe, motivated and focused on learning.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 2: engaging pupils in learning" do %>
+  <% accordion.with_section heading_text: "Module 2: engaging pupils in learning" do %>
     <p>Teachers will look at the impact of pupils’ prior knowledge on their learning and how knowledge changes through the cooperation of working and long-term memory.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 3: developing quality pedagogy" do %>
+  <% accordion.with_section heading_text: "Module 3: developing quality pedagogy" do %>
     <p>Teachers will extend their knowledge of effective modelling that enables pupils to tackle difficult concepts.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 4: making productive use of assessment" do %>
+  <% accordion.with_section heading_text: "Module 4: making productive use of assessment" do %>
     <p>Teachers will build on their existing knowledge of assessment principles.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 5: fulfilling professional responsibilities" do %>
+  <% accordion.with_section heading_text: "Module 5: fulfilling professional responsibilities" do %>
     <p>Teachers will consider what it means to be professional, and approaches to managing their professional development.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 6: enabling pupil learning, part 2" do %>
+  <% accordion.with_section heading_text: "Module 6: enabling pupil learning, part 2" do %>
     <p>Teachers will focus on one particular part of their teaching to evaluate the impact their practices have on their pupils.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 7: engaging pupils in learning, part 2" do %>
+  <% accordion.with_section heading_text: "Module 7: engaging pupils in learning, part 2" do %>
     <p>Teachers will focus on how to improve their teaching without adding to their workload.</p>
   <% end %>
 
-  <% accordion.section heading_text: "Module 8: developing quality pedagogy and making use of assessment, part 2" do %>
+  <% accordion.with_section heading_text: "Module 8: developing quality pedagogy and making use of assessment, part 2" do %>
     <p>Teachers will look at how to gather evidence about the impact their teaching is having, followed by practical tips on altering their practices to get better results.</p>
   <% end %>
 <% end %>

--- a/app/views/pages/induction_tutor_materials/_course_year_sub_nav.html.erb
+++ b/app/views/pages/induction_tutor_materials/_course_year_sub_nav.html.erb
@@ -1,8 +1,8 @@
 <%= render SubnavComponent.new do |component| %>
-  <%= component.nav_item(path: induction_tutor_materials_path(provider: provider, year: "year-one")) do %>
+  <%= component.with_nav_item(path: induction_tutor_materials_path(provider: provider, year: "year-one")) do %>
     Year 1
   <% end %>
-  <%= component.nav_item(path: induction_tutor_materials_path(provider: provider, year: "year-two")) do %>
+  <%= component.with_nav_item(path: induction_tutor_materials_path(provider: provider, year: "year-two")) do %>
     Year 2
   <% end %>
 <% end %>

--- a/app/views/pages/year_2020_core_materials_info.html.erb
+++ b/app/views/pages/year_2020_core_materials_info.html.erb
@@ -23,7 +23,7 @@
     </div>
 
     <%= govuk_accordion do |accordion| %>
-      <% accordion.section heading_text: "Ambition Institute" do %>
+      <% accordion.with_section heading_text: "Ambition Institute" do %>
         <h3 class="govuk-heading-m">Modules</h3>
 
         <h4 class="govuk-heading-s">Behaviour:</h4>
@@ -48,7 +48,7 @@
         </ul>
       <% end %>
 
-      <% accordion.section heading_text: "Education Development Trust" do %>
+      <% accordion.with_section heading_text: "Education Development Trust" do %>
         <h3 class="govuk-heading-m">Modules</h3>
         <h4 class="govuk-heading-s">Establishing a positive climate for learning</h4>
         <p>Teachers will learn about teaching pupils how to behave in the classroom, setting clear expectations and reinforcing these with consistent routines.</p>
@@ -84,7 +84,7 @@
         <p>Teachers will build on their existing knowledge to develop further practical ways to hone their assessment, feedback and questioning techniques.</p>
       <% end %>
 
-      <% accordion.section heading_text: "Teach First" do %>
+      <% accordion.with_section heading_text: "Teach First" do %>
         <h3 class="govuk-heading-m">Modules</h3>
 
         <h4 class="govuk-heading-s">How to create an effective learning environment</h4>
@@ -106,7 +106,7 @@
         <p>Teachers will learn how to design a carefully sequenced and coherent scheme of work and how this will improve learning for their pupils.</p>
       <% end %>
 
-      <% accordion.section heading_text: "UCL Early Career Teacher Consortium" do %>
+      <% accordion.with_section heading_text: "UCL Early Career Teacher Consortium" do %>
         <h3 class="govuk-heading-m">Modules</h3>
 
         <h4 class="govuk-heading-s">Enabling pupil learning, part 1</h4>

--- a/app/views/schools/add_participants/_ect_or_mentor_answers.html.erb
+++ b/app/views/schools/add_participants/_ect_or_mentor_answers.html.erb
@@ -1,20 +1,20 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "Name" } %>
-    <% row.value { form.full_name } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Name" } %>
+    <% row.with_value { form.full_name } %>
     <% unless form.found_participant_in_dqt? %>
-      <% row.action(text: "Change",
+      <% row.with_action(text: "Change",
                     visually_hidden_text: "name",
                     href: form.change_path_for(step: :name)) %>
     <% end %>
   <% end %>
 
   <% if form.trn %>
-    <% summary_list.row do |row| %>
-      <% row.key { "TRN" } %>
-      <% row.value { form.trn } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "TRN" } %>
+      <% row.with_value { form.trn } %>
       <% unless form.found_participant_in_dqt? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "TRN",
                       href: form.change_path_for(step: :trn)) %>
       <% end %>
@@ -22,41 +22,41 @@
   <% end %>
 
   <% if form.date_of_birth %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Date of birth" } %>
-      <% row.value { form.date_of_birth.to_date.to_fs(:govuk) } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Date of birth" } %>
+      <% row.with_value { form.date_of_birth.to_date.to_fs(:govuk) } %>
       <% unless form.found_participant_in_dqt? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "date of birth",
                       href: form.change_path_for(step: :date_of_birth)) %>
       <% end %>
     <% end %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Email address" } %>
-    <% row.value { form.email } %>
-    <% row.action(text: "Change",
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Email address" } %>
+    <% row.with_value { form.email } %>
+    <% row.with_action(text: "Change",
                  visually_hidden_text: "email address",
                  href: form.change_path_for(step: :email)) %>
   <% end %>
 
   <% if form.show_start_term? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Start term" } %>
-      <% row.value { form.start_term_description } %>
-      <% row.action(text: "Change",
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Start term" } %>
+      <% row.with_value { form.start_term_description } %>
+      <% row.with_action(text: "Change",
                     visually_hidden_text: "start term",
                     href: form.change_path_for(step: :start_term)) %>
     <% end %>
   <% end %>
 
   <% if form.ect_participant? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Mentor" } %>
-      <% row.value { form.mentor.present? ? form.mentor.full_name : "Add later" } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Mentor" } %>
+      <% row.with_value { form.mentor.present? ? form.mentor.full_name : "Add later" } %>
       <% if !form.sit_mentor? && form.mentor_options.any? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "mentor",
                       href: form.change_path_for(step: :choose_mentor)) %>
       <% end %>
@@ -64,21 +64,21 @@
   <% end %>
 
   <% if form.appropriate_body_selected.present? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Appropriate body" } %>
-      <% row.value do %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Appropriate body" } %>
+      <% row.with_value do %>
         <p class="govuk-body"><%= form.appropriate_body_selected.name %></p>
       <% end %>
-      <% row.action(text: "Change",
+      <% row.with_action(text: "Change",
                     visually_hidden_text: "mentor",
                     href: form.change_path_for(step: :confirm_appropriate_body)) %>
     <% end %>
   <% end %>
 
   <% if form.show_default_induction_programme_details? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Training with" } %>
-      <% row.value do %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Training with" } %>
+      <% row.with_value do %>
         <%= tag.p(form.lead_provider.name, class: "govuk-body") if form.lead_provider.present? %>
         <%= tag.p(form.delivery_partner.name, class: "govuk-body") if form.delivery_partner.present? %>
       <% end %>

--- a/app/views/schools/add_participants/_sit_mentor_answers.html.erb
+++ b/app/views/schools/add_participants/_sit_mentor_answers.html.erb
@@ -1,40 +1,40 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "Name" } %>
-    <% row.value { form.full_name } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Name" } %>
+    <% row.with_value { form.full_name } %>
     <% unless form.found_participant_in_dqt? %>
-      <% row.action(text: "Change",
+      <% row.with_action(text: "Change",
                     visually_hidden_text: "name",
                     href: show_change_schools_add_participants_path(step: :name)) %>
       <% else %>
-        <% row.action() %>
+        <% row.with_action() %>
       <% end %>
   <% end %>
 
   <% if form.trn %>
-    <% summary_list.row do |row| %>
-      <% row.key { "TRN" } %>
-      <% row.value { form.trn } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "TRN" } %>
+      <% row.with_value { form.trn } %>
       <% unless form.found_participant_in_dqt? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "TRN",
                       href: show_change_schools_add_participants_path(step: :trn)) %>
       <% else %>
-        <% row.action() %>
+        <% row.with_action() %>
       <% end %>
     <% end %>
   <% end %>
 
   <% if form.date_of_birth %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Date of birth" } %>
-      <% row.value { form.date_of_birth.to_date.to_fs(:govuk) } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Date of birth" } %>
+      <% row.with_value { form.date_of_birth.to_date.to_fs(:govuk) } %>
       <% unless form.found_participant_in_dqt? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "date of birth",
                       href: show_change_schools_add_participants_path(step: :date_of_birth)) %>
       <% else %>
-        <% row.action() %>
+        <% row.with_action() %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/schools/add_participants/_transferring_ect_or_mentor_answers.html.erb
+++ b/app/views/schools/add_participants/_transferring_ect_or_mentor_answers.html.erb
@@ -1,110 +1,110 @@
 <%= govuk_summary_list do |summary_list| %>
-  <% summary_list.row do |row| %>
-    <% row.key { "Name" } %>
-    <% row.value { form.full_name } %>
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Name" } %>
+    <% row.with_value { form.full_name } %>
     <% unless form.found_participant_in_dqt? %>
-      <% row.action(text: "Change",
+      <% row.with_action(text: "Change",
                     visually_hidden_text: "name",
                     href: form.change_path_for(step: :name)) %>
     <% else %>
-      <% row.action() %>
+      <% row.with_action() %>
     <% end %>
   <% end %>
 
   <% if form.trn %>
-   <% summary_list.row do |row| %>
-       <% row.key { "TRN" } %>
-       <% row.value { form.trn } %>
+   <% summary_list.with_row do |row| %>
+       <% row.with_key { "TRN" } %>
+       <% row.with_value { form.trn } %>
        <% unless form.found_participant_in_dqt? %>
-         <% row.action(text: "Change",
+         <% row.with_action(text: "Change",
                        visually_hidden_text: "TRN",
                        href: form.change_path_for(step: :trn)) %>
        <% else %>
-         <% row.action() %>
+         <% row.with_action() %>
        <% end %>
      <% end %>
    <% end %>
 
   <% if form.date_of_birth %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Date of birth" } %>
-      <% row.value { form.date_of_birth.to_date.to_fs(:govuk) } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Date of birth" } %>
+      <% row.with_value { form.date_of_birth.to_date.to_fs(:govuk) } %>
       <% unless form.found_participant_in_dqt? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "date of birth",
                       href: form.change_path_for(step: :date_of_birth)) %>
       <% else %>
-        <% row.action() %>
+        <% row.with_action() %>
       <% end %>
     <% end %>
   <% end %>
 
-  <% summary_list.row do |row| %>
-    <% row.key { "Email address" } %>
-    <% row.value { form.email } %>
-    <% row.action(text: "Change",
+  <% summary_list.with_row do |row| %>
+    <% row.with_key { "Email address" } %>
+    <% row.with_value { form.email } %>
+    <% row.with_action(text: "Change",
                  visually_hidden_text: "email address",
                  href: form.change_path_for(step: :email)) %>
   <% end %>
 
   <% if form.start_date %>
-    <% summary_list.row do |row| %>
-        <% row.key { "Joining date" } %>
-        <% row.value { form.start_date.to_date.to_fs(:govuk) } %>
-        <% row.action(text: "Change",
+    <% summary_list.with_row do |row| %>
+        <% row.with_key { "Joining date" } %>
+        <% row.with_value { form.start_date.to_date.to_fs(:govuk) } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "joining date",
                       href: form.change_path_for(step: :joining_date)) %>
     <% end %>
   <% end %>
 
   <% if form.ect_participant? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Mentor" } %>
-      <% row.value { form.mentor.present? ? form.mentor.full_name : "Add later" } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Mentor" } %>
+      <% row.with_value { form.mentor.present? ? form.mentor.full_name : "Add later" } %>
       <% if !form.sit_mentor? && form.mentor_options.any? %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "mentor",
                       href: form.change_path_for(step: :"choose-mentor")) %>
       <% else %>
-        <% row.action() %>
+        <% row.with_action() %>
       <% end %>
     <% end %>
   <% end %>
 
   <% if form.appropriate_body_selected.present? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Appropriate body" } %>
-      <% row.value do %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Appropriate body" } %>
+      <% row.with_value do %>
         <p class="govuk-body"><%= form.appropriate_body_selected.name %></p>
       <% end %>
-      <% row.action(text: "Change",
+      <% row.with_action(text: "Change",
                     visually_hidden_text: "mentor",
                     href: form.change_path_for(step: :"appropriate-body")) %>
     <% end %>
   <% end %>
 
   <% if form.show_training_provider_section? %>
-    <% summary_list.row do |row| %>
-      <% row.key { "Training with" } %>
+    <% summary_list.with_row do |row| %>
+      <% row.with_key { "Training with" } %>
       <% if form.chose_to_continue_current_programme? %>
-        <% row.value do %>
+        <% row.with_value do %>
           <div><%= form.existing_lead_provider&.name %></div>
           <div><%= form.existing_delivery_partner&.name %></div>
         <% end %>
-        <% row.action(text: "Change",
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "training programme",
                       href: form.change_path_for(step: :continue_current_programme)) %>
       <% else %>
-        <% row.value do %>
+        <% row.with_value do %>
           <div><%= form.lead_provider&.name %></div>
           <div><%= form.delivery_partner&.name %></div>
         <% end %>
         <% if form.switching_programme? %>
-          <% row.action(text: "Change",
+          <% row.with_action(text: "Change",
                         visually_hidden_text: "training programme",
                         href: form.change_path_for(step: :continue_current_programme)) %>
         <% else %>
-          <% row.action(text: :none) %>
+          <% row.with_action(text: :none) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/schools/add_participants/cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/cannot_find_their_details.html.erb
@@ -18,18 +18,18 @@
     </p>
 
     <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.row do |row| %>
-        <% row.key { "TRN" } %>
-        <% row.value { @wizard.trn } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "TRN" } %>
+        <% row.with_value { @wizard.trn } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "TRN",
                       href: @wizard.change_path_for(step: :trn)) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Date of birth" } %>
-        <% row.value { @wizard.date_of_birth.to_date.to_fs(:govuk) } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Date of birth" } %>
+        <% row.with_value { @wizard.date_of_birth.to_date.to_fs(:govuk) } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "date of birth",
                       href: @wizard.change_path_for(step: :date_of_birth)) %>
       <% end %>

--- a/app/views/schools/add_participants/still_cannot_find_their_details.html.erb
+++ b/app/views/schools/add_participants/still_cannot_find_their_details.html.erb
@@ -14,26 +14,26 @@
     </p>
 
     <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.row do |row| %>
-        <% row.key { "TRN" } %>
-        <% row.value { @wizard.trn } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "TRN" } %>
+        <% row.with_value { @wizard.trn } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "TRN",
                       href: @wizard.change_path_for(step: :trn)) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Date of birth" } %>
-        <% row.value { @wizard.date_of_birth.to_date.to_fs(:govuk) } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Date of birth" } %>
+        <% row.with_value { @wizard.date_of_birth.to_date.to_fs(:govuk) } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "date of birth",
                       href: @wizard.change_path_for(step: :date_of_birth)) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "National Insurance number" } %>
-        <% row.value { @wizard.nino } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "National Insurance number" } %>
+        <% row.with_value { @wizard.nino } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "National Insurance number",
                       href: @wizard.change_path_for(step: :nino)) %>
       <% end %>

--- a/app/views/schools/dashboard/_school_cohort_details.html.erb
+++ b/app/views/schools/dashboard/_school_cohort_details.html.erb
@@ -7,57 +7,57 @@
 <% end %>
 
 <%= govuk_summary_list do |list| %>
-  <% list.row do |row| %>
-    <% row.key(text: "Programme") %>
-    <% row.value(text: t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes])) %>
-    <% row.action(text: "Change", href: change_programme_schools_cohort_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "induction programme choice") %>
+  <% list.with_row do |row| %>
+    <% row.with_key(text: "Programme") %>
+    <% row.with_value(text: t(school_cohort.induction_programme_choice, scope: %i[manage_your_training induction_programmes])) %>
+    <% row.with_action(text: "Change", href: change_programme_schools_cohort_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "induction programme choice") %>
   <% end %>
 
   <% if school_cohort.core_induction_programme? %>
-    <% list.row do |row| %>
-      <% row.key(text: "Materials supplier") %>
-      <% row.value(text: school_cohort.default_induction_programme&.core_induction_programme&.name) %>
+    <% list.with_row do |row| %>
+      <% row.with_key(text: "Materials supplier") %>
+      <% row.with_value(text: school_cohort.default_induction_programme&.core_induction_programme&.name) %>
       <% if school_cohort.default_induction_programme&.core_induction_programme.blank? %>
-        <% row.action(text: "Choose", href: info_schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
+        <% row.with_action(text: "Choose", href: info_schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
       <% else %>
-        <% row.action(text: "Change", href: schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
+        <% row.with_action(text: "Change", href: schools_core_programme_materials_path(cohort_id: school_cohort.cohort.start_year), visually_hidden_text: "materials") %>
       <% end %>
     <% end %>
   <% end %>
 
   <% if school_cohort.appropriate_body.present? %>
-    <% list.row do |row| %>
-      <% row.key(text: "Appropriate body") %>
-      <% row.value(text: school_cohort.appropriate_body.name) %>
-      <% row.action(text: "Change", href: change_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
+    <% list.with_row do |row| %>
+      <% row.with_key(text: "Appropriate body") %>
+      <% row.with_value(text: school_cohort.appropriate_body.name) %>
+      <% row.with_action(text: "Change", href: change_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
     <% end %>
   <% else %>
-    <% list.row do |row| %>
-      <% row.key(text: "Appropriate body") %>
-      <% row.value(text: "") %>
-      <% row.action(text: "Add", href: add_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
+    <% list.with_row do |row| %>
+      <% row.with_key(text: "Appropriate body") %>
+      <% row.with_value(text: "") %>
+      <% row.with_action(text: "Add", href: add_appropriate_body_schools_cohort_path(cohort_id: school_cohort.cohort.start_year)) %>
     <% end %>
   <% end %>
 
   <% if school_cohort.full_induction_programme? %>
-    <% list.row do |row| %>
-      <% row.key(text: "Lead provider") %>
+    <% list.with_row do |row| %>
+      <% row.with_key(text: "Lead provider") %>
       <% if latest_partnership&.challenged? == true %>
-        <% row.value(text: nil) %>
+        <% row.with_value(text: nil) %>
       <% else %>
-        <% row.value(text: school_cohort_lead_provider_name(school_cohort)) %>
+        <% row.with_value(text: school_cohort_lead_provider_name(school_cohort)) %>
       <% end %>
-      <% row.action(text: :none) %>
+      <% row.with_action(text: :none) %>
     <% end %>
 
-    <% list.row do |row| %>
-      <% row.key(text: "Delivery partner") %>
+    <% list.with_row do |row| %>
+      <% row.with_key(text: "Delivery partner") %>
       <% if latest_partnership&.challenged? == true %>
-        <% row.value(text: nil) %>
+        <% row.with_value(text: nil) %>
       <% else %>
-        <% row.value(text: school_cohort_delivery_partner_name(school_cohort)) %>
+        <% row.with_value(text: school_cohort_delivery_partner_name(school_cohort)) %>
       <% end %>
-      <% row.action(text: :none) %>
+      <% row.with_action(text: :none) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -45,12 +45,12 @@
       <h2 class="govuk-heading-m">Academic year</h2>
       <%= govuk_tabs(title: "Cohorts") do |component| %>
         <% if set_up_new_cohort? %>
-          <% component.tab(label: TabLabelDecorator.new(Cohort.active_registration_cohort.description)) do %>
+          <% component.with_tab(label: TabLabelDecorator.new(Cohort.active_registration_cohort.description)) do %>
             <%= render partial: "setup_school_cohort" %>
           <% end %>
         <% end %>
         <% @school_cohorts.each do |school_cohort| %>
-          <% component.tab(label: TabLabelDecorator.new(school_cohort.description)) do %>
+          <% component.with_tab(label: TabLabelDecorator.new(school_cohort.description)) do %>
             <% if school_cohort.induction_programme_choice == "no_early_career_teachers" %>
               <%= render partial: "no_ects_cohort_details", locals: { school_cohort: school_cohort } %>
             <% else %>

--- a/app/views/schools/dashboard/show.html.erb
+++ b/app/views/schools/dashboard/show.html.erb
@@ -14,29 +14,29 @@
 
       <h2 class="govuk-heading-m">Participant summary</h2>
       <%= govuk_summary_list do |list| %>
-        <% list.row do |row| %>
-          <% row.key(text: "Induction tutor") %>
-          <% row.value(text: @school.induction_coordinators.first.full_name) %>
-          <% row.action(text: "Change", href: name_schools_change_sit_path, visually_hidden_text: "induction tutor") %>
+        <% list.with_row do |row| %>
+          <% row.with_key(text: "Induction tutor") %>
+          <% row.with_value(text: @school.induction_coordinators.first.full_name) %>
+          <% row.with_action(text: "Change", href: name_schools_change_sit_path, visually_hidden_text: "induction tutor") %>
         <% end %>
 
         <% if manage_ects_and_mentors?(@school_cohorts) %>
-          <% list.row do |row| %>
-            <% row.key(text: "Mentors") %>
-            <% row.value(text: mentor_count(@school_cohorts)) %>
-            <% row.action(text: :none) %>
+          <% list.with_row do |row| %>
+            <% row.with_key(text: "Mentors") %>
+            <% row.with_value(text: mentor_count(@school_cohorts)) %>
+            <% row.with_action(text: :none) %>
           <% end %>
 
-          <% list.row do |row| %>
-            <% row.key(text: "ECTs") %>
-            <% row.value(text: ect_count(@school_cohorts)) %>
-            <% row.action(text: :none) %>
+          <% list.with_row do |row| %>
+            <% row.with_key(text: "ECTs") %>
+            <% row.with_value(text: ect_count(@school_cohorts)) %>
+            <% row.with_action(text: :none) %>
           <% end %>
 
-          <% list.row do |row| %>
-            <% row.key(text: "ECTs without mentors") %>
-            <% row.value(text: ect_with_no_mentor_count(@school_cohorts)) %>
-            <% row.action(text: :none) %>
+          <% list.with_row do |row| %>
+            <% row.with_key(text: "ECTs without mentors") %>
+            <% row.with_value(text: ect_with_no_mentor_count(@school_cohorts)) %>
+            <% row.with_action(text: :none) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/schools/participants/index.html.erb
+++ b/app/views/schools/participants/index.html.erb
@@ -47,12 +47,12 @@
             Mentor <span class="govuk-visually-hidden">- <%= mentor.full_name %></span>
           </h3>
           <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
-            <% list.row do |row| %>
-              <% row.key(text: govuk_link_to(mentor.full_name,
+            <% list.with_row do |row| %>
+              <% row.with_key(text: govuk_link_to(mentor.full_name,
                                              school_participant_path(id: mentor.participant_profile_id, school_id: @school),
                                              no_visited_state: true),
                          classes: ["govuk-!-font-weight-regular"]) %>
-              <% row.value(
+              <% row.with_value(
                    text: render(StatusTags::SchoolParticipantStatusTag.new(
                      participant_profile: mentor.participant_profile,
                      induction_record: mentor.induction_record,
@@ -66,13 +66,13 @@
 
           <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
             <% @participants.ects_mentored_by(mentor).sort_by(&:full_name).each do |ect| %>
-              <% list.row do |row| %>
-                <% row.key(text: govuk_link_to("#{ect.full_name}",
+              <% list.with_row do |row| %>
+                <% row.with_key(text: govuk_link_to("#{ect.full_name}",
                                                school_participant_path(id: ect.participant_profile_id,
                                                                         school_id: @school),
                                                no_visited_state: true),
                            classes: ["govuk-!-font-weight-regular", "govuk-\!-padding-bottom-static-0"]) %>
-                <% row.value(
+                <% row.with_value(
                      text: render(StatusTags::SchoolParticipantStatusTag.new(
                        participant_profile: ect.participant_profile,
                        induction_record: ect.induction_record,
@@ -90,13 +90,13 @@
 
         <%= govuk_summary_list(actions: false, borders: nil) do |list| %>
           <% @participants.not_mentoring_or_being_mentored.sort_by(&:full_name).each do |participant| %>
-            <% list.row do |row| %>
-              <% row.key(text: govuk_link_to(participant.full_name,
+            <% list.with_row do |row| %>
+              <% row.with_key(text: govuk_link_to(participant.full_name,
                                              school_participant_path(id: participant.participant_profile_id,
                                                                      school_id: @school),
                                              no_visited_state: true),
                          classes: ["govuk-!-font-weight-regular", "govuk-\!-padding-bottom-static-0"]) %>
-              <% row.value(
+              <% row.with_value(
                    text: render(StatusTags::SchoolParticipantStatusTag.new(
                      participant_profile: participant.participant_profile,
                      induction_record: participant.induction_record,

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -157,12 +157,12 @@
 
       <%= govuk_summary_list(classes: ["govuk-!-margin-bottom-7"]) do |list| %>
         <% @ects.each do |ect| %>
-          <% list.row do |row| %>
-            <% row.key(text: ect.full_name,
+          <% list.with_row do |row| %>
+            <% row.with_key(text: ect.full_name,
                        classes: ["govuk-!-font-weight-regular"]) %>
             <% if @mentors_added &&
                   ect.participant_profile.policy_class.new(current_user, ect.participant_profile).update_mentor? %>
-              <% row.action(text: "Change",
+              <% row.with_action(text: "Change",
                             visually_hidden_text: "mentor",
                             href: school_participant_edit_mentor_path(participant_id: ect.participant_profile_id,
                                                                       from_mentor: @profile.id)) %>

--- a/app/views/schools/transfer_out/check_answers.html.erb
+++ b/app/views/schools/transfer_out/check_answers.html.erb
@@ -8,16 +8,16 @@
     <h1 class="govuk-heading-xl">Check your answers</h1>
 
     <%= govuk_summary_list do |summary_list| %>
-      <% summary_list.row do |row| %>
-        <% row.key { "Name" } %>
-        <% row.value { @profile.user.full_name } %>
-        <% row.action(text: :none) %>
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Name" } %>
+        <% row.with_value { @profile.user.full_name } %>
+        <% row.with_action(text: :none) %>
       <% end %>
 
-      <% summary_list.row do |row| %>
-        <% row.key { "Leaving date" } %>
-        <% row.value { @transfer_out_form.end_date.to_date.to_fs(:govuk) } %>
-        <% row.action(text: "Change",
+      <% summary_list.with_row do |row| %>
+        <% row.with_key { "Leaving date" } %>
+        <% row.with_value { @transfer_out_form.end_date.to_date.to_fs(:govuk) } %>
+        <% row.with_action(text: "Change",
                       visually_hidden_text: "end date",
                       href: url_for({ action: :teacher_end_date})) %>
       <% end %>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "css-minimizer-webpack-plugin": "^3.4.1",
     "es6-promise": "^4.2.8",
     "file-loader": "^6.2.0",
-    "govuk-frontend": "^4.4.1",
+    "govuk-frontend": "^4.7.0",
     "mini-css-extract-plugin": "^2.7.6",
     "sass": "^1.65.1",
     "sass-loader": "^13.3.2",

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -3,7 +3,7 @@
 require "capybara"
 require "capybara/rspec"
 require "axe-rspec"
-require "webdrivers/chromedriver"
+require "selenium-webdriver"
 require "site_prism"
 require "site_prism/all_there" # Optional but needed to perform more complex matching
 
@@ -17,10 +17,6 @@ Capybara.register_driver :chrome_headless do |app|
     options: Selenium::WebDriver::Options.chrome(args:),
   )
 end
-
-# This is required as per https://github.com/titusfortner/webdrivers/issues/247
-# and can be removed when selenium 4.11 is released
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 Capybara.server_port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
 Capybara.javascript_driver = :chrome_headless

--- a/spec/helpers/finance_helper_spec.rb
+++ b/spec/helpers/finance_helper_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe FinanceHelper, type: :helper do
       let!(:induction_record) { create(:induction_record, participant_profile:, induction_programme:) }
 
       it "returns the change training status action button" do
-        expect(row).to receive(:action).with(
+        expect(row).to receive(:with_action).with(
           text: "Change",
           visually_hidden_text: "training status",
           href: new_finance_participant_profile_ecf_induction_records_path(participant_profile.id, induction_record.id),
@@ -86,7 +86,7 @@ RSpec.describe FinanceHelper, type: :helper do
       let!(:induction_record) { create(:induction_record, participant_profile:) }
 
       it "returns the change training status action button" do
-        expect(row).to receive(:action).with(text: :none)
+        expect(row).to receive(:with_action).with(text: :none)
 
         helper.change_induction_record_training_status_button(induction_record, participant_profile, row)
       end

--- a/spec/requests/admin/schools_spec.rb
+++ b/spec/requests/admin/schools_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Admin::Schools", type: :request do
 
         expect(response).to render_template("admin/schools/show")
         expect(response.body).to include(CGI.escapeHTML(school.name))
-        expect(response.body).to include(%(Add <span class="govuk-visually-hidden">induction tutor</span>))
+        expect(response.body).to include(%(Add<span class="govuk-visually-hidden"> induction tutor</span>))
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe "Admin::Schools", type: :request do
 
         expect(response).to render_template("admin/schools/show")
         expect(response.body).to include(CGI.escapeHTML(school.name))
-        expect(response.body).to include(%(Add <span class="govuk-visually-hidden">induction tutor</span>))
+        expect(response.body).to include(%(Add<span class="govuk-visually-hidden"> induction tutor</span>))
       end
     end
 

--- a/spec/support/features/sections/output_payments_finance_panel.rb
+++ b/spec/support/features/sections/output_payments_finance_panel.rb
@@ -13,11 +13,11 @@ module Sections
     end
 
     def has_started_declarations?(band_a_total = 0, band_b_total = 0, band_c_total = 0, band_d_total = 0)
-      element_has_content? output_payments[0], "Starts #{band_a_total} #{band_b_total} #{band_c_total} #{band_d_total}".strip
+      element_has_content? output_payments[0], "Starts#{band_a_total}#{band_b_total}#{band_c_total}#{band_d_total}".strip
     end
 
     def has_retained_1_declarations?(band_a_total = 0, band_b_total = 0, band_c_total = 0, band_d_total = 0)
-      element_has_content? output_payments[2], "Retained 1 #{band_a_total} #{band_b_total} #{band_c_total} #{band_d_total}".strip
+      element_has_content? output_payments[2], "Retained 1#{band_a_total}#{band_b_total}#{band_c_total}#{band_d_total}".strip
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4442,10 +4442,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.4.1.tgz#88857c4ad8508255a4e983030a3964d6e1674107"
-  integrity sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==
+govuk-frontend@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
+  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"


### PR DESCRIPTION
### Context

We're _a long way_ behind the latest versions of GOV.UK Frontend, and the form builder and components libraries that are tied to it. This is a quick attempt at doing the upgrade.

### Changes proposed in this pull request

- Upgrade to GOV.UK Frontend 4.7.0
- Upgrade components, form builder and pagy gems
- Update tables to use new 'with' syntax
- Update summary lists to use new 'with' syntax
- Update header to use new 'with' syntax
- Update accordions to use new 'with' syntax
- Update tabs to use new 'with' syntax
- Remove deprecated SlotableV2 inclusion
- Update subnav component to use 'with' syntax
- Update banner to use the new 'with' syntax
- Fix visually hidden spacing
