### PR TITLE
[CST-1924] Send access info when unregistered users are trying to login

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,6 +2,7 @@
 
 class UserMailer < ApplicationMailer
   SIGN_IN_EMAIL_TEMPLATE = "7ab8db5b-9842-4bc3-8dbb-f590a3198d9e"
+  ACCESS_INFO_EMAIL_TEMPLATE = "fa5a9bca-ac57-435d-b450-201ca209379b"
 
   def test_email
     user = params[:user]
@@ -31,5 +32,20 @@ class UserMailer < ApplicationMailer
         subject: "Link to sign in",
       },
     ).tag(:sign_in)
+  end
+
+  def access_info_email
+    recipient = params[:recipient]
+
+    template_mail(
+      ACCESS_INFO_EMAIL_TEMPLATE,
+      to: recipient,
+      rails_mailer: mailer_name,
+      rails_mail_template: action_name,
+      personalisation: {
+        sign_in: new_user_session_url,
+        request_access: resend_email_request_nomination_invite_url,
+      },
+    ).tag(:access_info_email).associate_with(recipient)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -43,6 +43,7 @@ class UserMailer < ApplicationMailer
       rails_mailer: mailer_name,
       rails_mail_template: action_name,
       personalisation: {
+        service_url: root_url,
         sign_in: new_user_session_url,
         request_access: resend_email_request_nomination_invite_url,
       },

--- a/lib/devise/strategies/passwordless_authenticatable.rb
+++ b/lib/devise/strategies/passwordless_authenticatable.rb
@@ -40,6 +40,7 @@ module Devise
             UserMailer.with(email: email.downcase, full_name: user.full_name, url:, token_expiry: token_expiry.localtime.to_fs(:govuk)).sign_in_email.deliver_later(queue: "priority_mailers")
             raise LoginIncompleteError
           else
+            UserMailer.with(recipient: email.downcase).access_info_email.deliver_later(queue: "priority_mailers")
             raise EmailNotFoundError
           end
         end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -20,4 +20,21 @@ RSpec.describe UserMailer, type: :mailer do
       expect(sign_in_email.from).to eq(["mail@example.com"])
     end
   end
+
+  describe "#access_info_email" do
+    let(:recipient) { Faker::Internet.email }
+
+    let(:access_info_email) do
+      UserMailer.with(recipient:).access_info_email.deliver_now
+    end
+
+    it "renders the right headers" do
+      expect(access_info_email.to).to eq([recipient])
+      expect(access_info_email.from).to eq(["mail@example.com"])
+    end
+
+    it "uses the correct Notify template" do
+      expect(UserMailer::ACCESS_INFO_EMAIL_TEMPLATE).to eq("fa5a9bca-ac57-435d-b450-201ca209379b")
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Ticket: CST-1924

Unregistered users try to sign into the service and they get confused. We want to send them an email about what they should do to gain access.

### Changes proposed in this pull request
- Add a new user mailer
- Update the passwordless strategy to send the email when the user is not found

### Guidance to review
- Try to sign-in with a random email address
- Verify that the email is sent by checking on `Notify -> API integration`
- Confirm the email body is correct (mainly the URLs passed to the Notify template)
