### PR TITLE
Use API Token owner to identity `whodunnit` in change log versions

### DIFF
--- a/app/views/admin/npq/applications/change_logs/show.html.erb
+++ b/app/views/admin/npq/applications/change_logs/show.html.erb
@@ -9,8 +9,11 @@
 <% @versions.each_with_index do |version| %>
 
   <p class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-top-4"><%= version.created_at.strftime('%d %B %Y %H:%M:%S') %></p>
-  <p class="govuk-caption-m govuk-!-margin-top-0 govuk-!-margin-bottom-2">Updated
-    by <%= User.find(version.whodunnit).email %></p>
+  <% if version.whodunnit != NPQRegistrationApiToken.new.owner %>
+    <p class="govuk-caption-m govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+      Updated by <%= User.find(version.whodunnit).email %>
+    </p>
+  <% end %>
 
   <%= govuk_table(classes: 'govuk-!-margin-top-2') do |table|
     table.with_head do |head|

--- a/spec/features/admin/npq_applications/change_logs_spec.rb
+++ b/spec/features/admin/npq_applications/change_logs_spec.rb
@@ -23,10 +23,30 @@ RSpec.feature "Admin NPQ Application change logs", js: true, rutabaga: false do
     then_i_can_see_a_change_log_on_eligible_attribute
   end
 
+  scenario "Show a change log for an Applicant (API - first version)" do
+    given_there_is_an_npq_application_via_api
+    and_i_am_signed_in_as_an_admin
+
+    when_i_visit the_npq_applications_edge_cases
+    when_i_select_the_first_applicant
+    when_i_mark_the_applicant_as_eligible
+    when_i_see_the_applicant_change_log
+
+    expect(page).to have_content("Changed from", count: 2)
+    expect(page).to have_content("Updated by", count: 1)
+  end
+
 private
 
   def given_there_is_an_npq_application
     application = create :npq_application, :edge_case
+
+    allow(User).to receive(:find).and_return(application.user)
+  end
+
+  def given_there_is_an_npq_application_via_api
+    application = create :npq_application, :edge_case
+    application.versions.first.update!(whodunnit: NPQRegistrationApiToken.new.owner)
 
     allow(User).to receive(:find).and_return(application.user)
   end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDNPQ-1308

Continuation of https://github.com/DFE-Digital/early-careers-framework/pull/3810

### Context 

Users reported that when accessing the ChangeLog in the NPQ admin section, 
were redirected to the `Page not found` page (See screenshots)

The root cause seems to be related to the `Papertrail` attribute `whodunnit` 
when the NPQApplication is created via the API.

I have decided to check if the user has been created via the API in the template
and only display the author of the change when an actual admin has performed 
the change.

### Screenshots

<img width="571" alt="image" src="https://github.com/DFE-Digital/early-careers-framework/assets/227328/16b6d950-8a10-4746-8c02-e092d40f2550">

<img width="448" alt="image" src="https://github.com/DFE-Digital/early-careers-framework/assets/227328/3e78dad3-42f1-45c4-be30-cdd4d52df56f">

