### PR TITLE
Prevent primary/duplicate ids swapping in path on dedupe

### DIFF
--- a/app/controllers/finance/ecf/duplicates/compare_controller.rb
+++ b/app/controllers/finance/ecf/duplicates/compare_controller.rb
@@ -15,8 +15,8 @@ module Finance
         end
 
         def deduplicate
-          @primary_profile = Duplicate.find(params[:duplicate_id])
-          @duplicate_profile = Duplicate.find(params[:compare_id])
+          @primary_profile = Duplicate.find(params[:compare_id])
+          @duplicate_profile = Duplicate.find(params[:duplicate_id])
 
           dedup!
           set_breadcrumbs

--- a/app/views/finance/ecf/duplicates/compare/_deduplicate.html.erb
+++ b/app/views/finance/ecf/duplicates/compare/_deduplicate.html.erb
@@ -9,9 +9,9 @@
     </div>
 
     <div class="govuk-button-group">
-      <%= button_to "Dry Run", finance_ecf_duplicate_compare_deduplicate_path(primary_profile, duplicate_profile, anchor: :deduplicate), method: :put, class: "govuk-button govuk-button--secondary", params: { dry_run: true } %>
+      <%= button_to "Dry Run", finance_ecf_duplicate_compare_deduplicate_path(duplicate_profile, primary_profile, anchor: :deduplicate), method: :put, class: "govuk-button govuk-button--secondary", params: { dry_run: true } %>
       <%= button_to "Swap", finance_ecf_duplicate_compare_path(primary_profile, duplicate_profile, anchor: :deduplicate), method: :get, class: "govuk-button govuk-button--secondary" %>
-      <%= button_to "Deduplicate", finance_ecf_duplicate_compare_deduplicate_path(primary_profile, duplicate_profile, anchor: :deduplicate), method: :put, class: "govuk-button govuk-button--warning", disabled: !@can_deduplicate, params: { dry_run: false } %>
+      <%= button_to "Deduplicate", finance_ecf_duplicate_compare_deduplicate_path(duplicate_profile, primary_profile, anchor: :deduplicate), method: :put, class: "govuk-button govuk-button--warning", disabled: !@can_deduplicate, params: { dry_run: false } %>
     </div>
 
     <% if @dedup_changes %>


### PR DESCRIPTION
The dedupe path was configured to be the opposite of the compare path, which meant the ids were getting swapped in the URL on the dry-run/dedupe. Whilst functionally this is fine and was working it makes it confusing as I often copy/paste paths when I'm working through the duplicates and it meant I was manually swapping them by accident.

Update dedupe paths to use the same duplicate/primary profile ID ordering as the compare path.
