### PR TITLE
Set time for azure migration in production

### DIFF
--- a/app/components/banners/maintenance_component.rb
+++ b/app/components/banners/maintenance_component.rb
@@ -18,7 +18,7 @@ module Banners
     end
 
     def render?
-      date.present? && !date_is_past? && FeatureFlag.active?(:maintenance_banner)
+      date.present? && date_is_in_future? && FeatureFlag.active?(:maintenance_banner)
     end
 
     def unavailable_timeframe_string
@@ -47,7 +47,7 @@ module Banners
       DATE
     end
 
-    def date_is_past?
+    def date_is_in_future?
       date.to_time.beginning_of_day > Time.current.end_of_day
     end
 

--- a/app/components/banners/maintenance_component.rb
+++ b/app/components/banners/maintenance_component.rb
@@ -9,9 +9,9 @@ module Banners
     # date - required (for rendering)
     # start_time - optional
     # end_time - optional
-    DATE       = nil # Date.new(2021, 8, 4)
-    START_TIME = nil # Time.zone.local(2021, 8, 4, 9, 0, 0)
-    END_TIME   = nil # Time.zone.local(2023, 8, 4, 17, 0, 0)
+    DATE       = Date.new(2023, 9, 14)
+    START_TIME = Time.zone.local(2023, 9, 14, 18, 0, 0)
+    END_TIME   = Time.zone.local(2023, 9, 14, 21, 0, 0)
 
     def initialize(wide_container_view: false)
       @wide_container_view = wide_container_view


### PR DESCRIPTION
### Context
Set banner for production azure migration. Which will happen on the 14th of September between 6pm - 9pm
- Ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2424

### Changes proposed in this pull request
Add banner times for prod only. Sandbox will have a release note and comms sent out

### Guidance to review
I went with 3 hours to be cautious just incase, let me know your thoughts
