### PR TITLE
Fix error message on participant type form

### DIFF
--- a/app/forms/schools/add_participants/wizard_steps/participant_type_step.rb
+++ b/app/forms/schools/add_participants/wizard_steps/participant_type_step.rb
@@ -6,7 +6,7 @@ module Schools
       class ParticipantTypeStep < ::WizardStep
         attr_accessor :participant_type
 
-        validates :participant_type, presence: true, inclusion: { in: %w[ect mentor self transfer] }
+        validates :participant_type, inclusion: { in: %w[ect mentor self transfer] }
 
         def self.permitted_params
           %i[

--- a/app/views/schools/add_participants/participant_type.html.erb
+++ b/app/views/schools/add_participants/participant_type.html.erb
@@ -5,10 +5,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <span class="govuk-caption-xl"><%= @school.name %></span>
 
     <%= form_with model: @form, url: url_for(action: :update), scope: @wizard.form_scope, method: :put do |f| %>
       <%= f.govuk_error_summary %>
+      <span class="govuk-caption-xl"><%= @school.name %></span>
       <%= f.govuk_radio_buttons_fieldset :participant_type , legend: { text: "Who do you want to add?", tag: 'h1', size: 'xl' } do %>
         <p class="govuk-body govuk-!-margin-top-4">
           This could be a new teacher or a teacher transferring from another school where they’ve started ECF-based training or mentoring.

--- a/app/views/schools/add_participants/participant_type.html.erb
+++ b/app/views/schools/add_participants/participant_type.html.erb
@@ -18,7 +18,7 @@
             You can also add yourself as a mentor.
           </p>
         <% end %>
-        <%= f.govuk_radio_button :participant_type, :ect, label: { text: "ECT" } %>
+        <%= f.govuk_radio_button :participant_type, :ect, label: { text: "ECT" }, link_errors: true %>
         <%= f.govuk_radio_button :participant_type, :mentor, label: { text: "Mentor" } %>
         <% if @wizard.sit_can_become_a_mentor? %>
           <%= f.govuk_radio_button :participant_type, :self, label: { text: "Yourself as a mentor" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,7 +374,7 @@ en:
         schools/add_participants/wizard_steps/participant_type_step:
           attributes:
             participant_type:
-              inclusion: "Select whether to add an ECT or a Mentor"
+              inclusion: "Select ECT or mentor"
         schools/add_participants/wizard_steps/name_step:
           attributes:
             full_name:


### PR DESCRIPTION
See Jira ticket https://dfedigital.atlassian.net/browse/CST-1636?atlOrigin=eyJpIjoiZGY1YTUwYWU5MDBhNDQzZDljYWVjZmU1NDI3OGRlOWQiLCJwIjoiaiJ9 for more information

I've updated the error message content for participant_type. This error should be applied to the /participants/who/participant-type screen as part of this PR.