### PR TITLE
Make prod restore target the actual prod database

### DIFF
--- a/.github/actions/backup-paas-database/action.yml
+++ b/.github/actions/backup-paas-database/action.yml
@@ -67,23 +67,7 @@ runs:
     - name: Setup postgres client
       uses: DFE-Digital/github-actions/install-postgres-client@master
 
-    - name: Backup database (staging, sandbox)
+    - name: Backup database
       shell: bash
-      if: inputs.environment == 'staging' || inputs.environment == 'sandbox'
       run: |
         cf conduit ecf-postgres-${{ inputs.environment }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --no-privileges --verbose -f backup-${{ inputs.environment }}.sql.gz
-
-    # this is temporary while we test restoring production using the backup, re-merge it with
-    # the step above when we're ready to test for real
-    - name: Backup database (production)
-      shell: bash
-      if: inputs.environment == 'production'
-      run: |
-        cf conduit ecf-postgres-production-backup-restore -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --no-privileges --verbose -f backup-${{ inputs.environment }}.sql.gz
-
-    - name: Upload backup
-      uses: actions/upload-artifact@v3
-      with:
-        name: backup-${{ inputs.environment }}
-        path: backup-${{ inputs.environment }}.sql.gz
-        retention-days: 1


### PR DESCRIPTION
Previously we'd used our backup database to test with so we didn't add unnecessary load to the real production database while testing. We're getting closer to the actual migration date now so it makes sense to ensure it _actually works_ 😄
