### PR TITLE
[CST-1828] Add job and schedule to pull in completion dates from DQT

### DIFF
--- a/app/jobs/set_participant_completion_date_job.rb
+++ b/app/jobs/set_participant_completion_date_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# This is a one off job to update all of the induction completion dates from DQT for
+# all of the 2021/2022 ECTs that do not currently have them.
+# It runs in batches of 200 as we have a 300 lookup per minute limit on the API
+# This could get adapted later to be a regular running process with a bit more logic
+class SetParticipantCompletionDateJob < ApplicationJob
+  def perform
+    ParticipantProfile::ECT
+      .eligible_status
+      .joins(:teacher_profile)
+      .includes(:teacher_profile)
+      .where.not(teacher_profile: { trn: nil })
+      .where.not(induction_start_date: nil)
+      .where(created_at: ...Cohort.find_by(start_year: 2023).registration_start_date)
+      .order(:updated_at)
+      .limit(200)
+      .each do |participant_profile|
+        induction = DQT::GetInductionRecord.call(trn: participant_profile.teacher_profile.trn)
+
+        # prevent touches from cascading up to User and being exposed in the API
+        User.no_touching do
+          if induction.blank?
+            participant_profile.touch
+            next
+          end
+
+          completion_date = induction["endDate"]
+
+          Induction::Complete.call(participant_profile:, completion_date:) if completion_date.present?
+
+          # put at the bottom of the list for the next iteration if nothing changed
+          participant_profile.touch
+        end
+      end
+  rescue StandardError => e
+    Rails.logger.error("SetParticipantCompletionDateJob: #{e.message}")
+  end
+end

--- a/app/services/induction/complete.rb
+++ b/app/services/induction/complete.rb
@@ -2,6 +2,8 @@
 
 class Induction::Complete < BaseService
   def call
+    return unless participant_profile.ect?
+
     ActiveRecord::Base.transaction do
       participant_profile.update!(induction_completion_date: completion_date)
 

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -33,12 +33,6 @@ send_outcomes_to_qualified_teachers_api:
   cron: "*/10 * * * *"
   class: "ParticipantOutcomes::BatchSendLatestOutcomesJob"
   queue: participant_outcomes
-set_participant_start_date_job:
-  cron: "*/2 0-8 * * *"
-  class: "SetParticipantStartDateJob"
-  queue: default
-  status: "disabled"
-  description: "Disabled for now but maybe required in the near future"
 set_participant_completion_date_job:
   cron: "*/2 0-8 * * *"
   class: "SetParticipantCompletionDateJob"

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -39,6 +39,10 @@ set_participant_start_date_job:
   queue: default
   status: "disabled"
   description: "Disabled for now but maybe required in the near future"
+set_participant_completion_date_job:
+  cron: "*/2 0-8 * * *"
+  class: "SetParticipantCompletionDateJob"
+  queue: default
 detect_sidekiq_metrics_issues_job:
   cron: "0 * * * *"
   class: "DetectSidekiqMetricsIssuesJob"

--- a/spec/services/induction/complete_spec.rb
+++ b/spec/services/induction/complete_spec.rb
@@ -58,5 +58,21 @@ RSpec.describe Induction::Complete do
         expect(induction_record.reload).to be_completed_induction_status
       end
     end
+
+    context "when the participant is not an ECT" do
+      let(:participant_profile) { create(:mentor_participant_profile, school_cohort:) }
+
+      before do
+        service.call(participant_profile:, completion_date:)
+      end
+
+      it "does not set the completion date" do
+        expect(participant_profile.induction_completion_date).to be_nil
+      end
+
+      it "does not set the completed status" do
+        expect(participant_profile.latest_induction_record).not_to be_completed_induction_status
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Ticket: [Jira](https://dfedigital.atlassian.net/browse/CST-1828)

Pull in the induction completion dates for pre-2023 ECTs as a one time job.  The job is scheduled to run every 2 minutes from midnight to 9am and pull in 200 participants at a time so that we don't have/cause issues with the DQT API 300 requests per minute limit.

### Changes proposed in this pull request
Add a job to read the induction records from DQT and use the `Induction::Complete` service to update the participants records.

