### PR TITLE
Always build review apps unless dependabot

### DIFF
--- a/.github/workflows/aks_deploy.yml
+++ b/.github/workflows/aks_deploy.yml
@@ -71,7 +71,7 @@ jobs:
   deploy_review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: contains(github.event.pull_request.labels.*.name, 'review-app') && github.event_name == 'pull_request'
+    if: github.actor != 'dependabot[bot]'
     needs: [docker, brakeman]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
### Context

Sometimes changes to things like seed files/factories can cause apps not to deploy properly. Deploying to review apps helps mitigate this risk.
