### PR TITLE
Hard-code primary/duplicate headings

### DIFF
--- a/app/views/finance/ecf/duplicates/compare/_details.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_details.html.erb
@@ -5,8 +5,8 @@
   table.with_body(classes: ["govuk-body-s"]) do |body|
     body.with_row do |row|
       row.with_cell(header: true, text: "Record type")
-      row.with_cell { |_| tag_for(primary_profile) }
-      row.with_cell { |_| tag_for(duplicate_profile) }
+      row.with_cell { |row| govuk_tag(text: "primary", colour: "green") }
+      row.with_cell { |row| govuk_tag(text: "duplicate", colour: "grey") }
     end
     body.with_row { |row| comparative_table_row_for(row: row, header: "Profile type", method: :profile_type, primary_profile:, duplicate_profile:) }
     body.with_row { |row| comparative_table_row_for(row: row, header: "User ID", method: :user_id, primary_profile:, duplicate_profile:) }


### PR DESCRIPTION
Previously the headings were inferred from the profile records, however to work with the 'swap' button on the deduplication tool we need to hard-code the headings.

We can revert this change when we're done with the deduplication tool. This change was in production but appears to have been accidentally reverted in a merge:

https://github.com/DFE-Digital/early-careers-framework/pull/3835/commits/838bbe1ec04eb5a54301e2591085433e5fc91d02#diff-1630548633cfb9cc618d3eef61aa3be488aaea3c24da5e75cdb169f98f8585caL6-L7
