### PR TITLE
Make destroy review app action run for all PRs

### DIFF
--- a/.github/workflows/aks_destroy_review.yml
+++ b/.github/workflows/aks_destroy_review.yml
@@ -9,7 +9,7 @@ jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'review-app') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     environment: review
     steps:


### PR DESCRIPTION
### Context

We loosened the criteria for review apps to be generated from having to have the 'review-app' label to simply not being generated by Dependabot to prevent problems where the app won't boot.

This change sets the same critera in the destory action.

Refs #3857
