### PR TITLE
Handle schedule changes for duplicate profiles

### DIFF
--- a/app/services/change_schedule_on_duplicate.rb
+++ b/app/services/change_schedule_on_duplicate.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ChangeScheduleOnDuplicate < ChangeSchedule
+  attribute :profile
+
+  validates :profile, presence: true
+
+  def call
+    return if invalid?
+
+    # The ChangeSchedule service would create an additional InductionRecord
+    # that we want to avoid when deduping, so we update manually here.
+    school = profile.latest_induction_record_for(cpd_lead_provider:).school
+    profile.update!(
+      school_cohort: SchoolCohort.find_by(school:, cohort: new_schedule.cohort),
+      schedule: new_schedule,
+    )
+  end
+
+  def participant_profile
+    profile
+  end
+end

--- a/app/services/change_schedule_on_duplicate.rb
+++ b/app/services/change_schedule_on_duplicate.rb
@@ -5,18 +5,6 @@ class ChangeScheduleOnDuplicate < ChangeSchedule
 
   validates :profile, presence: true
 
-  def call
-    return if invalid?
-
-    # The ChangeSchedule service would create an additional InductionRecord
-    # that we want to avoid when deduping, so we update manually here.
-    school = profile.latest_induction_record_for(cpd_lead_provider:).school
-    profile.update!(
-      school_cohort: SchoolCohort.find_by(school:, cohort: new_schedule.cohort),
-      schedule: new_schedule,
-    )
-  end
-
   def participant_profile
     profile
   end

--- a/lib/participant_profile_deduplicator.rb
+++ b/lib/participant_profile_deduplicator.rb
@@ -43,6 +43,7 @@ private
 
   def log_overview_info
     log_info("~~~ DRY RUN ~~~") if dry_run
+    log_info("User: #{primary_profile.user_id}")
     log_info("Primary profile: #{primary_profile_id}")
     log_info("Duplicate profile: #{duplicate_profile_id}")
   end
@@ -98,7 +99,7 @@ private
 
     raise DeduplicationError, change_schedule.errors.first.message if change_schedule.invalid?
 
-    log_info("Changed schedule on primary profile: #{new_schedule.schedule_identifier} (#{new_schedule.id}).")
+    log_info("Changed schedule on primary profile: #{new_schedule.schedule_identifier}, #{new_schedule.cohort.start_year} (#{new_schedule.id}).")
 
     change_schedule.call
   end
@@ -118,7 +119,7 @@ private
 
     primary_profile.induction_records.oldest.update!(school_transfer: true)
 
-    log_info("Primary profile oldest induction record set as school transfer.")
+    log_info("Primary profile oldest induction record set as school transfer. Current school: #{primary_profile.latest_induction_record.school.urn}.")
 
     duplicate_induction_record = duplicate_profile.latest_induction_record
     end_date = determine_induction_record_end_date(primary_profile.induction_records.oldest, duplicate_induction_record)

--- a/spec/lib/participant_profile_deduplicator_spec.rb
+++ b/spec/lib/participant_profile_deduplicator_spec.rb
@@ -23,6 +23,7 @@ describe ParticipantProfileDeduplicator do
         expect { dedup! }.not_to change(ParticipantProfile::ECF, :count)
         expect_changes([
           "~~~ DRY RUN ~~~",
+          "User: #{primary_profile.user.id}",
           "Primary profile: #{primary_profile.id}",
           "Duplicate profile: #{duplicate_profile.id}",
           "Destroyed duplicate profile.",
@@ -118,7 +119,7 @@ describe ParticipantProfileDeduplicator do
       it "sets school_transfer to true on the primary profile's oldest induction record" do
         expect { dedup! }.to change { primary_oldest_induction_record.reload.school_transfer }.from(false).to(true)
 
-        expect_changes("Primary profile oldest induction record set as school transfer.")
+        expect_changes("Primary profile oldest induction record set as school transfer. Current school: #{primary_profile.school.urn}.")
       end
 
       context "when the induction record start dates are the same" do
@@ -327,7 +328,7 @@ describe ParticipantProfileDeduplicator do
 
           expect(primary_profile.reload.schedule).to eq(duplicate_profile_schedule)
           expect(primary_profile.school_cohort.cohort).to eq(duplicate_profile_cohort)
-          expect_changes("Changed schedule on primary profile: #{duplicate_profile_schedule.schedule_identifier} (#{duplicate_profile_schedule.id}).")
+          expect_changes("Changed schedule on primary profile: #{duplicate_profile_schedule.schedule_identifier}, #{duplicate_profile_cohort.start_year} (#{duplicate_profile_schedule.id}).")
         end
 
         it "creates an induction record with the new schedule" do

--- a/spec/lib/participant_profile_deduplicator_spec.rb
+++ b/spec/lib/participant_profile_deduplicator_spec.rb
@@ -330,6 +330,12 @@ describe ParticipantProfileDeduplicator do
           expect_changes("Changed schedule on primary profile: #{duplicate_profile_schedule.schedule_identifier} (#{duplicate_profile_schedule.id}).")
         end
 
+        it "creates an induction record with the new schedule" do
+          dedup!
+
+          expect(primary_profile.latest_induction_record.schedule).to eq(duplicate_profile_schedule)
+        end
+
         it "voids the declarations on the primary profile" do
           dedup!
 


### PR DESCRIPTION
[Jira-1728](https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-1728)

### Context

The deduplication tool is currently unable to reconcile profiles that have different schedules. We now have a set of rules to follow when merging these records:

- Work out which schedule to retain (the earliest non-voidable declaration will belong to this schedule)
- Void all declarations on the profile not associated with the schedule we are retaining
- If the primary profile has the relevant schedule we can carry on as normal
- If the duplicate profile has the relevant schedule we need to update the primary profile to use this schedule/cohort (without creating a new induction record)

### Changes proposed in this pull request

- Handle schedule changes for duplicate records

### Guidance to review

I haven't added explicit tests for the `ChangeScheduleOnDuplicate` subclass as its only temporary (while we clean up the duplicates) and its _mostly_ tested through the deduplicator specs. We are also going to be eyeballing each duplicate manually before we run it.