### PR TITLE
Use `azure_enable_high_availability` instead of `postgres_enable_high_availability`

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -26,12 +26,12 @@ module "postgres" {
 
   cluster_configuration_map = module.cluster_data.configuration_map
 
-  azure_sku_name                      = var.postgres_flexible_server_sku
-  postgres_enable_high_availability   = var.postgres_enable_high_availability
-  azure_enable_backup_storage         = var.azure_enable_backup_storage
-  use_azure                           = var.deploy_azure_backing_services
-  azure_enable_monitoring             = var.enable_monitoring
-  azure_extensions                    = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
+  azure_sku_name                 = var.postgres_flexible_server_sku
+  azure_enable_high_availability = var.postgres_enable_high_availability
+  azure_enable_backup_storage    = var.azure_enable_backup_storage
+  use_azure                      = var.deploy_azure_backing_services
+  azure_enable_monitoring        = var.enable_monitoring
+  azure_extensions               = ["citext", "fuzzystrmatch", "pg_stat_statements", "pgcrypto", "plpgsql", "uuid-ossp"]
 }
 
 resource "azurerm_postgresql_flexible_server_database" "analytics" {


### PR DESCRIPTION
### Context
This is failiing as `postgres_enable_high_availability` doesn't exist in the terraform module
- Ticket: n/a

### Changes proposed in this pull request
Change to `azure_enable_high_availability`

### Guidance to review

