### PR TITLE
[CST-1923] Iterations to the SIT sign-in journey

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -42,6 +42,7 @@ class Users::SessionsController < Devise::SessionsController
   def create
     super
   rescue Devise::Strategies::PasswordlessAuthenticatable::Error
+    @login_email = params[:user][:email]
     render :login_email_sent
   end
 

--- a/app/forms/nomination_request_form.rb
+++ b/app/forms/nomination_request_form.rb
@@ -7,7 +7,7 @@ class NominationRequestForm
   attr_accessor :local_authority_id, :school_id
 
   validates :local_authority_id,
-            presence: { message: I18n.t("errors.schools.blank") },
+            presence: { message: I18n.t("errors.local_authority.blank") },
             on: %i[local_authority save]
   validates :school_id,
             presence: { message: I18n.t("errors.schools.blank") },

--- a/app/views/nominations/request_nomination_invite/resend_email.html.erb
+++ b/app/views/nominations/request_nomination_invite/resend_email.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Send induction tutor link" %>
+<% content_for :title, "Request access to this service" %>
 <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
 
 <div class="govuk-grid-row">

--- a/app/views/nominations/request_nomination_invite/resend_email.html.erb
+++ b/app/views/nominations/request_nomination_invite/resend_email.html.erb
@@ -2,15 +2,19 @@
 <% content_for :before_content, govuk_back_link(text: "Back", href: :back) %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">Send your school a link to use this service</h1>
+    <h1 class="govuk-heading-l">Request access to this service</h1>
+    <p class="govuk-body">We’ll email an access link to your school. For security, we’ll send a link to the email
+      address held in the Get Information about Schools (GIAS) register.</p>
 
-        <p class="govuk-body">We need some information to help us find your school in the Get Information about Schools (GIAS) register.</p>
-        <p class="govuk-body">We’ll then send a link to the email address held in the register.</p>
-        <p class="govuk-body govuk-!-margin-bottom-7 govuk-inset-text">You can <%= govuk_link_to "sign in to the DfE", "https://services.signin.education.gov.uk/", class: "govuk-link govuk-link--no-visited-state" %> to check that your school’s email address is up to date before you start.</p>
+    <p class="govuk-body govuk-!-margin-bottom-7 govuk-inset-text">
+      You can
+      <%= govuk_link_to "use DfE Sign-in", "https://services.signin.education.gov.uk/", class: "govuk-link govuk-link--no-visited-state" %>
+      to check that your school’s email address is up to date before you start.
+    </p>
 
-        <%= govuk_button_link_to "Continue", choose_location_request_nomination_invite_path %>
+    <%= govuk_button_link_to "Continue", choose_location_request_nomination_invite_path %>
 
-    </div>
+  </div>
 </div>

--- a/app/views/nominations/request_nomination_invite/review.html.erb
+++ b/app/views/nominations/request_nomination_invite/review.html.erb
@@ -6,12 +6,11 @@
 
     <h1 class="govuk-heading-xl">Confirm this is your school</h1>
 
-    <h2 class="govuk-heading-m">Personal details</h2>
 
     <%= render partial: 'nominations/school_details', locals: { school: @nomination_request_form.school, title: "Your school" } %>
 
     <p class="govuk-body">
-      We'll email an access link to
+      We’ll email an access link to
       <%= EmailDecorator::new(@nomination_request_form.school.primary_contact_email).partial_email %>
     </p>
 

--- a/app/views/nominations/request_nomination_invite/review.html.erb
+++ b/app/views/nominations/request_nomination_invite/review.html.erb
@@ -1,19 +1,24 @@
 <% content_for :title, "Confirm this is your school" %>
-<% content_for :before_content, govuk_back_link( text: "Back", href: choose_school_request_nomination_invite_path) %>
+<% content_for :before_content, govuk_back_link(text: "Back", href: choose_school_request_nomination_invite_path) %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">Confirm this is your school</h1>
+    <h1 class="govuk-heading-xl">Confirm this is your school</h1>
 
-        <h2 class="govuk-heading-m">Personal details</h2>
+    <h2 class="govuk-heading-m">Personal details</h2>
 
-        <%= render partial: 'nominations/school_details', locals: { school: @nomination_request_form.school, title: "Your school" }  %>
+    <%= render partial: 'nominations/school_details', locals: { school: @nomination_request_form.school, title: "Your school" } %>
 
-        <%= form_for :confirmation, url: review_request_nomination_invite_path, method: :post do |f| %>
-            <%= f.hidden_field :answers_checked, value: true %>
-            <%= f.govuk_submit "Confirm and send" %>
-        <% end %>
+    <p class="govuk-body">
+      We'll email an access link to
+      <%= EmailDecorator::new(@nomination_request_form.school.primary_contact_email).partial_email %>
+    </p>
 
-    </div>
+    <%= form_for :confirmation, url: review_request_nomination_invite_path, method: :post do |f| %>
+      <%= f.hidden_field :answers_checked, value: true %>
+      <%= f.govuk_submit "Confirm and send" %>
+    <% end %>
+
+  </div>
 </div>

--- a/app/views/nominations/request_nomination_invite/success.html.erb
+++ b/app/views/nominations/request_nomination_invite/success.html.erb
@@ -5,9 +5,10 @@
 
     <%= govuk_panel title_text: "Your school has been sent a link", text: nil, classes: "govuk-!-margin-bottom-7" %>
 
-    <p class="govuk-body">We’ve sent a link to the school’s email address at</p>
-
-    <p><strong><%= EmailDecorator::new(@school_email).partial_email %></strong></p>
+    <p class="govuk-body">
+      We’ve sent an email to
+      <strong><%= EmailDecorator::new(@school_email).partial_email %></strong>
+    </p>
 
     <h2 class="govuk-heading-m">What happens next</h2>
     <ol class="govuk-list govuk-list--number">

--- a/app/views/nominations/request_nomination_invite/success.html.erb
+++ b/app/views/nominations/request_nomination_invite/success.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= govuk_panel title_text: "Your school has been sent a link", text: nil, classes: "govuk-!-margin-bottom-7" %>
+  <h1 class="govuk-heading-xl">Check your school email</h1>
 
     <p class="govuk-body">
       We’ve sent an email to

--- a/app/views/nominations/request_nomination_invite/success.html.erb
+++ b/app/views/nominations/request_nomination_invite/success.html.erb
@@ -10,13 +10,14 @@
       <strong><%= EmailDecorator::new(@school_email).partial_email %></strong>
     </p>
 
-    <h2 class="govuk-heading-m">What happens next</h2>
-    <ol class="govuk-list govuk-list--number">
-      <li>Check you have received the email.</li>
-      <li>Sign in to the service using the link in the email.</li>
-      <li>Nominate a new school induction tutor.</li>
-      <li>The new induction tutor will get an email with a link to sign in and start using the service.</li>
-    </ol>
-
+    <p class="govuk-body">If the email does not arrive within 5 minutes, check the spam or junk folder.</p>
+    <p class="govuk-body">You can also
+      <%= govuk_link_to "request another link", resend_email_request_nomination_invite_path %>
+    </p>
+    <p class="govuk-body">If you still need help, contact us:
+      <a class="govuk-link govuk-link--no-visited-state" href="mailto:continuing-professional-development@digital.education.gov.uk">
+        continuing-professional-development@digital.education.gov.uk
+      </a>
+    </p>
   </div>
 </div>

--- a/app/views/nominations/request_nomination_invite/success.html.erb
+++ b/app/views/nominations/request_nomination_invite/success.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "New link sent" %>
+<% content_for :title, "Check your school email" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/users/sessions/login_email_sent.html.erb
+++ b/app/views/users/sessions/login_email_sent.html.erb
@@ -1,13 +1,13 @@
-<% content_for :title, "Check email" %>
+<% content_for :title, "Check your email" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">Check your email</h1>
-    <p class="govuk-body">We've sent an email to <strong><%= @login_email %></strong>.</p>
+    <p class="govuk-body">We’ve sent an email to <strong><%= @login_email %></strong>.</p>
 
     <p class="govuk-body">
-      If it does not arrivate within 5 minutes, check your spam or junk folder or
+      If it does not arrive within 5 minutes, check your spam or junk folder or
       <%= govuk_link_to "try again", new_user_session_path %>
     </p>
 

--- a/app/views/users/sessions/login_email_sent.html.erb
+++ b/app/views/users/sessions/login_email_sent.html.erb
@@ -1,18 +1,17 @@
 <% content_for :title, "Check email" %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">Check your email</h1>
-        <p class="govuk-body">If you have an account, we’ve sent you a link to sign in.</p>
+    <h1 class="govuk-heading-xl">Check your email</h1>
+    <p class="govuk-body">We've sent an email to <strong><%= @login_email %></strong>.</p>
 
-        <h2 class="govuk-heading-m">If you do not get an email</h2>
-      	<ol class="govuk-list govuk-list--number">
-            <li>Check your spam or junk folder.</li>
-            <li>Try signing in again, making sure your email address is typed correctly and does not include any spaces.</li>
-		</ol>
-        <p class="govuk-body">If you’re not registered, <%= govuk_link_to "find out how to get an account", check_account_path, class: "govuk-link govuk-link--no-visited-state" %>.</p>
-	    <p class="govuk-body">If you still need help, contact us: <%= render MailToSupportComponent.new %></p>
+    <p class="govuk-body">
+      If it does not arrivate within 5 minutes, check your spam or junk folder or
+      <%= govuk_link_to "try again", new_user_session_path %>
+    </p>
 
-    </div>
+    <p class="govuk-body">If you need help, contact us: <%= render MailToSupportComponent.new %></p>
+
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,9 @@ en:
     how_to_continue:
       blank: "Select an answer"
     schools:
-      blank: "The details you entered do not match any schools"
+      blank: "Enter your school’s name"
+    local_authority:
+      blank: "Enter your school’s local authority"
     programme_choice:
       blank: "Select how you want to run your induction"
     cohorts:

--- a/spec/features/request_access_spec.rb
+++ b/spec/features/request_access_spec.rb
@@ -37,7 +37,7 @@ private
   alias_method :when_i_click_on_continue, :and_i_click_on_continue
 
   def then_i_am_on_the_send_link_page
-    expect(page).to have_text("Send your school a link to use this service")
+    expect(page).to have_text("Request access to this service")
   end
 
   def when_i_fill_local_authority_name

--- a/spec/features/request_access_spec.rb
+++ b/spec/features/request_access_spec.rb
@@ -66,6 +66,6 @@ private
 
   def and_i_see_the_school_redacted_email(school)
     redacted_email = EmailDecorator.new(school.primary_contact_email).to_s
-    expect(page).to have_text("We'll email an access link to #{redacted_email}")
+    expect(page).to have_text("We’ll email an access link to #{redacted_email}")
   end
 end

--- a/spec/features/request_access_spec.rb
+++ b/spec/features/request_access_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Request access to the service", type: :feature, js: true, rutabaga: false do
+  let!(:school) { create(:school, :with_local_authority) }
+
+  scenario "Request access to the service" do
+    given_i_am_on_the_start_page
+    when_i_click_on_request_access_link
+    then_i_am_on_the_send_link_page
+
+    when_i_click_on_continue
+    then_i_am_on_the_choose_local_authority_page
+
+    when_i_fill_local_authority_name
+    and_i_click_on_continue
+    then_i_am_on_the_choose_school_page
+
+    when_i_fill_school_name
+    and_i_click_on_continue
+    then_i_am_on_the_confirmation_page
+    and_i_see_the_school_name
+    and_i_see_the_school_redacted_email(school)
+  end
+
+  private
+
+  def when_i_click_on_request_access_link
+    click_on "request access to the service"
+  end
+
+  def and_i_click_on_continue
+    click_on "Continue"
+  end
+
+  alias when_i_click_on_continue and_i_click_on_continue
+
+  def then_i_am_on_the_send_link_page
+    expect(page).to have_text("Send your school a link to use this service")
+  end
+
+  def when_i_fill_local_authority_name
+    when_i_fill_in_autocomplete "nomination-request-form-local-authority-id-field", with: school.local_authorities.first.name
+  end
+
+  def then_i_am_on_the_choose_local_authority_page
+    expect(page).to have_text("What’s your school’s local authority?")
+  end
+
+  def when_i_fill_school_name
+    when_i_fill_in_autocomplete "nomination-request-form-school-id-field", with: school.name
+  end
+
+  def then_i_am_on_the_choose_school_page
+    expect(page).to have_text("What’s the name of your school?")
+  end
+
+  def then_i_am_on_the_confirmation_page
+    expect(page).to have_text("Confirm this is your school")
+  end
+
+  def and_i_see_the_school_name
+    expect(page).to have_text(school.name)
+  end
+
+  def and_i_see_the_school_redacted_email(school)
+    redacted_email = EmailDecorator.new(school.primary_contact_email).to_s
+    expect(page).to have_text("We'll email an access link to #{redacted_email}")
+  end
+end

--- a/spec/features/request_access_spec.rb
+++ b/spec/features/request_access_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Request access to the service", type: :feature, js: true, rutabag
     and_i_see_the_school_redacted_email(school)
   end
 
-  private
+private
 
   def when_i_click_on_request_access_link
     click_on "request access to the service"
@@ -34,7 +34,7 @@ RSpec.feature "Request access to the service", type: :feature, js: true, rutabag
     click_on "Continue"
   end
 
-  alias when_i_click_on_continue and_i_click_on_continue
+  alias_method :when_i_click_on_continue, :and_i_click_on_continue
 
   def then_i_am_on_the_send_link_page
     expect(page).to have_text("Send your school a link to use this service")

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Sign in", type: :feature, js: true, rutabaga: false do
+  scenario "Signing in from the Start page" do
+    given_i_am_on_the_start_page
+    when_i_start_now_from_the_start_page
+    then_i_am_on_the_sign_in_page
+
+    when_i_fill_in_the_email_adress
+    and_click_on_sign_in
+    then_i_see_the_confirmation_message
+  end
+
+private
+
+  def when_i_fill_in_the_email_adress
+    fill_in "Email address", with: "user@myschool.org"
+  end
+
+  def and_click_on_sign_in
+    click_on "Sign in"
+  end
+
+  def then_i_see_the_confirmation_message
+    expect(page).to have_text("We've sent an email to user@myschool.org")
+  end
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -24,6 +24,6 @@ private
   end
 
   def then_i_see_the_confirmation_message
-    expect(page).to have_text("We've sent an email to user@myschool.org")
+    expect(page).to have_text("We’ve sent an email to user@myschool.org")
   end
 end

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -13,12 +13,6 @@ RSpec.feature "Start user journey", type: :feature, js: true, rutabaga: false do
     then_i_am_on_the_start_page
   end
 
-  scenario "Signing in from the Start page" do
-    given_i_am_on_the_start_page
-    when_i_start_now_from_the_start_page
-    then_i_am_on_the_sign_in_page
-  end
-
 private
 
   def given_i_am_at_the_root_of_the_service

--- a/spec/forms/nomination_request_form_spec.rb
+++ b/spec/forms/nomination_request_form_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe NominationRequestForm, type: :model do
   describe "validations" do
     it {
       is_expected.to validate_presence_of(:local_authority_id)
-                       .with_message("The details you entered do not match any schools")
+                       .with_message("Enter your school’s local authority")
                        .on(%i[local_authority save])
     }
 
     it {
       is_expected.to validate_presence_of(:school_id)
-                       .with_message("The details you entered do not match any schools")
+                       .with_message("Enter your school’s name")
                        .on(%i[school save])
     }
   end

--- a/spec/requests/nominations/request_nomination_invite_spec.rb
+++ b/spec/requests/nominations/request_nomination_invite_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Requesting an invitation to nominate an induction tutor", type: 
     it "shows validation error" do
       post "/nominations/choose-location"
       expect(response).to render_template(:choose_location)
-      expect(response.body).to include(CGI.escapeHTML("The details you entered do not match any schools"))
+      expect(response.body).to include(CGI.escapeHTML("Enter your school’s local authority"))
     end
 
     it "redirects to choose-school" do
@@ -35,7 +35,7 @@ RSpec.describe "Requesting an invitation to nominate an induction tutor", type: 
     it "shows validation error" do
       post "/nominations/choose-school"
       expect(response).to render_template(:choose_school)
-      expect(response.body).to include(CGI.escapeHTML("The details you entered do not match any schools"))
+      expect(response.body).to include(CGI.escapeHTML("Enter your school’s name"))
     end
 
     context "when given an eligible, un-nominated school" do


### PR DESCRIPTION
### Context

- Ticket: CST-1923

### Changes proposed in this pull request

* Display the email address we’ve sent the magic link to on sign-in
* Show a redacted email address on the GIAS renominate route
* Confirmation page in the GIAS renomination route
