### PR TITLE
[CPDLP-2190] Change the order we look up for a user on Identity service

### DIFF
--- a/app/controllers/concerns/current_user.rb
+++ b/app/controllers/concerns/current_user.rb
@@ -9,7 +9,7 @@ module CurrentUser
     original = super
     return if original.nil?
 
-    transferred_identity = ParticipantIdentity.secondary.find_by(external_identifier: original.id)
+    transferred_identity = ParticipantIdentity.secondary.find_by(user_id: original.id)
 
     @deduped_current_user = transferred_identity&.user || original
   end
@@ -20,7 +20,7 @@ module CurrentUser
     original = super
     return if original.nil?
 
-    transferred_identity = ParticipantIdentity.secondary.find_by(external_identifier: original.id)
+    transferred_identity = ParticipantIdentity.secondary.find_by(user_id: original.id)
 
     @deduped_true_user = transferred_identity&.user || original
   end

--- a/app/services/identity.rb
+++ b/app/services/identity.rb
@@ -6,10 +6,10 @@ module Identity
   def self.find_user_by(params = {})
     if params.key?(:id)
       id = params[:id]
-      ParticipantIdentity.find_by(external_identifier: id)&.user || User.find_by(id:)
+      User.find_by(id:) || ParticipantIdentity.find_by(user_id: id)&.user || ParticipantIdentity.find_by(external_identifier: id)&.user
     elsif params.key?(:email)
       email = params[:email]
-      ParticipantIdentity.find_by(email:)&.user || User.find_by(email:)
+      User.find_by(email:) || ParticipantIdentity.find_by(email:)&.user
     else
       User.find_by(params)
     end

--- a/spec/services/identity_spec.rb
+++ b/spec/services/identity_spec.rb
@@ -35,9 +35,16 @@ RSpec.describe Identity do
       let(:external_id) { SecureRandom.uuid }
       let!(:identity) { create(:participant_identity, user:, external_identifier: external_id) }
 
-      context "when a matching identity record exists" do
+      context "when a matching identity record external id exists" do
         it "returns the associated user record" do
           result = described_class.find_user_by(id: external_id)
+          expect(result).to eq user
+        end
+      end
+
+      context "when a matching identity record user id exists" do
+        it "returns the associated user record" do
+          result = described_class.find_user_by(id: identity.user_id)
           expect(result).to eq user
         end
       end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2190](https://dfedigital.atlassian.net/browse/CPDLP-2190)

User gets a buggy "impersonate" screen when trying to sign into DP service. User uses same email address for DP service as for ECF (mentor) and NPQ applications. 

### Changes proposed in this pull request

### Guidance to review

Lookup user by email first so it won't select the wrong user attached to a participant identity with the same email address.

[CPDLP-2190]: https://dfedigital.atlassian.net/browse/CPDLP-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ