### PR TITLE
Match id description to component schema for transfer ID

### DIFF
--- a/swagger/v3/api_spec.json
+++ b/swagger/v3/api_spec.json
@@ -3819,7 +3819,7 @@
         ],
         "properties": {
           "id": {
-            "description": "The unique identifier of the mentor record",
+            "description": "The unique identifier of the participant record",
             "type": "string",
             "format": "uuid",
             "example": "db3a7848-7308-4879-942a-c4a70ced400a"


### PR DESCRIPTION
### Context
The doc description for transfer ID is incorrect, and doesn't match component schema

- Ticket: n/a

### Changes proposed in this pull request
Fix content for ID in transfers in API spec

### Guidance to review

