### PR TITLE
Add new service classes in importers for create new course

### DIFF
--- a/app/services/importers/create_new_npq_course.rb
+++ b/app/services/importers/create_new_npq_course.rb
@@ -10,7 +10,7 @@ module Importers
       CreateNPQCourse.new(path_to_csv: npq_course_csv).call
 
       logger.info "Running CreateNPQContract with: '#{contract_csv}'"
-      CreateNPQContract.new(path_to_csv: contract_csv, new_course_flag: true).call
+      CreateNPQContract.new(path_to_csv: contract_csv, set_to_latest_version: true).call
     end
 
   private
@@ -26,7 +26,7 @@ module Importers
     def check_csvs!
       return if npq_course_csv.present? && contract_csv.present?
 
-      raise "All scripts need to be present to create a new ECF cohort"
+      raise "All scripts need to be present to create a new NPQ Course"
     end
   end
 end

--- a/app/services/importers/create_new_npq_course.rb
+++ b/app/services/importers/create_new_npq_course.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Importers
+  class CreateNewNPQCourse
+    attr_reader :npq_course_csv, :contract_csv, :logger
+
+    def initialize(npq_course_csv:, contract_csv:, logger: Rails.logger)
+      @npq_course_csv = npq_course_csv
+      @contract_csv = contract_csv
+      @logger = logger
+    end
+
+    def call
+      logger.info "Running CreateNPQCourse with: '#{npq_course_csv}'"
+      CreateNPQCourse.new(path_to_csv: npq_course_csv).call
+
+      logger.info "Running CreateNPQContract with: '#{contract_csv}'"
+      CreateNPQContract.new(path_to_csv: contract_csv, new_course_flag: true).call
+    end
+  end
+end

--- a/app/services/importers/create_new_npq_course.rb
+++ b/app/services/importers/create_new_npq_course.rb
@@ -2,6 +2,19 @@
 
 module Importers
   class CreateNewNPQCourse
+    def call
+      logger.info "CreateNewNPQCourse: Started!"
+      check_csvs!
+
+      logger.info "Running CreateNPQCourse with: '#{npq_course_csv}'"
+      CreateNPQCourse.new(path_to_csv: npq_course_csv).call
+
+      logger.info "Running CreateNPQContract with: '#{contract_csv}'"
+      CreateNPQContract.new(path_to_csv: contract_csv, new_course_flag: true).call
+    end
+
+  private
+
     attr_reader :npq_course_csv, :contract_csv, :logger
 
     def initialize(npq_course_csv:, contract_csv:, logger: Rails.logger)
@@ -10,12 +23,10 @@ module Importers
       @logger = logger
     end
 
-    def call
-      logger.info "Running CreateNPQCourse with: '#{npq_course_csv}'"
-      CreateNPQCourse.new(path_to_csv: npq_course_csv).call
+    def check_csvs!
+      return if npq_course_csv.present? && contract_csv.present?
 
-      logger.info "Running CreateNPQContract with: '#{contract_csv}'"
-      CreateNPQContract.new(path_to_csv: contract_csv, new_course_flag: true).call
+      raise "All scripts need to be present to create a new ECF cohort"
     end
   end
 end

--- a/app/services/importers/create_npq_contract.rb
+++ b/app/services/importers/create_npq_contract.rb
@@ -13,7 +13,7 @@ module Importers
 
     def call
       check_headers
-      version = get_latest_version if new_course_flag == true
+      version = Finance::Statement::NPQ.latest.contract_version if new_course_flag == true && Finance::Statement::NPQ.count.positive?
 
       ActiveRecord::Base.transaction do
         rows.each do |row|
@@ -90,10 +90,6 @@ module Importers
 
     def rows
       @rows ||= CSV.read(path_to_csv, headers: true, skip_blanks: true)
-    end
-
-    def get_latest_version
-      Finance::Statement::NPQ.all.order(contract_version: :asc).pluck(:contract_version).last
     end
   end
 end

--- a/app/services/importers/create_npq_course.rb
+++ b/app/services/importers/create_npq_course.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Importers
+  class CreateNPQCourse < BaseService
+    def call
+      check_headers!
+
+      logger.info "CreateNPQCourse: Started!"
+
+      ActiveRecord::Base.transaction do
+        rows.each do |row|
+          create_npq_course(row)
+        end
+      end
+
+      logger.info "CreateNPQCourse: Finished!"
+    end
+
+  private
+
+    attr_reader :path_to_csv, :logger
+
+    def initialize(path_to_csv:, logger: Rails.logger)
+      @path_to_csv = path_to_csv
+      @logger = logger
+    end
+
+    def create_npq_course(row)
+      NPQCourse.find_or_create_by!(
+        {
+          name: row["name"],
+          identifier: row["identifier"],
+        },
+      )
+
+      logger.info "CreateNPQCourse: Course for identifier #{row['identifier']} successfully find_or_created"
+    end
+
+    def check_headers!
+      unless %w[name identifier].all? { |header| rows.headers.include?(header) }
+        raise NameError, "Invalid headers"
+      end
+    end
+
+    def rows
+      @rows ||= CSV.read(path_to_csv, headers: true)
+    end
+  end
+end

--- a/spec/services/importers/create_new_npq_course_spec.rb
+++ b/spec/services/importers/create_new_npq_course_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::CreateNewNPQCourse do
+  describe "#call" do
+    let(:start_year) { Cohort.ordered_by_start_year.last.start_year }
+
+    let!(:cpd_lead_provider) { create(:cpd_lead_provider, :with_npq_lead_provider, name: "Koala Institute") }
+    let!(:npq_course) { create(:npq_course, identifier: "npq-leading-primary-mathematics") }
+
+    let(:npq_course_csv) do
+      csv = Tempfile.new("npq_course_csv_data.csv")
+      csv.write "name,identifier"
+      csv.write "\n"
+      csv.write "#{npq_course.name},#{npq_course.identifier},"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    let(:contract_csv) do
+      csv = Tempfile.new("contract_csv_data.csv")
+      csv.write "provider_name,cohort_year,course_identifier,recruitment_target,per_participant,service_fee_installments"
+      csv.write "\n"
+      csv.write "#{cpd_lead_provider.name},#{start_year},npq-leading-primary-mathematics,321,654.87,14"
+      csv.write "\n"
+      csv.close
+      csv.path
+    end
+
+    subject do
+      described_class.new(npq_course_csv:, contract_csv:)
+    end
+
+    context "create new Course" do
+      it "creates course" do
+        subject.call
+        expect(NPQCourse.count).to eql(1)
+      end
+
+      it "creates npq contract" do
+        expect(NPQContract.count).to eql(0)
+        subject.call
+        expect(NPQContract.count).to eql(1)
+        expect(NPQContract.first.course_identifier).to eql("npq-leading-primary-mathematics")
+      end
+    end
+  end
+end

--- a/spec/services/importers/create_npq_course_spec.rb
+++ b/spec/services/importers/create_npq_course_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Importers::CreateNPQCourse do
+  let(:csv) { Tempfile.new("data.csv") }
+  let(:path_to_csv) { csv.path }
+
+  subject(:importer) { described_class.new(path_to_csv:) }
+
+  describe "#call" do
+    context "with new npq_courses" do
+      before do
+        csv.write "name,identifier"
+        csv.write "\n"
+        csv.write "NPQ Leading Teaching (NPQLT),npq-leading-teaching, "
+        csv.write "\n"
+        csv.write "NPQ for Senior Leadership (NPQSL),npq-senior-leadership,"
+        csv.write "\n"
+        csv.write "NPQ for Leading Primary Mathematics (NPQLPM),npq-leading-primary-mathematics,"
+        csv.write "\n"
+        csv.write "NPQ for Headship (NPQH),npq-headship,"
+        csv.write "\n"
+        csv.close
+      end
+
+      it "creates npq_course records" do
+        expect { importer.call }.to change { NPQCourse.count }.by(4)
+      end
+
+      it "sets the correct identifier on the record" do
+        importer.call
+
+        course = NPQCourse.find_by(name: "NPQ Leading Teaching (NPQLT)")
+        expect(course.identifier).to eq "npq-leading-teaching"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Add new service classes in importers for create new course

### Ticket: 

https://dfedigital.atlassian.net/browse/CPDNPQ-1257

### Changes proposed in this pull request

Introduced new service classes in importers for create new courses through csv and update `create_npq_contract` service for update or create new contract with specified version. The version is **Finance::Statement** latest version.

### Guidance to review

Looked into create `new_npq_course`, `create_npq_course` as they are inspire from old code and reviewed the private method named `get_latest_version` in **app/services/importers/create_npq_contract.rb** because this method use to get latest version.
