### PR TITLE
Update duplicates view to select correct school

### DIFF
--- a/db/migrate/20230816132809_update_ecf_duplicates_to_version_5.rb
+++ b/db/migrate/20230816132809_update_ecf_duplicates_to_version_5.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateECFDuplicatesToVersion5 < ActiveRecord::Migration[7.0]
+  def change
+    update_view :ecf_duplicates, version: 5, revert_to_version: 4
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_02_144905) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_16_132809) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -1239,11 +1239,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_02_144905) do
               lead_providers.name AS lead_provider_name,
               induction_programmes.training_programme,
               row_number() OVER (PARTITION BY induction_records.participant_profile_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
-             FROM ((((induction_records
+             FROM (((((induction_records
                JOIN induction_programmes ON ((induction_programmes.id = induction_records.induction_programme_id)))
                LEFT JOIN partnerships ON ((partnerships.id = induction_programmes.partnership_id)))
                LEFT JOIN lead_providers ON ((lead_providers.id = partnerships.lead_provider_id)))
-               LEFT JOIN schools ON ((schools.id = partnerships.school_id)))) latest_induction_records ON (((latest_induction_records.participant_profile_id = participant_profiles.id) AND (latest_induction_records.induction_record_sort_order = 1))))
+               LEFT JOIN school_cohorts ON ((school_cohorts.id = induction_programmes.school_cohort_id)))
+               LEFT JOIN schools ON ((schools.id = school_cohorts.school_id)))) latest_induction_records ON (((latest_induction_records.participant_profile_id = participant_profiles.id) AND (latest_induction_records.induction_record_sort_order = 1))))
        JOIN participant_identities ON ((participant_identities.id = participant_profiles.participant_identity_id)))
        JOIN ( SELECT participant_identities_1.user_id,
               count(*) AS count

--- a/db/views/ecf_duplicates_v05.sql
+++ b/db/views/ecf_duplicates_v05.sql
@@ -1,0 +1,82 @@
+SELECT
+  participant_identities.user_id AS user_id,
+  participant_identities.external_identifier AS external_identifier,
+  participant_profiles.id,
+  participant_profiles.created_at,
+  participant_profiles.updated_at,
+  FIRST_VALUE(participant_profiles.id) OVER (
+               PARTITION BY participant_identities.user_id
+               ORDER BY CASE
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status = 'active' THEN 1
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status != 'active' THEN 2
+               WHEN latest_induction_records.training_status != 'active' AND latest_induction_records.induction_status = 'active' THEN 3
+               ELSE 4 END,
+               COALESCE(declarations.count, 0) DESC, participant_profiles.created_at DESC
+  ) AS primary_participant_profile_id,
+  CASE participant_profiles.type WHEN 'ParticipantProfile::Mentor' THEN 'mentor' ELSE 'ect' END AS profile_type,
+  duplicates.count            AS duplicate_profile_count,
+  latest_induction_records.id AS latest_induction_record_id,
+  latest_induction_records.induction_status,
+  latest_induction_records.training_status,
+  latest_induction_records.start_date,
+  latest_induction_records.end_date,
+  latest_induction_records.school_transfer,
+  latest_induction_records.school_id,
+  latest_induction_records.school_name,
+  latest_induction_records.lead_provider_name  AS provider_name,
+  latest_induction_records.training_programme,
+  schedules.schedule_identifier,
+  cohorts.start_year   AS cohort,
+  teacher_profiles.trn AS teacher_profile_trn,
+  teacher_profiles.id  AS teacher_profile_id,
+  COALESCE(declarations.count, 0) AS declaration_count,
+  ROW_NUMBER() OVER (
+               PARTITION BY participant_identities.user_id
+               ORDER BY CASE
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status = 'active' THEN 1
+               WHEN latest_induction_records.training_status = 'active' AND latest_induction_records.induction_status != 'active' THEN 2
+               WHEN latest_induction_records.training_status != 'active' AND latest_induction_records.induction_status = 'active' THEN 3
+               ELSE 4 END
+  ) AS participant_profile_status
+FROM participant_profiles
+LEFT OUTER JOIN (
+     SELECT
+       induction_records.*,
+       partnerships.lead_provider_id,
+       schools.id AS school_id,
+       schools.name AS school_name,
+       lead_providers.name AS lead_provider_name,
+       induction_programmes.training_programme AS training_programme,
+       ROW_NUMBER() OVER (PARTITION BY participant_profile_id ORDER BY induction_records.created_at DESC) AS induction_record_sort_order
+     FROM induction_records
+     JOIN induction_programmes ON induction_programmes.id = induction_records.induction_programme_id
+     LEFT OUTER JOIN partnerships         ON partnerships.id         = induction_programmes.partnership_id
+     LEFT OUTER JOIN lead_providers       ON lead_providers.id       = partnerships.lead_provider_id
+     LEFT OUTER JOIN school_cohorts       ON school_cohorts.id       = induction_programmes.school_cohort_id
+     LEFT OUTER JOIN schools              ON schools.id              = school_cohorts.school_id
+) AS latest_induction_records ON latest_induction_records.participant_profile_id = participant_profiles.id AND induction_record_sort_order = 1
+JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+JOIN (
+      SELECT
+        user_id,
+        COUNT(*) as count
+      FROM participant_profiles
+      JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+      WHERE type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      GROUP BY type, user_id
+) AS duplicates ON duplicates.user_id = participant_identities.user_id
+LEFT OUTER JOIN teacher_profiles ON teacher_profiles.id = participant_profiles.teacher_profile_id
+LEFT OUTER JOIN schedules ON latest_induction_records.schedule_id = schedules.id
+LEFT OUTER JOIN cohorts ON schedules.cohort_id = cohorts.id
+LEFT OUTER JOIN (
+     SELECT participant_profile_id, COUNT(*) AS count FROM participant_declarations GROUP BY participant_profile_id
+) AS declarations ON participant_profiles.id = declarations.participant_profile_id
+WHERE participant_identities.user_id IN (
+      SELECT user_id
+      FROM participant_profiles
+      JOIN participant_identities ON participant_identities.id = participant_profiles.participant_identity_id
+      WHERE type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+      GROUP BY type, user_id
+      HAVING COUNT(*) > 1)
+     AND participant_profiles.type IN ('ParticipantProfile::ECT', 'ParticipantProfile::Mentor')
+ORDER BY participant_identities.external_identifier ASC, participant_profile_status ASC, participant_profiles.created_at DESC;


### PR DESCRIPTION
[Jira-1728](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1728)

### Context

Previously we were selecting the school via the `partnership` relationship, however we should go through `induction_programme.school_cohort` instead.

### Changes proposed in this pull request

- Update duplicates view to select correct school

### Guidance to review

The db schema got a bunch of unnecessary changes when I ran the migration; I've manually cleaned them up so only the applicable changes are in this PR but worth paying close attention to that file.