### PR TITLE
Update our Redis instance to standard/premium in AKS

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -7,6 +7,9 @@ module "redis" {
   service_name          = local.service_name
   service_short         = var.service_short
   config_short          = var.config_short
+  azure_capacity        = var.redis_queue_capacity
+  azure_family          = var.redis_queue_family
+  azure_sku_name        = var.redis_queue_sku_name
 
   cluster_configuration_map = module.cluster_data.configuration_map
 

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -61,3 +61,15 @@ variable "postgres_enable_high_availability" {
 variable "azure_enable_backup_storage" {
   default = false
 }
+
+variable "redis_queue_capacity" {
+  default = 1
+}
+
+variable "redis_queue_family" {
+  default = "C"
+}
+
+variable "redis_queue_sku_name" {
+  default = "Standard"
+}

--- a/terraform/aks/workspace_variables/production_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/production_aks.tfvars.json
@@ -6,5 +6,8 @@
   "cluster": "production",
   "deploy_azure_backing_services": true,
   "enable_monitoring": false,
-  "namespace": "cpd-production"
+  "namespace": "cpd-production",
+  "redis_queue_family": "P",
+  "redis_queue_capacity": 6,
+  "redis_queue_sku_name": "Premium"
 }


### PR DESCRIPTION
### Context
We can't make use of the current cache Redis in AKS in production as it's for Sidekiq and not caching purposes

- Ticket: n/a

### Changes proposed in this pull request
Bump our Redis instance to standard in other ENVs and premium in prod. I named it queue to allow us to add caching later as we need a separate instance as well similar to Apply

### Guidance to review
DId I miss anything?
