### PR TITLE
Adjust the cohort component behaviour

### DIFF
--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -2,8 +2,11 @@
   <%= tag.h2(heading, class: "govuk-heading-l") %>
 
   <% if empty? %>
-    <p class="govuk-body">No partnerships or relationships in the <%= cohort.start_year %> cohort.</p>
-  <% else %>
+
+    No school cohort set up for <%= cohort.start_year %>.
+
+  <% elsif fip? %>
+
     <% partnership_components.each do |pc| %>
       <%= pc %>
     <% end %>
@@ -15,5 +18,34 @@
         <%= rc %>
       <% end %>
     <% end %>
+
+  <% else %>
+
+    <%=
+      govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key(text: "Training programme")
+          row.with_value(text: training_programme)
+
+          if allow_change_programme?
+            row.with_action(text: "Change", visually_hidden_text: "induction programme",  href: change_programme_href)
+          end
+        end
+
+        if cip?
+          summary_list.with_row do |row|
+            row.with_key(text: "Materials")
+            row.with_value(text: materials)
+            row.with_action(text: "Change", visually_hidden_text: "materials", href: change_materials_href)
+          end
+
+          summary_list.with_row do |row|
+            row.with_key(text: "Appropriate body")
+            row.with_value(text: school_cohort&.appropriate_body&.name || "No appropriate body")
+          end
+        end
+      end
+    %>
+
   <% end %>
 </div>

--- a/app/components/admin/schools/cohort_component.rb
+++ b/app/components/admin/schools/cohort_component.rb
@@ -68,9 +68,7 @@ module Admin
       end
 
       def allow_change_programme?
-        return true if cip? || other?
-
-        school_cohort.lead_provider.nil?
+        cip? || other? || school_cohort.lead_provider.nil?
       end
 
       def change_programme_href

--- a/app/components/admin/schools/partnership_component.html.erb
+++ b/app/components/admin/schools/partnership_component.html.erb
@@ -3,18 +3,6 @@
     summary_list.with_row do |row|
       row.with_key(text: "Training programme")
       row.with_value(text: training_programme)
-
-      if allow_change_programme?
-        row.with_action(text: "Change", visually_hidden_text: "induction programme",  href: change_programme_href)
-      end
-    end
-
-    if cip?
-      summary_list.with_row do |row|
-        row.with_key(text: "Materials")
-        row.with_value(text: materials)
-        row.with_action(text: "Change", visually_hidden_text: "materials", href: change_materials_href)
-      end
     end
 
     summary_list.with_row do |row|

--- a/app/components/admin/schools/partnership_component.rb
+++ b/app/components/admin/schools/partnership_component.rb
@@ -11,48 +11,15 @@ module Admin
         @school_cohort = school_cohort
       end
 
-      def heading
-        tag.h2(safe_join([cohort.start_year, "partnership"], " "))
-      end
-
-      def cip?
-        induction_programme_choice == "core_induction_programme"
-      end
-
-      def fip?
-        induction_programme_choice == "full_induction_programme"
-      end
-
-      def other?
-        !cip? && !fip?
-      end
-
       def training_programme
         {
-          "core_induction_programme" => "Using DfE-accredited materials",
-          "design_our_own"           => "Designing their own training",
           "full_induction_programme" => "Working with a DfE-funded provider",
-          "no_early_career_teachers" => "No ECTs this year",
           "school_funded_fip"        => "School-funded full induction programme",
-        }.fetch(induction_programme_choice, "Not using service")
+        }.fetch(induction_programme_choice)
       end
 
-      def allow_change_programme?
-        return true if cip? || other?
-
-        school_cohort.lead_provider.nil?
-      end
-
-      def change_programme_href
-        admin_school_change_programme_path(id: school_cohort.start_year, school_id: school.slug)
-      end
-
-      def materials
-        school_cohort.default_induction_programme&.core_induction_programme&.name
-      end
-
-      def change_materials_href
-        admin_school_change_training_materials_path(id: school_cohort.cohort.start_year, school_id: school_cohort.school.slug)
+      def heading
+        tag.h2(safe_join([cohort.start_year, "partnership"], " "))
       end
 
       def appropriate_body_name

--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::Schools::CohortComponent, type: :component do
+  let(:induction_programme_choice) { "full_induction_programme" }
   let(:school) { FactoryBot.create(:seed_school) }
   let(:cohort) { FactoryBot.create(:seed_cohort) }
-  let(:school_cohort) { FactoryBot.create(:seed_school_cohort, school:, cohort:) }
+  let(:school_cohort) { FactoryBot.create(:seed_school_cohort, :fip, school:, cohort:, induction_programme_choice:) }
   let(:partnership) { FactoryBot.create(:seed_partnership, :valid, school:, cohort:) }
   let(:relationships) { FactoryBot.create_list(:seed_partnership, 2, :valid, school:, cohort:, relationship: true) }
   let(:partnerships_and_relationships) { [partnership, *relationships] }
@@ -47,6 +48,112 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
 
       context "when there are relationships and partnerships" do
         it { is_expected.to be_empty }
+      end
+    end
+
+    describe "#training_programme" do
+      {
+        "core_induction_programme" => "Using DfE-accredited materials",
+        "design_our_own"           => "Designing their own training",
+        "no_early_career_teachers" => "No ECTs this year",
+      }.each do |training_programme, description|
+        describe "training programme '#{training_programme}" do
+          let(:school_cohort) { FactoryBot.create(:seed_school_cohort, :with_cohort, induction_programme_choice: training_programme, school:) }
+
+          it("has description #{description}") { expect(subject.training_programme).to eql(description) }
+        end
+      end
+    end
+
+    describe "#change_programme_href" do
+      before { render_inline(subject) }
+
+      it "is the change programme path with appropriate params" do
+        expected = %(/admin/schools/#{school.slug}/cohorts/#{school_cohort.start_year}/change-programme)
+        expect(subject.change_programme_href).to eql(expected)
+      end
+    end
+
+    describe "#change_materials_href" do
+      before { render_inline(subject) }
+
+      it "is the change programme path with appropriate params" do
+        expected = %(/admin/schools/#{school.slug}/cohorts/#{school_cohort.start_year}/change-training-materials)
+        expect(subject.change_materials_href).to eql(expected)
+      end
+    end
+
+    describe "#materials" do
+      let(:default_induction_programme) { FactoryBot.create(:seed_induction_programme, :cip, :with_school_cohort, :with_core_induction_programme, school:) }
+      let(:school_cohort) { FactoryBot.create(:seed_school_cohort, :with_cohort, school:, default_induction_programme:) }
+
+      it "returns the default induction programme's core induction programme name" do
+        expected = school_cohort.default_induction_programme.core_induction_programme.name
+        expect(subject.materials).to eql(expected)
+      end
+    end
+
+    describe "#cip?" do
+      let(:induction_programme_choice) { "core_induction_programme" }
+
+      it { is_expected.to be_cip }
+      it { is_expected.not_to be_fip }
+      it { is_expected.not_to be_other }
+    end
+
+    describe "#fip?" do
+      let(:induction_programme_choice) { "full_induction_programme" }
+
+      it { is_expected.to be_fip }
+      it { is_expected.not_to be_cip }
+      it { is_expected.not_to be_other }
+    end
+
+    describe "#other?" do
+      %w[design_our_own no_early_career_teachers school_funded_fip].each do |other_programme|
+        context "when #{other_programme}" do
+          let(:induction_programme_choice) { other_programme }
+
+          it { is_expected.to be_other }
+          it { is_expected.not_to be_fip }
+          it { is_expected.not_to be_cip }
+        end
+      end
+    end
+
+    describe "#allow_change_programme?" do
+      context "when CIP" do
+        let(:induction_programme_choice) { "core_induction_programme" }
+
+        it "allows changing of induction programme" do
+          expect(subject.allow_change_programme?).to be(true)
+        end
+      end
+
+      context "when FIP" do
+        let(:induction_programme_choice) { "full_induction_programme" }
+
+        context "when lead provider is present" do
+          it "allows changing of induction programme" do
+            expect(subject.allow_change_programme?).to be(false)
+          end
+        end
+
+        context "when lead provider is nil" do
+          before { allow(school_cohort).to receive(:lead_provider).and_return(nil) }
+
+          it "allows changing of induction programme" do
+            expect(subject.allow_change_programme?).to be(true)
+          end
+        end
+      end
+
+      context "when other" do
+        let(:induction_programme_choice) { "no_early_career_teachers" }
+
+        it "allows changing of induction programme" do
+          expect(subject.allow_change_programme?).to be(true)
+        end
       end
     end
   end

--- a/spec/components/admin/schools/partnership_component_spec.rb
+++ b/spec/components/admin/schools/partnership_component_spec.rb
@@ -25,14 +25,6 @@ RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
       expect(rendered_content).not_to have_content("Change induction programme")
     end
 
-    context "when cip" do
-      let(:induction_programme_choice) { "core_induction_programme" }
-
-      it "renders the training programme a change link" do
-        expect(rendered_content).to have_css("dd", text: "Change induction programme")
-      end
-    end
-
     it "renders the appropriate body" do
       expect(rendered_content).to have_css("dt", text: "Appropriate body")
       expect(rendered_content).to have_css("dd", text: school_cohort.appropriate_body.name)
@@ -57,10 +49,7 @@ RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
   describe "methods" do
     describe "#training_programme" do
       {
-        "core_induction_programme" => "Using DfE-accredited materials",
-        "design_our_own"           => "Designing their own training",
         "full_induction_programme" => "Working with a DfE-funded provider",
-        "no_early_career_teachers" => "No ECTs this year",
         "school_funded_fip"        => "School-funded full induction programme",
       }.each do |training_programme, description|
         describe "training programme '#{training_programme}" do
@@ -68,88 +57,6 @@ RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
 
           it("has description #{description}") { expect(subject.training_programme).to eql(description) }
         end
-      end
-    end
-
-    describe "#allow_change_programme?" do
-      context "when CIP" do
-        let(:induction_programme_choice) { "core_induction_programme" }
-
-        it "allows changing of induction programme" do
-          expect(subject.allow_change_programme?).to be(true)
-        end
-      end
-
-      context "when FIP" do
-        let(:induction_programme_choice) { "full_induction_programme" }
-
-        context "when lead provider is present" do
-          it "allows changing of induction programme" do
-            expect(subject.allow_change_programme?).to be(false)
-          end
-        end
-
-        context "when lead provider is nil" do
-          before { allow(school_cohort).to receive(:lead_provider).and_return(nil) }
-
-          it "allows changing of induction programme" do
-            expect(subject.allow_change_programme?).to be(true)
-          end
-        end
-      end
-
-      context "when other" do
-        let(:induction_programme_choice) { "no_early_career_teachers" }
-
-        it "allows changing of induction programme" do
-          expect(subject.allow_change_programme?).to be(true)
-        end
-      end
-    end
-
-    describe "#cip?" do
-      let(:induction_programme_choice) { "core_induction_programme" }
-
-      it { is_expected.to be_cip }
-      it { is_expected.not_to be_fip }
-      it { is_expected.not_to be_other }
-    end
-
-    describe "#fip?" do
-      let(:induction_programme_choice) { "full_induction_programme" }
-
-      it { is_expected.to be_fip }
-      it { is_expected.not_to be_cip }
-      it { is_expected.not_to be_other }
-    end
-
-    describe "#other?" do
-      %w[design_our_own no_early_career_teachers school_funded_fip].each do |other_programme|
-        context "when #{other_programme}" do
-          let(:induction_programme_choice) { other_programme }
-
-          it { is_expected.to be_other }
-          it { is_expected.not_to be_fip }
-          it { is_expected.not_to be_cip }
-        end
-      end
-    end
-
-    describe "#change_programme_href" do
-      before { render_inline(subject) }
-
-      it "is the change programme path with appropriate params" do
-        expected = %(/admin/schools/#{school.slug}/cohorts/#{school_cohort.start_year}/change-programme)
-        expect(subject.change_programme_href).to eql(expected)
-      end
-    end
-
-    describe "#change_materials_href" do
-      before { render_inline(subject) }
-
-      it "is the change programme path with appropriate params" do
-        expected = %(/admin/schools/#{school.slug}/cohorts/#{school_cohort.start_year}/change-training-materials)
-        expect(subject.change_materials_href).to eql(expected)
       end
     end
 
@@ -168,16 +75,6 @@ RSpec.describe Admin::Schools::PartnershipComponent, type: :component do
     describe "#appropriate_body" do
       it "is the appropriate body's name" do
         expect(subject.appropriate_body_name).to eql(school_cohort.appropriate_body.name)
-      end
-    end
-
-    describe "#materials" do
-      let(:default_induction_programme) { FactoryBot.create(:seed_induction_programme, :cip, :with_school_cohort, :with_core_induction_programme, school:) }
-      let(:school_cohort) { FactoryBot.create(:seed_school_cohort, :with_cohort, school:, default_induction_programme:) }
-
-      it "returns the default induction programme's core induction programme name" do
-        expected = school_cohort.default_induction_programme.core_induction_programme.name
-        expect(subject.materials).to eql(expected)
       end
     end
   end


### PR DESCRIPTION
### Context

In my previous attempt to rewrite these components (#3846) I misunderstood the role of partnerships/relationships in CIP/FIP. Only FIP schools have partnerships and relationships; CIP schools instead have materials provided by their core induction programme.

As a result I've had to move some of the functionality previosuly in `Schools::PartnershipComponent` into `Schools::CohortComponent`.

Hopefully this makes more sense 😅

![image](https://github.com/DFE-Digital/early-careers-framework/assets/128088/932fb01d-f478-4baf-acf0-5014a30e5ed3)


