### PR TITLE
Schedule backups from PaaS to Azure

### DIFF
--- a/.github/workflows/backup-paas-database.yml
+++ b/.github/workflows/backup-paas-database.yml
@@ -1,4 +1,4 @@
-name: Backup a database on GOV.UK PaaS
+name: Backup GOV.UK PaaS DB and restore in Azure
 on:
   workflow_dispatch:
     inputs:
@@ -11,6 +11,13 @@ on:
           - sandbox
           - production
         required: true
+  workflow_call:
+    inputs:
+      environment:
+        description: GitHub environment to backup and restore
+        type: string
+        required: true
+        default: staging
 
 jobs:
   backup:

--- a/.github/workflows/backup-paas-schedule.yml
+++ b/.github/workflows/backup-paas-schedule.yml
@@ -1,7 +1,7 @@
 name: Run scheduled database backups
 on:
   schedule:
-    - cron: "30 4 * * *"
+    - cron: "20 18 * * *"
 
 jobs:
   run-backup-and-restore:

--- a/.github/workflows/backup-paas-schedule.yml
+++ b/.github/workflows/backup-paas-schedule.yml
@@ -1,0 +1,16 @@
+name: Run scheduled database backups
+on:
+  schedule:
+    - cron: "30 4 * * *"
+
+jobs:
+  run-backup-and-restore:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [staging, sandbox, production]
+    steps:
+      - name: Run scheduled backup task for the ${{ matrix.environment }} database
+        uses: ./.github/workflows/backup-paas-database.yml
+        with:
+          environment: ${{ matrix.environment }}


### PR DESCRIPTION
~~**Note, this follows on from #3842, rebase once that's merged. We just care about teh final commit ([fa26a72](https://github.com/DFE-Digital/early-careers-framework/pull/3864/commits/fa26a728402745630f08f4123bc7d5714ee507aa)) here**~~

This new workflow schedules the copying of data from PaaS to Azure every night at 04:30. The jobs are run simultaneously and should take approximately half an hour to finish.
