### PR TITLE
Display the AB in participant's profile even when schools don't have any

### DIFF
--- a/app/controllers/schools/participants_controller.rb
+++ b/app/controllers/schools/participants_controller.rb
@@ -158,6 +158,6 @@ private
   end
 
   def can_appropriate_body_be_changed?
-    @induction_record.school_cohort.appropriate_body.present? && @profile.ect? && !@induction_record.training_status_withdrawn?
+    @profile.ect? && !@induction_record.training_status_withdrawn?
   end
 end

--- a/app/views/schools/participants/show.html.erb
+++ b/app/views/schools/participants/show.html.erb
@@ -143,8 +143,10 @@
             <% if @profile.ect? &&
                   @profile.policy_class.new(current_user, @profile).add_appropriate_body? &&
                   policy(@induction_record).edit_appropriate_body? %>
-              <%= govuk_link_to(participant_has_appropriate_body? ? "Change" : "Add",
-                                { action: :add_appropriate_body, participant_id: @profile }) %>
+
+              <%= govuk_link_to({ action: :add_appropriate_body, participant_id: @profile }) do %>
+                <%= participant_has_appropriate_body? ? 'Change' : 'Add' %> <span class="govuk-visually-hidden"> Appropriate body</span>
+              <% end %>
             <% end %>
           </dd>
         </div>

--- a/spec/features/schools/participants/update_participants_details_spec.rb
+++ b/spec/features/schools/participants/update_participants_details_spec.rb
@@ -204,10 +204,10 @@ RSpec.describe "Changing participant details from the dashboard", type: :feature
   end
 
   context "When the school cohort does not have an appropriate body assigned" do
-    scenario "Induction tutor does not see the appropriate body from participant profile page" do
+    scenario "Induction tutor can see the appropriate body from participant profile page" do
       click_on "Sally Teacher"
       then_i_am_taken_to_participant_profile
-      and_i_dont_see_appropriate_body
+      and_i_see_no_appropriate_body_selected
     end
   end
 

--- a/spec/features/schools/training_dashboard/manage_training_steps.rb
+++ b/spec/features/schools/training_dashboard/manage_training_steps.rb
@@ -175,7 +175,7 @@ module ManageTrainingSteps
   end
 
   def and_i_can_change_the_appropriate_body
-    expect(page).to have_summary_row_action("Appropriate body", "Change")
+    expect(page).to have_summary_row_action("Appropriate body", "Change Appropriate body")
   end
 
   def and_i_can_manage_ects_and_mentors


### PR DESCRIPTION
This helps with transferred participants that are associated to an Appropriate  Body and want to keep it.

### Context

- Ticket: CST-1803

### Changes proposed in this pull request
Remove the school cohort AB check from the `can_appropriate_body_be_changed?` helper method

### Guidance to review
- Find a school with participants in a cohort without an Appropriate Body
- Visit the page of one of those participants
- The Appropriate Body row should be displayed
