### PR TITLE
Reinstate image building/pushing to allow deployment to paas

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -1,0 +1,107 @@
+name: Deploy to Dev
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'documentation/**'
+
+jobs:
+  build-base:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1 # More recent buildx versions generate an OCI manifest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+
+      - name: Build and push docker image from builder target
+        uses: docker/build-push-action@v4
+        with:
+          target: builder
+          context: .
+          cache-from: |
+            ${{ env.DOCKER_REPOSITORY }}-dev:builder
+          tags: |
+            ${{ env.DOCKER_REPOSITORY }}-dev:builder
+          push: true
+          provenance: false
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Build and push docker image from early-careers-framework-gems-node-modules target
+        uses: docker/build-push-action@v4
+        with:
+          target: early-careers-framework-gems-node-modules
+          context: .
+          cache-from: |
+            ${{ env.DOCKER_REPOSITORY }}-dev:gems-node-modules
+          tags: |
+            ${{ env.DOCKER_REPOSITORY }}-dev:gems-node-modules
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Build and push docker image from assets-precompile target
+        uses: docker/build-push-action@v4
+        with:
+          target: assets-precompile
+          context: .
+          cache-from: |
+            ${{ env.DOCKER_REPOSITORY }}-dev:assets-precompile
+          tags: |
+            ${{ env.DOCKER_REPOSITORY }}-dev:assets-precompile
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+  build-release:
+    runs-on: ubuntu-20.04
+    needs: [build-base]
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Code
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1 # More recent buildx versions generate an OCI manifest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+
+      - name: Build and push docker image from production target
+        uses: docker/build-push-action@v4
+        with:
+          target: production
+          context: .
+          cache-from: |
+            ${{ env.DOCKER_REPOSITORY }}-prod:latest
+          tags: |
+            ${{ env.DOCKER_REPOSITORY }}-prod:${{ github.sha }}
+            ${{ env.DOCKER_REPOSITORY }}-prod:latest
+          push: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            SHA=${{ github.sha }}


### PR DESCRIPTION
### Context

We need to push the image as latest to docker so we can still deploy to PaaS

- Ticket: n/a

### Changes proposed in this pull request

Add all steps back except deploying to old dev Paas

### Guidance to review

