### PR TITLE
Find most recent declaration by declaration_date

### DIFF
--- a/lib/participant_profile_deduplicator.rb
+++ b/lib/participant_profile_deduplicator.rb
@@ -195,7 +195,7 @@ private
 
     return unless conflicting_declaration
 
-    most_recent_declaration = [declaration, conflicting_declaration].max_by(&:created_at)
+    most_recent_declaration = [declaration, conflicting_declaration].max_by(&:declaration_date)
     void_or_clawback_declaration(most_recent_declaration)
   end
 


### PR DESCRIPTION
We were previously ordering by `created_at` on the declaration, but we think it makes more sense to find the earliest by `declaration_date`.

Fix flakey specs by calculating relative `declaration_dates`; previously we were updating to `some.time.ago`, which meant on occasion a date outside the milestone would be set (which is not valid).v
