### PR TITLE
Add participant presenter to change_log_controller

### DIFF
--- a/app/controllers/admin/participants/change_log_controller.rb
+++ b/app/controllers/admin/participants/change_log_controller.rb
@@ -5,12 +5,10 @@ module Admin::Participants
     include RetrieveProfile
 
     def show
+      @participant_presenter = Admin::ParticipantPresenter.new(@participant_profile)
       @event_list = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events
-
-      add_breadcrumb(
-        school.name,
-        admin_school_participants_path(school),
-      )
+      
+      add_breadcrumb(school.name, admin_school_participants_path(school)) if school.present?
     end
 
   private

--- a/app/controllers/admin/participants/change_log_controller.rb
+++ b/app/controllers/admin/participants/change_log_controller.rb
@@ -7,7 +7,7 @@ module Admin::Participants
     def show
       @participant_presenter = Admin::ParticipantPresenter.new(@participant_profile)
       @event_list = Participants::HistoryBuilder.from_participant_profile(@participant_profile).events
-      
+
       add_breadcrumb(school.name, admin_school_participants_path(school)) if school.present?
     end
 

--- a/spec/requests/admin/participants/change_log_spec.rb
+++ b/spec/requests/admin/participants/change_log_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Participants::ChangeLog", type: :request do
+  let(:admin_user) { create(:user, :admin) }
+
+  let!(:mentor_profile) { create(:mentor) }
+  let!(:ect_profile) { create(:ect, mentor_profile_id: mentor_profile.id) }
+  let!(:npq_profile) { create(:npq_participant_profile) }
+  let!(:withdrawn_ect_profile_record) { create(:ect, :withdrawn_record) }
+  let!(:mentor_with_no_ir) { create(:mentor).tap { |profile| profile.induction_records.destroy_all } }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /admin/participants" do
+    context "when participant is a mentor" do
+      let(:route) { "/admin/participants/#{mentor_profile.id}/change_log" }
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/change_log/show"
+      end
+    end
+
+    context "when participant is an ECT" do
+      let(:route) { "/admin/participants/#{ect_profile.id}/change_log" }
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/change_log/show"
+      end
+    end
+
+    context "when participant is an NPQ Trainee" do
+      let(:route) { "/admin/participants/#{npq_profile.id}/change_log" }
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/change_log/show"
+      end
+    end
+
+    context "when participant is a withdrawn ECT" do
+      let(:route) { "/admin/participants/#{withdrawn_ect_profile_record.id}/change_log" }
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/change_log/show"
+      end
+    end
+
+    context "when participant is missing their induction records" do
+      let(:route) { "/admin/participants/#{mentor_with_no_ir.id}/change_log" }
+
+      it "renders without errors" do
+        get route
+        expect(response).to render_template "admin/participants/change_log/show"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://dfe-teacher-services.sentry.io/issues/4414607011/?alert_rule_id=7310304&alert_type=issue&project=5748989&referrer=slack

The change log tabs in the admin console fail to load because the header now requires the ParticipantPresenter to correctly find the cohort start_year to display.

### Changes proposed in this pull request

- Add ParticipantPresenter to the view model of the change log controller

