### PR TITLE
Remove mocks from seeds as not required

### DIFF
--- a/db/new_seeds/scenarios/cohorts/cohort.rb
+++ b/db/new_seeds/scenarios/cohorts/cohort.rb
@@ -4,8 +4,6 @@ module NewSeeds
   module Scenarios
     module Cohorts
       class Cohort
-        include RSpec::Mocks::Syntax
-
         attr_reader :cohort, :schedules, :start_year, :is_current
 
         def initialize(start_year: Time.zone.now.year.to_i)


### PR DESCRIPTION
### Context

This is breaking in review apps when generating seeds, and is not required

- Ticket: n/a

### Changes proposed in this pull request

Remove redundant require

### Guidance to review

