### PR TITLE
CST-1885: participants whose DQT induction status is InProgress are n…

### DIFF
--- a/app/presenters/dqt_record_presenter.rb
+++ b/app/presenters/dqt_record_presenter.rb
@@ -41,6 +41,10 @@ class DQTRecordPresenter < SimpleDelegator
     dqt_record.dig("induction", "status") == "Exempt"
   end
 
+  def induction_in_progress?
+    dqt_record.dig("induction", "status") == "InProgress"
+  end
+
 private
 
   def dqt_record

--- a/app/services/participant_validation_service.rb
+++ b/app/services/participant_validation_service.rb
@@ -41,6 +41,7 @@ private
   def previous_induction?(validation_data)
     return true if validation_data.induction_completion_date.present?
     return false if validation_data.induction_start_date.nil?
+    return false if validation_data.induction_in_progress?
 
     # this should always be a check against 2021 not Cohort.current.start_year
     validation_data.induction_start_date < ActiveSupport::TimeZone["London"].local(2021, 9, 1)

--- a/spec/services/participant_validation_service_spec.rb
+++ b/spec/services/participant_validation_service_spec.rb
@@ -259,6 +259,31 @@ RSpec.describe ParticipantValidationService do
         end
       end
 
+      context "when the participant's induction status is InProgress" do
+        let(:induction) do
+          {
+            "start_date" => induction_start_date,
+            "status" => "InProgress",
+          }
+        end
+
+        it "does not raise an error" do
+          expect { validation_result }.not_to raise_error
+        end
+
+        it "returns previous_induction as false" do
+          expect(validation_result[:previous_induction]).to eq false
+        end
+
+        it "returns no_induction as false" do
+          expect(validation_result[:no_induction]).to eq false
+        end
+
+        it "returns induction_start_date" do
+          expect(validation_result[:induction_start_date]).to eq(induction_start_date)
+        end
+      end
+
       context "when the participant has previously had an induction and participation" do
         let!(:eligibility) { create(:ineligible_participant, trn:, reason: :previous_participation) }
         let(:induction) do


### PR DESCRIPTION
…ow eligible for funding

### Context

- Ticket: [Ensure that post-transitional ECTs have an InProgress induction in DQT before we deem them eligible for funding](https://dfedigital.atlassian.net/browse/CST-1885)

### Changes proposed in this pull request
Take into account DQT induction status of a participant to determine their `previous induction` status

### Guidance to review

