### PR TITLE
Reinstate the choose induction programme button

### DIFF
--- a/app/components/admin/schools/cohort_component.html.erb
+++ b/app/components/admin/schools/cohort_component.html.erb
@@ -3,7 +3,9 @@
 
   <% if empty? %>
 
-    No school cohort set up for <%= cohort.start_year %>.
+    <p class="govuk-body">No induction programme chosen for <%= school.name %> in <%= cohort.academic_year %>.</p>
+
+    <%= govuk_button_link_to "Choose an induction programme", admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug), secondary: true %>
 
   <% elsif fip? %>
 

--- a/app/components/admin/schools/relationship_component.rb
+++ b/app/components/admin/schools/relationship_component.rb
@@ -20,10 +20,9 @@ module Admin
       def actions
         [
           if allow_challenge?
-            govuk_link_to(
-              "Challenge relationship",
-              new_admin_school_partnership_challenge_partnership_path(school_cohort.school, relationship),
-            )
+            govuk_link_to(new_admin_school_partnership_challenge_partnership_path(school_cohort.school, relationship)) do
+              safe_join(["Challenge relationship", tag.span("with #{relationship.lead_provider.name}", class: "govuk-visually-hidden")], " ")
+            end
           end,
         ].compact
       end

--- a/spec/components/admin/schools/cohort_component_spec.rb
+++ b/spec/components/admin/schools/cohort_component_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe Admin::Schools::CohortComponent, type: :component do
 
       it("renders no relationships") { expect(rendered_content).not_to have_css(relationship_matcher) }
     end
+
+    context "when no school cohort, partnerships or relationships are present" do
+      let(:partnership) { nil }
+      let(:relationships) { nil }
+      let(:school_cohort) { nil }
+
+      it("shows an message explaining there is no programme") do
+        expect(page).to have_content("No induction programme chosen for #{school.name} in #{cohort.academic_year}")
+      end
+
+      it "renders a link styled as a secondary button so admins can set one up" do
+        expect(page).to have_link("Choose an induction programme", href: admin_school_change_programme_path(id: cohort.start_year, school_id: school.slug), class: "govuk-button--secondary")
+      end
+    end
   end
 
   describe "methods" do

--- a/spec/components/admin/schools/relationship_component_spec.rb
+++ b/spec/components/admin/schools/relationship_component_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Admin::Schools::RelationshipComponent, type: :component do
         expected = "/admin/schools/#{school.slug}/partnerships/#{relationship.id}/challenge-partnership/new"
         expect(rendered_content).to have_link("Challenge", href: expected)
       end
+
+      it "has visually hidden text describing the challenge link" do
+        expect(page).to have_content("Challenge relationship with #{relationship.lead_provider.name}")
+      end
     end
 
     describe "listing participants under this relationship" do


### PR DESCRIPTION
### Context

The choose induction programme button was lost when rewriting the cohort component. The loss wasn't noticed as there were no tests. Now it's back and there are tests ensuring it remains.

### Changes proposed in this pull request

#### Add visually hidden text to the challenge link

![Screenshot from 2023-09-06 15-27-29](https://github.com/DFE-Digital/early-careers-framework/assets/128088/c8abce16-ac06-47ef-adf2-15e38760e0a6)


#### Reinstate 'Choose an induction programme' button

![image](https://github.com/DFE-Digital/early-careers-framework/assets/128088/2dffc887-653c-41ae-998a-241e0e112311)

