### PR TITLE
[CST-1828] Populate existing induction complete dates

### DIFF
--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# This is a one off job to update all of the induction completion dates from DQT for
+# all of the 2021/2022 ECTs that do not currently have them.
+# It runs in batches of 200 as we have a 300 lookup per minute limit on the API
+# This could get adapted later to be a regular running process with a bit more logic
+class SetParticipantCompletionDateJob < ApplicationJob
+  def perform
+    ParticipantProfile::ECT
+      .eligible_status
+      .joins(:teacher_profile)
+      .includes(:teacher_profile)
+      .where.not(teacher_profile: { trn: nil })
+      .where.not(induction_start_date: nil)
+      .where(created_at: ...Cohort.find_by(start_year: 2023).registration_start_date)
+      .order(:updated_at)
+      .limit(200)
+      .each do |participant_profile|
+        induction = DQT::GetInductionRecord.call(trn: participant_profile.teacher_profile.trn)
+
+        # prevent touches from cascading up to User and being exposed in the API
+        User.no_touching do
+          if induction.blank?
+            participant_profile.touch
+            next
+          end
+
+          completion_date = induction["endDate"]
+
+          Induction::Complete.call(participant_profile:, completion_date:) if completion_date.present?
+
+          # put at the bottom of the list for the next iteration if nothing changed
+          participant_profile.touch
+        end
+      end
+  rescue StandardError => e
+    Rails.logger.error("SetParticipantCompletionDateJob: #{e.message}")
+  end
+end

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -39,6 +39,10 @@ set_participant_start_date_job:
   queue: default
   status: "disabled"
   description: "Disabled for now but maybe required in the near future"
+set_participant_completion_date_job:
+  cron: "*/2 0-8 * * *"
+  class: "SetParticipantCompletionDateJob"
+  queue: default
 detect_sidekiq_metrics_issues_job:
   cron: "0 * * * *"
   class: "DetectSidekiqMetricsIssuesJob"


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1828)

Pull in the induction completion dates for pre-2023 ECTs as a one time job.  The job is scheduled to run every 2 minutes from midnight to 9am and pull in 200 participants at a time so that we don't have/cause issues with the DQT API 300 requests per minute limit.

### Changes proposed in this pull request
Add a job to read the induction records from DQT and use the `Induction::Complete` service to update the participants records.

### Guidance to review

