### PR TITLE
Remove induction start date job from the cron schedule

### DIFF
--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -33,7 +33,3 @@ send_outcomes_to_qualified_teachers_api:
   cron: "*/10 * * * *"
   class: "ParticipantOutcomes::BatchSendLatestOutcomesJob"
   queue: participant_outcomes
-set_participant_start_date_job:
-  cron: "*/2 0-8 * * *"
-  class: "SetParticipantStartDateJob"
-  queue: default

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -33,3 +33,9 @@ send_outcomes_to_qualified_teachers_api:
   cron: "*/10 * * * *"
   class: "ParticipantOutcomes::BatchSendLatestOutcomesJob"
   queue: participant_outcomes
+set_participant_start_date_job:
+  cron: "*/2 0-8 * * *"
+  class: "SetParticipantStartDateJob"
+  queue: default
+  status: "disabled"
+  description: "Disabled for now but maybe required in the near future"


### PR DESCRIPTION
### Context

Remove the `SetParticipantStartDateJob` from the schedule as it has now updated all that it can in the given criteria.  Not removing the actual job now as that may be still required (perhaps with a tweak to the query) in the near future.

### Changes proposed in this pull request
Remove the cron job from the schedule
