### PR TITLE
Fix to ensure old cron jobs are purged from schedule

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -36,6 +36,6 @@ end
 # Sidekiq Cron
 if Sidekiq.server?
   Rails.application.config.after_initialize do
-    Sidekiq::Cron::Job.load_from_hash(YAML.load_file(Rails.root.join("config/sidekiq_cron_schedule.yml")))
+    Sidekiq::Cron::Job.load_from_hash!(YAML.load_file(Rails.root.join("config/sidekiq_cron_schedule.yml")))
   end
 end


### PR DESCRIPTION
### Context

Noticed on production that we had old cron jobs still in the list of jobs with sidekiq `Sidekiq::Cron::Job.all` even though these had been removed from the schedule.
After a bit of research it appears that the docs tell you to use `Sidekiq::Cron::Job.load_from_hash` in the initializer but this doesn't remove jobs from the list only adds new ones. Using `.load_from_hash!` instead should do what we want.

### Changes proposed in this pull request
Switch the initializer to load the schedule using `.load_from_hash!`

### Guidance to review

