### PR TITLE
Amend spec to nullify school cohort as opposed to partnerships

### DIFF
--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
 
   describe "methods" do
     describe "#empty?" do
-      let(:partnerships_and_relationships) { [] }
+      let(:school_cohort) { nil }
 
       context "when there are relationships and partnerships" do
         it { is_expected.to be_empty }


### PR DESCRIPTION
### Context
We are getting failures on the following spec: https://github.com/DFE-Digital/early-careers-framework/actions/runs/6027756337/job/16374067146

When testing cohort component, logic for showing empty changed to school cohorts rather than partnerships: https://github.com/DFE-Digital/early-careers-framework/pull/3908/files#diff-988e63f8e759873f86e923baaf3f38be6c211e14a75dc1067f84cf82cbffd0daR43
- Ticket: n/a

### Changes proposed in this pull request

Amend spec to unset school cohort rather than partnership to match new logic

### Guidance to review
Did I miss anything?
