### PR TITLE
[CPDLP-2414] Add a new field to statements table to capture marked as paid timestamp

### DIFF
--- a/app/models/finance/statement.rb
+++ b/app/models/finance/statement.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Finance::Statement < ApplicationRecord
+  has_paper_trail
+
   self.table_name = "statements"
 
   belongs_to :cpd_lead_provider

--- a/db/migrate/20230905155638_add_marked_as_paid_at_to_statements.rb
+++ b/db/migrate/20230905155638_add_marked_as_paid_at_to_statements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMarkedAsPaidAtToStatements < ActiveRecord::Migration[7.0]
+  def change
+    add_column :statements, :marked_as_paid_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_154316) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_155638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -1025,6 +1025,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_154316) do
     t.boolean "output_fee", default: true
     t.string "contract_version", default: "0.0.1"
     t.decimal "reconcile_amount", default: "0.0", null: false
+    t.datetime "marked_as_paid_at"
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["cpd_lead_provider_id"], name: "index_statements_on_cpd_lead_provider_id"
   end


### PR DESCRIPTION
### Context

- Ticket: [CPDLP-2414](https://dfedigital.atlassian.net/browse/CPDLP-2414)

We will be adding the ability to track when a statement was marked as paid in the new finance dashboard workflow.

### Changes proposed in this pull request

- Add a new field which captures the timestamp when a statement has been marked as paid
- Add papertrail to the statement model to ensure we also have further auditing

[CPDLP-2414]: https://dfedigital.atlassian.net/browse/CPDLP-2414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ