### PR TITLE
Update deduplicator to handle additional scenarios

### DIFF
--- a/lib/participant_profile_deduplicator.rb
+++ b/lib/participant_profile_deduplicator.rb
@@ -56,7 +56,7 @@ private
   end
 
   def same_school_different_lead_provider?
-    primary_profile.lead_provider&.id != duplicate_profile.lead_provider&.id && school(primary_profile) == school(duplicate_profile)
+    lead_provider(primary_profile)&.id != lead_provider(duplicate_profile)&.id && school(primary_profile) == school(duplicate_profile)
   end
 
   def duplicate_has_declarations?
@@ -102,7 +102,7 @@ private
   end
 
   def update_primary_profile_schedule(new_schedule)
-    cpd_lead_provider = primary_profile.lead_provider.cpd_lead_provider
+    cpd_lead_provider = lead_provider(primary_profile).cpd_lead_provider
     change_schedule = ChangeScheduleOnDuplicate.new(
       participant_id: primary_profile.user_id,
       profile: primary_profile,
@@ -261,6 +261,10 @@ private
 
   def school(participant_profile)
     participant_profile.latest_induction_record&.school || participant_profile.school
+  end
+
+  def lead_provider(participant_profile)
+    participant_profile.latest_induction_record&.lead_provider || participant_profile.lead_provider
   end
 
   def preferred_identity(duplicate_induction_record)

--- a/spec/lib/participant_profile_deduplicator_spec.rb
+++ b/spec/lib/participant_profile_deduplicator_spec.rb
@@ -316,7 +316,7 @@ describe ParticipantProfileDeduplicator do
                cpd_lead_provider: duplicate_profile.lead_provider.cpd_lead_provider)
       end
       let!(:primary_profile_schedule) { primary_profile.latest_induction_record.schedule }
-      let(:duplicate_profile_cohort) { create(:cohort) }
+      let(:duplicate_profile_cohort) { create(:cohort, start_year: primary_profile.cohort.start_year + 1) }
       let!(:duplicate_profile_schedule) do
         create(:schedule, name: "other-schedule", cohort: duplicate_profile_cohort).tap do |schedule|
           duplicate_profile.latest_induction_record.update!(schedule:)


### PR DESCRIPTION
### Context

We can now handle duplicates with a different lead provider but the same school - providing there are no declarations on the duplicate - by destroying the duplicate profile _without_ reconciling it with the primary.

After working through a change in training programme with Nathan on a call we've decided we can probably handle these but they need a warning to ensure we double check the ordering and scrutinise them more closely.

### Changes proposed in this pull request

- Update deduplicator to handle additional scenarios

### Guidance to review

